### PR TITLE
fix testing clock and simplify receiveServiceResponse

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -281,10 +281,7 @@ receiveServiceResponse(UA_Client *client, void *response, const UA_DataType *res
         retval = UA_Connection_receiveChunksBlocking(&client->connection, &rd,
                                                      client_processChunk, timeout);
 
-        if (retval == UA_STATUSCODE_GOODNONCRITICALTIMEOUT)
-            break;
-
-        if(retval != UA_STATUSCODE_GOOD) {
+        if(retval != UA_STATUSCODE_GOOD && retval != UA_STATUSCODE_GOODNONCRITICALTIMEOUT) {
             if(retval == UA_STATUSCODE_BADCONNECTIONCLOSED)
                 client->state = UA_CLIENTSTATE_DISCONNECTED;
             else

--- a/tests/client/check_client_securechannel.c
+++ b/tests/client/check_client_securechannel.c
@@ -56,7 +56,8 @@ START_TEST(SecureChannel_timeout_max) {
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-    UA_fakeSleep(UA_ClientConfig_default.secureChannelLifeTime);
+    UA_fakeSleep((UA_UInt32)(UA_ClientConfig_default.secureChannelLifeTime*0.95));
+                             // Less than UA_ClientConfig_default.secureChannelLifeTime
 
     UA_Variant val;
     UA_NodeId nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
@@ -76,7 +77,8 @@ START_TEST(SecureChannel_timeout_fail) {
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_fakeSleep(UA_ClientConfig_default.secureChannelLifeTime+1);
-    UA_realSleep(50 + 1); // UA_MAXTIMEOUT+1 wait to be sure UA_Server_run_iterate can be completely executed 
+    UA_realSleep(200); // wait to be sure UA_Server_run_iterate can be one time completely executed
+                       // must be greater than 2*UA_MAXTIMEOUT
 
     UA_Variant val;
     UA_Variant_init(&val);
@@ -97,7 +99,8 @@ START_TEST(SecureChannel_networkfail) {
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     *blockServer = true;
-    UA_realSleep(100);
+    UA_realSleep(200); // wait to be sure UA_Server_run_iterate can be one time completely executed
+                       // must be greater than 2*UA_MAXTIMEOUT
 
     UA_Variant val;
     UA_Variant_init(&val);

--- a/tests/testing-plugins/testing_clock.c
+++ b/tests/testing-plugins/testing_clock.c
@@ -19,17 +19,37 @@
 #include "testing_clock.h"
 
 #ifdef _WIN32
-#include <windows.h>	/* WinAPI */
+# include <windows.h>	/* WinAPI */
+#else
+# include <sys/time.h>
 #endif
 
 UA_DateTime testingClock = 0;
 
+static UA_DateTime _UA_DateTime_now(void) {
+#if defined(_WIN32)
+    /* Windows filetime has the same definition as UA_DateTime */
+    FILETIME ft;
+    SYSTEMTIME st;
+    GetSystemTime(&st);
+    SystemTimeToFileTime(&st, &ft);
+    ULARGE_INTEGER ul;
+    ul.LowPart = ft.dwLowDateTime;
+    ul.HighPart = ft.dwHighDateTime;
+    return (UA_DateTime)ul.QuadPart;
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (tv.tv_sec * UA_SEC_TO_DATETIME) + (tv.tv_usec * UA_USEC_TO_DATETIME) + UA_DATETIME_UNIX_EPOCH;
+#endif
+}
+
 UA_DateTime UA_DateTime_now(void) {
-    return testingClock;
+    return testingClock + _UA_DateTime_now();
 }
 
 UA_DateTime UA_DateTime_nowMonotonic(void) {
-    return testingClock;
+    return testingClock + _UA_DateTime_now();
 }
 
 void


### PR DESCRIPTION
testing_clock must take into account the real elapsed time (for example while waiting on a select).

With testing_clock fixed, receiveServiceResponse can now be simplified.

@Pro can you see why discovery test fails ?

https://travis-ci.org/StalderT/open62541/jobs/307870584#L6383

https://github.com/open62541/open62541/blob/5ff6e4b3fc29b53e580f68acafbd6a3e6ff25617/tests/server/check_discovery.c#L178-L187