### PR TITLE
./configure --enable-multithreading=yes -> MT-Flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,17 +32,26 @@ AM_COND_IF([TARGET_LINUX],
 AC_ARG_ENABLE(debug,
 AS_HELP_STRING([--enable-debug],
                [enable debugging, default: no]),
-[case "${enableval}" in
-             yes) debug=true ;;
-             no)  debug=false ;;
-             *)   AC_MSG_ERROR([bad value ${enableval} for --enable-debug]) ;;
-esac],
-[debug=false])
-
+			   [case "${enableval}" in
+               		 yes) debug=true ;;
+             		 no)  debug=false ;;
+             		 *)   AC_MSG_ERROR([bad value ${enableval} for --enable-debug]) ;; esac],
+				[debug=false])
 AM_CONDITIONAL(DEBUG, test x"$debug" = x"true")
 AM_COND_IF([DEBUG],
     AC_DEFINE([DEBUG])) #define DEBUG is accessible from pre-processor
 
+AC_ARG_ENABLE(multithreading,
+AS_HELP_STRING([--enable-multithreading],
+               [enable debugging, default: yes]),
+			   [case "${enableval}" in
+               		 yes) multithreading=true ;;
+             		 no)  multithreading=false ;;
+             		 *)   AC_MSG_ERROR([bad value ${enableval} for --enable-multithreading]) ;; esac],
+[multithreading=true])
+AM_CONDITIONAL(MULTITHREADING, test x"$multithreading" = x"true")
+AM_COND_IF([MULTITHREADING],
+    AC_DEFINE([MULTITHREADING])) #define MULTITHREADING is accessible from pre-processor
    
 AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -7,7 +7,12 @@ __top_builddir__bin_exampleServer_LDADD= $(top_builddir)/lib/libopen62541.a
 
 __top_builddir__bin_exampleServerMT_CFLAGS = -I$(top_builddir)/src -I$(top_builddir)/include
 __top_builddir__bin_exampleServerMT_SOURCES = opcuaServerMT.c networklayer.c
-__top_builddir__bin_exampleServerMT_LDADD= $(top_builddir)/lib/libopen62541.a -lpthread
+if MULTITHREADING
+MT_LDADD = -lpthread
+else
+MT_LDADD =
+endif
+__top_builddir__bin_exampleServerMT_LDADD= $(top_builddir)/lib/libopen62541.a $(MT_LDADD)
 
 __top_builddir__bin_exampleServerACPLT_CFLAGS = -I$(top_builddir)/src -I$(top_builddir)/include
 __top_builddir__bin_exampleServerACPLT_SOURCES = opcuaServerACPLT.c 

--- a/examples/src/networklayer.c
+++ b/examples/src/networklayer.c
@@ -161,7 +161,9 @@ void* NL_TCP_listen(NL_connection* c) {
 				UA_list_addPayloadToBack(&(tld->connections),cclient);
 				if (tld->threaded == NL_THREADINGTYPE_PTHREAD) {
 					// TODO: handle retval of pthread_create
+#ifdef MULTITHREADING
 					pthread_create( &(cclient->readerThreadHandle), NULL, (void*(*)(void*)) NL_TCP_reader, (void*) cclient);
+#endif
 				} else {
 					NL_TCP_SetNonBlocking(cclient->connection.connectionHandle);
 				}
@@ -271,7 +273,9 @@ UA_Int32 NL_TCP_init(NL_data* tld, UA_Int32 port) {
 		UA_list_addPayloadToBack(&(tld->connections),c);
 		if (tld->threaded == NL_THREADINGTYPE_PTHREAD) {
 			// TODO: handle retval of pthread_create
+#ifdef MULTITHREADING
 			pthread_create( &(c->readerThreadHandle), NULL, (void*(*)(void*)) NL_TCP_listen, (void*) c);
+#endif
 		} else {
 			NL_TCP_SetNonBlocking(c->connection.connectionHandle);
 		}

--- a/examples/src/networklayer.h
+++ b/examples/src/networklayer.h
@@ -13,7 +13,9 @@
 #include "ua_transportLayer.h"
 #include "ua_list.h"
 
+#ifdef MULTITHREADING
 #include <pthread.h> // pthreadcreate, pthread_t
+#endif
 #include <sys/select.h> // FD_ZERO, FD_SET
 
 #define NL_MAXCONNECTIONS_DEFAULT 10


### PR DESCRIPTION
Removing pthread affects more than just networking. This was just not visible so far, as the namespace was not compiled into the example servers.
Compiler flags are ugly. But I don't see a way to get around them if we don't want to duplicate most of the service/application-layer.

Please review and pull if approved.
