### PR TITLE
reviving server's certificates in an example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,15 +362,6 @@ if(UA_BUILD_DOCUMENTATION)
     add_subdirectory(doc)
 endif()
 
-if(UA_BUILD_SELFSIGNED_CERTIFICATE)
-    find_package(OpenSSL REQUIRED)
-    add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/server_cert.der ${PROJECT_BINARY_DIR}/ca.crt
-                       COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py ${PROJECT_BINARY_DIR}
-                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tools/certs/create_self-signed.py
-                               ${CMAKE_CURRENT_SOURCE_DIR}/tools/certs/localhost.cnf)
-    add_custom_target(selfsigned ALL DEPENDS ${PROJECT_BINARY_DIR}/server_cert.der ${PROJECT_BINARY_DIR}/ca.crt)
-endif()
-
 if(UA_BUILD_EXAMPLES_NODESET_COMPILER)
   add_custom_target(generate_informationmodel ALL
                     DEPENDS ${PROJECT_BINARY_DIR}/src_generated/nodeset.h ${PROJECT_BINARY_DIR}/src_generated/nodeset.c)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ build_script:
   - md build
   - cd build
   - echo "Testing MinGW32"
-  - cmake -DUA_BUILD_EXAMPLES:BOOL=ON -G"MinGW Makefiles" ..
+  - cmake -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE:BOOL=ON -G"MinGW Makefiles" ..
   - mingw32-make
   - cd ..
   - rd /s /q build
@@ -69,7 +69,7 @@ build_script:
   - rd /s /q build
   - md build
   - cd build
-  - cmake -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON -G"Visual Studio 12 2013" ..
+  - cmake -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON -G"Visual Studio 12 2013" ..
   - msbuild open62541.sln /m
   - copy C:\projects\open62541\build\open62541.c C:\projects\open62541\build\Debug\open62541.c
   - copy C:\projects\open62541\build\open62541.h C:\projects\open62541\build\Debug\open62541.h
@@ -77,7 +77,7 @@ build_script:
   - echo "Win 64 build"
   - md build64
   - cd build64
-  - cmake -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON -G"Visual Studio 12 2013 Win64" ..
+  - cmake -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON -G"Visual Studio 12 2013 Win64" ..
   - msbuild open62541.sln /m
   - copy C:\projects\open62541\build64\open62541.c C:\projects\open62541\build64\Debug\open62541.c
   - copy C:\projects\open62541\build64\open62541.h C:\projects\open62541\build64\Debug\open62541.h

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -72,6 +72,16 @@ if(UA_ENABLE_METHODCALLS)
   target_link_libraries(server_method ${LIBS})
 endif()
 
+if(UA_BUILD_SELFSIGNED_CERTIFICATE)
+  find_package(OpenSSL REQUIRED)
+  add_custom_command(OUTPUT server_cert.der ca.crt
+                     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py ${CMAKE_CURRENT_SOURCE_DIR}
+                     DEPENDS ${PROJECT_BINARY_DIR}/tools/certs/create_self-signed.py
+                             ${PROJECT_BINARY_DIR}/tools/certs/localhost.cnf)
+  add_executable(server_certificate server_certificate.c $<TARGET_OBJECTS:open62541-object> server_cert.der ca.crt)
+  target_link_libraries(server_certificate ${LIBS})
+endif()
+
 add_executable(server_readspeed server_readspeed.c $<TARGET_OBJECTS:open62541-object>)
 target_include_directories(server_readspeed PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/deps) # needs an internal header
 target_link_libraries(server_readspeed ${LIBS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -78,6 +78,9 @@ if(UA_BUILD_SELFSIGNED_CERTIFICATE)
                      COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py ${CMAKE_CURRENT_SOURCE_DIR}
                      DEPENDS ${PROJECT_BINARY_DIR}/tools/certs/create_self-signed.py
                              ${PROJECT_BINARY_DIR}/tools/certs/localhost.cnf)
+                             
+  add_custom_target(selfsigned ALL DEPENDS server_cert.der ca.crt)
+
   add_executable(server_certificate server_certificate.c $<TARGET_OBJECTS:open62541-object> server_cert.der ca.crt)
   target_link_libraries(server_certificate ${LIBS})
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 if(UA_BUILD_SELFSIGNED_CERTIFICATE)
   find_package(OpenSSL REQUIRED)
   add_custom_command(OUTPUT server_cert.der ca.crt
-                     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py ${CMAKE_CURRENT_SOURCE_DIR}
+                     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py ${CMAKE_CURRENT_BINARY_DIR}
                      DEPENDS ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py
                              ${PROJECT_SOURCE_DIR}/tools/certs/localhost.cnf)
                              

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -76,8 +76,8 @@ if(UA_BUILD_SELFSIGNED_CERTIFICATE)
   find_package(OpenSSL REQUIRED)
   add_custom_command(OUTPUT server_cert.der ca.crt
                      COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py ${CMAKE_CURRENT_SOURCE_DIR}
-                     DEPENDS ${PROJECT_BINARY_DIR}/tools/certs/create_self-signed.py
-                             ${PROJECT_BINARY_DIR}/tools/certs/localhost.cnf)
+                     DEPENDS ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py
+                             ${PROJECT_SOURCE_DIR}/tools/certs/localhost.cnf)
                              
   add_custom_target(selfsigned ALL DEPENDS server_cert.der ca.crt)
 

