### PR TITLE
Generation hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src_generated/ua_types_generated
                           ${PROJECT_BINARY_DIR}/src_generated/ua_types_generated.h
                    COMMAND python ${PROJECT_SOURCE_DIR}/tools/generate_builtin.py ${generate_src_options} ${PROJECT_SOURCE_DIR}/schema/Opc.Ua.Types.bsd ${PROJECT_BINARY_DIR}/src_generated/ua_types_generated
                    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tools/generate_builtin.py
+                           ${CMAKE_CURRENT_SOURCE_DIR}/tools/plugin_*.py                 	
                            ${CMAKE_CURRENT_SOURCE_DIR}/schema/Opc.Ua.Types.bsd)
 
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_0.c

--- a/src/server/ua_application.c
+++ b/src/server/ua_application.c
@@ -552,6 +552,20 @@ void appMockup_init() {
 	/* v->historizing = UA_FALSE; */
 	/* Namespace_insert(ns0,np); */
 
+	//FIXME: not tested
+	//we will probably need to source out the definition into a ua_opaque types.c,
+	//since it will be used on different places: here and at least once in the binaryEncode
+	//function, just before encoding the value, or in the service just before reading, dunno yet
+	/*
+	 struct UA_Open62541Data{
+	 //FIXME: enum or union to come
+	 	UA_Int32(*readCallback)(const UA_NodeId* nodeid, UA_Int32 typeId, const UA_Variant* value);
+		UA_Int32(*writeCallback)(const UA_NodeId* nodeid, UA_Int32 typeId, const UA_Variant* value);
+	 };
+	 v->Open62541Data = (UA_Open62541Data*)malloc(sizeof(UA_Open62541Data));
+	 free(namespaceArray->value.data)
+	 */
+
 	/*******************/
 	/* Namespace local */
 	/*******************/

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -99,7 +99,7 @@ static UA_DataValue service_read_node(Application *app, const UA_ReadValueId *id
 		break;
 
 	case UA_ATTRIBUTEID_ISABSTRACT:
-		CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE);
+		CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE | UA_NODECLASS_OBJECTTYPE | UA_NODECLASS_VARIABLETYPE | UA_NODECLASS_DATATYPE);
 		v.encodingMask = UA_DATAVALUE_ENCODINGMASK_VARIANT;
 		retval |=
 		    UA_Variant_copySetValue(&v.value, &UA_.types[UA_BOOLEAN],
@@ -128,14 +128,14 @@ static UA_DataValue service_read_node(Application *app, const UA_ReadValueId *id
 		break;
 
 	case UA_ATTRIBUTEID_EVENTNOTIFIER:
-		CHECK_NODECLASS(UA_NODECLASS_VIEW);
+		CHECK_NODECLASS(UA_NODECLASS_VIEW | UA_NODECLASS_OBJECT);
 		v.encodingMask = UA_DATAVALUE_ENCODINGMASK_VARIANT;
 		retval |= UA_Variant_copySetValue(&v.value, &UA_.types[UA_BYTE],
 		                                  &((UA_ViewNode *)node)->eventNotifier);
 		break;
 
 	case UA_ATTRIBUTEID_VALUE:
-		CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
+		CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
 		v.encodingMask = UA_DATAVALUE_ENCODINGMASK_VARIANT;
 		// TODO: Ensure that the borrowed value is not freed prematurely (multithreading)
 		/* retval |= UA_Variant_borrowSetValue(&v.value, &UA_.types[UA_VARIANT], */

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1151,11 +1151,3 @@ void UA_Array_print(const void *p, UA_Int32 noElements, UA_VTable_Entry *vt, FIL
 	}
 }
 #endif
-
-/***********************************/
-/* Structs for internal node-data  */
-/***********************************/
-void UA_Open62541Data_init(UA_Open62541Data *p){
-	p->readCallback = UA_NULL;
-	p->writeCallback = UA_NULL;
-}

--- a/src/ua_types.h
+++ b/src/ua_types.h
@@ -518,14 +518,8 @@ typedef struct UA_VTable {
 /* Internal node-data  			   */
 /***********************************/
 
-/** @brief Struct to hold internal data that is not seen on the wire */
-typedef struct UA_Open62541Data {
-	//enum or union to come
-	UA_Int32(*readCallback)(const UA_NodeId* nodeid, UA_Int32 typeId, const UA_Variant* value);
-	UA_Int32(*writeCallback)(const UA_NodeId* nodeid, UA_Int32 typeId, const UA_Variant* value);
-} UA_Open62541Data;
-
-void UA_Open62541Data_init(UA_Open62541Data *p);
+/** @brief Forward-declaration of a struct to hold internal data that is not seen on the wire */
+typedef struct UA_Open62541Data UA_Open62541Data;
 
 /// @} /* end of group */
 

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -411,6 +411,7 @@ UA_Int32 UA_NodeId_calcSizeBinary(UA_NodeId const *p) {
 
 		default:
 			UA_assert(UA_FALSE); // this must never happen
+			break;
 		}
 	}
 	return length;
@@ -522,6 +523,7 @@ UA_Int32 UA_NodeId_decodeBinary(UA_ByteString const *src, UA_UInt32 *offset, UA_
 
 	default:
 		retval = UA_ERROR; // the client sends an encodingByte we do not recognize
+		break;
 	}
 	return retval;
 }

