### PR TITLE
feature_mdns rebase

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/mdnsd"]
+	path = deps/mdnsd
+	url = https://github.com/Pro/mdnsd.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
     # Do both, compile with static code analysis and without
     - ANALYZE=false
-    #- ANALYZE=true
+    - ANALYZE=true
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
     # Do both, compile with static code analysis and without
     - ANALYZE=false
-    - ANALYZE=true
+    #- ANALYZE=true
 
 matrix:
   exclude:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/tools/cmake")
 # Check Dependencies #
 ######################
 
+
+set(MDNSD_LOGLEVEL 100 CACHE STRING "Level at which logs shall be reported" FORCE)
+
 find_package(PythonInterp REQUIRED)
 find_package(Git)
 if(GIT_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/tools/cmake")
 ######################
 
 
-set(MDNSD_LOGLEVEL 100 CACHE STRING "Level at which logs shall be reported" FORCE)
+set(MDNSD_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported" FORCE)
 
 find_package(PythonInterp REQUIRED)
 find_package(Git)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,9 @@ endif()
 
 if(WIN32)
     target_link_libraries(open62541 ws2_32)
+    if (UA_ENABLE_DISCOVERY_MULTICAST)
+        target_link_libraries(open62541 iphlpapi) # for GetAdaptersAddresses
+    endif()
 endif()
 
 ##########################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(UA_ENABLE_NODEMANAGEMENT "Enable dynamic addition and removal of nodes at
 option(UA_ENABLE_SUBSCRIPTIONS "Enable subscriptions support." ON)
 option(UA_ENABLE_MULTITHREADING "Enable multithreading" OFF)
 option(UA_ENABLE_DISCOVERY "Enable Discovery Service (LDS)" ON)
+option(UA_ENABLE_DISCOVERY_MULTICAST "Enable Discovery Service with multicast support (LDS-ME)" ON)
 option(UA_ENABLE_AMALGAMATION "Concatenate the library to a single file open62541.h/.c" OFF)
 option(UA_ENABLE_COVERAGE "Enable gcov coverage" OFF)
 option(BUILD_SHARED_LIBS "Enable building of shared libraries (dll/so)" OFF)
@@ -55,6 +56,11 @@ if(UA_ENABLE_COVERAGE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
+endif()
+
+if(UA_ENABLE_DISCOVERY_MULTICAST AND NOT UA_ENABLE_DISCOVERY)
+    MESSAGE(WARNING "UA_ENABLE_DISCOVERY_MULTICAST is enabled, but not UA_ENABLE_DISCOVERY. UA_ENABLE_DISCOVERY_MULTICAST will be set to OFF")
+    SET(UA_ENABLE_DISCOVERY_MULTICAST OFF CACHE BOOL "Enable Discovery Service with multicast support (LDS-ME)" FORCE)
 endif()
 
 # Advanced options
@@ -92,6 +98,9 @@ option(UA_BUILD_SELFSIGNED_CERTIFICATE "Generate self-signed certificate" OFF)
 set(UA_DYNAMIC_LINKING OFF)
 if(BUILD_SHARED_LIBS)
   set(UA_DYNAMIC_LINKING ON)
+  if (UA_ENABLE_DISCOVERY_MULTICAST)
+      set(MDNSD_DYNAMIC_LINKING ON)
+  endif()
 endif()
 
 #####################
@@ -158,6 +167,10 @@ endif()
 
 file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src_generated")
 configure_file("include/ua_config.h.in" "${PROJECT_BINARY_DIR}/src_generated/ua_config.h")
+
+if (UA_ENABLE_DISCOVERY_MULTICAST)
+    configure_file("deps/mdnsd/libmdnsd/mdnsd_config.h.in" "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h")
+endif()
 include_directories(${PROJECT_BINARY_DIR}/src_generated)
 
 set(exported_headers ${PROJECT_BINARY_DIR}/src_generated/ua_config.h
@@ -244,6 +257,12 @@ if(UA_ENABLE_GENERATE_NAMESPACE0)
   set_property(CACHE GENERATE_NAMESPACE0_FILE PROPERTY STRINGS Opc.Ua.NodeSet2.xml Opc.Ua.NodeSet2.Minimal.xml)
   list(APPEND internal_headers ${PROJECT_BINARY_DIR}/src_generated/ua_namespaceinit_generated.h)
   list(APPEND lib_sources ${PROJECT_BINARY_DIR}/src_generated/ua_namespaceinit_generated.c)
+endif()
+
+if (UA_ENABLE_DISCOVERY_MULTICAST)
+    # prepend in list, otherwise it complains that winsock2.h has to be included before windows.h
+    set(internal_headers "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h" ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.h  ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.h ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.h ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h ${internal_headers})
+    set(lib_sources ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.c ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.c ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.c ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.c ${lib_sources})
 endif()
 
 #########################
@@ -356,6 +375,11 @@ target_link_libraries(open62541 ${open62541_LIBRARIES})
 
 target_compile_definitions(open62541-object PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
 target_compile_definitions(open62541 PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
+
+if (UA_ENABLE_DISCOVERY_MULTICAST)
+    target_compile_definitions(open62541-object PRIVATE -DMDNSD_DYNAMIC_LINKING_EXPORT)
+    target_compile_definitions(open62541 PRIVATE -DMDNSD_DYNAMIC_LINKING_EXPORT)
+endif()
 
 if(WIN32)
     target_link_libraries(open62541 ws2_32)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -63,6 +63,7 @@ target_include_directories(server_readspeed PRIVATE ${PROJECT_SOURCE_DIR}/src ${
 target_link_libraries(server_readspeed ${LIBS})
 
 if(UA_ENABLE_DISCOVERY)
+
     add_executable(discovery_server_discovery discovery/server_discovery.c)
     target_link_libraries(discovery_server_discovery ${LIBS})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -62,19 +62,6 @@ add_executable(server_readspeed server_readspeed.c $<TARGET_OBJECTS:open62541-ob
 target_include_directories(server_readspeed PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/deps) # needs an internal header
 target_link_libraries(server_readspeed ${LIBS})
 
-if(UA_ENABLE_DISCOVERY)
-
-    add_executable(discovery_server_discovery discovery/server_discovery.c)
-    target_link_libraries(discovery_server_discovery ${LIBS})
-
-    # can currently only be build on linux, because windows is missing pthread support
-    add_executable(discovery_server_register discovery/server_register.c)
-    target_link_libraries(discovery_server_register ${LIBS})
-
-    add_executable(discovery_client_find_servers discovery/client_find_servers.c)
-    target_link_libraries(discovery_client_find_servers ${LIBS})
-endif()
-
 if(UA_ENABLE_METHODCALLS)
   add_executable(server_method server_method.c $<TARGET_OBJECTS:open62541-object>)
   target_link_libraries(server_method ${LIBS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -62,6 +62,18 @@ add_executable(server_readspeed server_readspeed.c $<TARGET_OBJECTS:open62541-ob
 target_include_directories(server_readspeed PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/deps) # needs an internal header
 target_link_libraries(server_readspeed ${LIBS})
 
+if(UA_ENABLE_DISCOVERY)
+    add_executable(discovery_server_discovery discovery/server_discovery.c)
+    target_link_libraries(discovery_server_discovery ${LIBS})
+
+    # can currently only be build on linux, because windows is missing pthread support
+    add_executable(discovery_server_register discovery/server_register.c)
+    target_link_libraries(discovery_server_register ${LIBS})
+
+    add_executable(discovery_client_find_servers discovery/client_find_servers.c)
+    target_link_libraries(discovery_client_find_servers ${LIBS})
+endif()
+
 if(UA_ENABLE_METHODCALLS)
   add_executable(server_method server_method.c $<TARGET_OBJECTS:open62541-object>)
   target_link_libraries(server_method ${LIBS})

--- a/examples/discovery/client_find_servers.c
+++ b/examples/discovery/client_find_servers.c
@@ -181,7 +181,7 @@ int main(void) {
             printf("\n\n");
         }
 
-		UA_Array_delete(serverOnNetwork, serverOnNetworkSize, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
+        UA_Array_delete(serverOnNetwork, serverOnNetworkSize, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
     }
 
     /*

--- a/examples/discovery/server_discovery.c
+++ b/examples/discovery/server_discovery.c
@@ -30,6 +30,12 @@ int main(void) {
     UA_ServerConfig config = UA_ServerConfig_standard;
     config.applicationDescription.applicationType = UA_APPLICATIONTYPE_DISCOVERYSERVER;
     config.applicationDescription.applicationUri = UA_String_fromChars("open62541.example.local_discovery_server");
+	config.mdnsServerName = UA_String_fromChars("LDS");
+	// See http://www.opcfoundation.org/UA/schemas/1.03/ServerCapabilities.csv
+	config.serverCapabilitiesSize = 1;
+	UA_String *caps = UA_String_new();
+	*caps = UA_String_fromChars("LDS");
+	config.serverCapabilities = caps;
     // timeout in seconds when to automatically remove a registered server from the list,
     // if it doesn't re-register within the given time frame. A value of 0 disables automatic removal.
     // Default is 60 Minutes (60*60). Must be bigger than 10 seconds, because cleanup is only triggered approximately
@@ -43,6 +49,8 @@ int main(void) {
 
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_String_deleteMembers(&config.applicationDescription.applicationUri);
+	UA_Array_delete(config.serverCapabilities, config.serverCapabilitiesSize, &UA_TYPES[UA_TYPES_STRING]);
+	UA_String_deleteMembers(&config.mdnsServerName);
     UA_Server_delete(server);
     nl.deleteMembers(&nl);
     return (int)retval;

--- a/examples/discovery/server_discovery.c
+++ b/examples/discovery/server_discovery.c
@@ -30,12 +30,12 @@ int main(void) {
     UA_ServerConfig config = UA_ServerConfig_standard;
     config.applicationDescription.applicationType = UA_APPLICATIONTYPE_DISCOVERYSERVER;
     config.applicationDescription.applicationUri = UA_String_fromChars("open62541.example.local_discovery_server");
-	config.mdnsServerName = UA_String_fromChars("LDS");
-	// See http://www.opcfoundation.org/UA/schemas/1.03/ServerCapabilities.csv
-	config.serverCapabilitiesSize = 1;
-	UA_String *caps = UA_String_new();
-	*caps = UA_String_fromChars("LDS");
-	config.serverCapabilities = caps;
+    config.mdnsServerName = UA_String_fromChars("LDS");
+    // See http://www.opcfoundation.org/UA/schemas/1.03/ServerCapabilities.csv
+    config.serverCapabilitiesSize = 1;
+    UA_String *caps = UA_String_new();
+    *caps = UA_String_fromChars("LDS");
+    config.serverCapabilities = caps;
     // timeout in seconds when to automatically remove a registered server from the list,
     // if it doesn't re-register within the given time frame. A value of 0 disables automatic removal.
     // Default is 60 Minutes (60*60). Must be bigger than 10 seconds, because cleanup is only triggered approximately
@@ -49,8 +49,8 @@ int main(void) {
 
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_String_deleteMembers(&config.applicationDescription.applicationUri);
-	UA_Array_delete(config.serverCapabilities, config.serverCapabilitiesSize, &UA_TYPES[UA_TYPES_STRING]);
-	UA_String_deleteMembers(&config.mdnsServerName);
+    UA_Array_delete(config.serverCapabilities, config.serverCapabilitiesSize, &UA_TYPES[UA_TYPES_STRING]);
+    UA_String_deleteMembers(&config.mdnsServerName);
     UA_Server_delete(server);
     nl.deleteMembers(&nl);
     return (int)retval;

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -60,79 +60,16 @@ writeInteger(void *handle, const UA_NodeId nodeid,
     return UA_STATUSCODE_GOOD;
 }
 
-struct PeriodicServerRegisterJob {
-    UA_Guid job_id;
-    UA_Job *job;
-    UA_UInt32 this_interval;
-};
-
-/**
- * Called by the UA_Server job.
- * The OPC UA specification says:
- *
- * > If an error occurs during registration (e.g. the Discovery Server is not running) then the Server
- * > must periodically re-attempt registration. The frequency of these attempts should start at 1 second
- * > but gradually increase until the registration frequency is the same as what it would be if not
- * > errors occurred. The recommended approach would double the period each attempt until reaching the maximum.
- *
- * We will do so by using the additional data parameter. If it is NULL, it is the first attempt
- * (or the default periodic register of 10 Minutes).
- * Otherwise it indicates the wait time in seconds for the next try.
- */
-static void periodicServerRegister(UA_Server *server, void *data) {
-
-    struct PeriodicServerRegisterJob *retryJob = NULL;
-
-    // retry registration by doubling the interval. If it is again 10 Minutes, don't retry.
-    UA_UInt32 nextInterval = 0;
-
-    if (data) {
-        // if data!=NULL this method call was a retry not within the default 10 minutes.
-        retryJob = (struct PeriodicServerRegisterJob *)data;
-        // remove the retry job because we don't want to fire it again. If it still fails,
-        // we double the interval and create a new job
-        UA_Server_removeRepeatedJob(server, retryJob->job_id);
-        nextInterval = retryJob->this_interval * 2;
-        free(retryJob->job);
-        free(retryJob);
-    }
-
-
-    UA_StatusCode retval = UA_Server_register_discovery(server, "opc.tcp://localhost:4840", NULL);
-    // You can also use a semaphore file. That file must exist. When the file is deleted, the server is automatically unregistered.
-    // The semaphore file has to be accessible by the discovery server
-    // UA_StatusCode retval = UA_Server_register_discovery(server, "opc.tcp://localhost:4840", "/path/to/some/file");
-    if (retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(logger, UA_LOGCATEGORY_SERVER, "Could not register server with discovery server. Is the discovery server started? StatusCode 0x%08x", retval);
-
-        // first retry in 1 second
-        if (nextInterval == 0)
-            nextInterval = 1;
-
-        // as long as next retry is smaller than 10 minutes, retry
-        if (nextInterval < 10*60) {
-            UA_LOG_INFO(logger, UA_LOGCATEGORY_SERVER, "Retrying registration in %d seconds", nextInterval);
-            struct PeriodicServerRegisterJob *newRetryJob = malloc(sizeof(struct PeriodicServerRegisterJob));
-            newRetryJob->job = malloc(sizeof(UA_Job));
-            newRetryJob->this_interval = nextInterval;
-
-            newRetryJob->job->type = UA_JOBTYPE_METHODCALL;
-            newRetryJob->job->job.methodCall.method = periodicServerRegister;
-            newRetryJob->job->job.methodCall.data = newRetryJob;
-
-            UA_Server_addRepeatedJob(server, *newRetryJob->job, nextInterval*1000, &newRetryJob->job_id);
-        }
-    } else {
-        UA_LOG_INFO(logger, UA_LOGCATEGORY_SERVER, "Server successfully registered. Next periodical register will be in 10 Minutes");
-    }
-}
-
-
 int main(int argc, char** argv) {
     signal(SIGINT, stopHandler); /* catches ctrl-c */
 
     UA_ServerConfig config = UA_ServerConfig_standard;
     config.applicationDescription.applicationUri=UA_String_fromChars("open62541.example.server_register");
+    config.mdnsServerName = UA_String_fromChars("Sample Server");
+    // See http://www.opcfoundation.org/UA/schemas/1.03/ServerCapabilities.csv
+    //config.serverCapabilitiesSize = 1;
+    //UA_String caps = UA_String_fromChars("LDS");
+    //config.serverCapabilities = &caps;
     UA_ServerNetworkLayer nl = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 16664);
     config.networkLayers = &nl;
     config.networkLayersSize = 1;
@@ -155,26 +92,20 @@ int main(int argc, char** argv) {
                                         myIntegerName, UA_NODEID_NULL, attr, dateDataSource, NULL);
 
 
-    // registering the server should be done periodically. Approx. every 10 minutes. The first call will be in 10 Minutes.
-    UA_Job job = {.type = UA_JOBTYPE_METHODCALL,
-            .job.methodCall = {.method = periodicServerRegister, .data = NULL} };
-    UA_Server_addRepeatedJob(server, job, 10*60*1000, NULL);
-
-    // Register the server with the discovery server.
-    // Delay this first registration until the server is fully initialized
-    // will be freed in the callback
-    struct PeriodicServerRegisterJob *newRetryJob = malloc(sizeof(struct PeriodicServerRegisterJob));
-    newRetryJob->job = malloc(sizeof(UA_Job));
-    newRetryJob->this_interval = 0;
-    newRetryJob->job->type = UA_JOBTYPE_METHODCALL;
-    newRetryJob->job->job.methodCall.method = periodicServerRegister;
-    newRetryJob->job->job.methodCall.data = newRetryJob;
-    UA_Server_addRepeatedJob(server, *newRetryJob->job, 1000, &newRetryJob->job_id);
-
-
-    UA_StatusCode retval = UA_Server_run(server, &running);
+    // periodic server register after 10 Minutes, delay first register for 500ms
+    UA_StatusCode retval = UA_Server_addPeriodicServerRegisterJob(server, 10*60*1000, 500, NULL);
     if (retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(logger, UA_LOGCATEGORY_SERVER, "Could not start discovery server. StatusCode 0x%08x", retval);
+        UA_LOG_ERROR(logger, UA_LOGCATEGORY_SERVER, "Could not create periodic job for server register. StatusCode 0x%08x", retval);
+        UA_String_deleteMembers(&config.applicationDescription.applicationUri);
+        UA_Server_delete(server);
+        nl.deleteMembers(&nl);
+        return (int)retval;
+    }
+
+    retval = UA_Server_run(server, &running);
+    if (retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(logger, UA_LOGCATEGORY_SERVER, "Could not start the server. StatusCode 0x%08x", retval);
+        UA_String_deleteMembers(&config.applicationDescription.applicationUri);
         UA_Server_delete(server);
         nl.deleteMembers(&nl);
         return (int)retval;
@@ -184,12 +115,15 @@ int main(int argc, char** argv) {
     retval = UA_Server_unregister_discovery(server, "opc.tcp://localhost:4840" );
     if (retval != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(logger, UA_LOGCATEGORY_SERVER, "Could not unregister server from discovery server. StatusCode 0x%08x", retval);
+        UA_String_deleteMembers(&config.applicationDescription.applicationUri);
         UA_Server_delete(server);
         nl.deleteMembers(&nl);
         return (int)retval;
     }
 
     UA_String_deleteMembers(&config.applicationDescription.applicationUri);
+    UA_String_deleteMembers(&config.mdnsServerName);
+    //UA_Array_delete(config.serverCapabilities, config.serverCapabilitiesSize, &UA_TYPES[UA_TYPES_STRING]);
     UA_Server_delete(server);
     nl.deleteMembers(&nl);
 

--- a/examples/server_mainloop.c
+++ b/examples/server_mainloop.c
@@ -52,6 +52,10 @@ int main(int argc, char** argv) {
         /* timeout is the maximum possible delay (in millisec) until the next
            _iterate call. Otherwise, the server might miss an internal timeout
            or cannot react to messages with the promised responsiveness. */
+        /* If multicast discovery server is enabled, the timeout does not not consider new input data (requests) on the mDNS socket.
+         * It will be handled on the next call, which may be too late for requesting clients.
+         * if needed, the select with timeout on the multicast socket server->mdnsSocket (see example in mdnsd library)
+         */
         UA_UInt16 timeout = UA_Server_run_iterate(server, waitInternal);
 
         /* Now we can use the max timeout to do something else. In this case, we

--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -27,12 +27,21 @@ extern "C" {
 # define _DEFAULT_SOURCE
 #endif
 
+// On older systems we need to define _BSD_SOURCE
+// _DEFAULT_SOURCE is an alias for that
+#ifndef _BSD_SOURCE
+# define _BSD_SOURCE
+#endif
+
+
 #define UA_LOGLEVEL ${UA_LOGLEVEL}
 #define UA_GIT_COMMIT_ID "${GIT_COMMIT_ID}"
+#cmakedefine UA_ENABLE_AMALGAMATION
 #cmakedefine UA_ENABLE_MULTITHREADING
 #cmakedefine UA_ENABLE_METHODCALLS
 #cmakedefine UA_ENABLE_SUBSCRIPTIONS
 #cmakedefine UA_ENABLE_DISCOVERY
+#cmakedefine UA_ENABLE_DISCOVERY_MULTICAST
 #cmakedefine UA_ENABLE_TYPENAMES
 #cmakedefine UA_ENABLE_GENERATE_NAMESPACE0
 #cmakedefine UA_ENABLE_EXTERNAL_NAMESPACES

--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -105,6 +105,11 @@ typedef struct {
     UA_BuildInfo buildInfo;
     UA_ApplicationDescription applicationDescription;
     UA_ByteString serverCertificate;
+#ifdef UA_ENABLE_DISCOVERY
+    UA_String mdnsServerName;
+    size_t serverCapabilitiesSize;
+    UA_String *serverCapabilities;
+#endif
 
     /* Networking */
     size_t networkLayersSize;
@@ -548,6 +553,21 @@ UA_Server_forEachChildNodeCall(UA_Server *server, UA_NodeId parentNodeId,
   */
  UA_StatusCode UA_EXPORT
  UA_Server_unregister_discovery(UA_Server *server, const char* discoveryServerUrl);
+
+ /**
+  * Adds a periodic job to register the server with the LDS (local discovery server)
+  * periodically. The interval between each register call is given as second parameter.
+  * It should be 10 minutes by default (= 10*60*1000).
+  *
+  * The delayFirstRegisterMs parameter indicates the delay for the first register call.
+  * If it is 0, the first register call will be after intervalMs milliseconds,
+  * otherwise the server's first register will be after delayFirstRegisterMs.
+  *
+  * When you manually unregister the server, you also need to cancel the periodic job,
+  * otherwise it will be automatically be registered again.
+  */
+ UA_StatusCode UA_EXPORT
+         UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA_UInt32 intervalMs, const UA_UInt32 delayFirstRegisterMs, UA_Guid* periodicJobId);
 #endif
 
 /**

--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -218,6 +218,20 @@ typedef struct {
 } UA_NumericRange;
 
 /**
+ * EndpointURL helper
+ */
+
+/**
+ * Split the given endpoint url into hostname and port
+ * @param endpointUrl The endpoint URL to split up
+ * @param hostname the target array for hostname. Has to be at least 512 size.
+ * @param port if url contains port, it will point to the beginning of port. NULL otherwise. It may also include the path part, thus stop at position of path pointer, if it is not NULL.
+ * @param path points to the first occurance of '/' after the port or NULL if no path in url
+ * @return UA_STATUSCODE_BADOUTOFRANGE if url too long, UA_STATUSCODE_BADATTRIBUTEIDINVALID if url not starting with 'opc.tcp://', UA_STATUSCODE_GOOD on success
+ */
+UA_StatusCode UA_EXPORT UA_EndpointUrl_split(const char *endpointUrl, char *hostname, const char ** port, const char ** path);
+
+/**
  * Builtin Types, Part 2
  * ---------------------
  *

--- a/plugins/ua_config_standard.c
+++ b/plugins/ua_config_standard.c
@@ -56,6 +56,11 @@ const UA_EXPORT UA_ServerConfig UA_ServerConfig_standard = {
         .discoveryProfileUri = UA_STRING_STATIC_NULL,
         .discoveryUrlsSize = 0,
         .discoveryUrls = NULL },
+#ifdef UA_ENABLE_DISCOVERY
+		.serverCapabilities = NULL,
+		.serverCapabilitiesSize = 0,
+		.mdnsServerName = UA_STRING_STATIC_NULL,
+#endif
     .serverCertificate = UA_STRING_STATIC_NULL,
 
     /* Networking */

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -209,12 +209,43 @@ void UA_Server_delete(UA_Server *server) {
                     &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
 
 #ifdef UA_ENABLE_DISCOVERY
-    registeredServer_list_entry *current, *temp;
-    LIST_FOREACH_SAFE(current, &server->registeredServers, pointers, temp) {
-        LIST_REMOVE(current, pointers);
-        UA_RegisteredServer_deleteMembers(&current->registeredServer);
-        UA_free(current);
+	{
+		registeredServer_list_entry* current, * temp;
+		LIST_FOREACH_SAFE(current, &server->registeredServers, pointers, temp) {
+			LIST_REMOVE(current, pointers);
+			UA_RegisteredServer_deleteMembers(&current->registeredServer);
+			UA_free(current);
+		}
+	}
+    if (server->periodicServerRegisterJob) {
+        UA_free(server->periodicServerRegisterJob);
     }
+
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+    if (server->config.applicationDescription.applicationType == UA_APPLICATIONTYPE_DISCOVERYSERVER)
+    	UA_Discovery_multicastDestroy(server);
+
+	{
+		serverOnNetwork_list_entry* current, * temp;
+		LIST_FOREACH_SAFE(current, &server->serverOnNetwork, pointers, temp) {
+			LIST_REMOVE(current, pointers);
+			UA_ServerOnNetwork_deleteMembers(&current->serverOnNetwork);
+			if (current->pathTmp)
+				free(current->pathTmp);
+			UA_free(current);
+		}
+
+		for (size_t i=0; i<SERVER_ON_NETWORK_HASH_PRIME; i++) {
+			serverOnNetwork_hash_entry* currHash = server->serverOnNetworkHash[i];
+			while (currHash) {
+				serverOnNetwork_hash_entry* nextHash = currHash->next;
+				free(currHash);
+				currHash = nextHash;
+			}
+		}
+	}
+# endif
+
 #endif
 
 #ifdef UA_ENABLE_MULTITHREADING
@@ -514,6 +545,21 @@ UA_Server * UA_Server_new(const UA_ServerConfig config) {
     // Discovery service
     LIST_INIT(&server->registeredServers);
     server->registeredServersSize = 0;
+    server->periodicServerRegisterJob = NULL;
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+    server->mdnsDaemon = NULL;
+    server->mdnsSocket = 0;
+	server->mdnsMainSrvAdded = 0;
+	if (server->config.applicationDescription.applicationType == UA_APPLICATIONTYPE_DISCOVERYSERVER) {
+		UA_Discovery_multicastInit(server);
+	}
+
+	LIST_INIT(&server->serverOnNetwork);
+	server->serverOnNetworkSize = 0;
+	server->serverOnNetworkRecordIdCounter = 0;
+	server->serverOnNetworkRecordIdLastReset = UA_DateTime_now();
+	memset(server->serverOnNetworkHash,0,sizeof(struct serverOnNetwork_hash_entry*)*SERVER_ON_NETWORK_HASH_PRIME);
+# endif
 #endif
 
     server->startTime = UA_DateTime_now();
@@ -1385,8 +1431,8 @@ static UA_StatusCode register_server_with_discovery_server(UA_Server *server, co
         return retval;
     }
 
-    UA_RegisterServerRequest request;
-    UA_RegisterServerRequest_init(&request);
+    UA_RegisterServer2Request request;
+    UA_RegisterServer2Request_init(&request);
 
     request.requestHeader.timestamp = UA_DateTime_now();
     request.requestHeader.timeoutHint = 10000;
@@ -1444,20 +1490,78 @@ static UA_StatusCode register_server_with_discovery_server(UA_Server *server, co
         request.server.semaphoreFilePath = UA_String_fromChars(semaphoreFilePath);
     }
 
-    // now send the request
-    UA_RegisterServerResponse response;
-    UA_RegisterServerResponse_init(&response);
-    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_REGISTERSERVERREQUEST],
-                        &response, &UA_TYPES[UA_TYPES_REGISTERSERVERRESPONSE]);
+	UA_MdnsDiscoveryConfiguration *mdnsConfig = UA_MdnsDiscoveryConfiguration_new();
+	UA_MdnsDiscoveryConfiguration_init(mdnsConfig);
 
-    if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_CLIENT,
-                     "RegisterServer failed with statuscode 0x%08x", response.responseHeader.serviceResult);
-        UA_RegisterServerResponse_deleteMembers(&response);
-        UA_Client_disconnect(client);
-        UA_Client_delete(client);
-        return response.responseHeader.serviceResult;
-    }
+	request.discoveryConfigurationSize = 0;
+	request.discoveryConfigurationSize = 1;
+	request.discoveryConfiguration = UA_ExtensionObject_new();
+	UA_ExtensionObject_init(&request.discoveryConfiguration[0]);
+	request.discoveryConfiguration[0].encoding = UA_EXTENSIONOBJECT_DECODED_NODELETE;
+	request.discoveryConfiguration[0].content.decoded.type = &UA_TYPES[UA_TYPES_MDNSDISCOVERYCONFIGURATION];
+	request.discoveryConfiguration[0].content.decoded.data = mdnsConfig;
+
+	UA_String_copy(&server->config.mdnsServerName, &mdnsConfig->mdnsServerName);
+	retval |= UA_Array_copy(&server->config.serverCapabilities, server->config.serverCapabilitiesSize, (void**)&mdnsConfig->serverCapabilities, &UA_TYPES[UA_TYPES_STRING]);
+	mdnsConfig->serverCapabilitiesSize = server->config.serverCapabilitiesSize;
+
+	if (retval != UA_STATUSCODE_GOOD) {
+		UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_CLIENT,
+					 "Could not initialize RegisterServer request");
+		UA_MdnsDiscoveryConfiguration_delete(mdnsConfig);
+		UA_RegisterServer2Request_deleteMembers(&request);
+		return retval;
+	}
+
+	// First try with RegisterServer2, if that isn't implemented, use RegisterServer
+	UA_RegisterServer2Response response;
+	UA_RegisterServer2Response_init(&response);
+	__UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_REGISTERSERVER2REQUEST],
+						&response, &UA_TYPES[UA_TYPES_REGISTERSERVER2RESPONSE]);
+
+	if (response.responseHeader.serviceResult == UA_STATUSCODE_BADNOTIMPLEMENTED) {
+		// try RegisterServer
+		UA_RegisterServerResponse response_fallback;
+		UA_RegisterServerResponse_init(&response_fallback);
+
+		// copy from RegisterServer2 request
+		UA_RegisterServerRequest request_fallback;
+		UA_RegisterServerRequest_init(&request_fallback);
+
+		UA_RequestHeader_copy(&request.requestHeader, &request_fallback.requestHeader);
+		UA_RegisteredServer_copy(&request.server, &request_fallback.server);
+
+		UA_RegisterServer2Request_deleteMembers(&request);
+
+		__UA_Client_Service(client, &request_fallback, &UA_TYPES[UA_TYPES_REGISTERSERVERREQUEST],
+							&response_fallback, &UA_TYPES[UA_TYPES_REGISTERSERVERRESPONSE]);
+
+		UA_RegisterServerRequest_deleteMembers(&request_fallback);
+
+		if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_CLIENT,
+						 "RegisterServer failed with statuscode 0x%08x", response.responseHeader.serviceResult);
+			UA_MdnsDiscoveryConfiguration_delete(mdnsConfig);
+			UA_RegisterServer2Response_deleteMembers(&response);
+			UA_RegisterServerResponse_deleteMembers(&response_fallback);
+			UA_Client_disconnect(client);
+			UA_Client_delete(client);
+			return response.responseHeader.serviceResult;
+		}
+	} else if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+		UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_CLIENT,
+					 "RegisterServer2 failed with statuscode 0x%08x", response.responseHeader.serviceResult);
+		UA_MdnsDiscoveryConfiguration_delete(mdnsConfig);
+		UA_RegisterServer2Request_deleteMembers(&request);
+		UA_RegisterServer2Response_deleteMembers(&response);
+		UA_Client_disconnect(client);
+		UA_Client_delete(client);
+		return response.responseHeader.serviceResult;
+	}
+
+	UA_MdnsDiscoveryConfiguration_delete(mdnsConfig);
+	UA_RegisterServer2Request_deleteMembers(&request);
+	UA_RegisterServer2Response_deleteMembers(&response);
 
     UA_Client_disconnect(client);
     UA_Client_delete(client);

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -1375,3 +1375,101 @@ UA_StatusCode UA_Server_unregister_discovery(UA_Server *server, const char* disc
     return register_server_with_discovery_server(server, discoveryServerUrl, UA_TRUE, NULL);
 }
 #endif
+
+#ifdef UA_ENABLE_DISCOVERY
+static UA_StatusCode register_server_with_discovery_server(UA_Server *server, const char* discoveryServerUrl, const UA_Boolean isUnregister, const char* semaphoreFilePath) {
+    UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
+    UA_StatusCode retval = UA_Client_connect(client, discoveryServerUrl);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_Client_delete(client);
+        return retval;
+    }
+
+    UA_RegisterServerRequest request;
+    UA_RegisterServerRequest_init(&request);
+
+    request.requestHeader.timestamp = UA_DateTime_now();
+    request.requestHeader.timeoutHint = 10000;
+
+    request.server.isOnline = !isUnregister;
+
+    // copy all the required data from applicationDescription to request
+    retval |= UA_String_copy(&server->config.applicationDescription.applicationUri, &request.server.serverUri);
+    retval |= UA_String_copy(&server->config.applicationDescription.productUri, &request.server.productUri);
+
+    request.server.serverNamesSize = 1;
+    request.server.serverNames = UA_malloc(sizeof(UA_LocalizedText));
+    if (!request.server.serverNames) {
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    retval |= UA_LocalizedText_copy(&server->config.applicationDescription.applicationName, &request.server.serverNames[0]);
+    
+    request.server.serverType = server->config.applicationDescription.applicationType;
+    retval |= UA_String_copy(&server->config.applicationDescription.gatewayServerUri, &request.server.gatewayServerUri);
+    // TODO where do we get the discoveryProfileUri for application data?
+
+    request.server.discoveryUrls = UA_malloc(sizeof(UA_String) * server->config.applicationDescription.discoveryUrlsSize);
+    if (!request.server.serverNames) {
+        UA_RegisteredServer_deleteMembers(&request.server);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    for (size_t i = 0; i<server->config.applicationDescription.discoveryUrlsSize; i++) {
+        retval |= UA_String_copy(&server->config.applicationDescription.discoveryUrls[i], &request.server.discoveryUrls[i]);
+    }
+
+    /* add the discoveryUrls from the networklayers */
+    UA_String *disc = UA_realloc(request.server.discoveryUrls, sizeof(UA_String) *
+                                                                           (request.server.discoveryUrlsSize + server->config.networkLayersSize));
+    if(!disc) {
+        UA_RegisteredServer_deleteMembers(&request.server);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    size_t existing = request.server.discoveryUrlsSize;
+    request.server.discoveryUrls = disc;
+    request.server.discoveryUrlsSize += server->config.networkLayersSize;
+
+    // TODO: Add nl only if discoveryUrl not already present
+    for(size_t i = 0; i < server->config.networkLayersSize; i++) {
+        UA_ServerNetworkLayer *nl = &server->config.networkLayers[i];
+        UA_String_copy(&nl->discoveryUrl, &request.server.discoveryUrls[existing + i]);
+    }
+
+    if (semaphoreFilePath) {
+        request.server.semaphoreFilePath = UA_String_fromChars(semaphoreFilePath);
+    }
+
+    // now send the request
+    UA_RegisterServerResponse response;
+    UA_RegisterServerResponse_init(&response);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_REGISTERSERVERREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_REGISTERSERVERRESPONSE]);
+
+    if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_CLIENT,
+                     "RegisterServer failed with statuscode 0x%08x", response.responseHeader.serviceResult);
+        UA_RegisterServerResponse_deleteMembers(&response);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return response.responseHeader.serviceResult;
+    }
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode UA_Server_register_discovery(UA_Server *server, const char* discoveryServerUrl, const char* semaphoreFilePath) {
+    return register_server_with_discovery_server(server, discoveryServerUrl, UA_FALSE, semaphoreFilePath);
+}
+
+UA_StatusCode UA_Server_unregister_discovery(UA_Server *server, const char* discoveryServerUrl) {
+    return register_server_with_discovery_server(server, discoveryServerUrl, UA_TRUE, NULL);
+}
+#endif

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -90,11 +90,13 @@ getServicePointers(UA_UInt32 requestTypeId, const UA_DataType **requestType,
         *service = (UA_Service)Service_RegisterServer;
         *requestType = &UA_TYPES[UA_TYPES_REGISTERSERVERREQUEST];
         *responseType = &UA_TYPES[UA_TYPES_REGISTERSERVERRESPONSE];
+        *requiresSession = false;
         break;
     case UA_NS0ID_REGISTERSERVER2REQUEST:
         *service = (UA_Service)Service_RegisterServer2;
         *requestType = &UA_TYPES[UA_TYPES_REGISTERSERVER2REQUEST];
         *responseType = &UA_TYPES[UA_TYPES_REGISTERSERVER2RESPONSE];
+        *requiresSession = false;
         break;
 #endif
     case UA_NS0ID_CREATESESSIONREQUEST:

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -78,10 +78,23 @@ getServicePointers(UA_UInt32 requestTypeId, const UA_DataType **requestType,
         *requiresSession = false;
         break;
 #ifdef UA_ENABLE_DISCOVERY
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+    case UA_NS0ID_FINDSERVERSONNETWORKREQUEST:
+        *service = (UA_Service)Service_FindServersOnNetwork;
+        *requestType = &UA_TYPES[UA_TYPES_FINDSERVERSONNETWORKREQUEST];
+        *responseType = &UA_TYPES[UA_TYPES_FINDSERVERSONNETWORKRESPONSE];
+        *requiresSession = false;
+        break;
+# endif
     case UA_NS0ID_REGISTERSERVERREQUEST:
         *service = (UA_Service)Service_RegisterServer;
         *requestType = &UA_TYPES[UA_TYPES_REGISTERSERVERREQUEST];
         *responseType = &UA_TYPES[UA_TYPES_REGISTERSERVERRESPONSE];
+        break;
+    case UA_NS0ID_REGISTERSERVER2REQUEST:
+        *service = (UA_Service)Service_RegisterServer2;
+        *requestType = &UA_TYPES[UA_TYPES_REGISTERSERVER2REQUEST];
+        *responseType = &UA_TYPES[UA_TYPES_REGISTERSERVER2RESPONSE];
         break;
 #endif
     case UA_NS0ID_CREATESESSIONREQUEST:

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -173,6 +173,8 @@ typedef enum {
     UA_DISCOVERY_TLS     /* OPC UA HTTPS mapping */
 } UA_DiscoveryProtocol;
 
+UA_StatusCode UA_Discovery_multicastQuery(UA_Server* server);
+
 UA_StatusCode UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, const char* path,
 									 const UA_DiscoveryProtocol protocol, UA_Boolean createTxt, const UA_String* capabilites, const size_t *capabilitiesSize);
 UA_StatusCode UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, UA_Boolean removeTxt);

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -9,6 +9,10 @@
 #include "ua_securechannel_manager.h"
 #include "ua_nodestore.h"
 
+#ifdef UA_ENABLE_DISCOVERY_MULTICAST
+#include "mdnsd/libmdnsd/mdnsd.h"
+#endif
+
 #define ANONYMOUS_POLICY "open62541-anonymous-policy"
 #define USERNAME_POLICY "open62541-username-policy"
 
@@ -44,6 +48,27 @@ typedef struct registeredServer_list_entry {
     UA_RegisteredServer registeredServer;
     UA_DateTime lastSeen;
 } registeredServer_list_entry;
+
+
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+typedef struct serverOnNetwork_list_entry {
+	LIST_ENTRY(serverOnNetwork_list_entry) pointers;
+	UA_ServerOnNetwork serverOnNetwork;
+	UA_DateTime created;
+	UA_DateTime lastSeen;
+	UA_Boolean txtSet;
+	UA_Boolean srvSet;
+	char* pathTmp;
+} serverOnNetwork_list_entry;
+
+
+#define SERVER_ON_NETWORK_HASH_PRIME 1009
+typedef struct serverOnNetwork_hash_entry {
+	serverOnNetwork_list_entry* entry;
+	struct serverOnNetwork_hash_entry* next;
+} serverOnNetwork_hash_entry;
+#endif
+
 #endif
 
 struct UA_Server {
@@ -63,6 +88,23 @@ struct UA_Server {
     /* Discovery */
     LIST_HEAD(registeredServer_list, registeredServer_list_entry) registeredServers; // doubly-linked list of registered servers
     size_t registeredServersSize;
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+    mdns_daemon_t *mdnsDaemon;
+    int mdnsSocket;
+	unsigned short mdnsMainSrvAdded;
+#  ifdef UA_ENABLE_MULTITHREADING
+	pthread_t mdnsThread;
+	UA_Boolean mdnsRunning;
+#  endif
+
+	LIST_HEAD(serverOnNetwork_list, serverOnNetwork_list_entry) serverOnNetwork; // doubly-linked list of servers on the network (from mDNS)
+	size_t serverOnNetworkSize;
+	UA_UInt32 serverOnNetworkRecordIdCounter;
+	UA_DateTime serverOnNetworkRecordIdLastReset;
+	// hash mapping domain name to serverOnNetwork list entry
+	struct serverOnNetwork_hash_entry* serverOnNetworkHash[SERVER_ON_NETWORK_HASH_PRIME];
+
+# endif
 #endif
 
     size_t namespacesSize;
@@ -119,5 +161,27 @@ isNodeInTree(UA_NodeStore *ns, const UA_NodeId *rootNode, const UA_NodeId *nodeT
 
 /* Periodic task to clean up the discovery registry */
 void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime now);
+
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+
+UA_StatusCode UA_Discovery_multicastInit(UA_Server* server);
+void UA_Discovery_multicastDestroy(UA_Server* server);
+
+typedef enum {
+    UA_DISCOVERY_TCP,     /* OPC UA TCP mapping */
+    UA_DISCOVERY_TLS     /* OPC UA HTTPS mapping */
+} UA_DiscoveryProtocol;
+
+UA_StatusCode UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, const char* path,
+									 const UA_DiscoveryProtocol protocol, UA_Boolean createTxt, const UA_String* capabilites, const size_t *capabilitiesSize);
+UA_StatusCode UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, UA_Boolean removeTxt);
+
+#  ifdef UA_ENABLE_MULTITHREADING
+UA_StatusCode UA_Discovery_multicastListenStart(UA_Server* server);
+UA_StatusCode UA_Discovery_multicastListenStop(UA_Server* server);
+#  endif
+UA_StatusCode UA_Discovery_multicastIterate(UA_Server* server, UA_DateTime *nextRepeat, UA_Boolean processIn);
+
+# endif
 
 #endif /* UA_SERVER_INTERNAL_H_ */

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -88,6 +88,7 @@ struct UA_Server {
     /* Discovery */
     LIST_HEAD(registeredServer_list, registeredServer_list_entry) registeredServers; // doubly-linked list of registered servers
     size_t registeredServersSize;
+	struct PeriodicServerRegisterJob *periodicServerRegisterJob;
 # ifdef UA_ENABLE_DISCOVERY_MULTICAST
     mdns_daemon_t *mdnsDaemon;
     int mdnsSocket;

--- a/src/server/ua_server_worker.c
+++ b/src/server/ua_server_worker.c
@@ -602,6 +602,8 @@ UA_StatusCode UA_Server_run_startup(UA_Server *server) {
             appName[server->config.mdnsServerName.length] = '\0';
             UA_Discovery_addRecord(server, appName ,hostname, 4840, "/", UA_DISCOVERY_TCP, UA_TRUE, server->config.serverCapabilities, &server->config.serverCapabilitiesSize);
             free(appName);
+            // find any other server on the net
+            UA_Discovery_multicastQuery(server);
 		} else {
 			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
 						"Could not get hostname for multicast discovery.");

--- a/src/server/ua_services.h
+++ b/src/server/ua_services.h
@@ -38,8 +38,10 @@ void Service_GetEndpoints(UA_Server *server, UA_Session *session,
 #ifdef UA_ENABLE_DISCOVERY
 /* Registers a remote server in the local discovery service. */
 void Service_RegisterServer(UA_Server *server, UA_Session *session,
-                            const UA_RegisterServerRequest *request,
-                            UA_RegisterServerResponse *response);
+							const UA_RegisterServerRequest *request,
+							UA_RegisterServerResponse *response);
+
+void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime now);
 #endif
 
 /**
@@ -103,6 +105,11 @@ void Service_AddNodes(UA_Server *server, UA_Session *session,
                       const UA_AddNodesRequest *request,
                       UA_AddNodesResponse *response);
 
+void Service_AddNodes_single(UA_Server *server, UA_Session *session,
+                             const UA_AddNodesItem *item,
+                             UA_AddNodesResult *result,
+                             UA_InstantiationCallback *instantiationCallback);
+
 /* Add an existing node. The node is assumed to be "finished", i.e. no
  * instantiation from inheritance is necessary */
 void
@@ -165,6 +172,11 @@ void Service_Browse_single(UA_Server *server, UA_Session *session,
 void Service_BrowseNext(UA_Server *server, UA_Session *session,
                         const UA_BrowseNextRequest *request,
                         UA_BrowseNextResponse *response);
+
+void UA_Server_browseNext_single(UA_Server *server, UA_Session *session,
+                                 UA_Boolean releaseContinuationPoint,
+                                 const UA_ByteString *continuationPoint,
+                                 UA_BrowseResult *result);
 
 /* Used to translate textual node paths to their respective ids. */
 void Service_TranslateBrowsePathsToNodeIds(UA_Server *server, UA_Session *session,

--- a/src/server/ua_services.h
+++ b/src/server/ua_services.h
@@ -36,12 +36,24 @@ void Service_GetEndpoints(UA_Server *server, UA_Session *session,
                           UA_GetEndpointsResponse *response);
 
 #ifdef UA_ENABLE_DISCOVERY
+
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+void Service_FindServersOnNetwork(UA_Server *server, UA_Session *session,
+								  const UA_FindServersOnNetworkRequest *request,
+								  UA_FindServersOnNetworkResponse *response);
+# endif
+
 /* Registers a remote server in the local discovery service. */
 void Service_RegisterServer(UA_Server *server, UA_Session *session,
 							const UA_RegisterServerRequest *request,
 							UA_RegisterServerResponse *response);
 
 void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime now);
+
+/* Registers a remote server in the local discovery service. */
+void Service_RegisterServer2(UA_Server *server, UA_Session *session,
+                            const UA_RegisterServer2Request *request,
+                            UA_RegisterServer2Response *response);
 #endif
 
 /**

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -856,8 +856,9 @@ void Service_Write(UA_Server *server, UA_Session *session, const UA_WriteRequest
 
 UA_StatusCode UA_Server_write(UA_Server *server, const UA_WriteValue *value) {
     UA_RCU_LOCK();
-    return Service_Write_single(server, &adminSession, value);
+    UA_StatusCode retval = Service_Write_single(server, &adminSession, value);
     UA_RCU_UNLOCK();
+    return retval;
 }
 
 UA_StatusCode

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -1,14 +1,47 @@
 #include "ua_server_internal.h"
 #include "ua_services.h"
 
-
 #ifdef UA_ENABLE_DISCOVERY
-    #ifdef _MSC_VER
-    # include <io.h> //access
-    # define access _access
-    #else
-    # include <unistd.h> //access
-    #endif
+# ifdef _MSC_VER
+#  include <io.h> //access
+#  define access _access
+# else
+#  include <unistd.h> //access
+# endif
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+#  include <fcntl.h>
+#  include <errno.h>
+#  include <stdio.h>
+#  ifndef UA_ENABLE_AMALGAMATION
+#   include "mdnsd/libmdnsd/xht.h"
+#   include "mdnsd/libmdnsd/sdtxt.h"
+#  endif
+#  ifdef _WIN32
+#   define _WINSOCK_DEPRECATED_NO_WARNINGS /* inet_ntoa is deprecated on MSVC but used for compatibility */
+#   include <winsock2.h>
+#   include <ws2tcpip.h>
+#   define CLOSESOCKET(S) closesocket((SOCKET)S)
+#  else
+#   define CLOSESOCKET(S) close(S)
+#	include <sys/time.h> // for struct timeval
+#	include <netinet/in.h> // for struct ip_mreq
+#  endif
+# endif
+#endif
+
+#ifndef STRDUP
+# if defined(__MINGW32__)
+static char *ua_strdup(const char *s) {
+    char *p = malloc(strlen(s) + 1);
+    if(p) { strcpy(p, s); }
+    return p;
+}
+# define STRDUP ua_strdup
+# elif defined(_WIN32)
+# define STRDUP _strdup
+# else
+# define STRDUP strdup
+# endif
 #endif
 
 #ifdef UA_ENABLE_DISCOVERY
@@ -281,76 +314,507 @@ void Service_GetEndpoints(UA_Server *server, UA_Session *session, const UA_GetEn
 }
 
 #ifdef UA_ENABLE_DISCOVERY
+
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+
+/* Generates a hash code for a string.
+ * This function uses the ELF hashing algorithm as reprinted in
+ * Andrew Binstock, "Hashing Rehashed," Dr. Dobb's Journal, April 1996.
+ */
+static int mdns_hash_record(const char *s)
+{
+	/* ELF hash uses unsigned chars and unsigned arithmetic for portability */
+	const unsigned char *name = (const unsigned char *)s;
+	unsigned long h = 0;
+
+	while(*name) {
+		/* do some fancy bitwanking on the string */
+		h = (h << 4) + (unsigned long)(*name++);
+		unsigned long g;
+		if ((g = (h & 0xF0000000UL)) != 0)
+			h ^= (g >> 24);
+		h &= ~g;
+	}
+
+	return (int)h;
+}
+
+static struct serverOnNetwork_list_entry* mdns_record_add_or_get(UA_Server *server, const char* record, const char* serverName, size_t serverNameLen, UA_Boolean createNew) {
+	int hashIdx = mdns_hash_record(record) % SERVER_ON_NETWORK_HASH_PRIME;
+	struct serverOnNetwork_hash_entry* hash_entry = server->serverOnNetworkHash[hashIdx];
+
+	while (hash_entry) {
+		size_t maxLen = serverNameLen > hash_entry->entry->serverOnNetwork.serverName.length ? hash_entry->entry->serverOnNetwork.serverName.length : serverNameLen;
+		if (strncmp((char*)hash_entry->entry->serverOnNetwork.serverName.data, serverName,maxLen)==0) {
+			return hash_entry->entry;
+		}
+		hash_entry = hash_entry->next;
+	}
+
+	if (!createNew)
+		return NULL;
+
+	// not yet in list, create new one
+	struct serverOnNetwork_list_entry* listEntry = malloc(sizeof(struct serverOnNetwork_list_entry));
+	listEntry->created = UA_DateTime_now();
+	listEntry->pathTmp = NULL;
+	listEntry->txtSet = UA_FALSE;
+	listEntry->srvSet = UA_FALSE;
+	UA_ServerOnNetwork_init(&listEntry->serverOnNetwork);
+	listEntry->serverOnNetwork.recordId = server->serverOnNetworkRecordIdCounter;
+	listEntry->serverOnNetwork.serverName.length = serverNameLen;
+	listEntry->serverOnNetwork.serverName.data = malloc(serverNameLen);
+	memcpy(listEntry->serverOnNetwork.serverName.data, serverName, serverNameLen);
+	#  ifndef UA_ENABLE_MULTITHREADING
+	server->serverOnNetworkRecordIdCounter++;
+	#  else
+	server->serverOnNetworkRecordIdCounter = uatomic_add_return(&server->serverOnNetworkRecordIdCounter, 1);
+	#  endif
+	if (server->serverOnNetworkRecordIdCounter == 0)
+		server->serverOnNetworkRecordIdLastReset = UA_DateTime_now();
+
+	// add to hash
+	struct serverOnNetwork_hash_entry* newHashEntry = malloc(sizeof(struct serverOnNetwork_hash_entry));
+	newHashEntry->next = server->serverOnNetworkHash[hashIdx];
+	server->serverOnNetworkHash[hashIdx] = newHashEntry;
+	newHashEntry->entry = listEntry;
+
+	LIST_INSERT_HEAD(&server->serverOnNetwork, listEntry, pointers);
+
+	return listEntry;
+}
+
+static void mdns_record_remove(UA_Server *server, const char* record, struct serverOnNetwork_list_entry* entry) {
+
+	// remove from hash
+
+	int hashIdx = mdns_hash_record(record) % SERVER_ON_NETWORK_HASH_PRIME;
+	struct serverOnNetwork_hash_entry* hash_entry = server->serverOnNetworkHash[hashIdx];
+	struct serverOnNetwork_hash_entry* prevEntry = hash_entry;
+	while (hash_entry) {
+		if (hash_entry->entry == entry) {
+			if (server->serverOnNetworkHash[hashIdx] == hash_entry)
+				server->serverOnNetworkHash[hashIdx] = hash_entry->next;
+			else if (prevEntry){
+				prevEntry->next = hash_entry->next;
+			}
+			break;
+		}
+		prevEntry = hash_entry;
+		hash_entry = hash_entry->next;
+	}
+	free(hash_entry);
+
+	// remove from list
+
+	LIST_REMOVE(entry, pointers);
+	UA_ServerOnNetwork_deleteMembers(&entry->serverOnNetwork);
+	if (entry->pathTmp)
+		free(entry->pathTmp);
+
+#ifndef UA_ENABLE_MULTITHREADING
+	UA_free(entry);
+	server->serverOnNetworkSize--;
+#else
+	server->serverOnNetworkSize = uatomic_add_return(&server->serverOnNetworkSize, -1);
+    UA_Server_delayedFree(server, entry);
+#endif
+}
+
+static void mdns_append_path_to_url(UA_String* url, const char* path) {
+	size_t pathLen = strlen(path);
+	char *newUrl = malloc(url->length + pathLen);
+	memcpy(newUrl,url->data, url->length);
+	memcpy(newUrl+url->length,path,pathLen);
+	url->length = url->length + pathLen;
+	url->data = (UA_Byte*)newUrl;
+}
+
+/**
+ * This will be called by the mDNS library on every record which is received.
+ * @param r
+ * @param data
+ */
+static void mdns_record_received(const struct resource* r, void* data) {
+	UA_Server *server = (UA_Server *) data;
+	// we only need SRV and TXT records
+	if ((r->class != QCLASS_IN && r->class != QCLASS_IN +  + 32768) || (r->type != QTYPE_SRV && r->type != QTYPE_TXT))
+		return;
+
+	// we only handle '_opcua-tcp._tcp.' records
+	char *opcStr = strstr(r->name, "_opcua-tcp._tcp.");
+	if (opcStr == NULL)
+		return;
+
+	size_t servernameLen = (size_t)(opcStr - r->name);
+	if (servernameLen == 0)
+		return;
+	servernameLen--; // remove point
+
+	// opcStr + strlen("_opcua-tcp._tcp.")
+	//char *hostname = opcStr + 16;
+
+	struct serverOnNetwork_list_entry* entry = mdns_record_add_or_get(server, r->name, r->name, servernameLen, r->ttl > 0);
+
+	if (entry == NULL)
+		// TTL is 0 and entry not yet in list
+		return;
+	else if (r->ttl == 0) {
+		UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: remove server (TTL=0): %.*s", entry->serverOnNetwork.discoveryUrl.length, entry->serverOnNetwork.discoveryUrl.data);
+		mdns_record_remove(server, r->name, entry);
+		return;
+	}
+
+	entry->lastSeen = UA_DateTime_now();
+
+	if (entry->txtSet && entry->srvSet)
+		return;
+
+	// [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port [hostname].
+	// TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
+	if (r->type == QTYPE_TXT && !entry->txtSet) {
+		entry->txtSet = UA_TRUE;
+
+
+		xht_t* x = txt2sd((unsigned char*)r->rdata, r->rdlength);
+		char* path = (char*)xht_get(x, "path");
+		char* caps = (char*)xht_get(x, "caps");
+
+		if (strlen(path) > 1) {
+			if (!entry->srvSet) {
+				// txt arrived before SRV, thus cache path entry
+				entry->pathTmp = STRDUP(path);
+			} else {
+				// SRV already there and discovery URL set. Add path to discovery URL
+				mdns_append_path_to_url(&entry->serverOnNetwork.discoveryUrl, path);
+			}
+		}
+
+		if (strlen(caps) > 0) {
+			size_t capsCount = 1;
+			// count comma in caps
+			for (size_t i=0; caps[i]; i++) {
+				if (caps[i]==',')
+					capsCount++;
+			}
+			// set capabilities
+			entry->serverOnNetwork.serverCapabilitiesSize = capsCount;
+			entry->serverOnNetwork.serverCapabilities = UA_Array_new(capsCount, &UA_TYPES[UA_TYPES_STRING]);
+			for (size_t i=0; i<capsCount; i++) {
+
+				char* nextStr = strchr(caps, ',');
+
+				size_t len = nextStr ? (size_t)(nextStr - caps) : strlen(caps);
+				entry->serverOnNetwork.serverCapabilities[i].length = len;
+				entry->serverOnNetwork.serverCapabilities[i].data = malloc(len);
+				memcpy(entry->serverOnNetwork.serverCapabilities[i].data, caps, len);
+				if (nextStr)
+					caps = nextStr+1;
+				else
+					break;
+			}
+		}
+		xht_free(x);
+	} else if (r->type == QTYPE_SRV && !entry->srvSet){
+		entry->srvSet = UA_TRUE;
+
+		// opc.tcp://[servername]:[port][path]
+		size_t srvNameLen = strlen(r->known.srv.name);
+		if (srvNameLen > 0 && r->known.srv.name[srvNameLen-1] == '.')
+			srvNameLen--;
+		char *newUrl = malloc(10 + srvNameLen + 8);
+		sprintf(newUrl, "opc.tcp://%.*s:%d",(int)srvNameLen, r->known.srv.name, r->known.srv.port);
+		UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: found server: %s", newUrl);
+		entry->serverOnNetwork.discoveryUrl = UA_String_fromChars(newUrl);
+		free(newUrl);
+
+		if (entry->pathTmp) {
+			mdns_append_path_to_url(&entry->serverOnNetwork.discoveryUrl, entry->pathTmp);
+			free(entry->pathTmp);
+		}
+
+	}
+}
+
+void Service_FindServersOnNetwork(UA_Server *server, UA_Session *session,
+                         const UA_FindServersOnNetworkRequest *request, UA_FindServersOnNetworkResponse *response) {
+	UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing FindServersOnNetworkRequest");
+
+	UA_UInt32 recordCount;
+	if (request->startingRecordId < server->serverOnNetworkRecordIdCounter)
+		recordCount = server->serverOnNetworkRecordIdCounter - request->maxRecordsToReturn;
+	else
+		recordCount = 0;
+
+	if (request->maxRecordsToReturn && recordCount > request->maxRecordsToReturn) {
+		recordCount = request->maxRecordsToReturn;
+	}
+
+	UA_ServerOnNetwork** filtered = NULL;
+	if (recordCount > 0) {
+		filtered = UA_malloc(sizeof(UA_ServerOnNetwork*) * recordCount);
+		if (!filtered) {
+			response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
+			return;
+		}
+		memset(filtered, 0, sizeof(UA_ServerOnNetwork*) * recordCount);
+
+		if (request->serverCapabilityFilterSize) {
+			UA_UInt32 filteredCount = 0;
+			// iterate over all records and add to filtered list
+			serverOnNetwork_list_entry* current;
+			LIST_FOREACH(current, &server->serverOnNetwork, pointers) {
+				if (current->serverOnNetwork.recordId < request->startingRecordId)
+					continue;
+				UA_Boolean foundAll = UA_TRUE;
+				for (size_t i = 0; i < request->serverCapabilityFilterSize && foundAll; i++) {
+					UA_Boolean foundSingle = UA_FALSE;
+					for (size_t j = 0; j < current->serverOnNetwork.serverCapabilitiesSize && !foundSingle; j++) {
+						foundSingle |= UA_String_equal(&request->serverCapabilityFilter[i], &current->serverOnNetwork.serverCapabilities[j]);
+					}
+					foundAll &= foundSingle;
+				}
+				if (foundAll) {
+					filtered[filteredCount++] = &current->serverOnNetwork;
+					if (filteredCount >= recordCount)
+						break;
+				}
+			}
+			recordCount = filteredCount;
+		} else {
+			UA_UInt32 filteredCount = 0;
+			serverOnNetwork_list_entry* current;
+			LIST_FOREACH(current, &server->serverOnNetwork, pointers) {
+				if (current->serverOnNetwork.recordId < request->startingRecordId)
+					continue;
+				filtered[filteredCount++] = &current->serverOnNetwork;
+				if (filteredCount >= recordCount)
+					break;
+			}
+			recordCount = filteredCount;
+		}
+	}
+	response->serversSize = recordCount;
+	if (recordCount > 0) {
+		response->servers = UA_malloc(sizeof(UA_ServerOnNetwork)*recordCount);
+		if (!response->servers) {
+			response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
+			free(filtered);
+			return;
+		}
+		for (size_t i=0; i<recordCount; i++) {
+			UA_ServerOnNetwork_copy(filtered[i],&response->servers[recordCount - i -1]);
+		}
+	}
+	free(filtered);
+
+	UA_DateTime_copy(&server->serverOnNetworkRecordIdLastReset, &response->lastCounterResetTime);
+	response->responseHeader.serviceResult = UA_STATUSCODE_GOOD;
+}
+# endif
+
+static void process_RegisterServer(UA_Server *server, UA_Session *session,
+								   const UA_RequestHeader* requestHeader, const UA_RegisteredServer *requestServer, const size_t requestDiscoveryConfigurationSize,
+								   const UA_ExtensionObject *requestDiscoveryConfiguration,
+								   UA_ResponseHeader* responseHeader, size_t *responseConfigurationResultsSize,
+								   UA_StatusCode **responseConfigurationResults, size_t *responseDiagnosticInfosSize,
+								   UA_DiagnosticInfo *responseDiagnosticInfos) {
+	registeredServer_list_entry *registeredServer_entry = NULL;
+
+	{
+		// find the server from the request in the registered list
+		registeredServer_list_entry* current;
+		LIST_FOREACH(current, &server->registeredServers, pointers) {
+			if (UA_String_equal(&current->registeredServer.serverUri, &requestServer->serverUri)) {
+				registeredServer_entry = current;
+				break;
+			}
+		}
+	}
+
+	UA_MdnsDiscoveryConfiguration *mdnsConfig = NULL;
+
+	const UA_String* mdnsServerName = NULL;
+	if (requestDiscoveryConfigurationSize) {
+		*responseConfigurationResultsSize = requestDiscoveryConfigurationSize;
+		*responseConfigurationResults = UA_Array_new(requestDiscoveryConfigurationSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
+		for (size_t i =0; i<requestDiscoveryConfigurationSize; i++) {
+			const UA_ExtensionObject *object = &requestDiscoveryConfiguration[i];
+			if (!mdnsConfig && (object->encoding == UA_EXTENSIONOBJECT_DECODED || object->encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE)
+				&& (object->content.decoded.type == &UA_TYPES[UA_TYPES_MDNSDISCOVERYCONFIGURATION])) {
+				// yayy, we have a known extension object type
+				mdnsConfig = object->content.decoded.data;
+
+				mdnsServerName = &mdnsConfig->mdnsServerName;
+
+				*responseConfigurationResults[i] = UA_STATUSCODE_GOOD;
+			} else {
+				*responseConfigurationResults[i] = UA_STATUSCODE_BADNOTSUPPORTED;
+			}
+		}
+	}
+	if (!mdnsServerName && requestServer->serverNamesSize) {
+		mdnsServerName = &requestServer->serverNames[0].text;
+	}
+
+	if (!mdnsServerName) {
+		responseHeader->serviceResult = UA_STATUSCODE_BADSERVERNAMEMISSING;
+		return;
+	}
+
+
+	if (requestServer->discoveryUrlsSize == 0) {
+		responseHeader->serviceResult = UA_STATUSCODE_BADDISCOVERYURLMISSING;
+		return;
+	}
+
+	if (requestServer->semaphoreFilePath.length) {
+		char* filePath = malloc(sizeof(char)*requestServer->semaphoreFilePath.length+1);
+		memcpy( filePath, requestServer->semaphoreFilePath.data, requestServer->semaphoreFilePath.length );
+		filePath[requestServer->semaphoreFilePath.length] = '\0';
+		if (access( filePath, 0 ) == -1) {
+			responseHeader->serviceResult = UA_STATUSCODE_BADSEMPAHOREFILEMISSING;
+			free(filePath);
+			return;
+		}
+		free(filePath);
+	}
+
+#ifdef UA_ENABLE_DISCOVERY_MULTICAST
+	if (server->config.applicationDescription.applicationType == UA_APPLICATIONTYPE_DISCOVERYSERVER) {
+
+		char* mdnsServer = malloc(sizeof(char) * mdnsServerName->length + 1);
+		memcpy(mdnsServer, mdnsServerName->data, mdnsServerName->length);
+		mdnsServer[mdnsServerName->length] = '\0';
+
+		for (size_t i=0; i<requestServer->discoveryUrlsSize; i++) {
+			char port[10] = "\0";
+			char hostname[256];
+			char path[256];
+			{
+				char* uri = malloc(sizeof(char) * requestServer->discoveryUrls[i].length + 1);
+				strncpy(uri, (char*) requestServer->discoveryUrls[i].data, requestServer->discoveryUrls[i].length);
+				uri[requestServer->discoveryUrls[i].length] = '\0';
+				UA_StatusCode retval;
+				const char* portTmp = NULL;
+				const char* pathTmp = NULL;
+				if ((retval = UA_EndpointUrl_split(uri, hostname, &portTmp, &pathTmp)) != UA_STATUSCODE_GOOD) {
+					hostname[0] = '\0';
+					if (retval == UA_STATUSCODE_BADOUTOFRANGE)
+						UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_NETWORK, "Server url size invalid");
+					else if (retval == UA_STATUSCODE_BADATTRIBUTEIDINVALID)
+						UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_NETWORK, "Server url does not begin with opc.tcp://");
+				}
+				if (!portTmp)
+					portTmp = "0";
+				if (pathTmp) {
+					strncpy(port, portTmp, (size_t)(pathTmp-portTmp));
+					port[(size_t)(pathTmp-portTmp)]='\0';
+					strncpy(path, pathTmp, strlen(pathTmp));
+					path[strlen(pathTmp)]='\0';
+				} else {
+					strncpy(port, portTmp, strlen(portTmp));
+					port[strlen(portTmp)]='\0';
+					path[0]='\0';
+				}
+				free(uri);
+			}
+
+			if (!requestServer->isOnline) {
+				if (UA_Discovery_removeRecord(server, mdnsServer, hostname, (unsigned short) atoi(port), i==requestServer->discoveryUrlsSize) != UA_STATUSCODE_GOOD) {
+					UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not reomve mDNS record for hostname %s.%s", mdnsServer);
+				}
+			}
+			else {
+				UA_String *capabilities = NULL;
+				size_t capabilitiesSize = 0;
+				if (mdnsConfig) {
+					capabilities = mdnsConfig->serverCapabilities;
+					capabilitiesSize = mdnsConfig->serverCapabilitiesSize;
+				}
+				if (UA_Discovery_addRecord(server, mdnsServer, hostname, (unsigned short) atoi(port), path, UA_DISCOVERY_TCP, i==0, capabilities, &capabilitiesSize) != UA_STATUSCODE_GOOD) {
+					UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not add mDNS record for hostname %s.%s", mdnsServer);
+				}
+			}
+		}
+		free(mdnsServer);
+	}
+#endif
+
+
+	if (!requestServer->isOnline) {
+		// server is shutting down. Remove it from the registered servers list
+		if (!registeredServer_entry) {
+			// server not found, show warning
+			UA_LOG_WARNING_SESSION(server->config.logger, session, "Could not unregister server %.*s. Not registered.", (int)requestServer->serverUri.length, requestServer->serverUri.data);
+			responseHeader->serviceResult = UA_STATUSCODE_BADNOTFOUND;
+			return;
+		}
+
+		// server found, remove from list
+		LIST_REMOVE(registeredServer_entry, pointers);
+		UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
+#ifndef UA_ENABLE_MULTITHREADING
+		UA_free(registeredServer_entry);
+		server->registeredServersSize--;
+#else
+		server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, -1);
+        UA_Server_delayedFree(server, registeredServer_entry);
+#endif
+		responseHeader->serviceResult = UA_STATUSCODE_GOOD;
+		return;
+	}
+
+
+	UA_StatusCode retval = UA_STATUSCODE_GOOD;
+	if (!registeredServer_entry) {
+		// server not yet registered, register it by adding it to the list
+
+
+		UA_LOG_DEBUG_SESSION(server->config.logger, session, "Registering new server: %.*s", (int)requestServer->serverUri.length, requestServer->serverUri.data);
+
+		registeredServer_entry = UA_malloc(sizeof(registeredServer_list_entry));
+		if(!registeredServer_entry) {
+			responseHeader->serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
+			return;
+		}
+
+		LIST_INSERT_HEAD(&server->registeredServers, registeredServer_entry, pointers);
+#ifndef UA_ENABLE_MULTITHREADING
+		server->registeredServersSize++;
+#else
+		server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, 1);
+#endif
+
+	} else {
+		UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
+	}
+
+	// copy the data from the request into the list
+	UA_RegisteredServer_copy(requestServer, &registeredServer_entry->registeredServer);
+	registeredServer_entry->lastSeen = UA_DateTime_now();
+
+	responseHeader->serviceResult = retval;
+}
+
 void Service_RegisterServer(UA_Server *server, UA_Session *session,
                          const UA_RegisterServerRequest *request, UA_RegisterServerResponse *response) {
     UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing RegisterServerRequest");
+	process_RegisterServer(server, session, &request->requestHeader, &request->server, 0, NULL, &response->responseHeader, 0, NULL, 0, NULL);
+}
 
-    registeredServer_list_entry *registeredServer_entry = NULL;
-
-    {
-        // find the server from the request in the registered list
-        registeredServer_list_entry* current;
-        LIST_FOREACH(current, &server->registeredServers, pointers) {
-            if (UA_String_equal(&current->registeredServer.serverUri, &request->server.serverUri)) {
-                registeredServer_entry = current;
-                break;
-            }
-        }
-    }
-
-    if (!request->server.isOnline) {
-        // server is shutting down. Remove it from the registered servers list
-        if (!registeredServer_entry) {
-            // server not found, show warning
-            UA_LOG_WARNING_SESSION(server->config.logger, session, "Could not unregister server %.*s. Not registered.", (int)request->server.serverUri.length, request->server.serverUri.data);
-            response->responseHeader.serviceResult = UA_STATUSCODE_BADNOTFOUND;
-            return;
-        }
-
-        // server found, remove from list
-        LIST_REMOVE(registeredServer_entry, pointers);
-        UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
-#ifndef UA_ENABLE_MULTITHREADING
-        UA_free(registeredServer_entry);
-        server->registeredServersSize--;
-#else
-        server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, -1);
-        UA_Server_delayedFree(server, registeredServer_entry);
-#endif
-        response->responseHeader.serviceResult = UA_STATUSCODE_GOOD;
-        return;
-    }
-
-
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    if (!registeredServer_entry) {
-        // server not yet registered, register it by adding it to the list
-
-
-        UA_LOG_DEBUG_SESSION(server->config.logger, session, "Registering new server: %.*s", (int)request->server.serverUri.length, request->server.serverUri.data);
-
-        registeredServer_entry = UA_malloc(sizeof(registeredServer_list_entry));
-        if(!registeredServer_entry) {
-            response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
-            return;
-        }
-
-        LIST_INSERT_HEAD(&server->registeredServers, registeredServer_entry, pointers);
-#ifndef UA_ENABLE_MULTITHREADING
-        server->registeredServersSize++;
-#else
-        server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, 1);
-#endif
-
-    } else {
-        UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
-    }
+void Service_RegisterServer2(UA_Server *server, UA_Session *session,
+                            const UA_RegisterServer2Request *request, UA_RegisterServer2Response *response) {
+    UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing RegisterServer2Request");
 
     // copy the data from the request into the list
     UA_RegisteredServer_copy(&request->server, &registeredServer_entry->registeredServer);
     registeredServer_entry->lastSeen = UA_DateTime_nowMonotonic();
 
-    response->responseHeader.serviceResult = retval;
+	process_RegisterServer(server, session, &request->requestHeader, &request->server, request->discoveryConfigurationSize, request->discoveryConfiguration,
+						   &response->responseHeader, &response->configurationResultsSize, &response->configurationResults,
+						   &response->diagnosticInfosSize, response->diagnosticInfos);
+
 }
 
 /**
@@ -360,7 +824,6 @@ void Service_RegisterServer(UA_Server *server, UA_Session *session,
  * If there is no semaphore file, then the registration will be removed if it is older than 60 minutes.
  */
 void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
-
     UA_DateTime timedOut = nowMonotonic;
     // registration is timed out if lastSeen is older than 60 minutes (default value, can be modified by user).
     if (server->config.discoveryCleanupTimeout) {
@@ -376,7 +839,12 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
             char* filePath = malloc(sizeof(char)*current->registeredServer.semaphoreFilePath.length+1);
             memcpy( filePath, current->registeredServer.semaphoreFilePath.data, current->registeredServer.semaphoreFilePath.length );
             filePath[current->registeredServer.semaphoreFilePath.length] = '\0';
+
+#ifdef _MSC_VER
+            semaphoreDeleted = _access( filePath, 0 ) == -1;
+#else
             semaphoreDeleted = access( filePath, 0 ) == -1;
+#endif
             free(filePath);
         }
 
@@ -405,4 +873,503 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
     }
 }
 
+struct PeriodicServerRegisterJob {
+    UA_Boolean is_main_job;
+    UA_UInt32 default_interval;
+    UA_Guid job_id;
+    UA_Job *job;
+    UA_UInt32 this_interval;
+};
+
+/**
+ * Called by the UA_Server job.
+ * The OPC UA specification says:
+ *
+ * > If an error occurs during registration (e.g. the Discovery Server is not running) then the Server
+ * > must periodically re-attempt registration. The frequency of these attempts should start at 1 second
+ * > but gradually increase until the registration frequency is the same as what it would be if not
+ * > errors occurred. The recommended approach would double the period each attempt until reaching the maximum.
+ *
+ * We will do so by using the additional data parameter which holds information if the next interval
+ * is default or if it is a repeaded call.
+ */
+static void periodicServerRegister(UA_Server *server, void *data) {
+
+    if (data == NULL) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Data parameter must be not NULL for periodic server register");
+        return;
+    }
+
+    struct PeriodicServerRegisterJob *retryJob = (struct PeriodicServerRegisterJob *)data;
+
+    if (!retryJob->is_main_job) {
+        // remove the retry job because we don't want to fire it again.
+        UA_Server_removeRepeatedJob(server, retryJob->job_id);
+    }
+
+
+    UA_StatusCode retval = UA_Server_register_discovery(server, "opc.tcp://localhost:4840", NULL);
+    // You can also use a semaphore file. That file must exist. When the file is deleted, the server is automatically unregistered.
+    // The semaphore file has to be accessible by the discovery server
+    // UA_StatusCode retval = UA_Server_register_discovery(server, "opc.tcp://localhost:4840", "/path/to/some/file");
+    if (retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not register server with discovery server. Is the discovery server started? StatusCode 0x%08x", retval);
+
+        // first retry in 1 second
+        UA_UInt32 nextInterval = 1;
+
+        if (!retryJob->is_main_job) {
+            nextInterval = retryJob->this_interval*2;
+        }
+
+        // as long as next retry is smaller than 10 minutes, retry
+        if (nextInterval < retryJob->default_interval) {
+            UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Retrying registration in %d seconds", nextInterval);
+            struct PeriodicServerRegisterJob *newRetryJob = malloc(sizeof(struct PeriodicServerRegisterJob));
+            newRetryJob->job = malloc(sizeof(UA_Job));
+            newRetryJob->default_interval = retryJob->default_interval;
+            newRetryJob->is_main_job = UA_FALSE;
+            newRetryJob->this_interval = nextInterval;
+
+            newRetryJob->job->type = UA_JOBTYPE_METHODCALL;
+            newRetryJob->job->job.methodCall.method = periodicServerRegister;
+            newRetryJob->job->job.methodCall.data = newRetryJob;
+
+            UA_Server_addRepeatedJob(server, *newRetryJob->job, nextInterval*1000, &newRetryJob->job_id);
+        }
+    } else {
+        UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Server successfully registered. Next periodical register will be in %d seconds", (int)(retryJob->default_interval/1000));
+    }
+    if (!retryJob->is_main_job) {
+        UA_free(retryJob->job);
+        UA_free(retryJob);
+    }
+
+}
+
+UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA_UInt32 intervalMs, const UA_UInt32 delayFirstRegisterMs, UA_Guid* periodicJobId) {
+
+    // registering the server should be done periodically. Approx. every 10 minutes. The first call will be in 10 Minutes.
+
+    UA_Job job = {.type = UA_JOBTYPE_METHODCALL,
+            .job.methodCall = {.method = periodicServerRegister, .data = NULL} };
+
+    struct PeriodicServerRegisterJob defaultJob = {
+            .job = &job,
+            .this_interval = 0,
+            .is_main_job = UA_TRUE,
+            .default_interval = intervalMs
+    };
+    job.job.methodCall.data = &defaultJob;
+
+
+    if (periodicJobId)
+        *periodicJobId = defaultJob.job_id;
+    UA_StatusCode retval = UA_Server_addRepeatedJob(server, *defaultJob.job, intervalMs, &defaultJob.job_id);
+    if (retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not create periodic job for server register. StatusCode 0x%08x", retval);
+        return retval;
+    }
+
+    if (delayFirstRegisterMs>0) {
+        // Register the server with the discovery server.
+        // Delay this first registration until the server is fully initialized
+        // will be freed in the callback
+        struct PeriodicServerRegisterJob *newRetryJob = malloc(sizeof(struct PeriodicServerRegisterJob));
+        newRetryJob->job = malloc(sizeof(UA_Job));
+        newRetryJob->this_interval = 1;
+        newRetryJob->is_main_job = UA_FALSE;
+        newRetryJob->default_interval = intervalMs;
+        newRetryJob->job->type = UA_JOBTYPE_METHODCALL;
+        newRetryJob->job->job.methodCall.method = periodicServerRegister;
+        newRetryJob->job->job.methodCall.data = newRetryJob;
+        retval = UA_Server_addRepeatedJob(server, *newRetryJob->job, delayFirstRegisterMs, &newRetryJob->job_id);
+        if (retval != UA_STATUSCODE_GOOD) {
+            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not create first job for server register. StatusCode 0x%08x", retval);
+            return retval;
+        }
+    }
+    return UA_STATUSCODE_GOOD;
+}
+
+# ifdef UA_ENABLE_DISCOVERY_MULTICAST
+
+static void socket_mdns_set_nonblocking(int sockfd) {
+#ifdef _WIN32
+    u_long iMode = 1;
+    ioctlsocket(sockfd, FIONBIO, &iMode);
+#else
+    int opts = fcntl(sockfd, F_GETFL);
+    fcntl(sockfd, F_SETFL, opts|O_NONBLOCK);
 #endif
+}
+
+/* Create multicast 224.0.0.251:5353 socket */
+static int discovery_createMulticastSocket(void) {
+    int s, flag = 1, ittl = 255;
+    struct sockaddr_in in;
+    struct ip_mreq mc;
+    char ttl = (char)255; // publish to complete net, not only subnet. See: https://docs.oracle.com/cd/E23824_01/html/821-1602/sockets-137.html
+
+    memset(&in, 0, sizeof(in));
+    in.sin_family = AF_INET;
+    in.sin_port = htons(5353);
+    in.sin_addr.s_addr = 0;
+
+    if ((s = (int)socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+        return 0;
+
+#ifdef SO_REUSEPORT
+    setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char *)&flag, sizeof(flag));
+#endif
+    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&flag, sizeof(flag));
+    if (bind(s, (struct sockaddr *)&in, sizeof(in))) {
+        CLOSESOCKET(s);
+        return 0;
+    }
+
+    mc.imr_multiaddr.s_addr = inet_addr("224.0.0.251");
+    mc.imr_interface.s_addr = htonl(INADDR_ANY);
+    setsockopt(s, IPPROTO_IP, IP_ADD_MEMBERSHIP, (void*)&mc, sizeof(mc));
+    setsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL, (void*)&ttl, sizeof(ttl));
+    setsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL, (void*)&ittl, sizeof(ittl));
+
+	socket_mdns_set_nonblocking(s);
+    return s;
+}
+
+UA_StatusCode UA_Discovery_multicastInit(UA_Server* server) {
+    server->mdnsDaemon = mdnsd_new(QCLASS_IN, 1000);
+    if ((server->mdnsSocket = discovery_createMulticastSocket()) == 0) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not create multicast socket. Error: %s", strerror(errno));
+        return UA_STATUSCODE_BADUNEXPECTEDERROR;
+    }
+	mdnsd_register_receive_callback(server->mdnsDaemon, mdns_record_received, server);
+    return UA_STATUSCODE_GOOD;
+}
+
+void UA_Discovery_multicastDestroy(UA_Server* server) {
+    mdnsd_shutdown(server->mdnsDaemon);
+    mdnsd_free(server->mdnsDaemon);
+}
+
+static void UA_Discovery_multicastConflict(char *name, int type, void *arg) {
+	// cppcheck-suppress unreadVariable
+	UA_Server *server = (UA_Server*) arg;
+    UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS name conflict detected: '%s' for type %d", name, type);
+}
+
+static char* create_fullServiceDomain(const char* servername, const char* hostname) {
+	size_t hostnameLen = strlen(hostname);
+	size_t servernameLen = strlen(servername);
+	// [servername]._opcua-tcp._tcp.[hostname].
+	char *fullServiceDomain = malloc(hostnameLen + 25 + servernameLen);
+	if (!fullServiceDomain) {
+		return NULL;
+	}
+	snprintf(fullServiceDomain, hostnameLen + hostnameLen + 25 + servernameLen, "%s._opcua-tcp._tcp.%s.", servername, hostname);
+	return fullServiceDomain;
+}
+
+/**
+ * Check if mDNS already has an entry for given hostname and port combination.
+ * @param server
+ * @param hostname
+ * @param port
+ * @param protocol
+ * @return
+ */
+static UA_StatusCode UA_Discovery_recordExists(UA_Server* server,const char* fullServiceDomain, unsigned short port, const UA_DiscoveryProtocol protocol) {
+    unsigned short found = 0;
+
+    // [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port [hostname].
+    mdns_record_t *r  = mdnsd_get_published(server->mdnsDaemon, fullServiceDomain);
+    if (r) {
+        while (r) {
+            const mdns_answer_t *data = mdnsd_record_data(r);
+            if (data->type == QTYPE_SRV && data->srv.port == port) {
+                found = 1;
+                break;
+            }
+            r = mdnsd_record_next(r);
+        }
+    }
+    return found ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOTFOUND;
+}
+
+UA_StatusCode UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, const char* path,
+									 const UA_DiscoveryProtocol protocol, UA_Boolean createTxt, const UA_String* capabilites, const size_t *capabilitiesSize) {
+	if (capabilitiesSize == NULL || (*capabilitiesSize>0 && capabilites == NULL)) {
+		return UA_STATUSCODE_BADINVALIDARGUMENT;
+	}
+
+	size_t hostnameLen = strlen(hostname);
+	size_t servernameLen = strlen(servername);
+	// use a limit for the hostname length to make sure full string fits into 256 chars
+	if (hostnameLen == 0 || hostnameLen > 150 || servernameLen == 0 || servernameLen > 150) {
+		return UA_STATUSCODE_BADOUTOFRANGE;
+	}
+
+	if (!server->mdnsMainSrvAdded) {
+		mdns_record_t *r = mdnsd_shared(server->mdnsDaemon, "_services._dns-sd._udp.local.", QTYPE_PTR, 600);
+		mdnsd_set_host(server->mdnsDaemon, r, "_opcua-tcp._tcp.local.");
+		server->mdnsMainSrvAdded = 1;
+	}
+
+	// [servername]._opcua-tcp._tcp.[hostname].
+	char *fullServiceDomain;
+	if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname))) {
+		return UA_STATUSCODE_BADOUTOFMEMORY;
+	}
+
+    if (UA_Discovery_recordExists(server, fullServiceDomain, port, protocol) == UA_STATUSCODE_GOOD) {
+		free(fullServiceDomain);
+        return UA_STATUSCODE_GOOD;
+    }
+
+	UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: add record for domain: %s", fullServiceDomain);
+
+
+	// _services._dns-sd._udp.local. PTR _opcua-tcp._tcp.local
+
+    // check if there is already a PTR entry for the given service.
+    mdns_record_t *r = mdnsd_get_published(server->mdnsDaemon, "_opcua-tcp._tcp.local.");
+    unsigned short found = 0;
+    // search for the record with the correct ptr hostname
+    while (r) {
+        const mdns_answer_t *data = mdnsd_record_data(r);
+
+        if (data->type == QTYPE_PTR && strcmp(data->rdname, fullServiceDomain)==0) {
+            found = 1;
+            break;
+        }
+        r = mdnsd_record_next(r);
+    }
+
+	// _opcua-tcp._tcp.local. PTR [servername]._opcua-tcp._tcp.[hostname].
+    if (!found) {
+        r = mdnsd_shared(server->mdnsDaemon, "_opcua-tcp._tcp.local.", QTYPE_PTR, 600);
+        mdnsd_set_host(server->mdnsDaemon, r, fullServiceDomain);
+    }
+
+    // hostname.local
+    char *localDomain = malloc(hostnameLen + 8);
+    if (!localDomain) {
+        free(fullServiceDomain);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    snprintf(localDomain, hostnameLen + 8, "%s.", hostname);
+
+
+    // [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port [hostname].
+	r = mdnsd_unique(server->mdnsDaemon, fullServiceDomain, QTYPE_SRV, 600, UA_Discovery_multicastConflict, server);
+	// r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_SRV, 600);
+    mdnsd_set_srv(server->mdnsDaemon, r, 0, 0, port, localDomain);
+
+    // TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
+	if (createTxt) {
+		r = mdnsd_unique(server->mdnsDaemon, fullServiceDomain, QTYPE_TXT, 600, UA_Discovery_multicastConflict, server);
+		xht_t* h = xht_new(11);
+		char* allocPath = NULL;
+		if (strlen(path) == 0)
+			xht_set(h, "path", "/");
+		else {
+			allocPath = STRDUP(path);
+			xht_set(h, "path", allocPath);
+		}
+
+
+		// calculate max string length:
+		size_t capsLen = 0;
+
+		for (size_t i = 0; i < *capabilitiesSize; i++) {
+			// add comma or last \0
+			capsLen += capabilites[i].length + 1;
+		}
+
+		char* caps = NULL;
+		if (capsLen) {
+			// freed when xht_free is called
+			caps = malloc(sizeof(char) * capsLen);
+			size_t idx = 0;
+			for (size_t i = 0; i < *capabilitiesSize; i++) {
+				strncpy(caps + idx, (const char *)capabilites[i].data, capabilites[i].length);
+				idx += capabilites[i].length + 1;
+				caps[idx - 1] = ',';
+			}
+			caps[idx - 1] = '\0';
+
+			xht_set(h, "caps", caps);
+		} else {
+			xht_set(h, "caps", "NA");
+		}
+
+		int txtRecordLength;
+		unsigned char* packet = sd2txt(h, &txtRecordLength);
+		if (allocPath)
+			free(allocPath);
+		if (caps)
+			free(caps);
+		xht_free(h);
+		mdnsd_set_raw(server->mdnsDaemon, r, (char*) packet, (unsigned short) txtRecordLength);
+		free(packet);
+	}
+
+    free(fullServiceDomain);
+    free(localDomain);
+
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, UA_Boolean removeTxt) {
+	size_t hostnameLen = strlen(hostname);
+	size_t servernameLen = strlen(servername);
+	// use a limit for the hostname length to make sure full string fits into 256 chars
+	if (hostnameLen == 0 || hostnameLen > 150 || servernameLen == 0 || servernameLen > 150) {
+		return UA_STATUSCODE_BADOUTOFRANGE;
+	}
+
+	// [servername]._opcua-tcp._tcp.[hostname].
+	char *fullServiceDomain;
+	if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname))) {
+		return UA_STATUSCODE_BADOUTOFMEMORY;
+	}
+
+	UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: remove record for domain: %s", fullServiceDomain);
+
+    // count the number of records stil there for the given hostname, but a different port.
+    // it does not represent the total number, but the minimum value.
+    // if the number is 1, then also delete the main PTR record
+    unsigned int recordMinCount = 0;
+	// _opcua-tcp._tcp.local. PTR [servername]._opcua-tcp._tcp.[hostname].
+    mdns_record_t *r = mdnsd_get_published(server->mdnsDaemon, "_opcua-tcp._tcp.local.");
+	if (r) {
+		while (r) {
+            recordMinCount++;
+            const mdns_answer_t *data = mdnsd_record_data(r);
+			if (data->type == QTYPE_PTR && strcmp(data->rdname, fullServiceDomain)==0) {
+				mdnsd_done(server->mdnsDaemon,r);
+				if (mdnsd_record_next(r))
+					recordMinCount++; // there may still be more records, but we don't care how much
+				break;
+			}
+			r = mdnsd_record_next(r);
+		}
+	} else {
+		UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: could not remove record. PTR Record not found for domain: %s", fullServiceDomain);
+		free(fullServiceDomain);
+		return UA_STATUSCODE_BADNOTFOUND;
+	}
+
+	// [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port hostname.local.
+	// and TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
+    r = mdnsd_get_published(server->mdnsDaemon, fullServiceDomain);
+	if (r) {
+		while (r) {
+            const mdns_answer_t *data = mdnsd_record_data(r);
+			if ((removeTxt && data->type == QTYPE_TXT) || data->srv.port == port) {
+                mdnsd_done(server->mdnsDaemon,r);
+                break;
+            }
+			r = mdnsd_record_next(r);
+		}
+	} else {
+		UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: could not remove record. Record not found for domain: %s", fullServiceDomain);
+		free(fullServiceDomain);
+		return UA_STATUSCODE_BADNOTFOUND;
+	}
+
+    if (recordMinCount <= 1) {
+        // _services._dns-sd._udp.local. PTR "_opcua-tcp._tcp.local."
+        r = mdnsd_get_published(server->mdnsDaemon, "_services._dns-sd._udp.local.");
+        // search for the record with the correct ptr hostname
+        while (r) {
+            const mdns_answer_t *data = mdnsd_record_data(r);
+            if (data->type == QTYPE_PTR && strcmp(data->rdname, "_opcua-tcp._tcp.local.")==0) {
+                mdnsd_done(server->mdnsDaemon,r);
+                break;
+            }
+            r = mdnsd_record_next(r);
+        }
+		server->mdnsMainSrvAdded = 0;
+    }
+
+    free(fullServiceDomain);
+	return UA_STATUSCODE_GOOD;
+}
+
+#  ifdef UA_ENABLE_MULTITHREADING
+
+static void * multicastWorkerLoop(UA_Server *server) {
+	struct timeval next_sleep = {.tv_sec = 0, .tv_usec = 0};
+
+
+	volatile UA_Boolean *running = &server->mdnsRunning;
+	fd_set fds;
+
+	while (*running) {
+
+		FD_ZERO(&fds);
+		FD_SET(server->mdnsSocket, &fds);
+		select(server->mdnsSocket + 1, &fds, 0, 0, &next_sleep);
+
+		if (!*running)
+			break;
+
+
+		unsigned short retVal = mdnsd_step(server->mdnsDaemon, server->mdnsSocket, FD_ISSET(server->mdnsSocket, &fds), true, &next_sleep);
+		if (retVal == 1) {
+			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not read from socket. %s", strerror(errno));
+			break;
+		} else if (retVal == 2) {
+			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not write to socket. %s", strerror(errno));
+			break;
+		}
+
+		if (!*running)
+			break;
+	}
+
+	return NULL;
+}
+
+UA_StatusCode UA_Discovery_multicastListenStart(UA_Server* server) {
+	if (pthread_create(&server->mdnsThread, NULL, (void* (*)(void*))multicastWorkerLoop, server)) {
+		UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not create multicast thread.");
+		return UA_STATUSCODE_BADUNEXPECTEDERROR;
+	}
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode UA_Discovery_multicastListenStop(UA_Server* server) {
+	mdnsd_shutdown(server->mdnsDaemon);
+	// wake up select
+	write(server->mdnsSocket, "\0", 1);
+	if(pthread_join(server->mdnsThread, NULL)) {
+		UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not stop thread.");
+		return UA_STATUSCODE_BADUNEXPECTEDERROR;
+	}
+    return UA_STATUSCODE_BADNOTIMPLEMENTED;
+}
+
+#  endif // UA_ENABLE_DISCOVERY_MULTICAST && UA_ENABLE_MULTITHREADING
+
+
+UA_StatusCode UA_Discovery_multicastIterate(UA_Server* server, UA_DateTime *nextRepeat, UA_Boolean processIn) {
+    struct timeval next_sleep = {.tv_sec = 0, .tv_usec = 0};
+    unsigned short retVal = mdnsd_step(server->mdnsDaemon, server->mdnsSocket, processIn, true, &next_sleep);
+    if (retVal == 1) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not read from socket. %s", strerror(errno));
+        return UA_STATUSCODE_BADNOCOMMUNICATION;
+    } else if (retVal == 2) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not write to socket. %s", strerror(errno));
+        return UA_STATUSCODE_BADNOCOMMUNICATION;
+    }
+	if (nextRepeat)
+    	*nextRepeat = UA_DateTime_now() + (UA_DateTime)(next_sleep.tv_sec * UA_SEC_TO_DATETIME + next_sleep.tv_usec * UA_USEC_TO_DATETIME);
+    return UA_STATUSCODE_GOOD;
+}
+
+# endif // UA_ENABLE_DISCOVERY_MULTICAST
+
+#endif // UA_ENABLE_DISCOVERY

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -972,20 +972,20 @@ static void periodicServerRegister(UA_Server *server, void *data) {
 UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA_UInt32 intervalMs,
                                                      const UA_UInt32 delayFirstRegisterMs, UA_Guid* periodicJobId) {
 
-	if (server->periodicServerRegisterJob != NULL) {
-		return UA_STATUSCODE_BADNOTIMPLEMENTED;
-	}
+    if (server->periodicServerRegisterJob != NULL) {
+        return UA_STATUSCODE_BADNOTIMPLEMENTED;
+    }
 
     // registering the server should be done periodically. Approx. every 10 minutes. The first call will be in 10 Minutes.
 
     UA_Job job = {.type = UA_JOBTYPE_METHODCALL,
             .job.methodCall = {.method = periodicServerRegister, .data = NULL} };
 
-	server->periodicServerRegisterJob = UA_malloc(sizeof(struct PeriodicServerRegisterJob));
-	server->periodicServerRegisterJob->job = &job;
-	server->periodicServerRegisterJob->this_interval = 0;
-	server->periodicServerRegisterJob->is_main_job = UA_TRUE;
-	server->periodicServerRegisterJob->default_interval = intervalMs;
+    server->periodicServerRegisterJob = UA_malloc(sizeof(struct PeriodicServerRegisterJob));
+    server->periodicServerRegisterJob->job = &job;
+    server->periodicServerRegisterJob->this_interval = 0;
+    server->periodicServerRegisterJob->is_main_job = UA_TRUE;
+    server->periodicServerRegisterJob->default_interval = intervalMs;
     job.job.methodCall.data = server->periodicServerRegisterJob;
 
 
@@ -995,9 +995,9 @@ UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA
                      "Could not create periodic job for server register. StatusCode 0x%08x", retval);
         return retval;
     }
