### PR TITLE
Additional logic of setting monitoring mode

### DIFF
--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -390,7 +390,7 @@ Operation_SetMonitoringMode(UA_Server *server, UA_Session *session,
         return;
 
     mon->monitoringMode = smc->monitoringMode;
-    if(mon->monitoringMode == UA_MONITORINGMODE_REPORTING)
+    if(mon->monitoringMode == UA_MONITORINGMODE_REPORTING) {
         MonitoredItem_registerSampleCallback(server, mon);
     } else if (mon->monitoringMode == UA_MONITORINGMODE_DISABLED) {
         /*  Setting the mode to DISABLED causes all queued Notifications to be delete */

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -390,6 +390,11 @@ Operation_SetMonitoringMode(UA_Server *server, UA_Session *session,
         return;
     }
 
+    /* check monitoringMode is valid or not */
+    if(op_monitoringMode > UA_MONITORINGMODE_REPORTING) {
+        return;
+    }
+
     if(mon->monitoringMode == op_monitoringMode)
         return;
 
@@ -400,16 +405,14 @@ Operation_SetMonitoringMode(UA_Server *server, UA_Session *session,
         /*  Setting the mode to DISABLED causes all queued Notifications to be delete */
         MonitoredItem_queuedValue *val, *val_tmp;
         TAILQ_FOREACH_SAFE(val, &mon->queue, listEntry, val_tmp) {
-			TAILQ_REMOVE(&mon->queue, val, listEntry);
-			UA_DataValue_deleteMembers(&val->value);
-			UA_free(val);
-		}
-		mon->currentQueueSize = 0;
+            TAILQ_REMOVE(&mon->queue, val, listEntry);
+            UA_DataValue_deleteMembers(&val->value);
+            UA_free(val);
+        }
+        mon->currentQueueSize = 0;
 
-		/* initialize lastSampledValue */
-		mon->lastSampledValue.data = NULL;
-		mon->lastSampledValue.length = 0;
-
+        /* initialize lastSampledValue */
+        UA_ByteString_deleteMembers(&mon->lastSampledValue);
         MonitoredItem_unregisterSampleCallback(server, mon);
     }
 }


### PR DESCRIPTION
fix #1520  issue.

This commit is related with service specification (Part4)

```
7.18 Monitoring Mode

DISABLED_0
The item being monitored is not sampled or evaluated, and Notifications are not generated or queued. Notification reporting is disabled.

REPORTING_2
The item being monitored is sampled and evaluated, and Notifications are generated and queued. Notification reporting is enabled.
```