### PR TITLE
client side event support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -42,6 +42,8 @@ endif()
 
 add_example(tutorial_client_firststeps tutorial_client_firststeps.c)
 
+add_example(tutorial_client_events tutorial_client_events.c)
+
 ##################
 # Example Server #
 ##################

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -45,7 +45,7 @@ setupSelectClauses(void)
         UA_SimpleAttributeOperand_init(&selectClauses[i]);
     }
 
-    selectClauses[0].typeDefinitionId = UA_NODEID_NUMERIC(0, 2041) ; // BaseEventType
+    selectClauses[0].typeDefinitionId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
     selectClauses[0].browsePathSize = 1;
     selectClauses[0].browsePath = (UA_QualifiedName*)UA_Array_new(selectClauses[0].browsePathSize, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
     if(!selectClauses[0].browsePath) {
@@ -55,7 +55,7 @@ setupSelectClauses(void)
     selectClauses[0].attributeId = UA_ATTRIBUTEID_VALUE;
     selectClauses[0].browsePath[0] = UA_QUALIFIEDNAME_ALLOC(0, "Message");
 
-    selectClauses[1].typeDefinitionId = UA_NODEID_NUMERIC(0, 2041) ; // BaseEventType
+    selectClauses[1].typeDefinitionId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
     selectClauses[1].browsePathSize = 1;
     selectClauses[1].browsePath = (UA_QualifiedName*)UA_Array_new(selectClauses[1].browsePathSize, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
     if(!selectClauses[1].browsePath) {

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -108,6 +108,7 @@ int main(int argc, char *argv[]) {
 
     UA_Client_Subscriptions_addMonitoredEvent(client, subId, monitorThis, UA_ATTRIBUTEID_EVENTNOTIFIER,
                                               selectClauses, nSelectClauses,
+                                              NULL, 0,
                                               &handler_events, NULL, &monId);
     if (!monId) {
         UA_Array_delete(selectClauses, nSelectClauses, &UA_TYPES[UA_TYPES_SIMPLEATTRIBUTEOPERAND]);

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -1,0 +1,116 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <stdio.h>
+#include <signal.h>
+#include "open62541.h"
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+static void
+handler_events(UA_UInt32 monId, size_t nEventFields, UA_Variant *eventFields, void *context) {
+    printf("got an event! %d, %zu\n", monId, nEventFields);
+
+    for(size_t i = 0; i < nEventFields; ++i) {
+        printf("%s\n", eventFields[i].type->typeName);
+        if (UA_Variant_hasScalarType(&eventFields[i], &UA_TYPES[UA_TYPES_BYTESTRING])) {
+            UA_ByteString *string = (UA_ByteString *)eventFields[i].data;
+            printf("'%.*s'\n", (int)string->length, string->data);
+            for (size_t u = 0; u < string->length; ++u)
+                printf("%x", string->data[u]);
+            printf("\n");
+        } else if (UA_Variant_hasScalarType(&eventFields[i], &UA_TYPES[UA_TYPES_LOCALIZEDTEXT])) {
+            UA_LocalizedText *lt = (UA_LocalizedText *)eventFields[i].data;
+            printf("'%.*s'\n", (int)lt->text.length, lt->text.data);
+            printf("size: %zu\n", lt->text.length);
+        }
+    }
+}
+
+static UA_Boolean running = true;
+static void stopHandler(int sig) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "received ctrl-c");
+    running = false;
+}
+#endif
+
+int main(int argc, char *argv[]) {
+    signal(SIGINT, stopHandler);
+    signal(SIGTERM, stopHandler);
+
+    UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
+
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://uademo.prosysopc.com:53530/OPCUA/SimulationServer");
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_Client_delete(client);
+        return (int)retval;
+    }
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    /* Create a subscription */
+    UA_UInt32 subId = 0;
+    retval = UA_Client_Subscriptions_new(client, UA_SubscriptionSettings_standard, &subId);
+    if(!subId) {
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return (int)retval;
+    }
+    printf("Create subscription succeeded, id %u\n", subId);
+
+    /* Add a MonitoredItem */
+    UA_NodeId monitorThis = UA_NODEID_NUMERIC(0, 2253); // Root->Objects->Server
+    UA_UInt32 monId = 0;
+
+
+    // creating a single element array for the select clause of length 1
+    const size_t nSelectClauses = 1;
+    UA_SimpleAttributeOperand *selectClauses = (UA_SimpleAttributeOperand *)UA_Array_new(nSelectClauses, &UA_TYPES[UA_TYPES_SIMPLEATTRIBUTEOPERAND]);
+    if(!selectClauses){
+        UA_Client_Subscriptions_remove(client, subId);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return (int)UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    for(size_t i =0; i<nSelectClauses; ++i) {
+        UA_SimpleAttributeOperand_init(&selectClauses[i]);
+    }
+
+    selectClauses[0].typeDefinitionId = UA_NODEID_NUMERIC(0, 2041) ; // BaseEventType
+    selectClauses[0].browsePathSize = 1;
+    //selectClauses[0].browsePathSize = 2; // crashes
+    selectClauses[0].browsePath = (UA_QualifiedName*)UA_Array_new(selectClauses[0].browsePathSize, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
+    if(!selectClauses[0].browsePath) {
+        UA_Array_delete(selectClauses, nSelectClauses, &UA_TYPES[UA_TYPES_SIMPLEATTRIBUTEOPERAND]);
+        UA_Client_Subscriptions_remove(client, subId);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return (int)UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    selectClauses[0].attributeId = UA_ATTRIBUTEID_VALUE;
+    selectClauses[0].browsePath[0] = UA_QUALIFIEDNAME(0, "Message");
+    //selectClauses[0].browsePath[1] = UA_QUALIFIEDNAME(0, "Severity");  // crashes
+
+    UA_Client_Subscriptions_addMonitoredEvent(client, subId, monitorThis, UA_ATTRIBUTEID_EVENTNOTIFIER,
+                                              selectClauses, nSelectClauses,
+                                              &handler_events, NULL, &monId);
+    if (!monId) {
+        UA_Array_delete(selectClauses, nSelectClauses, &UA_TYPES[UA_TYPES_SIMPLEATTRIBUTEOPERAND]);
+        UA_Client_Subscriptions_remove(client, subId);
+        UA_Client_disconnect(client);
+        UA_Client_delete(client);
+        return (int)retval;
+    }
+    printf("Monitoring 'Root->Objects->Server', id %u\n", subId);
+
+    while (running)
+        UA_Client_Subscriptions_manuallySendPublishRequest(client);
+
+    /* Delete the subscription */
+    if(!UA_Client_Subscriptions_remove(client, subId))
+        printf("Subscription removed\n");
+#endif
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+    return (int) UA_STATUSCODE_GOOD;
+}

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -7,7 +7,7 @@
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static void
-handler_events(UA_UInt32 monId, size_t nEventFields, UA_Variant *eventFields, void *context) {
+handler_events(UA_UInt32 monId, size_t nEventFields, const UA_Variant *eventFields, const void *context) {
     printf("got an event! %d, %zu\n", monId, nEventFields);
 
     for(size_t i = 0; i < nEventFields; ++i) {

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -1,24 +1,26 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
-#include <stdio.h>
-#include <signal.h>
 #include "open62541.h"
+
+#include <signal.h>
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static void
 handler_events(const UA_UInt32 monId, const size_t nEventFields, const UA_Variant *eventFields, void *context) {
-    printf("Notification:\n");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Notification");
     for(size_t i = 0; i < nEventFields; ++i) {
         if (UA_Variant_hasScalarType(&eventFields[i], &UA_TYPES[UA_TYPES_UINT16])) {
             UA_UInt16 severity = *(UA_UInt16 *)eventFields[i].data;
-            printf("Severity: %u\n", severity);
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Severity: %u", severity);
         } else if (UA_Variant_hasScalarType(&eventFields[i], &UA_TYPES[UA_TYPES_LOCALIZEDTEXT])) {
             UA_LocalizedText *lt = (UA_LocalizedText *)eventFields[i].data;
-            printf("Message: '%.*s'\n", (int)lt->text.length, lt->text.data);
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                        "Message: '%.*s'", (int)lt->text.length, lt->text.data);
         }
         else {
-            printf("Don't know how to handle type: '%s'\n", eventFields[i].type->typeName);
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                        "Don't know how to handle type: '%s'", eventFields[i].type->typeName);
         }
     }
 }
@@ -90,7 +92,7 @@ int main(int argc, char *argv[]) {
         UA_Client_delete(client);
         return (int)retval;
     }
-    printf("Create subscription succeeded, id %u\n", subId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Create subscription succeeded, id %u", subId);
 
     /* Add a MonitoredItem */
     UA_NodeId monitorThis = UA_NODEID_NUMERIC(0, 2253); // Root->Objects->Server
@@ -114,14 +116,14 @@ int main(int argc, char *argv[]) {
         UA_Client_delete(client);
         return (int)retval;
     }
-    printf("Monitoring 'Root->Objects->Server', id %u\n", subId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Monitoring 'Root->Objects->Server', id %u", subId);
 
     while (running)
         UA_Client_Subscriptions_manuallySendPublishRequest(client);
 
     /* Delete the subscription */
     if(!UA_Client_Subscriptions_remove(client, subId))
-        printf("Subscription removed\n");
+        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Subscription removed");
 #endif
 
     UA_Client_disconnect(client);

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
     signal(SIGINT, stopHandler);
     signal(SIGTERM, stopHandler);
 
-    UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
+    UA_Client *client = UA_Client_new(UA_ClientConfig_default);
 
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://uademo.prosysopc.com:53530/OPCUA/SimulationServer");
     if(retval != UA_STATUSCODE_GOOD) {
@@ -48,7 +48,7 @@ int main(int argc, char *argv[]) {
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /* Create a subscription */
     UA_UInt32 subId = 0;
-    retval = UA_Client_Subscriptions_new(client, UA_SubscriptionSettings_standard, &subId);
+    retval = UA_Client_Subscriptions_new(client, UA_SubscriptionSettings_default, &subId);
     if(!subId) {
         UA_Client_disconnect(client);
         UA_Client_delete(client);

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -7,7 +7,7 @@
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static void
-handler_events(UA_UInt32 monId, size_t nEventFields, const UA_Variant *eventFields, const void *context) {
+handler_events(const UA_UInt32 monId, const size_t nEventFields, const UA_Variant *eventFields, void *context) {
     printf("got an event! %d, %zu\n", monId, nEventFields);
 
     for(size_t i = 0; i < nEventFields; ++i) {

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -53,7 +53,7 @@ setupSelectClauses(void)
         return NULL;
     }
     selectClauses[0].attributeId = UA_ATTRIBUTEID_VALUE;
-    selectClauses[0].browsePath[0] = UA_QUALIFIEDNAME(0, "Message");
+    selectClauses[0].browsePath[0] = UA_QUALIFIEDNAME_ALLOC(0, "Message");
 
     selectClauses[1].typeDefinitionId = UA_NODEID_NUMERIC(0, 2041) ; // BaseEventType
     selectClauses[1].browsePathSize = 1;
@@ -64,7 +64,7 @@ setupSelectClauses(void)
         return NULL;
     }
     selectClauses[1].attributeId = UA_ATTRIBUTEID_VALUE;
-    selectClauses[1].browsePath[0] = UA_QUALIFIEDNAME(0, "Severity");
+    selectClauses[1].browsePath[0] = UA_QUALIFIEDNAME_ALLOC(0, "Severity");
 
     return selectClauses;
 }

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -597,6 +597,8 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 sub
                                           const UA_NodeId nodeId, const UA_UInt32 attributeID,
                                           UA_SimpleAttributeOperand *selectClause,
                                           const size_t nSelectClauses,
+                                          UA_ContentFilterElement *whereClause,
+                                          const size_t nWhereClauses,
                                           const UA_MonitoredEventHandlingFunction hf,
                                           void *hfContext, UA_UInt32 *newMonitoredItemId);
 

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -587,6 +587,22 @@ UA_Client_Subscriptions_remove(UA_Client *client, UA_UInt32 subscriptionId);
 UA_StatusCode UA_EXPORT
 UA_Client_Subscriptions_manuallySendPublishRequest(UA_Client *client);
 
+typedef void (*UA_MonitoredEventHandlingFunction)(UA_UInt32 monId,
+                                                  size_t nEventFields,
+                                                  UA_Variant *eventFields,
+                                                  void *context);
+
+UA_StatusCode
+UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, UA_UInt32 subscriptionId,
+                                          UA_NodeId nodeId, UA_UInt32 attributeID,
+                                          UA_SimpleAttributeOperand *selectClause,
+                                          size_t nSelectClauses,
+                                          UA_MonitoredEventHandlingFunction hf,
+                                          void *hfContext, UA_UInt32 *newMonitoredItemId);
+
+// FIXME: do not forget about removeMonitoredEvent!
+
+
 typedef void (*UA_MonitoredItemHandlingFunction)(UA_UInt32 monId,
                                                  UA_DataValue *value,
                                                  void *context);

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -589,8 +589,8 @@ UA_Client_Subscriptions_manuallySendPublishRequest(UA_Client *client);
 
 typedef void (*UA_MonitoredEventHandlingFunction)(UA_UInt32 monId,
                                                   size_t nEventFields,
-                                                  UA_Variant *eventFields,
-                                                  void *context);
+                                                  const UA_Variant *eventFields,
+                                                  const void *context);
 
 UA_StatusCode
 UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, UA_UInt32 subscriptionId,

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -587,16 +587,16 @@ UA_Client_Subscriptions_remove(UA_Client *client, UA_UInt32 subscriptionId);
 UA_StatusCode UA_EXPORT
 UA_Client_Subscriptions_manuallySendPublishRequest(UA_Client *client);
 
-typedef void (*UA_MonitoredEventHandlingFunction)(UA_UInt32 monId,
-                                                  size_t nEventFields,
+typedef void (*UA_MonitoredEventHandlingFunction)(const UA_UInt32 monId,
+                                                  const size_t nEventFields,
                                                   const UA_Variant *eventFields,
-                                                  const void *context);
+                                                  void *context);
 
 UA_StatusCode
-UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, UA_UInt32 subscriptionId,
-                                          UA_NodeId nodeId, UA_UInt32 attributeID,
+UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 subscriptionId,
+                                          const UA_NodeId nodeId, const UA_UInt32 attributeID,
                                           UA_SimpleAttributeOperand *selectClause,
-                                          size_t nSelectClauses,
+                                          const size_t nSelectClauses,
                                           const UA_MonitoredEventHandlingFunction hf,
                                           void *hfContext, UA_UInt32 *newMonitoredItemId);
 

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -592,7 +592,7 @@ typedef void (*UA_MonitoredEventHandlingFunction)(const UA_UInt32 monId,
                                                   const UA_Variant *eventFields,
                                                   void *context);
 
-UA_StatusCode
+UA_StatusCode UA_EXPORT
 UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 subscriptionId,
                                           const UA_NodeId nodeId, const UA_UInt32 attributeID,
                                           UA_SimpleAttributeOperand *selectClause,

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -597,11 +597,8 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, UA_UInt32 subscript
                                           UA_NodeId nodeId, UA_UInt32 attributeID,
                                           UA_SimpleAttributeOperand *selectClause,
                                           size_t nSelectClauses,
-                                          UA_MonitoredEventHandlingFunction hf,
+                                          const UA_MonitoredEventHandlingFunction hf,
                                           void *hfContext, UA_UInt32 *newMonitoredItemId);
-
-// FIXME: do not forget about removeMonitoredEvent!
-
 
 typedef void (*UA_MonitoredItemHandlingFunction)(UA_UInt32 monId,
                                                  UA_DataValue *value,

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -143,7 +143,6 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 sub
     UA_EventFilter_init(evFilter);
     evFilter->selectClausesSize = nSelectClauses;
     evFilter->selectClauses = selectClause;
-    evFilter->selectClausesSize = nSelectClauses;
     evFilter->whereClause.elementsSize = 0; // FIXME: TBD
 
     item.requestedParameters.filter.encoding = UA_EXTENSIONOBJECT_DECODED_NODELETE;

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -112,10 +112,10 @@ UA_Client_Subscriptions_forceDelete(UA_Client *client,
 }
 
 UA_StatusCode
-UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, UA_UInt32 subscriptionId,
-                                         UA_NodeId nodeId, UA_UInt32 attributeID,
+UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 subscriptionId,
+                                         const UA_NodeId nodeId, const UA_UInt32 attributeID,
                                          UA_SimpleAttributeOperand *selectClause,
-                                         size_t nSelectClauses,
+                                         const size_t nSelectClauses,
                                          const UA_MonitoredEventHandlingFunction hf,
                                          void *hfContext, UA_UInt32 *newMonitoredItemId) {
     UA_Client_Subscription *sub = findSubscription(client, subscriptionId);

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -164,11 +164,17 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 sub
         retval = response.results[0].statusCode;
     if(retval != UA_STATUSCODE_GOOD) {
         UA_CreateMonitoredItemsResponse_deleteMembers(&response);
+        UA_EventFilter_delete(evFilter);
         return retval;
     }
 
     /* Create the handler */
     UA_Client_MonitoredItem *newMon = (UA_Client_MonitoredItem *)UA_malloc(sizeof(UA_Client_MonitoredItem));
+    if(!newMon) {
+        UA_CreateMonitoredItemsResponse_deleteMembers(&response);
+        UA_EventFilter_delete(evFilter);
+    }
+
     newMon->monitoringMode = UA_MONITORINGMODE_REPORTING;
     UA_NodeId_copy(&nodeId, &newMon->monitoredNodeId);
     newMon->attributeID = attributeID;

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -116,7 +116,7 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, UA_UInt32 subscript
                                          UA_NodeId nodeId, UA_UInt32 attributeID,
                                          UA_SimpleAttributeOperand *selectClause,
                                          size_t nSelectClauses,
-                                         UA_MonitoredEventHandlingFunction hf,
+                                         const UA_MonitoredEventHandlingFunction hf,
                                          void *hfContext, UA_UInt32 *newMonitoredItemId) {
     UA_Client_Subscription *sub = findSubscription(client, subscriptionId);
     if(!sub)

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -192,6 +192,7 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 sub
     UA_LOG_DEBUG(client->config.logger, UA_LOGCATEGORY_CLIENT,
                  "Created a monitored item with client handle %u", client->monitoredItemHandles);
 
+    UA_EventFilter_delete(evFilter);
     UA_CreateMonitoredItemsResponse_deleteMembers(&response);
     return UA_STATUSCODE_GOOD;
 }

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -173,6 +173,7 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 sub
     if(!newMon) {
         UA_CreateMonitoredItemsResponse_deleteMembers(&response);
         UA_EventFilter_delete(evFilter);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 
     newMon->monitoringMode = UA_MONITORINGMODE_REPORTING;

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -116,6 +116,8 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 sub
                                          const UA_NodeId nodeId, const UA_UInt32 attributeID,
                                          UA_SimpleAttributeOperand *selectClause,
                                          const size_t nSelectClauses,
+                                         UA_ContentFilterElement *whereClause,
+                                         const size_t nWhereClauses,
                                          const UA_MonitoredEventHandlingFunction hf,
                                          void *hfContext, UA_UInt32 *newMonitoredItemId) {
     UA_Client_Subscription *sub = findSubscription(client, subscriptionId);
@@ -143,7 +145,8 @@ UA_Client_Subscriptions_addMonitoredEvent(UA_Client *client, const UA_UInt32 sub
     UA_EventFilter_init(evFilter);
     evFilter->selectClausesSize = nSelectClauses;
     evFilter->selectClauses = selectClause;
-    evFilter->whereClause.elementsSize = 0; // FIXME: TBD
+    evFilter->whereClause.elementsSize = nWhereClauses;
+    evFilter->whereClause.elements = whereClause;
 
     item.requestedParameters.filter.encoding = UA_EXTENSIONOBJECT_DECODED_NODELETE;
     item.requestedParameters.filter.content.decoded.type = &UA_TYPES[UA_TYPES_EVENTFILTER];

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -5,7 +5,7 @@
 #include "ua_client_highlevel.h"
 #include "ua_client_internal.h"
 #include "ua_util.h"
-#include "stdio.h"
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS /* conditional compilation */
 
 UA_StatusCode
@@ -306,11 +306,6 @@ UA_Client_processPublishResponse(UA_Client *client, UA_PublishRequest *request,
     if(!sub)
         return;
 
-    if ((unsigned int)response->notificationMessage.notificationDataSize > 0)
-    printf(
-                 "Processing a publish response on subscription %u with %u notifications\n",
-                 sub->subscriptionID, (unsigned int)response->notificationMessage.notificationDataSize);
-
     /* Check if the server has acknowledged any of the sent ACKs */
     for(size_t i = 0; i < response->resultsSize && i < request->subscriptionAcknowledgementsSize; ++i) {
         /* remove also acks that are unknown to the server */
@@ -357,13 +352,11 @@ UA_Client_processPublishResponse(UA_Client *client, UA_PublishRequest *request,
         }
         else if(msg->notificationData[k].content.decoded.type == &UA_TYPES[UA_TYPES_EVENTNOTIFICATIONLIST]) {
             UA_EventNotificationList *eventNotificationList = (UA_EventNotificationList *)msg->notificationData[k].content.decoded.data;
-            printf("got an UA_TYPES_EVENTNOTIFICATIONLIST %zu\n", eventNotificationList->eventsSize);
             for (size_t j = 0; j < eventNotificationList->eventsSize; ++j) {
                 UA_EventFieldList *eventFieldList = &eventNotificationList->events[j];
                 UA_Client_MonitoredItem *mon;
                 LIST_FOREACH(mon, &sub->monitoredItems, listEntry) {
                     if(mon->clientHandle == eventFieldList->clientHandle) {
-                        printf("%p\n", (void*)eventFieldList->eventFields);
                         mon->handlerEvents(mon->monitoredItemId, eventFieldList->eventFieldsSize,
                                            eventFieldList->eventFields, mon->handlerContext);
                         break;

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -31,7 +31,7 @@ typedef struct UA_Client_MonitoredItem {
     UA_Boolean discardOldest;
     void (*handler)(UA_UInt32 monId, UA_DataValue *value, void *context);
     void *handlerContext;
-    void (*handlerEvents)(UA_UInt32 monId, size_t nEventFields, UA_Variant *eventFields, void *context);
+    void (*handlerEvents)(UA_UInt32 monId, size_t nEventFields, const UA_Variant *eventFields, const void *context);
     void *handlerEventsContext;
 } UA_Client_MonitoredItem;
 

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -31,7 +31,7 @@ typedef struct UA_Client_MonitoredItem {
     UA_Boolean discardOldest;
     void (*handler)(UA_UInt32 monId, UA_DataValue *value, void *context);
     void *handlerContext;
-    void (*handlerEvents)(UA_UInt32 monId, size_t nEventFields, const UA_Variant *eventFields, const void *context);
+    void (*handlerEvents)(const UA_UInt32 monId, const size_t nEventFields, const UA_Variant *eventFields, void *context);
     void *handlerEventsContext;
 } UA_Client_MonitoredItem;
 

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -31,6 +31,8 @@ typedef struct UA_Client_MonitoredItem {
     UA_Boolean discardOldest;
     void (*handler)(UA_UInt32 monId, UA_DataValue *value, void *context);
     void *handlerContext;
+    void (*handlerEvents)(UA_UInt32 monId, size_t nEventFields, UA_Variant *eventFields, void *context);
+    void *handlerEventsContext;
 } UA_Client_MonitoredItem;
 
 typedef struct UA_Client_Subscription {

--- a/tests/check_types_memory.c
+++ b/tests/check_types_memory.c
@@ -105,7 +105,8 @@ START_TEST(encodeShallYieldDecode) {
 END_TEST
 
 START_TEST(decodeShallFailWithTruncatedBufferButSurvive) {
-    if (_i == UA_TYPES_DISCOVERYCONFIGURATION)
+    //Skip test for void*
+    if (_i == UA_TYPES_DISCOVERYCONFIGURATION || _i == UA_TYPES_FILTEROPERAND || _i == UA_TYPES_MONITORINGFILTER)
         return;
     // given
     UA_ByteString msg1;
@@ -126,7 +127,7 @@ START_TEST(decodeShallFailWithTruncatedBufferButSurvive) {
     // when
     void *obj2 = UA_new(&UA_TYPES[_i]);
     size_t offset = 0;
-    retval = UA_decodeBinary(&msg1, &offset, obj2, &UA_TYPES[_i], 0, NULL); 
+    retval = UA_decodeBinary(&msg1, &offset, obj2, &UA_TYPES[_i], 0, NULL);
     ck_assert_int_ne(retval, UA_STATUSCODE_GOOD);
     UA_delete(obj2, &UA_TYPES[_i]);
     UA_ByteString_deleteMembers(&msg1);
@@ -207,6 +208,8 @@ START_TEST(calcSizeBinaryShallBeCorrect) {
     if(_i == UA_TYPES_VARIANT ||
        _i == UA_TYPES_VARIABLEATTRIBUTES ||
        _i == UA_TYPES_VARIABLETYPEATTRIBUTES ||
+       _i == UA_TYPES_FILTEROPERAND ||
+       _i == UA_TYPES_MONITORINGFILTER ||
        _i == UA_TYPES_DISCOVERYCONFIGURATION)
         return;
     void *obj = UA_new(&UA_TYPES[_i]);

--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -171,3 +171,10 @@ FindServersOnNetworkResponse
 DataChangeTrigger
 DeadbandType
 DataChangeFilter
+MonitoringFilter
+EventFilter
+FilterOperand
+SimpleAttributeOperand
+EventNotificationList
+EventFieldList
+StatusChangeNotification


### PR DESCRIPTION
This patchset add support for Events on the client side. This means on open62541-based client will be able to receive events from an non-open62541 OPC-UA server.

So far testing has been done exclusively against a public OPC-UA server provided by prosys.

The patchset provides an example on how to use the API.

Where-clauses should work, but haven't been tested.