### PR TITLE
fix #1458

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -111,13 +111,13 @@ static void
 processDecodedOPNResponse(UA_Client *client, UA_OpenSecureChannelResponse *response) {
     /* Replace the token */
     UA_ChannelSecurityToken_deleteMembers(&client->channel.securityToken);
-    client->channel.securityToken = response->securityToken;
-    UA_ChannelSecurityToken_init(&response->securityToken);
+    UA_ChannelSecurityToken_copy(&response->securityToken, &client->channel.securityToken);
+    UA_ChannelSecurityToken_deleteMembers(&response->securityToken);
 
     /* Replace the nonce */
     UA_ByteString_deleteMembers(&client->channel.remoteNonce);
-    client->channel.remoteNonce = response->serverNonce;
-    UA_ByteString_init(&response->serverNonce);
+    UA_ByteString_copy(&response->serverNonce, &client->channel.remoteNonce);
+    UA_ByteString_deleteMembers(&response->serverNonce);
 
     if(client->channel.state == UA_SECURECHANNELSTATE_OPEN)
         UA_LOG_DEBUG(client->config.logger, UA_LOGCATEGORY_SECURECHANNEL,


### PR DESCRIPTION
fix #1458 
see #1446 and #1443 

For info, the server part does not check if UA_ByteString_copy failed : 
https://github.com/open62541/open62541/blob/2b3c72dc48f65dd5210dc3ecbdc39db9a753959b/src/server/ua_securechannel_manager.c#L156
https://github.com/open62541/open62541/blob/2b3c72dc48f65dd5210dc3ecbdc39db9a753959b/src/server/ua_securechannel_manager.c#L201-L203

@WoutvdBerg can you test with this PR?