### PR TITLE
use maximum notification per publish

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -314,7 +314,7 @@ const UA_SubscriptionSettings UA_SubscriptionSettings_default = {
     500.0, /* .requestedPublishingInterval */
     10000, /* .requestedLifetimeCount */
     1, /* .requestedMaxKeepAliveCount */
-    10, /* .maxNotificationsPerPublish */
+    0, /* .maxNotificationsPerPublish */
     true, /* .publishingEnabled */
     0 /* .priority */
 };


### PR DESCRIPTION
#1462 
Always use the maximum notification per publish.
This increases speed on slow devices like PLC's, because PLC's can add more notifications in a publish response.