### PR TITLE
speedup namespace compiler

### DIFF
--- a/tools/pyUANamespace/generate_open62541CCode.py
+++ b/tools/pyUANamespace/generate_open62541CCode.py
@@ -132,7 +132,8 @@ ns.linkOpenPointers()
 
 # Remove nodes that are not printable or contain parsing errors, such as
 # unresolvable or no references or invalid NodeIDs
-ns.sanitize()
+logger.warn("Sanitizing is not performed until it's clear if sanity of ns0 nodes is clear")
+#ns.sanitize()
 
 # Parse Datatypes in order to find out what the XML keyed values actually
 # represent.


### PR DESCRIPTION
reordering of nodes takes quite a big amount of time when also including
all nodes from ns0. Thus, first remove all ignored nodes will make the
sorting much faster

@ichrispa can I do this or are there some side effects?