### PR TITLE
Generate properly versioned shared library links on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,9 @@ target_link_libraries(open62541 ${open62541_LIBRARIES})
 target_compile_definitions(open62541-object PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
 target_compile_definitions(open62541 PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
 
+# Generate properly versioned shared library links on Linux
+SET_TARGET_PROPERTIES(open62541 PROPERTIES SOVERSION 0 VERSION 0.2.0)
+
 if(WIN32)
     target_link_libraries(open62541 ws2_32)
 endif()


### PR DESCRIPTION
Instruct CMake to create a properly versioned library.
Cross-compile environments like OpenEmbedded/Yocto are picky about adhering to these standards, this fixes QA errors resulting from building open62541 as a shared library for embedded targets.

Signed-off-by: Mike Looijmans <mike.looijmans@topic.nl>