### PR TITLE
Added callback function to get client config from config plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,7 @@ set(exported_headers ${PROJECT_BINARY_DIR}/src_generated/ua_config.h
                      ${PROJECT_SOURCE_DIR}/include/ua_plugin_securitypolicy.h
                      ${PROJECT_SOURCE_DIR}/include/ua_plugin_nodestore.h
                      ${PROJECT_SOURCE_DIR}/include/ua_server_config.h
+                     ${PROJECT_SOURCE_DIR}/include/ua_client_config.h
                      ${PROJECT_SOURCE_DIR}/include/ua_client.h
                      ${PROJECT_SOURCE_DIR}/include/ua_client_highlevel.h
                      ${PROJECT_SOURCE_DIR}/include/ua_client_subscriptions.h)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -22,6 +22,7 @@ generate_rst(${PROJECT_SOURCE_DIR}/include/ua_constants.h ${DOC_SRC_DIR}/constan
 generate_rst(${PROJECT_BINARY_DIR}/src_generated/ua_types_generated.h ${DOC_SRC_DIR}/types_generated.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_server.h ${DOC_SRC_DIR}/server.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_server_config.h ${DOC_SRC_DIR}/server_config.rst)
+generate_rst(${PROJECT_SOURCE_DIR}/include/ua_client_config.h ${DOC_SRC_DIR}/client_config.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_client.h ${DOC_SRC_DIR}/client.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_client_highlevel.h ${DOC_SRC_DIR}/client_highlevel.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_plugin_log.h ${DOC_SRC_DIR}/plugin_log.rst)
@@ -44,7 +45,7 @@ add_custom_target(doc_latex ${SPHINX_EXECUTABLE}
   -b latex "${DOC_SRC_DIR}" "${DOC_LATEX_DIR}"
   DEPENDS ${DOC_SRC_DIR}/types.rst ${DOC_SRC_DIR}/constants.rst ${DOC_SRC_DIR}/types_generated.rst
           ${DOC_SRC_DIR}/server.rst ${DOC_SRC_DIR}/server_config.rst
-          ${DOC_SRC_DIR}/client.rst ${DOC_SRC_DIR}/client_highlevel.rst
+          ${DOC_SRC_DIR}/client.rst ${DOC_SRC_DIR}/client_highlevel.rst ${DOC_SRC_DIR}/client_config.rst
           ${DOC_SRC_DIR}/plugin_log.rst ${DOC_SRC_DIR}/plugin_network.rst
           ${DOC_SRC_DIR}/services.rst ${DOC_SRC_DIR}/plugin_access_control.rst
           ${DOC_SRC_DIR}/nodestore.rst
@@ -72,7 +73,7 @@ add_custom_target(doc ${SPHINX_EXECUTABLE}
   -b html "${DOC_SRC_DIR}" "${DOC_HTML_DIR}"
   DEPENDS ${DOC_SRC_DIR}/types.rst ${DOC_SRC_DIR}/constants.rst ${DOC_SRC_DIR}/types_generated.rst
           ${DOC_SRC_DIR}/server.rst ${DOC_SRC_DIR}/server_config.rst
-          ${DOC_SRC_DIR}/client.rst ${DOC_SRC_DIR}/client_highlevel.rst
+          ${DOC_SRC_DIR}/client.rst ${DOC_SRC_DIR}/client_highlevel.rst ${DOC_SRC_DIR}/client_config.rst
           ${DOC_SRC_DIR}/plugin_log.rst ${DOC_SRC_DIR}/plugin_network.rst
           ${DOC_SRC_DIR}/services.rst ${DOC_SRC_DIR}/plugin_access_control.rst
           ${DOC_SRC_DIR}/nodestore.rst

--- a/include/ua_client.h
+++ b/include/ua_client.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "ua_types_generated_handling.h"
 #include "ua_plugin_network.h"
 #include "ua_plugin_log.h"
+#include "ua_client_config.h"
 
 /**
  * .. _client:
@@ -45,61 +46,6 @@ extern "C" {
  *
  * Client Lifecycle
  * ---------------- */
-
-typedef enum {
-    UA_CLIENTSTATE_DISCONNECTED,        /* The client is disconnected */
-    UA_CLIENTSTATE_CONNECTED,           /* A TCP connection to the server is open */
-    UA_CLIENTSTATE_SECURECHANNEL,       /* A SecureChannel to the server is open */
-    UA_CLIENTSTATE_SESSION,             /* A session with the server is open */
-    UA_CLIENTSTATE_SESSION_RENEWED      /* A session with the server is open (renewed) */
-} UA_ClientState;
-
-struct UA_Client;
-typedef struct UA_Client UA_Client;
-
-/**
- * Client Lifecycle callback
- * ------------------------- */
-
-typedef void (*UA_ClientStateCallback)(UA_Client *client, UA_ClientState clientState);
-
-/**
- * Subscription Inactivity callback
- * ------------------------- */
-
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-typedef void (*UA_SubscriptionInactivityCallback)(UA_Client *client, UA_UInt32 subscriptionId, void *subContext);
-#endif
-
-/**
- * Client Configuration
- * -------------------- */
-
-typedef struct UA_ClientConfig {
-    UA_UInt32 timeout;               /* Sync response timeout in ms */
-    UA_UInt32 secureChannelLifeTime; /* Lifetime in ms (then the channel needs
-                                        to be renewed) */
-    UA_Logger logger;
-    UA_ConnectionConfig localConnectionConfig;
-    UA_ConnectClientConnection connectionFunc;
-
-    /* Custom DataTypes */
-    size_t customDataTypesSize;
-    const UA_DataType *customDataTypes;
-
-    /* Callback function */
-    UA_ClientStateCallback stateCallback;
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-    UA_SubscriptionInactivityCallback subscriptionInactivityCallback;
-#endif
-
-    void *clientContext;
-
-    /* number of PublishResponse standing in the sever */
-    /* 0 = background task disabled                    */
-    UA_UInt16 outStandingPublishRequests;
-} UA_ClientConfig;
-
 
 /* Create a new client */
 UA_Client UA_EXPORT *

--- a/include/ua_client_config.h
+++ b/include/ua_client_config.h
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2018 (c) Stefan Profanter, fortiss GmbH
+ */
+
+#ifndef UA_CLIENT_CONFIG_H
+#define UA_CLIENT_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ua_plugin_network.h"
+
+/**
+ * .. _client-configuration:
+ *
+ * Client Configuration
+ * --------------------
+ *
+ * The client configuration is used for setting connection parameters and
+ * additional settings used by the client.
+ * The configuration should not be modified after it is passed to a client.
+ * Currently, only one client can use a configuration at a time.
+ *
+ * Examples for configurations are provided in the ``/plugins`` folder.
+ * The usual usage is as follows:
+ *
+ * 1. Create a client configuration with default settings as a starting point
+ * 2. Modifiy the configuration, e.g. modifying the timeout
+ * 3. Instantiate a client with it
+ * 4. After shutdown of the client, clean up the configuration (free memory)
+ *
+ * The :ref:`tutorials` provide a good starting point for this. */
+
+typedef enum {
+    UA_CLIENTSTATE_DISCONNECTED,        /* The client is disconnected */
+    UA_CLIENTSTATE_CONNECTED,           /* A TCP connection to the server is open */
+    UA_CLIENTSTATE_SECURECHANNEL,       /* A SecureChannel to the server is open */
+    UA_CLIENTSTATE_SESSION,             /* A session with the server is open */
+    UA_CLIENTSTATE_SESSION_RENEWED      /* A session with the server is open (renewed) */
+} UA_ClientState;
+
+
+struct UA_Client;
+typedef struct UA_Client UA_Client;
+
+/**
+ * Client Lifecycle callback
+ * ------------------------- */
+
+typedef void (*UA_ClientStateCallback)(UA_Client *client, UA_ClientState clientState);
+
+/**
+ * Subscription Inactivity callback
+ * ------------------------- */
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+typedef void (*UA_SubscriptionInactivityCallback)(UA_Client *client, UA_UInt32 subscriptionId, void *subContext);
+#endif
+
+/**
+ * Client Configuration
+ * -------------------- */
+
+typedef struct UA_ClientConfig {
+    UA_UInt32 timeout;               /* Sync response timeout in ms */
+    UA_UInt32 secureChannelLifeTime; /* Lifetime in ms (then the channel needs
+                                        to be renewed) */
+    UA_Logger logger;
+    UA_ConnectionConfig localConnectionConfig;
+    UA_ConnectClientConnection connectionFunc;
+
+    /* Custom DataTypes */
+    size_t customDataTypesSize;
+    const UA_DataType *customDataTypes;
+
+    /* Callback function */
+    UA_ClientStateCallback stateCallback;
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    UA_SubscriptionInactivityCallback subscriptionInactivityCallback;
+#endif
+
+    void *clientContext;
+
+    /* number of PublishResponse standing in the sever */
+    /* 0 = background task disabled                    */
+    UA_UInt16 outStandingPublishRequests;
+} UA_ClientConfig;
+
+
+/** Get the client configuration from the configuration plugin. Used by the
+ * server when it needs client functionality to register to a discovery server
+ * or when the server needs to create a client for other purposes
+ *
+ * @return The client configuration structure
+ **/
+UA_ClientConfig UA_EXPORT
+UA_Server_getClientConfig(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* UA_CLIENT_CONFIG_H */

--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -20,13 +20,14 @@ extern "C" {
 #include "ua_types.h"
 #include "ua_types_generated.h"
 #include "ua_types_generated_handling.h"
-#include "ua_client.h"
 
 struct UA_ServerConfig;
 typedef struct UA_ServerConfig UA_ServerConfig;
 
 struct UA_Server;
 typedef struct UA_Server UA_Server;
+
+struct UA_ClientConfig;
 
 /**
  * .. _server:
@@ -540,13 +541,6 @@ UA_Server_setServerOnNetworkCallback(UA_Server *server,
                                      void* data);
 
 #endif /* UA_ENABLE_DISCOVERY_MULTICAST */
-
-/* Get the client configuration from the configuration plugin. Used by the
- * server when it needs client functionality to register to a discovery server.
- *
- * @return The client configuration structure */
-UA_ClientConfig UA_EXPORT
-UA_Server_getClientConfig(void);
 
 #endif /* UA_ENABLE_DISCOVERY */
 

--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -20,6 +20,7 @@ extern "C" {
 #include "ua_types.h"
 #include "ua_types_generated.h"
 #include "ua_types_generated_handling.h"
+#include "ua_client.h"
 
 struct UA_ServerConfig;
 typedef struct UA_ServerConfig UA_ServerConfig;
@@ -539,6 +540,13 @@ UA_Server_setServerOnNetworkCallback(UA_Server *server,
                                      void* data);
 
 #endif /* UA_ENABLE_DISCOVERY_MULTICAST */
+
+/* Get the client configuration from the configuration plugin. Used by the
+ * server when it needs client functionality to register to a discovery server.
+ *
+ * @return The client configuration structure */
+UA_ClientConfig UA_EXPORT
+UA_Server_getClientConfig(void);
 
 #endif /* UA_ENABLE_DISCOVERY */
 

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -11,12 +11,12 @@
 
 #include "ua_plugin_securitypolicy.h"
 #include "ua_config_default.h"
+#include "ua_client_config.h"
 #include "ua_log_stdout.h"
 #include "ua_network_tcp.h"
 #include "ua_accesscontrol_default.h"
 #include "ua_pki_certificate.h"
 #include "ua_nodestore_default.h"
-#include "ua_types_generated.h"
 #include "ua_securitypolicy_none.h"
 
 #ifdef UA_ENABLE_ENCRYPTION
@@ -24,9 +24,6 @@
 #include "ua_securitypolicy_basic256sha256.h"
 #endif
 
-#include "ua_types.h"
-#include "ua_types_generated_handling.h"
-#include "ua_client_subscriptions.h"
 
 /* Struct initialization works across ANSI C/C99/C++ if it is done when the
  * variable is first declared. Assigning values to existing structs is

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -1,5 +1,5 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
- * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. 
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
  *
  *    Copyright 2017 (c) Julius Pfrommer, Fraunhofer IOSB
  *    Copyright 2017 (c) Julian Grothoff
@@ -652,3 +652,8 @@ const UA_ClientConfig UA_ClientConfig_default = {
 
     10 /* .outStandingPublishRequests */
 };
+
+UA_ClientConfig UA_Server_getClientConfig(void)
+{
+    return UA_ClientConfig_default;
+}

--- a/src/server/ua_server_discovery.c
+++ b/src/server/ua_server_discovery.c
@@ -8,7 +8,6 @@
 
 #include "ua_server_internal.h"
 #include "ua_client.h"
-#include "ua_config_default.h"
 
 #ifdef UA_ENABLE_DISCOVERY
 
@@ -24,7 +23,8 @@ register_server_with_discovery_server(UA_Server *server,
     }
 
     /* Create the client */
-    UA_Client *client = UA_Client_new(UA_ClientConfig_default);
+    UA_ClientConfig clientConfig = UA_Server_getClientConfig();
+    UA_Client *client = UA_Client_new(clientConfig);
     if(!client)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 


### PR DESCRIPTION
The server implementation needs to initialize a client when it
shall register itself to a discovery server. To avoid including a
private header file of the plugin, a callback function has been
declared in the server header file to be implemented by the plugin
implementation. This callback function are called by the server
when it shall initialize a client.