### PR TITLE
only set UA_CONNECTION_OPENING when we have a valid socket

### DIFF
--- a/plugins/ua_network_tcp.c
+++ b/plugins/ua_network_tcp.c
@@ -762,7 +762,7 @@ UA_ClientConnectionTCP(UA_ConnectionConfig conf,
 
     UA_Connection connection;
     memset(&connection, 0, sizeof(UA_Connection));
-    connection.state = UA_CONNECTION_OPENING;
+    connection.state = UA_CONNECTION_CLOSED;
     connection.localConf = conf;
     connection.remoteConf = conf;
     connection.send = connection_write;
@@ -833,8 +833,6 @@ UA_ClientConnectionTCP(UA_ConnectionConfig conf,
      * want to try to connect. So use a loop and retry until timeout is
      * reached. */
     do {
-        connection.state = UA_CONNECTION_OPENING;
-
         /* Get a socket */
         clientsockfd = socket(server->ai_family,
                               server->ai_socktype,
@@ -849,6 +847,8 @@ UA_ClientConnectionTCP(UA_ConnectionConfig conf,
             freeaddrinfo(server);
             return connection;
         }
+
+        connection.state = UA_CONNECTION_OPENING;
 
         /* Connect to the server */
         connection.sockfd = (UA_Int32) clientsockfd; /* cast for win32 */


### PR DESCRIPTION
When the endpoint is invalid, ```UA_ClientConnectionTCP``` return with ```connection.state = UA_CONNECTION_OPENING```. Then the client try to write to a invalid socket.

https://github.com/open62541/open62541/blob/daaa58a92fa5583e6367759d9258c0c0403d65d6/plugins/ua_network_tcp.c#L782-L789

Same if DNS lookup failed : 
https://github.com/open62541/open62541/blob/daaa58a92fa5583e6367759d9258c0c0403d65d6/plugins/ua_network_tcp.c#L813-L825

Or if the socket can't be created : 

https://github.com/open62541/open62541/blob/daaa58a92fa5583e6367759d9258c0c0403d65d6/plugins/ua_network_tcp.c#L839-L851
Setting ```connection.state = UA_CONNECTION_OPENING``` only when we have a valid socket fix the issue.
