### PR TITLE
Zero-copy read service

### DIFF
--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -639,6 +639,18 @@ UA_Server_setNodeContext(UA_Server *server, UA_NodeId nodeId,
 typedef struct {
     /* Copies the data from the source into the provided value.
      *
+     * !! ZERO-COPY OPERATIONS POSSIBLE !!
+     * It is not required to return a copy of the actual content data. You can
+     * return a pointer to memory owned by the user. Memory can be reused
+     * between read callbacks of a DataSource, as the result is already encoded
+     * on the network buffer between each read operation.
+     *
+     * To use zero-copy reads, set the value of the `value->value` Variant
+     * without copying, e.g. with `UA_Variant_setScalar`. Then, also set
+     * `value->value.storageType` to `UA_VARIANT_DATA_NODELETE` to prevent the
+     * memory being cleaned up. Don't forget to also set `value->hasValue` to
+     * true to indicate the presence of a value.
+     *
      * @param handle An optional pointer to user-defined data for the
      *        specific data source
      * @param nodeid Id of the read node
@@ -659,8 +671,8 @@ typedef struct {
                           void *nodeContext, UA_Boolean includeSourceTimeStamp,
                           const UA_NumericRange *range, UA_DataValue *value);
 
-    /* Write into a data source. The write member of UA_DataSource can be empty
-     * if the operation is unsupported.
+    /* Write into a data source. This method pointer can be NULL if the
+     * operation is unsupported.
      *
      * @param handle An optional pointer to user-defined data for the
      *        specific data source

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -50,16 +50,23 @@ sendServiceFault(UA_SecureChannel *channel, const UA_ByteString *msg,
     // Send error message. Message type is MSG and not ERR, since we are on a securechannel!
     retval = UA_SecureChannel_sendSymmetricMessage(channel, requestId, UA_MESSAGETYPE_MSG,
                                                    response, responseType);
+
     UA_RequestHeader_deleteMembers(&requestHeader);
     UA_LOG_DEBUG(channel->securityPolicy->logger, UA_LOGCATEGORY_SERVER,
                  "Sent ServiceFault with error code %s", UA_StatusCode_name(error));
     return retval;
 }
 
+typedef enum {
+    UA_SERVICETYPE_NORMAL,
+    UA_SERVICETYPE_INSITU,
+    UA_SERVICETYPE_CUSTOM
+} UA_ServiceType;
+
 static void
 getServicePointers(UA_UInt32 requestTypeId, const UA_DataType **requestType,
                    const UA_DataType **responseType, UA_Service *service,
-                   UA_Boolean *requiresSession) {
+                   UA_Boolean *requiresSession, UA_ServiceType *serviceType) {
     switch(requestTypeId) {
     case UA_NS0ID_GETENDPOINTSREQUEST_ENCODING_DEFAULTBINARY:
         *service = (UA_Service)Service_GetEndpoints;
@@ -100,11 +107,13 @@ getServicePointers(UA_UInt32 requestTypeId, const UA_DataType **requestType,
         *requestType = &UA_TYPES[UA_TYPES_CREATESESSIONREQUEST];
         *responseType = &UA_TYPES[UA_TYPES_CREATESESSIONRESPONSE];
         *requiresSession = false;
+        *serviceType = UA_SERVICETYPE_CUSTOM;
         break;
     case UA_NS0ID_ACTIVATESESSIONREQUEST_ENCODING_DEFAULTBINARY:
         *service = (UA_Service)Service_ActivateSession;
         *requestType = &UA_TYPES[UA_TYPES_ACTIVATESESSIONREQUEST];
         *responseType = &UA_TYPES[UA_TYPES_ACTIVATESESSIONRESPONSE];
+        *serviceType = UA_SERVICETYPE_CUSTOM;
         break;
     case UA_NS0ID_CLOSESESSIONREQUEST_ENCODING_DEFAULTBINARY:
         *service = (UA_Service)Service_CloseSession;
@@ -115,6 +124,7 @@ getServicePointers(UA_UInt32 requestTypeId, const UA_DataType **requestType,
         *service = (UA_Service)Service_Read;
         *requestType = &UA_TYPES[UA_TYPES_READREQUEST];
         *responseType = &UA_TYPES[UA_TYPES_READRESPONSE];
+        *serviceType = UA_SERVICETYPE_INSITU;
         break;
     case UA_NS0ID_WRITEREQUEST_ENCODING_DEFAULTBINARY:
         *service = (UA_Service)Service_Write;
@@ -381,8 +391,9 @@ processMSG(UA_Server *server, UA_SecureChannel *channel,
     const UA_DataType *requestType = NULL;
     const UA_DataType *responseType = NULL;
     UA_Boolean sessionRequired = true;
+    UA_ServiceType serviceType = UA_SERVICETYPE_NORMAL;
     getServicePointers(requestTypeId.identifier.numeric, &requestType,
-                       &responseType, &service, &sessionRequired);
+                       &responseType, &service, &sessionRequired, &serviceType);
     if(!requestType) {
         if(requestTypeId.identifier.numeric == 787) {
             UA_LOG_INFO_CHANNEL(server->config.logger, channel,
@@ -509,26 +520,59 @@ processMSG(UA_Server *server, UA_SecureChannel *channel,
     }
 #endif
 
-    /* Call the service */
-    UA_assert(service); /* For all services besides publish, the service pointer is non-NULL*/
-    service(server, session, request, response);
+    send_response:
 
-send_response:
-    /* Send the response */
+    /* Prepare the ResponseHeader */
     ((UA_ResponseHeader*)response)->requestHandle = requestHeader->requestHandle;
     ((UA_ResponseHeader*)response)->timestamp = UA_DateTime_now();
-    retval = UA_SecureChannel_sendSymmetricMessage(channel, requestId, UA_MESSAGETYPE_MSG,
-                                                   response, responseType);
 
+    /* Start the message */
+    UA_NodeId typeId = UA_NODEID_NUMERIC(0, responseType->binaryEncodingId);
+    UA_MessageContext mc;
+    retval = UA_MessageContext_begin(&mc, channel, requestId, UA_MESSAGETYPE_MSG);
+    if(retval != UA_STATUSCODE_GOOD)
+        goto cleanup;
+
+    /* Assert's required for clang-analyzer */
+    UA_assert(mc.buf_pos == &mc.messageBuffer.data[UA_SECURE_MESSAGE_HEADER_LENGTH]);
+    UA_assert(mc.buf_end == &mc.messageBuffer.data[mc.messageBuffer.length]);
+
+    retval = UA_MessageContext_encode(&mc, &typeId, &UA_TYPES[UA_TYPES_NODEID]);
+    if(retval != UA_STATUSCODE_GOOD)
+        goto cleanup;
+
+    switch(serviceType) {
+    case UA_SERVICETYPE_CUSTOM:
+        /* Was processed before...*/
+        retval = UA_MessageContext_encode(&mc, response, responseType);
+        break;
+    case UA_SERVICETYPE_INSITU: 
+        retval = ((UA_InSituService)service)
+            (server, session, &mc, request, (UA_ResponseHeader*)response);
+        break;
+    case UA_SERVICETYPE_NORMAL:
+    default:
+        service(server, session, request, response);
+        retval = UA_MessageContext_encode(&mc, response, responseType);
+        break;
+    }
+
+    /* Finish sending the message */
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_MessageContext_abort(&mc);
+        goto cleanup;
+    }
+
+    retval = UA_MessageContext_finish(&mc);
+
+ cleanup:
     if(retval != UA_STATUSCODE_GOOD)
         UA_LOG_INFO_CHANNEL(server->config.logger, channel,
                             "Could not send the message over the SecureChannel "
                             "with StatusCode %s", UA_StatusCode_name(retval));
-
     /* Clean up */
     UA_deleteMembers(request, requestType);
     UA_deleteMembers(response, responseType);
-
     return retval;
 }
 

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -285,7 +285,7 @@ void Service_Browse_single(UA_Server *server, UA_Session *session,
 UA_DataValue
 UA_Server_readWithSession(UA_Server *server, UA_Session *session,
                           const UA_ReadValueId *item,
-                          UA_TimestampsToReturn timestamps);
+                          UA_TimestampsToReturn timestampsToReturn);
 
 /* Checks if a registration timed out and removes that registration.
  * Should be called periodically in main loop */

