### PR TITLE
enable shared libs build on travis and appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,10 +66,21 @@ build_script:
   - md build
   - cd build
   - echo "Testing %CC_NAME% with amalgamation"
-  - cmake -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON -DUA_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -G"%CC_NAME%" ..
+  - cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON -DUA_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -DBUILD_SHARED_LIBS:BOOL=OFF -G"%CC_NAME%" ..
   - '%MAKE%'
+  - 7z a -tzip open62541-%CC_SHORTNAME%-static.zip %APPVEYOR_BUILD_FOLDER%\build\*
+  - move open62541-%CC_SHORTNAME%-static.zip %APPVEYOR_BUILD_FOLDER%
+  - cd ..
+  - rd /s /q build
+  - md build
+  - cd build
+  - echo "Testing %CC_NAME% with amalgamation and .dll"
+  - cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON -DUA_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -DBUILD_SHARED_LIBS:BOOL=ON -G"%CC_NAME%" ..
+  - '%MAKE%'
+  - 7z a -tzip open62541-%CC_SHORTNAME%-dynamic.zip %APPVEYOR_BUILD_FOLDER%\build\*
+  - move open62541-%CC_SHORTNAME%-dynamic.zip %APPVEYOR_BUILD_FOLDER%
   - cd ..
 
 after_build:
-  - 7z a open62541-%CC_SHORTNAME%.zip %APPVEYOR_BUILD_FOLDER%\build*
-  - appveyor PushArtifact open62541-%CC_SHORTNAME%.zip
+  - appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\open62541-%CC_SHORTNAME%-static.zip
+  - appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\open62541-%CC_SHORTNAME%-dynamic.zip

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,41 +21,49 @@ if(UA_ENABLE_MULTITHREADING)
   list(APPEND LIBS urcu-cds urcu urcu-common)
 endif(UA_ENABLE_MULTITHREADING)
 
+
+set(STATIC_OBJECTS $<TARGET_OBJECTS:open62541-object>)
+if(WIN32 AND BUILD_SHARED_LIBS)
+	# on windows the .dll.a file has to be used for the linker
+	list(APPEND LIBS open62541)
+	set(STATIC_OBJECTS "")
+endif()
+
 #############
 # Tutorials #
 #############
 
