### PR TITLE
fix gcc 6.1.0 compilation

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -755,7 +755,7 @@ addOneWayReference(UA_Server *server, UA_Session *session, UA_Node *node, const 
         node->referencesSize = i+1;
     else
         UA_ReferenceNode_deleteMembers(&new_refs[i]);
-	return retval;
+    return retval;
 }
 
 UA_StatusCode


### PR DESCRIPTION
Scanning dependencies of target open62541-object
[ 37%] Building C object CMakeFiles/open62541-object.dir/open62541.c.o
/data/linux/open62541/src/build/open62541.c: In function 'addOneWayReference':
/data/linux/open62541/src/build/open62541.c:17596:5: error: this 'else' clause does not guard... [-Werror=misleading-indentation]
     else
     ^~~~
/data/linux/open62541/src/build/open62541.c:17598:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
  return retval;
  ^~~~~~
cc1: all warnings being treated as errors
CMakeFiles/open62541-object.dir/build.make:186: recipe for target 'CMakeFiles/open62541-object.dir/open62541.c.o' failed
make[2]: *** [CMakeFiles/open62541-object.dir/open62541.c.o] Error 1
CMakeFiles/Makefile2:178: recipe for target 'CMakeFiles/open62541-object.dir/all' failed
make[1]: *** [CMakeFiles/open62541-object.dir/all] Error 2
Makefile:83: recipe for target 'all' failed