### PR TITLE
Fix redefinition of SLIST_ENTRY on mingw winnt.h

### DIFF
--- a/deps/queue.h
+++ b/deps/queue.h
@@ -98,7 +98,12 @@ struct name {								\
  
 #define	SLIST_HEAD_INITIALIZER(head)					\
 	{ NULL }
- 
+
+/* Fix redefinition of SLIST_ENTRY on mingw winnt.h */
+# ifdef SLIST_ENTRY
+#  undef SLIST_ENTRY
+# endif
+
 #define SLIST_ENTRY(type)						\
 struct {								\
 	struct type *sle_next;	/* next element */			\


### PR DESCRIPTION
If the files are amalgameted there is a redefinition of SLIST_ENTRY. This was avoid earlier in the same way, but then moved to ua_util.h and finally deleted.