### PR TITLE
Fix build for iOS

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -84,6 +84,7 @@ Building on OS X
 
 .. code-block:: bash
 
+   xcode-select --install
    brew install cmake
    pip install six # python 2/3 compatibility workarounds
    pip install sphinx # for documentation generation

--- a/src/ua_util.h
+++ b/src/ua_util.h
@@ -37,6 +37,11 @@ extern "C" {
     #if (TARGET_IPHONE_SIMULATOR == 1 && TARGET_CPU_X86 == 1) || \
         (TARGET_OS_IPHONE == 1 && TARGET_CPU_ARM == 1)
         #define UA_THREAD_LOCAL
+    #else
+        #include <AvailabliltyMacros.h>
+        #if (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_7)
+            #define UA_THREAD_LOCAL
+        #endif
     #endif
 #endif
 

--- a/src/ua_util.h
+++ b/src/ua_util.h
@@ -32,16 +32,26 @@ extern "C" {
  * only used for some testing strategies. ``UA_THREAD_LOCAL`` is empty if the
  * feature is not available. */
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-# define UA_THREAD_LOCAL _Thread_local /* C11 */
-#elif defined(__cplusplus) && __cplusplus > 199711L
-# define UA_THREAD_LOCAL thread_local /* C++11 */
-#elif defined(__GNUC__)
-# define UA_THREAD_LOCAL __thread /* GNU extension */
-#elif defined(_MSC_VER)
-# define UA_THREAD_LOCAL __declspec(thread) /* MSVC extension */
-#else
-# define UA_THREAD_LOCAL
+#if defined(__APPLE__) && defined(__MACH__)
+    #include <TargetConditionals.h>
+    #if (TARGET_IPHONE_SIMULATOR == 1 && TARGET_CPU_X86 == 1) || \
+        (TARGET_OS_IPHONE == 1 && TARGET_CPU_ARM == 1)
+        #define UA_THREAD_LOCAL
+    #endif
+#endif
+
+#ifndef UA_THREAD_LOCAL
+    #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    # define UA_THREAD_LOCAL _Thread_local /* C11 */
+    #elif defined(__cplusplus) && __cplusplus > 199711L
+    # define UA_THREAD_LOCAL thread_local /* C++11 */
+    #elif defined(__GNUC__)
+    # define UA_THREAD_LOCAL __thread /* GNU extension */
+    #elif defined(_MSC_VER)
+    # define UA_THREAD_LOCAL __declspec(thread) /* MSVC extension */
+    #else
+    # define UA_THREAD_LOCAL
+    #endif
 #endif
 
 /* Integer Shortnames

--- a/tools/travis/travis_osx_before_install.sh
+++ b/tools/travis/travis_osx_before_install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ev
 
+xcode-select --install
+
 brew install check
 brew install valgrind
 brew install graphviz


### PR DESCRIPTION
When building open62541 for iOS, thread-local storage is not supported for arm and the i386 simulator but UA_THREAD_LOCAL gets expanded to _Thread_local and the build fails with "error: thread-local storage is not supported for the current target".

This patch fixes the issue by checking for these two platforms before the existing checks are done.