### PR TITLE
WIP: Forbid duplicated references

### DIFF
--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -990,7 +990,11 @@ UA_Server_addMethodNode(UA_Server *server, const UA_NodeId requestedNewNodeId,
  * _finish method adds the references to the parent (and the TypeDefinition if
  * applicable), copies mandatory children, performs type-checking of variables
  * and calls the node constructor(s) at the end. The _finish method may remove
- * the node if it encounters an error. */
+ * the node if it encounters an error.
+ * The _finishSkipParent is a variant of the _finish method which additionally
+ * allows to indicate if adding the parent reference should be skipped if it is
+ * already added before manually.
+ * */
 
 /* The ``attr`` argument must have a type according to the NodeClass.
  * ``VariableAttributes`` for variables, ``ObjectAttributes`` for objects, and
@@ -1011,12 +1015,28 @@ UA_Server_addNode_finish(UA_Server *server, const UA_NodeId nodeId,
                          const UA_NodeId typeDefinitionId);
 
 UA_StatusCode UA_EXPORT
+UA_Server_addNode_finishSkipParent(UA_Server *server, const UA_NodeId nodeId,
+                         const UA_NodeId parentNodeId,
+                         const UA_NodeId referenceTypeId,
+                         const UA_NodeId typeDefinitionId,
+                         UA_Boolean skipAddingParentReference);
+
+UA_StatusCode UA_EXPORT
 UA_Server_addMethodNode_finish(UA_Server *server, const UA_NodeId nodeId,
                          const UA_NodeId parentNodeId,
                          const UA_NodeId referenceTypeId,
                          UA_MethodCallback method,
                          size_t inputArgumentsSize, const UA_Argument* inputArguments,
                          size_t outputArgumentsSize, const UA_Argument* outputArguments);
+
+UA_StatusCode UA_EXPORT
+UA_Server_addMethodNode_finishSkipParent(UA_Server *server, const UA_NodeId nodeId,
+                         const UA_NodeId parentNodeId,
+                         const UA_NodeId referenceTypeId,
+                         UA_MethodCallback method,
+                         size_t inputArgumentsSize, const UA_Argument* inputArguments,
+                         size_t outputArgumentsSize, const UA_Argument* outputArguments,
+                         UA_Boolean skipAddingParentReference);
 
 /* Deletes a node and optionally all references leading to the node. */
 UA_StatusCode UA_EXPORT

--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -377,6 +377,9 @@ typedef struct {
     UA_UInt32 serverIndex;
 } UA_ExpandedNodeId;
 
+UA_Boolean UA_EXPORT UA_ExpandedNodeId_equal(const UA_ExpandedNodeId *n1,
+                                             const UA_ExpandedNodeId *n2);
+
 UA_EXPORT extern const UA_ExpandedNodeId UA_EXPANDEDNODEID_NULL;
 
 /** The following functions are shorthand for creating ExpandedNodeIds. */
@@ -443,6 +446,10 @@ UA_QUALIFIEDNAME_ALLOC(UA_UInt16 nsIndex, const char *chars) {
     UA_QualifiedName qn; qn.namespaceIndex = nsIndex;
     qn.name = UA_STRING_ALLOC(chars); return qn;
 }
+
+UA_Boolean UA_EXPORT
+UA_QualifiedName_equal(const UA_QualifiedName *qn1,
+                       const UA_QualifiedName *qn2);
 
 /**
  * LocalizedText

--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -527,13 +527,23 @@ addReferenceKind(UA_Node *node, const UA_AddReferencesItem *item) {
 
 UA_StatusCode
 UA_Node_addReference(UA_Node *node, const UA_AddReferencesItem *item) {
+    UA_NodeReferenceKind *existingRefs = NULL;
     for(size_t i = 0; i < node->referencesSize; ++i) {
         UA_NodeReferenceKind *refs = &node->references[i];
-        if(refs->isInverse == item->isForward)
-            continue;
-        if(!UA_NodeId_equal(&refs->referenceTypeId, &item->referenceTypeId))
-            continue;
-        return addReferenceTarget(refs, &item->targetNodeId);
+        if(refs->isInverse != item->isForward
+                && UA_NodeId_equal(&refs->referenceTypeId, &item->referenceTypeId)) {
+            existingRefs = refs;
+            break;
+        }
+    }
+    if(existingRefs != NULL) {
+        for(size_t i = 0; i < existingRefs->targetIdsSize; i++) {
+            if(UA_ExpandedNodeId_equal(&existingRefs->targetIds[i],
+                                       &item->targetNodeId)) {
+                return UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED;
+            }
+        }
+        return addReferenceTarget(existingRefs, &item->targetNodeId);
     }
     return addReferenceKind(node, item);
 }

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -347,7 +347,7 @@ Operation_addNode_begin(UA_Server *server, UA_Session *session, void *nodeContex
 UA_StatusCode
 Operation_addNode_finish(UA_Server *server, UA_Session *session,
                          const UA_NodeId *nodeId, const UA_NodeId *parentNodeId,
-                         const UA_NodeId *referenceTypeId, const UA_NodeId *typeDefinitionId);
+                         const UA_NodeId *referenceTypeId, const UA_NodeId *typeDefinitionId, UA_Boolean skipAddingParentReference);
 
 /**********************/
 /* Create Namespace 0 */

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -42,7 +42,7 @@ addNode_finish(UA_Server *server, UA_UInt32 nodeId,
     UA_NodeId referenceType = UA_NODEID_NUMERIC(0, referenceTypeId);
     UA_NodeId typeDefinition = UA_NODEID_NUMERIC(0, typeDefinitionId);
     return Operation_addNode_finish(server, &adminSession, &node, &parentNode,
-                                    &referenceType, &typeDefinition);
+                                    &referenceType, &typeDefinition, UA_FALSE);
 }
 
 static UA_StatusCode

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -103,6 +103,19 @@ String_deleteMembers(UA_String *s, const UA_DataType *_) {
     UA_free((void*)((uintptr_t)s->data & ~(uintptr_t)UA_EMPTY_ARRAY_SENTINEL));
 }
 
