### PR TITLE
Fix after_success scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,9 +95,7 @@ script:
 - if [ ${TRAVIS_OS_NAME} == "osx" ]; then sh ./tools/travis/travis_osx_script.sh; fi
 
 after_success:
-- if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" && $ANALYZE = "false" && ${TRAVIS_BRANCH} == "0.2" && ${TRAVIS_PULL_REQUEST} == "false" ) ]]; then sh ./tools/travis/travis_push_doc.sh; fi
-- if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" && $ANALYZE = "false" && ${TRAVIS_BRANCH} == "master" && ${TRAVIS_PULL_REQUEST} == "false" ) ]]; then sh ./tools/travis/travis_push_coverity.sh; fi
-- if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" ) ]]; then sh ./tools/travis/travis_push_release.sh; fi
+- if [ ${TRAVIS_OS_NAME} == "linux" ]; then sh ./tools/travis/travis_linux_after_success.sh; fi
 
 before_deploy:
 - rm build -rf && mkdir -p build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,8 +95,8 @@ script:
 - if [ ${TRAVIS_OS_NAME} == "osx" ]; then sh ./tools/travis/travis_osx_script.sh; fi
 
 after_success:
-- if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" && ${TRAVIS_BRANCH} == "0.2" && ${TRAVIS_PULL_REQUEST} == "false" ) ]]; then sh ./tools/travis/travis_push_doc.sh; fi
-- if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" && ${TRAVIS_BRANCH} == "master" && ${TRAVIS_PULL_REQUEST} == "false" ) ]]; then sh ./tools/travis/travis_push_coverity.sh; fi
+- if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" && $ANALYZE = "false" && ${TRAVIS_BRANCH} == "0.2" && ${TRAVIS_PULL_REQUEST} == "false" ) ]]; then sh ./tools/travis/travis_push_doc.sh; fi
+- if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" && $ANALYZE = "false" && ${TRAVIS_BRANCH} == "master" && ${TRAVIS_PULL_REQUEST} == "false" ) ]]; then sh ./tools/travis/travis_push_coverity.sh; fi
 - if [[ ( ${TRAVIS_OS_NAME} == "linux" && ${CC} == "gcc" ) ]]; then sh ./tools/travis/travis_push_release.sh; fi
 
 before_deploy:

--- a/tools/travis/travis_linux_after_success.sh
+++ b/tools/travis/travis_linux_after_success.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -ev
+
+if [ $ANALYZE = "true" ]; then
+    echo "=== Skipping after_success scripts in ANALYZE mode ==="
+
+else
+    echo "=== Executing after_success scripts ==="
+
+    if [[ "$CC" = "gcc" && "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ]]; then
+    	if [[ ${TRAVIS_PULL_REQUEST} == "false" ]]; then
+			if [[ ${TRAVIS_BRANCH} == "0.2" ]]; then
+				sh ./tools/travis/travis_push_doc.sh
+			fi
+			if [[ ${TRAVIS_BRANCH} == "master" ]]; then
+				sh ./tools/travis/travis_push_coverity.sh
+			fi
+    	fi
+
+    	sh ./tools/travis/travis_push_release.sh;
+    else
+        echo "  Skipping push scripts since not gcc and/or ${TRAVIS_REPO_SLUG} is not the main repo"
+	fi
+fi

--- a/tools/travis/travis_push_coverity.sh
+++ b/tools/travis/travis_push_coverity.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ev
 
 # This script is run by travis-ci and pushes the first commit
 # of the day to the coverity scan service

--- a/tools/travis/travis_push_doc.sh
+++ b/tools/travis/travis_push_doc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ev
 
 git clone --depth=5 -b gh-pages https://$GITAUTH@github.com/open62541/open62541-www
 cd open62541-www

--- a/tools/travis/travis_push_release.sh
+++ b/tools/travis/travis_push_release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ev
 
 TAGSTOSAVE=50
 TAG="$(git rev-parse --short=10 HEAD)"


### PR DESCRIPTION
There was a race condition for the after success scripts which were also executed if `ANALYZE=true` and thus created invalid doc.

Could not yet fully test, since it needs to be in the main repo. Please merge and then I'll fix if there are build errors.
