### PR TITLE
Enable CI encryption, temporarily disabled OSX and appveyor latex builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,13 @@ matrix:
     #- os: linux
     #  compiler: gcc
     #  env: LINT=true
-    # - os: osx
-    #   compiler: clang
-    #   # disable homebrew auto update which takes a lot of time
-    #   env: HOMEBREW_NO_AUTO_UPDATE=1
-    #   cache:
-    #     directories:
-    #       - $HOME/Library/Caches/Homebrew
+    - os: osx
+      compiler: clang
+      # disable homebrew auto update which takes a lot of time
+      env: HOMEBREW_NO_AUTO_UPDATE=1
+      cache:
+        directories:
+          - $HOME/Library/Caches/Homebrew
 
 addons:
   apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,13 @@ if(UA_ENABLE_COVERAGE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 
+if(UA_BUILD_FUZZING OR UA_BUILD_OSS_FUZZ OR UA_BUILD_FUZZING_CORPUS)
+    # Force enable options not passed in the build script, to also fuzzy-test this code
+    set(UA_ENABLE_DISCOVERY ON CACHE STRING "" FORCE)
+    set(UA_ENABLE_DISCOVERY_MULTICAST ON CACHE STRING "" FORCE)
+    set(UA_ENABLE_ENCRYPTION ON CACHE STRING "" FORCE)
+endif()
+
 if(UA_ENABLE_DISCOVERY_MULTICAST AND NOT UA_ENABLE_DISCOVERY)
     MESSAGE(WARNING "UA_ENABLE_DISCOVERY_MULTICAST is enabled, but not UA_ENABLE_DISCOVERY. UA_ENABLE_DISCOVERY_MULTICAST will be set to OFF")
     SET(UA_ENABLE_DISCOVERY_MULTICAST OFF CACHE BOOL "Enable Discovery Service with multicast support (LDS-ME)" FORCE)
@@ -688,9 +695,6 @@ if(UA_BUILD_UNIT_TESTS)
 endif()
 
 if(UA_BUILD_FUZZING OR UA_BUILD_OSS_FUZZ OR UA_BUILD_FUZZING_CORPUS)
-    # Force enable discovery, to also fuzzy-test this code
-    set(UA_ENABLE_DISCOVERY ON CACHE STRING "" FORCE)
-    set(UA_ENABLE_DISCOVERY_MULTICAST ON CACHE STRING "" FORCE)
     add_subdirectory(tests/fuzz)
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ environment:
 cache:
   - C:\ProgramData\chocolatey\bin -> tools/appveyor/install.ps1
   - C:\ProgramData\chocolatey\lib -> tools/appveyor/install.ps1
+  - C:\tools\vcpkg\installed -> tools/appveyor/install.ps1
   #- 'c:\miktex'
 
 init:
@@ -50,7 +51,7 @@ install:
 
 before_build:
   # Add installed tools to PATH
-  - set PATH=C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin;C:\Program Files (x86)\Dr. Memory\bin;C:\Program Files\CMake\bin;%PATH%
+  - set PATH=C:\Python27;C:\msys64\mingw64\bin;C:\Program Files (x86)\Dr. Memory\bin;C:\Program Files\CMake\bin;%PATH%
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   # Miktex

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,18 @@
+# Load CMake Packages
+find_package(Check REQUIRED)
+set(LIBS ${CHECK_LIBRARIES} ${open62541_LIBRARIES})
+include_directories(${CHECK_INCLUDE_DIRS})
+find_package(Threads REQUIRED)
+if(NOT MSVC AND UA_ENABLE_UNIT_TESTS_MEMCHECK)
+    find_package(Valgrind REQUIRED)
+endif()
+
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/deps)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/src/server)
 include_directories(${PROJECT_SOURCE_DIR}/plugins)
 include_directories(${PROJECT_BINARY_DIR}/src_generated)
-include_directories(${CHECK_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR}/tests/testing-plugins)
 
 #############################
