### PR TITLE
Add EndpointUrl to CreateSessionRequest

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -473,6 +473,7 @@ static UA_StatusCode SessionHandshake(UA_Client *client) {
     UA_ByteString_copy(&client->channel->clientNonce, &request.clientNonce);
     request.requestedSessionTimeout = 1200000;
     request.maxResponseMessageSize = UA_INT32_MAX;
+    UA_String_copy(&client->endpointUrl, &request.endpointUrl);
 
     UA_CreateSessionResponse response;
     UA_CreateSessionResponse_init(&response);


### PR DESCRIPTION
OPC UA Part4 says (page 24):

```
endpointUrl:
The network address that the Client used to access the Session Endpoint.
The HostName portion of the URL should be one of the HostNames for the
application that are specified in the Server’s ApplicationInstanceCertificate (see 7.2).
The Server shall raise an AuditUrlMismatchEventType event if the URL does not
match the Server’s HostNames. AuditUrlMismatchEventType event type is defined in
Part 5.
The Server uses this information for diagnostics and to determine the set of
EndpointDescriptions to return in the response.
```

Eclipse Milo requires EndpointUrl to be not null in the CreateSession request.