### PR TITLE
Adds dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.3
+RUN apk add --no-cache cmake gcc musl-dev python py-lxml make && rm -rf /var/cache/apk/*
+ADD . /tmp/open62541
+WORKDIR /tmp/open62541/build
+RUN cmake -D UA_ENABLE_AMALGAMATION=true /tmp/open62541 && make
+RUN cp *.h /usr/include/ && \
+    cp *.so /usr/lib && \
+    cp *.a /usr/lib

--- a/TinyDockerfile
+++ b/TinyDockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.3
+ADD . /tmp/open62541
+WORKDIR /tmp/open62541/build
+RUN apk add --no-cache cmake gcc musl-dev python py-lxml make && rm -rf /var/cache/apk/* && \
+    cmake -D UA_ENABLE_AMALGAMATION=true /tmp/open62541 && \
+    make && \
+    cp *.h /usr/include/ && \
+    cp *.so /usr/lib && \
+    cp *.a /usr/lib && \
+    make clean && \
+    apk del cmake gcc musl-dev python py-lxml make


### PR DESCRIPTION
This uses alpine linux and attempts to create a minimal install with tools to develop using open62541
Copies the amalgamated header file into /usr/include and the dynamic and static libraries into /usr/lib
This should allow default gcc to pick them up easy enough

EDIT: also my C/CMake is a little rusty. I wanted to add the files in standard OS locations so people didn't need to mess with installs. If a cmake install target is added it would probably be better to run that instead of the manual CP steps I've done for the docker image.