@@ -18,18 +26,6 @@ else()
 	set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests)
 endif()
 
-# Load CMake Packages
-find_package(Check REQUIRED)
-find_package(Threads REQUIRED)
-if(NOT MSVC AND UA_ENABLE_UNIT_TESTS_MEMCHECK)
-    find_package(Valgrind REQUIRED)
-endif()
-
-set(LIBS ${CHECK_LIBRARIES} ${open62541_LIBRARIES})
-if(NOT MSVC)
-    LIST(APPEND LIBS subunit)
-endif()
-include_directories(${CHECK_INCLUDE_DIRS})
 
 # Use different plugins for testing
 set(test_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.c

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -61,6 +61,11 @@ set(fuzzing_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.c
         ${PROJECT_SOURCE_DIR}/plugins/ua_pki_certificate.c
         ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_none.c)
 
+if(UA_ENABLE_ENCRYPTION)
+    set(fuzzing_plugin_sources ${fuzzing_plugin_sources}
+        ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.c)
+endif()
+
 add_library(open62541-fuzzplugins OBJECT ${fuzzing_plugin_sources})
 add_dependencies(open62541-fuzzplugins open62541)
 

--- a/tests/fuzz/generate_corpus.sh
+++ b/tests/fuzz/generate_corpus.sh
@@ -32,7 +32,7 @@ else
 	export CXX=clang++-3.9
 fi
 # First build and run the unit tests without any specific fuzz settings
-cmake -DUA_BUILD_FUZZING_CORPUS=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON ..
+cmake -DUA_BUILD_FUZZING_CORPUS=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_ENABLE_ENCRYPTION=ON ..
 make -j && make test ARGS="-V"
 if [ $? -ne 0 ] ; then exit 1 ; fi
 # Run our special generator

--- a/tools/appveyor/build.ps1
+++ b/tools/appveyor/build.ps1
@@ -10,24 +10,24 @@ Copy-Item LICENSE pack
 Copy-Item AUTHORS pack
 Copy-Item README.md pack
 
-# Write-Host -ForegroundColor Green "`n###################################################################"
-# Write-Host -ForegroundColor Green "`n##### Building Documentation on $env:CC_NAME #####`n"
-# New-Item -ItemType directory -Path build
-# cd build
-# & cmake -DMIKTEX_BINARY_PATH=c:\miktex\texmfs\install\miktex\bin -DCMAKE_BUILD_TYPE=Release -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DUA_BUILD_EXAMPLES:BOOL=OFF -G"$env:CC_NAME" ..
-# & cmake --build . --target doc_latex
-# if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-# 	Write-Host -ForegroundColor Red "`n`n*** Make doc_latex. Exiting ... ***"
-# 	exit $LASTEXITCODE
-# }
-# & cmake --build . --target doc_pdf
-# if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-# 	Write-Host -ForegroundColor Red "`n`n*** Make doc_pdf. Exiting ... ***"
-# 	exit $LASTEXITCODE
-# }
-# cd ..
-# Move-Item -Path "build\doc_latex\open62541.pdf" -Destination pack\
-# Remove-Item -Path build -Recurse -Force
+Write-Host -ForegroundColor Green "`n###################################################################"
+Write-Host -ForegroundColor Green "`n##### Building Documentation on $env:CC_NAME #####`n"
+New-Item -ItemType directory -Path build
+cd build
+& cmake -DMIKTEX_BINARY_PATH=c:\miktex\texmfs\install\miktex\bin -DCMAKE_BUILD_TYPE=Release -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DUA_BUILD_EXAMPLES:BOOL=OFF -G"$env:CC_NAME" ..
+& cmake --build . --target doc_latex
+if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+	Write-Host -ForegroundColor Red "`n`n*** Make doc_latex. Exiting ... ***"
+	exit $LASTEXITCODE
+}
+& cmake --build . --target doc_pdf
+if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+	Write-Host -ForegroundColor Red "`n`n*** Make doc_pdf. Exiting ... ***"
+	exit $LASTEXITCODE
+}
+cd ..
+Move-Item -Path "build\doc_latex\open62541.pdf" -Destination pack\
+Remove-Item -Path build -Recurse -Force
 
 Write-Host -ForegroundColor Green "`n###################################################################"
 Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME #####`n"
