### PR TITLE
Fix UA_Server_readDataType memory leak

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -506,7 +506,10 @@ __UA_Server_read(UA_Server *server, const UA_NodeId *nodeId,
     if(attributeId == UA_ATTRIBUTEID_VALUE ||
        attributeId == UA_ATTRIBUTEID_ARRAYDIMENSIONS)
         memcpy(v, &dv.value, sizeof(UA_Variant));
-    else {
+    else if(attributeId == UA_ATTRIBUTEID_DATATYPE) {
+        UA_copy(dv.value.data, v, dv.value.type);
+        UA_DataValue_deleteMembers(&dv);
+    } else {
         memcpy(v, dv.value.data, dv.value.type->memSize);
         dv.value.data = NULL;
         dv.value.arrayLength = 0;


### PR DESCRIPTION
Here is a quick fix related to #748.

Fix is quite ugly:

1. Casting `void*` to `NodeId*`.
I'm not sure that typeId is always numeric. If it is, then `UA_NodeId_copy` can be safely replaced with `memcpy`.

2. Adding unneeded malloc in case of UA_VALUESOURCE_VARIANT.
`getVariableNodeDataType` always makes a new copy of typeId to be deterministic for `__UA_Server_read`. One of the proposals is to give `__UA_Server_read` some flag indicating whether it should free memory or not.