### PR TITLE
Generic BSD detection for tcp/udp plugin

### DIFF
--- a/plugins/ua_network_tcp.c
+++ b/plugins/ua_network_tcp.c
@@ -42,9 +42,12 @@
 # ifdef __QNX__
 #  include <sys/socket.h>
 # endif
-# ifdef __OpenBSD__
-#  include <sys/socket.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+# include <sys/param.h>
+# if defined(BSD)
+#  include<sys/socket.h>
 # endif
+#endif
 # ifndef __CYGWIN__
 #  include <netinet/tcp.h>
 # endif

--- a/plugins/ua_network_udp.c
+++ b/plugins/ua_network_udp.c
@@ -24,9 +24,12 @@
 #ifdef __QNX__
 #include <sys/socket.h>
 #endif
-#ifdef __OpenBSD__
-#include <sys/socket.h>
-#endif 
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+# include <sys/param.h>
+# if defined(BSD)
+#  include<sys/socket.h>
+# endif
+#endif
 # define CLOSESOCKET(S) close(S)
 
 #define MAXBACKLOG 100


### PR DESCRIPTION
Added a generic [BSD detection](http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system#BSD)
This should support DragonFly BSD, FreeBSD, OpenBSD, NetBSD and Apple OSX/iOS. 
Hopefully no further changes are needed for them. 

superseeds #798