@@ -113,7 +113,7 @@ if ($env:CC_SHORTNAME -eq "vs2015") {
 	Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with unit tests #####`n"
 	New-Item -ItemType directory -Path "build"
 	cd build
-	& cmake -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=OFF -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON -DCMAKE_LIBRARY_PATH=c:\check\lib -DCMAKE_INCLUDE_PATH=c:\check\include -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -G"$env:CC_NAME" ..
+	& cmake -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=OFF -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_ENABLE_ENCRYPTION=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON -DCMAKE_LIBRARY_PATH=c:\check\lib -DCMAKE_INCLUDE_PATH=c:\check\include -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -G"$env:CC_NAME" ..
 	Invoke-Expression $make_cmd
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
     	Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"

--- a/tools/appveyor/install.ps1
+++ b/tools/appveyor/install.ps1
@@ -4,6 +4,7 @@ $ErrorActionPreference = "Stop"
 
 Write-Host -ForegroundColor Green "`n### Installing CMake and python ###`n"
 & cinst --no-progress cmake python2
+& C:\Python27\Scripts\pip.exe install six
 
 Write-Host -ForegroundColor Green "`n### Installing sphinx ###`n"
 & pip install --user sphinx sphinx_rtd_theme
@@ -21,7 +22,25 @@ if (-not (Test-Path "c:\miktex\texmfs\install\miktex\bin\pdflatex.exe")) {
 }
 
 Write-Host -ForegroundColor Green "`n### Installing graphviz ###`n"
-& cinst --no-progress graphviz.portable
+& cinst --no-progress graphviz
+if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+	Write-Host -ForegroundColor Red "`n`n*** Installing graphviz failed. Exiting ... ***"
+	exit $LASTEXITCODE
+}
+
+Write-Host -ForegroundColor Green "`n### Installing mbedtls ###`n"
+
+if ($env:CC_SHORTNAME -eq "mingw") {
+	& C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-mbedtls
+} elseif ($env:CC_SHORTNAME -eq "vs2015") {
+	# we need the static version, since open62541 is built with /MT
+	# vcpkg currently only supports VS2015 and newer builds
+	& vcpkg install mbedtls:x86-windows-static
+}
+if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+	Write-Host -ForegroundColor Red "`n`n*** Installing mbedtls failed. Exiting ... ***"
+	exit $LASTEXITCODE
+}
 
 if ($env:CC_SHORTNAME -eq "vs2015") {
 	Write-Host -ForegroundColor Green "`n### Installing libcheck ###`n"

--- a/tools/cmake/FindCheck.cmake
+++ b/tools/cmake/FindCheck.cmake
@@ -1,64 +1,73 @@
-# - Try to find the CHECK libraries
-#  Once done this will define
+# Find CHECK libraries
 #
+# This module defines:
 #  CHECK_FOUND - system has check
 #  CHECK_INCLUDE_DIRS - the check include directory
 #  CHECK_LIBRARIES - check library
-#  
-#  Copyright (c) 2007 Daniel Gollub <gollub@b1-systems.de>
-#  Copyright (c) 2007-2009 Bjoern Ricks  <bjoern.ricks@gmail.com>
 #
-#  Redistribution and use is allowed according to the terms of the New
-#  BSD license.
-#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+# If you have libcheck installed in a non-standard place, you can define
+# CHECK_PREFIX to tell cmake where it is.
 
-
-INCLUDE( FindPkgConfig )
-
-IF ( Check_FIND_REQUIRED )
-	SET( _pkgconfig_REQUIRED "REQUIRED" )
-ELSE( Check_FIND_REQUIRED )
-	SET( _pkgconfig_REQUIRED "" )	
-ENDIF ( Check_FIND_REQUIRED )
-
-if(NOT MSVC)
-	IF ( CHECK_MIN_VERSION )
-		PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check>=${CHECK_MIN_VERSION} )
-	ELSE ( CHECK_MIN_VERSION )
-		PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check )
-	ENDIF ( CHECK_MIN_VERSION )
+if(CHECK_PREFIX)
+    set(CHECK_PREFIX_INC "${CHECK_PREFIX}/include")
+    set(CHECK_PREFIX_LIB "${CHECK_PREFIX}/lib")
 endif()
 
