### PR TITLE
VariableTypeNode has no attribute accessLevel

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -846,13 +846,15 @@ Service_AddNode_finish(UA_Server *server, UA_Session *session, const UA_NodeId *
             return retval;
         }
 
-        /* Set AccessLevel to readable */
-        const UA_VariableNode *vn = (const UA_VariableNode*)node;
-        if(!(vn->accessLevel & (UA_ACCESSLEVELMASK_READ))) {
-            UA_LOG_INFO_SESSION(server->config.logger, session,
-                                "AddNodes: Set the AccessLevel to readable by default");
-            UA_Byte readable = vn->accessLevel | (UA_ACCESSLEVELMASK_READ);
-            UA_Server_writeAccessLevel(server, vn->nodeId, readable);
+        if(node->nodeClass == UA_NODECLASS_VARIABLE) {
+            /* Set AccessLevel to readable */
+            const UA_VariableNode *vn = (const UA_VariableNode*)node;
+            if(!(vn->accessLevel & (UA_ACCESSLEVELMASK_READ))) {
+                UA_LOG_INFO_SESSION(server->config.logger, session,
+                                    "AddNodes: Set the AccessLevel to readable by default");
+                UA_Byte readable = vn->accessLevel | (UA_ACCESSLEVELMASK_READ);
+                UA_Server_writeAccessLevel(server, vn->nodeId, readable);
+            }
         }
     }
 


### PR DESCRIPTION
Since somit 645e4ef5 node management services fail to add VariableTypeNodes because it is tried to set _accessLevel_ attribute of _VariableTypeNode_ which has effectively no such attribute and further checks will fail properly with _UA_STATUSCODE_BADNODECLASSINVALID_.