### PR TITLE
Fix decoding of zero float and double values.

### DIFF
--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -413,7 +413,7 @@ Float_decodeBinary(UA_Float *dst, const UA_DataType *_) {
     else if(decoded == FLOAT_NEG_ZERO) *dst = -0.0f;
     else if(decoded == FLOAT_INF) *dst = INFINITY;
     else if(decoded == FLOAT_NEG_INF) *dst = -INFINITY;
-    if((decoded >= 0x7f800001 && decoded <= 0x7fffffff) ||
+    else if((decoded >= 0x7f800001 && decoded <= 0x7fffffff) ||
        (decoded >= 0xff800001 && decoded <= 0xffffffff)) *dst = NAN;
     else *dst = (UA_Float)unpack754(decoded, 32, 8);
     return UA_STATUSCODE_GOOD;
@@ -449,7 +449,7 @@ Double_decodeBinary(UA_Double *dst, const UA_DataType *_) {
     else if(decoded == DOUBLE_INF) *dst = INFINITY;
     else if(decoded == DOUBLE_NEG_INF) *dst = -INFINITY;
     //cppcheck-suppress redundantCondition
-    if((decoded >= 0x7ff0000000000001L && decoded <= 0x7fffffffffffffffL) ||
+    else if((decoded >= 0x7ff0000000000001L && decoded <= 0x7fffffffffffffffL) ||
        (decoded >= 0xfff0000000000001L && decoded <= 0xffffffffffffffffL)) *dst = NAN;
     else *dst = (UA_Double)unpack754(decoded, 64, 11);
     return UA_STATUSCODE_GOOD;


### PR DESCRIPTION
Due to a missing else in front of an if branch in `Float_decodeBinary`
and `Double_decodeBinary`, special cases (like zero values) where not
handled correctly. Instead, `unpack754` was always used unless the value
was NaN.

This patch fixes this problem by adding the missing `else`.