### PR TITLE
Add runtime to install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,7 @@ install(TARGETS open62541
         EXPORT open62541Targets
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
         INCLUDES DESTINATION include/open62541 ${open62541_deps_dir})
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Otherwise, using a shared build, the dll will be left out during install
step on Windows.