### PR TITLE
Added more allowed status codes in Operation_CreateMonitoredItem

### DIFF
--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -215,7 +215,10 @@ Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session,
     if(v.hasStatus && (v.status >> 30) > 1 &&
        v.status != UA_STATUSCODE_BADRESOURCEUNAVAILABLE &&
        v.status != UA_STATUSCODE_BADCOMMUNICATIONERROR &&
-       v.status != UA_STATUSCODE_BADWAITINGFORINITIALDATA) {
+       v.status != UA_STATUSCODE_BADWAITINGFORINITIALDATA &&
+       v.status != UA_STATUSCODE_BADUSERACCESSDENIED &&
+       v.status != UA_STATUSCODE_BADNOTREADABLE &&
+       v.status != UA_STATUSCODE_BADINDEXRANGENODATA) {
         result->statusCode = v.status;
         UA_DataValue_deleteMembers(&v);
         return;


### PR DESCRIPTION
According to UA Specification Part 4, chapter 5.12.2.1, the add
operation for the item shall succeed for the following statues:
* Denied read access (Bad_NotReadable)
* No access rights (Bad_UserAccessDenied)
* The index range does not deliver any data for the current value
  (Bad_IndexRangeNoData)