### PR TITLE
One way reference ofr external namespaces

### DIFF
--- a/include/ua_server_external_ns.h
+++ b/include/ua_server_external_ns.h
@@ -42,6 +42,9 @@ typedef UA_Int32 (*UA_ExternalNodeStore_addReferences)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_AddReferencesItem* referencesToAdd,
  UA_UInt32 *indices,UA_UInt32 indicesSize, UA_StatusCode *addReferencesResults,
  UA_DiagnosticInfo *diagnosticInfos);
+ 
+ typedef UA_Int32 (*UA_ExternalNodeStore_addOneWayReference)
+(void *ensHandle, const UA_AddReferencesItem *item);
 
 typedef UA_Int32 (*UA_ExternalNodeStore_deleteNodes)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_DeleteNodesItem *nodesToDelete, UA_UInt32 *indices,
@@ -82,6 +85,7 @@ typedef struct UA_ExternalNodeStore {
 	UA_ExternalNodeStore_translateBrowsePathsToNodeIds translateBrowsePathsToNodeIds;
 	UA_ExternalNodeStore_addReferences addReferences;
 	UA_ExternalNodeStore_deleteReferences deleteReferences;
+	UA_ExternalNodeStore_addOneWayReference addOneWayReference;
 	UA_ExternalNodeStore_delete destroy;
 } UA_ExternalNodeStore;
 

--- a/plugins/networklayer_tcp.c
+++ b/plugins/networklayer_tcp.c
@@ -289,10 +289,12 @@ ServerNetworkLayerTCP_closeConnection(UA_Connection *connection) {
         return;
     connection->state = UA_CONNECTION_CLOSED;
 #endif
-    //cppcheck-suppress unreadVariable
+#if UA_LOGLEVEL <= 300   
+   //cppcheck-suppress unreadVariable
     ServerNetworkLayerTCP *layer = connection->handle;
     UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK, "Connection %i | Force closing the connection",
                 connection->sockfd);
+#endif
     /* only "shutdown" here. this triggers the select, where the socket is
        "closed" in the mainloop */
     shutdown(connection->sockfd, 2);

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -853,7 +853,7 @@ addOneWayReference(UA_Server *server, UA_Session *session, UA_Node *node, const 
 
 UA_StatusCode
 Service_AddReferences_single(UA_Server *server, UA_Session *session, const UA_AddReferencesItem *item) {
-UA_StatusCode retval;
+UA_StatusCode retval = UA_STATUSCODE_GOOD;
 #ifdef UA_ENABLE_EXTERNAL_NAMESPACES
 	UA_Boolean handledExternally = UA_FALSE;
 #endif  
@@ -866,7 +866,7 @@ UA_StatusCode retval;
                 continue;
 		} else {
 			UA_ExternalNodeStore *ens = &server->externalNamespaces[j].externalNodeStore;
-			ens->addOneWayReference(ens->ensHandle, item);
+			retval = ens->addOneWayReference(ens->ensHandle, item);
 			handledExternally = UA_TRUE;
 			break;
         }
@@ -898,7 +898,7 @@ UA_StatusCode retval;
                 continue;
 		} else {
 			UA_ExternalNodeStore *ens = &server->externalNamespaces[j].externalNodeStore;
-			ens->addOneWayReference(ens->ensHandle, &secondItem);
+			retval = ens->addOneWayReference(ens->ensHandle, &secondItem);
 			handledExternally = UA_TRUE;
 			break;
         }


### PR DESCRIPTION
Ran into a Problem when trying to bridge from NS0 to an external NS with a Reference. The referenced node in the external NS is obviously not found by findNode (called from editNode, called from addReferences_Single).

The standard says, it is ok for references to external nodes when only the source of the reference is edited in the local server. As my problem occurred on an external NS, not on real external nodes, this does not fully apply, but at least it is close. The fix I included in this pull request does its job quite well in first tests, but I'm happy to learn a better alternative.