### PR TITLE
fix building with namespace compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ if(UA_ENABLE_AMALGAMATION)
     add_library(open62541-object OBJECT ${PROJECT_BINARY_DIR}/open62541.c ${PROJECT_BINARY_DIR}/open62541.h)
     target_include_directories(open62541-object PRIVATE ${PROJECT_BINARY_DIR})
 else()
+    add_definitions(-DUA_NO_AMALGAMATION)
     add_library(open62541-object OBJECT ${lib_sources} ${internal_headers} ${exported_headers})
     target_include_directories(open62541-object PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src
                                                         ${PROJECT_SOURCE_DIR}/plugins ${PROJECT_SOURCE_DIR}/deps)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,8 +3,6 @@ include_directories(${PROJECT_SOURCE_DIR}/plugins)
 
 if(UA_ENABLE_AMALGAMATION)
     include_directories(${PROJECT_BINARY_DIR}) # contain open62541.h
-else()
-    add_definitions(-DUA_NO_AMALGAMATION)
 endif()
 
 list(APPEND LIBS ${open62541_LIBRARIES})
@@ -63,6 +61,7 @@ target_link_libraries(server_repeated_job ${LIBS})
 
 if(UA_BUILD_EXAMPLES_NODESET_COMPILER)
   add_executable(server_nodeset server_nodeset.c ${PROJECT_BINARY_DIR}/src_generated/nodeset.c $<TARGET_OBJECTS:open62541-object>)
+  set_source_files_properties(${PROJECT_BINARY_DIR}/src_generated/nodeset.c PROPERTIES GENERATED TRUE)
   target_link_libraries(server_nodeset ${LIBS})
   target_include_directories(server_nodeset PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/deps) # needs an internal header
 endif()


### PR DESCRIPTION
* generating NS0 need to know UA_NO_AMALGAMATION
* set src_generated/nodeset.c to be automatically generated in order to allow Cmake to handle the target correct


By the way, do we need
```
if(UA_BUILD_EXAMPLES_NODESET_COMPILER)
  add_custom_target(generate_informationmodel ALL
                    DEPENDS ${PROJECT_BINARY_DIR}/src_generated/nodeset.h ${PROJECT_BINARY_DIR}/src_generated/nodeset.c)
endif()
```
in the main CMakeLists.txt?

I would also prefer to put lines 314-329 (generating the example information model) in the example-CMake