### PR TITLE
Fixed c&p bug (?) while adding a VariableTypeNode

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -465,7 +465,7 @@ void Service_AddNodes_single(UA_Server *server, UA_Session *session, const UA_Ad
         node = objectTypeNodeFromAttributes(item, item->nodeAttributes.content.decoded.data);
         break;
     case UA_NODECLASS_VARIABLETYPE:
-        if(item->nodeAttributes.content.decoded.type != &UA_TYPES[UA_TYPES_OBJECTTYPEATTRIBUTES]) {
+        if(item->nodeAttributes.content.decoded.type != &UA_TYPES[UA_TYPES_VARIABLETYPEATTRIBUTES]) {
             result->statusCode = UA_STATUSCODE_BADNODEATTRIBUTESINVALID;
             return;
         }


### PR DESCRIPTION
The nodeClass "UA_NODECLASS_VARIABLETYPE" shall have the type "UA_TYPES_VARIABLETYPEATTRIBUTES", not "UA_TYPES_OBJECTTYPEATTRIBUTES". So we can't add them yet.