--- a/examples/server.c
+++ b/examples/server.c
@@ -16,11 +16,12 @@
 # include "open62541.h"
 #endif
 
-#include <signal.h>
-#include <errno.h> // errno, EINTR
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
 #endif
+
+#include <signal.h>
+#include <errno.h> // errno, EINTR
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/server.c
+++ b/examples/server.c
@@ -19,7 +19,7 @@
 #include <signal.h>
 #include <errno.h> // errno, EINTR
 #ifdef _WIN32
-#define _CRT_SECURE_NO_DEPRECATE //disable fopen deprication warning in msvs
+#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
 #endif
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/server.c
+++ b/examples/server.c
@@ -5,6 +5,10 @@
  * - single-threaded: gcc -std=c99 server.c open62541.c -o server
  * - multi-threaded: gcc -std=c99 server.c open62541.c -o server -lurcu-cds -lurcu -lurcu-common -lpthread */
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
+#endif
+
 #ifdef UA_NO_AMALGAMATION
 # include <time.h>
 # include "ua_types.h"
@@ -14,10 +18,6 @@
 # include "ua_log_stdout.h"
 #else
 # include "open62541.h"
-#endif
-
-#ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
 #endif
 
 #include <signal.h>

--- a/examples/server.c
+++ b/examples/server.c
@@ -18,6 +18,9 @@
 
 #include <signal.h>
 #include <errno.h> // errno, EINTR
+#ifdef _WIN32
+#define _CRT_SECURE_NO_DEPRECATE //disable fopen deprication warning in msvs
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/server.c
+++ b/examples/server.c
@@ -39,6 +39,32 @@
 
 UA_Boolean running = 1;
 UA_Logger logger = UA_Log_Stdout;
