### PR TITLE
 type check value fix: if target data type is a sub type of a built-i…

### DIFF
--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -195,6 +195,9 @@ UA_Server_workerCallback(UA_Server *server, UA_ServerCallback callback, void *da
 /* Utility Functions */
 /*********************/
 
+/* A few global NodeId definitions */
+extern const UA_NodeId subtypeId;
+
 UA_StatusCode
 UA_NumericRange_parseFromString(UA_NumericRange *range, const UA_String *str);
 

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -69,7 +69,7 @@ typeEquivalence(const UA_DataType *t) {
     return TYPE_EQUIVALENCE_NONE;
 }
 
-static const UA_NodeId subtypeId = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASSUBTYPE}};
+const UA_NodeId subtypeId = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASSUBTYPE}};
 static const UA_NodeId enumNodeId = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_ENUMERATION}};
 
 UA_Boolean

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -95,7 +95,6 @@ checkParentReference(UA_Server *server, UA_Session *session, UA_NodeClass nodeCl
     }
 
     /* Check hassubtype relation for type nodes */
-    const UA_NodeId subtypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE);
     if(nodeClass == UA_NODECLASS_DATATYPE ||
        nodeClass == UA_NODECLASS_VARIABLETYPE ||
        nodeClass == UA_NODECLASS_OBJECTTYPE ||


### PR DESCRIPTION
…n type then the value may have the type of the "parent" built-in type, too

This PR implements fixes a typechecking edge-case as proposed by @janitza-thbe in #1167.