### PR TITLE
fix UA_Client_disconnect/close crash

### DIFF
--- a/include/ua_plugin_network.h
+++ b/include/ua_plugin_network.h
@@ -50,12 +50,12 @@ typedef struct {
 } UA_ConnectionConfig;
 
 typedef enum {
+    UA_CONNECTION_CLOSED,      /* The socket has been closed and the connection
+                                * will be deleted */
     UA_CONNECTION_OPENING,     /* The socket is open, but the HEL/ACK handshake
                                 * is not done */
-    UA_CONNECTION_ESTABLISHED, /* The socket is open and the connection
+    UA_CONNECTION_ESTABLISHED  /* The socket is open and the connection
                                 * configured */
-    UA_CONNECTION_CLOSED       /* The socket has been closed and the connection
-                                * will be deleted */
 } UA_ConnectionState;
 
 struct UA_Connection {

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -216,6 +216,14 @@ START_TEST(Client_activateSessionClose) {
 }
 END_TEST
 
+START_TEST(Client_delete_without_connect) {
+    UA_ClientConfig clientConfig = UA_ClientConfig_default;
+    UA_Client *client = UA_Client_new(clientConfig);
+    ck_assert_msg(client != NULL);
+    UA_Client_delete(client);
+}
+END_TEST
+
 START_TEST(Client_activateSessionTimeout) {
     // restart server
     teardown();
@@ -270,6 +278,7 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_client, Client_connect_username);
     tcase_add_test(tc_client, Client_endpoints);
     tcase_add_test(tc_client, Client_read);
+    tcase_add_test(tc_client, Client_delete_without_connect);
     suite_add_tcase(s,tc_client);
     TCase *tc_client_reconnect = tcase_create("Client Reconnect");
     tcase_add_checked_fixture(tc_client_reconnect, setup, teardown);


### PR DESCRIPTION
Calling ```UA_Client_delete``` without calling ```UA_Client_connect``` cause a crash

```
    UA_ClientConfig config = UA_ClientConfig_default;
    UA_Client *client = UA_Client_new(config);
    UA_Client_delete(client);
```

```
==77752== Memcheck, a memory error detector
==77752== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==77752== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==77752== Command: bin/examples/client_subscription_loop
==77752== 
==77752== Jump to the invalid address stated on the next line
==77752==    at 0x0: ???
==77752==    by 0x112779: UA_Client_deleteMembers (ua_client.c:54)
==77752==    by 0x11291E: UA_Client_delete (ua_client.c:88)
==77752==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==77752== 
==77752== 
==77752== Process terminating with default action of signal 11 (SIGSEGV)
==77752==  Bad permissions for mapped region at address 0x0
==77752==    at 0x0: ???
==77752==    by 0x112779: UA_Client_deleteMembers (ua_client.c:54)
==77752==    by 0x11291E: UA_Client_delete (ua_client.c:88)
```

set UA_CONNECTION_CLOSED as default value fix the issue