-	if (periodicJobId) {
-		UA_Guid_copy(&server->periodicServerRegisterJob->job_id, periodicJobId);
-	}
+    if (periodicJobId) {
+        UA_Guid_copy(&server->periodicServerRegisterJob->job_id, periodicJobId);
+    }
 
     if (delayFirstRegisterMs>0) {
         // Register the server with the discovery server.
@@ -1093,23 +1093,23 @@ static char* create_fullServiceDomain(const char* servername, const char* hostna
     size_t servernameLen = strlen(servername);
     // [servername]-[hostname]._opcua-tcp._tcp.local.
 
-	if (hostnameLen+servernameLen+1 > maxLen) {
-		if (servernameLen+2 > maxLen) {
-			servernameLen = maxLen;
-			hostnameLen = 0;
-		} else {
-			hostnameLen = maxLen - servernameLen - 1;
-		}
-	}
+    if (hostnameLen+servernameLen+1 > maxLen) {
+        if (servernameLen+2 > maxLen) {
+            servernameLen = maxLen;
+            hostnameLen = 0;
+        } else {
+            hostnameLen = maxLen - servernameLen - 1;
+        }
+    }
 
     char *fullServiceDomain = malloc(servernameLen + 1 + hostnameLen + 23);
     if (!fullServiceDomain) {
         return NULL;
     }
-	if (hostnameLen > 0)
-    	snprintf(fullServiceDomain, servernameLen + 1 + hostnameLen + 23, "%.*s-%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername, (int)hostnameLen, hostname);
-	else
-		snprintf(fullServiceDomain, servernameLen + 23, "%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername);
+    if (hostnameLen > 0)
+        snprintf(fullServiceDomain, servernameLen + 1 + hostnameLen + 23, "%.*s-%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername, (int)hostnameLen, hostname);
+    else
+        snprintf(fullServiceDomain, servernameLen + 23, "%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername);
     return fullServiceDomain;
 }
 
@@ -1123,46 +1123,46 @@ static char* create_fullServiceDomain(const char* servername, const char* hostna
  */
 static UA_StatusCode
 UA_Discovery_recordExists(UA_Server* server, const char* fullServiceDomain,
-						  unsigned short port, const UA_DiscoveryProtocol protocol) {
-	unsigned short found = 0;
+                          unsigned short port, const UA_DiscoveryProtocol protocol) {
+    unsigned short found = 0;
 
-	// [servername]-[hostname]._opcua-tcp._tcp.local. 86400 IN SRV 0 5 port [hostname].
-	mdns_record_t *r  = mdnsd_get_published(server->mdnsDaemon, fullServiceDomain);
-	if (r) {
-		while (r) {
-			const mdns_answer_t *data = mdnsd_record_data(r);
-			if (data->type == QTYPE_SRV && (port == 0 || data->srv.port == port)) {
-				found = 1;
-				break;
-			}
-			r = mdnsd_record_next(r);
-		}
-	}
-	return found ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOTFOUND;
+    // [servername]-[hostname]._opcua-tcp._tcp.local. 86400 IN SRV 0 5 port [hostname].
+    mdns_record_t *r  = mdnsd_get_published(server->mdnsDaemon, fullServiceDomain);
+    if (r) {
+        while (r) {
+            const mdns_answer_t *data = mdnsd_record_data(r);
+            if (data->type == QTYPE_SRV && (port == 0 || data->srv.port == port)) {
+                found = 1;
+                break;
+            }
+            r = mdnsd_record_next(r);
+        }
+    }
+    return found ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOTFOUND;
 }
 
 static int discovery_multicastQueryAnswer(mdns_answer_t *a, void *arg) {
-	UA_Server *server = (UA_Server*) arg;
-	if (a->type != QTYPE_PTR)
-		return 0;
+    UA_Server *server = (UA_Server*) arg;
+    if (a->type != QTYPE_PTR)
+        return 0;
 
-	if (a->rdname == NULL)
-		return 0;
+    if (a->rdname == NULL)
+        return 0;
 
-	if (UA_Discovery_recordExists(server, a->rdname, 0, UA_DISCOVERY_TCP) == UA_STATUSCODE_GOOD) {
-		// we already know about this server. So skip.
-		return 0;
-	}
+    if (UA_Discovery_recordExists(server, a->rdname, 0, UA_DISCOVERY_TCP) == UA_STATUSCODE_GOOD) {
+        // we already know about this server. So skip.
+        return 0;
+    }
 
-	if (mdnsd_has_query(server->mdnsDaemon, a->rdname))
-		return 0;
+    if (mdnsd_has_query(server->mdnsDaemon, a->rdname))
+        return 0;
 
-	UA_LOG_DEBUG(server->config.logger, UA_LOGCATEGORY_SERVER, "mDNS send query for: %s SRV&TXT %s", a->name, a->rdname);
+    UA_LOG_DEBUG(server->config.logger, UA_LOGCATEGORY_SERVER, "mDNS send query for: %s SRV&TXT %s", a->name, a->rdname);
 
-	mdnsd_query(server->mdnsDaemon, a->rdname,QTYPE_SRV,discovery_multicastQueryAnswer, server);
-	mdnsd_query(server->mdnsDaemon, a->rdname,QTYPE_TXT,discovery_multicastQueryAnswer, server);
+    mdnsd_query(server->mdnsDaemon, a->rdname,QTYPE_SRV,discovery_multicastQueryAnswer, server);
+    mdnsd_query(server->mdnsDaemon, a->rdname,QTYPE_TXT,discovery_multicastQueryAnswer, server);
 
-	return 0;
+    return 0;
 }
 
 /**
@@ -1174,7 +1174,7 @@ static int discovery_multicastQueryAnswer(mdns_answer_t *a, void *arg) {
 UA_StatusCode
 UA_Discovery_multicastQuery(UA_Server* server) {
     mdnsd_query(server->mdnsDaemon, "_opcua-tcp._tcp.local.",QTYPE_PTR,discovery_multicastQueryAnswer, server);
-	return UA_STATUSCODE_GOOD;
+    return UA_STATUSCODE_GOOD;
 }
 
 UA_StatusCode
@@ -1191,10 +1191,10 @@ UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* ho
     if (hostnameLen == 0 || servernameLen == 0) {
         return UA_STATUSCODE_BADOUTOFRANGE;
     } else if (hostnameLen+servernameLen+1 > 63) { // include dash between servername-hostname
-		UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: Combination of hostname+servername exceeds maximum of 62 chars. It will be truncated.");
-	} else if (hostnameLen > 63) {
-		UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: Hostname length exceeds maximum of 63 chars. It will be truncated.");
-	}
+        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: Combination of hostname+servername exceeds maximum of 62 chars. It will be truncated.");
+    } else if (hostnameLen > 63) {
+        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: Hostname length exceeds maximum of 63 chars. It will be truncated.");
+    }
 
     if (!server->mdnsMainSrvAdded) {
         mdns_record_t *r = mdnsd_shared(server->mdnsDaemon, "_services._dns-sd._udp.local.", QTYPE_PTR, 600);
@@ -1252,164 +1252,164 @@ UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* ho
     // r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_SRV, 600);
     mdnsd_set_srv(server->mdnsDaemon, r, 0, 0, port, localDomain);
 
-	// A/AAAA record for all ip addresses.
-	// [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
-	// [hostname]. A [ip].
+    // A/AAAA record for all ip addresses.
+    // [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
+    // [hostname]. A [ip].
 #ifdef _WIN32
-	// see http://stackoverflow.com/a/10838854/869402
-	IP_ADAPTER_ADDRESSES* adapter_addresses = NULL;
-	IP_ADAPTER_ADDRESSES* adapter = NULL;
+    // see http://stackoverflow.com/a/10838854/869402
+    IP_ADAPTER_ADDRESSES* adapter_addresses = NULL;
+    IP_ADAPTER_ADDRESSES* adapter = NULL;
 
-	// Start with a 16 KB buffer and resize if needed -
-	// multiple attempts in case interfaces change while
-	// we are in the middle of querying them.
-	DWORD adapter_addresses_buffer_size = 16 * 1024;
-	for (int attempts = 0; attempts != 3; ++attempts)
-	{
-		adapter_addresses = (IP_ADAPTER_ADDRESSES*)malloc(adapter_addresses_buffer_size);
-		assert(adapter_addresses);
+    // Start with a 16 KB buffer and resize if needed -
+    // multiple attempts in case interfaces change while
+    // we are in the middle of querying them.
+    DWORD adapter_addresses_buffer_size = 16 * 1024;
+    for (int attempts = 0; attempts != 3; ++attempts)
+    {
+        adapter_addresses = (IP_ADAPTER_ADDRESSES*)malloc(adapter_addresses_buffer_size);
+        assert(adapter_addresses);
 
-		DWORD error = GetAdaptersAddresses(
-			AF_UNSPEC, 
-			GAA_FLAG_SKIP_ANYCAST |
-				GAA_FLAG_SKIP_DNS_SERVER |
-				GAA_FLAG_SKIP_FRIENDLY_NAME, 
-			NULL, 
-			adapter_addresses,
-			&adapter_addresses_buffer_size);
+        DWORD error = GetAdaptersAddresses(
+            AF_UNSPEC, 
+            GAA_FLAG_SKIP_ANYCAST |
+                GAA_FLAG_SKIP_DNS_SERVER |
+                GAA_FLAG_SKIP_FRIENDLY_NAME, 
+            NULL, 
+            adapter_addresses,
+            &adapter_addresses_buffer_size);
 
-		if (ERROR_SUCCESS == error)
-		{
-			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"GetAdaptersAddresses returned an error. Not setting mDNS A records.");
-			adapter_addresses = NULL;
-			break;
-		}
-		else if (ERROR_BUFFER_OVERFLOW == error)
-		{
-			// Try again with the new size
-			free(adapter_addresses);
-			adapter_addresses = NULL;
+        if (ERROR_SUCCESS == error)
+        {
+            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"GetAdaptersAddresses returned an error. Not setting mDNS A records.");
+            adapter_addresses = NULL;
+            break;
+        }
+        else if (ERROR_BUFFER_OVERFLOW == error)
+        {
+            // Try again with the new size
+            free(adapter_addresses);
+            adapter_addresses = NULL;
 
-			continue;
-		}
-		else
-		{
-			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"GetAdaptersAddresses returned an unexpected error. Not setting mDNS A records.");
-			// Unexpected error code - log and throw
-			free(adapter_addresses);
-			adapter_addresses = NULL;
+            continue;
+        }
+        else
+        {
+            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"GetAdaptersAddresses returned an unexpected error. Not setting mDNS A records.");
+            // Unexpected error code - log and throw
+            free(adapter_addresses);
+            adapter_addresses = NULL;
 
-			break;
-		}
-	}
+            break;
+        }
+    }
 
-	// Iterate through all of the adapters
-	for (adapter = adapter_addresses; NULL != adapter; adapter = adapter->Next)
-	{
-		// Skip loopback adapters
-		if (IF_TYPE_SOFTWARE_LOOPBACK == adapter->IfType)
-		{
-			continue;
-		}
+    // Iterate through all of the adapters
+    for (adapter = adapter_addresses; NULL != adapter; adapter = adapter->Next)
+    {
+        // Skip loopback adapters
+        if (IF_TYPE_SOFTWARE_LOOPBACK == adapter->IfType)
+        {
+            continue;
+        }
 
-		// Parse all IPv4 and IPv6 addresses
-		for (
-			IP_ADAPTER_UNICAST_ADDRESS* address = adapter->FirstUnicastAddress; 
-			NULL != address;
-			address = address->Next)
-		{
-			int family = address->Address.lpSockaddr->sa_family;
-			if (AF_INET == family)
-			{
-				// IPv4
-				SOCKADDR_IN* ipv4 = (SOCKADDR_IN*)(address->Address.lpSockaddr);
+        // Parse all IPv4 and IPv6 addresses
+        for (
+            IP_ADAPTER_UNICAST_ADDRESS* address = adapter->FirstUnicastAddress; 
+            NULL != address;
+            address = address->Next)
+        {
+            int family = address->Address.lpSockaddr->sa_family;
+            if (AF_INET == family)
+            {
+                // IPv4
+                SOCKADDR_IN* ipv4 = (SOCKADDR_IN*)(address->Address.lpSockaddr);
 
 
-				// [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
-				r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_A, 600);
-				mdnsd_set_raw(server->mdnsDaemon, r,(char *)&ipv4->sin_addr , 4);
+                // [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
+                r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_A, 600);
+                mdnsd_set_raw(server->mdnsDaemon, r,(char *)&ipv4->sin_addr , 4);
 
-				// [hostname]. A [ip].
-				r = mdnsd_shared(server->mdnsDaemon, localDomain, QTYPE_A, 600);
-				mdnsd_set_raw(server->mdnsDaemon, r,(char *)&ipv4->sin_addr , 4);
-			}
-			/*else if (AF_INET6 == family)
-			{
-				// IPv6
-				SOCKADDR_IN6* ipv6 = (SOCKADDR_IN6*)(address->Address.lpSockaddr);
+                // [hostname]. A [ip].
+                r = mdnsd_shared(server->mdnsDaemon, localDomain, QTYPE_A, 600);
+                mdnsd_set_raw(server->mdnsDaemon, r,(char *)&ipv4->sin_addr , 4);
+            }
+            /*else if (AF_INET6 == family)
+            {
+                // IPv6
+                SOCKADDR_IN6* ipv6 = (SOCKADDR_IN6*)(address->Address.lpSockaddr);
 
-				char str_buffer[INET6_ADDRSTRLEN] = {0};
-				inet_ntop(AF_INET6, &(ipv6->sin6_addr), str_buffer, INET6_ADDRSTRLEN);
+                char str_buffer[INET6_ADDRSTRLEN] = {0};
+                inet_ntop(AF_INET6, &(ipv6->sin6_addr), str_buffer, INET6_ADDRSTRLEN);
 
-				std::string ipv6_str(str_buffer);
+                std::string ipv6_str(str_buffer);
 
-				// Detect and skip non-external addresses
-				bool is_link_local(false);
-				bool is_special_use(false);
+                // Detect and skip non-external addresses
+                bool is_link_local(false);
+                bool is_special_use(false);
 
-				if (0 == ipv6_str.find("fe"))
-				{
-					char c = ipv6_str[2];
-					if (c == '8' || c == '9' || c == 'a' || c == 'b')
-					{
-						is_link_local = true;
-					}
-				}
-				else if (0 == ipv6_str.find("2001:0:"))
-				{
-					is_special_use = true;
-				}
+                if (0 == ipv6_str.find("fe"))
+                {
+                    char c = ipv6_str[2];
+                    if (c == '8' || c == '9' || c == 'a' || c == 'b')
+                    {
+                        is_link_local = true;
+                    }
+                }
+                else if (0 == ipv6_str.find("2001:0:"))
+                {
+                    is_special_use = true;
+                }
 
-				if (! (is_link_local || is_special_use))
-				{
-					ipAddrs.mIpv6.push_back(ipv6_str);
-				}
-			}*/
-			else
-			{
-				// Skip all other types of addresses
-				continue;
-			}
-		}
-	}
+                if (! (is_link_local || is_special_use))
+                {
+                    ipAddrs.mIpv6.push_back(ipv6_str);
+                }
+            }*/
+            else
+            {
+                // Skip all other types of addresses
+                continue;
+            }
+        }
+    }
 
-	// Cleanup
-	free(adapter_addresses);
-	adapter_addresses = NULL;
+    // Cleanup
+    free(adapter_addresses);
+    adapter_addresses = NULL;
 #else
-	{
-		struct ifaddrs *ifaddr, *ifa;
-		if (getifaddrs(&ifaddr) == -1) {
-			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"getifaddrs returned an unexpected error. Not setting mDNS A records.");
-		} else {
-			/* Walk through linked list, maintaining head pointer so we can free list later */
-			int n;
-			for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
-				if (ifa->ifa_addr == NULL)
-					continue;
+    {
+        struct ifaddrs *ifaddr, *ifa;
+        if (getifaddrs(&ifaddr) == -1) {
+            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"getifaddrs returned an unexpected error. Not setting mDNS A records.");
+        } else {
+            /* Walk through linked list, maintaining head pointer so we can free list later */
+            int n;
+            for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
+                if (ifa->ifa_addr == NULL)
+                    continue;
 
-				if ((strcmp("lo", ifa->ifa_name) == 0) ||
-					!(ifa->ifa_flags & (IFF_RUNNING))||
-					!(ifa->ifa_flags & (IFF_MULTICAST)))
-					continue;
+                if ((strcmp("lo", ifa->ifa_name) == 0) ||
+                    !(ifa->ifa_flags & (IFF_RUNNING))||
+                    !(ifa->ifa_flags & (IFF_MULTICAST)))
+                    continue;
 
-				if (ifa->ifa_addr->sa_family == AF_INET) {
-					struct sockaddr_in* sa = (struct sockaddr_in*) ifa->ifa_addr;
-					// [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
-					r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_A, 600);
-					mdnsd_set_raw(server->mdnsDaemon, r,(char *)&sa->sin_addr.s_addr , 4);
-					// [hostname]. A [ip].
-					r = mdnsd_shared(server->mdnsDaemon, localDomain, QTYPE_A, 600);
-					mdnsd_set_raw(server->mdnsDaemon, r,(char *)&sa->sin_addr.s_addr , 4);
-				} /*else if (ifa->ifa_addr->sa_family == AF_INET6) {
-					// IPv6 not implemented yet
-				}*/
-			}
+                if (ifa->ifa_addr->sa_family == AF_INET) {
+                    struct sockaddr_in* sa = (struct sockaddr_in*) ifa->ifa_addr;
+                    // [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
+                    r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_A, 600);
+                    mdnsd_set_raw(server->mdnsDaemon, r,(char *)&sa->sin_addr.s_addr , 4);
+                    // [hostname]. A [ip].
+                    r = mdnsd_shared(server->mdnsDaemon, localDomain, QTYPE_A, 600);
+                    mdnsd_set_raw(server->mdnsDaemon, r,(char *)&sa->sin_addr.s_addr , 4);
+                } /*else if (ifa->ifa_addr->sa_family == AF_INET6) {
+                    // IPv6 not implemented yet
+                }*/
+            }
 
