### PR TITLE
Fixed problem with enumeration decoding.

### DIFF
--- a/src/server/ua_services_call.c
+++ b/src/server/ua_services_call.c
@@ -44,7 +44,7 @@ argumentsConformsToDefinition(UA_Server *server, const UA_VariableNode *argRequi
     for(size_t i = 0; i < argReqsSize; ++i)
         retval |= typeCheckValue(server, &argReqs[i].dataType, argReqs[i].valueRank,
                                  argReqs[i].arrayDimensionsSize, argReqs[i].arrayDimensions,
-                                 &args[i], NULL, args);
+                                 &args[i], NULL, &args[i]);
     return retval;
 }
 


### PR DESCRIPTION
If a method with Enumerations is called the typeCheckValue-Function overwrites the Variant. At the moment every time the first value was overwritten. Now the correct value will be overwritten.