-# Look for CHECK include dir and libraries
-IF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+find_path(CHECK_INCLUDE_DIRS check.h "${CHECK_PREFIX_INC}")
+find_library(CHECK_LIBRARY check HINTS "${CHECK_PREFIX_LIB}")
 
-	FIND_PATH( CHECK_INCLUDE_DIRS check.h )
+if(MSVC)
 
-	FIND_LIBRARY( CHECK_LIBRARIES NAMES check )
-
-	if (MSVC)
-		FIND_LIBRARY( CHECK_COMPAT_LIBRARIES NAMES compat )
-	endif()
+    find_library(COMPAT_LIBRARY compat HINTS "${CHECK_PREFIX_LIB}")
+    set(CHECK_LIBRARIES "${CHECK_LIBRARY}" "${COMPAT_LIBRARY}")
 
 
-	IF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
-		if ( CHECK_COMPAT_LIBRARIES )
-			LIST(APPEND CHECK_LIBRARIES "${CHECK_COMPAT_LIBRARIES}")
-		endif()
-		SET( CHECK_FOUND 1 )
-		IF ( NOT Check_FIND_QUIETLY )
-			MESSAGE ( STATUS "Found CHECK: ${CHECK_LIBRARIES}" )
-		ENDIF ( NOT Check_FIND_QUIETLY )
-	ELSE ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
-		IF ( Check_FIND_REQUIRED )
-			MESSAGE( FATAL_ERROR "Could NOT find CHECK" )
-		ELSE ( Check_FIND_REQUIRED )
-			IF ( NOT Check_FIND_QUIETLY )
-				MESSAGE( STATUS "Could NOT find CHECK" )	
-			ENDIF ( NOT Check_FIND_QUIETLY )
-		ENDIF ( Check_FIND_REQUIRED )
-	ENDIF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
-ENDIF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(CHECK DEFAULT_MSG	CHECK_INCLUDE_DIRS CHECK_LIBRARIES)
 
-# Hide advanced variables from CMake GUIs
-MARK_AS_ADVANCED( CHECK_INCLUDE_DIRS CHECK_LIBRARIES )
+    mark_as_advanced(CHECK_INCLUDE_DIRS CHECK_LIBRARIES)
+else()
+
+    INCLUDE( FindPkgConfig )
+
+    IF ( Check_FIND_REQUIRED )
+        SET( _pkgconfig_REQUIRED "REQUIRED" )
+    ELSE( Check_FIND_REQUIRED )
+        SET( _pkgconfig_REQUIRED "" )
+    ENDIF ( Check_FIND_REQUIRED )
+
+    IF ( CHECK_MIN_VERSION )
+        PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check>=${CHECK_MIN_VERSION} )
+    ELSE ( CHECK_MIN_VERSION )
+        PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check )
+    ENDIF ( CHECK_MIN_VERSION )
+
+    # Look for CHECK include dir and libraries
+    IF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+
+        SET(CHECK_LIBRARIES "CHECK_LIBRARIES-NOTFOUND")
+        FIND_LIBRARY( SUBUNIT_LIBRARY NAMES subunit HINTS "${CHECK_PREFIX_LIB}")
+
+        IF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARY )
+            SET(CHECK_LIBRARIES "${CHECK_LIBRARY}")
+            if ( SUBUNIT_LIBRARY )
+                LIST(APPEND CHECK_LIBRARIES "${SUBUNIT_LIBRARY}")
+            endif()
+            SET( CHECK_FOUND 1 )
+            IF ( NOT Check_FIND_QUIETLY )
+                MESSAGE ( STATUS "Found CHECK: ${CHECK_LIBRARIES}" )
+            ENDIF ( NOT Check_FIND_QUIETLY )
+        ELSE ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+            IF ( Check_FIND_REQUIRED )
+                MESSAGE( FATAL_ERROR "Could NOT find CHECK" )
+            ELSE ( Check_FIND_REQUIRED )
+                IF ( NOT Check_FIND_QUIETLY )
+                    MESSAGE( STATUS "Could NOT find CHECK" )
+                ENDIF ( NOT Check_FIND_QUIETLY )
+            ENDIF ( Check_FIND_REQUIRED )
+        ENDIF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+    ENDIF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+
+    # Hide advanced variables from CMake GUIs
+    MARK_AS_ADVANCED( CHECK_INCLUDE_DIRS CHECK_LIBRARIES )
+endif()

