### PR TITLE
fix client handle logging

### DIFF
--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -191,7 +191,7 @@ addMonitoredItems(UA_Client *client, const UA_UInt32 subscriptionId,
         newMonitoredItemIds[i] = newMon->monitoredItemId;
         UA_LOG_DEBUG(client->config.logger, UA_LOGCATEGORY_CLIENT,
                      "Created a monitored item with client handle %u",
-                     client->monitoredItemHandles);
+                     newMon->clientHandle);
     }
 
  cleanup:


### PR DESCRIPTION
solves problem when last client handle will be logged for all monitored items when there is more than 1 monitored item.