-add_executable(tutorial_datatypes tutorial_datatypes.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(tutorial_datatypes tutorial_datatypes.c ${STATIC_OBJECTS})
 add_dependencies(tutorial_datatypes open625451_amalgamation)
 target_link_libraries(tutorial_datatypes ${LIBS})
 
-add_executable(tutorial_server_firststeps tutorial_server_firststeps.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(tutorial_server_firststeps tutorial_server_firststeps.c ${STATIC_OBJECTS})
 add_dependencies(tutorial_server_firststeps open625451_amalgamation)
 target_link_libraries(tutorial_server_firststeps ${LIBS})
 
-add_executable(tutorial_server_variable tutorial_server_variable.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(tutorial_server_variable tutorial_server_variable.c ${STATIC_OBJECTS})
 add_dependencies(tutorial_server_variable open625451_amalgamation)
 target_link_libraries(tutorial_server_variable ${LIBS})
 
-add_executable(tutorial_server_datasource tutorial_server_datasource.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(tutorial_server_datasource tutorial_server_datasource.c ${STATIC_OBJECTS})
 add_dependencies(tutorial_server_datasource open625451_amalgamation)
 target_link_libraries(tutorial_server_datasource ${LIBS})
 
-add_executable(tutorial_server_variabletype tutorial_server_variabletype.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(tutorial_server_variabletype tutorial_server_variabletype.c ${STATIC_OBJECTS})
 add_dependencies(tutorial_server_variabletype open625451_amalgamation)
 target_link_libraries(tutorial_server_variabletype ${LIBS})
 
-add_executable(tutorial_server_object tutorial_server_object.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(tutorial_server_object tutorial_server_object.c ${STATIC_OBJECTS})
 add_dependencies(tutorial_server_object open625451_amalgamation)
 target_link_libraries(tutorial_server_object ${LIBS})
 
 if(UA_ENABLE_METHODCALLS)
-  add_executable(tutorial_server_method tutorial_server_method.c $<TARGET_OBJECTS:open62541-object>)
+  add_executable(tutorial_server_method tutorial_server_method.c ${STATIC_OBJECTS})
   add_dependencies(tutorial_server_method open625451_amalgamation)
   target_link_libraries(tutorial_server_method ${LIBS})
 endif()
 
-add_executable(tutorial_client_firststeps tutorial_client_firststeps.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(tutorial_client_firststeps tutorial_client_firststeps.c ${STATIC_OBJECTS})
 add_dependencies(tutorial_client_firststeps open625451_amalgamation)
 target_link_libraries(tutorial_client_firststeps ${LIBS})
 
@@ -63,11 +71,11 @@ target_link_libraries(tutorial_client_firststeps ${LIBS})
 # Example Server #
 ##################
 
-add_executable(server server.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(server server.c ${STATIC_OBJECTS})
 target_link_libraries(server ${LIBS})
 
 if(UA_ENABLE_NONSTANDARD_UDP)
-  add_executable(server_udp server_udp.c $<TARGET_OBJECTS:open62541-object> ${PROJECT_SOURCE_DIR}/plugins/ua_network_udp.c)
+  add_executable(server_udp server_udp.c ${STATIC_OBJECTS} ${PROJECT_SOURCE_DIR}/plugins/ua_network_udp.c)
   target_link_libraries(server_udp ${LIBS})
 endif()
 
@@ -75,27 +83,28 @@ endif()
 # Example Client #
 ##################
 
-add_executable(client client.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(client client.c ${STATIC_OBJECTS})
 target_link_libraries(client ${LIBS})
 
 ####################
 # Feature Examples #
 ####################
 
-add_executable(server_mainloop server_mainloop.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(server_mainloop server_mainloop.c ${STATIC_OBJECTS})
 target_link_libraries(server_mainloop ${LIBS})
 
-add_executable(server_instantiation server_instantiation.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(server_instantiation server_instantiation.c ${STATIC_OBJECTS})
 target_link_libraries(server_instantiation ${LIBS})
 
-add_executable(server_repeated_job server_repeated_job.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(server_repeated_job server_repeated_job.c ${STATIC_OBJECTS})
 target_link_libraries(server_repeated_job ${LIBS})
 
-add_executable(server_inheritance server_inheritance.c $<TARGET_OBJECTS:open62541-object>)
+add_executable(server_inheritance server_inheritance.c ${STATIC_OBJECTS})
 target_link_libraries(server_inheritance ${LIBS})
 
-if(UA_BUILD_EXAMPLES_NODESET_COMPILER)
-  add_executable(server_nodeset server_nodeset.c ${PROJECT_BINARY_DIR}/src_generated/nodeset.c $<TARGET_OBJECTS:open62541-object>)
+if(NOT BUILD_SHARED_LIBS AND UA_BUILD_EXAMPLES_NODESET_COMPILER)
+  # needs internal methods which are not exported in the dynamic lib
+  add_executable(server_nodeset server_nodeset.c ${PROJECT_BINARY_DIR}/src_generated/nodeset.c ${STATIC_OBJECTS})
   target_link_libraries(server_nodeset ${LIBS})
   target_include_directories(server_nodeset PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/deps) # needs an internal header
 endif()
@@ -109,10 +118,13 @@ if(UA_BUILD_SELFSIGNED_CERTIFICATE)
                              
   add_custom_target(selfsigned ALL DEPENDS server_cert.der ca.crt)
 
-  add_executable(server_certificate server_certificate.c $<TARGET_OBJECTS:open62541-object> server_cert.der ca.crt)
+  add_executable(server_certificate server_certificate.c ${STATIC_OBJECTS} server_cert.der ca.crt)
   target_link_libraries(server_certificate ${LIBS})
 endif()
 
-add_executable(server_readspeed server_readspeed.c $<TARGET_OBJECTS:open62541-object>)
-target_include_directories(server_readspeed PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/deps) # needs an internal header
-target_link_libraries(server_readspeed ${LIBS})
+if(NOT BUILD_SHARED_LIBS)
+  # needs internal methods which are not exported in the dynamic lib
+  add_executable(server_readspeed server_readspeed.c ${STATIC_OBJECTS})
+  target_include_directories(server_readspeed PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/deps) # needs an internal header
+  target_link_libraries(server_readspeed ${LIBS})
+endif()

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -127,6 +127,13 @@ if [ -z ${DOCKER+x} ]; then
 		cd .. && rm build -rf
 		echo -en 'travis_fold:end:script.build.example\\r'
 
+		echo "Compile as shared lib version" && echo -en 'travis_fold:start:script.build.shared_libs\\r'
+		mkdir -p build && cd build
+		cmake -DBUILD_SHARED_LIBS=ON -DUA_ENABLE_AMALGAMATION=ON -DUA_BUILD_EXAMPLES=ON ..
+		make -j
+		cd .. && rm build -rf
+		echo -en 'travis_fold:end:script.build.shared_libs\\r'
+
 		echo "Compile multithreaded version" && echo -en 'travis_fold:start:script.build.multithread\\r'
 		mkdir -p build && cd build
 		cmake -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLESERVER=ON -DUA_BUILD_EXAMPLES=ON ..


### PR DESCRIPTION
Now AppVeyor creates two artifacts:

- open62541-vs2013-static.zip
- open62541-vs2013-dynamic.zip

In travis an additional build is run with `BUILD_SHARED_LIBS=ON`