### PR TITLE
Combine c runtime linkage with build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,8 +224,14 @@ endif()
 
 if(MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3 /WX") # Compiler warnings, error on warning
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
+
+  if(NOT BUILD_SHARED_LIB)
+    set(CompilerFlags CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE)
+    foreach(CompilerFlag ${CompilerFlags})
+      string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+    endforeach()
+  endif()
 endif()
 
 #########################


### PR DESCRIPTION
When compiling as a shared lib, link against the dynamic c-runtime
version.
Additionally, clean up the compile flags to append /MT to /MD and rather
replace it. This fixes warnings from the compiler.