--- a/src/server/ua_services.h
+++ b/src/server/ua_services.h
@@ -38,6 +38,9 @@ extern "C" {
 typedef void (*UA_Service)(UA_Server*, UA_Session*,
                            const void *request, void *response);
 
+typedef UA_StatusCode (*UA_InSituService)(UA_Server*, UA_Session*, UA_MessageContext *mc,
+                                          const void *request, UA_ResponseHeader *rh);
+
 /**
  * Discovery Service Set
  * ---------------------
@@ -293,9 +296,8 @@ void Service_UnregisterNodes(UA_Server *server, UA_Session *session,
  * elements are indexed, such as an array, this Service allows Clients to read
  * the entire set of indexed values as a composite, to read individual elements
  * or to read ranges of elements of the composite. */
-void Service_Read(UA_Server *server, UA_Session *session,
-                  const UA_ReadRequest *request,
-                  UA_ReadResponse *response);
+UA_StatusCode Service_Read(UA_Server *server, UA_Session *session, UA_MessageContext *mc,
+                           const UA_ReadRequest *request, UA_ResponseHeader *responseHeader);
 
 /**
  * Write Service

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "ua_server_internal.h"
+#include "ua_types_encoding_binary.h"
 #include "ua_services.h"
 
 /******************/
@@ -56,8 +57,14 @@ readArrayDimensionsAttribute(const UA_VariableNode *vn, UA_DataValue *v) {
     UA_Variant_setArray(&v->value, vn->arrayDimensions,
                         vn->arrayDimensionsSize, &UA_TYPES[UA_TYPES_UINT32]);
     v->value.storageType = UA_VARIANT_DATA_NODELETE;
-    v->hasValue = true;
     return UA_STATUSCODE_GOOD;
+}
+
+static void
+setScalarNoDelete(UA_Variant *v, const void * UA_RESTRICT p,
+                  const UA_DataType *type) {
+    UA_Variant_setScalar(v, (void*)(uintptr_t)p, type);
+    v->storageType = UA_VARIANT_DATA_NODELETE;
 }
 
 static UA_StatusCode
@@ -79,7 +86,10 @@ readIsAbstractAttribute(const UA_Node *node, UA_Variant *v) {
     default:
         return UA_STATUSCODE_BADATTRIBUTEIDINVALID;
     }
-    return UA_Variant_setScalarCopy(v, isAbstract, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    setScalarNoDelete(v, isAbstract, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    v->storageType = UA_VARIANT_DATA_NODELETE;
+    return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
@@ -151,18 +161,19 @@ readValueAttribute(UA_Server *server, UA_Session *session,
 static const UA_String binEncoding = {sizeof("Default Binary")-1, (UA_Byte*)"Default Binary"};
 /* static const UA_String xmlEncoding = {sizeof("Default Xml")-1, (UA_Byte*)"Default Xml"}; */
 
-/* Thread-local variables to pass additional arguments into the operation */
-static UA_THREAD_LOCAL UA_TimestampsToReturn op_timestampsToReturn;
-
 #define CHECK_NODECLASS(CLASS)                                  \
     if(!(node->nodeClass & (CLASS))) {                          \
         retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;           \
         break;                                                  \
     }
 
+/* Returns a datavalue that may point into the node via the
+ * UA_VARIANT_DATA_NODELETE tag. Don't access the returned DataValue once the
+ * node has been released! */
 static void
-Operation_Read(UA_Server *server, UA_Session *session,
-               const UA_ReadValueId *id, UA_DataValue *v) {
+Read(const UA_Node *node, UA_Server *server, UA_Session *session,
+     UA_TimestampsToReturn timestampsToReturn,
+     const UA_ReadValueId *id, UA_DataValue *v) {
     UA_LOG_DEBUG_SESSION(server->config.logger, session,
                          "Read the attribute %i", id->attributeId);
 
@@ -181,34 +192,26 @@ Operation_Read(UA_Server *server, UA_Session *session,
         return;
     }
 
-    /* Get the node */
-    const UA_Node *node = UA_Nodestore_get(server, &id->nodeId);
-    if(!node) {
-        v->hasStatus = true;
-        v->status = UA_STATUSCODE_BADNODEIDUNKNOWN;
-        return;
-    }
-
     /* Read the attribute */
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     switch(id->attributeId) {
     case UA_ATTRIBUTEID_NODEID:
-        retval = UA_Variant_setScalarCopy(&v->value, &node->nodeId, &UA_TYPES[UA_TYPES_NODEID]);
+        setScalarNoDelete(&v->value, &node->nodeId, &UA_TYPES[UA_TYPES_NODEID]);
         break;
     case UA_ATTRIBUTEID_NODECLASS:
-        retval = UA_Variant_setScalarCopy(&v->value, &node->nodeClass, &UA_TYPES[UA_TYPES_NODECLASS]);
+        setScalarNoDelete(&v->value, &node->nodeClass, &UA_TYPES[UA_TYPES_NODECLASS]);
         break;
     case UA_ATTRIBUTEID_BROWSENAME:
-        retval = UA_Variant_setScalarCopy(&v->value, &node->browseName, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
+        setScalarNoDelete(&v->value, &node->browseName, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
         break;
     case UA_ATTRIBUTEID_DISPLAYNAME:
-        retval = UA_Variant_setScalarCopy(&v->value, &node->displayName, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+        setScalarNoDelete(&v->value, &node->displayName, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
         break;
     case UA_ATTRIBUTEID_DESCRIPTION:
-        retval = UA_Variant_setScalarCopy(&v->value, &node->description, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+        setScalarNoDelete(&v->value, &node->description, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
         break;
     case UA_ATTRIBUTEID_WRITEMASK:
-        retval = UA_Variant_setScalarCopy(&v->value, &node->writeMask, &UA_TYPES[UA_TYPES_UINT32]);
+        setScalarNoDelete(&v->value, &node->writeMask, &UA_TYPES[UA_TYPES_UINT32]);
         break;
     case UA_ATTRIBUTEID_USERWRITEMASK: {
         UA_UInt32 userWriteMask = getUserWriteMask(server, session, node);
@@ -219,23 +222,23 @@ Operation_Read(UA_Server *server, UA_Session *session,
         break;
     case UA_ATTRIBUTEID_SYMMETRIC:
         CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_ReferenceTypeNode*)node)->symmetric,
-                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        setScalarNoDelete(&v->value, &((const UA_ReferenceTypeNode*)node)->symmetric,
+                          &UA_TYPES[UA_TYPES_BOOLEAN]);
         break;
     case UA_ATTRIBUTEID_INVERSENAME:
         CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_ReferenceTypeNode*)node)->inverseName,
-                                          &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+        setScalarNoDelete(&v->value, &((const UA_ReferenceTypeNode*)node)->inverseName,
+                          &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
         break;
     case UA_ATTRIBUTEID_CONTAINSNOLOOPS:
         CHECK_NODECLASS(UA_NODECLASS_VIEW);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_ViewNode*)node)->containsNoLoops,
-                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        setScalarNoDelete(&v->value, &((const UA_ViewNode*)node)->containsNoLoops,
+                          &UA_TYPES[UA_TYPES_BOOLEAN]);
         break;
     case UA_ATTRIBUTEID_EVENTNOTIFIER:
         CHECK_NODECLASS(UA_NODECLASS_VIEW | UA_NODECLASS_OBJECT);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_ViewNode*)node)->eventNotifier,
-                                          &UA_TYPES[UA_TYPES_BYTE]);
+        setScalarNoDelete(&v->value, &((const UA_ViewNode*)node)->eventNotifier,
+                          &UA_TYPES[UA_TYPES_BYTE]);
         break;
     case UA_ATTRIBUTEID_VALUE: {
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
@@ -256,18 +259,18 @@ Operation_Read(UA_Server *server, UA_Session *session,
             }
         }
         retval = readValueAttributeComplete(server, session, (const UA_VariableNode*)node,
-                                            op_timestampsToReturn, &id->indexRange, v);
+                                            timestampsToReturn, &id->indexRange, v);
         break;
     }
     case UA_ATTRIBUTEID_DATATYPE:
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_VariableTypeNode*)node)->dataType,
-                                          &UA_TYPES[UA_TYPES_NODEID]);
+        setScalarNoDelete(&v->value, &((const UA_VariableTypeNode*)node)->dataType,
+                          &UA_TYPES[UA_TYPES_NODEID]);
         break;
     case UA_ATTRIBUTEID_VALUERANK:
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_VariableTypeNode*)node)->valueRank,
-                                          &UA_TYPES[UA_TYPES_INT32]);
+        setScalarNoDelete(&v->value, &((const UA_VariableTypeNode*)node)->valueRank,
+                          &UA_TYPES[UA_TYPES_INT32]);
         break;
     case UA_ATTRIBUTEID_ARRAYDIMENSIONS:
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
@@ -275,8 +278,8 @@ Operation_Read(UA_Server *server, UA_Session *session,
         break;
     case UA_ATTRIBUTEID_ACCESSLEVEL:
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_VariableNode*)node)->accessLevel,
-                                          &UA_TYPES[UA_TYPES_BYTE]);
+        setScalarNoDelete(&v->value, &((const UA_VariableNode*)node)->accessLevel,
+                          &UA_TYPES[UA_TYPES_BYTE]);
         break;
     case UA_ATTRIBUTEID_USERACCESSLEVEL: {
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
@@ -286,18 +289,18 @@ Operation_Read(UA_Server *server, UA_Session *session,
         break; }
     case UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL:
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_VariableNode*)node)->minimumSamplingInterval,
-                                          &UA_TYPES[UA_TYPES_DOUBLE]);
+        setScalarNoDelete(&v->value, &((const UA_VariableNode*)node)->minimumSamplingInterval,
+                          &UA_TYPES[UA_TYPES_DOUBLE]);
         break;
     case UA_ATTRIBUTEID_HISTORIZING:
         CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_VariableNode*)node)->historizing,
