### PR TITLE
Corrected format of LocaleId in LocalizedText attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
     /* Add a variable node */
     /* 1) Define the node attributes */
     UA_VariableAttributes attr = UA_VariableAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", "the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "the answer");
     UA_Int32 myInteger = 42;
     UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
 

--- a/doc/namespace_compiler.rst
+++ b/doc/namespace_compiler.rst
@@ -41,7 +41,7 @@ We take the following information model snippet as the starting point of the fol
                     i=33
                 </Reference>
             </References>
-            <InverseName Locale="en_US">inputProcidedBy</InverseName>
+            <InverseName Locale="en-US">inputProcidedBy</InverseName>
         </UAReferenceType>
         <UAObjectType IsAbstract="true" NodeId="ns=1;i=1001"
                       BrowseName="1:FieldDevice">
@@ -321,8 +321,8 @@ Let's look at an example that will create a pump instance given the newly define
       UA_ObjectAttributes object_attr;
       UA_ObjectAttributes_init(&object_attr);
       
-      object_attr.description = UA_LOCALIZEDTEXT("en_US","A pump!");
-      object_attr.displayName = UA_LOCALIZEDTEXT("en_US","Pump1");
+      object_attr.description = UA_LOCALIZEDTEXT("en-US","A pump!");
+      object_attr.displayName = UA_LOCALIZEDTEXT("en-US","Pump1");
       
       UA_InstantiationCallback theAnswerCallback;
       theAnswerCallback.method = pumpInstantiationCallback;