+UA_Boolean
+UA_QualifiedName_equal(const UA_QualifiedName *qn1,
+                       const UA_QualifiedName *qn2) {
+    if(qn1 == NULL || qn2 == NULL)
+        return false;
+    if(qn1->namespaceIndex != qn2->namespaceIndex)
+        return false;
+    if(qn1->name.length != qn2->name.length)
+        return false;
+    return (memcmp((char const*)qn1->name.data,
+                   (char const*)qn2->name.data, qn1->name.length) == 0);
+}
+
 /* DateTime */
 UA_DateTimeStruct
 UA_DateTime_toStruct(UA_DateTime t) {
@@ -288,6 +301,17 @@ UA_NodeId_equal(const UA_NodeId *n1, const UA_NodeId *n2) {
                                    &n2->identifier.byteString);
     }
     return false;
+}
+
+UA_Boolean
+UA_ExpandedNodeId_equal(const UA_ExpandedNodeId *n1, const UA_ExpandedNodeId *n2) {
+    if(n1 == NULL || n2 == NULL)
+        return false;
+    if(n1->serverIndex != n2->serverIndex)
+        return false;
+    if(!UA_String_equal(&n1->namespaceUri, &n2->namespaceUri))
+        return false;
+    return UA_NodeId_equal(&n1->nodeId, &n2->nodeId);
 }
 
 /* FNV non-cryptographic hash function. See

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -236,6 +236,8 @@ extern UA_StatusCode %s(UA_Server *server);
                 writec(code)
 
         # Print inverse references leading to this node
+        # This also includes the parent reference. We already need it here otherwise some type checks will fail.
+        # Therefore within the _finish we need to set the parent ref to NULL
         for ref in node.printRefs:
             writec(generateReferenceCode(ref))
             

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -529,23 +529,25 @@ def generateNodeCode_finish(node, generate_ns0, parentrefs):
 
 
     if isinstance(node, MethodNode):
-        code.append("UA_Server_addMethodNode_finish(server, ")
+        code.append("UA_Server_addMethodNode_finishSkipParent(server, ")
     else:
-        code.append("UA_Server_addNode_finish(server, ")
+        code.append("UA_Server_addNode_finishSkipParent(server, ")
     code.append(generateNodeIdCode(node.id) + ",")
     code.append(generateNodeIdCode(parentNode) + ",")
     code.append(generateNodeIdCode(parentRef) + ",")
 
+    # last parameter is set to true to skip adding parent reference since it is already added manually before
+
     if isinstance(node, MethodNode):
-        code.append("NULL, 0, NULL, 0, NULL);")
+        code.append("NULL, 0, NULL, 0, NULL, UA_TRUE);")
     else:
 
         if isinstance(node, VariableTypeNode):
             # we need the HasSubtype reference
-            code.append(generateSubtypeOfDefinitionCode(node) + ");")
+            code.append(generateSubtypeOfDefinitionCode(node) + ", UA_TRUE);")
         else:
             typeDefCode = "UA_NODEID_NULL" if typeDef is None else generateNodeIdCode(typeDef)
-            code.append(typeDefCode + ");")
+            code.append(typeDefCode + ", UA_TRUE);")
 
     return "\n".join(code)
 


### PR DESCRIPTION
Implemented detection of duplicated references.
Prevents to add equal references more than once and to break the model (on deletion only the first matched reference is deleted since each reference must be unique) and returns UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED