### PR TITLE
Don't copy elements for RegisterServer call

### DIFF
--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -342,16 +342,20 @@ __UA_Client_readAttribute(UA_Client *client, const UA_NodeId *nodeId,
         return retval;
     }
 
+    /* Set the StatusCode */
     UA_DataValue *res = response.results;
-    if(res->hasStatus != UA_STATUSCODE_GOOD)
-        retval = res->hasStatus;
-    else if(!res->hasValue)
-        retval = UA_STATUSCODE_BADUNEXPECTEDERROR;
-    if(retval != UA_STATUSCODE_GOOD) {
+    if(res->hasStatus)
+        retval = res->status;
+
+    /* Return early of no value is given */
+    if(!res->hasValue) {
+        if(retval == UA_STATUSCODE_GOOD)
+            retval = UA_STATUSCODE_BADUNEXPECTEDERROR;
         UA_ReadResponse_deleteMembers(&response);
         return retval;
     }
 
+    /* Copy value into out */
     if(attributeId == UA_ATTRIBUTEID_VALUE) {
         memcpy(out, &res->value, sizeof(UA_Variant));
         UA_Variant_init(&res->value);

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -838,7 +838,7 @@ UA_Server_addDataSourceVariableNode(UA_Server *server, const UA_NodeId requested
     item.typeDefinition.nodeId = typeDefinition;
     item.parentNodeId.nodeId = parentNodeId;
     retval |= copyStandardAttributes((UA_Node*)node, &item, (const UA_NodeAttributes*)&editAttr);
-    retval |= copyCommonVariableAttributes(server, node, &item, &editAttr);
+    retval |= copyVariableNodeAttributes(server, node, &item, &editAttr);
     UA_DataValue_deleteMembers(&node->value.data.value);
     node->valueSource = UA_VALUESOURCE_DATASOURCE;
     node->value.dataSource = dataSource;

--- a/tests/check_services_view.c
+++ b/tests/check_services_view.c
@@ -1,37 +1,38 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "ua_types.h"
-#include "server/ua_services.h"
 #include "check.h"
+#include "ua_server.h"
+#include "ua_config_standard.h"
 
-/* START_TEST(Service_TranslateBrowsePathsToNodeIds_SmokeTest)
+START_TEST(Service_Browse_WithBrowseName)
 {
-    UA_TranslateBrowsePathsToNodeIdsRequest request;
-    UA_TranslateBrowsePathsToNodeIdsRequest_init(&request);
+    UA_Server * server = UA_Server_new(UA_ServerConfig_standard);
 
-    UA_TranslateBrowsePathsToNodeIdsResponse response;
-    UA_TranslateBrowsePathsToNodeIdsResponse_init(&response);
+    UA_BrowseDescription bd;
+    UA_BrowseDescription_init(&bd);
+    bd.resultMask = UA_BROWSERESULTMASK_BROWSENAME;
+    bd.nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    bd.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    bd.browseDirection = UA_BROWSEDIRECTION_FORWARD;
 
-    request.browsePathsSize = 1;
-    UA_Array_new((void**)&request.browsePaths,request.browsePathsSize, &UA_.types[UA_BROWSEPATH]);
+    UA_BrowseResult br = UA_Server_browse(server, 0, &bd);
 
-    Service_TranslateBrowsePathsToNodeIds(NULL,&request,&response);
+    ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert(br.referencesSize > 0);
+    ck_assert(!UA_String_equal(&br.references[0].browseName.name, &UA_STRING_NULL));
 
-    ck_assert_int_eq(response.resultsSize,request.browsePathsSize);
-    ck_assert_int_eq(response.results[0].statusCode,UA_STATUSCODE_BADNOMATCH);
-
-    //finally
-    UA_TranslateBrowsePathsToNodeIdsRequest_deleteMembers(&request);
-    UA_TranslateBrowsePathsToNodeIdsResponse_deleteMembers(&response);
+    UA_BrowseResult_deleteMembers(&br);
+    UA_Server_delete(server);
 }
-END_TEST */
+END_TEST
 
 static Suite* testSuite_Service_TranslateBrowsePathsToNodeIds(void) {
     Suite *s = suite_create("Service_TranslateBrowsePathsToNodeIds");
-    TCase *tc_core = tcase_create("Core");
-    //tcase_add_test(tc_core, Service_TranslateBrowsePathsToNodeIds_SmokeTest);
-    suite_add_tcase(s,tc_core);
+    TCase *tc_browse = tcase_create("Browse Service");
+    tcase_add_test(tc_browse, Service_Browse_WithBrowseName);
+
+    suite_add_tcase(s,tc_browse);
     return s;
 }
 
@@ -43,7 +44,8 @@ int main(void) {
 
     s = testSuite_Service_TranslateBrowsePathsToNodeIds();
     sr = srunner_create(s);
-    srunner_run_all(sr,CK_NORMAL);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
     number_failed += srunner_ntests_failed(sr);
     srunner_free(sr);
 


### PR DESCRIPTION
This simplifies `register_server_with_discovery_server` a bit.
Notably, members of the request are not copied but point into the server config.
Otherwise, we have to check the statuscode of every array allocation and every UA_copy.

Also, I'm under the impression that `request.server.discoveryUrlsSize` was always zero in the realloc.

@Pro Can you review the changes?