--- a/examples/client.c
+++ b/examples/client.c
@@ -180,9 +180,9 @@ int main(int argc, char *argv[]) {
     UA_NodeId ref_id;
     UA_ReferenceTypeAttributes ref_attr;
     UA_ReferenceTypeAttributes_init(&ref_attr);
-    ref_attr.displayName = UA_LOCALIZEDTEXT("en_US", "NewReference");
-    ref_attr.description = UA_LOCALIZEDTEXT("en_US", "References something that might or might not exist");
-    ref_attr.inverseName = UA_LOCALIZEDTEXT("en_US", "IsNewlyReferencedBy");
+    ref_attr.displayName = UA_LOCALIZEDTEXT("en-US", "NewReference");
+    ref_attr.description = UA_LOCALIZEDTEXT("en-US", "References something that might or might not exist");
+    ref_attr.inverseName = UA_LOCALIZEDTEXT("en-US", "IsNewlyReferencedBy");
     retval = UA_Client_addReferenceTypeNode(client,
                                             UA_NODEID_NUMERIC(1, 12133),
                                             UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
@@ -196,8 +196,8 @@ int main(int argc, char *argv[]) {
     UA_NodeId objt_id;
     UA_ObjectTypeAttributes objt_attr;
     UA_ObjectTypeAttributes_init(&objt_attr);
-    objt_attr.displayName = UA_LOCALIZEDTEXT("en_US", "TheNewObjectType");
-    objt_attr.description = UA_LOCALIZEDTEXT("en_US", "Put innovative description here");
+    objt_attr.displayName = UA_LOCALIZEDTEXT("en-US", "TheNewObjectType");
+    objt_attr.description = UA_LOCALIZEDTEXT("en-US", "Put innovative description here");
     retval = UA_Client_addObjectTypeNode(client,
                                          UA_NODEID_NUMERIC(1, 12134),
                                          UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
@@ -211,8 +211,8 @@ int main(int argc, char *argv[]) {
     UA_NodeId obj_id;
     UA_ObjectAttributes obj_attr;
     UA_ObjectAttributes_init(&obj_attr);
-    obj_attr.displayName = UA_LOCALIZEDTEXT("en_US", "TheNewGreatNode");
-    obj_attr.description = UA_LOCALIZEDTEXT("de_DE", "Hier koennte Ihre Webung stehen!");
+    obj_attr.displayName = UA_LOCALIZEDTEXT("en-US", "TheNewGreatNode");
+    obj_attr.description = UA_LOCALIZEDTEXT("de-DE", "Hier koennte Ihre Webung stehen!");
     retval = UA_Client_addObjectNode(client,
                                      UA_NODEID_NUMERIC(1, 0),
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
@@ -227,9 +227,9 @@ int main(int argc, char *argv[]) {
     UA_NodeId var_id;
     UA_VariableAttributes var_attr;
     UA_VariableAttributes_init(&var_attr);
-    var_attr.displayName = UA_LOCALIZEDTEXT("en_US", "TheNewVariableNode");
+    var_attr.displayName = UA_LOCALIZEDTEXT("en-US", "TheNewVariableNode");
     var_attr.description =
-        UA_LOCALIZEDTEXT("en_US", "This integer is just amazing - it has digits and everything.");
+        UA_LOCALIZEDTEXT("en-US", "This integer is just amazing - it has digits and everything.");
     UA_Int32 int_value = 1234;
     /* This does not copy the value */
     UA_Variant_setScalar(&var_attr.value, &int_value, &UA_TYPES[UA_TYPES_INT32]);

--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -121,8 +121,8 @@ int main(int argc, char **argv) {
     dateDataSource.write = writeInteger;
     UA_VariableAttributes attr;
     UA_VariableAttributes_init(&attr);
-    attr.description = UA_LOCALIZEDTEXT("en_US", "the answer");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", "the answer");
+    attr.description = UA_LOCALIZEDTEXT("en-US", "the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "the answer");
 
     UA_Server_addDataSourceVariableNode(server, myIntegerNodeId,
                                         UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -83,8 +83,8 @@ int main(int argc, char **argv) {
     dateDataSource.write = writeInteger;
     UA_VariableAttributes attr;
     UA_VariableAttributes_init(&attr);
-    attr.description = UA_LOCALIZEDTEXT("en_US", "the answer");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", "the answer");
+    attr.description = UA_LOCALIZEDTEXT("en-US", "the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "the answer");
 
     UA_Server_addDataSourceVariableNode(server, myIntegerNodeId,
                                         UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),

--- a/examples/server.c
+++ b/examples/server.c
@@ -125,8 +125,8 @@ int main(int argc, char** argv) {
     /* add a static variable node to the server */
     UA_VariableAttributes myVar;
     UA_VariableAttributes_init(&myVar);
-    myVar.description = UA_LOCALIZEDTEXT("en_US", "the answer");
-    myVar.displayName = UA_LOCALIZEDTEXT("en_US", "the answer");
+    myVar.description = UA_LOCALIZEDTEXT("en-US", "the answer");
+    myVar.displayName = UA_LOCALIZEDTEXT("en-US", "the answer");
     myVar.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
     UA_Int32 myInteger = 42;
     UA_Variant_setScalarCopy(&myVar.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
@@ -144,8 +144,8 @@ int main(int argc, char** argv) {
     dateDataSource.write = NULL;
     UA_VariableAttributes v_attr;
     UA_VariableAttributes_init(&v_attr);
-    v_attr.description = UA_LOCALIZEDTEXT("en_US","current time");
-    v_attr.displayName = UA_LOCALIZEDTEXT("en_US","current time");
+    v_attr.description = UA_LOCALIZEDTEXT("en-US","current time");
+    v_attr.displayName = UA_LOCALIZEDTEXT("en-US","current time");
     v_attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
     const UA_QualifiedName dateName = UA_QUALIFIEDNAME(1, "current time");
     UA_NodeId dataSourceId;
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
     UA_Argument inputArguments;
     UA_Argument_init(&inputArguments);
     inputArguments.dataType = UA_TYPES[UA_TYPES_STRING].typeId;
-    inputArguments.description = UA_LOCALIZEDTEXT("en_US", "Say your name");
+    inputArguments.description = UA_LOCALIZEDTEXT("en-US", "Say your name");
     inputArguments.name = UA_STRING("Name");
     inputArguments.valueRank = -1; /* scalar argument */
 
@@ -168,13 +168,13 @@ int main(int argc, char** argv) {
     outputArguments.arrayDimensionsSize = 0;
     outputArguments.arrayDimensions = NULL;
     outputArguments.dataType = UA_TYPES[UA_TYPES_STRING].typeId;
-    outputArguments.description = UA_LOCALIZEDTEXT("en_US", "Receive a greeting");
+    outputArguments.description = UA_LOCALIZEDTEXT("en-US", "Receive a greeting");
     outputArguments.name = UA_STRING("greeting");
     outputArguments.valueRank = -1;
 
     UA_MethodAttributes addmethodattributes;
     UA_MethodAttributes_init(&addmethodattributes);
-    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en_US", "Hello World");
+    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en-US", "Hello World");
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
     UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1, 62541),
@@ -194,29 +194,29 @@ int main(int argc, char** argv) {
 
     UA_ObjectAttributes object_attr;
     UA_ObjectAttributes_init(&object_attr);
-    object_attr.description = UA_LOCALIZEDTEXT("en_US", "Demo");
-    object_attr.displayName = UA_LOCALIZEDTEXT("en_US", "Demo");
+    object_attr.description = UA_LOCALIZEDTEXT("en-US", "Demo");
+    object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Demo");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, DEMOID),
         UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
         UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Demo"),
         UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
-    object_attr.description = UA_LOCALIZEDTEXT("en_US", "Scalar");
-    object_attr.displayName = UA_LOCALIZEDTEXT("en_US", "Scalar");
+    object_attr.description = UA_LOCALIZEDTEXT("en-US", "Scalar");
+    object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Scalar");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, SCALARID),
         UA_NODEID_NUMERIC(1, DEMOID), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
         UA_QUALIFIEDNAME(1, "Scalar"),
         UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
-    object_attr.description = UA_LOCALIZEDTEXT("en_US", "Array");
-    object_attr.displayName = UA_LOCALIZEDTEXT("en_US", "Array");
+    object_attr.description = UA_LOCALIZEDTEXT("en-US", "Array");
+    object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Array");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, ARRAYID),
         UA_NODEID_NUMERIC(1, DEMOID), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
         UA_QUALIFIEDNAME(1, "Array"),
         UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
-    object_attr.description = UA_LOCALIZEDTEXT("en_US", "Matrix");
-    object_attr.displayName = UA_LOCALIZEDTEXT("en_US", "Matrix");
+    object_attr.description = UA_LOCALIZEDTEXT("en-US", "Matrix");
+    object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Matrix");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, MATRIXID), UA_NODEID_NUMERIC(1, DEMOID),
         UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Matrix"),
         UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
@@ -238,10 +238,10 @@ int main(int argc, char** argv) {
 #else
         sprintf(name, "%02d", type);
 #endif
-        attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+        attr.displayName = UA_LOCALIZEDTEXT("en-US", name);
         UA_QualifiedName qualifiedName = UA_QUALIFIEDNAME(1, name);
 #else
-        attr.displayName = UA_LOCALIZEDTEXT_ALLOC("en_US", UA_TYPES[type].typeName);
+        attr.displayName = UA_LOCALIZEDTEXT_ALLOC("en-US", UA_TYPES[type].typeName);
         UA_QualifiedName qualifiedName = UA_QUALIFIEDNAME_ALLOC(1, UA_TYPES[type].typeName);
 #endif
         attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
@@ -285,8 +285,8 @@ int main(int argc, char** argv) {
     /* Hierarchy of depth 10 for CTT testing with forward and inverse references */
     /* Enter node "depth 9" in CTT configuration - Project->Settings->Server
        Test->NodeIds->Paths->Starting Node 1 */
-    object_attr.description = UA_LOCALIZEDTEXT("en_US","DepthDemo");
-    object_attr.displayName = UA_LOCALIZEDTEXT("en_US","DepthDemo");
+    object_attr.description = UA_LOCALIZEDTEXT("en-US","DepthDemo");
+    object_attr.displayName = UA_LOCALIZEDTEXT("en-US","DepthDemo");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, DEPTHID),
                             UA_NODEID_NUMERIC(1, DEMOID),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "DepthDemo"),
@@ -300,8 +300,8 @@ int main(int argc, char** argv) {
 #else
         sprintf(name, "depth%i", i);
 #endif
-        object_attr.description = UA_LOCALIZEDTEXT("en_US",name);
-        object_attr.displayName = UA_LOCALIZEDTEXT("en_US",name);
+        object_attr.description = UA_LOCALIZEDTEXT("en-US",name);
+        object_attr.displayName = UA_LOCALIZEDTEXT("en-US",name);
         UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, id+i),
                                 UA_NODEID_NUMERIC(1, i==1 ? DEPTHID : id+i-1), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                                 UA_QUALIFIEDNAME(1, name),
@@ -316,7 +316,7 @@ int main(int argc, char** argv) {
                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), answer_nodeid, true);
 
     /* Example for manually setting an attribute within the server */
-    UA_LocalizedText objectsName = UA_LOCALIZEDTEXT("en_US", "Objects");
+    UA_LocalizedText objectsName = UA_LOCALIZEDTEXT("en-US", "Objects");
     UA_Server_writeDisplayName(server, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), objectsName);
 
 #define NOARGID     60000
@@ -327,7 +327,7 @@ int main(int argc, char** argv) {
     /* adding some more method nodes to pass CTT */
     /* Method without arguments */
     UA_MethodAttributes_init(&addmethodattributes);
-    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en_US", "noarg");
+    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en-US", "noarg");
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
     UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1, NOARGID),
@@ -339,13 +339,13 @@ int main(int argc, char** argv) {
 
     /* Method with in arguments */
     UA_MethodAttributes_init(&addmethodattributes);
-    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en_US", "inarg");
+    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en-US", "inarg");
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
 
     UA_Argument_init(&inputArguments);
     inputArguments.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
-    inputArguments.description = UA_LOCALIZEDTEXT("en_US", "Input");
+    inputArguments.description = UA_LOCALIZEDTEXT("en-US", "Input");
     inputArguments.name = UA_STRING("Input");
     inputArguments.valueRank = -1; //uaexpert will crash if set to 0 ;)
 
@@ -358,13 +358,13 @@ int main(int argc, char** argv) {
 
     /* Method with out arguments */
     UA_MethodAttributes_init(&addmethodattributes);
-    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en_US", "outarg");
+    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en-US", "outarg");
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
 
     UA_Argument_init(&outputArguments);
     outputArguments.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
-    outputArguments.description = UA_LOCALIZEDTEXT("en_US", "Output");
+    outputArguments.description = UA_LOCALIZEDTEXT("en-US", "Output");
     outputArguments.name = UA_STRING("Output");
     outputArguments.valueRank = -1;
 
@@ -377,7 +377,7 @@ int main(int argc, char** argv) {
 
     /* Method with inout arguments */
     UA_MethodAttributes_init(&addmethodattributes);
-    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en_US", "inoutarg");
+    addmethodattributes.displayName = UA_LOCALIZEDTEXT("en-US", "inoutarg");
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
 

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -32,8 +32,8 @@ int main() {
     UA_VariableAttributes_init(&attr);
     UA_Int32 myInteger = 42;
     UA_Variant_setScalarCopy(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    attr.description = UA_LOCALIZEDTEXT_ALLOC("en_US","the answer");
-    attr.displayName = UA_LOCALIZEDTEXT_ALLOC("en_US","the answer");
+    attr.description = UA_LOCALIZEDTEXT_ALLOC("en-US","the answer");
+    attr.displayName = UA_LOCALIZEDTEXT_ALLOC("en-US","the answer");
     UA_NodeId myIntegerNodeId = UA_NODEID_STRING_ALLOC(1, "the.answer");
     UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME_ALLOC(1, "the answer");
     UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);

--- a/examples/server_inheritance.c
+++ b/examples/server_inheritance.c
@@ -36,8 +36,8 @@ int main(void) {
     UA_ObjectTypeAttributes otAttr;
     UA_ObjectTypeAttributes_init(&otAttr);
 
-    otAttr.description = UA_LOCALIZEDTEXT("en_US", "A mamal");
-    otAttr.displayName = UA_LOCALIZEDTEXT("en_US", "MamalType");
+    otAttr.description = UA_LOCALIZEDTEXT("en-US", "A mamal");
+    otAttr.displayName = UA_LOCALIZEDTEXT("en-US", "MamalType");
     UA_Server_addObjectTypeNode(server, UA_NODEID_NUMERIC(1, 10000),
                                 UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
                                 UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
@@ -45,8 +45,8 @@ int main(void) {
 
     UA_VariableAttributes   vAttr;
     UA_VariableAttributes_init(&vAttr);
-    vAttr.description =  UA_LOCALIZEDTEXT("en_US", "This mamals class");
-    vAttr.displayName =  UA_LOCALIZEDTEXT("en_US", "Class");
+    vAttr.description =  UA_LOCALIZEDTEXT("en-US", "This mamals class");
+    vAttr.displayName =  UA_LOCALIZEDTEXT("en-US", "Class");
     UA_String classVar = UA_STRING("mamalia");
     UA_Variant_setScalar(&vAttr.value, &classVar, &UA_TYPES[UA_TYPES_STRING]);
     UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 10001),
@@ -56,8 +56,8 @@ int main(void) {
                               vAttr, NULL, NULL);
 
     UA_VariableAttributes_init(&vAttr);
-    vAttr.description =  UA_LOCALIZEDTEXT("en_US", "This mamals species");
-    vAttr.displayName =  UA_LOCALIZEDTEXT("en_US", "Species");
+    vAttr.description =  UA_LOCALIZEDTEXT("en-US", "This mamals species");
+    vAttr.displayName =  UA_LOCALIZEDTEXT("en-US", "Species");
     UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 10002),
                               UA_NODEID_NUMERIC(1, 10000),
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY),
@@ -67,16 +67,16 @@ int main(void) {
 
 
     UA_ObjectTypeAttributes_init(&otAttr);
-    otAttr.description = UA_LOCALIZEDTEXT("en_US", "A dog, subtype of mamal");
-    otAttr.displayName = UA_LOCALIZEDTEXT("en_US", "DogType");
+    otAttr.description = UA_LOCALIZEDTEXT("en-US", "A dog, subtype of mamal");
+    otAttr.displayName = UA_LOCALIZEDTEXT("en-US", "DogType");
     UA_Server_addObjectTypeNode(server, UA_NODEID_NUMERIC(1, 20000),
                                 UA_NODEID_NUMERIC(1, 10000),
                                 UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
                                 UA_QUALIFIEDNAME(1, "DogType"), otAttr, NULL, NULL);
 
     UA_VariableAttributes_init(&vAttr);
-    vAttr.description =  UA_LOCALIZEDTEXT("en_US", "This dogs species");
-    vAttr.displayName =  UA_LOCALIZEDTEXT("en_US", "Species");
+    vAttr.description =  UA_LOCALIZEDTEXT("en-US", "This dogs species");
+    vAttr.displayName =  UA_LOCALIZEDTEXT("en-US", "Species");
     UA_String defaultSpecies = UA_STRING("Canis");
     UA_Variant_setScalar(&vAttr.value, &defaultSpecies, &UA_TYPES[UA_TYPES_STRING]);
     UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 20001),
@@ -86,8 +86,8 @@ int main(void) {
                               vAttr, NULL, NULL);
 
     UA_VariableAttributes_init(&vAttr);
-    vAttr.description =  UA_LOCALIZEDTEXT("en_US", "This dogs name");
-    vAttr.displayName =  UA_LOCALIZEDTEXT("en_US", "Name");
+    vAttr.description =  UA_LOCALIZEDTEXT("en-US", "This dogs name");
+    vAttr.displayName =  UA_LOCALIZEDTEXT("en-US", "Name");
     UA_String defaultName = UA_STRING("unnamed dog");
     UA_Variant_setScalar(&vAttr.value, &defaultName, &UA_TYPES[UA_TYPES_STRING]);
     UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 20002),
@@ -106,8 +106,8 @@ int main(void) {
 
     UA_ObjectAttributes oAttr;
     UA_ObjectAttributes_init(&oAttr);
-    oAttr.description = UA_LOCALIZEDTEXT("en_US", "A dog named Bello");
-    oAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Bello");
+    oAttr.description = UA_LOCALIZEDTEXT("en-US", "A dog named Bello");
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Bello");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, 0),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -115,8 +115,8 @@ int main(void) {
                             oAttr, NULL, NULL);
 
     UA_ObjectAttributes_init(&oAttr);
-    oAttr.description = UA_LOCALIZEDTEXT("en_US", "Another dog");
-    oAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Dog2");
+    oAttr.description = UA_LOCALIZEDTEXT("en-US", "Another dog");
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Dog2");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, 0),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -124,8 +124,8 @@ int main(void) {
                             oAttr, NULL, NULL);
 
     UA_ObjectAttributes_init(&oAttr);
-    oAttr.description = UA_LOCALIZEDTEXT("en_US", "A mamal");
-    oAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Mamal1");
+    oAttr.description = UA_LOCALIZEDTEXT("en-US", "A mamal");
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Mamal1");
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, 0),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),

--- a/examples/server_instantiation.c
+++ b/examples/server_instantiation.c
@@ -28,16 +28,16 @@ int main(void) {
      */ 
     UA_StatusCode retval;
     UA_ObjectTypeAttributes otAttr = UA_ObjectTypeAttributes_default;
-    otAttr.description = UA_LOCALIZEDTEXT("en_US", "A mamal");
-    otAttr.displayName = UA_LOCALIZEDTEXT("en_US", "MamalType");
+    otAttr.description = UA_LOCALIZEDTEXT("en-US", "A mamal");
+    otAttr.displayName = UA_LOCALIZEDTEXT("en-US", "MamalType");
     UA_Server_addObjectTypeNode(server, UA_NODEID_NUMERIC(1, 10000), 
                                 UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
                                 UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
                                 UA_QUALIFIEDNAME(1, "MamalType"), otAttr, NULL, NULL);
   
     UA_VariableAttributes vAttr = UA_VariableAttributes_default;
-    vAttr.description = UA_LOCALIZEDTEXT("en_US", "This mamals Age in months");
-    vAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Age");
+    vAttr.description =  UA_LOCALIZEDTEXT("en-US", "This mamals Age in months");
+    vAttr.displayName =  UA_LOCALIZEDTEXT("en-US", "Age");
     UA_UInt32 ageVar = 0;
     UA_Variant_setScalar(&vAttr.value, &ageVar, &UA_TYPES[UA_TYPES_UINT32]);
     UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 10001), 
@@ -45,15 +45,15 @@ int main(void) {
                               UA_QUALIFIEDNAME(1, "Age"), UA_NODEID_NULL, vAttr, NULL, NULL);
   
     otAttr = UA_ObjectTypeAttributes_default;
-    otAttr.description = UA_LOCALIZEDTEXT("en_US", "A dog, subtype of mamal");
-    otAttr.displayName = UA_LOCALIZEDTEXT("en_US", "DogType");
-    UA_Server_addObjectTypeNode(server, UA_NODEID_NUMERIC(1, 10002), 
+    otAttr.description = UA_LOCALIZEDTEXT("en-US", "A dog, subtype of mamal");
+    otAttr.displayName = UA_LOCALIZEDTEXT("en-US", "DogType");
+    UA_Server_addObjectTypeNode(server, UA_NODEID_NUMERIC(1, 10002),
                                 UA_NODEID_NUMERIC(1, 10000), UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
                                 UA_QUALIFIEDNAME(1, "DogType"), otAttr, NULL, NULL);
     
     vAttr = UA_VariableAttributes_default;
-    vAttr.description =  UA_LOCALIZEDTEXT("en_US", "This mamals Age in months");
-    vAttr.displayName =  UA_LOCALIZEDTEXT("en_US", "Name");
+    vAttr.description =  UA_LOCALIZEDTEXT("en-US", "This mamals Age in months");
+    vAttr.displayName =  UA_LOCALIZEDTEXT("en-US", "Name");
     UA_String defaultName = UA_STRING("unnamed dog");
     UA_Variant_setScalar(&vAttr.value, &defaultName, &UA_TYPES[UA_TYPES_STRING]);
     UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 10003), 
@@ -68,9 +68,9 @@ int main(void) {
      */
     
     UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
-    oAttr.description = UA_LOCALIZEDTEXT("en_US", "A dog named Bello");
-    oAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Bello");
-    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, 0), 
+    oAttr.description = UA_LOCALIZEDTEXT("en-US", "A dog named Bello");
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Bello");
+    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, 0),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                             UA_QUALIFIEDNAME(1, "Bello"), UA_NODEID_NUMERIC(1, 10002),

--- a/examples/server_udp.c
+++ b/examples/server_udp.c
@@ -30,8 +30,8 @@ int main(int argc, char** argv) {
     UA_VariableAttributes_init(&attr);
     UA_Int32 myInteger = 42;
     UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    attr.description = UA_LOCALIZEDTEXT("en_US","the answer");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","the answer");
+    attr.description = UA_LOCALIZEDTEXT("en-US","the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","the answer");
     UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
     UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "the answer");
     UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);

--- a/examples/tutorial_server_datasource.c
+++ b/examples/tutorial_server_datasource.c
@@ -42,7 +42,7 @@ addCurrentTimeVariable(UA_Server *server) {
     UA_DateTime now = 0;
     UA_VariableAttributes attr;
     UA_VariableAttributes_init(&attr);
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", "Current time");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "Current time");
     UA_Variant_setScalar(&attr.value, &now, &UA_TYPES[UA_TYPES_DATETIME]);
 
     UA_NodeId currentNodeId = UA_NODEID_STRING(1, "current-time");
@@ -134,7 +134,7 @@ static void
 addCurrentTimeDataSourceVariable(UA_Server *server) {
     UA_VariableAttributes attr;
     UA_VariableAttributes_init(&attr);
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", "Current time - data source");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "Current time - data source");
 
     UA_NodeId currentNodeId = UA_NODEID_STRING(1, "current-time-datasource");
     UA_QualifiedName currentName = UA_QUALIFIEDNAME(1, "current-time-datasource");

--- a/examples/tutorial_server_method.c
+++ b/examples/tutorial_server_method.c
@@ -57,21 +57,21 @@ static void
 addHellWorldMethod(UA_Server *server) {
     UA_Argument inputArgument;
     UA_Argument_init(&inputArgument);
-    inputArgument.description = UA_LOCALIZEDTEXT("en_US", "A String");
+    inputArgument.description = UA_LOCALIZEDTEXT("en-US", "A String");
     inputArgument.name = UA_STRING("MyInput");
     inputArgument.dataType = UA_TYPES[UA_TYPES_STRING].typeId;
     inputArgument.valueRank = -1; /* scalar */
 
     UA_Argument outputArgument;
     UA_Argument_init(&outputArgument);
-    outputArgument.description = UA_LOCALIZEDTEXT("en_US", "A String");
+    outputArgument.description = UA_LOCALIZEDTEXT("en-US", "A String");
     outputArgument.name = UA_STRING("MyOutput");
     outputArgument.dataType = UA_TYPES[UA_TYPES_STRING].typeId;
     outputArgument.valueRank = -1; /* scalar */
 
     UA_MethodAttributes helloAttr = UA_MethodAttributes_default;
-    helloAttr.description = UA_LOCALIZEDTEXT("en_US","Say `Hello World`");
-    helloAttr.displayName = UA_LOCALIZEDTEXT("en_US","Hello World");
+    helloAttr.description = UA_LOCALIZEDTEXT("en-US","Say `Hello World`");
+    helloAttr.displayName = UA_LOCALIZEDTEXT("en-US","Hello World");
     helloAttr.executable = true;
     helloAttr.userExecutable = true;
     UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1,62541),
@@ -117,7 +117,7 @@ addIncInt32ArrayMethod(UA_Server *server) {
     /* Two input arguments */
     UA_Argument inputArguments[2];
     UA_Argument_init(&inputArguments[0]);
-    inputArguments[0].description = UA_LOCALIZEDTEXT("en_US", "int32[5] array");
+    inputArguments[0].description = UA_LOCALIZEDTEXT("en-US", "int32[5] array");
     inputArguments[0].name = UA_STRING("int32 array");
     inputArguments[0].dataType = UA_TYPES[UA_TYPES_INT32].typeId;
     inputArguments[0].valueRank = 1;
@@ -126,7 +126,7 @@ addIncInt32ArrayMethod(UA_Server *server) {
     inputArguments[0].arrayDimensions = &pInputDimension;
 
     UA_Argument_init(&inputArguments[1]);
-    inputArguments[1].description = UA_LOCALIZEDTEXT("en_US", "int32 delta");
+    inputArguments[1].description = UA_LOCALIZEDTEXT("en-US", "int32 delta");
     inputArguments[1].name = UA_STRING("int32 delta");
     inputArguments[1].dataType = UA_TYPES[UA_TYPES_INT32].typeId;
     inputArguments[1].valueRank = -1; /* scalar */
@@ -134,7 +134,7 @@ addIncInt32ArrayMethod(UA_Server *server) {
     /* One output argument */
     UA_Argument outputArgument;
     UA_Argument_init(&outputArgument);
-    outputArgument.description = UA_LOCALIZEDTEXT("en_US", "int32[5] array");
+    outputArgument.description = UA_LOCALIZEDTEXT("en-US", "int32[5] array");
     outputArgument.name = UA_STRING("each entry is incremented by the delta");
     outputArgument.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
     outputArgument.valueRank = 1;
@@ -144,8 +144,8 @@ addIncInt32ArrayMethod(UA_Server *server) {
 
     /* Add the method node */
     UA_MethodAttributes incAttr = UA_MethodAttributes_default;
-    incAttr.description = UA_LOCALIZEDTEXT("en_US", "IncInt32ArrayValues");
-    incAttr.displayName = UA_LOCALIZEDTEXT("en_US", "IncInt32ArrayValues");
+    incAttr.description = UA_LOCALIZEDTEXT("en-US", "IncInt32ArrayValues");
+    incAttr.displayName = UA_LOCALIZEDTEXT("en-US", "IncInt32ArrayValues");
     incAttr.executable = true;
     incAttr.userExecutable = true;
     UA_Server_addMethodNode(server, UA_NODEID_STRING(1, "IncInt32ArrayValues"),

--- a/examples/tutorial_server_object.c
+++ b/examples/tutorial_server_object.c
@@ -62,7 +62,7 @@ static void
 manuallyDefinePump(UA_Server *server) {
     UA_NodeId pumpId; /* get the nodeid assigned by the server */
     UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
-    oAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Pump (Manual)");
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Pump (Manual)");
     UA_Server_addObjectNode(server, UA_NODEID_NULL,
                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
@@ -72,7 +72,7 @@ manuallyDefinePump(UA_Server *server) {
     UA_VariableAttributes mnAttr = UA_VariableAttributes_default;
     UA_String manufacturerName = UA_STRING("Pump King Ltd.");
     UA_Variant_setScalar(&mnAttr.value, &manufacturerName, &UA_TYPES[UA_TYPES_STRING]);
-    mnAttr.displayName = UA_LOCALIZEDTEXT("en_US", "ManufacturerName");
+    mnAttr.displayName = UA_LOCALIZEDTEXT("en-US", "ManufacturerName");
     UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpId,
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                               UA_QUALIFIEDNAME(1, "ManufacturerName"),
@@ -81,7 +81,7 @@ manuallyDefinePump(UA_Server *server) {
     UA_VariableAttributes modelAttr = UA_VariableAttributes_default;
     UA_String modelName = UA_STRING("Mega Pump 3000");
     UA_Variant_setScalar(&modelAttr.value, &modelName, &UA_TYPES[UA_TYPES_STRING]);
-    modelAttr.displayName = UA_LOCALIZEDTEXT("en_US", "ModelName");
+    modelAttr.displayName = UA_LOCALIZEDTEXT("en-US", "ModelName");
     UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpId,
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                               UA_QUALIFIEDNAME(1, "ModelName"),
@@ -90,7 +90,7 @@ manuallyDefinePump(UA_Server *server) {
     UA_VariableAttributes statusAttr = UA_VariableAttributes_default;
     UA_Boolean status = true;
     UA_Variant_setScalar(&statusAttr.value, &status, &UA_TYPES[UA_TYPES_BOOLEAN]);
-    statusAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Status");
+    statusAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Status");
     UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpId,
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                               UA_QUALIFIEDNAME(1, "Status"),
@@ -99,7 +99,7 @@ manuallyDefinePump(UA_Server *server) {
     UA_VariableAttributes rpmAttr = UA_VariableAttributes_default;
     UA_Double rpm = 50.0;
     UA_Variant_setScalar(&rpmAttr.value, &rpm, &UA_TYPES[UA_TYPES_DOUBLE]);
-    rpmAttr.displayName = UA_LOCALIZEDTEXT("en_US", "MotorRPM");
+    rpmAttr.displayName = UA_LOCALIZEDTEXT("en-US", "MotorRPM");
     UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpId,
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                               UA_QUALIFIEDNAME(1, "MotorRPMs"),
@@ -170,7 +170,7 @@ defineObjectTypes(UA_Server *server) {
     /* Define the object type for "Device" */
     UA_NodeId deviceTypeId; /* get the nodeid assigned by the server */
     UA_ObjectTypeAttributes dtAttr = UA_ObjectTypeAttributes_default;
-    dtAttr.displayName = UA_LOCALIZEDTEXT("en_US", "DeviceType");
+    dtAttr.displayName = UA_LOCALIZEDTEXT("en-US", "DeviceType");
     UA_Server_addObjectTypeNode(server, UA_NODEID_NULL,
                                 UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
                                 UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
@@ -178,7 +178,7 @@ defineObjectTypes(UA_Server *server) {
                                 NULL, &deviceTypeId);
 
     UA_VariableAttributes mnAttr = UA_VariableAttributes_default;
-    mnAttr.displayName = UA_LOCALIZEDTEXT("en_US", "ManufacturerName");
+    mnAttr.displayName = UA_LOCALIZEDTEXT("en-US", "ManufacturerName");
     UA_NodeId manufacturerNameId;
     UA_Server_addVariableNode(server, UA_NODEID_NULL, deviceTypeId,
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -191,7 +191,7 @@ defineObjectTypes(UA_Server *server) {
 
 
     UA_VariableAttributes modelAttr = UA_VariableAttributes_default;
-    modelAttr.displayName = UA_LOCALIZEDTEXT("en_US", "ModelName");
+    modelAttr.displayName = UA_LOCALIZEDTEXT("en-US", "ModelName");
     UA_Server_addVariableNode(server, UA_NODEID_NULL, deviceTypeId,
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                               UA_QUALIFIEDNAME(1, "ModelName"),
@@ -199,14 +199,14 @@ defineObjectTypes(UA_Server *server) {
 
     /* Define the object type for "Pump" */
     UA_ObjectTypeAttributes ptAttr = UA_ObjectTypeAttributes_default;
-    ptAttr.displayName = UA_LOCALIZEDTEXT("en_US", "PumpType");
+    ptAttr.displayName = UA_LOCALIZEDTEXT("en-US", "PumpType");
     UA_Server_addObjectTypeNode(server, pumpTypeId,
                                 deviceTypeId, UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
                                 UA_QUALIFIEDNAME(1, "PumpType"), ptAttr,
                                 NULL, NULL);
 
     UA_VariableAttributes statusAttr = UA_VariableAttributes_default;
-    statusAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Status");
+    statusAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Status");
     statusAttr.valueRank = -1;
     UA_NodeId statusId;
     UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpTypeId,
@@ -219,7 +219,7 @@ defineObjectTypes(UA_Server *server) {
                            UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_MODELLINGRULE_MANDATORY), true);
 
     UA_VariableAttributes rpmAttr = UA_VariableAttributes_default;
-    rpmAttr.displayName = UA_LOCALIZEDTEXT("en_US", "MotorRPM");
+    rpmAttr.displayName = UA_LOCALIZEDTEXT("en-US", "MotorRPM");
     rpmAttr.valueRank = -1;
     UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpTypeId,
                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -238,7 +238,7 @@ defineObjectTypes(UA_Server *server) {
 static void
 addPumpObjectInstance(UA_Server *server, char *name) {
     UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
-    oAttr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", name);
     UA_Server_addObjectNode(server, UA_NODEID_NULL,
                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),

--- a/examples/tutorial_server_variable.c
+++ b/examples/tutorial_server_variable.c
@@ -21,8 +21,8 @@ addVariable(UA_Server *server) {
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     UA_Int32 myInteger = 42;
     UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    attr.description = UA_LOCALIZEDTEXT("en_US","the answer");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","the answer");
+    attr.description = UA_LOCALIZEDTEXT("en-US","the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","the answer");
     attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
 
     /* Add the variable node to the information model */

--- a/examples/tutorial_server_variabletype.c
+++ b/examples/tutorial_server_variabletype.c
@@ -31,7 +31,7 @@ addVariableType2DPoint(UA_Server *server) {
     UA_UInt32 arrayDims[1] = {2};
     vtAttr.arrayDimensions = arrayDims;
     vtAttr.arrayDimensionsSize = 1;
-    vtAttr.displayName = UA_LOCALIZEDTEXT("en_US", "2DPoint Type");
+    vtAttr.displayName = UA_LOCALIZEDTEXT("en-US", "2DPoint Type");
 
     /* a matching default value is required */
     UA_Double zero[2] = {0.0, 0.0};
@@ -61,7 +61,7 @@ addVariable(UA_Server *server) {
     UA_UInt32 arrayDims[1] = {2};
     vAttr.arrayDimensions = arrayDims;
     vAttr.arrayDimensionsSize = 1;
-    vAttr.displayName = UA_LOCALIZEDTEXT("en_US", "2DPoint Variable");
+    vAttr.displayName = UA_LOCALIZEDTEXT("en-US", "2DPoint Variable");
     /* vAttr.value is left empty, the server instantiates with the default value */
 
     /* Add the node */
@@ -84,7 +84,7 @@ addVariableFail(UA_Server *server) {
     UA_VariableAttributes vAttr = UA_VariableAttributes_default;
     vAttr.dataType = UA_TYPES[UA_TYPES_DOUBLE].typeId;
     vAttr.valueRank = -1; /* a scalar. this is not allowed per the variable type */
-    vAttr.displayName = UA_LOCALIZEDTEXT("en_US", "2DPoint Variable (fail)");
+    vAttr.displayName = UA_LOCALIZEDTEXT("en-US", "2DPoint Variable (fail)");
     UA_String s = UA_STRING("2dpoint?");
     UA_Variant_setScalar(&vAttr.value, &s, &UA_TYPES[UA_TYPES_STRING]);
 

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -187,7 +187,7 @@ static void
 addDataTypeNode(UA_Server *server, char* name, UA_UInt32 datatypeid,
                 UA_Boolean isAbstract, UA_UInt32 parentid) {
     UA_DataTypeAttributes attr = UA_DataTypeAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    attr.displayName = UA_LOCALIZEDTEXT("", name);
     attr.isAbstract = isAbstract;
     UA_Server_addDataTypeNode(server, UA_NODEID_NUMERIC(0, datatypeid),
                               UA_NODEID_NUMERIC(0, parentid), UA_NODEID_NULL,
@@ -198,7 +198,7 @@ static void
 addObjectTypeNode(UA_Server *server, char* name, UA_UInt32 objecttypeid,
                   UA_Boolean isAbstract, UA_UInt32 parentid) {
     UA_ObjectTypeAttributes attr = UA_ObjectTypeAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    attr.displayName = UA_LOCALIZEDTEXT("", name);
     attr.isAbstract = isAbstract;
     UA_Server_addObjectTypeNode(server, UA_NODEID_NUMERIC(0, objecttypeid),
                                 UA_NODEID_NUMERIC(0, parentid), UA_NODEID_NULL,
@@ -209,7 +209,7 @@ static void
 addObjectNode(UA_Server *server, char* name, UA_UInt32 objectid,
               UA_UInt32 parentid, UA_UInt32 referenceid, UA_UInt32 type_id) {
     UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
-    object_attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    object_attr.displayName = UA_LOCALIZEDTEXT("", name);
     UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(0, objectid),
                             UA_NODEID_NUMERIC(0, parentid),
                             UA_NODEID_NUMERIC(0, referenceid),
@@ -223,11 +223,11 @@ static void
 addReferenceTypeNode(UA_Server *server, char* name, char *inverseName, UA_UInt32 referencetypeid,
                      UA_Boolean isabstract, UA_Boolean symmetric, UA_UInt32 parentid) {
     UA_ReferenceTypeAttributes reference_attr = UA_ReferenceTypeAttributes_default;
-    reference_attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    reference_attr.displayName = UA_LOCALIZEDTEXT("", name);
     reference_attr.isAbstract = isabstract;
     reference_attr.symmetric = symmetric;
     if(inverseName)
-        reference_attr.inverseName = UA_LOCALIZEDTEXT("en_US", inverseName);
+        reference_attr.inverseName = UA_LOCALIZEDTEXT("", inverseName);
     UA_Server_addReferenceTypeNode(server, UA_NODEID_NUMERIC(0, referencetypeid),
                                    UA_NODEID_NUMERIC(0, parentid), UA_NODEID_NULL,
                                    UA_QUALIFIEDNAME(0, name), reference_attr, NULL, NULL);
@@ -238,7 +238,7 @@ addVariableTypeNode(UA_Server *server, char* name, UA_UInt32 variabletypeid,
                     UA_Boolean isAbstract, UA_Int32 valueRank, UA_UInt32 dataType,
                     const UA_DataType *type, UA_UInt32 parentid) {
     UA_VariableTypeAttributes attr = UA_VariableTypeAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    attr.displayName = UA_LOCALIZEDTEXT("", name);
     attr.dataType = UA_NODEID_NUMERIC(0, dataType);
     attr.isAbstract = isAbstract;
     attr.valueRank = valueRank;
@@ -257,7 +257,7 @@ addVariableNode(UA_Server *server, UA_UInt32 nodeid, char* name, UA_Int32 valueR
                 const UA_NodeId *dataType, UA_Variant *value, UA_UInt32 parentid,
                 UA_UInt32 referenceid, UA_UInt32 type_id) {
     UA_VariableAttributes attr = UA_VariableAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    attr.displayName = UA_LOCALIZEDTEXT("", name);
     attr.valueRank = valueRank;
     attr.dataType = *dataType;
     if(value)
@@ -272,7 +272,7 @@ addDataSourceVariableNode(UA_Server *server, UA_UInt32 nodeid, char* name, UA_In
                           const UA_NodeId *dataType, UA_DataSource *dataSource, void *nodeContext,
                           UA_UInt32 parentid,UA_UInt32 referenceid, UA_UInt32 type_id) {
     UA_VariableAttributes attr = UA_VariableAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    attr.displayName = UA_LOCALIZEDTEXT("", name);
     attr.valueRank = valueRank;
     attr.dataType = *dataType;
     UA_Server_addDataSourceVariableNode(server, UA_NODEID_NUMERIC(0, nodeid), UA_NODEID_NUMERIC(0, parentid),
@@ -292,18 +292,18 @@ void UA_Server_createNS0(UA_Server *server) {
 
     /* Bootstrap References and HasSubtype */
     UA_ReferenceTypeAttributes references_attr = UA_ReferenceTypeAttributes_default;
-    references_attr.displayName = UA_LOCALIZEDTEXT("en_US", "References");
+    references_attr.displayName = UA_LOCALIZEDTEXT("", "References");
     references_attr.isAbstract = true;
     references_attr.symmetric = true;
-    references_attr.inverseName = UA_LOCALIZEDTEXT("en_US", "References");
+    references_attr.inverseName = UA_LOCALIZEDTEXT("", "References");
     UA_Server_addReferenceTypeNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_REFERENCES),
                                          UA_QUALIFIEDNAME(0, "References"), references_attr, NULL, NULL);
 
     UA_ReferenceTypeAttributes hassubtype_attr = UA_ReferenceTypeAttributes_default;
-    hassubtype_attr.displayName = UA_LOCALIZEDTEXT("en_US", "HasSubtype");
+    hassubtype_attr.displayName = UA_LOCALIZEDTEXT("", "HasSubtype");
     hassubtype_attr.isAbstract = false;
     hassubtype_attr.symmetric = false;
-    hassubtype_attr.inverseName = UA_LOCALIZEDTEXT("en_US", "SubtypeOf");
+    hassubtype_attr.inverseName = UA_LOCALIZEDTEXT("", "SubtypeOf");
     UA_Server_addReferenceTypeNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
                                          UA_QUALIFIEDNAME(0, "HasSubtype"), hassubtype_attr, NULL, NULL);
 
@@ -364,7 +364,7 @@ void UA_Server_createNS0(UA_Server *server) {
 
     /* Bootstrap BaseDataType */
     UA_DataTypeAttributes basedatatype_attr = UA_DataTypeAttributes_default;
-    basedatatype_attr.displayName = UA_LOCALIZEDTEXT("en_US", "BaseDataType");
+    basedatatype_attr.displayName = UA_LOCALIZEDTEXT("", "BaseDataType");
     basedatatype_attr.isAbstract = true;
     UA_Server_addDataTypeNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATATYPE),
                                     UA_QUALIFIEDNAME(0, "BaseDataType"), basedatatype_attr, NULL, NULL);
@@ -408,7 +408,7 @@ void UA_Server_createNS0(UA_Server *server) {
 
     /* Bootstrap BaseVariableType */
     UA_VariableTypeAttributes basevar_attr = UA_VariableTypeAttributes_default;
-    basevar_attr.displayName = UA_LOCALIZEDTEXT("en_US", "BaseVariableType");
+    basevar_attr.displayName = UA_LOCALIZEDTEXT("", "BaseVariableType");
     basevar_attr.isAbstract = true;
     basevar_attr.valueRank = -2;
     basevar_attr.dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATATYPE);
@@ -435,7 +435,7 @@ void UA_Server_createNS0(UA_Server *server) {
 
     /* Bootstrap BaseObjectType */
     UA_ObjectTypeAttributes baseobj_attr = UA_ObjectTypeAttributes_default;
-    baseobj_attr.displayName = UA_LOCALIZEDTEXT("en_US", "BaseObjectType");
+    baseobj_attr.displayName = UA_LOCALIZEDTEXT("", "BaseObjectType");
     UA_Server_addObjectTypeNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
                                       UA_QUALIFIEDNAME(0, "BaseObjectType"), baseobj_attr, NULL, NULL);
 
@@ -459,7 +459,7 @@ void UA_Server_createNS0(UA_Server *server) {
     /******************/
 
     UA_ObjectAttributes root_attr = UA_ObjectAttributes_default;
-    root_attr.displayName = UA_LOCALIZEDTEXT("en_US", "Root");
+    root_attr.displayName = UA_LOCALIZEDTEXT("", "Root");
     UA_Server_addObjectNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_ROOTFOLDER),
                                   UA_QUALIFIEDNAME(0, "Root"), root_attr, NULL, NULL);
     addReferenceInternal(server, UA_NS0ID_ROOTFOLDER, UA_NS0ID_HASTYPEDEFINITION,
@@ -516,7 +516,7 @@ void UA_Server_createNS0(UA_Server *server) {
 
     /* Begin Server object */ 
     UA_ObjectAttributes server_attr = UA_ObjectAttributes_default;
-    server_attr.displayName = UA_LOCALIZEDTEXT("en_US", "Server");
+    server_attr.displayName = UA_LOCALIZEDTEXT("", "Server");
     UA_Server_addObjectNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER),
                                   UA_QUALIFIEDNAME(0, "Server"), server_attr, NULL, NULL);
 
@@ -529,7 +529,7 @@ void UA_Server_createNS0(UA_Server *server) {
     
     /* NamespaceArray */
     UA_VariableAttributes nsarray_attr = UA_VariableAttributes_default;
-    nsarray_attr.displayName = UA_LOCALIZEDTEXT("en_US", "NamespaceArray");
+    nsarray_attr.displayName = UA_LOCALIZEDTEXT("", "NamespaceArray");
     nsarray_attr.valueRank = 1;
     nsarray_attr.minimumSamplingInterval = 50.0;
     nsarray_attr.dataType = UA_TYPES[UA_TYPES_STRING].typeId;
@@ -546,7 +546,7 @@ void UA_Server_createNS0(UA_Server *server) {
 
     /* Begin ServerCapabilities */
     UA_ObjectAttributes servercap_attr = UA_ObjectAttributes_default;
-    servercap_attr.displayName = UA_LOCALIZEDTEXT("en_US", "ServerCapabilities");
+    servercap_attr.displayName = UA_LOCALIZEDTEXT("", "ServerCapabilities");
     UA_Server_addObjectNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERCAPABILITIES),
                                   UA_QUALIFIEDNAME(0, "ServerCapabilities"), servercap_attr, NULL, NULL);
     
@@ -621,7 +621,7 @@ void UA_Server_createNS0(UA_Server *server) {
 
     /* Begin ServerDiagnostics */
     UA_ObjectAttributes serverdiag_attr = UA_ObjectAttributes_default;
-    serverdiag_attr.displayName = UA_LOCALIZEDTEXT("en_US", "ServerDiagnostics");
+    serverdiag_attr.displayName = UA_LOCALIZEDTEXT("", "ServerDiagnostics");
     UA_Server_addObjectNode_begin(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERDIAGNOSTICS),
                                   UA_QUALIFIEDNAME(0, "ServerDiagnostics"), serverdiag_attr, NULL, NULL);
     

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -1230,7 +1230,7 @@ UA_Server_addMethodNode_finish(UA_Server *server, const UA_NodeId nodeId,
     if(inputArgumentsSize > 0 && UA_NodeId_isNull(&inputArgsId)) {
         UA_VariableAttributes inputargs;
         UA_VariableAttributes_init(&inputargs);
-        inputargs.displayName = UA_LOCALIZEDTEXT("en_US", "InputArguments");
+        inputargs.displayName = UA_LOCALIZEDTEXT("", "InputArguments");
         /* UAExpert creates a monitoreditem on inputarguments ... */
         inputargs.minimumSamplingInterval = 100000.0f;
         inputargs.valueRank = 1;
@@ -1248,7 +1248,7 @@ UA_Server_addMethodNode_finish(UA_Server *server, const UA_NodeId nodeId,
     if(outputArgumentsSize > 0 && UA_NodeId_isNull(&outputArgsId)) {
         UA_VariableAttributes outputargs;
         UA_VariableAttributes_init(&outputargs);
-        outputargs.displayName = UA_LOCALIZEDTEXT("en_US", "OutputArguments");
+        outputargs.displayName = UA_LOCALIZEDTEXT("", "OutputArguments");
         /* UAExpert creates a monitoreditem on outputarguments ... */
         outputargs.minimumSamplingInterval = 100000.0f;
         outputargs.valueRank = 1;

--- a/tests/check_client.c
+++ b/tests/check_client.c
@@ -28,8 +28,8 @@ addVariable(size_t size) {
     UA_Variant_setArray(&attr.value, array, size, &UA_TYPES[UA_TYPES_INT32]);
 
     char name[] = "my.variable";
-    attr.description = UA_LOCALIZEDTEXT("en_US", name);
-    attr.displayName = UA_LOCALIZEDTEXT("en_US", name);
+    attr.description = UA_LOCALIZEDTEXT("en-US", name);
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", name);
     attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
 
     /* Add the variable node to the information model */

--- a/tests/check_discovery.c
+++ b/tests/check_discovery.c
@@ -377,7 +377,7 @@ START_TEST(Client_filter_locale) {
         UA_STRING("Anmeldungsserver")
     };
     const UA_String expectedLocales[] = {UA_STRING("en"), UA_STRING("de")};
-    // even if we request en_US, the server will return de_DE because it only has that name.
+    // even if we request en-US, the server will return de-DE because it only has that name.
     FindAndCheck(expectedUris, 2, expectedLocales, expectedNames, NULL, "en");
 
 }

--- a/tests/check_server_readspeed.c
+++ b/tests/check_server_readspeed.c
@@ -21,8 +21,8 @@ int main(int argc, char** argv) {
     UA_VariableAttributes_init(&attr);
     UA_Int32 myInteger = 42;
     UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    attr.description = UA_LOCALIZEDTEXT("en_US","the answer");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","the answer");
+    attr.description = UA_LOCALIZEDTEXT("en-US","the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","the answer");
     UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
     UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "the answer");
     UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);

--- a/tests/check_services_attributes.c
+++ b/tests/check_services_attributes.c
@@ -335,7 +335,7 @@ START_TEST(ReadSingleAttributeInverseNameWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     UA_LocalizedText* respval = (UA_LocalizedText*) resp.value.data;
-    const UA_LocalizedText comp = UA_LOCALIZEDTEXT("en-US", "OrganizedBy");
+    const UA_LocalizedText comp = UA_LOCALIZEDTEXT("", "OrganizedBy");
     ck_assert_int_eq(0, resp.value.arrayLength);
     ck_assert_ptr_eq(&UA_TYPES[UA_TYPES_LOCALIZEDTEXT],resp.value.type);
     ck_assert(UA_String_equal(&comp.text, &respval->text));
@@ -597,7 +597,7 @@ START_TEST(WriteSingleAttributeBrowseName) {
 START_TEST(WriteSingleAttributeDisplayName) {
     UA_WriteValue wValue;
     UA_WriteValue_init(&wValue);
-    UA_LocalizedText testValue = UA_LOCALIZEDTEXT("en_EN", "the.answer");
+    UA_LocalizedText testValue = UA_LOCALIZEDTEXT("en-EN", "the.answer");
     UA_Variant_setScalar(&wValue.value.value, &testValue, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     wValue.value.hasValue = true;
     wValue.nodeId = UA_NODEID_STRING(1, "the.answer");
@@ -609,7 +609,7 @@ START_TEST(WriteSingleAttributeDisplayName) {
 START_TEST(WriteSingleAttributeDescription) {
     UA_WriteValue wValue;
     UA_WriteValue_init(&wValue);
-    UA_LocalizedText testValue = UA_LOCALIZEDTEXT("en_EN", "the.answer");
+    UA_LocalizedText testValue = UA_LOCALIZEDTEXT("en-EN", "the.answer");
     UA_Variant_setScalar(&wValue.value.value, &testValue, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     wValue.value.hasValue = true;
     wValue.nodeId = UA_NODEID_STRING(1, "the.answer");

--- a/tests/check_services_attributes.c
+++ b/tests/check_services_attributes.c
@@ -67,8 +67,8 @@ static void setup(void) {
     UA_DataSource temperatureDataSource;
     temperatureDataSource.read = readCPUTemperature;
     temperatureDataSource.write = NULL;
-    vattr.description = UA_LOCALIZEDTEXT("en_US","temperature");
-    vattr.displayName = UA_LOCALIZEDTEXT("en_US","temperature");
+    vattr.description = UA_LOCALIZEDTEXT("en-US","temperature");
+    vattr.displayName = UA_LOCALIZEDTEXT("en-US","temperature");
     retval = UA_Server_addDataSourceVariableNode(server, UA_NODEID_STRING(1, "cpu.temperature"),
                                                  UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                                  UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
@@ -99,8 +99,8 @@ static void setup(void) {
 
     /* ObjectNode */
     UA_ObjectAttributes obj_attr = UA_ObjectAttributes_default;
-    obj_attr.description = UA_LOCALIZEDTEXT("en_US","Demo");
-    obj_attr.displayName = UA_LOCALIZEDTEXT("en_US","Demo");
+    obj_attr.description = UA_LOCALIZEDTEXT("en-US","Demo");
+    obj_attr.displayName = UA_LOCALIZEDTEXT("en-US","Demo");
     retval = UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, 50),
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
@@ -111,8 +111,8 @@ static void setup(void) {
 
     /* ViewNode */
     UA_ViewAttributes view_attr = UA_ViewAttributes_default;
-    view_attr.description = UA_LOCALIZEDTEXT("en_US", "Viewtest");
-    view_attr.displayName = UA_LOCALIZEDTEXT("en_US", "Viewtest");
+    view_attr.description = UA_LOCALIZEDTEXT("en-US", "Viewtest");
+    view_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Viewtest");
     retval = UA_Server_addViewNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_VIEWNODE),
                                    UA_NODEID_NUMERIC(0, UA_NS0ID_VIEWSFOLDER),
                                    UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
@@ -122,8 +122,8 @@ static void setup(void) {
 #ifdef UA_ENABLE_METHODCALLS
     /* MethodNode */
     UA_MethodAttributes ma = UA_MethodAttributes_default;
-    ma.description = UA_LOCALIZEDTEXT("en_US", "Methodtest");
-    ma.displayName = UA_LOCALIZEDTEXT("en_US", "Methodtest");
+    ma.description = UA_LOCALIZEDTEXT("en-US", "Methodtest");
+    ma.displayName = UA_LOCALIZEDTEXT("en-US", "Methodtest");
     retval = UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_METHODNODE),
                                      UA_NODEID_NUMERIC(0, 3),
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -335,7 +335,7 @@ START_TEST(ReadSingleAttributeInverseNameWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     UA_LocalizedText* respval = (UA_LocalizedText*) resp.value.data;
-    const UA_LocalizedText comp = UA_LOCALIZEDTEXT("en_US", "OrganizedBy");
+    const UA_LocalizedText comp = UA_LOCALIZEDTEXT("en-US", "OrganizedBy");
     ck_assert_int_eq(0, resp.value.arrayLength);
     ck_assert_ptr_eq(&UA_TYPES[UA_TYPES_LOCALIZEDTEXT],resp.value.type);
     ck_assert(UA_String_equal(&comp.text, &respval->text));
@@ -660,7 +660,7 @@ START_TEST(WriteSingleAttributeSymmetric) {
 START_TEST(WriteSingleAttributeInverseName) {
     UA_WriteValue wValue;
     UA_WriteValue_init(&wValue);
-    UA_LocalizedText testValue = UA_LOCALIZEDTEXT("en_US", "not.the.answer");
+    UA_LocalizedText testValue = UA_LOCALIZEDTEXT("en-US", "not.the.answer");
     UA_Variant_setScalar(&wValue.value.value, &testValue, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     wValue.nodeId = UA_NODEID_STRING(1, "the.answer");
     wValue.attributeId = UA_ATTRIBUTEID_INVERSENAME;

--- a/tests/check_services_nodemanagement.c
+++ b/tests/check_services_nodemanagement.c
@@ -50,8 +50,8 @@ START_TEST(AddVariableNode) {
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     UA_Int32 myInteger = 42;
     UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    attr.description = UA_LOCALIZEDTEXT("en_US","the answer");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","the answer");
+    attr.description = UA_LOCALIZEDTEXT("en-US","the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","the answer");
     UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
     UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "the answer");
     UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
@@ -67,8 +67,8 @@ START_TEST(AddVariableNode) {
 START_TEST(AddComplexTypeWithInheritance) {
     /* add a variable node to the address space */
     UA_ObjectAttributes attr = UA_ObjectAttributes_default;
-    attr.description = UA_LOCALIZEDTEXT("en_US","fakeServerStruct");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","fakeServerStruct");
+    attr.description = UA_LOCALIZEDTEXT("en-US","fakeServerStruct");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","fakeServerStruct");
   
     UA_NodeId myObjectNodeId = UA_NODEID_STRING(1, "the.fake.Server.Struct");
     UA_QualifiedName myObjectName = UA_QUALIFIEDNAME(1, "the.fake.Server.Struct");
@@ -88,8 +88,8 @@ START_TEST(AddNodeTwiceGivesError) {
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     UA_Int32 myInteger = 42;
     UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    attr.description = UA_LOCALIZEDTEXT("en_US","the answer");
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","the answer");
+    attr.description = UA_LOCALIZEDTEXT("en-US","the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","the answer");
     UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
     UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "the answer");
     UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
@@ -122,7 +122,7 @@ START_TEST(AddObjectWithConstructor) {
     /* Add an object type */
     UA_NodeId objecttypeid = UA_NODEID_NUMERIC(0, 13371337);
     UA_ObjectTypeAttributes attr = UA_ObjectTypeAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","my objecttype");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","my objecttype");
     UA_StatusCode res =
         UA_Server_addObjectTypeNode(server, objecttypeid,
                                     UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
@@ -140,7 +140,7 @@ START_TEST(AddObjectWithConstructor) {
 
     /* Add an object of the type */
     UA_ObjectAttributes attr2 = UA_ObjectAttributes_default;
-    attr2.displayName = UA_LOCALIZEDTEXT("en_US","my object");
+    attr2.displayName = UA_LOCALIZEDTEXT("en-US","my object");
     res = UA_Server_addObjectNode(server, UA_NODEID_NULL,
                                   UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                   UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -166,7 +166,7 @@ START_TEST(DeleteObjectWithDestructor) {
     /* Add an object type */
     UA_NodeId objecttypeid = UA_NODEID_NUMERIC(0, 13371337);
     UA_ObjectTypeAttributes attr = UA_ObjectTypeAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","my objecttype");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","my objecttype");
     UA_StatusCode res =
         UA_Server_addObjectTypeNode(server, objecttypeid,
                                     UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
@@ -184,7 +184,7 @@ START_TEST(DeleteObjectWithDestructor) {
     /* Add an object of the type */
     UA_NodeId objectid = UA_NODEID_NUMERIC(0, 23372337);
     UA_ObjectAttributes attr2 = UA_ObjectAttributes_default;
-    attr2.displayName = UA_LOCALIZEDTEXT("en_US","my object");
+    attr2.displayName = UA_LOCALIZEDTEXT("en-US","my object");
     res = UA_Server_addObjectNode(server, objectid,
                                   UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                   UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -202,7 +202,7 @@ START_TEST(DeleteObjectWithDestructor) {
 START_TEST(DeleteObjectAndReferences) {
     /* Add an object of the type */
     UA_ObjectAttributes attr = UA_ObjectAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","my object");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","my object");
     UA_NodeId objectid = UA_NODEID_NUMERIC(0, 23372337);
     UA_StatusCode res;
     res = UA_Server_addObjectNode(server, objectid,
@@ -246,7 +246,7 @@ START_TEST(DeleteObjectAndReferences) {
 
     /* Add an object the second time */
     attr = UA_ObjectAttributes_default;
-    attr.displayName = UA_LOCALIZEDTEXT("en_US","my object");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","my object");
     objectid = UA_NODEID_NUMERIC(0, 23372337);
     res = UA_Server_addObjectNode(server, objectid,
                                   UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
@@ -279,7 +279,7 @@ START_TEST(InstantiateObjectType) {
     /* Define the object type for "Device" */
     UA_NodeId deviceTypeId; /* get the nodeid assigned by the server */
     UA_ObjectTypeAttributes dtAttr = UA_ObjectTypeAttributes_default;
-    dtAttr.displayName = UA_LOCALIZEDTEXT("en_US", "DeviceType");
+    dtAttr.displayName = UA_LOCALIZEDTEXT("en-US", "DeviceType");
     retval = UA_Server_addObjectTypeNode(server, UA_NODEID_NULL,
                                          UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
                                          UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
@@ -288,7 +288,7 @@ START_TEST(InstantiateObjectType) {
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_VariableAttributes mnAttr = UA_VariableAttributes_default;
-    mnAttr.displayName = UA_LOCALIZEDTEXT("en_US", "ManufacturerName");
+    mnAttr.displayName = UA_LOCALIZEDTEXT("en-US", "ManufacturerName");
     UA_NodeId manufacturerNameId;
     retval = UA_Server_addVariableNode(server, UA_NODEID_NULL, deviceTypeId,
                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -303,7 +303,7 @@ START_TEST(InstantiateObjectType) {
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_VariableAttributes modelAttr = UA_VariableAttributes_default;
-    modelAttr.displayName = UA_LOCALIZEDTEXT("en_US", "ModelName");
+    modelAttr.displayName = UA_LOCALIZEDTEXT("en-US", "ModelName");
     retval = UA_Server_addVariableNode(server, UA_NODEID_NULL, deviceTypeId,
                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                                        UA_QUALIFIEDNAME(1, "ModelName"),
@@ -313,7 +313,7 @@ START_TEST(InstantiateObjectType) {
 
     /* Define the object type for "Pump" */
     UA_ObjectTypeAttributes ptAttr = UA_ObjectTypeAttributes_default;
-    ptAttr.displayName = UA_LOCALIZEDTEXT("en_US", "PumpType");
+    ptAttr.displayName = UA_LOCALIZEDTEXT("en-US", "PumpType");
     retval = UA_Server_addObjectTypeNode(server, pumpTypeId, deviceTypeId,
                                          UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
                                          UA_QUALIFIEDNAME(1, "PumpType"), ptAttr,
@@ -321,7 +321,7 @@ START_TEST(InstantiateObjectType) {
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_VariableAttributes statusAttr = UA_VariableAttributes_default;
-    statusAttr.displayName = UA_LOCALIZEDTEXT("en_US", "Status");
+    statusAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Status");
     statusAttr.valueRank = -1;
     UA_NodeId statusId;
     retval = UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpTypeId,
@@ -338,7 +338,7 @@ START_TEST(InstantiateObjectType) {
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_VariableAttributes rpmAttr = UA_VariableAttributes_default;
-    rpmAttr.displayName = UA_LOCALIZEDTEXT("en_US", "MotorRPM");
+    rpmAttr.displayName = UA_LOCALIZEDTEXT("en-US", "MotorRPM");
     rpmAttr.valueRank = -1;
     retval = UA_Server_addVariableNode(server, UA_NODEID_NULL, pumpTypeId,
                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
@@ -349,7 +349,7 @@ START_TEST(InstantiateObjectType) {
 
     /* Instantiate the variable */
     UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
-    oAttr.displayName = UA_LOCALIZEDTEXT("en_US", "MyPump");
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "MyPump");
     retval = UA_Server_addObjectNode(server, UA_NODEID_NULL,
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),

--- a/tools/pyUANamespace/open62541_MacroHelper.py
+++ b/tools/pyUANamespace/open62541_MacroHelper.py
@@ -291,9 +291,9 @@ class open62541_MacroHelper():
       else:
         code.append(node.getCodePrintableID() + "->browseName = UA_QUALIFIEDNAME_ALLOC(0, \"" + node.browseName() + "\");")
     if not "displayname" in self.supressGenerationOfAttribute:
-      code.append(node.getCodePrintableID() + "->displayName = UA_LOCALIZEDTEXT_ALLOC(\"en_US\", \"" +  node.displayName() + "\");")
+      code.append(node.getCodePrintableID() + "->displayName = UA_LOCALIZEDTEXT_ALLOC(\"\", \"" +  node.displayName() + "\");")
     if not "description" in self.supressGenerationOfAttribute:
-      code.append(node.getCodePrintableID() + "->description = UA_LOCALIZEDTEXT_ALLOC(\"en_US\", \"" +  node.description() + "\");")
+      code.append(node.getCodePrintableID() + "->description = UA_LOCALIZEDTEXT_ALLOC(\"\", \"" +  node.description() + "\");")
 
     if not "writemask" in self.supressGenerationOfAttribute:
         if node.__node_writeMask__ != 0:

--- a/tools/pyUANamespace/ua_builtin_types.py
+++ b/tools/pyUANamespace/ua_builtin_types.py
@@ -564,21 +564,21 @@ class opcua_BuiltinType_localizedtext_t(opcua_value_t):
 
     if xmlvalue.firstChild == None:
       if self.alias() != None:
-        logger.debug("Neither locale nor text in XML description field " + self.alias() + ". Setting to default ['en_US','']")
+        logger.debug("Neither locale nor text in XML description field " + self.alias() + ". Setting to default ['','']")
       else:
-        logger.debug("Neither locale nor text in XML description. Setting to default ['en_US','']")
-      self.value = ['en_US','']
+        logger.debug("Neither locale nor text in XML description. Setting to default ['','']")
+      self.value = ['','']
       return
 
     self.value = []
     tmp = xmlvalue.getElementsByTagName("Locale")
     if len(tmp) == 0:
-      logger.warn("Did not find a locale. Setting to en_US per default.")
-      self.value.append('en_US')
+      logger.warn("Did not find a locale. Setting to \"\" per default.")
+      self.value.append('')
     else:
       if tmp[0].firstChild == None:
-        logger.warn("Locale tag without contents. Setting to en_US per default.")
-        self.value.append('en_US')
+        logger.warn("Locale tag without contents. Setting to \"\" per default.")
+        self.value.append('')
       else:
         self.value.append(tmp[0].firstChild.data)
       clean = ""

--- a/tools/pyUANamespace/ua_node_types.py
+++ b/tools/pyUANamespace/ua_node_types.py
@@ -847,7 +847,7 @@ class opcua_node_referenceType_t(opcua_node_t):
     if self.symmetric():
       code.append(self.getCodePrintableID() + "->symmetric  = true;")
     if self.__reference_inverseName__ != "":
-      code.append(self.getCodePrintableID() + "->inverseName  = UA_LOCALIZEDTEXT_ALLOC(\"en_US\", \"" + self.__reference_inverseName__ + "\");")
+      code.append(self.getCodePrintableID() + "->inverseName  = UA_LOCALIZEDTEXT_ALLOC(\"\", \"" + self.__reference_inverseName__ + "\");")
     return code;
 
 


### PR DESCRIPTION
The LocaleIds was formatted with an underscore as separator between the language and region. According to the OPC UA specification the language and the region shall be separated by a hyphen.
Also removed LocaleId in those cases where a specific language is not addressed, i.e. when presenting a type name.

Changes based on discussion of issue #1173 