--- a/tools/travis/travis_linux_before_install.sh
+++ b/tools/travis/travis_linux_before_install.sh
@@ -21,7 +21,7 @@ if [ -z ${DOCKER+x} ]; then
 	if [ "$CC" = "tcc" ]; then
 		mkdir tcc_install && cd tcc_install
 		wget https://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27.tar.bz2
-		tar xvf tcc-0.9.27.tar.bz2
+		tar xf tcc-0.9.27.tar.bz2
 		cd tcc-0.9.27
 		./configure
 		make
@@ -30,8 +30,13 @@ if [ -z ${DOCKER+x} ]; then
 		rm -rf tcc_install
 	fi
 
-	sudo add-apt-repository -y ppa:lttng/ppa
-	sudo apt-get update -qq
+	wget https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.6.1.tar.gz
+	tar xf mbedtls-2.6.1.tar.gz
+	cd mbedtls-mbedtls-2.6.1
+	cmake -DENABLE_TESTING=Off .
+	make -j
+	sudo make install
+
 	echo -en 'travis_fold:end:script.before_install.external\\r'
 
 	echo "=== Installing python packages ===" && echo -en 'travis_fold:start:before_install.python\\r'

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -25,11 +25,11 @@ fi
 if ! [ -z ${FUZZER+x} ]; then
     # Test the corpus generator and use new corpus for fuzz test
     ./tests/fuzz/generate_corpus.sh
-	if [ $? -ne 0 ] ; then exit 1 ; fi
+    if [ $? -ne 0 ] ; then exit 1 ; fi
 
-	cd build_fuzz
-	make && make run_fuzzer
-	if [ $? -ne 0 ] ; then exit 1 ; fi
+    cd build_fuzz
+    make && make run_fuzzer
+    if [ $? -ne 0 ] ; then exit 1 ; fi
     exit 0
 fi
 
@@ -172,58 +172,71 @@ else
     make -j
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
+    echo -en 'travis_fold:end:script.build.shared_libs\\r'
 
-	if [ "$CC" != "tcc" ]; then
-		echo -en 'travis_fold:end:script.build.shared_libs\\r'echo -e "\r\n==Compile multithreaded version==" && echo -en 'travis_fold:start:script.build.multithread\\r'
-		mkdir -p build && cd build
-		cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLES=ON ..
-		make -j
-		if [ $? -ne 0 ] ; then exit 1 ; fi
-		cd .. && rm build -rf
-		echo -en 'travis_fold:end:script.build.multithread\\r'
-	fi
+    if [ "$CC" != "tcc" ]; then
+        echo -e "\r\n==Compile multithreaded version==" && echo -en 'travis_fold:start:script.build.multithread\\r'
+        mkdir -p build && cd build
+        cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_MULTITHREADING=ON -DUA_BUILD_EXAMPLES=ON ..
+        make -j
+        if [ $? -ne 0 ] ; then exit 1 ; fi
+        cd .. && rm build -rf
+        echo -en 'travis_fold:end:script.build.multithread\\r'
+    fi
 