-                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        setScalarNoDelete(&v->value, &((const UA_VariableNode*)node)->historizing,
+                          &UA_TYPES[UA_TYPES_BOOLEAN]);
         break;
     case UA_ATTRIBUTEID_EXECUTABLE:
         CHECK_NODECLASS(UA_NODECLASS_METHOD);
-        retval = UA_Variant_setScalarCopy(&v->value, &((const UA_MethodNode*)node)->executable,
-                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        setScalarNoDelete(&v->value, &((const UA_MethodNode*)node)->executable,
+                          &UA_TYPES[UA_TYPES_BOOLEAN]);
         break;
     case UA_ATTRIBUTEID_USEREXECUTABLE: {
         CHECK_NODECLASS(UA_NODECLASS_METHOD);
@@ -309,9 +312,6 @@ Operation_Read(UA_Server *server, UA_Session *session,
         retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
     }
 
-    /* Release nodes */
-    UA_Nodestore_release(server, node);
-
     /* Return error code when reading has failed */
     if(retval != UA_STATUSCODE_GOOD) {
         v->hasStatus = true;
@@ -322,16 +322,16 @@ Operation_Read(UA_Server *server, UA_Session *session,
     v->hasValue = true;
 
     /* Create server timestamp */
-    if(op_timestampsToReturn == UA_TIMESTAMPSTORETURN_SERVER ||
-       op_timestampsToReturn == UA_TIMESTAMPSTORETURN_BOTH) {
+    if(timestampsToReturn == UA_TIMESTAMPSTORETURN_SERVER ||
+       timestampsToReturn == UA_TIMESTAMPSTORETURN_BOTH) {
         v->serverTimestamp = UA_DateTime_now();
         v->hasServerTimestamp = true;
     }
 
     /* Handle source time stamp */
     if(id->attributeId == UA_ATTRIBUTEID_VALUE) {
-        if(op_timestampsToReturn == UA_TIMESTAMPSTORETURN_SERVER ||
-           op_timestampsToReturn == UA_TIMESTAMPSTORETURN_NEITHER) {
+        if(timestampsToReturn == UA_TIMESTAMPSTORETURN_SERVER ||
+           timestampsToReturn == UA_TIMESTAMPSTORETURN_NEITHER) {
             v->hasSourceTimestamp = false;
             v->hasSourcePicoseconds = false;
         } else if(!v->hasSourceTimestamp) {
@@ -341,45 +341,114 @@ Operation_Read(UA_Server *server, UA_Session *session,
     }
 }
 
-void Service_Read(UA_Server *server, UA_Session *session,
-                  const UA_ReadRequest *request, UA_ReadResponse *response) {
+static UA_StatusCode
+Operation_Read(UA_Server *server, UA_Session *session, UA_MessageContext *mc,
+               UA_TimestampsToReturn timestampsToReturn, const UA_ReadValueId *id) {
+    UA_DataValue dv;
+    UA_DataValue_init(&dv);
+
+    /* Get the node */
+    const UA_Node *node = UA_Nodestore_get(server, &id->nodeId);
+
+    /* Perform the read operation */
+    if(node) {
+        Read(node, server, session, timestampsToReturn, id, &dv);
+    } else {
+        dv.hasStatus = true;
+        dv.status = UA_STATUSCODE_BADNODEIDUNKNOWN;
+    }
+
+    /* Encode (and send) the results */
+    UA_StatusCode retval = UA_MessageContext_encode(mc, &dv, &UA_TYPES[UA_TYPES_DATAVALUE]);
+
+    /* Free copied data and release the node */
+    UA_Variant_deleteMembers(&dv.value);
+    UA_Nodestore_release(server, node);
+    return retval;
+}
+
+UA_StatusCode Service_Read(UA_Server *server, UA_Session *session, UA_MessageContext *mc,
+                           const UA_ReadRequest *request, UA_ResponseHeader *responseHeader) {
     UA_LOG_DEBUG_SESSION(server->config.logger, session,
                          "Processing ReadRequest");
 
     /* Check if the timestampstoreturn is valid */
-    op_timestampsToReturn = request->timestampsToReturn;
-    if(op_timestampsToReturn > UA_TIMESTAMPSTORETURN_NEITHER) {
-        response->responseHeader.serviceResult = UA_STATUSCODE_BADTIMESTAMPSTORETURNINVALID;
-        return;
-    }
+    if(request->timestampsToReturn > UA_TIMESTAMPSTORETURN_NEITHER)
+        responseHeader->serviceResult = UA_STATUSCODE_BADTIMESTAMPSTORETURNINVALID;
+
+    if(request->nodesToReadSize == 0)
+        responseHeader->serviceResult = UA_STATUSCODE_BADNOTHINGTODO;
 
     /* Check if maxAge is valid */
-    if(request->maxAge < 0) {
-        response->responseHeader.serviceResult = UA_STATUSCODE_BADMAXAGEINVALID;
-        return;
-    }
+    if(request->maxAge < 0)
+        responseHeader->serviceResult = UA_STATUSCODE_BADMAXAGEINVALID;
 
+    /* Check if there are too many operations */
     if(server->config.maxNodesPerRead != 0 &&
-       request->nodesToReadSize > server->config.maxNodesPerRead) {
-        response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
-        return;
+       request->nodesToReadSize > server->config.maxNodesPerRead)
+        responseHeader->serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
+
+    /* Encode the response header */
+    UA_StatusCode retval =
+        UA_MessageContext_encode(mc, responseHeader, &UA_TYPES[UA_TYPES_RESPONSEHEADER]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* Process nothing if we return an error code for the entire service */
+    UA_Int32 arraySize = (UA_Int32)request->nodesToReadSize;
+    if(responseHeader->serviceResult != UA_STATUSCODE_GOOD)
+        arraySize = 0;
+
+    /* Process all ReadValueIds */
+    retval = UA_MessageContext_encode(mc, &arraySize, &UA_TYPES[UA_TYPES_INT32]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    for(UA_Int32 i = 0; i < arraySize; i++) {
+        retval = Operation_Read(server, session, mc, request->timestampsToReturn,
+                                &request->nodesToRead[i]);
+        if(retval != UA_STATUSCODE_GOOD)
+            return retval;
     }
 
-    response->responseHeader.serviceResult = 
-        UA_Server_processServiceOperations(server, session,
-                  (UA_ServiceOperation)Operation_Read,
-                  &request->nodesToReadSize, &UA_TYPES[UA_TYPES_READVALUEID],
-                  &response->resultsSize, &UA_TYPES[UA_TYPES_DATAVALUE]);
+    /* Don't return any DiagnosticInfo */
+    arraySize = -1;
+    return UA_MessageContext_encode(mc, &arraySize, &UA_TYPES[UA_TYPES_INT32]);
 }
 
 UA_DataValue
 UA_Server_readWithSession(UA_Server *server, UA_Session *session,
                           const UA_ReadValueId *item,
-                          UA_TimestampsToReturn timestamps) {
+                          UA_TimestampsToReturn timestampsToReturn) {
     UA_DataValue dv;
     UA_DataValue_init(&dv);
-    op_timestampsToReturn = timestamps;
-    Operation_Read(server, session, item, &dv);
+
+    /* Get the node */
+    const UA_Node *node = UA_Nodestore_get(server, &item->nodeId);
+    if(!node) {
+        dv.hasStatus = true;
+        dv.status = UA_STATUSCODE_BADNODEIDUNKNOWN;
+        return dv;
+    }
+
+    /* Perform the read operation */
+    Read(node, server, session, timestampsToReturn, item, &dv);
+
+    /* Do we have to copy the result before releasing the node? */
+    if(dv.hasValue && dv.value.storageType == UA_VARIANT_DATA_NODELETE) {
+        UA_DataValue dv2;
+        UA_StatusCode retval = UA_DataValue_copy(&dv, &dv2);
+        if(retval == UA_STATUSCODE_GOOD) {
+            dv = dv2;
+        } else {
+            UA_DataValue_init(&dv);
+            dv.hasStatus = true;
+            dv.status = retval;
+        }
+    }
+
+    /* Release the node and return */
+    UA_Nodestore_release(server, node);
     return dv;
 }
 
@@ -413,28 +482,14 @@ __UA_Server_read(UA_Server *server, const UA_NodeId *nodeId,
         return retval;
     }
 
-    /* Prepare the result */
     if(attributeId == UA_ATTRIBUTEID_VALUE ||
        attributeId == UA_ATTRIBUTEID_ARRAYDIMENSIONS) {
         /* Return the entire variant */
-        if(dv.value.storageType == UA_VARIANT_DATA_NODELETE) {
-            retval = UA_Variant_copy(&dv.value,(UA_Variant *) v);
-        } else {
-            /* storageType is UA_VARIANT_DATA. Copy the entire variant
-             * (including pointers and all) */
-            memcpy(v, &dv.value, sizeof(UA_Variant));
-        }
+        memcpy(v, &dv.value, sizeof(UA_Variant));
     } else {
         /* Return the variant content only */
-        if(dv.value.storageType == UA_VARIANT_DATA_NODELETE) {
-            retval = UA_copy(dv.value.data, v, dv.value.type);
-        } else {
-            /* storageType is UA_VARIANT_DATA. Copy the content of the type
-             * (including pointers and all) */
-            memcpy(v, dv.value.data, dv.value.type->memSize);
-            /* Delete the "carrier" in the variant */
-            UA_free(dv.value.data);
-        }
+        memcpy(v, dv.value.data, dv.value.type->memSize);
+        UA_free(dv.value.data);
     }
     return retval;
 }

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -14,7 +14,6 @@
 
 #define UA_BITMASK_MESSAGETYPE 0x00ffffff
 #define UA_BITMASK_CHUNKTYPE 0xff000000
-#define UA_SECURE_MESSAGE_HEADER_LENGTH 24
 #define UA_ASYMMETRIC_ALG_SECURITY_HEADER_FIXED_LENGTH 12
 #define UA_SYMMETRIC_ALG_SECURITY_HEADER_LENGTH 4
 #define UA_SEQUENCE_HEADER_LENGTH 8
@@ -31,27 +30,13 @@ UA_THREAD_LOCAL UA_StatusCode sendAsym_sendFailure;
 UA_THREAD_LOCAL UA_StatusCode processSym_seqNumberFailure;
 #endif
 
-/* Callback data for sending responses in multiple chunks */
-typedef struct {
-    UA_SecureChannel *channel;
-    UA_UInt32 requestId;
-    UA_UInt32 messageType;
-
-    UA_UInt16 chunksSoFar;
-    size_t messageSizeSoFar;
-
-    UA_ByteString messageBuffer;
-    UA_Boolean final;
-} UA_ChunkInfo;
-
 UA_StatusCode
 UA_SecureChannel_init(UA_SecureChannel *channel,
                       const UA_SecurityPolicy *securityPolicy,
                       const UA_ByteString *remoteCertificate) {
 
-    if(channel == NULL || securityPolicy == NULL || remoteCertificate == NULL) {
+    if(channel == NULL || securityPolicy == NULL || remoteCertificate == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
-    }
 
     memset(channel, 0, sizeof(UA_SecureChannel));
     channel->state = UA_SECURECHANNELSTATE_FRESH;
@@ -252,8 +237,8 @@ calculatePaddingAsym(const UA_SecurityPolicy *securityPolicy, const void *channe
     size_t signatureSize = securityPolicy->asymmetricModule.cryptoModule.
         getLocalSignatureSize(securityPolicy, channelContext);
     size_t paddingBytes = 1;
-    if(securityPolicy->asymmetricModule.cryptoModule.getRemoteEncryptionKeyLength(securityPolicy,
-                                                                                  channelContext) > 2048)
+    if(securityPolicy->asymmetricModule.cryptoModule.
+       getRemoteEncryptionKeyLength(securityPolicy, channelContext) > 2048)
         ++paddingBytes;
     size_t padding = (plainTextBlockSize - ((bytesToWrite + signatureSize + paddingBytes) % plainTextBlockSize));
     *paddingSize = (UA_Byte) (padding & 0xff);
@@ -292,9 +277,9 @@ hideBytesAsym(UA_SecureChannel *const channel, UA_Byte **const buf_start,
         *buf_end -= 2; // padding byte and extraPadding byte
 
         /* Add some overhead length due to RSA implementations adding a signature themselves */
-        *buf_end -= securityPolicy->channelModule
-                                  .getRemoteAsymEncryptionBufferLengthOverhead(channel->channelContext,
-                                                                               potentialEncryptionMaxSize);
+        *buf_end -= securityPolicy->channelModule.
+            getRemoteAsymEncryptionBufferLengthOverhead(channel->channelContext,
+                                                        potentialEncryptionMaxSize);
     }
 }
 
@@ -358,9 +343,8 @@ UA_SecureChannel_sendAsymmetricOPNMessage(UA_SecureChannel *channel, UA_UInt32 r
             *buf_pos = paddingSize;
             ++buf_pos;
         }
-        if(securityPolicy->asymmetricModule.cryptoModule.getRemoteEncryptionKeyLength(securityPolicy,
-                                                                                      channel->channelContext)
-           > 2048) {
+        if(securityPolicy->asymmetricModule.cryptoModule.
+           getRemoteEncryptionKeyLength(securityPolicy, channel->channelContext) > 2048) {
             *buf_pos = extraPaddingSize;
             ++buf_pos;
         }
@@ -465,35 +449,49 @@ calculatePaddingSym(const UA_SecurityPolicy *securityPolicy, const void *channel
     return padding;
 }
 
-/* Sends a message using symmetric encryption if defined
- *
- * @param ci the chunk information that is used to send the chunk.
- * @param buf_pos the position in the send buffer after the body was encoded.
- *                Should be less than or equal to buf_end.
- * @param buf_end the maximum position of the body. */
+static void
+setBufPos(UA_MessageContext *mc) {
+    const UA_SecureChannel *channel= mc->channel;
+    const UA_SecurityPolicy *securityPolicy = channel->securityPolicy;
+
+    /* Forward the data pointer so that the payload is encoded after the
+     * message header */
+    mc->buf_pos = &mc->messageBuffer.data[UA_SECURE_MESSAGE_HEADER_LENGTH];
+    mc->buf_end = &mc->messageBuffer.data[mc->messageBuffer.length];
+
+    if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
+       channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
+        mc->buf_end -= securityPolicy->symmetricModule.cryptoModule.
+            getLocalSignatureSize(securityPolicy, channel->channelContext);
+
+    /* Hide a byte needed for padding */
+    if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
+        mc->buf_end -= 2;
+}
+
 static UA_StatusCode
-sendChunkSymmetric(UA_ChunkInfo *ci, UA_Byte **buf_pos, const UA_Byte **buf_end) {
+sendSymmetricChunk(UA_MessageContext *mc) {
     UA_StatusCode res = UA_STATUSCODE_GOOD;
-    UA_SecureChannel *const channel = ci->channel;
+    UA_SecureChannel *const channel = mc->channel;
     const UA_SecurityPolicy *securityPolicy = channel->securityPolicy;
     UA_Connection *const connection = channel->connection;
     if(!connection)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* Will this chunk surpass the capacity of the SecureChannel for the message? */
-    UA_Byte *buf_body_start = ci->messageBuffer.data + UA_SECURE_MESSAGE_HEADER_LENGTH;
-    UA_Byte *buf_body_end = *buf_pos;
+    UA_Byte *buf_body_start = mc->messageBuffer.data + UA_SECURE_MESSAGE_HEADER_LENGTH;
+    const UA_Byte *buf_body_end = mc->buf_pos;
     size_t bodyLength = (uintptr_t) buf_body_end - (uintptr_t) buf_body_start;
-    ci->messageSizeSoFar += bodyLength;
-    ci->chunksSoFar++;
-    if(ci->messageSizeSoFar > connection->remoteConf.maxMessageSize &&
+    mc->messageSizeSoFar += bodyLength;
+    mc->chunksSoFar++;
+    if(mc->messageSizeSoFar > connection->remoteConf.maxMessageSize &&
        connection->remoteConf.maxMessageSize != 0)
         res = UA_STATUSCODE_BADRESPONSETOOLARGE;
-    if(ci->chunksSoFar > connection->remoteConf.maxChunkCount &&
+    if(mc->chunksSoFar > connection->remoteConf.maxChunkCount &&
        connection->remoteConf.maxChunkCount != 0)
         res = UA_STATUSCODE_BADRESPONSETOOLARGE;
     if(res != UA_STATUSCODE_GOOD) {
-        connection->releaseSendBuffer(channel->connection, &ci->messageBuffer);
+        connection->releaseSendBuffer(channel->connection, &mc->messageBuffer);
         return res;
     }
 
@@ -509,58 +507,59 @@ sendChunkSymmetric(UA_ChunkInfo *ci, UA_Byte **buf_pos, const UA_Byte **buf_end)
 
         // This is <= because the paddingSize byte also has to be written.
         for(UA_UInt16 i = 0; i <= totalPaddingSize; ++i) {
-            **buf_pos = paddingSize;
-            ++(*buf_pos);
+            *mc->buf_pos = paddingSize;
+            ++(mc->buf_pos);
         }
         if(extraPaddingSize > 0) {
-            **buf_pos = extraPaddingSize;
-            ++(*buf_pos);
+            *mc->buf_pos = extraPaddingSize;
+            ++(mc->buf_pos);
         }
     }
 
     /* The total message length */
-    size_t pre_sig_length = (uintptr_t) (*buf_pos) - (uintptr_t) ci->messageBuffer.data;
+    size_t pre_sig_length = (uintptr_t) (mc->buf_pos) - (uintptr_t) mc->messageBuffer.data;
     size_t total_length = pre_sig_length;
     if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
        channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
         total_length += securityPolicy->symmetricModule.cryptoModule.
             getLocalSignatureSize(securityPolicy, channel->channelContext);
+    mc->messageBuffer.length = total_length; /* For giving the buffer to the network layer */
 
     /* Encode the chunk headers at the beginning of the buffer */
     UA_assert(res == UA_STATUSCODE_GOOD);
-    UA_Byte *header_pos = ci->messageBuffer.data;
+    UA_Byte *header_pos = mc->messageBuffer.data;
     UA_SecureConversationMessageHeader respHeader;
     respHeader.secureChannelId = channel->securityToken.channelId;
-    respHeader.messageHeader.messageTypeAndChunkType = ci->messageType;
-    respHeader.messageHeader.messageSize = (UA_UInt32) total_length;
-    if(ci->final)
+    respHeader.messageHeader.messageTypeAndChunkType = mc->messageType;
+    respHeader.messageHeader.messageSize = (UA_UInt32)total_length;
+    if(mc->final)
         respHeader.messageHeader.messageTypeAndChunkType += UA_CHUNKTYPE_FINAL;
     else
         respHeader.messageHeader.messageTypeAndChunkType += UA_CHUNKTYPE_INTERMEDIATE;
     res = UA_encodeBinary(&respHeader, &UA_TRANSPORT[UA_TRANSPORT_SECURECONVERSATIONMESSAGEHEADER],
-                          &header_pos, buf_end, NULL, NULL);
+                          &header_pos, &mc->buf_end, NULL, NULL);
 
     UA_SymmetricAlgorithmSecurityHeader symSecHeader;
     symSecHeader.tokenId = channel->securityToken.tokenId;
     res |= UA_encodeBinary(&symSecHeader.tokenId,
                            &UA_TRANSPORT[UA_TRANSPORT_SYMMETRICALGORITHMSECURITYHEADER],
-                           &header_pos, buf_end, NULL, NULL);
+                           &header_pos, &mc->buf_end, NULL, NULL);
 
     UA_SequenceHeader seqHeader;
-    seqHeader.requestId = ci->requestId;
+    seqHeader.requestId = mc->requestId;
     seqHeader.sequenceNumber = UA_atomic_add(&channel->sendSequenceNumber, 1);
     res |= UA_encodeBinary(&seqHeader, &UA_TRANSPORT[UA_TRANSPORT_SEQUENCEHEADER],
-                           &header_pos, buf_end, NULL, NULL);
+                           &header_pos, &mc->buf_end, NULL, NULL);
 
     /* Sign message */
     if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
        channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT) {
-        UA_ByteString dataToSign = ci->messageBuffer;
+        UA_ByteString dataToSign = mc->messageBuffer;
         dataToSign.length = pre_sig_length;
         UA_ByteString signature;
         signature.length = securityPolicy->symmetricModule.cryptoModule.
             getLocalSignatureSize(securityPolicy, channel->channelContext);
-        signature.data = *buf_pos;
+        signature.data = mc->buf_pos;
         res |= securityPolicy->symmetricModule.cryptoModule.
             sign(securityPolicy, channel->channelContext, &dataToSign, &signature);
     }
@@ -568,115 +567,130 @@ sendChunkSymmetric(UA_ChunkInfo *ci, UA_Byte **buf_pos, const UA_Byte **buf_end)
     /* Encrypt message */
     if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT) {
         UA_ByteString dataToEncrypt;
-        dataToEncrypt.data = ci->messageBuffer.data + UA_SECUREMH_AND_SYMALGH_LENGTH;
+        dataToEncrypt.data = mc->messageBuffer.data + UA_SECUREMH_AND_SYMALGH_LENGTH;
         dataToEncrypt.length = total_length - UA_SECUREMH_AND_SYMALGH_LENGTH;
         res |= securityPolicy->symmetricModule.cryptoModule.
             encrypt(securityPolicy, channel->channelContext, &dataToEncrypt);
     }
 
     if(res != UA_STATUSCODE_GOOD) {
-        connection->releaseSendBuffer(channel->connection, &ci->messageBuffer);
+        connection->releaseSendBuffer(channel->connection, &mc->messageBuffer);
         return res;
     }
 
     /* Send the chunk, the buffer is freed in the network layer */
-    ci->messageBuffer.length = respHeader.messageHeader.messageSize;
-    res = connection->send(channel->connection, &ci->messageBuffer);
-    if(res != UA_STATUSCODE_GOOD)
-        return res;
+    return connection->send(channel->connection, &mc->messageBuffer);
+}
 
-    /* Replace with the buffer for the next chunk */
-    if(!ci->final) {
-        res = connection->getSendBuffer(connection, connection->localConf.sendBufferSize,
-                                        &ci->messageBuffer);
-        if(res != UA_STATUSCODE_GOOD)
-            return res;
+/* Callback from the encoding layer. Send the chunk and replace the buffer. */
+static UA_StatusCode
+sendSymmetricEncodingCallback(void *data, UA_Byte **buf_pos, const UA_Byte **buf_end) {
+    /* Set buf values from encoding in the messagecontext */
+    UA_MessageContext *mc = (UA_MessageContext*)data;
+    mc->buf_pos = *buf_pos;
+    mc->buf_end = *buf_end;
 
-        /* Forward the data pointer so that the payload is encoded after the
-         * message header */
-        *buf_pos = &ci->messageBuffer.data[UA_SECURE_MESSAGE_HEADER_LENGTH];
-        *buf_end = &ci->messageBuffer.data[ci->messageBuffer.length];
+    /* Send out */
+    UA_StatusCode retval = sendSymmetricChunk(mc);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
 
-        if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
-           channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
-            *buf_end -= securityPolicy->symmetricModule.cryptoModule.
-                getLocalSignatureSize(securityPolicy, channel->channelContext);
+    /* Set a new buffer for the next chunk */
+    UA_Connection *connection = mc->channel->connection;
+    retval = connection->getSendBuffer(connection, connection->localConf.sendBufferSize,
+                                       &mc->messageBuffer);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
 
-        /* Hide a byte needed for padding */
-        if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
-            *buf_end -= 2;
-    }
-    return res;
+    /* Hide bytes for header, padding and signature */
+    setBufPos(mc);
+    *buf_pos = mc->buf_pos;
+    *buf_end = mc->buf_end;
+    return UA_STATUSCODE_GOOD;
 }
 
 UA_StatusCode
-UA_SecureChannel_sendSymmetricMessage(UA_SecureChannel *channel, UA_UInt32 requestId,
-                                      UA_MessageType messageType, const void *content,
-                                      const UA_DataType *contentType) {
-    const UA_SecurityPolicy *const securityPolicy = channel->securityPolicy;
+UA_MessageContext_begin(UA_MessageContext *mc, UA_SecureChannel *channel,
+                        UA_UInt32 requestId, UA_MessageType messageType) {
     UA_Connection *connection = channel->connection;
     if(!connection)
         return UA_STATUSCODE_BADINTERNALERROR;
+
+    /* Create the chunking info structure */
+    mc->channel = channel;
+    mc->requestId = requestId;
+    mc->chunksSoFar = 0;
+    mc->messageSizeSoFar = 0;
+    mc->final = false;
+    mc->messageBuffer = UA_BYTESTRING_NULL;
+    mc->messageType = messageType;
 
     /* Minimum required size */
     if(connection->localConf.sendBufferSize <= UA_SECURE_MESSAGE_HEADER_LENGTH)
         return UA_STATUSCODE_BADRESPONSETOOLARGE;
 
-    /* Create the chunking info structure */
-    UA_ChunkInfo ci;
-    ci.channel = channel;
-    ci.requestId = requestId;
-    ci.chunksSoFar = 0;
-    ci.messageSizeSoFar = 0;
-    ci.final = false;
-    ci.messageBuffer = UA_BYTESTRING_NULL;
-    ci.messageType = messageType;
-
     /* Allocate the message buffer */
     UA_StatusCode retval =
         connection->getSendBuffer(connection, connection->localConf.sendBufferSize,
-                                  &ci.messageBuffer);
+                                  &mc->messageBuffer);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
-    /* Hide the message beginning where the header will be encoded */
-    UA_Byte *buf_start = &ci.messageBuffer.data[UA_SECURE_MESSAGE_HEADER_LENGTH];
-    const UA_Byte *buf_end = &ci.messageBuffer.data[ci.messageBuffer.length];
+    /* Hide bytes for header, padding and signature */
+    setBufPos(mc);
+    return UA_STATUSCODE_GOOD;
+}
 
-    /* Hide bytes for signature */
-    if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
-       channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
-        buf_end -= securityPolicy->symmetricModule.cryptoModule.
-            getLocalSignatureSize(securityPolicy, channel->channelContext);
-
-    /* Hide one byte for padding */
-    if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
-        buf_end -= 2;
-
-    /* Encode the message type */
-    UA_NodeId typeId = UA_NODEID_NUMERIC(0, contentType->binaryEncodingId);
-    retval = UA_encodeBinary(&typeId, &UA_TYPES[UA_TYPES_NODEID],
-                             &buf_start, &buf_end, NULL, NULL);
-
-    /* Encode with the chunking callback */
-    retval |= UA_encodeBinary(content, contentType, &buf_start, &buf_end,
-                              (UA_exchangeEncodeBuffer) sendChunkSymmetric, &ci);
-
-    /* TODO: Error handling. Send out an abort chunk if this is not the first chunk.
-     * If this is the first chunk of the message:
-     * - Client: Do nothing, maybe revert the sequence number?
-     * - Server: Send a ServiceFault response? Depending on which error codes? */
+UA_StatusCode
+UA_MessageContext_encode(UA_MessageContext *mc, const void *content,
+                         const UA_DataType *contentType) {
+    UA_StatusCode retval = UA_encodeBinary(content, contentType, &mc->buf_pos, &mc->buf_end,
+                                           sendSymmetricEncodingCallback, mc);
     if(retval != UA_STATUSCODE_GOOD) {
-        /* the abort message was not sent */
-        if(!ci.final)
-            sendChunkSymmetric(&ci, &buf_start, &buf_end);
-        connection->releaseSendBuffer(connection, &ci.messageBuffer);
-        return retval;
+        /* TODO: Send the abort message */
+        if(mc->messageBuffer.length > 0) {
+            UA_Connection *connection = mc->channel->connection;
+            connection->releaseSendBuffer(connection, &mc->messageBuffer);
+        }
     }
+    return retval;
+}
 
-    /* Encoding finished, send the final chunk */
-    ci.final = UA_TRUE;
-    return sendChunkSymmetric(&ci, &buf_start, &buf_end);
+UA_StatusCode
+UA_MessageContext_finish(UA_MessageContext *mc) {
+    mc->final = true;
+    return sendSymmetricChunk(mc);
+}
+
+void
+UA_MessageContext_abort(UA_MessageContext *mc) {
+    UA_ByteString_deleteMembers(&mc->messageBuffer);
+}
+
+UA_StatusCode
+UA_SecureChannel_sendSymmetricMessage(UA_SecureChannel *channel, UA_UInt32 requestId,
+                                      UA_MessageType messageType, void *payload,
+                                      const UA_DataType *payloadType) {
+    UA_MessageContext mc;
+    UA_StatusCode retval;
+    UA_NodeId typeId = UA_NODEID_NUMERIC(0, payloadType->binaryEncodingId);
+    retval = UA_MessageContext_begin(&mc, channel, requestId, UA_MESSAGETYPE_MSG);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* Assert's required for clang-analyzer */
+    UA_assert(mc.buf_pos == &mc.messageBuffer.data[UA_SECURE_MESSAGE_HEADER_LENGTH]);
+    UA_assert(mc.buf_end == &mc.messageBuffer.data[mc.messageBuffer.length]);
+
+    retval |= UA_MessageContext_encode(&mc, &typeId, &UA_TYPES[UA_TYPES_NODEID]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    retval |= UA_MessageContext_encode(&mc, payload, payloadType);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    return UA_MessageContext_finish(&mc);
 }
 
 /*****************************/
@@ -794,8 +808,7 @@ decryptChunk(UA_SecureChannel *channel, const UA_SecurityPolicyCryptoModule *cry
        channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT ||
        messageType == UA_MESSAGETYPE_OPN) {
         /* Compute the padding size */
-        sigsize = cryptoModule->
-                                  getRemoteSignatureSize(securityPolicy, channel->channelContext);
+        sigsize = cryptoModule-> getRemoteSignatureSize(securityPolicy, channel->channelContext);
 
         if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT ||
            (messageType == UA_MESSAGETYPE_OPN &&
@@ -803,7 +816,7 @@ decryptChunk(UA_SecureChannel *channel, const UA_SecurityPolicyCryptoModule *cry
             paddingSize = chunk->data[chunkSizeAfterDecryption - sigsize - 1];
 
             size_t keyLength = cryptoModule->
-                                               getRemoteEncryptionKeyLength(securityPolicy, channel->channelContext);
+                getRemoteEncryptionKeyLength(securityPolicy, channel->channelContext);
             if(keyLength > 2048) {
                 paddingSize <<= 8; /* Extra padding size */
                 paddingSize += chunk->data[chunkSizeAfterDecryption - sigsize - 2];

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <src_generated/ua_types_generated.h>
-#include <testing_networklayers.h>
 #include <ua_types_encoding_binary.h>
 #include <src_generated/ua_transport_generated_encoding_binary.h>
 #include <src_generated/ua_transport_generated.h>
@@ -14,6 +13,7 @@
 #include <ua_plugin_securitypolicy.h>
 #include <src_generated/ua_transport_generated_handling.h>
 
+#include "testing_networklayers.h"
 #include "testing_policy.h"
 #include "ua_securechannel.h"
 
@@ -44,7 +44,7 @@ setup_secureChannel(void) {
     TestingPolicy(&dummyPolicy, dummyCertificate, &fCalled, &keySizes);
     UA_SecureChannel_init(&testChannel, &dummyPolicy, &dummyCertificate);
 
-    testingConnection = createDummyConnection(&sentData);
+    testingConnection = createDummyConnection(65535, &sentData);
     UA_Connection_attachSecureChannel(&testingConnection, &testChannel);
     testChannel.connection = &testingConnection;
 }
@@ -53,8 +53,7 @@ static void
 teardown_secureChannel(void) {
     UA_SecureChannel_deleteMembersCleanup(&testChannel);
     dummyPolicy.deleteMembers(&dummyPolicy);
-
-    memset(&testingConnection, 0, sizeof(UA_Connection));
+    testingConnection.close(&testingConnection);
 }
 
 static void

--- a/tests/fuzz/fuzz_binary_message.cc
+++ b/tests/fuzz/fuzz_binary_message.cc
@@ -14,8 +14,7 @@
 */
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    UA_ByteString sentData = UA_BYTESTRING_NULL;
-    UA_Connection c = createDummyConnection(&sentData);
+    UA_Connection c = createDummyConnection(65535, NULL);
     UA_ServerConfig *config = UA_ServerConfig_new_default();
     UA_Server *server = UA_Server_new(config);
 

--- a/tests/testing-plugins/testing_networklayers.c
+++ b/tests/testing-plugins/testing_networklayers.c
@@ -8,20 +8,22 @@
 #include "testing_clock.h"
 #include "ua_config_default.h"
 
-UA_ByteString *vBuffer;
+static UA_ByteString *vBuffer;
+static UA_ByteString sendBuffer;
 
 UA_StatusCode UA_Client_recvTesting_result = UA_STATUSCODE_GOOD;
 
 static UA_StatusCode
 dummyGetSendBuffer(UA_Connection *connection, size_t length, UA_ByteString *buf) {
-    buf->data = (length == 0) ? NULL : (UA_Byte*)UA_malloc(length);
+    if(length > sendBuffer.length)
+        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
+    *buf = sendBuffer;
     buf->length = length;
     return UA_STATUSCODE_GOOD;
 }
 
 static void
 dummyReleaseSendBuffer(UA_Connection *connection, UA_ByteString *buf) {
-    UA_ByteString_deleteMembers(buf);
 }
 
 static UA_StatusCode
@@ -29,9 +31,10 @@ dummySend(UA_Connection *connection, UA_ByteString *buf) {
     assert(connection != NULL);
     assert(buf != NULL);
 
-    UA_ByteString_deleteMembers(vBuffer);
-    UA_ByteString_copy(buf, vBuffer);
-    UA_ByteString_deleteMembers(buf);
+    if(vBuffer) {
+        UA_ByteString_deleteMembers(vBuffer);
+        UA_ByteString_copy(buf, vBuffer);
+    }
     return UA_STATUSCODE_GOOD;
 }
 
@@ -41,13 +44,16 @@ dummyReleaseRecvBuffer(UA_Connection *connection, UA_ByteString *buf) {
 
 static void
 dummyClose(UA_Connection *connection) {
-    UA_ByteString_deleteMembers(vBuffer);
+    if(vBuffer)
+        UA_ByteString_deleteMembers(vBuffer);
+    UA_ByteString_deleteMembers(&sendBuffer);
 }
 
-UA_Connection createDummyConnection(UA_ByteString *verificationBuffer) {
-    assert(verificationBuffer != NULL);
-
+UA_Connection createDummyConnection(size_t sendBufferSize,
+                                    UA_ByteString *verificationBuffer) {
     vBuffer = verificationBuffer;
+    UA_ByteString_allocBuffer(&sendBuffer, sendBufferSize);
+
     UA_Connection c;
     c.state = UA_CONNECTION_ESTABLISHED;
     c.localConf = UA_ConnectionConfig_default;

--- a/tests/testing-plugins/testing_networklayers.h
+++ b/tests/testing-plugins/testing_networklayers.h
@@ -11,12 +11,15 @@
 extern "C" {
 #endif
 
-/** @brief Create the TCP networklayer and listen to the specified port
+/**
+ * Create the TCP networklayer and listen to the specified port
  *
- * @param verificationBuffer the send function will write the data that is sent to this buffer, so that it is
- *                           possible to check what the send function received.
- */
-UA_Connection createDummyConnection(UA_ByteString *verificationBuffer);
+ * @param sendBufferSize The send buffer is reused. This is the max chunk size
+ * @param verificationBuffer the send function will copy the data that is sent
+ *        to this buffer, so that it is possible to check what the send function
+ *        received. */
+UA_Connection createDummyConnection(size_t sendBufferSize,
+                                    UA_ByteString *verificationBuffer);
 
 /**
  * Simulate network timing conditions


### PR DESCRIPTION
This PR is split in two commits:
- build up infrastructure for zero-copy services where we encode (and send) between operations of the same service
- use that for a zero-copy implementation of the read service. If possible, we can encode the value directly to the network buffer