### PR TITLE
Fix #1180 ensure enums are 32bit integers

### DIFF
--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -267,6 +267,20 @@ extern "C" {
 # define UA_BINARY_OVERLAYABLE_FLOAT 0
 #endif
 
+/**
+ * Static Assert
+ * ^^^^^^^^^^^^^
+ *
+ * Outputs an error message at compile time if the assert fails.
+ * Example usage:
+ * UA_STATIC_ASSERT(sizeof(long)==7, use_another_compiler_luke) *
+ * See: https://stackoverflow.com/a/4815532/869402 */
+#define UA_CTASTR2(pre,post) pre ## post
+#define UA_CTASTR(pre,post) UA_CTASTR2(pre,post)
+#define UA_STATIC_ASSERT(cond,msg) \
+    typedef struct { int UA_CTASTR(static_assertion_failed_,msg) : !!(cond); } \
+        UA_CTASTR(static_assertion_failed_,__COUNTER__)
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -191,7 +191,9 @@ class EnumerationType(Type):
         else:
             values = self.elements.items()
         return "typedef enum {\n    " + ",\n    ".join(map(lambda kv : "UA_" + self.name.upper() + "_" + kv[0].upper() + \
-                                                            " = " + kv[1], values)) + "\n} UA_%s;" % self.name
+                                                            " = " + kv[1], values)) + \
+               ",\n    __UA_{0}_FORCE32BIT = 0x7fffffff\n".format(self.name.upper()) + "} " + \
+               "UA_{0};\nUA_STATIC_ASSERT(sizeof(UA_{0}) == sizeof(UA_Int32), enum_must_be_32bit);".format(self.name)
 
 class OpaqueType(Type):
     def __init__(self, outname, xml, namespace, baseType):


### PR DESCRIPTION
If that's not the case, the error during compile time will be similar to
`error: named bit-field 'static_assertion_failed_enum_must_be_32bit' has zero width`