### PR TITLE
Added the helper procedure UA_String_equalNative(..) that compares given UA_String directly with native / zero-temrinated C string. This is often required on browsing a node's references and finding nodes in result list by browseName(s). The overhead (...

### DIFF
--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -162,6 +162,7 @@ typedef struct {
 UA_String UA_EXPORT UA_String_fromChars(char const src[]) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
 UA_Boolean UA_EXPORT UA_String_equal(const UA_String *s1, const UA_String *s2);
+UA_Boolean UA_EXPORT UA_String_equalNative(const UA_String *s1, const char *s2);
 
 UA_EXPORT extern const UA_String UA_STRING_NULL;
 

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -87,6 +87,15 @@ UA_String_equal(const UA_String *s1, const UA_String *s2) {
     return (is == 0) ? true : false;
 }
 
+bool
+UA_String_equalNative(const UA_String *s1, const char *s2) {
+    if(s1->length != strlen(s2))
+        return false;
+    i32 is = memcmp((char const*)s1->data,
+                    (char const*)s2, s1->length);
+    return (is == 0) ? true : false;
+}
+
 static void
 String_deleteMembers(UA_String *s, const UA_DataType *_) {
     UA_free((void*)((uintptr_t)s->data & ~(uintptr_t)UA_EMPTY_ARRAY_SENTINEL));


### PR DESCRIPTION
...memory and CPU) to generate/alloc UA_String for equality comparison only is not acceptable.