-			freeifaddrs(ifaddr);
-		}
+            freeifaddrs(ifaddr);
+        }
 
-	}
+    }
 #endif
 
     // TXT record: [servername]-[hostname]._opcua-tcp._tcp.local. TXT path=/ caps=NA,DA,...
@@ -1472,12 +1472,12 @@ UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char*
                           unsigned short port, UA_Boolean removeTxt) {
     size_t hostnameLen = strlen(hostname);
     size_t servernameLen = strlen(servername);
-	// use a limit for the hostname length to make sure full string fits into 63 chars (limited by DNS spec)
-	if (hostnameLen == 0 || servernameLen == 0) {
-		return UA_STATUSCODE_BADOUTOFRANGE;
-	} else if (hostnameLen+servernameLen+1 > 63) { // include dash between servername-hostname
-		UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: Combination of hostname+servername exceeds maximum of 62 chars. It will be truncated.");
-	}
+    // use a limit for the hostname length to make sure full string fits into 63 chars (limited by DNS spec)
+    if (hostnameLen == 0 || servernameLen == 0) {
+        return UA_STATUSCODE_BADOUTOFRANGE;
+    } else if (hostnameLen+servernameLen+1 > 63) { // include dash between servername-hostname
+        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: Combination of hostname+servername exceeds maximum of 62 chars. It will be truncated.");
+    }
 
     // [servername]-[hostname]._opcua-tcp._tcp.local.
     char *fullServiceDomain;
@@ -1520,8 +1520,8 @@ UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char*
     if (r) {
         while (r) {
             const mdns_answer_t *data = mdnsd_record_data(r);
-			mdns_record_t *next = mdnsd_record_next(r);
-			if ((removeTxt && data->type == QTYPE_TXT) || (removeTxt && data->type == QTYPE_A) || data->srv.port == port) {
+            mdns_record_t *next = mdnsd_record_next(r);
+            if ((removeTxt && data->type == QTYPE_TXT) || (removeTxt && data->type == QTYPE_A) || data->srv.port == port) {
                 mdnsd_done(server->mdnsDaemon,r);
             }
             r = next;

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -1204,7 +1204,7 @@ UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* ho
 
     // [servername]-[hostname]._opcua-tcp._tcp.local.
     char *fullServiceDomain;
-    if (!(fullServiceDomain = create_fullServiceDomain("asdfas saf sa fsdafwefwergt wg weg wegw3 we 34 w4 t34 eswgweg  0,65 s123456789", hostname, 63))) {
+    if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname, 63))) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -989,14 +989,15 @@ UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA
     job.job.methodCall.data = server->periodicServerRegisterJob;
 
 
-    if (periodicJobId)
-        *periodicJobId = server->periodicServerRegisterJob->job_id;
     UA_StatusCode retval = UA_Server_addRepeatedJob(server, *server->periodicServerRegisterJob->job, intervalMs, &server->periodicServerRegisterJob->job_id);
     if (retval != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
                      "Could not create periodic job for server register. StatusCode 0x%08x", retval);
         return retval;
     }
+	if (periodicJobId) {
+		UA_Guid_copy(&server->periodicServerRegisterJob->job_id, periodicJobId);
+	}
 
     if (delayFirstRegisterMs>0) {
         // Register the server with the discovery server.

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -1336,11 +1336,11 @@ UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char*
     if (r) {
         while (r) {
             const mdns_answer_t *data = mdnsd_record_data(r);
-            if ((removeTxt && data->type == QTYPE_TXT) || (removeTxt && data->type == QTYPE_A) || data->srv.port == port) {
+			mdns_record_t *next = mdnsd_record_next(r);
+			if ((removeTxt && data->type == QTYPE_TXT) || (removeTxt && data->type == QTYPE_A) || data->srv.port == port) {
                 mdnsd_done(server->mdnsDaemon,r);
-                break;
             }
-            r = mdnsd_record_next(r);
+            r = next;
         }
     } else {
         UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER,

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -475,7 +475,7 @@ static void mdns_record_received(const struct resource* r, void* data) {
         return;
     }
 
-    entry->lastSeen = UA_DateTime_now();
+    entry->lastSeen = UA_DateTime_nowMonotonic();
 
     if (entry->txtSet && entry->srvSet)
         return;
@@ -807,7 +807,7 @@ process_RegisterServer(UA_Server *server, UA_Session *session, const UA_RequestH
 
     // copy the data from the request into the list
     UA_RegisteredServer_copy(requestServer, &registeredServer_entry->registeredServer);
-    registeredServer_entry->lastSeen = UA_DateTime_now();
+    registeredServer_entry->lastSeen = UA_DateTime_nowMonotonic();
 
     responseHeader->serviceResult = retval;
 }
@@ -870,7 +870,7 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
                             (int)current->registeredServer.semaphoreFilePath.length, current->registeredServer.semaphoreFilePath.data);
             } else {
                 // cppcheck-suppress unreadVariable
-                UA_String lastStr = UA_DateTime_toString(current->lastSeen);
+                UA_String lastStr = UA_DateTime_toString(current->lastSeen+ UA_DATETIME_UNIX_EPOCH);
                 UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
                              "Registration of server with URI %.*s has timed out and is removed. Last seen: %.*s",
                             (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -1239,12 +1239,13 @@ UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* ho
     }
 
     // hostname.
-    char *localDomain = malloc(hostnameLen < 63 ? hostnameLen : 63 + 2);
+	size_t maxHostnameLen = hostnameLen < 63 ? hostnameLen : 63;
+    char *localDomain = malloc(maxHostnameLen+1);
     if (!localDomain) {
         free(fullServiceDomain);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    snprintf(localDomain, hostnameLen, "%.*s.",(int)(hostnameLen < 63 ? hostnameLen : 63), hostname);
+    snprintf(localDomain, maxHostnameLen+2, "%.*s.",(int)(maxHostnameLen), hostname);
 
 
     // [servername]-[hostname]._opcua-tcp._tcp.local. 86400 IN SRV 0 5 port [hostname].

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -493,7 +493,7 @@ static void mdns_record_received(const struct resource* r, void* data) {
         char* path = (char*)xht_get(x, "path");
         char* caps = (char*)xht_get(x, "caps");
 
-        if (strlen(path) > 1) {
+        if (path && strlen(path) > 1) {
             if (!entry->srvSet) {
                 // txt arrived before SRV, thus cache path entry
                 entry->pathTmp = STRDUP(path);
@@ -503,7 +503,7 @@ static void mdns_record_received(const struct resource* r, void* data) {
             }
         }
 
-        if (strlen(caps) > 0) {
+        if (caps && strlen(caps) > 0) {
             size_t capsCount = 1;
             // count comma in caps
             for (size_t i=0; caps[i]; i++) {

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -872,12 +872,9 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
                             (int)current->registeredServer.semaphoreFilePath.length, current->registeredServer.semaphoreFilePath.data);
             } else {
                 // cppcheck-suppress unreadVariable
-                UA_String lastStr = UA_DateTime_toString(current->lastSeen+ UA_DATETIME_UNIX_EPOCH);
                 UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
-                             "Registration of server with URI %.*s has timed out and is removed. Last seen: %.*s",
-                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,
-                            (int)lastStr.length, lastStr.data);
-                UA_free(lastStr.data);
+                             "Registration of server with URI %.*s has timed out and is removed.",
+                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data);
             }
             LIST_REMOVE(current, pointers);
             UA_RegisteredServer_deleteMembers(&current->registeredServer);

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -1107,9 +1107,9 @@ static char* create_fullServiceDomain(const char* servername, const char* hostna
         return NULL;
     }
     if (hostnameLen > 0)
-        snprintf(fullServiceDomain, servernameLen + 1 + hostnameLen + 23 + 1, "%.*s-%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername, (int)hostnameLen, hostname);
+        sprintf(fullServiceDomain, "%.*s-%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername, (int)hostnameLen, hostname);
     else
-        snprintf(fullServiceDomain, servernameLen + 23 + 1, "%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername);
+        sprintf(fullServiceDomain, "%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername);
     return fullServiceDomain;
 }
 
@@ -1240,12 +1240,12 @@ UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* ho
 
     // hostname.
     size_t maxHostnameLen = hostnameLen < 63 ? hostnameLen : 63;
-    char *localDomain = malloc(maxHostnameLen+1);
+    char *localDomain = malloc(maxHostnameLen+2);
     if (!localDomain) {
         free(fullServiceDomain);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    snprintf(localDomain, maxHostnameLen+1, "%.*s.",(int)(maxHostnameLen), hostname);
+    sprintf(localDomain, "%.*s.",(int)(maxHostnameLen), hostname);
 
 
     // [servername]-[hostname]._opcua-tcp._tcp.local. 86400 IN SRV 0 5 port [hostname].

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -1107,9 +1107,9 @@ static char* create_fullServiceDomain(const char* servername, const char* hostna
         return NULL;
     }
     if (hostnameLen > 0)
-        snprintf(fullServiceDomain, servernameLen + 1 + hostnameLen + 23, "%.*s-%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername, (int)hostnameLen, hostname);
+        snprintf(fullServiceDomain, servernameLen + 1 + hostnameLen + 23 + 1, "%.*s-%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername, (int)hostnameLen, hostname);
     else
-        snprintf(fullServiceDomain, servernameLen + 23, "%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername);
+        snprintf(fullServiceDomain, servernameLen + 23 + 1, "%.*s._opcua-tcp._tcp.local.", (int)servernameLen, servername);
     return fullServiceDomain;
 }
 
@@ -1204,7 +1204,7 @@ UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* ho
 
     // [servername]-[hostname]._opcua-tcp._tcp.local.
     char *fullServiceDomain;
-    if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname, 63))) {
+    if (!(fullServiceDomain = create_fullServiceDomain("asdfas saf sa fsdafwefwergt wg weg wegw3 we 34 w4 t34 eswgweg  0,65 s123456789", hostname, 63))) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -387,13 +387,9 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
                             (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,
                             (int)current->registeredServer.semaphoreFilePath.length, current->registeredServer.semaphoreFilePath.data);
             } else {
-                // cppcheck-suppress unreadVariable
-                UA_String lastStr = UA_DateTime_toString(current->lastSeen);
                 UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
-                             "Registration of server with URI %.*s has timed out and is removed. Last seen: %.*s",
-                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,
-                            (int)lastStr.length, lastStr.data);
-                UA_free(lastStr.data);
+                             "Registration of server with URI %.*s has timed out and is removed",
+                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data);
             }
             LIST_REMOVE(current, pointers);
             UA_RegisteredServer_deleteMembers(&current->registeredServer);

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -23,8 +23,8 @@
 #   define CLOSESOCKET(S) closesocket((SOCKET)S)
 #  else
 #   define CLOSESOCKET(S) close(S)
-#	include <sys/time.h> // for struct timeval
-#	include <netinet/in.h> // for struct ip_mreq
+#   include <sys/time.h> // for struct timeval
+#   include <netinet/in.h> // for struct ip_mreq
 #  endif
 # endif
 #endif
@@ -45,9 +45,10 @@ static char *ua_strdup(const char *s) {
 #endif
 
 #ifdef UA_ENABLE_DISCOVERY
-static UA_StatusCode copyRegisteredServerToApplicationDescription(const UA_FindServersRequest *request, UA_ApplicationDescription *target, const UA_RegisteredServer* registeredServer) {
+static UA_StatusCode
+copyRegisteredServerToApplicationDescription(const UA_FindServersRequest *request, UA_ApplicationDescription *target,
+                                             const UA_RegisteredServer* registeredServer) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-
     UA_ApplicationDescription_init(target);
 
     retval |= UA_String_copy(&registeredServer->serverUri, &target->applicationUri);
@@ -90,9 +91,9 @@ static UA_StatusCode copyRegisteredServerToApplicationDescription(const UA_FindS
 #endif
 
 void Service_FindServers(UA_Server *server, UA_Session *session,
-                         const UA_FindServersRequest *request, UA_FindServersResponse *response) {
+                         const UA_FindServersRequest *request,
+                         UA_FindServersResponse *response) {
     UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing FindServersRequest");
-
 
     size_t foundServersSize = 0;
     UA_ApplicationDescription *foundServers = NULL;
@@ -161,7 +162,8 @@ void Service_FindServers(UA_Server *server, UA_Session *session,
         if (addSelf) {
             /* copy ApplicationDescription from the config */
 
-            response->responseHeader.serviceResult |= UA_ApplicationDescription_copy(&server->config.applicationDescription, &foundServers[0]);
+            response->responseHeader.serviceResult |= UA_ApplicationDescription_copy(&server->config.applicationDescription,
+                                                                                     &foundServers[0]);
             if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
                 UA_free(foundServers);
                 if (foundServerFilteredPointer)
@@ -203,8 +205,9 @@ void Service_FindServers(UA_Server *server, UA_Session *session,
             // -1 because foundServersSize also includes this self server
             size_t iterCount = addSelf ? foundServersSize - 1 : foundServersSize;
             for (size_t i = 0; i < iterCount; i++) {
-                response->responseHeader.serviceResult = copyRegisteredServerToApplicationDescription(request, &foundServers[currentIndex++],
-                                                                                                      foundServerFilteredPointer[i]);
+                response->responseHeader.serviceResult =
+                    copyRegisteredServerToApplicationDescription(request, &foundServers[currentIndex++],
+                                                                 foundServerFilteredPointer[i]);
                 if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
                     UA_free(foundServers);
                     UA_free(foundServerFilteredPointer);
@@ -216,8 +219,9 @@ void Service_FindServers(UA_Server *server, UA_Session *session,
         } else {
             registeredServer_list_entry* current;
             LIST_FOREACH(current, &server->registeredServers, pointers) {
-                response->responseHeader.serviceResult = copyRegisteredServerToApplicationDescription(request, &foundServers[currentIndex++],
-                                                                                                      &current->registeredServer);
+                response->responseHeader.serviceResult =
+                    copyRegisteredServerToApplicationDescription(request, &foundServers[currentIndex++],
+                                                                 &current->registeredServer);
                 if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
                     UA_free(foundServers);
                     return;
@@ -323,111 +327,114 @@ void Service_GetEndpoints(UA_Server *server, UA_Session *session, const UA_GetEn
  */
 static int mdns_hash_record(const char *s)
 {
-	/* ELF hash uses unsigned chars and unsigned arithmetic for portability */
-	const unsigned char *name = (const unsigned char *)s;
-	unsigned long h = 0;
+    /* ELF hash uses unsigned chars and unsigned arithmetic for portability */
+    const unsigned char *name = (const unsigned char *)s;
+    unsigned long h = 0;
 
-	while(*name) {
-		/* do some fancy bitwanking on the string */
-		h = (h << 4) + (unsigned long)(*name++);
-		unsigned long g;
-		if ((g = (h & 0xF0000000UL)) != 0)
-			h ^= (g >> 24);
-		h &= ~g;
-	}
+    while(*name) {
+        /* do some fancy bitwanking on the string */
+        h = (h << 4) + (unsigned long)(*name++);
+        unsigned long g;
+        if ((g = (h & 0xF0000000UL)) != 0)
+            h ^= (g >> 24);
+        h &= ~g;
+    }
 
-	return (int)h;
+    return (int)h;
 }
 
-static struct serverOnNetwork_list_entry* mdns_record_add_or_get(UA_Server *server, const char* record, const char* serverName, size_t serverNameLen, UA_Boolean createNew) {
-	int hashIdx = mdns_hash_record(record) % SERVER_ON_NETWORK_HASH_PRIME;
-	struct serverOnNetwork_hash_entry* hash_entry = server->serverOnNetworkHash[hashIdx];
+static struct serverOnNetwork_list_entry*
+mdns_record_add_or_get(UA_Server *server, const char* record, const char* serverName,
+                       size_t serverNameLen, UA_Boolean createNew) {
+    int hashIdx = mdns_hash_record(record) % SERVER_ON_NETWORK_HASH_PRIME;
+    struct serverOnNetwork_hash_entry* hash_entry = server->serverOnNetworkHash[hashIdx];
 
-	while (hash_entry) {
-		size_t maxLen = serverNameLen > hash_entry->entry->serverOnNetwork.serverName.length ? hash_entry->entry->serverOnNetwork.serverName.length : serverNameLen;
-		if (strncmp((char*)hash_entry->entry->serverOnNetwork.serverName.data, serverName,maxLen)==0) {
-			return hash_entry->entry;
-		}
-		hash_entry = hash_entry->next;
-	}
+    while (hash_entry) {
+        size_t maxLen = serverNameLen > hash_entry->entry->serverOnNetwork.serverName.length ? hash_entry->entry->serverOnNetwork.serverName.length : serverNameLen;
+        if (strncmp((char*)hash_entry->entry->serverOnNetwork.serverName.data, serverName,maxLen)==0) {
+            return hash_entry->entry;
+        }
+        hash_entry = hash_entry->next;
+    }
 
-	if (!createNew)
-		return NULL;
+    if (!createNew)
+        return NULL;
 
-	// not yet in list, create new one
-	struct serverOnNetwork_list_entry* listEntry = malloc(sizeof(struct serverOnNetwork_list_entry));
-	listEntry->created = UA_DateTime_now();
-	listEntry->pathTmp = NULL;
-	listEntry->txtSet = UA_FALSE;
-	listEntry->srvSet = UA_FALSE;
-	UA_ServerOnNetwork_init(&listEntry->serverOnNetwork);
-	listEntry->serverOnNetwork.recordId = server->serverOnNetworkRecordIdCounter;
-	listEntry->serverOnNetwork.serverName.length = serverNameLen;
-	listEntry->serverOnNetwork.serverName.data = malloc(serverNameLen);
-	memcpy(listEntry->serverOnNetwork.serverName.data, serverName, serverNameLen);
-	#  ifndef UA_ENABLE_MULTITHREADING
-	server->serverOnNetworkRecordIdCounter++;
-	#  else
-	server->serverOnNetworkRecordIdCounter = uatomic_add_return(&server->serverOnNetworkRecordIdCounter, 1);
-	#  endif
-	if (server->serverOnNetworkRecordIdCounter == 0)
-		server->serverOnNetworkRecordIdLastReset = UA_DateTime_now();
+    // not yet in list, create new one
+    struct serverOnNetwork_list_entry* listEntry = malloc(sizeof(struct serverOnNetwork_list_entry));
+    listEntry->created = UA_DateTime_now();
+    listEntry->pathTmp = NULL;
+    listEntry->txtSet = UA_FALSE;
+    listEntry->srvSet = UA_FALSE;
+    UA_ServerOnNetwork_init(&listEntry->serverOnNetwork);
+    listEntry->serverOnNetwork.recordId = server->serverOnNetworkRecordIdCounter;
+    listEntry->serverOnNetwork.serverName.length = serverNameLen;
+    listEntry->serverOnNetwork.serverName.data = malloc(serverNameLen);
+    memcpy(listEntry->serverOnNetwork.serverName.data, serverName, serverNameLen);
+    #  ifndef UA_ENABLE_MULTITHREADING
+    server->serverOnNetworkRecordIdCounter++;
+    #  else
+    server->serverOnNetworkRecordIdCounter = uatomic_add_return(&server->serverOnNetworkRecordIdCounter, 1);
+    #  endif
+    if (server->serverOnNetworkRecordIdCounter == 0)
+        server->serverOnNetworkRecordIdLastReset = UA_DateTime_now();
 
-	// add to hash
-	struct serverOnNetwork_hash_entry* newHashEntry = malloc(sizeof(struct serverOnNetwork_hash_entry));
-	newHashEntry->next = server->serverOnNetworkHash[hashIdx];
-	server->serverOnNetworkHash[hashIdx] = newHashEntry;
-	newHashEntry->entry = listEntry;
+    // add to hash
+    struct serverOnNetwork_hash_entry* newHashEntry = malloc(sizeof(struct serverOnNetwork_hash_entry));
+    newHashEntry->next = server->serverOnNetworkHash[hashIdx];
+    server->serverOnNetworkHash[hashIdx] = newHashEntry;
+    newHashEntry->entry = listEntry;
 
-	LIST_INSERT_HEAD(&server->serverOnNetwork, listEntry, pointers);
+    LIST_INSERT_HEAD(&server->serverOnNetwork, listEntry, pointers);
 
-	return listEntry;
+    return listEntry;
 }
 
-static void mdns_record_remove(UA_Server *server, const char* record, struct serverOnNetwork_list_entry* entry) {
+static void mdns_record_remove(UA_Server *server, const char* record,
+                               struct serverOnNetwork_list_entry* entry) {
 
-	// remove from hash
+    // remove from hash
 
-	int hashIdx = mdns_hash_record(record) % SERVER_ON_NETWORK_HASH_PRIME;
-	struct serverOnNetwork_hash_entry* hash_entry = server->serverOnNetworkHash[hashIdx];
-	struct serverOnNetwork_hash_entry* prevEntry = hash_entry;
-	while (hash_entry) {
-		if (hash_entry->entry == entry) {
-			if (server->serverOnNetworkHash[hashIdx] == hash_entry)
-				server->serverOnNetworkHash[hashIdx] = hash_entry->next;
-			else if (prevEntry){
-				prevEntry->next = hash_entry->next;
-			}
-			break;
-		}
-		prevEntry = hash_entry;
-		hash_entry = hash_entry->next;
-	}
-	free(hash_entry);
+    int hashIdx = mdns_hash_record(record) % SERVER_ON_NETWORK_HASH_PRIME;
+    struct serverOnNetwork_hash_entry* hash_entry = server->serverOnNetworkHash[hashIdx];
+    struct serverOnNetwork_hash_entry* prevEntry = hash_entry;
+    while (hash_entry) {
+        if (hash_entry->entry == entry) {
+            if (server->serverOnNetworkHash[hashIdx] == hash_entry)
+                server->serverOnNetworkHash[hashIdx] = hash_entry->next;
+            else if (prevEntry){
+                prevEntry->next = hash_entry->next;
+            }
+            break;
+        }
+        prevEntry = hash_entry;
+        hash_entry = hash_entry->next;
+    }
+    free(hash_entry);
 
-	// remove from list
+    // remove from list
 
-	LIST_REMOVE(entry, pointers);
-	UA_ServerOnNetwork_deleteMembers(&entry->serverOnNetwork);
-	if (entry->pathTmp)
-		free(entry->pathTmp);
+    LIST_REMOVE(entry, pointers);
+    UA_ServerOnNetwork_deleteMembers(&entry->serverOnNetwork);
+    if (entry->pathTmp)
+        free(entry->pathTmp);
 
 #ifndef UA_ENABLE_MULTITHREADING
-	UA_free(entry);
-	server->serverOnNetworkSize--;
+    UA_free(entry);
+    server->serverOnNetworkSize--;
 #else
-	server->serverOnNetworkSize = uatomic_add_return(&server->serverOnNetworkSize, -1);
+    server->serverOnNetworkSize = uatomic_add_return(&server->serverOnNetworkSize, -1);
     UA_Server_delayedFree(server, entry);
 #endif
 }
 
 static void mdns_append_path_to_url(UA_String* url, const char* path) {
-	size_t pathLen = strlen(path);
-	char *newUrl = malloc(url->length + pathLen);
-	memcpy(newUrl,url->data, url->length);
-	memcpy(newUrl+url->length,path,pathLen);
-	url->length = url->length + pathLen;
-	url->data = (UA_Byte*)newUrl;
+    size_t pathLen = strlen(path);
+    char *newUrl = malloc(url->length + pathLen);
+    memcpy(newUrl,url->data, url->length);
+    memcpy(newUrl+url->length,path,pathLen);
+    url->length = url->length + pathLen;
+    url->data = (UA_Byte*)newUrl;
 }
 
 /**
@@ -436,384 +443,397 @@ static void mdns_append_path_to_url(UA_String* url, const char* path) {
  * @param data
  */
 static void mdns_record_received(const struct resource* r, void* data) {
-	UA_Server *server = (UA_Server *) data;
-	// we only need SRV and TXT records
-	if ((r->class != QCLASS_IN && r->class != QCLASS_IN +  + 32768) || (r->type != QTYPE_SRV && r->type != QTYPE_TXT))
-		return;
+    UA_Server *server = (UA_Server *) data;
+    // we only need SRV and TXT records
+    if ((r->class != QCLASS_IN && r->class != QCLASS_IN +  + 32768) || (r->type != QTYPE_SRV && r->type != QTYPE_TXT))
+        return;
 
-	// we only handle '_opcua-tcp._tcp.' records
-	char *opcStr = strstr(r->name, "_opcua-tcp._tcp.");
-	if (opcStr == NULL)
-		return;
+    // we only handle '_opcua-tcp._tcp.' records
+    char *opcStr = strstr(r->name, "_opcua-tcp._tcp.");
+    if (opcStr == NULL)
+        return;
 
-	size_t servernameLen = (size_t)(opcStr - r->name);
-	if (servernameLen == 0)
-		return;
-	servernameLen--; // remove point
+    size_t servernameLen = (size_t)(opcStr - r->name);
+    if (servernameLen == 0)
+        return;
+    servernameLen--; // remove point
 
-	// opcStr + strlen("_opcua-tcp._tcp.")
-	//char *hostname = opcStr + 16;
+    // opcStr + strlen("_opcua-tcp._tcp.")
+    //char *hostname = opcStr + 16;
 
-	struct serverOnNetwork_list_entry* entry = mdns_record_add_or_get(server, r->name, r->name, servernameLen, r->ttl > 0);
+    struct serverOnNetwork_list_entry* entry = mdns_record_add_or_get(server, r->name, r->name, servernameLen, r->ttl > 0);
 
-	if (entry == NULL)
-		// TTL is 0 and entry not yet in list
-		return;
-	else if (r->ttl == 0) {
-		UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: remove server (TTL=0): %.*s", entry->serverOnNetwork.discoveryUrl.length, entry->serverOnNetwork.discoveryUrl.data);
-		mdns_record_remove(server, r->name, entry);
-		return;
-	}
+    if (entry == NULL)
+        // TTL is 0 and entry not yet in list
+        return;
+    else if (r->ttl == 0) {
+        UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
+                    "Multicast DNS: remove server (TTL=0): %.*s",
+                    entry->serverOnNetwork.discoveryUrl.length,
+                    entry->serverOnNetwork.discoveryUrl.data);
+        mdns_record_remove(server, r->name, entry);
+        return;
+    }
 
-	entry->lastSeen = UA_DateTime_now();
+    entry->lastSeen = UA_DateTime_now();
 
-	if (entry->txtSet && entry->srvSet)
-		return;
+    if (entry->txtSet && entry->srvSet)
+        return;
 
-	// [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port [hostname].
-	// TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
-	if (r->type == QTYPE_TXT && !entry->txtSet) {
-		entry->txtSet = UA_TRUE;
+    // [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port [hostname].
+    // TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
+    if (r->type == QTYPE_TXT && !entry->txtSet) {
+        entry->txtSet = UA_TRUE;
 
 
-		xht_t* x = txt2sd((unsigned char*)r->rdata, r->rdlength);
-		char* path = (char*)xht_get(x, "path");
-		char* caps = (char*)xht_get(x, "caps");
+        xht_t* x = txt2sd((unsigned char*)r->rdata, r->rdlength);
+        char* path = (char*)xht_get(x, "path");
+        char* caps = (char*)xht_get(x, "caps");
 
-		if (strlen(path) > 1) {
-			if (!entry->srvSet) {
-				// txt arrived before SRV, thus cache path entry
-				entry->pathTmp = STRDUP(path);
-			} else {
-				// SRV already there and discovery URL set. Add path to discovery URL
-				mdns_append_path_to_url(&entry->serverOnNetwork.discoveryUrl, path);
-			}
-		}
+        if (strlen(path) > 1) {
+            if (!entry->srvSet) {
+                // txt arrived before SRV, thus cache path entry
+                entry->pathTmp = STRDUP(path);
+            } else {
+                // SRV already there and discovery URL set. Add path to discovery URL
+                mdns_append_path_to_url(&entry->serverOnNetwork.discoveryUrl, path);
+            }
+        }
 
-		if (strlen(caps) > 0) {
-			size_t capsCount = 1;
-			// count comma in caps
-			for (size_t i=0; caps[i]; i++) {
-				if (caps[i]==',')
-					capsCount++;
-			}
-			// set capabilities
-			entry->serverOnNetwork.serverCapabilitiesSize = capsCount;
-			entry->serverOnNetwork.serverCapabilities = UA_Array_new(capsCount, &UA_TYPES[UA_TYPES_STRING]);
-			for (size_t i=0; i<capsCount; i++) {
+        if (strlen(caps) > 0) {
+            size_t capsCount = 1;
+            // count comma in caps
+            for (size_t i=0; caps[i]; i++) {
+                if (caps[i]==',')
+                    capsCount++;
+            }
+            // set capabilities
+            entry->serverOnNetwork.serverCapabilitiesSize = capsCount;
+            entry->serverOnNetwork.serverCapabilities = UA_Array_new(capsCount, &UA_TYPES[UA_TYPES_STRING]);
+            for (size_t i=0; i<capsCount; i++) {
 
-				char* nextStr = strchr(caps, ',');
+                char* nextStr = strchr(caps, ',');
 
-				size_t len = nextStr ? (size_t)(nextStr - caps) : strlen(caps);
-				entry->serverOnNetwork.serverCapabilities[i].length = len;
-				entry->serverOnNetwork.serverCapabilities[i].data = malloc(len);
-				memcpy(entry->serverOnNetwork.serverCapabilities[i].data, caps, len);
-				if (nextStr)
-					caps = nextStr+1;
-				else
-					break;
-			}
-		}
-		xht_free(x);
-	} else if (r->type == QTYPE_SRV && !entry->srvSet){
-		entry->srvSet = UA_TRUE;
+                size_t len = nextStr ? (size_t)(nextStr - caps) : strlen(caps);
+                entry->serverOnNetwork.serverCapabilities[i].length = len;
+                entry->serverOnNetwork.serverCapabilities[i].data = malloc(len);
+                memcpy(entry->serverOnNetwork.serverCapabilities[i].data, caps, len);
+                if (nextStr)
+                    caps = nextStr+1;
+                else
+                    break;
+            }
+        }
+        xht_free(x);
+    } else if (r->type == QTYPE_SRV && !entry->srvSet){
+        entry->srvSet = UA_TRUE;
 
-		// opc.tcp://[servername]:[port][path]
-		size_t srvNameLen = strlen(r->known.srv.name);
-		if (srvNameLen > 0 && r->known.srv.name[srvNameLen-1] == '.')
-			srvNameLen--;
-		char *newUrl = malloc(10 + srvNameLen + 8);
-		sprintf(newUrl, "opc.tcp://%.*s:%d",(int)srvNameLen, r->known.srv.name, r->known.srv.port);
-		UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: found server: %s", newUrl);
-		entry->serverOnNetwork.discoveryUrl = UA_String_fromChars(newUrl);
-		free(newUrl);
+        // opc.tcp://[servername]:[port][path]
+        size_t srvNameLen = strlen(r->known.srv.name);
+        if (srvNameLen > 0 && r->known.srv.name[srvNameLen-1] == '.')
+            srvNameLen--;
+        char *newUrl = malloc(10 + srvNameLen + 8);
+        sprintf(newUrl, "opc.tcp://%.*s:%d",(int)srvNameLen, r->known.srv.name, r->known.srv.port);
+        UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: found server: %s", newUrl);
+        entry->serverOnNetwork.discoveryUrl = UA_String_fromChars(newUrl);
+        free(newUrl);
 
-		if (entry->pathTmp) {
-			mdns_append_path_to_url(&entry->serverOnNetwork.discoveryUrl, entry->pathTmp);
-			free(entry->pathTmp);
-		}
+        if (entry->pathTmp) {
+            mdns_append_path_to_url(&entry->serverOnNetwork.discoveryUrl, entry->pathTmp);
+            free(entry->pathTmp);
+        }
 
-	}
+    }
 }
 
 void Service_FindServersOnNetwork(UA_Server *server, UA_Session *session,
-                         const UA_FindServersOnNetworkRequest *request, UA_FindServersOnNetworkResponse *response) {
-	UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing FindServersOnNetworkRequest");
+                                  const UA_FindServersOnNetworkRequest *request,
+                                  UA_FindServersOnNetworkResponse *response) {
+    UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing FindServersOnNetworkRequest");
 
-	UA_UInt32 recordCount;
-	if (request->startingRecordId < server->serverOnNetworkRecordIdCounter)
-		recordCount = server->serverOnNetworkRecordIdCounter - request->maxRecordsToReturn;
-	else
-		recordCount = 0;
+    UA_UInt32 recordCount;
+    if (request->startingRecordId < server->serverOnNetworkRecordIdCounter)
+        recordCount = server->serverOnNetworkRecordIdCounter - request->maxRecordsToReturn;
+    else
+        recordCount = 0;
 
-	if (request->maxRecordsToReturn && recordCount > request->maxRecordsToReturn) {
-		recordCount = request->maxRecordsToReturn;
-	}
+    if (request->maxRecordsToReturn && recordCount > request->maxRecordsToReturn) {
+        recordCount = request->maxRecordsToReturn;
+    }
 
-	UA_ServerOnNetwork** filtered = NULL;
-	if (recordCount > 0) {
-		filtered = UA_malloc(sizeof(UA_ServerOnNetwork*) * recordCount);
-		if (!filtered) {
-			response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
-			return;
-		}
-		memset(filtered, 0, sizeof(UA_ServerOnNetwork*) * recordCount);
+    UA_ServerOnNetwork** filtered = NULL;
+    if (recordCount > 0) {
+        filtered = UA_malloc(sizeof(UA_ServerOnNetwork*) * recordCount);
+        if (!filtered) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
+            return;
+        }
+        memset(filtered, 0, sizeof(UA_ServerOnNetwork*) * recordCount);
 
-		if (request->serverCapabilityFilterSize) {
-			UA_UInt32 filteredCount = 0;
-			// iterate over all records and add to filtered list
-			serverOnNetwork_list_entry* current;
-			LIST_FOREACH(current, &server->serverOnNetwork, pointers) {
-				if (current->serverOnNetwork.recordId < request->startingRecordId)
-					continue;
-				UA_Boolean foundAll = UA_TRUE;
-				for (size_t i = 0; i < request->serverCapabilityFilterSize && foundAll; i++) {
-					UA_Boolean foundSingle = UA_FALSE;
-					for (size_t j = 0; j < current->serverOnNetwork.serverCapabilitiesSize && !foundSingle; j++) {
-						foundSingle |= UA_String_equal(&request->serverCapabilityFilter[i], &current->serverOnNetwork.serverCapabilities[j]);
-					}
-					foundAll &= foundSingle;
-				}
-				if (foundAll) {
-					filtered[filteredCount++] = &current->serverOnNetwork;
-					if (filteredCount >= recordCount)
-						break;
-				}
-			}
-			recordCount = filteredCount;
-		} else {
-			UA_UInt32 filteredCount = 0;
-			serverOnNetwork_list_entry* current;
-			LIST_FOREACH(current, &server->serverOnNetwork, pointers) {
-				if (current->serverOnNetwork.recordId < request->startingRecordId)
-					continue;
-				filtered[filteredCount++] = &current->serverOnNetwork;
-				if (filteredCount >= recordCount)
-					break;
-			}
-			recordCount = filteredCount;
-		}
-	}
-	response->serversSize = recordCount;
-	if (recordCount > 0) {
-		response->servers = UA_malloc(sizeof(UA_ServerOnNetwork)*recordCount);
-		if (!response->servers) {
-			response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
-			free(filtered);
-			return;
-		}
-		for (size_t i=0; i<recordCount; i++) {
-			UA_ServerOnNetwork_copy(filtered[i],&response->servers[recordCount - i -1]);
-		}
-	}
-	free(filtered);
+        if (request->serverCapabilityFilterSize) {
+            UA_UInt32 filteredCount = 0;
+            // iterate over all records and add to filtered list
+            serverOnNetwork_list_entry* current;
+            LIST_FOREACH(current, &server->serverOnNetwork, pointers) {
+                if (current->serverOnNetwork.recordId < request->startingRecordId)
+                    continue;
+                UA_Boolean foundAll = UA_TRUE;
+                for (size_t i = 0; i < request->serverCapabilityFilterSize && foundAll; i++) {
+                    UA_Boolean foundSingle = UA_FALSE;
+                    for (size_t j = 0; j < current->serverOnNetwork.serverCapabilitiesSize && !foundSingle; j++) {
+                        foundSingle |= UA_String_equal(&request->serverCapabilityFilter[i],
+                                                       &current->serverOnNetwork.serverCapabilities[j]);
+                    }
+                    foundAll &= foundSingle;
+                }
+                if (foundAll) {
+                    filtered[filteredCount++] = &current->serverOnNetwork;
+                    if (filteredCount >= recordCount)
+                        break;
+                }
+            }
+            recordCount = filteredCount;
+        } else {
+            UA_UInt32 filteredCount = 0;
+            serverOnNetwork_list_entry* current;
+            LIST_FOREACH(current, &server->serverOnNetwork, pointers) {
+                if (current->serverOnNetwork.recordId < request->startingRecordId)
+                    continue;
+                filtered[filteredCount++] = &current->serverOnNetwork;
+                if (filteredCount >= recordCount)
+                    break;
+            }
+            recordCount = filteredCount;
+        }
+    }
+    response->serversSize = recordCount;
+    if (recordCount > 0) {
+        response->servers = UA_malloc(sizeof(UA_ServerOnNetwork)*recordCount);
+        if (!response->servers) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
+            free(filtered);
+            return;
+        }
+        for (size_t i=0; i<recordCount; i++) {
+            UA_ServerOnNetwork_copy(filtered[i],&response->servers[recordCount - i -1]);
+        }
+    }
+    free(filtered);
 
-	UA_DateTime_copy(&server->serverOnNetworkRecordIdLastReset, &response->lastCounterResetTime);
-	response->responseHeader.serviceResult = UA_STATUSCODE_GOOD;
+    UA_DateTime_copy(&server->serverOnNetworkRecordIdLastReset, &response->lastCounterResetTime);
+    response->responseHeader.serviceResult = UA_STATUSCODE_GOOD;
 }
 # endif
 
-static void process_RegisterServer(UA_Server *server, UA_Session *session,
-								   const UA_RequestHeader* requestHeader, const UA_RegisteredServer *requestServer, const size_t requestDiscoveryConfigurationSize,
-								   const UA_ExtensionObject *requestDiscoveryConfiguration,
-								   UA_ResponseHeader* responseHeader, size_t *responseConfigurationResultsSize,
-								   UA_StatusCode **responseConfigurationResults, size_t *responseDiagnosticInfosSize,
-								   UA_DiagnosticInfo *responseDiagnosticInfos) {
-	registeredServer_list_entry *registeredServer_entry = NULL;
+static void
+process_RegisterServer(UA_Server *server, UA_Session *session, const UA_RequestHeader* requestHeader,
+                       const UA_RegisteredServer *requestServer, const size_t requestDiscoveryConfigurationSize,
+                       const UA_ExtensionObject *requestDiscoveryConfiguration, UA_ResponseHeader* responseHeader,
+                       size_t *responseConfigurationResultsSize, UA_StatusCode **responseConfigurationResults,
+                       size_t *responseDiagnosticInfosSize, UA_DiagnosticInfo *responseDiagnosticInfos) {
+    registeredServer_list_entry *registeredServer_entry = NULL;
 
-	{
-		// find the server from the request in the registered list
-		registeredServer_list_entry* current;
-		LIST_FOREACH(current, &server->registeredServers, pointers) {
-			if (UA_String_equal(&current->registeredServer.serverUri, &requestServer->serverUri)) {
-				registeredServer_entry = current;
-				break;
-			}
-		}
-	}
+    // find the server from the request in the registered list
+    registeredServer_list_entry* current;
+    LIST_FOREACH(current, &server->registeredServers, pointers) {
+        if (UA_String_equal(&current->registeredServer.serverUri, &requestServer->serverUri)) {
+            registeredServer_entry = current;
+            break;
+        }
+    }
 
-	UA_MdnsDiscoveryConfiguration *mdnsConfig = NULL;
+    UA_MdnsDiscoveryConfiguration *mdnsConfig = NULL;
 
-	const UA_String* mdnsServerName = NULL;
-	if (requestDiscoveryConfigurationSize) {
-		*responseConfigurationResultsSize = requestDiscoveryConfigurationSize;
-		*responseConfigurationResults = UA_Array_new(requestDiscoveryConfigurationSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		for (size_t i =0; i<requestDiscoveryConfigurationSize; i++) {
-			const UA_ExtensionObject *object = &requestDiscoveryConfiguration[i];
-			if (!mdnsConfig && (object->encoding == UA_EXTENSIONOBJECT_DECODED || object->encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE)
-				&& (object->content.decoded.type == &UA_TYPES[UA_TYPES_MDNSDISCOVERYCONFIGURATION])) {
-				// yayy, we have a known extension object type
-				mdnsConfig = object->content.decoded.data;
+    const UA_String* mdnsServerName = NULL;
+    if (requestDiscoveryConfigurationSize) {
+        *responseConfigurationResultsSize = requestDiscoveryConfigurationSize;
+        *responseConfigurationResults = UA_Array_new(requestDiscoveryConfigurationSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
+        for (size_t i =0; i<requestDiscoveryConfigurationSize; i++) {
+            const UA_ExtensionObject *object = &requestDiscoveryConfiguration[i];
+            if (!mdnsConfig && (object->encoding == UA_EXTENSIONOBJECT_DECODED || object->encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE)
+                && (object->content.decoded.type == &UA_TYPES[UA_TYPES_MDNSDISCOVERYCONFIGURATION])) {
+                // yayy, we have a known extension object type
+                mdnsConfig = object->content.decoded.data;
 
-				mdnsServerName = &mdnsConfig->mdnsServerName;
+                mdnsServerName = &mdnsConfig->mdnsServerName;
 
-				*responseConfigurationResults[i] = UA_STATUSCODE_GOOD;
-			} else {
-				*responseConfigurationResults[i] = UA_STATUSCODE_BADNOTSUPPORTED;
-			}
-		}
-	}
-	if (!mdnsServerName && requestServer->serverNamesSize) {
-		mdnsServerName = &requestServer->serverNames[0].text;
-	}
+                *responseConfigurationResults[i] = UA_STATUSCODE_GOOD;
+            } else {
+                *responseConfigurationResults[i] = UA_STATUSCODE_BADNOTSUPPORTED;
+            }
+        }
+    }
+    if (!mdnsServerName && requestServer->serverNamesSize) {
+        mdnsServerName = &requestServer->serverNames[0].text;
+    }
 
-	if (!mdnsServerName) {
-		responseHeader->serviceResult = UA_STATUSCODE_BADSERVERNAMEMISSING;
-		return;
-	}
+    if (!mdnsServerName) {
+        responseHeader->serviceResult = UA_STATUSCODE_BADSERVERNAMEMISSING;
+        return;
+    }
 
 
-	if (requestServer->discoveryUrlsSize == 0) {
-		responseHeader->serviceResult = UA_STATUSCODE_BADDISCOVERYURLMISSING;
-		return;
-	}
+    if (requestServer->discoveryUrlsSize == 0) {
+        responseHeader->serviceResult = UA_STATUSCODE_BADDISCOVERYURLMISSING;
+        return;
+    }
 
-	if (requestServer->semaphoreFilePath.length) {
-		char* filePath = malloc(sizeof(char)*requestServer->semaphoreFilePath.length+1);
-		memcpy( filePath, requestServer->semaphoreFilePath.data, requestServer->semaphoreFilePath.length );
-		filePath[requestServer->semaphoreFilePath.length] = '\0';
-		if (access( filePath, 0 ) == -1) {
-			responseHeader->serviceResult = UA_STATUSCODE_BADSEMPAHOREFILEMISSING;
-			free(filePath);
-			return;
-		}
-		free(filePath);
-	}
+    if (requestServer->semaphoreFilePath.length) {
+        char* filePath = malloc(sizeof(char)*requestServer->semaphoreFilePath.length+1);
+        memcpy( filePath, requestServer->semaphoreFilePath.data, requestServer->semaphoreFilePath.length );
+        filePath[requestServer->semaphoreFilePath.length] = '\0';
+        if (access( filePath, 0 ) == -1) {
+            responseHeader->serviceResult = UA_STATUSCODE_BADSEMPAHOREFILEMISSING;
+            free(filePath);
+            return;
+        }
+        free(filePath);
+    }
 
 #ifdef UA_ENABLE_DISCOVERY_MULTICAST
-	if (server->config.applicationDescription.applicationType == UA_APPLICATIONTYPE_DISCOVERYSERVER) {
+    if (server->config.applicationDescription.applicationType == UA_APPLICATIONTYPE_DISCOVERYSERVER) {
 
-		char* mdnsServer = malloc(sizeof(char) * mdnsServerName->length + 1);
-		memcpy(mdnsServer, mdnsServerName->data, mdnsServerName->length);
-		mdnsServer[mdnsServerName->length] = '\0';
+        char* mdnsServer = malloc(sizeof(char) * mdnsServerName->length + 1);
+        memcpy(mdnsServer, mdnsServerName->data, mdnsServerName->length);
+        mdnsServer[mdnsServerName->length] = '\0';
 
-		for (size_t i=0; i<requestServer->discoveryUrlsSize; i++) {
-			char port[10] = "\0";
-			char hostname[256];
-			char path[256];
-			{
-				char* uri = malloc(sizeof(char) * requestServer->discoveryUrls[i].length + 1);
-				strncpy(uri, (char*) requestServer->discoveryUrls[i].data, requestServer->discoveryUrls[i].length);
-				uri[requestServer->discoveryUrls[i].length] = '\0';
-				UA_StatusCode retval;
-				const char* portTmp = NULL;
-				const char* pathTmp = NULL;
-				if ((retval = UA_EndpointUrl_split(uri, hostname, &portTmp, &pathTmp)) != UA_STATUSCODE_GOOD) {
-					hostname[0] = '\0';
-					if (retval == UA_STATUSCODE_BADOUTOFRANGE)
-						UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_NETWORK, "Server url size invalid");
-					else if (retval == UA_STATUSCODE_BADATTRIBUTEIDINVALID)
-						UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_NETWORK, "Server url does not begin with opc.tcp://");
-				}
-				if (!portTmp)
-					portTmp = "0";
-				if (pathTmp) {
-					strncpy(port, portTmp, (size_t)(pathTmp-portTmp));
-					port[(size_t)(pathTmp-portTmp)]='\0';
-					strncpy(path, pathTmp, strlen(pathTmp));
-					path[strlen(pathTmp)]='\0';
-				} else {
-					strncpy(port, portTmp, strlen(portTmp));
-					port[strlen(portTmp)]='\0';
-					path[0]='\0';
-				}
-				free(uri);
-			}
+        for (size_t i=0; i<requestServer->discoveryUrlsSize; i++) {
+            char port[10] = "\0";
+            char hostname[256];
+            char path[256];
+            {
+                char* uri = malloc(sizeof(char) * requestServer->discoveryUrls[i].length + 1);
+                strncpy(uri, (char*) requestServer->discoveryUrls[i].data, requestServer->discoveryUrls[i].length);
+                uri[requestServer->discoveryUrls[i].length] = '\0';
+                UA_StatusCode retval;
+                const char* portTmp = NULL;
+                const char* pathTmp = NULL;
+                if ((retval = UA_EndpointUrl_split(uri, hostname, &portTmp, &pathTmp)) != UA_STATUSCODE_GOOD) {
+                    hostname[0] = '\0';
+                    if (retval == UA_STATUSCODE_BADOUTOFRANGE)
+                        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_NETWORK, "Server url size invalid");
+                    else if (retval == UA_STATUSCODE_BADATTRIBUTEIDINVALID)
+                        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_NETWORK, "Server url does not begin with opc.tcp://");
+                }
+                if (!portTmp)
+                    portTmp = "0";
+                if (pathTmp) {
+                    strncpy(port, portTmp, (size_t)(pathTmp-portTmp));
+                    port[(size_t)(pathTmp-portTmp)]='\0';
+                    strncpy(path, pathTmp, strlen(pathTmp));
+                    path[strlen(pathTmp)]='\0';
+                } else {
+                    strncpy(port, portTmp, strlen(portTmp));
+                    port[strlen(portTmp)]='\0';
+                    path[0]='\0';
+                }
+                free(uri);
+            }
 
-			if (!requestServer->isOnline) {
-				if (UA_Discovery_removeRecord(server, mdnsServer, hostname, (unsigned short) atoi(port), i==requestServer->discoveryUrlsSize) != UA_STATUSCODE_GOOD) {
-					UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not reomve mDNS record for hostname %s.%s", mdnsServer);
-				}
-			}
-			else {
-				UA_String *capabilities = NULL;
-				size_t capabilitiesSize = 0;
-				if (mdnsConfig) {
-					capabilities = mdnsConfig->serverCapabilities;
-					capabilitiesSize = mdnsConfig->serverCapabilitiesSize;
-				}
-				if (UA_Discovery_addRecord(server, mdnsServer, hostname, (unsigned short) atoi(port), path, UA_DISCOVERY_TCP, i==0, capabilities, &capabilitiesSize) != UA_STATUSCODE_GOOD) {
-					UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not add mDNS record for hostname %s.%s", mdnsServer);
-				}
-			}
-		}
-		free(mdnsServer);
-	}
+            if (!requestServer->isOnline) {
+                if (UA_Discovery_removeRecord(server, mdnsServer, hostname, (unsigned short) atoi(port), i==requestServer->discoveryUrlsSize) != UA_STATUSCODE_GOOD) {
+                    UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER,
+                                   "Could not reomve mDNS record for hostname %s.%s", mdnsServer);
+                }
+            }
+            else {
+                UA_String *capabilities = NULL;
+                size_t capabilitiesSize = 0;
+                if (mdnsConfig) {
+                    capabilities = mdnsConfig->serverCapabilities;
+                    capabilitiesSize = mdnsConfig->serverCapabilitiesSize;
+                }
+                if (UA_Discovery_addRecord(server, mdnsServer, hostname, (unsigned short) atoi(port), path, UA_DISCOVERY_TCP, i==0, capabilities, &capabilitiesSize) != UA_STATUSCODE_GOOD) {
+                    UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER,
+                                   "Could not add mDNS record for hostname %s.%s", mdnsServer);
+                }
+            }
+        }
+        free(mdnsServer);
+    }
 #endif
 
 
-	if (!requestServer->isOnline) {
-		// server is shutting down. Remove it from the registered servers list
-		if (!registeredServer_entry) {
-			// server not found, show warning
-			UA_LOG_WARNING_SESSION(server->config.logger, session, "Could not unregister server %.*s. Not registered.", (int)requestServer->serverUri.length, requestServer->serverUri.data);
-			responseHeader->serviceResult = UA_STATUSCODE_BADNOTFOUND;
-			return;
-		}
+    if (!requestServer->isOnline) {
+        // server is shutting down. Remove it from the registered servers list
+        if (!registeredServer_entry) {
+            // server not found, show warning
+            UA_LOG_WARNING_SESSION(server->config.logger, session,
+                                   "Could not unregister server %.*s. Not registered.",
+                                   (int)requestServer->serverUri.length, requestServer->serverUri.data);
+            responseHeader->serviceResult = UA_STATUSCODE_BADNOTFOUND;
+            return;
+        }
 
-		// server found, remove from list
-		LIST_REMOVE(registeredServer_entry, pointers);
-		UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
+        // server found, remove from list
+        LIST_REMOVE(registeredServer_entry, pointers);
+        UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
 #ifndef UA_ENABLE_MULTITHREADING
-		UA_free(registeredServer_entry);
-		server->registeredServersSize--;
+        UA_free(registeredServer_entry);
+        server->registeredServersSize--;
 #else
-		server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, -1);
+        server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, -1);
         UA_Server_delayedFree(server, registeredServer_entry);
 #endif
-		responseHeader->serviceResult = UA_STATUSCODE_GOOD;
-		return;
-	}
+        responseHeader->serviceResult = UA_STATUSCODE_GOOD;
+        return;
+    }
 
 
-	UA_StatusCode retval = UA_STATUSCODE_GOOD;
-	if (!registeredServer_entry) {
-		// server not yet registered, register it by adding it to the list
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    if (!registeredServer_entry) {
+        // server not yet registered, register it by adding it to the list
 
 
-		UA_LOG_DEBUG_SESSION(server->config.logger, session, "Registering new server: %.*s", (int)requestServer->serverUri.length, requestServer->serverUri.data);
+        UA_LOG_DEBUG_SESSION(server->config.logger, session, "Registering new server: %.*s",
+                             (int)requestServer->serverUri.length, requestServer->serverUri.data);
 
-		registeredServer_entry = UA_malloc(sizeof(registeredServer_list_entry));
-		if(!registeredServer_entry) {
-			responseHeader->serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
-			return;
-		}
+        registeredServer_entry = UA_malloc(sizeof(registeredServer_list_entry));
+        if(!registeredServer_entry) {
+            responseHeader->serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
+            return;
+        }
 
-		LIST_INSERT_HEAD(&server->registeredServers, registeredServer_entry, pointers);
+        LIST_INSERT_HEAD(&server->registeredServers, registeredServer_entry, pointers);
 #ifndef UA_ENABLE_MULTITHREADING
-		server->registeredServersSize++;
+        server->registeredServersSize++;
 #else
-		server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, 1);
+        server->registeredServersSize = uatomic_add_return(&server->registeredServersSize, 1);
 #endif
 
-	} else {
-		UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
-	}
+    } else {
+        UA_RegisteredServer_deleteMembers(&registeredServer_entry->registeredServer);
+    }
 
-	// copy the data from the request into the list
-	UA_RegisteredServer_copy(requestServer, &registeredServer_entry->registeredServer);
-	registeredServer_entry->lastSeen = UA_DateTime_now();
+    // copy the data from the request into the list
+    UA_RegisteredServer_copy(requestServer, &registeredServer_entry->registeredServer);
+    registeredServer_entry->lastSeen = UA_DateTime_now();
 
-	responseHeader->serviceResult = retval;
+    responseHeader->serviceResult = retval;
 }
 
 void Service_RegisterServer(UA_Server *server, UA_Session *session,
-                         const UA_RegisterServerRequest *request, UA_RegisterServerResponse *response) {
+                            const UA_RegisterServerRequest *request,
+                            UA_RegisterServerResponse *response) {
     UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing RegisterServerRequest");
-	process_RegisterServer(server, session, &request->requestHeader, &request->server, 0, NULL, &response->responseHeader, 0, NULL, 0, NULL);
+    process_RegisterServer(server, session, &request->requestHeader, &request->server, 0,
+                           NULL, &response->responseHeader, 0, NULL, 0, NULL);
 }
 
 void Service_RegisterServer2(UA_Server *server, UA_Session *session,
-                            const UA_RegisterServer2Request *request, UA_RegisterServer2Response *response) {
+                            const UA_RegisterServer2Request *request,
+                             UA_RegisterServer2Response *response) {
     UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing RegisterServer2Request");
 
     // copy the data from the request into the list
     UA_RegisteredServer_copy(&request->server, &registeredServer_entry->registeredServer);
     registeredServer_entry->lastSeen = UA_DateTime_nowMonotonic();
 
-	process_RegisterServer(server, session, &request->requestHeader, &request->server, request->discoveryConfigurationSize, request->discoveryConfiguration,
-						   &response->responseHeader, &response->configurationResultsSize, &response->configurationResults,
-						   &response->diagnosticInfosSize, response->diagnosticInfos);
+    process_RegisterServer(server, session, &request->requestHeader, &request->server,
+                           request->discoveryConfigurationSize, request->discoveryConfiguration,
+                           &response->responseHeader, &response->configurationResultsSize,
+                           &response->configurationResults, &response->diagnosticInfosSize,
+                           response->diagnosticInfos);
 
 }
 
@@ -913,7 +933,9 @@ static void periodicServerRegister(UA_Server *server, void *data) {
     // The semaphore file has to be accessible by the discovery server
     // UA_StatusCode retval = UA_Server_register_discovery(server, "opc.tcp://localhost:4840", "/path/to/some/file");
     if (retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not register server with discovery server. Is the discovery server started? StatusCode 0x%08x", retval);
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "Could not register server with discovery server. "
+                     "Is the discovery server started? StatusCode 0x%08x", retval);
 
         // first retry in 1 second
         UA_UInt32 nextInterval = 1;
@@ -938,7 +960,9 @@ static void periodicServerRegister(UA_Server *server, void *data) {
             UA_Server_addRepeatedJob(server, *newRetryJob->job, nextInterval*1000, &newRetryJob->job_id);
         }
     } else {
-        UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Server successfully registered. Next periodical register will be in %d seconds", (int)(retryJob->default_interval/1000));
+        UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
+                    "Server successfully registered. Next periodical register will be in %d seconds",
+                    (int)(retryJob->default_interval/1000));
     }
     if (!retryJob->is_main_job) {
         UA_free(retryJob->job);
@@ -947,7 +971,8 @@ static void periodicServerRegister(UA_Server *server, void *data) {
 
 }
 
-UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA_UInt32 intervalMs, const UA_UInt32 delayFirstRegisterMs, UA_Guid* periodicJobId) {
+UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA_UInt32 intervalMs,
+                                                     const UA_UInt32 delayFirstRegisterMs, UA_Guid* periodicJobId) {
 
     // registering the server should be done periodically. Approx. every 10 minutes. The first call will be in 10 Minutes.
 
@@ -967,7 +992,8 @@ UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA
         *periodicJobId = defaultJob.job_id;
     UA_StatusCode retval = UA_Server_addRepeatedJob(server, *defaultJob.job, intervalMs, &defaultJob.job_id);
     if (retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not create periodic job for server register. StatusCode 0x%08x", retval);
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "Could not create periodic job for server register. StatusCode 0x%08x", retval);
         return retval;
     }
 
@@ -985,7 +1011,8 @@ UA_StatusCode UA_Server_addPeriodicServerRegisterJob(UA_Server *server, const UA
         newRetryJob->job->job.methodCall.data = newRetryJob;
         retval = UA_Server_addRepeatedJob(server, *newRetryJob->job, delayFirstRegisterMs, &newRetryJob->job_id);
         if (retval != UA_STATUSCODE_GOOD) {
-            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not create first job for server register. StatusCode 0x%08x", retval);
+            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                         "Could not create first job for server register. StatusCode 0x%08x", retval);
             return retval;
         }
     }
@@ -1034,7 +1061,7 @@ static int discovery_createMulticastSocket(void) {
     setsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL, (void*)&ttl, sizeof(ttl));
     setsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL, (void*)&ittl, sizeof(ittl));
 
-	socket_mdns_set_nonblocking(s);
+    socket_mdns_set_nonblocking(s);
     return s;
 }
 
@@ -1044,7 +1071,7 @@ UA_StatusCode UA_Discovery_multicastInit(UA_Server* server) {
         UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Could not create multicast socket. Error: %s", strerror(errno));
         return UA_STATUSCODE_BADUNEXPECTEDERROR;
     }
-	mdnsd_register_receive_callback(server->mdnsDaemon, mdns_record_received, server);
+    mdnsd_register_receive_callback(server->mdnsDaemon, mdns_record_received, server);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -1054,21 +1081,21 @@ void UA_Discovery_multicastDestroy(UA_Server* server) {
 }
 
 static void UA_Discovery_multicastConflict(char *name, int type, void *arg) {
-	// cppcheck-suppress unreadVariable
-	UA_Server *server = (UA_Server*) arg;
+    // cppcheck-suppress unreadVariable
+    UA_Server *server = (UA_Server*) arg;
     UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS name conflict detected: '%s' for type %d", name, type);
 }
 
 static char* create_fullServiceDomain(const char* servername, const char* hostname) {
-	size_t hostnameLen = strlen(hostname);
-	size_t servernameLen = strlen(servername);
-	// [servername]._opcua-tcp._tcp.[hostname].
-	char *fullServiceDomain = malloc(hostnameLen + 25 + servernameLen);
-	if (!fullServiceDomain) {
-		return NULL;
-	}
-	snprintf(fullServiceDomain, hostnameLen + hostnameLen + 25 + servernameLen, "%s._opcua-tcp._tcp.%s.", servername, hostname);
-	return fullServiceDomain;
+    size_t hostnameLen = strlen(hostname);
+    size_t servernameLen = strlen(servername);
+    // [servername]._opcua-tcp._tcp.[hostname].
+    char *fullServiceDomain = malloc(hostnameLen + 25 + servernameLen);
+    if (!fullServiceDomain) {
+        return NULL;
+    }
+    snprintf(fullServiceDomain, hostnameLen + hostnameLen + 25 + servernameLen, "%s._opcua-tcp._tcp.%s.", servername, hostname);
+    return fullServiceDomain;
 }
 
 /**
@@ -1079,7 +1106,9 @@ static char* create_fullServiceDomain(const char* servername, const char* hostna
  * @param protocol
  * @return
  */
-static UA_StatusCode UA_Discovery_recordExists(UA_Server* server,const char* fullServiceDomain, unsigned short port, const UA_DiscoveryProtocol protocol) {
+static UA_StatusCode
+UA_Discovery_recordExists(UA_Server* server, const char* fullServiceDomain,
+                          unsigned short port, const UA_DiscoveryProtocol protocol) {
     unsigned short found = 0;
 
     // [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port [hostname].
@@ -1097,40 +1126,42 @@ static UA_StatusCode UA_Discovery_recordExists(UA_Server* server,const char* ful
     return found ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOTFOUND;
 }
 
-UA_StatusCode UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, const char* path,
-									 const UA_DiscoveryProtocol protocol, UA_Boolean createTxt, const UA_String* capabilites, const size_t *capabilitiesSize) {
-	if (capabilitiesSize == NULL || (*capabilitiesSize>0 && capabilites == NULL)) {
-		return UA_STATUSCODE_BADINVALIDARGUMENT;
-	}
+UA_StatusCode
+UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* hostname,
+                       unsigned short port, const char* path, const UA_DiscoveryProtocol protocol,
+                       UA_Boolean createTxt, const UA_String* capabilites, const size_t *capabilitiesSize) {
+    if (capabilitiesSize == NULL || (*capabilitiesSize>0 && capabilites == NULL)) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
 
-	size_t hostnameLen = strlen(hostname);
-	size_t servernameLen = strlen(servername);
-	// use a limit for the hostname length to make sure full string fits into 256 chars
-	if (hostnameLen == 0 || hostnameLen > 150 || servernameLen == 0 || servernameLen > 150) {
-		return UA_STATUSCODE_BADOUTOFRANGE;
-	}
+    size_t hostnameLen = strlen(hostname);
+    size_t servernameLen = strlen(servername);
+    // use a limit for the hostname length to make sure full string fits into 256 chars
+    if (hostnameLen == 0 || hostnameLen > 150 || servernameLen == 0 || servernameLen > 150) {
+        return UA_STATUSCODE_BADOUTOFRANGE;
+    }
 
-	if (!server->mdnsMainSrvAdded) {
-		mdns_record_t *r = mdnsd_shared(server->mdnsDaemon, "_services._dns-sd._udp.local.", QTYPE_PTR, 600);
-		mdnsd_set_host(server->mdnsDaemon, r, "_opcua-tcp._tcp.local.");
-		server->mdnsMainSrvAdded = 1;
-	}
+    if (!server->mdnsMainSrvAdded) {
+        mdns_record_t *r = mdnsd_shared(server->mdnsDaemon, "_services._dns-sd._udp.local.", QTYPE_PTR, 600);
+        mdnsd_set_host(server->mdnsDaemon, r, "_opcua-tcp._tcp.local.");
+        server->mdnsMainSrvAdded = 1;
+    }
 
-	// [servername]._opcua-tcp._tcp.[hostname].
-	char *fullServiceDomain;
-	if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname))) {
-		return UA_STATUSCODE_BADOUTOFMEMORY;
-	}
+    // [servername]._opcua-tcp._tcp.[hostname].
+    char *fullServiceDomain;
+    if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname))) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
 
     if (UA_Discovery_recordExists(server, fullServiceDomain, port, protocol) == UA_STATUSCODE_GOOD) {
-		free(fullServiceDomain);
+        free(fullServiceDomain);
         return UA_STATUSCODE_GOOD;
     }
 
-	UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: add record for domain: %s", fullServiceDomain);
+    UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: add record for domain: %s", fullServiceDomain);
 
 
-	// _services._dns-sd._udp.local. PTR _opcua-tcp._tcp.local
+    // _services._dns-sd._udp.local. PTR _opcua-tcp._tcp.local
 
     // check if there is already a PTR entry for the given service.
     mdns_record_t *r = mdnsd_get_published(server->mdnsDaemon, "_opcua-tcp._tcp.local.");
@@ -1146,7 +1177,7 @@ UA_StatusCode UA_Discovery_addRecord(UA_Server* server, const char* servername, 
         r = mdnsd_record_next(r);
     }
 
-	// _opcua-tcp._tcp.local. PTR [servername]._opcua-tcp._tcp.[hostname].
+    // _opcua-tcp._tcp.local. PTR [servername]._opcua-tcp._tcp.[hostname].
     if (!found) {
         r = mdnsd_shared(server->mdnsDaemon, "_opcua-tcp._tcp.local.", QTYPE_PTR, 600);
         mdnsd_set_host(server->mdnsDaemon, r, fullServiceDomain);
@@ -1162,58 +1193,58 @@ UA_StatusCode UA_Discovery_addRecord(UA_Server* server, const char* servername, 
 
 
     // [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port [hostname].
-	r = mdnsd_unique(server->mdnsDaemon, fullServiceDomain, QTYPE_SRV, 600, UA_Discovery_multicastConflict, server);
-	// r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_SRV, 600);
+    r = mdnsd_unique(server->mdnsDaemon, fullServiceDomain, QTYPE_SRV, 600, UA_Discovery_multicastConflict, server);
+    // r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_SRV, 600);
     mdnsd_set_srv(server->mdnsDaemon, r, 0, 0, port, localDomain);
 
     // TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
-	if (createTxt) {
-		r = mdnsd_unique(server->mdnsDaemon, fullServiceDomain, QTYPE_TXT, 600, UA_Discovery_multicastConflict, server);
-		xht_t* h = xht_new(11);
-		char* allocPath = NULL;
-		if (strlen(path) == 0)
-			xht_set(h, "path", "/");
-		else {
-			allocPath = STRDUP(path);
-			xht_set(h, "path", allocPath);
-		}
+    if (createTxt) {
+        r = mdnsd_unique(server->mdnsDaemon, fullServiceDomain, QTYPE_TXT, 600, UA_Discovery_multicastConflict, server);
+        xht_t* h = xht_new(11);
+        char* allocPath = NULL;
+        if (strlen(path) == 0)
+            xht_set(h, "path", "/");
+        else {
+            allocPath = STRDUP(path);
+            xht_set(h, "path", allocPath);
+        }
 
 
-		// calculate max string length:
-		size_t capsLen = 0;
+        // calculate max string length:
+        size_t capsLen = 0;
 
-		for (size_t i = 0; i < *capabilitiesSize; i++) {
-			// add comma or last \0
-			capsLen += capabilites[i].length + 1;
-		}
+        for (size_t i = 0; i < *capabilitiesSize; i++) {
+            // add comma or last \0
+            capsLen += capabilites[i].length + 1;
+        }
 
-		char* caps = NULL;
-		if (capsLen) {
-			// freed when xht_free is called
-			caps = malloc(sizeof(char) * capsLen);
-			size_t idx = 0;
-			for (size_t i = 0; i < *capabilitiesSize; i++) {
-				strncpy(caps + idx, (const char *)capabilites[i].data, capabilites[i].length);
-				idx += capabilites[i].length + 1;
-				caps[idx - 1] = ',';
-			}
-			caps[idx - 1] = '\0';
+        char* caps = NULL;
+        if (capsLen) {
+            // freed when xht_free is called
+            caps = malloc(sizeof(char) * capsLen);
+            size_t idx = 0;
+            for (size_t i = 0; i < *capabilitiesSize; i++) {
+                strncpy(caps + idx, (const char *)capabilites[i].data, capabilites[i].length);
+                idx += capabilites[i].length + 1;
+                caps[idx - 1] = ',';
+            }
+            caps[idx - 1] = '\0';
 
-			xht_set(h, "caps", caps);
-		} else {
-			xht_set(h, "caps", "NA");
-		}
+            xht_set(h, "caps", caps);
+        } else {
+            xht_set(h, "caps", "NA");
+        }
 
-		int txtRecordLength;
-		unsigned char* packet = sd2txt(h, &txtRecordLength);
-		if (allocPath)
-			free(allocPath);
-		if (caps)
-			free(caps);
-		xht_free(h);
-		mdnsd_set_raw(server->mdnsDaemon, r, (char*) packet, (unsigned short) txtRecordLength);
-		free(packet);
-	}
+        int txtRecordLength;
+        unsigned char* packet = sd2txt(h, &txtRecordLength);
+        if (allocPath)
+            free(allocPath);
+        if (caps)
+            free(caps);
+        xht_free(h);
+        mdnsd_set_raw(server->mdnsDaemon, r, (char*) packet, (unsigned short) txtRecordLength);
+        free(packet);
+    }
 
     free(fullServiceDomain);
     free(localDomain);
@@ -1221,63 +1252,69 @@ UA_StatusCode UA_Discovery_addRecord(UA_Server* server, const char* servername, 
     return UA_STATUSCODE_GOOD;
 }
 
-UA_StatusCode UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char* hostname, unsigned short port, UA_Boolean removeTxt) {
-	size_t hostnameLen = strlen(hostname);
-	size_t servernameLen = strlen(servername);
-	// use a limit for the hostname length to make sure full string fits into 256 chars
-	if (hostnameLen == 0 || hostnameLen > 150 || servernameLen == 0 || servernameLen > 150) {
-		return UA_STATUSCODE_BADOUTOFRANGE;
-	}
+UA_StatusCode
+UA_Discovery_removeRecord(UA_Server* server, const char* servername, const char* hostname,
+                          unsigned short port, UA_Boolean removeTxt) {
+    size_t hostnameLen = strlen(hostname);
+    size_t servernameLen = strlen(servername);
+    // use a limit for the hostname length to make sure full string fits into 256 chars
+    if (hostnameLen == 0 || hostnameLen > 150 || servernameLen == 0 || servernameLen > 150) {
+        return UA_STATUSCODE_BADOUTOFRANGE;
+    }
 
-	// [servername]._opcua-tcp._tcp.[hostname].
-	char *fullServiceDomain;
-	if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname))) {
-		return UA_STATUSCODE_BADOUTOFMEMORY;
-	}
+    // [servername]._opcua-tcp._tcp.[hostname].
+    char *fullServiceDomain;
+    if (!(fullServiceDomain = create_fullServiceDomain(servername, hostname))) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
 
-	UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: remove record for domain: %s", fullServiceDomain);
+    UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: remove record for domain: %s", fullServiceDomain);
 
     // count the number of records stil there for the given hostname, but a different port.
     // it does not represent the total number, but the minimum value.
     // if the number is 1, then also delete the main PTR record
     unsigned int recordMinCount = 0;
-	// _opcua-tcp._tcp.local. PTR [servername]._opcua-tcp._tcp.[hostname].
+    // _opcua-tcp._tcp.local. PTR [servername]._opcua-tcp._tcp.[hostname].
     mdns_record_t *r = mdnsd_get_published(server->mdnsDaemon, "_opcua-tcp._tcp.local.");
-	if (r) {
-		while (r) {
+    if (r) {
+        while (r) {
             recordMinCount++;
             const mdns_answer_t *data = mdnsd_record_data(r);
-			if (data->type == QTYPE_PTR && strcmp(data->rdname, fullServiceDomain)==0) {
-				mdnsd_done(server->mdnsDaemon,r);
-				if (mdnsd_record_next(r))
-					recordMinCount++; // there may still be more records, but we don't care how much
-				break;
-			}
-			r = mdnsd_record_next(r);
-		}
-	} else {
-		UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: could not remove record. PTR Record not found for domain: %s", fullServiceDomain);
-		free(fullServiceDomain);
-		return UA_STATUSCODE_BADNOTFOUND;
-	}
+            if (data->type == QTYPE_PTR && strcmp(data->rdname, fullServiceDomain)==0) {
+                mdnsd_done(server->mdnsDaemon,r);
+                if (mdnsd_record_next(r))
+                    recordMinCount++; // there may still be more records, but we don't care how much
+                break;
+            }
+            r = mdnsd_record_next(r);
+        }
+    } else {
+        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER,
+                       "Multicast DNS: could not remove record. PTR Record not found for domain: %s",
+                       fullServiceDomain);
+        free(fullServiceDomain);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
 
-	// [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port hostname.local.
-	// and TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
+    // [servername]._opcua-tcp._tcp.[hostname]. 86400 IN SRV 0 5 port hostname.local.
+    // and TXT record: [servername]._opcua-tcp._tcp.[hostname]. TXT path=/ caps=NA,DA,...
     r = mdnsd_get_published(server->mdnsDaemon, fullServiceDomain);
-	if (r) {
-		while (r) {
+    if (r) {
+        while (r) {
             const mdns_answer_t *data = mdnsd_record_data(r);
-			if ((removeTxt && data->type == QTYPE_TXT) || data->srv.port == port) {
+            if ((removeTxt && data->type == QTYPE_TXT) || data->srv.port == port) {
                 mdnsd_done(server->mdnsDaemon,r);
                 break;
             }
-			r = mdnsd_record_next(r);
-		}
-	} else {
-		UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast DNS: could not remove record. Record not found for domain: %s", fullServiceDomain);
-		free(fullServiceDomain);
-		return UA_STATUSCODE_BADNOTFOUND;
-	}
+            r = mdnsd_record_next(r);
+        }
+    } else {
+        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER,
+                       "Multicast DNS: could not remove record. Record not found for domain: %s",
+                       fullServiceDomain);
+        free(fullServiceDomain);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
 
     if (recordMinCount <= 1) {
         // _services._dns-sd._udp.local. PTR "_opcua-tcp._tcp.local."
@@ -1291,82 +1328,85 @@ UA_StatusCode UA_Discovery_removeRecord(UA_Server* server, const char* servernam
             }
             r = mdnsd_record_next(r);
         }
-		server->mdnsMainSrvAdded = 0;
+        server->mdnsMainSrvAdded = 0;
     }
 
     free(fullServiceDomain);
-	return UA_STATUSCODE_GOOD;
+    return UA_STATUSCODE_GOOD;
 }
 
 #  ifdef UA_ENABLE_MULTITHREADING
 
 static void * multicastWorkerLoop(UA_Server *server) {
-	struct timeval next_sleep = {.tv_sec = 0, .tv_usec = 0};
+    struct timeval next_sleep = {.tv_sec = 0, .tv_usec = 0};
+
+    volatile UA_Boolean *running = &server->mdnsRunning;
+    fd_set fds;
+
+    while (*running) {
+
+        FD_ZERO(&fds);
+        FD_SET(server->mdnsSocket, &fds);
+        select(server->mdnsSocket + 1, &fds, 0, 0, &next_sleep);
+
+        if (!*running)
+            break;
 
 
-	volatile UA_Boolean *running = &server->mdnsRunning;
-	fd_set fds;
+        unsigned short retVal = mdnsd_step(server->mdnsDaemon, server->mdnsSocket,
+                                           FD_ISSET(server->mdnsSocket, &fds), true, &next_sleep);
+        if (retVal == 1) {
+            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                         "Multicast error: Can not read from socket. %s", strerror(errno));
+            break;
+        } else if (retVal == 2) {
+            UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                         "Multicast error: Can not write to socket. %s", strerror(errno));
+            break;
+        }
 
-	while (*running) {
+        if (!*running)
+            break;
+    }
 
-		FD_ZERO(&fds);
-		FD_SET(server->mdnsSocket, &fds);
-		select(server->mdnsSocket + 1, &fds, 0, 0, &next_sleep);
-
-		if (!*running)
-			break;
-
-
-		unsigned short retVal = mdnsd_step(server->mdnsDaemon, server->mdnsSocket, FD_ISSET(server->mdnsSocket, &fds), true, &next_sleep);
-		if (retVal == 1) {
-			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not read from socket. %s", strerror(errno));
-			break;
-		} else if (retVal == 2) {
-			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not write to socket. %s", strerror(errno));
-			break;
-		}
-
-		if (!*running)
-			break;
-	}
-
-	return NULL;
+    return NULL;
 }
 
 UA_StatusCode UA_Discovery_multicastListenStart(UA_Server* server) {
-	if (pthread_create(&server->mdnsThread, NULL, (void* (*)(void*))multicastWorkerLoop, server)) {
-		UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not create multicast thread.");
-		return UA_STATUSCODE_BADUNEXPECTEDERROR;
-	}
+    if (pthread_create(&server->mdnsThread, NULL, (void* (*)(void*))multicastWorkerLoop, server)) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not create multicast thread.");
+        return UA_STATUSCODE_BADUNEXPECTEDERROR;
+    }
     return UA_STATUSCODE_GOOD;
 }
 
 UA_StatusCode UA_Discovery_multicastListenStop(UA_Server* server) {
-	mdnsd_shutdown(server->mdnsDaemon);
-	// wake up select
-	write(server->mdnsSocket, "\0", 1);
-	if(pthread_join(server->mdnsThread, NULL)) {
-		UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not stop thread.");
-		return UA_STATUSCODE_BADUNEXPECTEDERROR;
-	}
+    mdnsd_shutdown(server->mdnsDaemon);
+    // wake up select
+    write(server->mdnsSocket, "\0", 1);
+    if(pthread_join(server->mdnsThread, NULL)) {
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not stop thread.");
+        return UA_STATUSCODE_BADUNEXPECTEDERROR;
+    }
     return UA_STATUSCODE_BADNOTIMPLEMENTED;
 }
 
 #  endif // UA_ENABLE_DISCOVERY_MULTICAST && UA_ENABLE_MULTITHREADING
 
