### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ matrix:
       compiler: gcc
     - os: osx
       env: ANALYZE=true
-  allow_failures:
-    - env: ANALYZE=true
-      compiler: gcc
+  #allow_failures:
+  #  - env: ANALYZE=true
+  #    compiler: gcc
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ addons:
       - build-essential
       - clang
       - cmake
-      - cppcheck
       - gcc-4.8
       - gcc-mingw-w64-i686
       - gcc-multilib

--- a/plugins/networklayer_tcp.c
+++ b/plugins/networklayer_tcp.c
@@ -288,6 +288,7 @@ ServerNetworkLayerTCP_closeConnection(UA_Connection *connection) {
         return;
     connection->state = UA_CONNECTION_CLOSED;
 #endif
+    //cppcheck-suppress unreadVariable
     ServerNetworkLayerTCP *layer = connection->handle;
     UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK, "Closing the Connection %i",
                 connection->sockfd);

--- a/plugins/networklayer_udp.c
+++ b/plugins/networklayer_udp.c
@@ -171,7 +171,7 @@ static size_t ServerNetworkLayerUDP_getJobs(ServerNetworkLayerUDP *layer, UA_Job
     socklen_t sendsize = sizeof(sender);
     bzero(&sender, sizeof(sender));
     buf.length = recvfrom(layer->serversockfd, buf.data, layer->conf.recvBufferSize, 0, &sender, &sendsize);
-    if (buf.length <= 0) {
+    if (buf.length == 0) {
     } else {
         UDPConnection *c = malloc(sizeof(UDPConnection));
         if(!c){

--- a/plugins/networklayer_udp.c
+++ b/plugins/networklayer_udp.c
@@ -170,9 +170,9 @@ static size_t ServerNetworkLayerUDP_getJobs(ServerNetworkLayerUDP *layer, UA_Job
     struct sockaddr sender;
     socklen_t sendsize = sizeof(sender);
     bzero(&sender, sizeof(sender));
-    buf.length = recvfrom(layer->serversockfd, buf.data, layer->conf.recvBufferSize, 0, &sender, &sendsize);
-    if (buf.length == 0) {
-    } else {
+	ssize_t rec_result = recvfrom(layer->serversockfd, buf.data, layer->conf.recvBufferSize, 0, &sender, &sendsize);
+    if (rec_result > 0) {
+    	buf.length = rec_result;
         UDPConnection *c = malloc(sizeof(UDPConnection));
         if(!c){
        	    free(items);
@@ -196,14 +196,13 @@ static size_t ServerNetworkLayerUDP_getJobs(ServerNetworkLayerUDP *layer, UA_Job
         items[j].job.binaryMessage.connection = (UA_Connection*)c;
         buf.data = NULL;
         j++;
-    }
+		*jobs = items;
+    } else {
+		free(items);
+		*jobs = NULL;
+	}
     if(buf.data)
         free(buf.data);
-    if(j == 0) {
-        free(items);
-        *jobs = NULL;
-    } else
-        *jobs = items;
     return j;
 }
 

--- a/src/server/ua_server_worker.c
+++ b/src/server/ua_server_worker.c
@@ -549,6 +549,7 @@ static void processMainLoopJobs(UA_Server *server) {
         processJobs(server, &mlw->job, 1);
         next = (struct MainLoopJob*)mlw->node.next;
         UA_free(mlw);
+        //cppcheck-suppress unreadVariable
     } while((mlw = next));
     //UA_free(head);
 }

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -10,9 +10,8 @@ readNumber(UA_Byte *buf, size_t buflen, UA_UInt32 *number) {
     UA_UInt32 n = 0;
     size_t progress = 0;
     /* read numbers until the end or a non-number character appears */
-    UA_Byte c;
     while(progress < buflen) {
-        c = buf[progress];
+        UA_Byte c = buf[progress];
         if('0' > c || '9' < c)
             break;
         n = (n*10) + (UA_UInt32)(c-'0');

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -823,7 +823,6 @@ void Service_AddReferences(UA_Server *server, UA_Session *session, const UA_AddR
 	}
 #endif
 
-	response->resultsSize = size;
 	for(size_t i = 0; i < response->resultsSize; i++) {
 #ifdef UA_ENABLE_EXTERNAL_NAMESPACES
 		if(!isExternal[i])

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -259,7 +259,7 @@ Service_Browse_single(UA_Server *server, UA_Session *session, struct Continuatio
     }
 
     /* if the node has no references, just return */
-    if(node->referencesSize <= 0) {
+    if(node->referencesSize == 0) {
         result->referencesSize = 0;
         if(!all_refs && descr->includeSubtypes)
             UA_Array_delete(relevant_refs, relevant_refs_size, &UA_TYPES[UA_TYPES_NODEID]);
@@ -270,7 +270,7 @@ Service_Browse_single(UA_Server *server, UA_Session *session, struct Continuatio
     size_t real_maxrefs = maxrefs;
     if(real_maxrefs == 0)
         real_maxrefs = node->referencesSize;
-    if(node->referencesSize <= 0)
+    if(node->referencesSize == 0)
         real_maxrefs = 0;
     else if(real_maxrefs > node->referencesSize)
         real_maxrefs = node->referencesSize;

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -541,9 +541,11 @@ UA_StatusCode UA_Variant_setScalarCopy(UA_Variant *v, const void *p, const UA_Da
     UA_StatusCode retval = UA_copy(p, new, type);
 	if(retval != UA_STATUSCODE_GOOD) {
 		UA_free(new);
+        //cppcheck-suppress memleak
 		return retval;
 	}
     UA_Variant_setScalar(v, new, type);
+    //cppcheck-suppress memleak
     return UA_STATUSCODE_GOOD;
 }
 

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -259,7 +259,7 @@ static long double unpack754(uint64_t i, unsigned bits, unsigned expbits) {
     long long shift = (long long)((i>>significandbits) & (uint64_t)((1LL<<expbits)-1)) - bias;
     while(shift > 0) { result *= 2.0; shift--; }
     while(shift < 0) { result /= 2.0; shift++; }
-    result *= (i>>(bits-1))&1? -1.0: 1.0;
+    result *= ((i>>(bits-1))&1)? -1.0: 1.0;
     return result;
 }
 
@@ -273,8 +273,10 @@ static UA_StatusCode
 Float_encodeBinary(UA_Float const *src, bufpos pos, bufend end) {
     UA_Float f = *src;
     UA_UInt32 encoded;
+    //cppcheck-suppress duplicateExpression
     if(f != f) encoded = FLOAT_NAN;
     else if(f == 0.0f) encoded = signbit(f) ? FLOAT_NEG_ZERO : 0;
+    //cppcheck-suppress duplicateExpression
     else if(f/f != f/f) encoded = f > 0 ? FLOAT_INF : FLOAT_NEG_INF;
     else encoded = (UA_UInt32)pack754(f, 32, 8);
     return UInt32_encodeBinary(&encoded, pos, end);
@@ -306,8 +308,10 @@ static UA_StatusCode
 Double_encodeBinary(UA_Double const *src, bufpos pos, bufend end) {
     UA_Double d = *src;
     UA_UInt64 encoded;
+    //cppcheck-suppress duplicateExpression
     if(d != d) encoded = DOUBLE_NAN;
     else if(d == 0.0) encoded = signbit(d) ? DOUBLE_NEG_ZERO : 0;
+    //cppcheck-suppress duplicateExpression
     else if(d/d != d/d) encoded = d > 0 ? DOUBLE_INF : DOUBLE_NEG_INF;
     else encoded = pack754(d, 64, 11);
     return UInt64_encodeBinary(&encoded, pos, end);
@@ -323,6 +327,7 @@ Double_decodeBinary(bufpos pos, bufend end, UA_Double *dst) {
     else if(decoded == DOUBLE_NEG_ZERO) *dst = -0.0;
     else if(decoded == DOUBLE_INF) *dst = INFINITY;
     else if(decoded == DOUBLE_NEG_INF) *dst = -INFINITY;
+    //cppcheck-suppress redundantCondition
     if((decoded >= 0x7ff0000000000001L && decoded <= 0x7fffffffffffffffL) ||
        (decoded >= 0xfff0000000000001L && decoded <= 0xffffffffffffffffL)) *dst = NAN;
     else *dst = (UA_Double)unpack754(decoded, 64, 11);

--- a/tools/travis/travis_linux_before_install.sh
+++ b/tools/travis/travis_linux_before_install.sh
@@ -2,8 +2,32 @@
 set -ev
 
 if [ $ANALYZE = "true" ]; then
-  	g++ --version
-  	cppcheck --version
+
+	cd $LOCAL_PKG
+	# travis caches the $LOCAL_PKG dir. If it is loaded, we don't need to reinstall the packages
+	if [ "$CC" = "clang" ]; then
+		clang --version
+	else
+
+		if [ ! -f $LOCAL_PKG/.cached_analyze ]; then
+
+			# Install newer cppcheck
+			wget https://github.com/danmar/cppcheck/archive/1.73.tar.gz -O cppcheck-1.73.tar.gz
+			tar xf cppcheck-1.73.tar.gz
+			cd $LOCAL_PKG/cppcheck-1.73
+			make SRCDIR=build CFGDIR="$LOCAL_PKG/cppcheck-1.73/cfg" HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" -j8
+			ln -s $LOCAL_PKG/cppcheck-1.73/cppcheck $LOCAL_PKG/cppcheck
+
+			# create cached flag
+			touch $LOCAL_PKG/.cached_analyze
+		else
+			echo "\n## Using local packages from cache\n"
+		fi
+
+		g++ --version
+		cppcheck --version
+	fi
+
 else
 	cd $LOCAL_PKG
 


### PR DESCRIPTION
Merge https://github.com/open62541/open62541/pull/587 first

Fixes the following warnings and enables cppcheck CI failure:
```
plugins/networklayer_udp.c(174): style (unsignedLessThanZero): Checking if unsigned variable 'length' is less than zero.
plugins/networklayer_tcp.c(291): style (unreadVariable): Variable 'layer' is assigned a value that is never used.
src/server/ua_services_attribute.c(13): style (variableScope): The scope of the variable 'c' can be reduced.
src/server/ua_server_worker.c(552): style (unreadVariable): Variable 'mlw' is assigned a value that is never used.
src/server/ua_services_view.c(262): style (unsignedLessThanZero): Checking if unsigned variable 'referencesSize' is less than zero.
src/server/ua_services_view.c(273): style (unsignedLessThanZero): Checking if unsigned variable 'referencesSize' is less than zero.
src/ua_types.c(544): error (memleak): Memory leak: new
src/ua_types.c(547): error (memleak): Memory leak: new
src/ua_types_encoding_binary.c(278): style (duplicateExpression): Same expression on both sides of '/'.
src/ua_types_encoding_binary.c(311): style (duplicateExpression): Same expression on both sides of '/'.
src/ua_types_encoding_binary.c(49): error (arrayIndexOutOfBounds): Array 'buf[4]' accessed at index 4, which is out of bounds.
src/ua_types_encoding_binary.c(49): error (arrayIndexOutOfBounds): Array 'buf[4]' accessed at index 5, which is out of bounds.
src/ua_types_encoding_binary.c(50): error (arrayIndexOutOfBounds): Array 'buf[4]' accessed at index 6, which is out of bounds.
src/ua_types_encoding_binary.c(50): error (arrayIndexOutOfBounds): Array 'buf[4]' accessed at index 7, which is out of bounds.
src/ua_types_encoding_binary.c(326): style (redundantCondition): Redundant condition: If decoded >= 9218868437227405313, the comparison decoded <= 9223372036854775807 is always true.
src/ua_types_encoding_binary.c(262): style (clarifyCalculation): Clarify calculation precedence for '&' and '?'.
src/ua_types_encoding_binary.c(276): style (duplicateExpression): Same expression on both sides of '!='.
src/ua_types_encoding_binary.c(278): style (duplicateExpression): Same expression on both sides of '!='.
src/ua_types_encoding_binary.c(309): style (duplicateExpression): Same expression on both sides of '!='.
src/ua_types_encoding_binary.c(311): style (duplicateExpression): Same expression on both sides of '!='.

plugins/networklayer_udp.c(202): style (knownConditionTrueFalse): Condition 'j==0' is always false
src/server/ua_services_nodemanagement.c(826): style (redundantAssignment): Variable 'resultsSize' is reassigned a value before the old one has been used.
```