### PR TITLE
Have a .pc.in file to install a pkg-config header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ endif()
 
 file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src_generated")
 configure_file("include/ua_config.h.in" "${PROJECT_BINARY_DIR}/src_generated/ua_config.h")
+configure_file("include/open62541.pc.in" "${PROJECT_BINARY_DIR}/src_generated/open62541.pc" @ONLY)
 
 if (UA_ENABLE_DISCOVERY_MULTICAST)
     configure_file("deps/mdnsd/libmdnsd/mdnsd_config.h.in" "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h")
@@ -551,8 +552,15 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/open62541-config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/open62541ConfigVersion.cmake"
         DESTINATION "${cmake_configfile_install}")
 
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    install(FILES "${PROJECT_BINARY_DIR}/src_generated/open62541.pc"
+            DESTINATION lib/pkgconfig)
+endif()
 # export amalgamated header open62541.h which is generated due to build of open62541-object
-install(FILES ${PROJECT_BINARY_DIR}/open62541.h DESTINATION include/open62541)
+if(UA_ENABLE_AMALGAMATION)
+    install(FILES ${PROJECT_BINARY_DIR}/open62541.h DESTINATION include/open62541)
+endif()
 install(DIRECTORY deps/ DESTINATION ${open62541_deps_dir})
 install(DIRECTORY tools/ DESTINATION ${open62541_tools_dir} USE_SOURCE_PERMISSIONS)
 

--- a/include/open62541.pc.in
+++ b/include/open62541.pc.in
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2014-2017 the contributors, as stated in the AUTHORS
+ * file
+ *
+ * This file is part of open62541. open62541 is free software: you can
+ * redistribute it and/or modify it under the terms of the Mozilla
+ * Public License v2.0, as stated in the LICENSE file provided with
+ * open62541.
+ *
+ * open62541 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_PREFIX@/lib
+sharedlibdir=@CMAKE_INSTALL_PREFIX@/share
+includedir=@CMAKE_INSTALL_PREFIX@/include
+
+Name: open62541
+Description: open62541 is an open source C (C99) implementation of OPC UA
+Version: @OPEN62541_VER_MAJOR@.@OPEN62541_VER_MINOR@.@OPEN62541_VER_PATCH@
+Libs: -L${libdir} -lopen62541
+Cflags: -I${includedir}/open62541


### PR DESCRIPTION
This way, people linking against installed open62541 on their systems
will be able to query its CFLAGS/LDFLAGS via pkg-config tool.

I also made the amalgamated header be installed only if the build flag
is set. The files that should be installed as headers otherwise are not
known to me. Anyway, all the examples point to the amalgamated header
nowadays.