### PR TITLE
fix UA_SecureChannel_sendSymmetricMessage

### DIFF
--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -625,7 +625,7 @@ UA_SecureChannel_sendSymmetricMessage(UA_SecureChannel *channel, UA_UInt32 reque
     UA_MessageContext mc;
     UA_StatusCode retval;
     UA_NodeId typeId = UA_NODEID_NUMERIC(0, payloadType->binaryEncodingId);
-    retval = UA_MessageContext_begin(&mc, channel, requestId, UA_MESSAGETYPE_MSG);
+    retval = UA_MessageContext_begin(&mc, channel, requestId, messageType);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 


### PR DESCRIPTION
Currently the server  indicates
```
[2018-01-24 13:15:52.061 (UTC+0100)] info/channel	Connection 5 | SecureChannel 1 | Unknown request with type identifier 452
```

when open62541 client tries to close the secure channel, because the message is of type MSG instead of CLO.

![image](https://user-images.githubusercontent.com/13799456/35331937-853698bc-0109-11e8-9f56-c3c76763ba93.png)
