### PR TITLE
fixed an unused variable error for loglevels greater 300

### DIFF
--- a/plugins/networklayer_tcp.c
+++ b/plugins/networklayer_tcp.c
@@ -289,10 +289,12 @@ ServerNetworkLayerTCP_closeConnection(UA_Connection *connection) {
         return;
     connection->state = UA_CONNECTION_CLOSED;
 #endif
-    //cppcheck-suppress unreadVariable
+#if UA_LOGLEVEL <= 300   
+   //cppcheck-suppress unreadVariable
     ServerNetworkLayerTCP *layer = connection->handle;
     UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK, "Connection %i | Force closing the connection",
                 connection->sockfd);
+#endif
     /* only "shutdown" here. this triggers the select, where the socket is
        "closed" in the mainloop */
     shutdown(connection->sockfd, 2);


### PR DESCRIPTION
compiling with mingw32 gcc version 4.5.2 there was an unused variable warning and hence a compile error. A loglevel ifdef fixed it.