### PR TITLE
Fix: Set accesslevel to read for arguments of methods

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -1234,6 +1234,7 @@ UA_Server_addMethodNode_finish(UA_Server *server, const UA_NodeId nodeId,
         /* UAExpert creates a monitoreditem on inputarguments ... */
         inputargs.minimumSamplingInterval = 100000.0f;
         inputargs.valueRank = 1;
+        inputargs.accessLevel = UA_ACCESSLEVELMASK_READ;
         inputargs.dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATATYPE);
         /* dirty-cast, but is treated as const ... */
         UA_Variant_setArray(&inputargs.value, (void*)(uintptr_t)inputArguments,
@@ -1251,6 +1252,7 @@ UA_Server_addMethodNode_finish(UA_Server *server, const UA_NodeId nodeId,
         /* UAExpert creates a monitoreditem on outputarguments ... */
         outputargs.minimumSamplingInterval = 100000.0f;
         outputargs.valueRank = 1;
+        outputargs.accessLevel = UA_ACCESSLEVELMASK_READ;
         outputargs.dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATATYPE);
         /* dirty-cast, but is treated as const ... */
         UA_Variant_setArray(&outputargs.value, (void*)(uintptr_t)outputArguments,


### PR DESCRIPTION
Hi,
Methods could not be called by UAExpert (caused from 733dcad11630fba5f4861f9e9668ab4c5b4d91d8 to 9c4faf8551ace93d54776cc69b03000e7f424356), because arguments are not readable.

ccvca