### PR TITLE
Add valgrind to unit tests (ported from master)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,56 +25,70 @@ if(CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID}" STREQUAL "xClang")
     add_definitions(-Wno-sign-conversion)
 endif()
 
+# Valgrind definition
+set(UA_TEST_WITH_VALGRIND ON)
+SET(VALGRIND_FLAGS --quiet --trace-children=yes --leak-check=full)
+macro(add_test_valgrind TEST_NAME)
+    IF(UA_TEST_WITH_VALGRIND)
+        add_test(${TEST_NAME}
+                valgrind --error-exitcode=1 ${VALGRIND_FLAGS} ${ARGN} )
+    ELSE()
+        add_test(${TEST_NAME} ${ARGN})
+    ENDIF()
+endmacro()
+
+
+
 # the unit test are built directly on the open62541 object files. so they can
 # access symbols that are hidden/not exported to the shared library
 
 add_executable(check_types_builtin check_types_builtin.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_types_builtin ${LIBS})
-add_test(types_builtin ${CMAKE_CURRENT_BINARY_DIR}/check_types_builtin)
+add_test_valgrind(types_builtin ${CMAKE_CURRENT_BINARY_DIR}/check_types_builtin)
 
 add_executable(check_types_memory check_types_memory.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_types_memory ${LIBS})
-add_test(types_memory ${CMAKE_CURRENT_BINARY_DIR}/check_types_memory)
+add_test_valgrind(types_memory ${CMAKE_CURRENT_BINARY_DIR}/check_types_memory)
 
 add_executable(check_types_range check_types_range.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_types_range ${LIBS})
-add_test(types_range ${CMAKE_CURRENT_BINARY_DIR}/check_types_range)
+add_test_valgrind(types_range ${CMAKE_CURRENT_BINARY_DIR}/check_types_range)
 
 add_executable(check_chunking check_chunking.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_chunking ${LIBS})
-add_test(chunking ${CMAKE_CURRENT_BINARY_DIR}/check_chunking)
+add_test_valgrind(chunking ${CMAKE_CURRENT_BINARY_DIR}/check_chunking)
 
 add_executable(check_services_view check_services_view.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_services_view ${LIBS})
-add_test(services_view ${CMAKE_CURRENT_BINARY_DIR}/check_services_view)
+add_test_valgrind(services_view ${CMAKE_CURRENT_BINARY_DIR}/check_services_view)
 
 add_executable(check_services_attributes check_services_attributes.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_services_attributes ${LIBS})
-add_test(services_attributes ${CMAKE_CURRENT_BINARY_DIR}/check_services_attributes)
+add_test_valgrind(services_attributes ${CMAKE_CURRENT_BINARY_DIR}/check_services_attributes)
 
 add_executable(check_services_nodemanagement check_services_nodemanagement.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_services_nodemanagement ${LIBS})
-add_test(services_nodemanagement ${CMAKE_CURRENT_BINARY_DIR}/check_services_nodemanagement)
+add_test_valgrind(services_nodemanagement ${CMAKE_CURRENT_BINARY_DIR}/check_services_nodemanagement)
 
 add_executable(check_services_subscriptions check_services_subscriptions.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_services_subscriptions ${LIBS})
-add_test(check_services_subscriptions ${CMAKE_CURRENT_BINARY_DIR}/check_services_subscriptions)
+add_test_valgrind(check_services_subscriptions ${CMAKE_CURRENT_BINARY_DIR}/check_services_subscriptions)
 
 add_executable(check_nodestore check_nodestore.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_nodestore ${LIBS})
-add_test(nodestore ${CMAKE_CURRENT_BINARY_DIR}/check_nodestore)
+add_test_valgrind(nodestore ${CMAKE_CURRENT_BINARY_DIR}/check_nodestore)
 
 add_executable(check_session check_session.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_session ${LIBS})
-add_test(session ${CMAKE_CURRENT_BINARY_DIR}/check_session)
+add_test_valgrind(session ${CMAKE_CURRENT_BINARY_DIR}/check_session)
 
 add_executable(check_server_jobs check_server_jobs.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_server_jobs ${LIBS})
-add_test(check_server_jobs ${CMAKE_CURRENT_BINARY_DIR}/check_server_jobs)
+add_test_valgrind(check_server_jobs ${CMAKE_CURRENT_BINARY_DIR}/check_server_jobs)
 
 add_executable(check_server_userspace check_server_userspace.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_server_userspace ${LIBS})
-add_test(check_server_userspace ${CMAKE_CURRENT_BINARY_DIR}/check_server_userspace)
+add_test_valgrind(check_server_userspace ${CMAKE_CURRENT_BINARY_DIR}/check_server_userspace)
 
 # test with canned interactions from files
 
@@ -107,19 +121,19 @@ target_include_directories(check_server_binary_messages PRIVATE ${PROJECT_SOURCE
 target_link_libraries(check_server_binary_messages ${LIBS})
 add_dependencies(check_server_binary_messages client_HELOPN.bin)
 
-add_test(check_server_binary_messages_browse ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
+add_test_valgrind(check_server_binary_messages_browse ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_HELOPN.bin
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_CreateActivateSession.bin
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_Browse.bin
                                              ${CMAKE_CURRENT_BINARY_DIR}/client_CLO.bin)
 
-add_test(check_server_binary_messages_read ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
+add_test_valgrind(check_server_binary_messages_read ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_HELOPN.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_CreateActivateSession.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_Read.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_CLO.bin)
 
-add_test(check_server_binary_messages_write ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
+add_test_valgrind(check_server_binary_messages_write ${CMAKE_CURRENT_BINARY_DIR}/check_server_binary_messages
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_HELOPN.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_CreateActivateSession.bin
                                            ${CMAKE_CURRENT_BINARY_DIR}/client_Write.bin
@@ -127,12 +141,12 @@ add_test(check_server_binary_messages_write ${CMAKE_CURRENT_BINARY_DIR}/check_se
 
 add_executable(check_client check_client.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_client ${LIBS})
-add_test(check_client ${CMAKE_CURRENT_BINARY_DIR}/check_client)
+add_test_valgrind(check_client ${CMAKE_CURRENT_BINARY_DIR}/check_client)
 
 add_executable(check_client_subscriptions check_client_subscriptions.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_client_subscriptions ${LIBS})
-add_test(check_client_subscriptions ${CMAKE_CURRENT_BINARY_DIR}/check_client_subscriptions)
+add_test_valgrind(check_client_subscriptions ${CMAKE_CURRENT_BINARY_DIR}/check_client_subscriptions)
 
 add_executable(check_utils check_utils.c $<TARGET_OBJECTS:open62541-object>)
 target_link_libraries(check_utils ${LIBS})
-add_test(check_utils ${CMAKE_CURRENT_BINARY_DIR}/check_utils)
+add_test_valgrind(check_utils ${CMAKE_CURRENT_BINARY_DIR}/check_utils)

--- a/tests/check_server_userspace.c
+++ b/tests/check_server_userspace.c
@@ -14,6 +14,8 @@ START_TEST(Server_addNamespace_ShallWork)
     UA_UInt16 b = UA_Server_addNamespace(server, "http://nameOfNamespace");
     UA_UInt16 c = UA_Server_addNamespace(server, "http://nameOfNamespace2");
 
+	UA_Server_delete(server);
+
     ck_assert_uint_gt(a, 0);
     ck_assert_uint_eq(a,b);
     ck_assert_uint_ne(a,c);


### PR DESCRIPTION
Valgrind is already used in master branch for the unit tests. This should also be enabled in the 0.2 branch.