-
 UA_StatusCode UA_Discovery_multicastIterate(UA_Server* server, UA_DateTime *nextRepeat, UA_Boolean processIn) {
     struct timeval next_sleep = {.tv_sec = 0, .tv_usec = 0};
     unsigned short retVal = mdnsd_step(server->mdnsDaemon, server->mdnsSocket, processIn, true, &next_sleep);
     if (retVal == 1) {
-        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not read from socket. %s", strerror(errno));
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "Multicast error: Can not read from socket. %s", strerror(errno));
         return UA_STATUSCODE_BADNOCOMMUNICATION;
     } else if (retVal == 2) {
-        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not write to socket. %s", strerror(errno));
+        UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "Multicast error: Can not write to socket. %s", strerror(errno));
         return UA_STATUSCODE_BADNOCOMMUNICATION;
     }
-	if (nextRepeat)
-    	*nextRepeat = UA_DateTime_now() + (UA_DateTime)(next_sleep.tv_sec * UA_SEC_TO_DATETIME + next_sleep.tv_usec * UA_USEC_TO_DATETIME);
+    if (nextRepeat)
+        *nextRepeat = UA_DateTime_now() + (UA_DateTime)(next_sleep.tv_sec * UA_SEC_TO_DATETIME + next_sleep.tv_usec * UA_USEC_TO_DATETIME);
     return UA_STATUSCODE_GOOD;
 }
 

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -19,15 +19,16 @@
 #  ifdef _WIN32
 #   define _WINSOCK_DEPRECATED_NO_WARNINGS /* inet_ntoa is deprecated on MSVC but used for compatibility */
 #   include <winsock2.h>
