### PR TITLE
Fix: Ignore good timeout

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -274,7 +274,8 @@ receiveServiceResponse(UA_Client *client, void *response, const UA_DataType *res
         UA_UInt32 timeout = (UA_UInt32)((maxDate - now) / UA_MSEC_TO_DATETIME);
         retval = UA_Connection_receiveChunksBlocking(&client->connection, &rd,
                                                      client_processChunk, timeout);
-        if(retval != UA_STATUSCODE_GOOD) {
+
+        if(retval != UA_STATUSCODE_GOOD && retval != UA_STATUSCODE_GOODNONCRITICALTIMEOUT) {
             if(retval == UA_STATUSCODE_BADCONNECTIONCLOSED)
                 client->state = UA_CLIENTSTATE_DISCONNECTED;
             else


### PR DESCRIPTION
Hi,
I just fix two bugs:

- UA_Client_runAsync return UA_GOOD even when connection->send failed
- __UA_Client_AsyncService close the connection when a timeout occure (in UA_Connection_receiveChunksBlocking)

ccvca