### PR TITLE
Setted referenceTypeId in UA_DeleteReferencesItem (related to #794)

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -1214,6 +1214,7 @@ Service_DeleteNodes_single(UA_Server *server, UA_Session *session,
         for(size_t i = 0; i < node->referencesSize; i++) {
             delItem.sourceNodeId = node->references[i].targetId.nodeId;
             delItem.isForward = node->references[i].isInverse;
+            delItem.referenceTypeId = node->references[i].referenceTypeId;
             Service_DeleteReferences_single(server, session, &delItem);
         }
     }


### PR DESCRIPTION
calling
`UA_Server_deleteNode(UA_Server *server, const UA_NodeId nodeId,UA_Boolean deleteReferences);` with `deleteReferences==true`

didnt delete references,
because 

`deleteOneWayReference(UA_Server *server, UA_Session *session, UA_Node *node,
                      const UA_DeleteReferencesItem *item);`
got null `item->referenceTypeId`