### PR TITLE
Resize newValueAsByteString (in MonitoredItem_QueuePushDataValue) as needed

### DIFF
--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -47,6 +47,7 @@ typedef struct UA_MonitoredItem {
     UA_Boolean discardOldest;
     UA_DateTime lastSampled;
     UA_ByteString lastSampledValue;
+    UA_UInt32 lastSampledSize;
     // FIXME: indexRange is ignored; array values default to element 0
     // FIXME: dataEncoding is hardcoded to UA binary
     TAILQ_HEAD(QueueOfQueueDataValues, MonitoredItem_queuedValue) queue;


### PR DESCRIPTION
I'm hitting a bug where some of my items are larger than what fits inside the staticly sized newValueAsByteString in MonitoredItem_QueuePushDataValue - causing the item to report as updated for every iteration this method is run.

I see there's been some talk about `calcSizeBinary` which doesn't yet exist. This is just a suggestion until a better solution is implemented.

At the moment, I let newValueAsByteString grow indefinitely at the moment. An upper bounds check could easily be added if wanted / required.