### PR TITLE
Array dimension 0 means variable length

### DIFF
--- a/src/server/ua_services_call.c
+++ b/src/server/ua_services_call.c
@@ -92,7 +92,8 @@ satisfySignature(UA_Server *server, const UA_Variant *var, const UA_Argument *ar
         if(arg->arrayDimensionsSize != varDimsSize)
             return UA_STATUSCODE_BADINVALIDARGUMENT;
         for(size_t i = 0; i < varDimsSize; i++) {
-            if((UA_Int32)arg->arrayDimensions[i] != varDims[i])
+            // A value of 0 for an individual dimension indicates that the dimension has a variable	length.
+            if((UA_Int32)arg->arrayDimensions[i]!=0 && (UA_Int32)arg->arrayDimensions[i] != varDims[i])
                 return UA_STATUSCODE_BADINVALIDARGUMENT;
         }
     }


### PR DESCRIPTION
Input/Output Arguments may have arrayDimensions set to 0 which means variable length.
See OPC Specification Part 3, page 61

So it should be fixed like this?