### PR TITLE
Client_highlevel unittests

### DIFF
--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -152,7 +152,7 @@ UA_Client_readValueRankAttribute(UA_Client *client, const UA_NodeId nodeId,
 
 UA_StatusCode UA_EXPORT
 UA_Client_readArrayDimensionsAttribute(UA_Client *client, const UA_NodeId nodeId,
-                                       UA_Int32 **outArrayDimensions,
+                                       UA_UInt32 **outArrayDimensions,
                                        size_t *outArrayDimensionsSize);
 
 static UA_INLINE UA_StatusCode
@@ -333,7 +333,7 @@ UA_Client_writeValueRankAttribute(UA_Client *client, const UA_NodeId nodeId,
 
 UA_StatusCode UA_EXPORT
 UA_Client_writeArrayDimensionsAttribute(UA_Client *client, const UA_NodeId nodeId,
-                                        const UA_Int32 *newArrayDimensions,
+                                        const UA_UInt32 *newArrayDimensions,
                                         size_t newArrayDimensionsSize);
 
 static UA_INLINE UA_StatusCode

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -434,7 +434,6 @@ UA_Client_readArrayDimensionsAttribute(UA_Client *client, const UA_NodeId nodeId
         goto cleanup;
     }
 
-    *outArrayDimensions = UA_Array_new(res->value.arrayLength, &UA_TYPES[UA_TYPES_UINT32]);
     retval = UA_Array_copy(res->value.data, res->value.arrayLength, (void **)&(*outArrayDimensions), &UA_TYPES[UA_TYPES_UINT32]);
     if (retval != UA_STATUSCODE_GOOD) {
         UA_free(res->value.data);

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -434,7 +434,12 @@ UA_Client_readArrayDimensionsAttribute(UA_Client *client, const UA_NodeId nodeId
         goto cleanup;
     }
 
-    *outArrayDimensions = res->value.data;
+    *outArrayDimensions = UA_Array_new(res->value.arrayLength, &UA_TYPES[UA_TYPES_UINT32]);
+    retval = UA_Array_copy(res->value.data, res->value.arrayLength, (void **)&(*outArrayDimensions), &UA_TYPES[UA_TYPES_UINT32]);
+    if (retval != UA_STATUSCODE_GOOD) {
+        UA_free(res->value.data);
+        goto cleanup;
+    }
     *outArrayDimensionsSize = res->value.arrayLength;
     UA_free(res->value.data);
     res->value.data = NULL;

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -206,7 +206,7 @@ typeCheckValue(UA_Server *server, const UA_NodeId *targetDataTypeId,
 static UA_StatusCode
 readArrayDimensionsAttribute(const UA_VariableNode *vn, UA_DataValue *v) {
     UA_Variant_setArray(&v->value, vn->arrayDimensions,
-                        vn->arrayDimensionsSize, &UA_TYPES[UA_TYPES_INT32]);
+                        vn->arrayDimensionsSize, &UA_TYPES[UA_TYPES_UINT32]);
     v->value.storageType = UA_VARIANT_DATA_NODELETE;
     v->hasValue = true;
     return UA_STATUSCODE_GOOD;

--- a/tests/check_client_highlevel.c
+++ b/tests/check_client_highlevel.c
@@ -393,14 +393,18 @@ START_TEST(Node_ReadWrite)
         ck_assert(UA_Variant_isScalar(val) && val->type == &UA_TYPES[UA_TYPES_INT32]);
         value = *(UA_Int32*)val->data;
         ck_assert_int_eq(value, 5678);
+        UA_Variant_delete(val);
 
         /* Write attribute */
         value++;
+        val = UA_Variant_new();
         UA_Variant_setScalarCopy(val, &value, &UA_TYPES[UA_TYPES_INT32]);
         retval = UA_Client_writeValueAttribute(client, nodeIntId, val);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        UA_Variant_delete(val);
 
         /* Read again to check value */
+        val = UA_Variant_new();
         retval = UA_Client_readValueAttribute(client, nodeIntId, val);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -420,6 +424,7 @@ START_TEST(Node_ReadWrite)
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
         ck_assert_int_eq(arrayDimsReadSize, 1);
         ck_assert_int_eq(arrayDimsRead[0], 3);
+        UA_Array_delete(arrayDimsRead, arrayDimsReadSize, &UA_TYPES[UA_TYPES_UINT32]);
 
     }
 END_TEST

--- a/tests/check_client_highlevel.c
+++ b/tests/check_client_highlevel.c
@@ -196,9 +196,7 @@ START_TEST(Node_Add)
             attr.description = UA_LOCALIZEDTEXT("en_US", "Top Coordinate");
             attr.displayName = UA_LOCALIZEDTEXT("en_US", "Top");
 
-            UA_Int32 values[2];
-            values[1] = 10;
-            values[2] = 20;
+            UA_Int32 values[2] = {10, 20};
 
             UA_Variant_setArray(&attr.value, values, 2, &UA_TYPES[UA_TYPES_INT32]);
             attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
@@ -278,6 +276,150 @@ START_TEST(Node_Add)
 
             ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
         }
+
+    }
+END_TEST
+
+unsigned int iteratedNodeCount = 0;
+UA_NodeId iteratedNodes[2];
+
+static UA_StatusCode
+nodeIter(UA_NodeId childId, UA_Boolean isInverse, UA_NodeId referenceTypeId, void *handle) {
+    if (isInverse ||
+            (referenceTypeId.identifierType == UA_NODEIDTYPE_NUMERIC &&
+                    referenceTypeId.identifier.numeric == UA_NS0ID_HASTYPEDEFINITION)
+            )
+        return UA_STATUSCODE_GOOD;
+
+    if (iteratedNodeCount >= 2)
+        return UA_STATUSCODE_BADINDEXRANGEINVALID;
+
+    UA_NodeId_copy(&childId, &iteratedNodes[iteratedNodeCount]);
+
+    iteratedNodeCount++;
+
+    return UA_STATUSCODE_GOOD;
+}
+
+START_TEST(Node_ReadWrite)
+    {
+        UA_StatusCode retval;
+        // Create a folder with two variables for testing
+
+        UA_NodeId unitTestNodeId;
+
+        UA_NodeId nodeArrayId;
+        UA_NodeId nodeIntId;
+
+        // create Coordinates Object within ObjectsFolder
+        {
+            UA_ObjectAttributes attr;
+            UA_ObjectAttributes_init(&attr);
+            attr.description = UA_LOCALIZEDTEXT("en_US", "UnitTest");
+            attr.displayName = UA_LOCALIZEDTEXT("en_US", "UnitTest");
+
+            retval = UA_Client_addObjectNode(client, UA_NODEID_NULL,
+                                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                             UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                             UA_QUALIFIEDNAME(1, "UnitTest"),
+                                             UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), attr, &unitTestNodeId);
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+
+        // create Variable 'Top' within UnitTest Object
+        {
+            UA_VariableAttributes attr;
+            UA_VariableAttributes_init(&attr);
+            attr.description = UA_LOCALIZEDTEXT("en_US", "Array");
+            attr.displayName = UA_LOCALIZEDTEXT("en_US", "Array");
+
+            /*UA_Int32 values[2];
+            values[1] = 10;
+            values[2] = 20;
+
+            UA_Variant_setArray(&attr.value, values, 2, &UA_TYPES[UA_TYPES_INT32]);*/
+            attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
+            attr.valueRank = 1; /* array with one dimension */
+            UA_UInt32 arrayDims[1] = {2};
+            attr.arrayDimensions = arrayDims;
+            attr.arrayDimensionsSize = 1;
+
+            retval = UA_Client_addVariableNode(client, UA_NODEID_NULL,
+                                               unitTestNodeId,
+                                               UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                               UA_QUALIFIEDNAME(1, "Array"),
+                                               UA_NODEID_NULL, attr, &nodeArrayId);
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+
+        // create Variable 'Bottom' within UnitTest Object
+        {
+            UA_VariableAttributes attr;
+            UA_VariableAttributes_init(&attr);
+            attr.description = UA_LOCALIZEDTEXT("en_US", "Int");
+            attr.displayName = UA_LOCALIZEDTEXT("en_US", "Int");
+
+            UA_Int32 int_value = 5678;
+
+            UA_Variant_setScalar(&attr.value, &int_value, &UA_TYPES[UA_TYPES_INT32]);
+            attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
+
+            retval = UA_Client_addVariableNode(client, UA_NODEID_NULL,
+                                               unitTestNodeId,
+                                               UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                               UA_QUALIFIEDNAME(1, "Int"),
+                                               UA_NODEID_NULL, attr, &nodeIntId);
+
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+
+        // iterate over children
+        {
+            retval = UA_Client_forEachChildNodeCall(client, unitTestNodeId,
+                                                    nodeIter, NULL);
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+            ck_assert(UA_NodeId_equal(&nodeArrayId, &iteratedNodes[0]));
+            ck_assert(UA_NodeId_equal(&nodeIntId, &iteratedNodes[1]));
+        }
+
+
+        /* Read attribute */
+        UA_Int32 value = 0;
+        UA_Variant *val = UA_Variant_new();
+        retval = UA_Client_readValueAttribute(client, nodeIntId, val);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+        ck_assert(UA_Variant_isScalar(val) && val->type == &UA_TYPES[UA_TYPES_INT32]);
+        value = *(UA_Int32*)val->data;
+        ck_assert_int_eq(value, 5678);
+
+        /* Write attribute */
+        value++;
+        UA_Variant_setScalarCopy(val, &value, &UA_TYPES[UA_TYPES_INT32]);
+        retval = UA_Client_writeValueAttribute(client, nodeIntId, val);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+        /* Read again to check value */
+        retval = UA_Client_readValueAttribute(client, nodeIntId, val);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+        ck_assert(UA_Variant_isScalar(val) && val->type == &UA_TYPES[UA_TYPES_INT32]);
+        value = *(UA_Int32*)val->data;
+        ck_assert_int_eq(value, 5679);
+        UA_Variant_delete(val);
+
+        UA_UInt32 arrayDimsNew[] = {3};
+        retval = UA_Client_writeArrayDimensionsAttribute(client, nodeArrayId, arrayDimsNew , 1);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+
+        UA_UInt32 *arrayDimsRead;
+        size_t arrayDimsReadSize;
+        retval = UA_Client_readArrayDimensionsAttribute(client, nodeArrayId, &arrayDimsRead , &arrayDimsReadSize);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        ck_assert_int_eq(arrayDimsReadSize, 1);
+        ck_assert_int_eq(arrayDimsRead[0], 3);
 
     }
 END_TEST
@@ -407,6 +549,7 @@ static Suite *testSuite_Client(void) {
     tcase_add_checked_fixture(tc_nodes, setup, teardown);
     tcase_add_test(tc_nodes, Node_Add);
     tcase_add_test(tc_nodes, Node_Browse);
+    tcase_add_test(tc_nodes, Node_ReadWrite);
     tcase_add_test(tc_nodes, Node_Register);
     suite_add_tcase(s, tc_nodes);
     return s;

--- a/tests/check_services_attributes.c
+++ b/tests/check_services_attributes.c
@@ -447,7 +447,7 @@ START_TEST(ReadSingleAttributeArrayDimensionsWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     ck_assert_int_eq(0, resp.value.arrayLength);
-    ck_assert_ptr_eq(&UA_TYPES[UA_TYPES_INT32], resp.value.type);
+    ck_assert_ptr_eq(&UA_TYPES[UA_TYPES_UINT32], resp.value.type);
     ck_assert_ptr_eq((UA_Int32*)resp.value.data,0);
     UA_DataValue_deleteMembers(&resp);
     UA_Server_delete(server);


### PR DESCRIPTION
This PR adds additional unit tests for client highlevel functions.

I had to change the type for ArrayDimensions from Int32 to UInt32, which is also the correct value in the specification part 3.

@open62541/open62541-core Since this introduces a small api break (https://github.com/open62541/open62541/pull/1024/commits/efafe2567d7797675d7706a535d5550669b29249#diff-fc6ee50978a5f2bda32297608b5360d6R209)
should I still merge it?