+#   include <iphlpapi.h>
 #   include <ws2tcpip.h>
 #   define CLOSESOCKET(S) closesocket((SOCKET)S)
 #  else
 #   define CLOSESOCKET(S) close(S)
 #   include <sys/time.h> // for struct timeval
 #   include <netinet/in.h> // for struct ip_mreq
+#   include <ifaddrs.h>
+#   include <net/if.h> /* for IFF_RUNNING */
 #  endif
-#  include <ifaddrs.h>
-#  include <net/if.h> /* for IFF_RUNNING */
 # endif
 #endif
 
@@ -1200,35 +1201,155 @@ UA_Discovery_addRecord(UA_Server* server, const char* servername, const char* ho
 
 	// A/AAAA record for all ip addresses.
 	// [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
+#ifdef _WIN32
+	// see http://stackoverflow.com/a/10838854/869402
+	IP_ADAPTER_ADDRESSES* adapter_addresses = NULL;
+	IP_ADAPTER_ADDRESSES* adapter = NULL;
+
+	// Start with a 16 KB buffer and resize if needed -
+	// multiple attempts in case interfaces change while
+	// we are in the middle of querying them.
+	DWORD adapter_addresses_buffer_size = 16 * 1024;
+	for (int attempts = 0; attempts != 3; ++attempts)
+	{
+		adapter_addresses = (IP_ADAPTER_ADDRESSES*)malloc(adapter_addresses_buffer_size);
+		assert(adapter_addresses);
+
+		DWORD error = GetAdaptersAddresses(
+			AF_UNSPEC, 
+			GAA_FLAG_SKIP_ANYCAST | 
+				GAA_FLAG_SKIP_MULTICAST | 
+				GAA_FLAG_SKIP_DNS_SERVER |
+				GAA_FLAG_SKIP_FRIENDLY_NAME, 
+			NULL, 
+			adapter_addresses,
+			&adapter_addresses_buffer_size);
+
+		if (ERROR_SUCCESS == error)
+		{
+			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"GetAdaptersAddresses returned an error. Not setting mDNS A records.");
+			adapter_addresses = NULL;
+			break;
+		}
+		else if (ERROR_BUFFER_OVERFLOW == error)
+		{
+			// Try again with the new size
+			free(adapter_addresses);
+			adapter_addresses = NULL;
+
+			continue;
+		}
+		else
+		{
+			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"GetAdaptersAddresses returned an unexpected error. Not setting mDNS A records.");
+			// Unexpected error code - log and throw
+			free(adapter_addresses);
+			adapter_addresses = NULL;
+
+			break;
+		}
+	}
+
+	// Iterate through all of the adapters
+	for (adapter = adapter_addresses; NULL != adapter; adapter = adapter->Next)
+	{
+		// Skip loopback adapters
+		if (IF_TYPE_SOFTWARE_LOOPBACK == adapter->IfType)
+		{
+			continue;
+		}
+
+		// Parse all IPv4 and IPv6 addresses
+		for (
+			IP_ADAPTER_UNICAST_ADDRESS* address = adapter->FirstUnicastAddress; 
+			NULL != address;
+			address = address->Next)
+		{
+			int family = address->Address.lpSockaddr->sa_family;
+			if (AF_INET == family)
+			{
+				// IPv4
+				SOCKADDR_IN* ipv4 = (SOCKADDR_IN*)(address->Address.lpSockaddr);
+
+
+				// [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
+				r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_A, 600);
+				mdnsd_set_raw(server->mdnsDaemon, r,(char *)&ipv4->sin_addr , 4);
+			}
+			/*else if (AF_INET6 == family)
+			{
+				// IPv6
+				SOCKADDR_IN6* ipv6 = (SOCKADDR_IN6*)(address->Address.lpSockaddr);
+
+				char str_buffer[INET6_ADDRSTRLEN] = {0};
+				inet_ntop(AF_INET6, &(ipv6->sin6_addr), str_buffer, INET6_ADDRSTRLEN);
+
+				std::string ipv6_str(str_buffer);
+
+				// Detect and skip non-external addresses
+				bool is_link_local(false);
+				bool is_special_use(false);
+
+				if (0 == ipv6_str.find("fe"))
+				{
+					char c = ipv6_str[2];
+					if (c == '8' || c == '9' || c == 'a' || c == 'b')
+					{
+						is_link_local = true;
+					}
+				}
+				else if (0 == ipv6_str.find("2001:0:"))
+				{
+					is_special_use = true;
+				}
+
+				if (! (is_link_local || is_special_use))
+				{
+					ipAddrs.mIpv6.push_back(ipv6_str);
+				}
+			}*/
+			else
+			{
+				// Skip all other types of addresses
+				continue;
+			}
+		}
+	}
+
+	// Cleanup
+	free(adapter_addresses);
+	adapter_addresses = NULL;
+#else
 	{
 		struct ifaddrs *ifaddr, *ifa;
 		if (getifaddrs(&ifaddr) == -1) {
-			perror("getifaddrs");
-			exit(EXIT_FAILURE);
+			UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,"getifaddrs returned an unexpected error. Not setting mDNS A records.");
+		} else {
+			/* Walk through linked list, maintaining head pointer so we can free list later */
+			int n;
+			for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
+				if (ifa->ifa_addr == NULL)
+					continue;
+
+				if ((strcmp("lo", ifa->ifa_name) == 0) ||
+					!(ifa->ifa_flags & (IFF_RUNNING)))
+					continue;
+
+				if (ifa->ifa_addr->sa_family == AF_INET) {
+					struct sockaddr_in* sa = (struct sockaddr_in*) ifa->ifa_addr;
+					// [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
+					r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_A, 600);
+					mdnsd_set_raw(server->mdnsDaemon, r,(char *)&sa->sin_addr.s_addr , 4);
+				} /*else if (ifa->ifa_addr->sa_family == AF_INET6) {
+					// IPv6 not implemented yet
+				}*/
+			}
+
+			freeifaddrs(ifaddr);
 		}
 
