### PR TITLE
ua_network_tcp select check error

### DIFF
--- a/plugins/ua_network_tcp.c
+++ b/plugins/ua_network_tcp.c
@@ -194,6 +194,12 @@ connection_recv(UA_Connection *connection, UA_ByteString *response,
         /* No result */
         if(resultsize == 0)
             return UA_STATUSCODE_GOODNONCRITICALTIMEOUT;
+
+        /* Error occurred */
+        if (resultsize == -1) {
+            connection->close(connection);
+            return UA_STATUSCODE_BADCONNECTIONCLOSED;
+        }
     }
 
     response->data = (UA_Byte*)


### PR DESCRIPTION
For example, pressing ctrl+c in client_subscription_loop cause "select" returning -1. After, the client infinity wait in the next recv. We must check when select return -1.