### PR TITLE
fix possible memory leak

### DIFF
--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -454,6 +454,7 @@ void MonitoredItem_QueuePushDataValue(UA_Server *server, UA_MonitoredItem *monit
     if(monitoredItem->queueSize.currentValue >= monitoredItem->queueSize.maxValue) {
         if(monitoredItem->discardOldest != UA_TRUE) {
             // We cannot remove the oldest value and theres no queue space left. We're done here.
+            UA_DataValue_deleteMembers(&newvalue->value);
             UA_free(newvalue);
             return;
         }


### PR DESCRIPTION
Hello,

I don't have test case and I don't know if it is needed but MonitoredItem_QueuePushDataValue always call UA_DataValue_deleteMembers(&newvalue->value) before UA_free(newvalue). "We cannot remove the oldest value and theres no queue space left. We're done here." is peraps for that?

It is just a question/suggestion. If no simply close the PR.