### PR TITLE
LDS customizable timeout for automatic de-register

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
     add_definitions(-DUA_NO_AMALGAMATION)
 endif()
 
-list(APPEND LIBS ${open62541_LIBRARIES})
+list(APPEND LIBS ${open62541_LIBRARIES} open62541)
 if(NOT WIN32)
   list(APPEND LIBS pthread)
   if (NOT APPLE)
@@ -68,6 +68,7 @@ if(UA_ENABLE_METHODCALLS)
 endif()
 
 if(UA_ENABLE_DISCOVERY)
+
     add_executable(discovery_server_discovery discovery/server_discovery.c)
     target_link_libraries(discovery_server_discovery ${LIBS})
 

--- a/examples/discovery/server_discovery.c
+++ b/examples/discovery/server_discovery.c
@@ -30,7 +30,13 @@ int main(void) {
     UA_ServerConfig config = UA_ServerConfig_standard;
     config.applicationDescription.applicationType = UA_APPLICATIONTYPE_DISCOVERYSERVER;
     config.applicationDescription.applicationUri = UA_String_fromChars("open62541.example.local_discovery_server");
-    UA_ServerNetworkLayer nl = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4048);
+    // timeout in seconds when to automatically remove a registered server from the list,
+    // if it doesn't re-register within the given time frame. A value of 0 disables automatic removal.
+    // Default is 60 Minutes (60*60). Must be bigger than 10 seconds, because cleanup is only triggered approximately
+    // ervery 10 seconds.
+    // The server will still be removed depending on the state of the semaphore file.
+    // config.discoveryCleanupTimeout = 60*60;
+    UA_ServerNetworkLayer nl = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4840);
     config.networkLayers = &nl;
     config.networkLayersSize = 1;
     UA_Server *server = UA_Server_new(config);

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -173,6 +173,12 @@ int main(int argc, char** argv) {
 
 
     UA_StatusCode retval = UA_Server_run(server, &running);
+    if (retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(logger, UA_LOGCATEGORY_SERVER, "Could not start discovery server. StatusCode 0x%08x", retval);
+        UA_Server_delete(server);
+        nl.deleteMembers(&nl);
+        return (int)retval;
+    }
 
     // UNregister the server from the discovery server.
     retval = UA_Server_unregister_discovery(server, "opc.tcp://localhost:4840" );

--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -129,6 +129,17 @@ typedef struct {
     /* Limits for MonitoredItems */
     UA_DoubleRange samplingIntervalLimits;
     UA_UInt32Range queueSizeLimits;
+
+#ifdef UA_ENABLE_DISCOVERY
+    /* Discovery */
+    // timeout in seconds when to automatically remove a registered server from the list,
+    // if it doesn't re-register within the given time frame. A value of 0 disables automatic removal.
+    // Default is 60 Minutes (60*60). Must be bigger than 10 seconds, because cleanup is only triggered approximately
+    // ervery 10 seconds.
+    // The server will still be removed depending on the state of the semaphore file.
+    UA_UInt32 discoveryCleanupTimeout;
+#endif
+
 } UA_ServerConfig;
 
 /**

--- a/plugins/ua_config_standard.c
+++ b/plugins/ua_config_standard.c
@@ -69,6 +69,10 @@ const UA_ServerConfig UA_ServerConfig_standard = {
     /* Limits for MonitoredItems */
     .samplingIntervalLimits = { .min = 50.0, .max = 24.0 * 3600.0 * 1000.0 },
     .queueSizeLimits = { .max = 100, .min = 1 }
+
+#ifdef UA_ENABLE_DISCOVERY
+	,.discoveryCleanupTimeout = 60*60
+#endif
 };
 
 const UA_EXPORT UA_ClientConfig UA_ClientConfig_standard = {

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -362,8 +362,10 @@ void Service_RegisterServer(UA_Server *server, UA_Session *session,
 void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
 
     UA_DateTime timedOut = nowMonotonic;
-    // registration is timed out if lastSeen is older than 60 minutes.
-    timedOut -= 60*60*UA_SEC_TO_DATETIME;
+    // registration is timed out if lastSeen is older than 60 minutes (default value, can be modified by user).
+    if (server->config.discoveryCleanupTimeout) {
+        timedOut -= server->config.discoveryCleanupTimeout*UA_SEC_TO_DATETIME;
+    }
 
     registeredServer_list_entry* current, *temp;
     LIST_FOREACH_SAFE(current, &server->registeredServers, pointers, temp) {
@@ -378,17 +380,20 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
             free(filePath);
         }
 
-
-        if (semaphoreDeleted || current->lastSeen < timedOut) {
+        if (semaphoreDeleted || (server->config.discoveryCleanupTimeout && current->lastSeen < timedOut)) {
             if (semaphoreDeleted) {
                 UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
                             "Registration of server with URI %.*s is removed because the semaphore file '%.*s' was deleted.",
                             (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,
                             (int)current->registeredServer.semaphoreFilePath.length, current->registeredServer.semaphoreFilePath.data);
             } else {
+                // cppcheck-suppress unreadVariable
+                UA_String lastStr = UA_DateTime_toString(current->lastSeen);
                 UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
-                             "Registration of server with URI %.*s has timed out and is removed",
-                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data);
+                             "Registration of server with URI %.*s has timed out and is removed. Last seen: %.*s",
+                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,
+                            (int)lastStr.length, lastStr.data);
+                UA_free(lastStr.data);
             }
             LIST_REMOVE(current, pointers);
             UA_RegisteredServer_deleteMembers(&current->registeredServer);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,48 +24,62 @@ if(CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID}" STREQUAL "xClang")
     add_definitions(-Wno-sign-conversion)
 endif()
 
+# Valgrind definition
+set(UA_TEST_WITH_VALGRIND ON)
+SET(VALGRIND_FLAGS --quiet --trace-children=yes --leak-check=full)
+macro(add_test_valgrind TEST_NAME)
+    IF(UA_TEST_WITH_VALGRIND)
+        add_test(${TEST_NAME}
+                valgrind --error-exitcode=1 ${VALGRIND_FLAGS} ${ARGN} )
+    ELSE()
+        add_test(${TEST_NAME} ${ARGN})
+    ENDIF()
+endmacro()
+
+
+
 # the unit test are built directly on the open62541 object files. so they can
 # access symbols that are hidden/not exported to the shared library
 
 add_executable(check_builtin check_builtin.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_builtin ${LIBS})
-add_test(builtin ${CMAKE_CURRENT_BINARY_DIR}/check_builtin)
+add_test_valgrind(builtin ${CMAKE_CURRENT_BINARY_DIR}/check_builtin)
 
 add_executable(check_memory check_memory.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_memory ${LIBS})
-add_test(memory ${CMAKE_CURRENT_BINARY_DIR}/check_memory)
+add_test_valgrind(memory ${CMAKE_CURRENT_BINARY_DIR}/check_memory)
 
 add_executable(check_chunking check_chunking.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_chunking ${LIBS})
-add_test(chunking ${CMAKE_CURRENT_BINARY_DIR}/check_chunking)
+add_test_valgrind(chunking ${CMAKE_CURRENT_BINARY_DIR}/check_chunking)
 
 add_executable(check_services_view check_services_view.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_services_view ${LIBS})
-add_test(services_view ${CMAKE_CURRENT_BINARY_DIR}/check_services_view)
+add_test_valgrind(services_view ${CMAKE_CURRENT_BINARY_DIR}/check_services_view)
 
 add_executable(check_services_attributes check_services_attributes.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_services_attributes ${LIBS})
-add_test(services_attributes ${CMAKE_CURRENT_BINARY_DIR}/check_services_attributes)
+add_test_valgrind(services_attributes ${CMAKE_CURRENT_BINARY_DIR}/check_services_attributes)
 
 add_executable(check_services_nodemanagement check_services_nodemanagement.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_services_nodemanagement ${LIBS})
-add_test(services_nodemanagement ${CMAKE_CURRENT_BINARY_DIR}/check_services_nodemanagement)
+add_test_valgrind(services_nodemanagement ${CMAKE_CURRENT_BINARY_DIR}/check_services_nodemanagement)
 
 add_executable(check_nodestore check_nodestore.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_nodestore ${LIBS})
-add_test(nodestore ${CMAKE_CURRENT_BINARY_DIR}/check_nodestore)
+add_test_valgrind(nodestore ${CMAKE_CURRENT_BINARY_DIR}/check_nodestore)
 
 add_executable(check_session check_session.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_session ${LIBS})
-add_test(session ${CMAKE_CURRENT_BINARY_DIR}/check_session)
+add_test_valgrind(session ${CMAKE_CURRENT_BINARY_DIR}/check_session)
 
 add_executable(check_server_userspace check_server_userspace.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_server_userspace ${LIBS})
-add_test(check_server_userspace ${CMAKE_CURRENT_BINARY_DIR}/check_server_userspace)
+add_test_valgrind(check_server_userspace ${CMAKE_CURRENT_BINARY_DIR}/check_server_userspace)
 
 add_executable(check_discovery check_discovery.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_discovery ${LIBS})
-add_test(discovery ${CMAKE_CURRENT_BINARY_DIR}/check_discovery)
+add_test_valgrind(discovery ${CMAKE_CURRENT_BINARY_DIR}/check_discovery)
 
 # test with canned interactions from files
 
@@ -98,19 +112,19 @@ target_include_directories(check_server_binary_messages PRIVATE ${PROJECT_SOURCE
 target_link_libraries(check_server_binary_messages ${LIBS})
 add_dependencies(check_server_binary_messages client_HELOPN.bin)
 
-add_test(check_server_binary_messages_browse ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
+add_test_valgrind(check_server_binary_messages_browse ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_HELOPN.bin
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_CreateActivateSession.bin
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_Browse.bin
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_CLO.bin)
 
-add_test(check_server_binary_messages_read ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
+add_test_valgrind(check_server_binary_messages_read ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_HELOPN.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_CreateActivateSession.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_Read.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_CLO.bin)
 
-add_test(check_server_binary_messages_write ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
+add_test_valgrind(check_server_binary_messages_write ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_HELOPN.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_CreateActivateSession.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_Write.bin
@@ -118,8 +132,8 @@ add_test(check_server_binary_messages_write ${CMAKE_CURRENT_BINARY_DIR}/check_se
 
 add_executable(check_client check_client.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_client ${LIBS})
-add_test(check_client ${CMAKE_CURRENT_BINARY_DIR}/check_client)
+add_test_valgrind(check_client ${CMAKE_CURRENT_BINARY_DIR}/check_client)
 
 add_executable(check_client_subscriptions check_client_subscriptions.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_client_subscriptions ${LIBS})
-add_test(check_client_subscriptions ${CMAKE_CURRENT_BINARY_DIR}/check_client_subscriptions)
+add_test_valgrind(check_client_subscriptions ${CMAKE_CURRENT_BINARY_DIR}/check_client_subscriptions)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${PROJECT_BINARY_DIR}/src_generated)
 find_package(Check REQUIRED)
 find_package(Threads REQUIRED)
 
-set(LIBS ${CHECK_LIBRARIES} ${open62541_LIBRARIES})
+set(LIBS ${CHECK_LIBRARIES} ${open62541_LIBRARIES} open62541)
 if(NOT WIN32)
   list(APPEND LIBS pthread m)
   if (NOT APPLE)

--- a/tests/check_discovery.c
+++ b/tests/check_discovery.c
@@ -3,6 +3,7 @@
 #include <pthread.h>
 #include <ua_util.h>
 #include <ua_types_generated.h>
+#include <server/ua_server_internal.h>
 
 #include "ua_client.h"
 #include "ua_config_standard.h"

--- a/tests/check_server_userspace.c
+++ b/tests/check_server_userspace.c
@@ -17,6 +17,8 @@ START_TEST(Server_addNamespace_ShallWork)
     ck_assert_uint_gt(a, 0);
     ck_assert_uint_eq(a,b);
     ck_assert_uint_ne(a,c);
+
+	UA_Server_delete(server);
 }
 END_TEST
 

--- a/tests/check_services_attributes.c
+++ b/tests/check_services_attributes.c
@@ -111,11 +111,13 @@ static UA_Server* makeTestSequence(void) {
     UA_MethodAttributes_init(&ma);
     ma.description = UA_LOCALIZEDTEXT("en_US", "Methodtest");
     ma.displayName = UA_LOCALIZEDTEXT("en_US", "Methodtest");
+    UA_QualifiedName qualifiedName = UA_QUALIFIEDNAME_ALLOC(0, "Methodtest");
     UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_METHODNODE),
                             UA_NODEID_NUMERIC(0, 3),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
-                            UA_QUALIFIEDNAME_ALLOC(0, "Methodtest"), ma,
+                            qualifiedName, ma,
                             NULL, NULL, 0, NULL, 0, NULL, NULL);
+    UA_QualifiedName_deleteMembers(&qualifiedName);
 #endif
 
 	return server;

--- a/tests/check_services_nodemanagement.c
+++ b/tests/check_services_nodemanagement.c
@@ -54,7 +54,7 @@ START_TEST(AddComplexTypeWithInheritance) {
   UA_QualifiedName myObjectName = UA_QUALIFIEDNAME(1, "the.fake.Server.Struct");
   UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
   UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
-  UA_Int32 handleCalled;
+  UA_Int32 handleCalled = 0;
   UA_InstantiationCallback iCallback = {.method=instantiationMethod, .handle = (void *) &handleCalled};
     
   UA_StatusCode res = UA_Server_addObjectNode(server, myObjectNodeId, parentNodeId, parentReferenceNodeId,


### PR DESCRIPTION
Added field in config to modify default timeout for de-registering a server.
`config.discoveryCleanupTimeout` in seconds