### PR TITLE
Fixed UA_Client_disconnect() if client is in error state

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -682,7 +682,7 @@ UA_Client_connect(UA_Client *client, const char *endpointUrl) {
 }
 
 UA_StatusCode UA_Client_disconnect(UA_Client *client) {
-    if(client->state != UA_CLIENTSTATE_CONNECTED)
+    if(client->state == UA_CLIENTSTATE_READY)
         return UA_STATUSCODE_BADNOTCONNECTED;
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     /* Is a session established? */


### PR DESCRIPTION
If the client runs into an error state, we can't disconnect.
As all states, but UA_CLIENTSTATE_READY are connected, we should be able to disconnect (which is necessary to renew the connection - as required by the error client states).
