### PR TITLE
fix a compilation problem

### DIFF
--- a/examples/server_certificate.c
+++ b/examples/server_certificate.c
@@ -26,7 +26,7 @@ static UA_ByteString loadCertificate(void) {
 
     fseek(fp, 0, SEEK_END);
     certificate.length = (size_t)ftell(fp);
-    certificate.data = UA_malloc(certificate.length*sizeof(UA_Byte));
+    certificate.data = (UA_Byte *)UA_malloc(certificate.length*sizeof(UA_Byte));
     if(!certificate.data)
         return certificate;
 


### PR DESCRIPTION
fix : 

```
/data/open62541-master/examples/server_certificate.c: In function 'loadCertificate':
/data/open62541-master/examples/server_certificate.c:29:22: error: request for implicit conversion from 'void *' to 'UA_Byte * {aka unsigned char *}' not permitted in C++ [-Werror=c++-compat]
     certificate.data = UA_malloc(certificate.length*sizeof(UA_Byte));
                      ^
/data/open62541-master/examples/server_certificate.c: At top level:
cc1: error: unrecognized command line option '-Wno-static-in-inline' [-Werror]
cc1: all warnings being treated as errors
```