+
+static UA_ByteString loadCertificate(void) {
+    UA_ByteString certificate = UA_STRING_NULL;
+    FILE *fp = NULL;
+    //FIXME: a potiential bug of locating the certificate, we need to get the path from the server's config
+    fp=fopen("server_cert.der", "rb");
+
+    if(!fp) {
+        errno = 0; // we read errno also from the tcp layer...
+        return certificate;
+    }
+
+    fseek(fp, 0, SEEK_END);
+    certificate.length = (size_t)ftell(fp);
+    certificate.data = malloc(certificate.length*sizeof(UA_Byte));
+    if(!certificate.data)
+        return certificate;
+
+    fseek(fp, 0, SEEK_SET);
+    if(fread(certificate.data, sizeof(UA_Byte), certificate.length, fp) < (size_t)certificate.length)
+        UA_ByteString_deleteMembers(&certificate); // error reading the cert
+    fclose(fp);
+
+    return certificate;
+}
+
 static void stopHandler(int sign) {
     UA_LOG_INFO(logger, UA_LOGCATEGORY_SERVER, "Received Ctrl-C");
     running = 0;
@@ -106,6 +132,10 @@ int main(int argc, char** argv) {
     UA_ServerConfig config = UA_ServerConfig_standard;
     config.networkLayers = &nl;
     config.networkLayersSize = 1;
+
+    /* load certificate */
+    config.serverCertificate = loadCertificate();
+
     UA_Server *server = UA_Server_new(config);
 
     /* add a static variable node to the server */
@@ -368,6 +398,10 @@ int main(int argc, char** argv) {
 
     /* run server */
     UA_StatusCode retval = UA_Server_run(server, &running); /* run until ctrl-c is received */
+
+    /* deallocate certificate's memory */
+    UA_ByteString_deleteMembers(&config.serverCertificate);
+
     UA_Server_delete(server);
     nl.deleteMembers(&nl);
     return (int)retval;

--- a/examples/server_certificate.c
+++ b/examples/server_certificate.c
@@ -1,5 +1,10 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
+#endif
+
 #ifdef UA_NO_AMALGAMATION
 #include "ua_types.h"
 #include "ua_server.h"
@@ -10,9 +15,6 @@
 #include "open62541.h"
 #endif
 
-#ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
-#endif
 #include <errno.h> // errno, EINTR
 #include <stdio.h>
 #include <signal.h>

--- a/examples/server_certificate.c
+++ b/examples/server_certificate.c
@@ -3,7 +3,7 @@
 
 #include <errno.h> // errno, EINTR
 #ifdef _WIN32
-#define _CRT_SECURE_NO_DEPRECATE //disable fopen deprication warning in msvs
+#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
 #endif
 #include <stdio.h>
 #include <signal.h>

--- a/examples/server_certificate.c
+++ b/examples/server_certificate.c
@@ -2,6 +2,9 @@
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
 #include <errno.h> // errno, EINTR
+#ifdef _WIN32
+#define _CRT_SECURE_NO_DEPRECATE //disable fopen deprication warning in msvs
+#endif
 #include <stdio.h>
 #include <signal.h>
 #include <stdlib.h>

--- a/examples/server_certificate.c
+++ b/examples/server_certificate.c
@@ -1,0 +1,78 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <errno.h> // errno, EINTR
+#include <stdio.h>
+#include <signal.h>
+#include <stdlib.h>
+
+#ifdef UA_NO_AMALGAMATION
+#include "ua_types.h"
+#include "ua_server.h"
+#include "ua_config_standard.h"
+#include "ua_network_tcp.h"
+#include "ua_log_stdout.h"
+#else
+#include "open62541.h"
+#endif
+
+UA_Boolean running = true;
+UA_Logger logger = UA_Log_Stdout;
+
+static UA_ByteString loadCertificate(void) {
+    UA_ByteString certificate = UA_STRING_NULL;
+    FILE *fp = NULL;
+    //FIXME: a potiential bug of locating the certificate, we need to get the path from the server's config
+    fp=fopen("server_cert.der", "rb");
+
+    if(!fp) {
+        errno = 0; // we read errno also from the tcp layer...
+        UA_LOG_ERROR(logger, UA_LOGCATEGORY_SERVER, "Could not open certificate file");
+        return certificate;
+    }
+
+    fseek(fp, 0, SEEK_END);
+    certificate.length = (size_t)ftell(fp);
+    certificate.data = malloc(certificate.length*sizeof(UA_Byte));
+    if(!certificate.data)
+        return certificate;
+
+    fseek(fp, 0, SEEK_SET);
+    if(fread(certificate.data, sizeof(UA_Byte), certificate.length, fp) < (size_t)certificate.length)
+        UA_ByteString_deleteMembers(&certificate); // error reading the cert
+    fclose(fp);
+
+    return certificate;
+}
+
+static void stopHandler(int sign) {
+    UA_LOG_INFO(logger, UA_LOGCATEGORY_SERVER, "received ctrl-c");
+    running = false;
+}
+
+int main(int argc, char** argv) {
+    signal(SIGINT, stopHandler); /* catches ctrl-c */
+
+    UA_ServerConfig config = UA_ServerConfig_standard;
+    UA_ServerNetworkLayer nl = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 16664);
+    config.networkLayers = &nl;
+    config.networkLayersSize = 1;
+
+    /* load certificate */
+    config.serverCertificate = loadCertificate();
+    if(config.serverCertificate.length > 0)
+        UA_LOG_INFO(logger, UA_LOGCATEGORY_SERVER, "Certificate loaded");
+
+
+    UA_Server *server = UA_Server_new(config);
+
+    UA_StatusCode retval = UA_Server_run(server, &running);
+
+    /* deallocate certificate's memory */
+    UA_ByteString_deleteMembers(&config.serverCertificate);
+
+    UA_Server_delete(server);
+    nl.deleteMembers(&nl);
+
+    return (int)retval;
+}

--- a/examples/server_certificate.c
+++ b/examples/server_certificate.c
@@ -1,14 +1,5 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
-
-#include <errno.h> // errno, EINTR
-#ifdef _WIN32
-#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
-#endif
-#include <stdio.h>
-#include <signal.h>
-#include <stdlib.h>
-
 #ifdef UA_NO_AMALGAMATION
 #include "ua_types.h"
 #include "ua_server.h"
@@ -18,6 +9,14 @@
 #else
 #include "open62541.h"
 #endif
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS //disable fopen deprication warning in msvs
+#endif
+#include <errno.h> // errno, EINTR
+#include <stdio.h>
+#include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 UA_Logger logger = UA_Log_Stdout;

--- a/tools/certs/localhost.cnf
+++ b/tools/certs/localhost.cnf
@@ -229,7 +229,7 @@ DNS.1 = localhost
 DNS.2 = ${hostname}
 IP.1 = 127.0.0.1
 IP.2 = 0.0.0.0
-URI.1 = urn:unconfigured:open62541:open62541Server
+URI.1 = urn:unconfigured:application
 
 [ v3_ca ]
 

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -43,7 +43,7 @@ else
     make doc
     make selfsigned
     cp -r doc ../../
-    cp server_cert.der ../../
+    cp ./examples/server_cert.der ../../
     cd .. && rm build -rf
 
     # cross compilation only with gcc


### PR DESCRIPTION
Apparently some clients (for example teslaSCADA) require a non-zero certificate. Together with #707 it is needed to get the two working together.