### PR TITLE
Extend external nodestore API to retrieve references in returnRelevan…

### DIFF
--- a/include/ua_server_external_ns.h
+++ b/include/ua_server_external_ns.h
@@ -32,8 +32,11 @@ typedef UA_StatusCode (*UA_ExternalNodeStore_addReferences)
  UA_UInt32 *indices,UA_UInt32 indicesSize, UA_StatusCode *addReferencesResults,
  UA_DiagnosticInfo *diagnosticInfos);
  
- typedef UA_StatusCode (*UA_ExternalNodeStore_addOneWayReference)
+typedef UA_StatusCode (*UA_ExternalNodeStore_addOneWayReference)
 (void *ensHandle, const UA_AddReferencesItem *item);
+
+typedef UA_StatusCode (*UA_ExternalNodeStore_getOneWayReferences)
+(void *ensHandle, UA_NodeId *nodeId, UA_UInt32 *referencesSize, UA_ReferenceNode **references);
 
 typedef UA_StatusCode (*UA_ExternalNodeStore_deleteNodes)
 (void *ensHandle, const UA_RequestHeader *requestHeader, UA_DeleteNodesItem *nodesToDelete, UA_UInt32 *indices,
@@ -80,6 +83,7 @@ typedef struct UA_ExternalNodeStore {
     UA_ExternalNodeStore_deleteReferences deleteReferences;
     UA_ExternalNodeStore_call call;
     UA_ExternalNodeStore_addOneWayReference addOneWayReference;
+    UA_ExternalNodeStore_getOneWayReferences getOneWayReferences;
     UA_ExternalNodeStore_delete destroy;
 } UA_ExternalNodeStore;
 

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -39,12 +39,12 @@ static const UA_Node *
 returnRelevantNodeExternal(UA_ExternalNodeStore *ens, const UA_BrowseDescription *descr,
                            const UA_ReferenceNode *reference) {
     /* prepare a read request in the external nodestore */
-    UA_ReadValueId *readValueIds = UA_Array_new(6,&UA_TYPES[UA_TYPES_READVALUEID]);
-    UA_UInt32 *indices = UA_Array_new(6,&UA_TYPES[UA_TYPES_UINT32]);
-    UA_UInt32 indicesSize = 6;
-    UA_DataValue *readNodesResults = UA_Array_new(6,&UA_TYPES[UA_TYPES_DATAVALUE]);
-    UA_DiagnosticInfo *diagnosticInfos = UA_Array_new(6,&UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-    for(UA_UInt32 i = 0; i < 6; ++i) {
+    UA_ReadValueId *readValueIds = UA_Array_new(5,&UA_TYPES[UA_TYPES_READVALUEID]);
+    UA_UInt32 *indices = UA_Array_new(5,&UA_TYPES[UA_TYPES_UINT32]);
+    UA_UInt32 indicesSize = 5;
+    UA_DataValue *readNodesResults = UA_Array_new(5,&UA_TYPES[UA_TYPES_DATAVALUE]);
+    UA_DiagnosticInfo *diagnosticInfos = UA_Array_new(5,&UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
+    for(UA_UInt32 i = 0; i < 5; ++i) {
         readValueIds[i].nodeId = reference->targetId.nodeId;
         indices[i] = i;
     }
@@ -53,7 +53,6 @@ returnRelevantNodeExternal(UA_ExternalNodeStore *ens, const UA_BrowseDescription
     readValueIds[2].attributeId = UA_ATTRIBUTEID_DISPLAYNAME;
     readValueIds[3].attributeId = UA_ATTRIBUTEID_DESCRIPTION;
     readValueIds[4].attributeId = UA_ATTRIBUTEID_WRITEMASK;
-    readValueIds[5].attributeId = UA_ATTRIBUTEID_USERWRITEMASK;
 
     ens->readNodes(ens->ensHandle, NULL, readValueIds, indices,
                    indicesSize, readNodesResults, false, diagnosticInfos);
@@ -71,12 +70,16 @@ returnRelevantNodeExternal(UA_ExternalNodeStore *ens, const UA_BrowseDescription
         UA_LocalizedText_copy((UA_LocalizedText*)readNodesResults[3].value.data, &(node->description));
     if(readNodesResults[4].status == UA_STATUSCODE_GOOD)
         UA_UInt32_copy((UA_UInt32*)readNodesResults[4].value.data, &(node->writeMask));
-    if(readNodesResults[5].status == UA_STATUSCODE_GOOD)
-        UA_UInt32_copy((UA_UInt32*)readNodesResults[5].value.data, &(node->userWriteMask));
-    UA_Array_delete(readValueIds,6, &UA_TYPES[UA_TYPES_READVALUEID]);
-    UA_Array_delete(indices,6, &UA_TYPES[UA_TYPES_UINT32]);
-    UA_Array_delete(readNodesResults,6, &UA_TYPES[UA_TYPES_DATAVALUE]);
-    UA_Array_delete(diagnosticInfos,6, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
+
+    UA_ReferenceNode **references = &node->references;
+    UA_UInt32 *referencesSize = (UA_UInt32*)&node->referencesSize;
+    
+    ens->getOneWayReferences (ens->ensHandle, &node->nodeId, referencesSize, references);
+
+    UA_Array_delete(readValueIds,5, &UA_TYPES[UA_TYPES_READVALUEID]);
+    UA_Array_delete(indices,5, &UA_TYPES[UA_TYPES_UINT32]);
+    UA_Array_delete(readNodesResults,5, &UA_TYPES[UA_TYPES_DATAVALUE]);
+    UA_Array_delete(diagnosticInfos,5, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
     if(node && descr->nodeClassMask != 0 && (node->nodeClass & descr->nodeClassMask) == 0) {
         UA_NodeStore_deleteNode(node);
         return NULL;


### PR DESCRIPTION
As described on the group list (https://groups.google.com/forum/#!topic/open62541/1XLhfjERsM8), I think there is an issue in the external namespace API. This pull request is supposed to be an initial fix suggestion and to maybe get more attention than on the list. Additionally, enabling external namespaces on master leads to compilation errors, since there is no userwritemask member in UA_Node. The fix is probably not following the initial API design ideas, but I am not very familiar with the codebase, so this is a quick fix to demonstrate the issue. My feeling is that this should be somewhat integrated into the readNodes callback, but the way it is designed right now does not allow returning arbitrary sized result arrays (in this case an array of all the references associated to an external node).