-    echo -e "\r\n== Compile without discovery version ==" && echo -en 'travis_fold:start:script.build.unit_test_valgrind\\r'
+    echo -e "\r\n== Compile with encryption ==" && echo -en 'travis_fold:start:script.build.encryption\\r'
+    mkdir -p build && cd build
+    cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_ENCRYPTION=ON -DUA_BUILD_EXAMPLES=ON ..
+    make -j
+    if [ $? -ne 0 ] ; then exit 1 ; fi
+    cd .. && rm build -rf
+    echo -en 'travis_fold:end:script.build.encryption\\r'
+
+    echo -e "\r\n== Compile without discovery version ==" && echo -en 'travis_fold:start:script.build.discovery\\r'
     mkdir -p build && cd build
     cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_DISCOVERY=OFF -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
     make -j
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
+    echo -en 'travis_fold:end:script.build.discovery\\r'
 
-    echo -e "\r\n== Compile discovery without multicast version =="
+    echo -e "\r\n== Compile discovery without multicast version ==" && echo -en 'travis_fold:start:script.build.multicast\\r'
     mkdir -p build && cd build
     cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=OFF -DUA_BUILD_EXAMPLES=ON ..
     make -j
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
+    echo -en 'travis_fold:end:script.build.multicast\\r'
 
-	if [ "$CC" != "tcc" ]; then
-		echo -e "\r\n== Compile multithreaded version with discovery =="
-		mkdir -p build && cd build
-		cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_MULTITHREADING=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_EXAMPLES=ON ..
-		make -j
-		if [ $? -ne 0 ] ; then exit 1 ; fi
-		cd .. && rm build -rf
-		echo -en 'travis_fold:end:script.build.multithread\\r'
-	fi
+    if [ "$CC" != "tcc" ]; then
+        echo -e "\r\n== Compile multithreaded version with discovery ==" && echo -en 'travis_fold:start:script.build.multithread_discovery\\r'
+        mkdir -p build && cd build
+        cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_MULTITHREADING=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_EXAMPLES=ON ..
+        make -j
+        if [ $? -ne 0 ] ; then exit 1 ; fi
+        cd .. && rm build -rf
+        echo -en 'travis_fold:end:script.build.multithread_discovery\\r'
+    fi
 
     echo -e "\r\n== Unit tests (full NS0) ==" && echo -en 'travis_fold:start:script.build.unit_test_ns0_full\\r'
     mkdir -p build && cd build
     # Valgrind cannot handle the full NS0 because the generated file is too big. Thus run NS0 full without valgrind
     cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON -DUA_ENABLE_FULL_NS0=ON \
-    -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
-    -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=OFF -DUA_ENABLE_UNIT_TESTS_MEMCHECK=OFF ..
+    -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_ENCRYPTION=ON -DUA_ENABLE_DISCOVERY=ON \
+    -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=OFF \
+    -DUA_ENABLE_UNIT_TESTS_MEMCHECK=OFF ..
     make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.unit_test_ns0\\r'
+    echo -en 'travis_fold:end:script.build.unit_test_ns0_full\\r'
 
-	if [ "$CC" != "tcc" ]; then
+    if [ "$CC" != "tcc" ]; then
         echo -e "\r\n== Unit tests (minimal NS0) ==" && echo -en 'travis_fold:start:script.build.unit_test_ns0_minimal\\r'
         mkdir -p build && cd build
         cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-              -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
-              -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=ON -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
+        -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON  -DUA_ENABLE_ENCRYPTION=ON -DUA_ENABLE_DISCOVERY=ON \
+        -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=ON \
+        -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
         make -j && make test ARGS="-V"
         if [ $? -ne 0 ] ; then exit 1 ; fi
         echo -en 'travis_fold:end:script.build.unit_test_ns0_minimal\\r'