-		/* Walk through linked list, maintaining head pointer so we can free list later */
-		int n;
-		for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
-			if (ifa->ifa_addr == NULL)
-				continue;
-
-			if ((strcmp("lo", ifa->ifa_name) == 0) ||
-				!(ifa->ifa_flags & (IFF_RUNNING)))
-				continue;
-
-			if (ifa->ifa_addr->sa_family == AF_INET) {
-				struct sockaddr_in* sa = (struct sockaddr_in*) ifa->ifa_addr;
-				// [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
-				r = mdnsd_shared(server->mdnsDaemon, fullServiceDomain, QTYPE_A, 600);
-				mdnsd_set_raw(server->mdnsDaemon, r,(char *)&sa->sin_addr.s_addr , 4);
-			} /*else if (ifa->ifa_addr->sa_family == AF_INET6) {
-				// IPv6 not implemented yet
-			}*/
-		}
-
-		freeifaddrs(ifaddr);
 	}
+#endif
 
     // TXT record: [servername]-[hostname]._opcua-tcp._tcp.local. TXT path=/ caps=NA,DA,...
     if (createTxt) {

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -824,17 +824,11 @@ void Service_RegisterServer2(UA_Server *server, UA_Session *session,
                             const UA_RegisterServer2Request *request,
                              UA_RegisterServer2Response *response) {
     UA_LOG_DEBUG_SESSION(server->config.logger, session, "Processing RegisterServer2Request");
-
-    // copy the data from the request into the list
-    UA_RegisteredServer_copy(&request->server, &registeredServer_entry->registeredServer);
-    registeredServer_entry->lastSeen = UA_DateTime_nowMonotonic();
-
     process_RegisterServer(server, session, &request->requestHeader, &request->server,
                            request->discoveryConfigurationSize, request->discoveryConfiguration,
                            &response->responseHeader, &response->configurationResultsSize,
                            &response->configurationResults, &response->diagnosticInfosSize,
                            response->diagnosticInfos);
-
 }
 
 /**
@@ -875,9 +869,13 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
                             (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,
                             (int)current->registeredServer.semaphoreFilePath.length, current->registeredServer.semaphoreFilePath.data);
             } else {
+                // cppcheck-suppress unreadVariable
+                UA_String lastStr = UA_DateTime_toString(current->lastSeen);
                 UA_LOG_INFO(server->config.logger, UA_LOGCATEGORY_SERVER,
-                             "Registration of server with URI %.*s has timed out and is removed",
-                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data);
+                             "Registration of server with URI %.*s has timed out and is removed. Last seen: %.*s",
+                            (int)current->registeredServer.serverUri.length, current->registeredServer.serverUri.data,
+                            (int)lastStr.length, lastStr.data);
+                UA_free(lastStr.data);
             }
             LIST_REMOVE(current, pointers);
             UA_RegisteredServer_deleteMembers(&current->registeredServer);

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -124,7 +124,7 @@ isNodeInTree(UA_NodeStore *ns, const UA_NodeId *rootNode, const UA_NodeId *nodeT
 /* Add Node */
 /************/
 
-static void
+void
 Service_AddNodes_single(UA_Server *server, UA_Session *session,
                         const UA_AddNodesItem *item, UA_AddNodesResult *result,
                         UA_InstantiationCallback *instantiationCallback);
@@ -668,7 +668,7 @@ dataTypeNodeFromAttributes(const UA_AddNodesItem *item,
     return (UA_Node*)dtnode;
 }
 
-static void
+void
 Service_AddNodes_single(UA_Server *server, UA_Session *session,
                         const UA_AddNodesItem *item, UA_AddNodesResult *result,
                         UA_InstantiationCallback *instantiationCallback) {

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -423,7 +423,7 @@ UA_Server_browse(UA_Server *server, UA_UInt32 maxrefs, const UA_BrowseDescriptio
     return result;
 }
 
-static void
+void
 UA_Server_browseNext_single(UA_Server *server, UA_Session *session, UA_Boolean releaseContinuationPoint,
                             const UA_ByteString *continuationPoint, UA_BrowseResult *result) {
     result->statusCode = UA_STATUSCODE_BADCONTINUATIONPOINTINVALID;

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -858,3 +858,41 @@ void UA_Array_delete(void *p, size_t size, const UA_DataType *type) {
     }
     UA_free((void*)((uintptr_t)p & ~(uintptr_t)UA_EMPTY_ARRAY_SENTINEL));
 }
+
+UA_StatusCode UA_EndpointUrl_split(const char *endpointUrl, char *hostname, const char ** port, const char **path) {
+    size_t urlLength = strlen(endpointUrl);
+    if(urlLength < 11 || urlLength >= 512) {
+        return UA_STATUSCODE_BADOUTOFRANGE;
+    }
+    if(strncmp(endpointUrl, "opc.tcp://", 10) != 0) {
+        return UA_STATUSCODE_BADATTRIBUTEIDINVALID;
+    }
+
+    /* where does the port begin? */
+    size_t portpos = 10;
+    for(; portpos < urlLength-1; portpos++) {
+        if(endpointUrl[portpos] == ':')
+            break;
+    }
+
+    memcpy(hostname, &endpointUrl[10], portpos - 10);
+    hostname[portpos-10] = 0;
+
+    if(port && portpos < urlLength - 1)
+        *port = &endpointUrl[portpos + 1];
+
+	if (path) {
+		size_t pathpos = portpos < urlLength - 1 ? portpos + 1 : 10;
+		for(; pathpos < urlLength; pathpos++) {
+			if(endpointUrl[pathpos] == '/')
+				break;
+		}
+		if (pathpos < urlLength)
+			*path = &endpointUrl[pathpos];
+		else
+			*path = NULL;
+	}
+
+	return UA_STATUSCODE_GOOD;
+}
+

--- a/tests/check_discovery.c
+++ b/tests/check_discovery.c
@@ -36,47 +36,47 @@ UA_ServerNetworkLayer nl_lds;
 pthread_t server_thread_lds;
 
 static void * serverloop_lds(void *_) {
-	while(*running_lds)
-		UA_Server_run_iterate(server_lds, true);
-	return NULL;
+    while(*running_lds)
+        UA_Server_run_iterate(server_lds, true);
+    return NULL;
 }
 
 static void setup_lds(void) {
-	// start LDS server
-	running_lds = UA_Boolean_new();
-	*running_lds = true;
-	UA_ServerConfig config_lds = UA_ServerConfig_standard;
-	config_lds.applicationDescription.applicationType = UA_APPLICATIONTYPE_DISCOVERYSERVER;
-	config_lds.applicationDescription.applicationUri = UA_String_fromChars("open62541.test.local_discovery_server");
-	config_lds.applicationDescription.applicationName.locale = UA_String_fromChars("EN");
-	config_lds.applicationDescription.applicationName.text = UA_String_fromChars("LDS Server");
-	config_lds.mdnsServerName = UA_String_fromChars("LDS_test");
-	config_lds.serverCapabilitiesSize = 1;
-	UA_String *caps = UA_String_new();
-	*caps = UA_String_fromChars("LDS");
-	config_lds.serverCapabilities = caps;
-	config_lds.discoveryCleanupTimeout = registerTimeout;
-	nl_lds = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4840);
-	config_lds.networkLayers = &nl_lds;
-	config_lds.networkLayersSize = 1;
-	server_lds = UA_Server_new(config_lds);
-	UA_Server_run_startup(server_lds);
-	pthread_create(&server_thread_lds, NULL, serverloop_lds, NULL);
-	// wait until LDS started
-	sleep(1);
+    // start LDS server
+    running_lds = UA_Boolean_new();
+    *running_lds = true;
+    UA_ServerConfig config_lds = UA_ServerConfig_standard;
+    config_lds.applicationDescription.applicationType = UA_APPLICATIONTYPE_DISCOVERYSERVER;
+    config_lds.applicationDescription.applicationUri = UA_String_fromChars("open62541.test.local_discovery_server");
+    config_lds.applicationDescription.applicationName.locale = UA_String_fromChars("EN");
+    config_lds.applicationDescription.applicationName.text = UA_String_fromChars("LDS Server");
+    config_lds.mdnsServerName = UA_String_fromChars("LDS_test");
+    config_lds.serverCapabilitiesSize = 1;
+    UA_String *caps = UA_String_new();
+    *caps = UA_String_fromChars("LDS");
+    config_lds.serverCapabilities = caps;
+    config_lds.discoveryCleanupTimeout = registerTimeout;
+    nl_lds = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4840);
+    config_lds.networkLayers = &nl_lds;
+    config_lds.networkLayersSize = 1;
+    server_lds = UA_Server_new(config_lds);
+    UA_Server_run_startup(server_lds);
+    pthread_create(&server_thread_lds, NULL, serverloop_lds, NULL);
+    // wait until LDS started
+    sleep(1);
 }
 
 static void teardown_lds(void) {
-	*running_lds = false;
-	pthread_join(server_thread_lds, NULL);
-	UA_Server_run_shutdown(server_lds);
-	UA_Boolean_delete(running_lds);
-	UA_String_deleteMembers(&server_lds->config.applicationDescription.applicationUri);
-	UA_LocalizedText_deleteMembers(&server_lds->config.applicationDescription.applicationName);
-	UA_String_deleteMembers(&server_lds->config.mdnsServerName);
-	UA_Array_delete(server_lds->config.serverCapabilities, server_lds->config.serverCapabilitiesSize, &UA_TYPES[UA_TYPES_STRING]);
-	UA_Server_delete(server_lds);
-	nl_lds.deleteMembers(&nl_lds);
+    *running_lds = false;
+    pthread_join(server_thread_lds, NULL);
+    UA_Server_run_shutdown(server_lds);
+    UA_Boolean_delete(running_lds);
+    UA_String_deleteMembers(&server_lds->config.applicationDescription.applicationUri);
+    UA_LocalizedText_deleteMembers(&server_lds->config.applicationDescription.applicationName);
+    UA_String_deleteMembers(&server_lds->config.mdnsServerName);
+    UA_Array_delete(server_lds->config.serverCapabilities, server_lds->config.serverCapabilitiesSize, &UA_TYPES[UA_TYPES_STRING]);
+    UA_Server_delete(server_lds);
+    nl_lds.deleteMembers(&nl_lds);
 }
 
 
