### PR TITLE
Bugfix UA_Client_NamespaceGetIndex not working

### DIFF
--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -13,6 +13,7 @@ UA_Client_NamespaceGetIndex(UA_Client *client, UA_String *namespaceUri,
     UA_ReadRequest request;
     UA_ReadRequest_init(&request);
     UA_ReadValueId id;
+    UA_ReadValueId_init(&id);  
     id.attributeId = UA_ATTRIBUTEID_VALUE;
     id.nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_NAMESPACEARRAY);
     request.nodesToRead = &id;


### PR DESCRIPTION
In UA_Client_NamespaceGetIndex the init of ReadDataId was missing, which caused an non-recoverable error on my system.