### PR TITLE
Generate pkgconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,6 +464,17 @@ install(TARGETS open62541
 # export amalgamated header open62541.h which is generated due to build of open62541-object
 install(FILES ${PROJECT_BINARY_DIR}/open62541.h DESTINATION include)
 
+if(UNIX)
+    set(prefix ${CMAKE_INSTALL_PREFIX})
+    set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+    set(libdir ${CMAKE_INSTALL_PREFIX}/lib)
+    set(includedir ${CMAKE_INSTALL_PREFIX}/include)
+    set(pkg_version 0.2.0)
+    #generate output file
+    configure_file("open62541.pc.in" "open62541.pc" @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/open62541.pc DESTINATION "lib/pkgconfig")
+endif()
+
 ##########################
 # Packaging (DEB/RPM)    #
 ##########################

--- a/open62541.pc.in
+++ b/open62541.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: open62541
+Description: Open62541 OPC UA
+Version: @pkg_version@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lopen62541


### PR DESCRIPTION
pkgconfig is used to simplify finding and to configure usage of open62541
inside of external projects.