### PR TITLE
Respect accessControl in nodemanagement service, Fix #1177

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -73,6 +73,11 @@ add_example(server_inheritance server_inheritance.c)
 add_example(custom_datatype_client custom_datatype/client_types_custom.c)
 add_example(custom_datatype_server custom_datatype/server_types_custom.c)
 
+if(UA_ENABLE_NODEMANAGEMENT)
+    add_example(access_control_server access_control/server_access_control.c)
+    add_example(access_control_client access_control/client_access_control.c)
+endif()
+
 if(UA_BUILD_EXAMPLES_NODESET_COMPILER)
   if(BUILD_SHARED_LIBS)
     message(FATAL_ERROR "The nodeset compiler currently requires static linking to access internal API")

--- a/examples/access_control/client_access_control.c
+++ b/examples/access_control/client_access_control.c
@@ -1,0 +1,67 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+/**
+ * Using access_control_server
+ */
+
+#include <stdio.h>
+
+#include "open62541.h"
+
+int main(void) {
+    UA_Client *client = UA_Client_new(UA_ClientConfig_default);
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_Client_delete(client);
+        return (int)retval;
+    }
+
+    UA_NodeId newVariableIdRequest = UA_NODEID_NUMERIC(1, 1001);
+    UA_NodeId newVariableId = UA_NODEID_NULL;
+
+    UA_VariableAttributes newVariableAttributes = UA_VariableAttributes_default;
+
+    newVariableAttributes.accessLevel = UA_ACCESSLEVELMASK_READ;
+    newVariableAttributes.description = UA_LOCALIZEDTEXT_ALLOC("en-US", "NewVariable desc");
+    newVariableAttributes.displayName = UA_LOCALIZEDTEXT_ALLOC("en-US", "NewVariable");
+    newVariableAttributes.dataType = UA_TYPES[UA_TYPES_UINT32].typeId;
+    {
+        UA_UInt32 value = 50;
+        UA_Variant_setScalarCopy(&newVariableAttributes.value, &value, &UA_TYPES[UA_TYPES_UINT32]);
+    }
+
+    UA_StatusCode retCode;
+
+    retCode = UA_Client_addVariableNode(client, newVariableIdRequest,
+                            UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                            UA_QUALIFIEDNAME(1, "newVariable"),
+                            UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                            newVariableAttributes, &newVariableId);
+
+    printf("addVariable returned: %s\n", UA_StatusCode_name(retCode));
+
+    UA_ExpandedNodeId extNodeId = UA_EXPANDEDNODEID_NUMERIC(0, 0);
+    extNodeId.nodeId = newVariableId;
+
+    retCode = UA_Client_addReference(client, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), UA_TRUE,
+                            UA_STRING_NULL, extNodeId, UA_NODECLASS_VARIABLE);
+
+    printf("addReference returned: %s\n", UA_StatusCode_name(retCode));
+
+    retCode = UA_Client_deleteReference(client, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_TRUE, extNodeId,
+                            UA_TRUE);
+
+    printf("deleteReference returned: %s\n", UA_StatusCode_name(retCode));
+
+    retCode = UA_Client_deleteNode(client, newVariableId, UA_TRUE);
+    printf("deleteNode returned: %s\n", UA_StatusCode_name(retCode));
+
+    /* Clean up */
+    UA_VariableAttributes_deleteMembers(&newVariableAttributes);
+    UA_Client_delete(client); /* Disconnects the client internally */
+    return UA_STATUSCODE_GOOD;
+}

--- a/examples/access_control/server_access_control.c
+++ b/examples/access_control/server_access_control.c
@@ -1,0 +1,65 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <signal.h>
+#include <stdio.h>
+
+#include "open62541.h"
+
+static UA_Boolean
+allowAddNode(const UA_NodeId *sessionId, void *sessionContext,
+    const UA_AddNodesItem *item)
+{
+    printf("Called allowAddNode\n");
+    return UA_TRUE;
+}
+
+static UA_Boolean
+allowAddReference(const UA_NodeId *sessionId, void *sessionContext,
+    const UA_AddReferencesItem *item)
+{
+    printf("Called allowAddReference\n");
+    return UA_TRUE;
+}
+
+static UA_Boolean
+allowDeleteNode(const UA_NodeId *sessionId, void *sessionContext,
+    const UA_DeleteNodesItem *item)
+{
+    printf("Called allowDeleteNode\n");
+    return UA_FALSE; // Do not allow deletion from client
+}
+
+static UA_Boolean
+allowDeleteReference(const UA_NodeId *sessionId, void *sessionContext,
+    const UA_DeleteReferencesItem *item)
+{
+    printf("Called allowDeleteReference\n");
+    return UA_TRUE;
+}
+
+UA_Boolean running = true;
+static void stopHandler(int sign) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
+    running = false;
+}
+
+int main(void) {
+    signal(SIGINT, stopHandler);
+    signal(SIGTERM, stopHandler);
+
+    UA_ServerConfig *config = UA_ServerConfig_new_default();
+
+    // Set accessControl functions for nodeManagement
+    config->accessControl.allowAddNode = allowAddNode;
+    config->accessControl.allowAddReference = allowAddReference;
+    config->accessControl.allowDeleteNode = allowDeleteNode;
+    config->accessControl.allowDeleteReference = allowDeleteReference;
+
+    UA_Server *server = UA_Server_new(config);
+
+    UA_StatusCode retval = UA_Server_run(server, &running);
+    UA_Server_delete(server);
+    UA_ServerConfig_delete(config);
+    return (int)retval;
+}


### PR DESCRIPTION
Fix Issue #1177

The extra functions (restricted*) prevent checking access rights when adding nodes/references by the server.