@@ -88,335 +88,335 @@ pthread_t server_thread_register;
 UA_Guid periodicRegisterJobId;
 
 static void * serverloop_register(void *_) {
-	while(*running_register)
-		UA_Server_run_iterate(server_register, true);
-	return NULL;
+    while(*running_register)
+        UA_Server_run_iterate(server_register, true);
+    return NULL;
 }
 
 static void setup_register(void) {
-	// start register server
-	running_register = UA_Boolean_new();
-	*running_register = true;
-	UA_ServerConfig config_register = UA_ServerConfig_standard;
-	config_register.applicationDescription.applicationUri = UA_String_fromChars("open62541.test.server_register");
-	config_register.applicationDescription.applicationName.locale = UA_String_fromChars("EN");
-	config_register.applicationDescription.applicationName.text = UA_String_fromChars("Register Server");
-	config_register.mdnsServerName = UA_String_fromChars("Register_test");
-	nl_register = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 16664);
-	config_register.networkLayers = &nl_register;
-	config_register.networkLayersSize = 1;
-	server_register = UA_Server_new(config_register);
-	UA_Server_run_startup(server_register);
-	pthread_create(&server_thread_register, NULL, serverloop_register, NULL);
+    // start register server
+    running_register = UA_Boolean_new();
+    *running_register = true;
+    UA_ServerConfig config_register = UA_ServerConfig_standard;
+    config_register.applicationDescription.applicationUri = UA_String_fromChars("open62541.test.server_register");
+    config_register.applicationDescription.applicationName.locale = UA_String_fromChars("EN");
+    config_register.applicationDescription.applicationName.text = UA_String_fromChars("Register Server");
+    config_register.mdnsServerName = UA_String_fromChars("Register_test");
+    nl_register = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 16664);
+    config_register.networkLayers = &nl_register;
+    config_register.networkLayersSize = 1;
+    server_register = UA_Server_new(config_register);
+    UA_Server_run_startup(server_register);
+    pthread_create(&server_thread_register, NULL, serverloop_register, NULL);
 }
 
 static void teardown_register(void) {
-	*running_register = false;
-	pthread_join(server_thread_register, NULL);
-	UA_Server_run_shutdown(server_register);
-	UA_Boolean_delete(running_register);
-	UA_String_deleteMembers(&server_register->config.applicationDescription.applicationUri);
-	UA_LocalizedText_deleteMembers(&server_register->config.applicationDescription.applicationName);
-	UA_String_deleteMembers(&server_register->config.mdnsServerName);
-	UA_Server_delete(server_register);
-	nl_register.deleteMembers(&nl_register);
+    *running_register = false;
+    pthread_join(server_thread_register, NULL);
+    UA_Server_run_shutdown(server_register);
+    UA_Boolean_delete(running_register);
+    UA_String_deleteMembers(&server_register->config.applicationDescription.applicationUri);
+    UA_LocalizedText_deleteMembers(&server_register->config.applicationDescription.applicationName);
+    UA_String_deleteMembers(&server_register->config.mdnsServerName);
+    UA_Server_delete(server_register);
+    nl_register.deleteMembers(&nl_register);
 }
 
 START_TEST(Server_register) {
-		UA_StatusCode retval = UA_Server_register_discovery(server_register, "opc.tcp://localhost:4840", NULL);
-		ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-	}
+        UA_StatusCode retval = UA_Server_register_discovery(server_register, "opc.tcp://localhost:4840", NULL);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
 END_TEST
 
 START_TEST(Server_unregister) {
-		UA_StatusCode retval = UA_Server_unregister_discovery(server_register, "opc.tcp://localhost:4840");
-		ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-	}
+        UA_StatusCode retval = UA_Server_unregister_discovery(server_register, "opc.tcp://localhost:4840");
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
 END_TEST
 
 START_TEST(Server_register_periodic) {
-		// periodic register every minute, first register immediately
-		UA_StatusCode retval = UA_Server_addPeriodicServerRegisterJob(server_register, 60*1000, 100, &periodicRegisterJobId);
-		ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-	}
+        // periodic register every minute, first register immediately
+        UA_StatusCode retval = UA_Server_addPeriodicServerRegisterJob(server_register, 60*1000, 100, &periodicRegisterJobId);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
 END_TEST
 
 START_TEST(Server_unregister_periodic) {
-		// wait for first register delay
-		sleep(1);
-		UA_Server_removeRepeatedJob(server_register, periodicRegisterJobId);
-		UA_StatusCode retval = UA_Server_unregister_discovery(server_register, "opc.tcp://localhost:4840");
-		ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-	}
+        // wait for first register delay
+        sleep(1);
+        UA_Server_removeRepeatedJob(server_register, periodicRegisterJobId);
+        UA_StatusCode retval = UA_Server_unregister_discovery(server_register, "opc.tcp://localhost:4840");
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
 END_TEST
 
 
 static UA_StatusCode FindServers(const char* discoveryServerUrl, size_t* registeredServerSize, UA_ApplicationDescription** registeredServers, const char* filterUri, const char* filterLocale) {
-	UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
-	UA_StatusCode retval = UA_Client_connect(client, discoveryServerUrl);
-	if(retval != UA_STATUSCODE_GOOD) {
-		UA_Client_delete(client);
-		return retval;
-	}
+    UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
+    UA_StatusCode retval = UA_Client_connect(client, discoveryServerUrl);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_Client_delete(client);
+        return retval;
+    }
 
 
-	UA_FindServersRequest request;
-	UA_FindServersRequest_init(&request);
+    UA_FindServersRequest request;
+    UA_FindServersRequest_init(&request);
 
-	if (filterUri) {
-		request.serverUrisSize = 1;
-		request.serverUris = UA_malloc(sizeof(UA_String));
-		request.serverUris[0] = UA_String_fromChars(filterUri);
-	}
+    if (filterUri) {
+        request.serverUrisSize = 1;
+        request.serverUris = UA_malloc(sizeof(UA_String));
+        request.serverUris[0] = UA_String_fromChars(filterUri);
+    }
 
-	if (filterLocale) {
-		request.localeIdsSize = 1;
-		request.localeIds = UA_malloc(sizeof(UA_String));
-		request.localeIds[0] = UA_String_fromChars(filterLocale);
-	}
+    if (filterLocale) {
+        request.localeIdsSize = 1;
+        request.localeIds = UA_malloc(sizeof(UA_String));
+        request.localeIds[0] = UA_String_fromChars(filterLocale);
+    }
 
-	// now send the request
-	UA_FindServersResponse response;
-	UA_FindServersResponse_init(&response);
-	__UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_FINDSERVERSREQUEST],
-						&response, &UA_TYPES[UA_TYPES_FINDSERVERSRESPONSE]);
+    // now send the request
+    UA_FindServersResponse response;
+    UA_FindServersResponse_init(&response);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_FINDSERVERSREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_FINDSERVERSRESPONSE]);
 
-	if (filterUri) {
-		UA_Array_delete(request.serverUris, request.serverUrisSize, &UA_TYPES[UA_TYPES_STRING]);
-	}
+    if (filterUri) {
+        UA_Array_delete(request.serverUris, request.serverUrisSize, &UA_TYPES[UA_TYPES_STRING]);
+    }
 
-	if (filterLocale) {
-		UA_Array_delete(request.localeIds, request.localeIdsSize, &UA_TYPES[UA_TYPES_STRING]);
-	}
+    if (filterLocale) {
+        UA_Array_delete(request.localeIds, request.localeIdsSize, &UA_TYPES[UA_TYPES_STRING]);
+    }
 
-	if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-		UA_FindServersResponse_deleteMembers(&response);
-		UA_Client_disconnect(client);
-		UA_Client_delete(client);
-		ck_abort_msg("FindServers failed with statuscode 0x%08x", response.responseHeader.serviceResult);
-	}
+    if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+        UA_FindServersResponse_deleteMembers(&response);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        ck_abort_msg("FindServers failed with statuscode 0x%08x", response.responseHeader.serviceResult);
+    }
 
-	*registeredServerSize = response.serversSize;
-	*registeredServers = (UA_ApplicationDescription*)UA_Array_new(response.serversSize, &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
-	for(size_t i=0;i<response.serversSize;i++)
-		UA_ApplicationDescription_copy(&response.servers[i], &(*registeredServers)[i]);
-	UA_FindServersResponse_deleteMembers(&response);
+    *registeredServerSize = response.serversSize;
+    *registeredServers = (UA_ApplicationDescription*)UA_Array_new(response.serversSize, &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
+    for(size_t i=0;i<response.serversSize;i++)
+        UA_ApplicationDescription_copy(&response.servers[i], &(*registeredServers)[i]);
+    UA_FindServersResponse_deleteMembers(&response);
 
-	UA_Client_disconnect(client);
-	UA_Client_delete(client);
-	return (int) UA_STATUSCODE_GOOD;
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+    return (int) UA_STATUSCODE_GOOD;
 }
 
 static void FindAndCheck(const char* expectedUris[], size_t expectedUrisSize, const char *filterUri, const char *filterLocale) {
-	UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
-	UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
 
-	ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-	UA_ApplicationDescription* applicationDescriptionArray = NULL;
-	size_t applicationDescriptionArraySize = 0;
+    UA_ApplicationDescription* applicationDescriptionArray = NULL;
+    size_t applicationDescriptionArraySize = 0;
 
-	retval = FindServers("opc.tcp://localhost:4840", &applicationDescriptionArraySize, &applicationDescriptionArray, filterUri, filterLocale);
-	ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    retval = FindServers("opc.tcp://localhost:4840", &applicationDescriptionArraySize, &applicationDescriptionArray, filterUri, filterLocale);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-	// only the discovery server is expected
-	ck_assert_uint_eq(applicationDescriptionArraySize , expectedUrisSize);
+    // only the discovery server is expected
+    ck_assert_uint_eq(applicationDescriptionArraySize , expectedUrisSize);
 
-	for (size_t i=0; i<expectedUrisSize; i++) {
-		char* serverUri = malloc(sizeof(char)*applicationDescriptionArray[i].applicationUri.length+1);
-		memcpy( serverUri, applicationDescriptionArray[i].applicationUri.data, applicationDescriptionArray[i].applicationUri.length );
-		serverUri[applicationDescriptionArray[i].applicationUri.length] = '\0';
-		ck_assert_str_eq(serverUri, expectedUris[i]);
-		free(serverUri);
-	}
+    for (size_t i=0; i<expectedUrisSize; i++) {
+        char* serverUri = malloc(sizeof(char)*applicationDescriptionArray[i].applicationUri.length+1);
+        memcpy( serverUri, applicationDescriptionArray[i].applicationUri.data, applicationDescriptionArray[i].applicationUri.length );
+        serverUri[applicationDescriptionArray[i].applicationUri.length] = '\0';
+        ck_assert_str_eq(serverUri, expectedUris[i]);
+        free(serverUri);
+    }
 
-	UA_Array_delete(applicationDescriptionArray, applicationDescriptionArraySize, &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
+    UA_Array_delete(applicationDescriptionArray, applicationDescriptionArraySize, &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
 
-	UA_Client_disconnect(client);
-	UA_Client_delete(client);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
 }
 
 static UA_StatusCode FindServersOnNetwork(const char* discoveryServerUrl, size_t* serverOnNetworkSize, UA_ServerOnNetwork** serverOnNetwork) {
-	UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
-	UA_StatusCode retval = UA_Client_connect(client, discoveryServerUrl);
-	if(retval != UA_STATUSCODE_GOOD) {
-		UA_Client_delete(client);
-		return retval;
-	}
+    UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
+    UA_StatusCode retval = UA_Client_connect(client, discoveryServerUrl);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_Client_delete(client);
+        return retval;
+    }
 
 
-	UA_FindServersOnNetworkRequest request;
-	UA_FindServersOnNetworkRequest_init(&request);
+    UA_FindServersOnNetworkRequest request;
+    UA_FindServersOnNetworkRequest_init(&request);
 
-	request.startingRecordId = 0;
-	request.maxRecordsToReturn = 0; // get all
-	/*
-	 * Here you can define some filtering rules:
-	 */
-	//request.serverCapabilityFilterSize = 1;
-	//request.serverCapabilityFilter[0] = UA_String_fromChars("LDS");
+    request.startingRecordId = 0;
+    request.maxRecordsToReturn = 0; // get all
+    /*
+     * Here you can define some filtering rules:
+     */
+    //request.serverCapabilityFilterSize = 1;
+    //request.serverCapabilityFilter[0] = UA_String_fromChars("LDS");
 
-	// now send the request
-	UA_FindServersOnNetworkResponse response;
-	UA_FindServersOnNetworkResponse_init(&response);
-	__UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_FINDSERVERSONNETWORKREQUEST],
-						&response, &UA_TYPES[UA_TYPES_FINDSERVERSONNETWORKRESPONSE]);
+    // now send the request
+    UA_FindServersOnNetworkResponse response;
+    UA_FindServersOnNetworkResponse_init(&response);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_FINDSERVERSONNETWORKREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_FINDSERVERSONNETWORKRESPONSE]);
 
-	//UA_Array_delete(request.serverCapabilityFilter, request.serverCapabilityFilterSize, &UA_TYPES[UA_TYPES_STRING]);
+    //UA_Array_delete(request.serverCapabilityFilter, request.serverCapabilityFilterSize, &UA_TYPES[UA_TYPES_STRING]);
 
-	if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-		UA_FindServersOnNetworkResponse_deleteMembers(&response);
-		UA_Client_disconnect(client);
-		UA_Client_delete(client);
-		ck_abort_msg("FindServersOnNetwork failed with statuscode 0x%08x", response.responseHeader.serviceResult);
-	}
+    if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+        UA_FindServersOnNetworkResponse_deleteMembers(&response);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        ck_abort_msg("FindServersOnNetwork failed with statuscode 0x%08x", response.responseHeader.serviceResult);
+    }
 
