### PR TITLE
Enable travis OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 
 os:
 - linux
-# - osx
+- osx
 
 # use new build environment (docker)
 dist: trusty

--- a/tools/travis/travis_osx_script.sh
+++ b/tools/travis/travis_osx_script.sh
@@ -6,35 +6,49 @@ if [ $ANALYZE = "true" ]; then
     exit 0
 else
     echo "\n=== Building ==="
+    export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
+    export PATH="/Users/travis/Library/Python/2.7/bin:$PATH"
 
-    echo "Create certificate for OS X build"
+
+    echo "Documentation and certificate build"  && echo -en 'travis_fold:start:script.build.doc\\r'
     mkdir -p build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_DOCUMENTATION=ON -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
     make selfsigned
-    cp server_cert.der ../
+    ls examples
+    cp examples/server_cert.der ../
     cd .. && rm -rf build
+    echo -en 'travis_fold:end:script.build.doc\\r'
 
-    echo "Compile release build for OS X"
+    echo "Full Namespace 0 Generation"  && echo -en 'travis_fold:start:script.build.ns0\\r'
+    mkdir -p build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Debug -DUA_ENABLE_GENERATE_NAMESPACE0=On -DUA_BUILD_EXAMPLES=ON  ..
+    make -j
+    cd .. && rm -rf build
+    echo -en 'travis_fold:end:script.build.ns0\\r'
+
+    echo "Compile release build for OS X" && echo -en 'travis_fold:start:script.build.osx\\r'
     mkdir -p build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DUA_ENABLE_AMALGAMATION=ON -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_DOCUMENTATION=ON -DUA_GENERATE_SELFSIGNED=ON ..
-    make -j8
-    tar -pczf open62541-osx.tar.gz ../doc ../server_cert.der ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
+	cmake -DCMAKE_BUILD_TYPE=Release -DUA_ENABLE_AMALGAMATION=ON -DUA_BUILD_EXAMPLES=ON ..
+    make -j
+    tar -pczf open62541-osx.tar.gz ../LICENSE ../AUTHORS ../README.md examples/server examples/client libopen62541.a open62541.h open62541.c
     cp open62541-osx.tar.gz ..
     cp open62541.h .. #copy single file-release
     cp open62541.c .. #copy single file-release
     cd .. && rm -rf build
+	echo -en 'travis_fold:end:script.build.osx\\r'
 
-    echo "Compile multithreaded version"
+    echo "Compile multithreaded version" && echo -en 'travis_fold:start:script.build.multithread\\r'
     mkdir -p build && cd build
-    cmake -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLES=ON ..
-    make -j8
+    cmake -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLESERVER=ON -DUA_BUILD_EXAMPLES=ON ..
+    make -j
     cd .. && rm -rf build
+	echo -en 'travis_fold:end:script.build.multithread\\r'
 
-    echo "Debug build and unit tests (64 bit)"
+    echo "Debug build and unit tests with valgrind" && echo -en 'travis_fold:start:script.build.unit_test\\r'
     mkdir -p build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_DEMO_NODESET=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_COVERAGE=ON ..
-    make -j8 && make test
-    echo "Run valgrind to see if the server leaks memory (just starting up and closing..)"
-    (valgrind --error-exitcode=3 ./server & export pid=$!; sleep 2; kill -INT $pid; wait $pid);
+    cmake -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=OFF -DUA_ENABLE_VALGRIND_UNIT_TESTS=OFF ..
+    make -j && make test ARGS="-V"
     cd .. && rm -rf build
+	echo -en 'travis_fold:end:script.build.unit_test\\r'
 fi


### PR DESCRIPTION
This enables OSX builds on travis.
Currently 0.2 builds just fine there.

One drawback is that it may take up to a few hours until the OSX build starts because the OSX machines on travis are overloaded.