### PR TITLE
Easy fix for broken external Namespace.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,6 @@ set(exported_headers ${PROJECT_BINARY_DIR}/src_generated/ua_config.h
                      ${PROJECT_SOURCE_DIR}/include/ua_job.h
                      ${PROJECT_SOURCE_DIR}/include/ua_log.h
                      ${PROJECT_SOURCE_DIR}/include/ua_server.h
-                     ${PROJECT_SOURCE_DIR}/include/ua_server_external_ns.h
                      ${PROJECT_SOURCE_DIR}/include/ua_client.h
                      ${PROJECT_SOURCE_DIR}/include/ua_client_highlevel.h
                      ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.h
@@ -244,6 +243,10 @@ if(UA_ENABLE_GENERATE_NAMESPACE0)
   set_property(CACHE GENERATE_NAMESPACE0_FILE PROPERTY STRINGS Opc.Ua.NodeSet2.xml Opc.Ua.NodeSet2.Minimal.xml)
   list(APPEND internal_headers ${PROJECT_BINARY_DIR}/src_generated/ua_namespaceinit_generated.h)
   list(APPEND lib_sources ${PROJECT_BINARY_DIR}/src_generated/ua_namespaceinit_generated.c)
+endif()
+
+if(UA_ENABLE_EXTERNAL_NAMESPACES)
+    list(APPEND exported_headers ${PROJECT_SOURCE_DIR}/include/ua_server_external_ns.h)
 endif()
 
 #########################

--- a/include/ua_server_external_ns.h
+++ b/include/ua_server_external_ns.h
@@ -34,50 +34,50 @@ extern "C" {
  * @{
  */
 
-typedef UA_Int32 (*UA_ExternalNodeStore_addNodes)
+typedef UA_StatusCode(*UA_ExternalNodeStore_addNodes)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_AddNodesItem *nodesToAdd, UA_UInt32 *indices,
  UA_UInt32 indicesSize, UA_AddNodesResult* addNodesResults, UA_DiagnosticInfo *diagnosticInfos);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_addReferences)
+typedef UA_StatusCode (*UA_ExternalNodeStore_addReferences)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_AddReferencesItem* referencesToAdd,
  UA_UInt32 *indices,UA_UInt32 indicesSize, UA_StatusCode *addReferencesResults,
  UA_DiagnosticInfo *diagnosticInfos);
  
- typedef UA_Int32 (*UA_ExternalNodeStore_addOneWayReference)
+ typedef UA_StatusCode (*UA_ExternalNodeStore_addOneWayReference)
 (void *ensHandle, const UA_AddReferencesItem *item);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_deleteNodes)
+typedef UA_StatusCode (*UA_ExternalNodeStore_deleteNodes)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_DeleteNodesItem *nodesToDelete, UA_UInt32 *indices,
  UA_UInt32 indicesSize, UA_StatusCode *deleteNodesResults, UA_DiagnosticInfo *diagnosticInfos);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_deleteReferences)
+typedef UA_StatusCode (*UA_ExternalNodeStore_deleteReferences)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_DeleteReferencesItem *referenceToDelete,
  UA_UInt32 *indices, UA_UInt32 indicesSize, UA_StatusCode deleteReferencesresults,
  UA_DiagnosticInfo *diagnosticInfos);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_readNodes)
+typedef UA_StatusCode (*UA_ExternalNodeStore_readNodes)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_ReadValueId *readValueIds, UA_UInt32 *indices,
  UA_UInt32 indicesSize,UA_DataValue *readNodesResults, UA_Boolean timeStampToReturn,
  UA_DiagnosticInfo *diagnosticInfos);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_writeNodes)
+typedef UA_StatusCode (*UA_ExternalNodeStore_writeNodes)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_WriteValue *writeValues, UA_UInt32 *indices,
  UA_UInt32 indicesSize, UA_StatusCode *writeNodesResults, UA_DiagnosticInfo *diagnosticInfo);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_browseNodes)
+typedef UA_StatusCode (*UA_ExternalNodeStore_browseNodes)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_BrowseDescription *browseDescriptions,
  UA_UInt32 *indices, UA_UInt32 indicesSize, UA_UInt32 requestedMaxReferencesPerNode,
  UA_BrowseResult *browseResults, UA_DiagnosticInfo *diagnosticInfos);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_translateBrowsePathsToNodeIds)
+typedef UA_StatusCode (*UA_ExternalNodeStore_translateBrowsePathsToNodeIds)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_BrowsePath *browsePath, UA_UInt32 *indices,
  UA_UInt32 indicesSize, UA_BrowsePathResult *browsePathResults, UA_DiagnosticInfo *diagnosticInfos);
 
-typedef UA_Int32 (*UA_ExternalNodeStore_call)
+typedef UA_StatusCode (*UA_ExternalNodeStore_call)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_CallMethodRequest *request, UA_UInt32 *indices,
  UA_UInt32 indicesSize,UA_CallMethodResult *results);
  
-typedef UA_Int32 (*UA_ExternalNodeStore_delete)(void *ensHandle);
+typedef UA_StatusCode (*UA_ExternalNodeStore_delete)(void *ensHandle);
 
 typedef struct UA_ExternalNodeStore {
     void *ensHandle;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -72,7 +72,7 @@ UA_UInt16 UA_Server_addNamespace(UA_Server *server, const char* name) {
             return i;
     }
 
-    /* Add a new namespace to the namsepace array */
+    /* Add a new namespace to the namespace array */
     server->namespaces = UA_realloc(server->namespaces,
                                     sizeof(UA_String) * (server->namespacesSize + 1));
     UA_String_copy(&nameString, &server->namespaces[server->namespacesSize]);
@@ -109,10 +109,10 @@ UA_Server_addExternalNamespace(UA_Server *server, const UA_String *url,
         return UA_STATUSCODE_BADARGUMENTSMISSING;
 
     char urlString[256];
-    if(url.length >= 256)
+    if(url->length >= 256)
         return UA_STATUSCODE_BADINTERNALERROR;
-    memcpy(urlString, url.data, url.length);
-    urlString[url.length] = 0;
+    memcpy(urlString, url->data, url->length);
+    urlString[url->length] = 0;
 
     size_t size = server->externalNamespacesSize;
     server->externalNamespaces =
@@ -122,7 +122,7 @@ UA_Server_addExternalNamespace(UA_Server *server, const UA_String *url,
     *assignedNamespaceIndex = (UA_UInt16)server->namespacesSize;
     UA_String_copy(url, &server->externalNamespaces[size].url);
     server->externalNamespacesSize++;
-    addNamespaceInternal(server, urlString);
+    UA_Server_addNamespace(server, urlString);
 
     return UA_STATUSCODE_GOOD;
 }


### PR DESCRIPTION
Changed return types of ExternalNodeStore functions from UA_Int32 to UA_StatusCode for clarity (and to fix Uint conversion).
Only include ua_server_external_ns if necessary.