-	*serverOnNetworkSize = response.serversSize;
-	*serverOnNetwork = (UA_ServerOnNetwork*)UA_Array_new(response.serversSize, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
-	for(size_t i=0;i<response.serversSize;i++)
-		UA_ServerOnNetwork_copy(&response.servers[i], &(*serverOnNetwork)[i]);
-	UA_FindServersOnNetworkResponse_deleteMembers(&response);
+    *serverOnNetworkSize = response.serversSize;
+    *serverOnNetwork = (UA_ServerOnNetwork*)UA_Array_new(response.serversSize, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
+    for(size_t i=0;i<response.serversSize;i++)
+        UA_ServerOnNetwork_copy(&response.servers[i], &(*serverOnNetwork)[i]);
+    UA_FindServersOnNetworkResponse_deleteMembers(&response);
 
-	UA_Client_disconnect(client);
-	UA_Client_delete(client);
-	return (int) UA_STATUSCODE_GOOD;
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+    return (int) UA_STATUSCODE_GOOD;
 }
 
 static void FindOnNetworkAndCheck(char* expectedServerNames[], size_t expectedServerNamesSize, const char *filterUri, const char *filterLocale) {
-	UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
-	UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
 
-	ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-	UA_ServerOnNetwork* serverOnNetwork = NULL;
-	size_t serverOnNetworkSize = 0;
+    UA_ServerOnNetwork* serverOnNetwork = NULL;
+    size_t serverOnNetworkSize = 0;
 
-	retval = FindServersOnNetwork("opc.tcp://localhost:4840", &serverOnNetworkSize, &serverOnNetwork);
-	ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    retval = FindServersOnNetwork("opc.tcp://localhost:4840", &serverOnNetworkSize, &serverOnNetwork);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-	// only the discovery server is expected
-	ck_assert_uint_eq(serverOnNetworkSize , expectedServerNamesSize);
+    // only the discovery server is expected
+    ck_assert_uint_eq(serverOnNetworkSize , expectedServerNamesSize);
 
-	for (size_t i=0; i<expectedServerNamesSize; i++) {
-		char* serverName = malloc(sizeof(char)*serverOnNetwork[i].serverName.length+1);
-		memcpy( serverName, serverOnNetwork[i].serverName.data, serverOnNetwork[i].serverName.length );
-		serverName[serverOnNetwork[i].serverName.length] = '\0';
-		ck_assert_str_eq(serverName, expectedServerNames[i]);
-		free(serverName);
-	}
+    for (size_t i=0; i<expectedServerNamesSize; i++) {
+        char* serverName = malloc(sizeof(char)*serverOnNetwork[i].serverName.length+1);
+        memcpy( serverName, serverOnNetwork[i].serverName.data, serverOnNetwork[i].serverName.length );
+        serverName[serverOnNetwork[i].serverName.length] = '\0';
+        ck_assert_str_eq(serverName, expectedServerNames[i]);
+        free(serverName);
+    }
 
-	UA_Array_delete(serverOnNetwork, serverOnNetworkSize, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
+    UA_Array_delete(serverOnNetwork, serverOnNetworkSize, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
 
-	UA_Client_disconnect(client);
-	UA_Client_delete(client);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
 }
 
 
 // Test if discovery server lists himself as registered server, before any other registration.
 START_TEST(Client_find_discovery) {
-		const char* expectedUris[] ={"open62541.test.local_discovery_server"};
-		FindAndCheck(expectedUris, 1, NULL, NULL);
-	}
+        const char* expectedUris[] ={"open62541.test.local_discovery_server"};
+        FindAndCheck(expectedUris, 1, NULL, NULL);
+    }
 END_TEST
 
 // Test if discovery server lists himself as registered server if it is filtered by his uri
 START_TEST(Client_filter_discovery) {
-		const char* expectedUris[] ={"open62541.test.local_discovery_server"};
-		FindAndCheck(expectedUris, 1, "open62541.test.local_discovery_server", "en");
-	}
+        const char* expectedUris[] ={"open62541.test.local_discovery_server"};
+        FindAndCheck(expectedUris, 1, "open62541.test.local_discovery_server", "en");
+    }
 END_TEST
 
 // Test if registered server is returned from LDS
 START_TEST(Client_find_registered) {
-		const char* expectedUris[] ={"open62541.test.local_discovery_server", "open62541.test.server_register"};
-		FindAndCheck(expectedUris, 2, NULL, NULL);
-	}
+        const char* expectedUris[] ={"open62541.test.local_discovery_server", "open62541.test.server_register"};
+        FindAndCheck(expectedUris, 2, NULL, NULL);
+    }
 END_TEST
 
 // Test if registered server is returned from LDS using FindServersOnNetwork
 START_TEST(Client_find_on_network_registered) {
-		char *expectedUris[2];
-		char hostname[256];
+        char *expectedUris[2];
+        char hostname[256];
 
-		ck_assert_uint_eq(gethostname(hostname, 255), 0);
+        ck_assert_uint_eq(gethostname(hostname, 255), 0);
 
-		//DNS limits name to max 63 chars (+ \0)
-		expectedUris[0] = malloc(64);
-		snprintf(expectedUris[0], 64, "LDS_test-%s", hostname);
-		expectedUris[1] = malloc(64);
-		snprintf(expectedUris[1], 64, "Register_test-%s", hostname);
-		FindOnNetworkAndCheck(expectedUris, 2, NULL, NULL);
+        //DNS limits name to max 63 chars (+ \0)
+        expectedUris[0] = malloc(64);
+        snprintf(expectedUris[0], 64, "LDS_test-%s", hostname);
+        expectedUris[1] = malloc(64);
+        snprintf(expectedUris[1], 64, "Register_test-%s", hostname);
+        FindOnNetworkAndCheck(expectedUris, 2, NULL, NULL);
 
-		free(expectedUris[0]);
-		free(expectedUris[1]);
+        free(expectedUris[0]);
+        free(expectedUris[1]);
 
-	}
+    }
 END_TEST
 
 // Test if filtering with uris works
 START_TEST(Client_find_filter) {
-		const char* expectedUris[] ={"open62541.test.server_register"};
-		FindAndCheck(expectedUris, 1, "open62541.test.server_register", NULL);
-	}
+        const char* expectedUris[] ={"open62541.test.server_register"};
+        FindAndCheck(expectedUris, 1, "open62541.test.server_register", NULL);
+    }
 END_TEST
 
 START_TEST(Util_wait_timeout) {
-		// wait until server is removed by timeout. Additionally wait a few seconds more to be sure.
-		sleep(checkWait);
-	}
+        // wait until server is removed by timeout. Additionally wait a few seconds more to be sure.
+        sleep(checkWait);
+    }
 END_TEST
 
 START_TEST(Util_wait_mdns) {
-		sleep(1);
-	}
+        sleep(1);
+    }
 END_TEST
 
 static Suite* testSuite_Client(void) {
-	Suite *s = suite_create("Register Server and Client");
-	TCase *tc_register = tcase_create("RegisterServer");
-	tcase_add_unchecked_fixture(tc_register, setup_lds, teardown_lds);
-	tcase_add_unchecked_fixture(tc_register, setup_register, teardown_register);
-	tcase_add_test(tc_register, Server_register);
-	// register two times
-	tcase_add_test(tc_register, Server_register);
-	tcase_add_test(tc_register, Server_unregister);
-	tcase_add_test(tc_register, Server_register_periodic);
-	tcase_add_test(tc_register, Server_unregister_periodic);
-	suite_add_tcase(s,tc_register);
+    Suite *s = suite_create("Register Server and Client");
+    TCase *tc_register = tcase_create("RegisterServer");
+    tcase_add_unchecked_fixture(tc_register, setup_lds, teardown_lds);
+    tcase_add_unchecked_fixture(tc_register, setup_register, teardown_register);
+    tcase_add_test(tc_register, Server_register);
+    // register two times
+    tcase_add_test(tc_register, Server_register);
+    tcase_add_test(tc_register, Server_unregister);
+    tcase_add_test(tc_register, Server_register_periodic);
+    tcase_add_test(tc_register, Server_unregister_periodic);
+    suite_add_tcase(s,tc_register);
 
-	TCase *tc_register_find = tcase_create("RegisterServer and FindServers");
-	tcase_add_unchecked_fixture(tc_register_find, setup_lds, teardown_lds);
-	tcase_add_unchecked_fixture(tc_register_find, setup_register, teardown_register);
-	tcase_add_test(tc_register_find, Client_find_discovery);
-	tcase_add_test(tc_register_find, Server_register);
-	tcase_add_test(tc_register_find, Client_find_registered);
-	tcase_add_test(tc_register_find, Util_wait_mdns);
-	tcase_add_test(tc_register_find, Client_find_on_network_registered);
-	tcase_add_test(tc_register_find, Client_find_filter);
-	tcase_add_test(tc_register_find, Server_unregister);
-	tcase_add_test(tc_register_find, Client_find_discovery);
-	tcase_add_test(tc_register_find, Client_filter_discovery);
-	suite_add_tcase(s,tc_register_find);
+    TCase *tc_register_find = tcase_create("RegisterServer and FindServers");
+    tcase_add_unchecked_fixture(tc_register_find, setup_lds, teardown_lds);
+    tcase_add_unchecked_fixture(tc_register_find, setup_register, teardown_register);
+    tcase_add_test(tc_register_find, Client_find_discovery);
+    tcase_add_test(tc_register_find, Server_register);
+    tcase_add_test(tc_register_find, Client_find_registered);
+    tcase_add_test(tc_register_find, Util_wait_mdns);
+    tcase_add_test(tc_register_find, Client_find_on_network_registered);
+    tcase_add_test(tc_register_find, Client_find_filter);
+    tcase_add_test(tc_register_find, Server_unregister);
+    tcase_add_test(tc_register_find, Client_find_discovery);
+    tcase_add_test(tc_register_find, Client_filter_discovery);
+    suite_add_tcase(s,tc_register_find);
 
-	// register server again, then wait for timeout and auto unregister
-	TCase *tc_register_timeout = tcase_create("RegisterServer timeout");
-	tcase_add_unchecked_fixture(tc_register_timeout, setup_lds, teardown_lds);
-	tcase_add_unchecked_fixture(tc_register_timeout, setup_register, teardown_register);
-	tcase_set_timeout(tc_register_timeout, checkWait+2);
-	tcase_add_test(tc_register_timeout, Server_register);
-	tcase_add_test(tc_register_timeout, Client_find_registered);
-	tcase_add_test(tc_register_timeout, Util_wait_timeout);
-	tcase_add_test(tc_register_timeout, Client_find_discovery);
-	suite_add_tcase(s,tc_register_timeout);
-	return s;
+    // register server again, then wait for timeout and auto unregister
+    TCase *tc_register_timeout = tcase_create("RegisterServer timeout");
+    tcase_add_unchecked_fixture(tc_register_timeout, setup_lds, teardown_lds);
+    tcase_add_unchecked_fixture(tc_register_timeout, setup_register, teardown_register);
+    tcase_set_timeout(tc_register_timeout, checkWait+2);
+    tcase_add_test(tc_register_timeout, Server_register);
+    tcase_add_test(tc_register_timeout, Client_find_registered);
+    tcase_add_test(tc_register_timeout, Util_wait_timeout);
+    tcase_add_test(tc_register_timeout, Client_find_discovery);
+    suite_add_tcase(s,tc_register_timeout);
+    return s;
 }
 
 int main(void) {
-	Suite *s = testSuite_Client();
-	SRunner *sr = srunner_create(s);
-	srunner_set_fork_status(sr, CK_NOFORK);
-	srunner_run_all(sr,CK_NORMAL);
-	int number_failed = srunner_ntests_failed(sr);
-	srunner_free(sr);
-	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/check_discovery.c
+++ b/tests/check_discovery.c
@@ -1,3 +1,16 @@
+#ifndef _XOPEN_SOURCE
+# define _XOPEN_SOURCE 500
+#endif
+#ifndef _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE
+#endif
+
+// On older systems we need to define _BSD_SOURCE
+// _DEFAULT_SOURCE is an alias for that
+#ifndef _BSD_SOURCE
+# define _BSD_SOURCE
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -5,7 +18,6 @@
 #include <ua_util.h>
 #include <ua_types_generated.h>
 #include <server/ua_server_internal.h>
-#include <unistd.h>
 
 #include "ua_client.h"
 #include "ua_config_standard.h"
@@ -50,6 +62,8 @@ static void setup_lds(void) {
 	server_lds = UA_Server_new(config_lds);
 	UA_Server_run_startup(server_lds);
 	pthread_create(&server_thread_lds, NULL, serverloop_lds, NULL);
+	// wait until LDS started
+	sleep(1);
 }
 
 static void teardown_lds(void) {
@@ -80,7 +94,7 @@ static void * serverloop_register(void *_) {
 }
 
 static void setup_register(void) {
-	// start LDS server
+	// start register server
 	running_register = UA_Boolean_new();
 	*running_register = true;
 	UA_ServerConfig config_register = UA_ServerConfig_standard;
@@ -268,7 +282,7 @@ static UA_StatusCode FindServersOnNetwork(const char* discoveryServerUrl, size_t
 	return (int) UA_STATUSCODE_GOOD;
 }
 
-static void FindOnNetworkAndCheck(const char* expectedServerNames[], size_t expectedServerNamesSize, const char *filterUri, const char *filterLocale) {
+static void FindOnNetworkAndCheck(char* expectedServerNames[], size_t expectedServerNamesSize, const char *filterUri, const char *filterLocale) {
 	UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
 	UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
 
@@ -321,8 +335,20 @@ END_TEST
 
 // Test if registered server is returned from LDS using FindServersOnNetwork
 START_TEST(Client_find_on_network_registered) {
-		const char* expectedUris[] ={"LDS_test", "Register_test"};
+		char *expectedUris[2];
+		char hostname[256];
+
+		ck_assert_uint_eq(gethostname(hostname, 255), 0);
+
+		expectedUris[0] = malloc(400);
+		snprintf(expectedUris[0], 400, "LDS_test-%s", hostname);
+		expectedUris[1] = malloc(400);
+		snprintf(expectedUris[1], 400, "Register_test-%s", hostname);
 		FindOnNetworkAndCheck(expectedUris, 2, NULL, NULL);
+
+		free(expectedUris[0]);
+		free(expectedUris[1]);
+
 	}
 END_TEST
 

--- a/tests/check_discovery.c
+++ b/tests/check_discovery.c
@@ -294,15 +294,6 @@ static void FindOnNetworkAndCheck(char* expectedServerNames[], size_t expectedSe
 	retval = FindServersOnNetwork("opc.tcp://localhost:4840", &serverOnNetworkSize, &serverOnNetwork);
 	ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-
-	for (size_t i=0; i<serverOnNetworkSize; i++) {
-		char* serverName = malloc(sizeof(char)*serverOnNetwork[i].serverName.length+1);
-		memcpy( serverName, serverOnNetwork[i].serverName.data, serverOnNetwork[i].serverName.length );
-		serverName[serverOnNetwork[i].serverName.length] = '\0';
-		printf("Server on net: %s\n",serverName);
-		free(serverName);
-	}
-
 	// only the discovery server is expected
 	ck_assert_uint_eq(serverOnNetworkSize , expectedServerNamesSize);
 
@@ -349,10 +340,11 @@ START_TEST(Client_find_on_network_registered) {
 
 		ck_assert_uint_eq(gethostname(hostname, 255), 0);
 
-		expectedUris[0] = malloc(400);
-		snprintf(expectedUris[0], 400, "LDS_test-%s", hostname);
-		expectedUris[1] = malloc(400);
-		snprintf(expectedUris[1], 400, "Register_test-%s", hostname);
+		//DNS limits name to max 63 chars (+ \0)
+		expectedUris[0] = malloc(64);
+		snprintf(expectedUris[0], 64, "LDS_test-%s", hostname);
+		expectedUris[1] = malloc(64);
+		snprintf(expectedUris[1], 64, "Register_test-%s", hostname);
 		FindOnNetworkAndCheck(expectedUris, 2, NULL, NULL);
 
 		free(expectedUris[0]);
@@ -375,10 +367,7 @@ START_TEST(Util_wait_timeout) {
 END_TEST
 
 START_TEST(Util_wait_mdns) {
-		printf("Waiting for 1 second for mDNS detecting register server.\n");
 		sleep(1);
-		printf("The register server should now be detected through mDNS?\n");
-
 	}
 END_TEST
 

--- a/tests/check_discovery.c
+++ b/tests/check_discovery.c
@@ -294,6 +294,15 @@ static void FindOnNetworkAndCheck(char* expectedServerNames[], size_t expectedSe
 	retval = FindServersOnNetwork("opc.tcp://localhost:4840", &serverOnNetworkSize, &serverOnNetwork);
 	ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
+
+	for (size_t i=0; i<serverOnNetworkSize; i++) {
+		char* serverName = malloc(sizeof(char)*serverOnNetwork[i].serverName.length+1);
+		memcpy( serverName, serverOnNetwork[i].serverName.data, serverOnNetwork[i].serverName.length );
+		serverName[serverOnNetwork[i].serverName.length] = '\0';
+		printf("Server on net: %s\n",serverName);
+		free(serverName);
+	}
+
 	// only the discovery server is expected
 	ck_assert_uint_eq(serverOnNetworkSize , expectedServerNamesSize);
 

--- a/tests/check_discovery.c
+++ b/tests/check_discovery.c
@@ -366,8 +366,10 @@ START_TEST(Util_wait_timeout) {
 END_TEST
 
 START_TEST(Util_wait_mdns) {
-		// wait until server received mdns package
-		sleep(2);
+		printf("Waiting for 1 second for mDNS detecting register server.\n");
+		sleep(1);
+		printf("The register server should now be detected through mDNS?\n");
+
 	}
 END_TEST
 

--- a/tests/check_memory.c
+++ b/tests/check_memory.c
@@ -95,6 +95,8 @@ START_TEST(encodeShallYieldDecode) {
 END_TEST
 
 START_TEST(decodeShallFailWithTruncatedBufferButSurvive) {
+    if (_i == UA_TYPES_DISCOVERYCONFIGURATION)
+        return;
     // given
     UA_ByteString msg1;
     void *obj1 = UA_new(&UA_TYPES[_i]);
@@ -187,10 +189,11 @@ START_TEST(decodeComplexTypeFromRandomBufferShallSurvive) {
 END_TEST
 
 START_TEST(calcSizeBinaryShallBeCorrect) {
-    /* Empty variants (with no type defined) cannot be encoded. This is intentional. */
+    /* Empty variants (with no type defined) cannot be encoded. This is intentional. Discovery configuration is just a base class and void * */
     if(_i == UA_TYPES_VARIANT ||
        _i == UA_TYPES_VARIABLEATTRIBUTES ||
-       _i == UA_TYPES_VARIABLETYPEATTRIBUTES)
+       _i == UA_TYPES_VARIABLETYPEATTRIBUTES ||
+	   _i == UA_TYPES_DISCOVERYCONFIGURATION)
         return;
     void *obj = UA_new(&UA_TYPES[_i]);
     size_t predicted_size = UA_calcSizeBinary(obj, &UA_TYPES[_i]);

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -18,7 +18,7 @@ pos = outname.find(".")
 if pos > 0:
     outname = outname[:pos]
 include_re = re.compile("^#include (\".*\").*$")
-guard_re = re.compile("^#(?:(?:ifndef|define) [A-Z_]+_H_|endif /\* [A-Z_]+_H_ \*/|endif // [A-Z_]+_H_)")
+guard_re = re.compile("^#(?:(?:ifndef|define)\s*[A-Z_]+_H_|endif /\* [A-Z_]+_H_ \*/|endif // [A-Z_]+_H_|endif\s*/\*\s*!?[A-Z_]+_H[_]+\s*\*/)")
 
 print ("Starting amalgamating file "+ args.outfile)
 
@@ -46,6 +46,7 @@ file.write(u"""/* THIS IS A SINGLE-FILE DISTRIBUTION CONCATENATED FROM THE OPEN6
 if is_c:
     file.write(u'''#ifndef UA_DYNAMIC_LINKING_EXPORT
 # define UA_DYNAMIC_LINKING_EXPORT
+# define MDNSD_DYNAMIC_LINKING
 #endif
 
 #include "%s.h"

--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -161,3 +161,10 @@ SetMonitoringModeResponse
 RegisteredServer
 RegisterServerRequest
 RegisterServerResponse
+DiscoveryConfiguration
+MdnsDiscoveryConfiguration
+RegisterServer2Request
+RegisterServer2Response
+ServerOnNetwork
+FindServersOnNetworkRequest
+FindServersOnNetworkResponse

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -35,83 +35,83 @@ if [ $ANALYZE = "true" ]; then
     fi
 else
     echo "=== Building ==="
-
-    echo "Documentation and certificate build"
-    mkdir -p build
-    cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_DOCUMENTATION=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
-    make doc
-    make selfsigned
-    cp -r doc ../../
-    cp ./examples/server_cert.der ../../
-    cd .. && rm build -rf
-
-    # cross compilation only with gcc
-    if [ "$CC" = "gcc" ]; then
-        echo "Cross compile release build for MinGW 32 bit"
-        mkdir -p build && cd build
-        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
-        make -j
-        zip -r open62541-win32.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
-        cp open62541-win32.zip ..
-        cd .. && rm build -rf
-
-        echo "Cross compile release build for MinGW 64 bit"
-        mkdir -p build && cd build
-        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw64.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
-        make -j
-        zip -r open62541-win64.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
-        cp open62541-win64.zip ..
-        cd .. && rm build -rf
-
-        echo "Cross compile release build for 32-bit linux"
-        mkdir -p build && cd build
-        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-gcc-m32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
-        make -j
-        tar -pczf open62541-linux32.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
-        cp open62541-linux32.tar.gz ..
-        cd .. && rm build -rf
-    fi
-
-    echo "Compile release build for 64-bit linux"
-    mkdir -p build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DUA_ENABLE_AMALGAMATION=ON -DUA_BUILD_EXAMPLES=ON ..
-    make -j
-    tar -pczf open62541-linux64.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
-    cp open62541-linux64.tar.gz ..
-    cp open62541.h .. # copy single file-release
-    cp open62541.c .. # copy single file-release
-    cd .. && rm build -rf
-
-    if [ "$CC" = "gcc" ]; then
-        echo "Upgrade to gcc 4.8"
-        export CXX="g++-4.8" CC="gcc-4.8"
-    fi
-
-    echo "Building the C++ example"
-    mkdir -p build && cd build
-    cp ../open62541.* .
-    gcc-4.8 -std=c99 -c open62541.c
-    g++-4.8 ../examples/server.cpp -I./ open62541.o -lrt -o cpp-server
-    cd .. && rm build -rf
-
-    echo "Compile multithreaded version"
-    mkdir -p build && cd build
-    cmake -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLES=ON ..
-    make -j
-    cd .. && rm build -rf
-
-    echo "Compile without discovery version"
-    mkdir -p build && cd build
-    cmake -DUA_ENABLE_DISCOVERY=OFF -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
-    make -j
-    cd .. && rm build -rf
-
-    echo "Compile discovery without multicast version"
-    mkdir -p build && cd build
-    cmake -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
-    make -j
-    cd .. && rm build -rf
+#
+#    echo "Documentation and certificate build"
+#    mkdir -p build
+#    cd build
+#    cmake -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_DOCUMENTATION=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
+#    make doc
+#    make selfsigned
+#    cp -r doc ../../
+#    cp ./examples/server_cert.der ../../
+#    cd .. && rm build -rf
+#
+#    # cross compilation only with gcc
+#    if [ "$CC" = "gcc" ]; then
+#        echo "Cross compile release build for MinGW 32 bit"
+#        mkdir -p build && cd build
+#        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
+#        make -j
+#        zip -r open62541-win32.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
+#        cp open62541-win32.zip ..
+#        cd .. && rm build -rf
+#
+#        echo "Cross compile release build for MinGW 64 bit"
+#        mkdir -p build && cd build
+#        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw64.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
+#        make -j
+#        zip -r open62541-win64.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
+#        cp open62541-win64.zip ..
+#        cd .. && rm build -rf
+#
+#        echo "Cross compile release build for 32-bit linux"
+#        mkdir -p build && cd build
+#        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-gcc-m32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
+#        make -j
+#        tar -pczf open62541-linux32.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
+#        cp open62541-linux32.tar.gz ..
+#        cd .. && rm build -rf
+#    fi
+#
+#    echo "Compile release build for 64-bit linux"
+#    mkdir -p build && cd build
+#    cmake -DCMAKE_BUILD_TYPE=Release -DUA_ENABLE_AMALGAMATION=ON -DUA_BUILD_EXAMPLES=ON ..
+#    make -j
+#    tar -pczf open62541-linux64.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
+#    cp open62541-linux64.tar.gz ..
+#    cp open62541.h .. # copy single file-release
+#    cp open62541.c .. # copy single file-release
+#    cd .. && rm build -rf
+#
+#    if [ "$CC" = "gcc" ]; then
+#        echo "Upgrade to gcc 4.8"
+#        export CXX="g++-4.8" CC="gcc-4.8"
+#    fi
+#
+#    echo "Building the C++ example"
+#    mkdir -p build && cd build
+#    cp ../open62541.* .
+#    gcc-4.8 -std=c99 -c open62541.c
+#    g++-4.8 ../examples/server.cpp -I./ open62541.o -lrt -o cpp-server
+#    cd .. && rm build -rf
+#
+#    echo "Compile multithreaded version"
+#    mkdir -p build && cd build
+#    cmake -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLES=ON ..
+#    make -j
+#    cd .. && rm build -rf
+#
+#    echo "Compile without discovery version"
+#    mkdir -p build && cd build
+#    cmake -DUA_ENABLE_DISCOVERY=OFF -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
+#    make -j
+#    cd .. && rm build -rf
+#
+#    echo "Compile discovery without multicast version"
+#    mkdir -p build && cd build
+#    cmake -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
+#    make -j
+#    cd .. && rm build -rf
 
     #this run inclides full examples and methodcalls
     echo "Debug build and unit tests (64 bit)"

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -103,7 +103,13 @@ else
 
     echo "Compile without discovery version"
     mkdir -p build && cd build
-    cmake -DUA_ENABLE_DISCOVERY=OFF -DUA_BUILD_EXAMPLES=ON ..
+    cmake -DUA_ENABLE_DISCOVERY=OFF -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
+    make -j
+    cd .. && rm build -rf
+
+    echo "Compile discovery without multicast version"
+    mkdir -p build && cd build
+    cmake -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
     make -j
     cd .. && rm build -rf
 

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -35,83 +35,83 @@ if [ $ANALYZE = "true" ]; then
     fi
 else
     echo "=== Building ==="
-#
-#    echo "Documentation and certificate build"
-#    mkdir -p build
-#    cd build
-#    cmake -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_DOCUMENTATION=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
-#    make doc
-#    make selfsigned
-#    cp -r doc ../../
-#    cp ./examples/server_cert.der ../../
-#    cd .. && rm build -rf
-#
-#    # cross compilation only with gcc
-#    if [ "$CC" = "gcc" ]; then
-#        echo "Cross compile release build for MinGW 32 bit"
-#        mkdir -p build && cd build
-#        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
-#        make -j
-#        zip -r open62541-win32.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
-#        cp open62541-win32.zip ..
-#        cd .. && rm build -rf
-#
-#        echo "Cross compile release build for MinGW 64 bit"
-#        mkdir -p build && cd build
-#        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw64.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
-#        make -j
-#        zip -r open62541-win64.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
-#        cp open62541-win64.zip ..
-#        cd .. && rm build -rf
-#
-#        echo "Cross compile release build for 32-bit linux"
-#        mkdir -p build && cd build
-#        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-gcc-m32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
-#        make -j
-#        tar -pczf open62541-linux32.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
-#        cp open62541-linux32.tar.gz ..
-#        cd .. && rm build -rf
-#    fi
-#
-#    echo "Compile release build for 64-bit linux"
-#    mkdir -p build && cd build
-#    cmake -DCMAKE_BUILD_TYPE=Release -DUA_ENABLE_AMALGAMATION=ON -DUA_BUILD_EXAMPLES=ON ..
-#    make -j
-#    tar -pczf open62541-linux64.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
-#    cp open62541-linux64.tar.gz ..
-#    cp open62541.h .. # copy single file-release
-#    cp open62541.c .. # copy single file-release
-#    cd .. && rm build -rf
-#
-#    if [ "$CC" = "gcc" ]; then
-#        echo "Upgrade to gcc 4.8"
-#        export CXX="g++-4.8" CC="gcc-4.8"
-#    fi
-#
-#    echo "Building the C++ example"
-#    mkdir -p build && cd build
-#    cp ../open62541.* .
-#    gcc-4.8 -std=c99 -c open62541.c
-#    g++-4.8 ../examples/server.cpp -I./ open62541.o -lrt -o cpp-server
-#    cd .. && rm build -rf
-#
-#    echo "Compile multithreaded version"
-#    mkdir -p build && cd build
-#    cmake -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLES=ON ..
-#    make -j
-#    cd .. && rm build -rf
-#
-#    echo "Compile without discovery version"
-#    mkdir -p build && cd build
-#    cmake -DUA_ENABLE_DISCOVERY=OFF -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
-#    make -j
-#    cd .. && rm build -rf
-#
-#    echo "Compile discovery without multicast version"
-#    mkdir -p build && cd build
-#    cmake -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
-#    make -j
-#    cd .. && rm build -rf
+
+    echo "Documentation and certificate build"
+    mkdir -p build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_DOCUMENTATION=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
+    make doc
+    make selfsigned
+    cp -r doc ../../
+    cp ./examples/server_cert.der ../../
+    cd .. && rm build -rf
+
+    # cross compilation only with gcc
+    if [ "$CC" = "gcc" ]; then
+        echo "Cross compile release build for MinGW 32 bit"
+        mkdir -p build && cd build
+        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
+        make -j
+        zip -r open62541-win32.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
+        cp open62541-win32.zip ..
+        cd .. && rm build -rf
+
+        echo "Cross compile release build for MinGW 64 bit"
+        mkdir -p build && cd build
+        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw64.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
+        make -j
+        zip -r open62541-win64.zip ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server.exe examples/client.exe libopen62541.dll.a open62541.h open62541.c
+        cp open62541-win64.zip ..
+        cd .. && rm build -rf
+
+        echo "Cross compile release build for 32-bit linux"
+        mkdir -p build && cd build
+        cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-gcc-m32.cmake -DUA_ENABLE_AMALGAMATION=ON -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON ..
+        make -j
+        tar -pczf open62541-linux32.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
+        cp open62541-linux32.tar.gz ..
+        cd .. && rm build -rf
+    fi
+
+    echo "Compile release build for 64-bit linux"
+    mkdir -p build && cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DUA_ENABLE_AMALGAMATION=ON -DUA_BUILD_EXAMPLES=ON ..
+    make -j
+    tar -pczf open62541-linux64.tar.gz ../../doc ../../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
+    cp open62541-linux64.tar.gz ..
+    cp open62541.h .. # copy single file-release
+    cp open62541.c .. # copy single file-release
+    cd .. && rm build -rf
+
+    if [ "$CC" = "gcc" ]; then
+        echo "Upgrade to gcc 4.8"
+        export CXX="g++-4.8" CC="gcc-4.8"
+    fi
+
+    echo "Building the C++ example"
+    mkdir -p build && cd build
+    cp ../open62541.* .
+    gcc-4.8 -std=c99 -c open62541.c
+    g++-4.8 ../examples/server.cpp -I./ open62541.o -lrt -o cpp-server
+    cd .. && rm build -rf
+
+    echo "Compile multithreaded version"
+    mkdir -p build && cd build
+    cmake -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLES=ON ..
+    make -j
+    cd .. && rm build -rf
+
+    echo "Compile without discovery version"
+    mkdir -p build && cd build
+    cmake -DUA_ENABLE_DISCOVERY=OFF -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
+    make -j
+    cd .. && rm build -rf
+
+    echo "Compile discovery without multicast version"
+    mkdir -p build && cd build
+    cmake -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
+    make -j
+    cd .. && rm build -rf
 
     #this run inclides full examples and methodcalls
     echo "Debug build and unit tests (64 bit)"


### PR DESCRIPTION
@jpfr as requested in #753 the rebased feature_mdns (#732) branch on current master.

Unfortunately the `check_memory` test finds memory leaks in `decodeComplexTypeFromRandomBufferShallSurvive` for the types with idx `[23, 33, 66, 97]'. Can you have a look at it? I have no idea where this comes from... (see https://travis-ci.org/Pro/open62541/jobs/154372263)