### PR TITLE
Fix server side indexRange support for monitored items

### DIFF
--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -273,6 +273,7 @@ Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session, struct cre
     }
     newMon->subscription = cmc->sub;
     newMon->attributeId = request->itemToMonitor.attributeId;
+    UA_String_copy(&request->itemToMonitor.indexRange, &newMon->indexRange);
     newMon->itemId = ++(cmc->sub->lastMonitoredItemId);
     newMon->timestampsToReturn = cmc->timestampsToReturn;
     setMonitoredItemSettings(server, newMon, request->monitoringMode,
@@ -285,7 +286,6 @@ Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session, struct cre
         UA_MonitoredItem_SampleCallback(server, newMon);
 
     /* Prepare the response */
-    UA_String_copy(&request->itemToMonitor.indexRange, &newMon->indexRange);
     result->revisedSamplingInterval = newMon->samplingInterval;
     result->revisedQueueSize = newMon->maxQueueSize;
     result->monitoredItemId = newMon->itemId;


### PR DESCRIPTION
IndexRange must be copied to the monitored item before the first call to UA_MonitoredItem_SampleCallback().
Not doing so produces a data change notification containing the entire array.