### PR TITLE
add client to dataChangeHandler (API change !!!!)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,19 @@
 This changelog reports changes to the public API. Internal refactorings and bug
 fixes are not reported here.
 
+2018-02-05 pro <profanter at fortiss.org>
+
+ * Also pass client to monitoredItem/Events callback
+
+   The UA_MonitoredItemHandlingFunction and UA_MonitoredEventHandlingFunction
+   did not include a reference to the corresponding client used for the call of
+   processPublishResponse.
+   This now also allows to get the client context within the monitored item
+   handling function.
+
+   The API changes are detected by the type-matching in the compiler. So there
+   is little risk for bugs due to unaligned implementations.
+
 2017-09-07 jpfr <julius.pfrommer at web.de>
 
  * Make Client Highlevel Interface consistent

--- a/examples/client.c
+++ b/examples/client.c
@@ -6,7 +6,7 @@
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static void
-handler_TheAnswerChanged(UA_UInt32 monId, UA_DataValue *value, void *context) {
+handler_TheAnswerChanged(UA_Client *client, UA_UInt32 monId, UA_DataValue *value, void *context) {
     printf("The Answer has changed!\n");
 }
 #endif

--- a/examples/client_subscription_loop.c
+++ b/examples/client_subscription_loop.c
@@ -43,7 +43,7 @@ static void stopHandler(int sign) {
 }
 
 static void
-handler_currentTimeChanged(UA_UInt32 monId, UA_DataValue *value, void *context) {
+handler_currentTimeChanged(UA_Client *client, UA_UInt32 monId, UA_DataValue *value, void *context) {
     UA_LOG_INFO(logger, UA_LOGCATEGORY_USERLAND, "currentTime has changed!");
     if(UA_Variant_hasScalarType(&value->value, &UA_TYPES[UA_TYPES_DATETIME])) {
         UA_DateTime raw_date = *(UA_DateTime *) value->value.data;

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -14,7 +14,8 @@ static void stopHandler(int sig) {
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 
 static void
-handler_events(const UA_UInt32 monId, const size_t nEventFields,
+handler_events(UA_Client *client,
+               const UA_UInt32 monId, const size_t nEventFields,
                const UA_Variant *eventFields, void *context) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Notification");
 

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -597,8 +597,8 @@ UA_Client_Subscriptions_manuallySendPublishRequest(UA_Client *client);
 
 /* Addition of monitored DataChanges */
 /* TODO for v0.4: Rename method to _DataChange. */
-typedef void (*UA_MonitoredItemHandlingFunction)(UA_UInt32 monId, UA_DataValue *value,
-                                                 void *context);
+typedef void (*UA_MonitoredItemHandlingFunction)(UA_Client *client, UA_UInt32 monId,
+                                                 UA_DataValue *value, void *context);
 
 UA_StatusCode UA_EXPORT
 UA_Client_Subscriptions_addMonitoredItems(UA_Client *client, const UA_UInt32 subscriptionId,

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -617,7 +617,8 @@ UA_Client_Subscriptions_addMonitoredItem(UA_Client *client, UA_UInt32 subscripti
 
 /* Monitored Events have different payloads from DataChanges. So they use a
  * different callback method signature. */
-typedef void (*UA_MonitoredEventHandlingFunction)(const UA_UInt32 monId,
+typedef void (*UA_MonitoredEventHandlingFunction)(UA_Client *client,
+                                                  const UA_UInt32 monId,
                                                   const size_t nEventFields,
                                                   const UA_Variant *eventFields,
                                                   void *context);

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -458,7 +458,7 @@ UA_Client_processPublishResponse(UA_Client *client, UA_PublishRequest *request,
                     continue;
                 }
 
-                mon->handler.eventHandler(mon->monitoredItemId, eventFieldList->eventFieldsSize,
+                mon->handler.eventHandler(client, mon->monitoredItemId, eventFieldList->eventFieldsSize,
                                           eventFieldList->eventFields, mon->handlerContext);
             }
         }

--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -424,7 +424,8 @@ UA_Client_processPublishResponse(UA_Client *client, UA_PublishRequest *request,
                     continue;
                 }
 
-                mon->handler.dataChangeHandler(mon->monitoredItemId, &mitemNot->value, mon->handlerContext);
+                mon->handler.dataChangeHandler(client, mon->monitoredItemId,
+                                               &mitemNot->value, mon->handlerContext);
             }
             continue;
         }

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -53,7 +53,7 @@ static void teardown(void) {
 UA_Boolean notificationReceived;
 UA_UInt32 countNotificationReceived = 0;
 
-static void monitoredItemHandler(UA_UInt32 monId, UA_DataValue *value, void *context) {
+static void monitoredItemHandler(UA_Client *client, UA_UInt32 monId, UA_DataValue *value, void *context) {
     notificationReceived = true;
     countNotificationReceived++;
 }

--- a/tests/fuzz/corpus_generator.c
+++ b/tests/fuzz/corpus_generator.c
@@ -360,7 +360,7 @@ translateBrowsePathsToNodeIdsRequest(UA_Client *client) {
 
 
 static void
-monitoredItemHandler(UA_UInt32 monId, UA_DataValue *value, void *context) {
+monitoredItemHandler(UA_Client *client, UA_UInt32 monId, UA_DataValue *value, void *context) {
 
 }
 


### PR DESCRIPTION
Sometimes we need to have the client context in the monitored item handling function. Eg: to get the ```clientContext``` (https://github.com/open62541/open62541/pull/1532). But ```client``` is not present. We can't use ```context``` because it can be used to identify the monitoredItem.

That change the API but it is really needed !