### PR TITLE
fix mem leak in client_connect_loop

### DIFF
--- a/examples/client_connect_loop.c
+++ b/examples/client_connect_loop.c
@@ -85,6 +85,7 @@ int main(void) {
             UA_LOG_INFO(logger, UA_LOGCATEGORY_CLIENT, "string date is: %.*s", (int) string_date.length, string_date.data);
             UA_String_deleteMembers(&string_date);
         }
+        UA_Variant_deleteMembers(&value);
         UA_sleep_ms(1000);
     };
 


### PR DESCRIPTION
```
==18584== 
==18584== HEAP SUMMARY:
==18584==     in use at exit: 16 bytes in 2 blocks
==18584==   total heap usage: 114 allocs, 112 frees, 1,219,690 bytes allocated
==18584== 
==18584== 16 bytes in 2 blocks are definitely lost in loss record 1 of 1
==18584==    at 0x4C2DBC5: calloc (vg_replace_malloc.c:711)
==18584==    by 0x1146F3: UA_new (ua_types.c:823)
==18584==    by 0x11ED01: Variant_decodeBinary (ua_types_encoding_binary.c:1160)
==18584==    by 0x11EFD9: DataValue_decodeBinary (ua_types_encoding_binary.c:1233)
==18584==    by 0x11D81E: Array_decodeBinary (ua_types_encoding_binary.c:569)
==18584==    by 0x11FA55: UA_decodeBinaryInternal (ua_types_encoding_binary.c:1511)
==18584==    by 0x11FBA7: UA_decodeBinary (ua_types_encoding_binary.c:1540)
==18584==    by 0x115A31: processServiceResponse (ua_client.c:217)
==18584==    by 0x122ECC: UA_SecureChannel_finalizeChunk (ua_securechannel.c:755)
==18584==    by 0x12368B: UA_SecureChannel_processChunk (ua_securechannel.c:1024)
==18584==    by 0x115BAA: client_processChunk (ua_client.c:259)
==18584==    by 0x120C5B: completeChunkTrampoline (ua_connection.c:187)
==18584== 
==18584== LEAK SUMMARY:
==18584==    definitely lost: 16 bytes in 2 blocks
==18584==    indirectly lost: 0 bytes in 0 blocks
==18584==      possibly lost: 0 bytes in 0 blocks
==18584==    still reachable: 0 bytes in 0 blocks
==18584==         suppressed: 0 bytes in 0 blocks
==18584== 
```