### PR TITLE
Session name management

### DIFF
--- a/src/server/ua_securechannel_manager.c
+++ b/src/server/ua_securechannel_manager.c
@@ -56,7 +56,7 @@ UA_SecureChannelManager_open(UA_SecureChannelManager *cm, UA_Connection *conn,
                              UA_OpenSecureChannelResponse *response) {
     if(request->securityMode != UA_MESSAGESECURITYMODE_NONE)
         return UA_STATUSCODE_BADSECURITYMODEREJECTED;
-    if(cm->currentChannelCount >= cm->maxChannelCount)
+    if(cm->currentChannelCount > cm->maxChannelCount)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     channel_list_entry *entry = UA_malloc(sizeof(channel_list_entry));
     if(!entry)

--- a/src/server/ua_securechannel_manager.c
+++ b/src/server/ua_securechannel_manager.c
@@ -56,7 +56,7 @@ UA_SecureChannelManager_open(UA_SecureChannelManager *cm, UA_Connection *conn,
                              UA_OpenSecureChannelResponse *response) {
     if(request->securityMode != UA_MESSAGESECURITYMODE_NONE)
         return UA_STATUSCODE_BADSECURITYMODEREJECTED;
-    if(cm->currentChannelCount > cm->maxChannelCount)
+    if(cm->currentChannelCount >= cm->maxChannelCount)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     channel_list_entry *entry = UA_malloc(sizeof(channel_list_entry));
     if(!entry)

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -442,7 +442,7 @@ UA_Server * UA_Server_new(const UA_ServerConfig config) {
         // UA_String_copy(&server->config.networkLayers[i].discoveryUrl, &endpoint->endpointUrl);
     } 
 
-#define MAXCHANNELCOUNT 100
+#define MAXCHANNELCOUNT 103
 #define STARTCHANNELID 1
 #define TOKENLIFETIME 600000 //this is in milliseconds //600000 seems to be the minimal allowet time for UaExpert
 #define STARTTOKENID 1
@@ -451,9 +451,8 @@ UA_Server * UA_Server_new(const UA_ServerConfig config) {
 
 #define MAXSESSIONCOUNT 1000
 #define MAXSESSIONLIFETIME 3600000
-#define STARTSESSIONID 1
     UA_SessionManager_init(&server->sessionManager, MAXSESSIONCOUNT, MAXSESSIONLIFETIME,
-                           STARTSESSIONID, server);
+                           server);
 
     UA_Job cleanup = {.type = UA_JOBTYPE_METHODCALL,
                       .job.methodCall = {.method = UA_Server_cleanup, .data = NULL} };

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -442,7 +442,7 @@ UA_Server * UA_Server_new(const UA_ServerConfig config) {
         // UA_String_copy(&server->config.networkLayers[i].discoveryUrl, &endpoint->endpointUrl);
     } 
 
-#define MAXCHANNELCOUNT 103
+#define MAXCHANNELCOUNT 100
 #define STARTCHANNELID 1
 #define TOKENLIFETIME 600000 //this is in milliseconds //600000 seems to be the minimal allowet time for UaExpert
 #define STARTTOKENID 1

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -126,6 +126,11 @@ Service_ActivateSession(UA_Server *server, UA_Session *session, const UA_Activat
             response->responseHeader.serviceResult = UA_STATUSCODE_BADIDENTITYTOKENINVALID;
             return;
         }
+        if(token->userName.length == 0 && token->password.length == 0) {
+            /* empty username and password */
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+            return;
+        }
         /* ok, trying to match the username */
         for(size_t i = 0; i < server->config.usernamePasswordLoginsSize; i++) {
             UA_String *user = &server->config.usernamePasswordLogins[i].username;

--- a/src/server/ua_session_manager.c
+++ b/src/server/ua_session_manager.c
@@ -3,11 +3,9 @@
 
 UA_StatusCode
 UA_SessionManager_init(UA_SessionManager *sm, UA_UInt32 maxSessionCount,
-                       UA_UInt32 maxSessionLifeTime, UA_UInt32 startSessionId,
-                       UA_Server *server) {
+                       UA_UInt32 maxSessionLifeTime, UA_Server *server) {
     LIST_INIT(&sm->sessions);
     sm->maxSessionCount = maxSessionCount;
-    sm->lastSessionId   = startSessionId;
     sm->maxSessionLifeTime  = maxSessionLifeTime;
     sm->currentSessionCount = 0;
     sm->server = server;
@@ -73,8 +71,9 @@ UA_SessionManager_createSession(UA_SessionManager *sm, UA_SecureChannel *channel
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
     sm->currentSessionCount++;
+    sm->lastSessionId++;
     UA_Session_init(&newentry->session);
-    newentry->session.sessionId = UA_NODEID_NUMERIC(1, sm->lastSessionId++);
+    newentry->session.sessionId = UA_NODEID_GUID(1, UA_Guid_random());
     newentry->session.authenticationToken = UA_NODEID_GUID(1, UA_Guid_random());
 
     if(request->requestedSessionTimeout <= sm->maxSessionLifeTime &&

--- a/src/server/ua_session_manager.h
+++ b/src/server/ua_session_manager.h
@@ -22,7 +22,7 @@ typedef struct UA_SessionManager {
 
 UA_StatusCode
 UA_SessionManager_init(UA_SessionManager *sessionManager, UA_UInt32 maxSessionCount,
-                       UA_UInt32 maxSessionLifeTime, UA_UInt32 startSessionId, UA_Server *server);
+                       UA_UInt32 maxSessionLifeTime, UA_Server *server);
 
 void UA_SessionManager_deleteMembers(UA_SessionManager *sessionManager);
 


### PR DESCRIPTION
remove session counter, session id is not a guid @jpfr @FlorianPalm maybe we should reserve ns=1 for internal purposes only
added some more logic to authenticator and sc-manager

please sign this off