### PR TITLE
Added missing status codes according to v1.03.3

### DIFF
--- a/include/ua_constants.h
+++ b/include/ua_constants.h
@@ -149,6 +149,9 @@ typedef enum {
 #define UA_STATUSCODE_BADTIMESTAMPSTORETURNINVALID 0x802b0000 // The timestamps to return parameter is invalid.
 #define UA_STATUSCODE_BADREQUESTCANCELLEDBYCLIENT 0x802c0000 // The request was cancelled by the client.
 #define UA_STATUSCODE_BADTOOMANYARGUMENTS 0x80e50000 // Too many arguments were provided.
+#define UA_STATUSCODE_BADLICENSEEXPIRED 0x810E0000 // The server requires a license to operate in general or to perform a service or operation, but existing license is expired.
+#define UA_STATUSCODE_BADLICENSELIMITSEXCEEDED 0x810F0000 // The server has limits on number of allowed operations / objects, based on installed licenses, and these limits where exceeded.
+#define UA_STATUSCODE_BADLICENSENOTAVAILABLE 0x81100000 // The server does not have a license which is required to operate in general or to perform a service or operation.
 #define UA_STATUSCODE_GOODSUBSCRIPTIONTRANSFERRED 0x002d0000 // The subscription was transferred to another session.
 #define UA_STATUSCODE_GOODCOMPLETESASYNCHRONOUSLY 0x002e0000 // The processing will complete asynchronously.
 #define UA_STATUSCODE_GOODOVERLOAD 0x002f0000 // Sampling has slowed down due to resource limitations.

--- a/tools/schema/Opc.Ua.StatusCodes.csv
+++ b/tools/schema/Opc.Ua.StatusCodes.csv
@@ -46,6 +46,9 @@ BadRequestHeaderInvalid,0x802A0000,The header for the request is missing or inva
 BadTimestampsToReturnInvalid,0x802B0000,The timestamps to return parameter is invalid.
 BadRequestCancelledByClient,0x802C0000,The request was cancelled by the client.
 BadTooManyArguments,0x80E50000,Too many arguments were provided.
+BadLicenseExpired,0x810E0000,The server requires a license to operate in general or to perform a service or operation, but existing license is expired.
+BadLicenseLimitsExceeded,0x810F0000,The server has limits on number of allowed operations / objects, based on installed licenses, and these limits where exceeded.
+BadLicenseNotAvailable,0x81100000,The server does not have a license which is required to operate in general or to perform a service or operation.
 GoodSubscriptionTransferred,0x002D0000,The subscription was transferred to another session.
 GoodCompletesAsynchronously,0x002E0000,The processing will complete asynchronously.
 GoodOverload,0x002F0000,Sampling has slowed down due to resource limitations.


### PR DESCRIPTION
Added 3 missing status codes according to underlying schema of OPC foundation git repository (3146d80, Errata-1.03.3) (status code descriptions of already existing status codes were updated before only)
Sorry for the inconvenience!