### PR TITLE
CYGWIN compilation error

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -88,7 +88,11 @@ UA_DateTime UA_DateTime_nowMonotonic(void) {
     return (mts.tv_sec * UA_SEC_TO_DATETIME) + (mts.tv_nsec / 100);
 #else
     struct timespec ts;
+#ifdef __CYGWIN__    
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+#else
     clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+#endif
     return (ts.tv_sec * UA_SEC_TO_DATETIME) + (ts.tv_nsec / 100);
 #endif
 }


### PR DESCRIPTION
When compiling under cygwin we have this error :

```
Scanning dependencies of target open62541-object
[ 10%] Building C object CMakeFiles/open62541-object.dir/src/ua_types.c.o
/home/btc/open62541-master/src/ua_types.c: In function ‘UA_DateTime_nowMonotonic’:
/home/btc/open62541-master/src/ua_types.c:91:19: erreur: ‘CLOCK_MONOTONIC_RAW’ undeclared (first use in this function)
     clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
                   ^
/home/btc/open62541-master/src/ua_types.c:91:19: note: each undeclared identifier is reported only once for each function it appears in
CMakeFiles/open62541-object.dir/build.make:90 : la recette pour la cible « CMakeFiles/open62541-object.dir/src/ua_types.c.o » a échouée
make[2]: *** [CMakeFiles/open62541-object.dir/src/ua_types.c.o] Erreur 1
CMakeFiles/Makefile2:104 : la recette pour la cible « CMakeFiles/open62541-object.dir/all » a échouée
make[1]: *** [CMakeFiles/open62541-object.dir/all] Erreur 2
Makefile:83 : la recette pour la cible « all » a échouée
make: *** [all] Erreur 2
```

I don't now if it is safe to use "CLOCK_MONOTONIC"