@@ -236,5 +249,5 @@ else
             echo -en 'travis_fold:end:script.build.coveralls\\r'
         fi
         cd .. && rm build -rf
-	fi
+    fi
 fi

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -13,11 +13,11 @@ fi
 
 # Cpplint checking
 if ! [ -z ${LINT+x} ]; then
-	mkdir -p build
-	cd build
-	cmake ..
-	make cpplint
-	if [ $? -ne 0 ] ; then exit 1 ; fi
+    mkdir -p build
+    cd build
+    cmake ..
+    make cpplint
+    if [ $? -ne 0 ] ; then exit 1 ; fi
     exit 0
 fi
 
@@ -38,8 +38,8 @@ if [ $ANALYZE = "true" ]; then
     if [ "$CC" = "clang" ]; then
         mkdir -p build
         cd build
-        scan-build-3.9 cmake -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_UNIT_TESTS=ON ..
-        scan-build-3.9 -enable-checker security.FloatLoopCounter \
+        scan-build cmake -DUA_BUILD_EXAMPLES=ON -DUA_BUILD_UNIT_TESTS=ON ..
+        scan-build -enable-checker security.FloatLoopCounter \
           -enable-checker security.insecureAPI.UncheckedReturn \
           --status-bugs -v \
           make -j
@@ -47,19 +47,13 @@ if [ $ANALYZE = "true" ]; then
 
         mkdir -p build
         cd build
-        scan-build-3.9 cmake -DUA_ENABLE_AMALGAMATION=ON ..
-        scan-build-3.9 -enable-checker security.FloatLoopCounter \
+        scan-build cmake -DUA_ENABLE_AMALGAMATION=ON ..
+        scan-build -enable-checker security.FloatLoopCounter \
           -enable-checker security.insecureAPI.UncheckedReturn \
           --status-bugs -v \
           make -j
         cd .. && rm build -rf
 
-        mkdir -p build
-        cd build
-        cmake -DUA_BUILD_EXAMPLES=ON ..
-        make -j
-        make lint
-        cd .. && rm build -rf
     else
         cppcheck --template "{file}({line}): {severity} ({id}): {message}" \
             --enable=style --force --std=c++11 -j 8 \

--- a/tools/travis/travis_osx_before_install.sh
+++ b/tools/travis/travis_osx_before_install.sh
@@ -5,6 +5,7 @@ brew install check
 brew install valgrind
 brew install graphviz
 brew install python
+brew install mbedtls
 
 pip2 install --user sphinx
 pip2 install --user breathe

--- a/tools/travis/travis_osx_script.sh
+++ b/tools/travis/travis_osx_script.sh
@@ -42,7 +42,7 @@ echo -en 'travis_fold:end:script.build.multithread\\r'
 
 echo "Debug build and unit tests with valgrind" && echo -en 'travis_fold:start:script.build.unit_test\\r'
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=ON -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
+cmake -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_ENCRYPTION=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=ON -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
 make -j && make test ARGS="-V"
 cd .. && rm -rf build
 echo -en 'travis_fold:end:script.build.unit_test\\r'

--- a/tools/travis/travis_osx_script.sh
+++ b/tools/travis/travis_osx_script.sh
@@ -42,7 +42,7 @@ echo -en 'travis_fold:end:script.build.multithread\\r'
 
 echo "Debug build and unit tests with valgrind" && echo -en 'travis_fold:start:script.build.unit_test\\r'
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_ENCRYPTION=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=ON -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
+cmake -DCHECK_PREFIX=/usr/local/Cellar/check/0.11.0 -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_ENCRYPTION=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON -DUA_BUILD_UNIT_TESTS=ON -DUA_ENABLE_COVERAGE=ON -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
 make -j && make test ARGS="-V"
 cd .. && rm -rf build
 echo -en 'travis_fold:end:script.build.unit_test\\r'


### PR DESCRIPTION
Set `UA_ENABLE_ENCRYPTION=ON` for continuous integration
Enable temporarily disabled CI checks