### PR TITLE
Remove -Werror from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ list(APPEND open62541_LIBRARIES "") # Collect libraries
 
 if(CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID}" STREQUAL "xClang")
     # Compiler
-    add_definitions(-std=c99 -pipe -Wall -Wextra -Werror -Wformat -Wno-unused-parameter
+    add_definitions(-std=c99 -pipe -Wall -Wextra -Wformat -Wno-unused-parameter
                     -Wno-unused-function -Wno-unused-label -Wpointer-arith -Wreturn-type -Wsign-compare
                     -Wmultichar -Wstrict-overflow -Wcast-qual -Wmissing-prototypes -Wstrict-prototypes
                     -Winit-self -Wuninitialized -Wformat-security -Wformat-nonliteral)


### PR DESCRIPTION
This should help with building on newer compilers
https://blog.flameeyes.eu/2009/02/future-proof-your-code-dont-use-werror/

This also fixes #1018 for compilation errors