### PR TITLE
fixed default variable/variabletype attributes

### DIFF
--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -382,9 +382,10 @@ const UA_VariableAttributes UA_VariableAttributes_default = {
      0, NULL, 0, NULL},          /* value */
     {0, UA_NODEIDTYPE_NUMERIC,
      {UA_NS0ID_BASEDATATYPE}},   /* dataType */
-    -2,                          /* valueRank */
+    -1,                          /* valueRank */
     0, NULL,                     /* arrayDimensions */
-    UA_ACCESSLEVELMASK_READ, 0,  /* accessLevel (userAccessLevel) */
+    UA_ACCESSLEVELMASK_READ,     /* accessLevel */
+    UA_ACCESSLEVELMASK_READ,     /* userAccessLevel */
     0.0,                         /* minimumSamplingInterval */
     false                        /* historizing */
 };
@@ -414,7 +415,7 @@ const UA_VariableTypeAttributes UA_VariableTypeAttributes_default = {
      0, NULL, 0, NULL},          /* value */
     {0, UA_NODEIDTYPE_NUMERIC,
      {UA_NS0ID_BASEDATATYPE}},   /* dataType */
-    -2,                          /* valueRank */
+    -1,                          /* valueRank */
     0, NULL,                     /* arrayDimensions */
     false                        /* isAbstract */
 };


### PR DESCRIPTION
fixed default variable/variabletype attributes according to specified default values in OPC foundation's XSD (http://opcfoundation.org/UA/2011/03/UANodeSet.xsd)
No further tests or example builds done due to defaults changes.