### PR TITLE
fixed encoding of overlayable types likes enums (these are int32!)

### DIFF
--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -1006,6 +1006,8 @@ enum UA_VARIANT_ENCODINGMASKTYPE {
     UA_VARIANT_ENCODINGMASKTYPE_ARRAY       = (0x01 << 7)  /* bit 7 */
 };
 
+
+
 ENCODE_BINARY(Variant) {
     /* Quit early for the empty variant */
     u8 encoding = 0;
@@ -1014,11 +1016,12 @@ ENCODE_BINARY(Variant) {
 
     /* Set the content type in the encoding mask */
     const bool isBuiltin = src->type->builtin;
-    const bool isOverlayable = src->type->overlayable;
+    const bool isAlias = src->type->membersSize == 1
+                         && UA_TYPES[src->type->members[0].memberTypeIndex].builtin;
     if(isBuiltin)
         encoding |= UA_VARIANT_ENCODINGMASKTYPE_TYPEID_MASK & (u8)(src->type->typeIndex + 1);
-    else if(isOverlayable)
-        encoding |= UA_VARIANT_ENCODINGMASKTYPE_TYPEID_MASK & (u8)(UA_TYPES_INT32 + 1);
+    else if(isAlias)
+        encoding |= UA_VARIANT_ENCODINGMASKTYPE_TYPEID_MASK & (u8)(src->type->members[0].memberTypeIndex + 1);
     else
         encoding |= UA_VARIANT_ENCODINGMASKTYPE_TYPEID_MASK & (u8)(UA_TYPES_EXTENSIONOBJECT + 1);
 
@@ -1037,7 +1040,7 @@ ENCODE_BINARY(Variant) {
         return ret;
 
     /* Encode the content */
-    if(!isBuiltin && !isOverlayable)
+    if(!isBuiltin && !isAlias)
         ret = Variant_encodeBinaryWrapExtensionObject(src, isArray, ctx);
     else if(!isArray)
         ret = encodeBinaryInternal(src->data, src->type, ctx);

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -1014,8 +1014,11 @@ ENCODE_BINARY(Variant) {
 
     /* Set the content type in the encoding mask */
     const bool isBuiltin = src->type->builtin;
+    const bool isOverlayable = src->type->overlayable;
     if(isBuiltin)
         encoding |= UA_VARIANT_ENCODINGMASKTYPE_TYPEID_MASK & (u8)(src->type->typeIndex + 1);
+    else if(isOverlayable)
+        encoding |= UA_VARIANT_ENCODINGMASKTYPE_TYPEID_MASK & (u8)(UA_TYPES_INT32 + 1);
     else
         encoding |= UA_VARIANT_ENCODINGMASKTYPE_TYPEID_MASK & (u8)(UA_TYPES_EXTENSIONOBJECT + 1);
 
@@ -1034,7 +1037,7 @@ ENCODE_BINARY(Variant) {
         return ret;
 
     /* Encode the content */
-    if(!isBuiltin)
+    if(!isBuiltin && !isOverlayable)
         ret = Variant_encodeBinaryWrapExtensionObject(src, isArray, ctx);
     else if(!isArray)
         ret = encodeBinaryInternal(src->data, src->type, ctx);


### PR DESCRIPTION
Currently overlayable types like Enumerations are encoded as ExtensionObjects which is errorneous.

You can see an example in the attached screenshot from UAExpert. There the node class attribute of each node (which is an as Int32 overlayable enum type indeed) is marked as faulty.

![ua_expert_nodeclass_invalid_datatype](https://user-images.githubusercontent.com/24267645/35563424-e46e070a-05b6-11e8-86cc-c81903574ca3.png)

This pull request changes the encoded type ID to Int32 for all overlayable types. After that UAExpert does not complain any more.