--- a/tools/generate_builtin.py
+++ b/tools/generate_builtin.py
@@ -168,8 +168,9 @@ def createStructured(element):
     #execute struct hook if registered
     if "structuredObject"+name in plugin_hooks:
         exec package_for_hook["structuredObject"+name][0]+"."+"calcSizeBinaryInsert(element, fc, fh)"
-    printc('''    if(ptr==UA_NULL) return sizeof(%(name)s);
-    return 0''')
+    else:
+    	printc('''    if(ptr==UA_NULL) return sizeof(%(name)s);''')
+    printc('''return 0''')
     has_fixed_size = True
     for n,t in membermap.iteritems():
         if t in fixed_size:

--- a/tools/plugin_VariableNode.py
+++ b/tools/plugin_VariableNode.py
@@ -7,13 +7,14 @@ def setup():
 	return config
 
 def structInsert(element, fc, fh):
-	print("\tUA_Open62541Data Open62541Data;", end='\n', file=fh)
+	print("\t//I will not be seen on the wire, I will not be freed by _destroy", end='\n', file=fh)
+	print("\tUA_Open62541Data* Open62541Data;", end='\n', file=fh)
 	return
 
 def initInsert(element, fc, fh):
-    print("\tUA_Open62541Data_init(&(p->Open62541Data));", end='\n', file=fc)
+    print("\tp->Open62541Data = UA_NULL;", end='\n', file=fc)
     return
 
 def calcSizeBinaryInsert(element, fc, fh):
-    print("\tif(ptr==UA_NULL) return sizeof(UA_"+element.get("Name")+")-sizeof(UA_Open62541Data);", end='\n', file=fc)
+    print("\tif(ptr==UA_NULL) return sizeof(UA_"+element.get("Name")+")-sizeof(void*);", end='\n', file=fc)
     return


### PR DESCRIPTION
okay, a next try

``` C
typedef struct UA_VariableNode {
    UA_NodeId nodeId;
    UA_NodeClass nodeClass;
    UA_QualifiedName browseName;
    UA_LocalizedText displayName;
    UA_LocalizedText description;
    UA_UInt32 writeMask;
    UA_UInt32 userWriteMask;
    UA_Int32 referencesSize;
    UA_ReferenceNode* references;
    UA_Variant value;
    UA_NodeId dataType;
    UA_Int32 valueRank;
    UA_Int32 arrayDimensionsSize;
    UA_UInt32* arrayDimensions;
    UA_Byte accessLevel;
    UA_Byte userAccessLevel;
    UA_Double minimumSamplingInterval;
    UA_Boolean historizing;
    //I will not be seen on the wire, I will not be freed by _destroy
    UA_Open62541Data* Open62541Data;
} UA_VariableNode;
```

The definition of UA_Open62541Data is hidden  and will be used in ua_application.c like this

```
    //FIXME: not tested
    /*
     struct UA_Open62541Data{
     //FIXME: enum or union to come
        UA_Int32(*readCallback)(const UA_NodeId* nodeid, UA_Int32 typeId, const UA_Variant* value);
        UA_Int32(*writeCallback)(const UA_NodeId* nodeid, UA_Int32 typeId, const UA_Variant* value);
     };
     v->Open62541Data = (UA_Open62541Data*)malloc(sizeof(UA_Open62541Data));
     free(v->Open62541Data);
     */
```

We will probably need to source out the definition into a ua_opaque_types.c, since it will be used on different places: here and at least once 
- in the binaryEncode function, just before encoding the value, 
- or in the service just before reading the variable node

dunno yet. 

I'd probably go for calling callbacks form a service
- then we will not need to hack more generated code
- we will have the nodeId at hands at the service layer
