### PR TITLE
Allow empty-element tag for base attributes

### DIFF
--- a/tools/pyUANamespace/ua_node_types.py
+++ b/tools/pyUANamespace/ua_node_types.py
@@ -624,7 +624,7 @@ class opcua_node_t:
           elif x.tagName == "UserWriteMask":
             self.userWriteMask(int(unicode(x.firstChild.data)))
             xmlelement.removeChild(x)
-        elif x.tagName == "References":
+        if x.tagName == "References":
           self.initiateDummyXMLReferences(x)
           xmlelement.removeChild(x)
     self.parseXMLSubType(xmlelement)

--- a/tools/pyUANamespace/ua_node_types.py
+++ b/tools/pyUANamespace/ua_node_types.py
@@ -608,21 +608,22 @@ class opcua_node_t:
 
     for x in thisxml.childNodes:
       if x.nodeType == x.ELEMENT_NODE:
-        if   x.tagName == "BrowseName":
-          self.browseName(unicode(x.firstChild.data))
-          xmlelement.removeChild(x)
-        elif x.tagName == "DisplayName":
-          self.displayName(unicode(x.firstChild.data))
-          xmlelement.removeChild(x)
-        elif x.tagName == "Description":
-          self.description(unicode(x.firstChild.data))
-          xmlelement.removeChild(x)
-        elif x.tagName == "WriteMask":
-          self.writeMask(int(unicode(x.firstChild.data)))
-          xmlelement.removeChild(x)
-        elif x.tagName == "UserWriteMask":
-          self.userWriteMask(int(unicode(x.firstChild.data)))
-          xmlelement.removeChild(x)
+        if x.firstChild:
+          if   x.tagName == "BrowseName":
+            self.browseName(unicode(x.firstChild.data))
+            xmlelement.removeChild(x)
+          elif x.tagName == "DisplayName":
+            self.displayName(unicode(x.firstChild.data))
+            xmlelement.removeChild(x)
+          elif x.tagName == "Description":
+            self.description(unicode(x.firstChild.data))
+            xmlelement.removeChild(x)
+          elif x.tagName == "WriteMask":
+            self.writeMask(int(unicode(x.firstChild.data)))
+            xmlelement.removeChild(x)
+          elif x.tagName == "UserWriteMask":
+            self.userWriteMask(int(unicode(x.firstChild.data)))
+            xmlelement.removeChild(x)
         elif x.tagName == "References":
           self.initiateDummyXMLReferences(x)
           xmlelement.removeChild(x)
@@ -801,7 +802,7 @@ class opcua_node_referenceType_t(opcua_node_t):
 
     for x in xmlelement.childNodes:
       if x.nodeType == x.ELEMENT_NODE:
-        if x.tagName == "InverseName":
+        if x.tagName == "InverseName" and x.firstChild:
           self.inverseName(str(unicode(x.firstChild.data)))
         else:
           logger.warn( "Unprocessable XML Element: " + x.tagName)


### PR DESCRIPTION
Allow empty-element tags for base attributes in node XMLs.

Some tools create node XML with empty elements like *<Description/>*.

open62541 should be able to handle this cause they are valid XML documents

example:
```
<UAReferenceType NodeId="ns=1;i=4001" BrowseName="1:providesInputTo">
        <DisplayName>providesInputTo</DisplayName>
       <Description/>
        <References>
            <Reference ReferenceType="HasSubtype" IsForward="false">i=33</Reference>
        </References>
        <InverseName/>
    </UAReferenceType>
```