### PR TITLE
Memory leak in MonitoredItem_CopyMonitoredValueToVariant

### DIFF
--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -381,11 +381,6 @@ UA_Boolean MonitoredItem_CopyMonitoredValueToVariant(UA_UInt32 attributeID, cons
                                                NULL, &sourceDataValue) != UA_STATUSCODE_GOOD)
                     break;
                 UA_DataValue_copy(&sourceDataValue, dst);
-                if(sourceDataValue.value.data) {
-                    UA_deleteMembers(sourceDataValue.value.data, sourceDataValue.value.type);
-                    UA_free(sourceDataValue.value.data);
-                    sourceDataValue.value.data = NULL;
-                }
                 UA_DataValue_deleteMembers(&sourceDataValue);
                 samplingError = UA_FALSE;
             }


### PR DESCRIPTION
I'm using open62541 built with address sanitizer, which reports a memory leak in `MonitoredItem_CopyMonitoredValueToVariant`.

The solution is to not touch the returned data, and let `UA_DataValue_deleteMembers` do all the cleanup (equivalent to how this is done in `getVariableNodeDataType` and `getVariableNodeArrayDimensions` in ua_services_attribute.c).