### PR TITLE
Request both timestamps in addMonitoredItems

### DIFF
--- a/src/client/ua_client_highlevel_subscriptions.c
+++ b/src/client/ua_client_highlevel_subscriptions.c
@@ -155,6 +155,7 @@ addMonitoredItems(UA_Client *client, const UA_UInt32 subscriptionId,
     request.subscriptionId = subscriptionId;
     request.itemsToCreate = items;
     request.itemsToCreateSize = itemsSize;
+    request.timestampsToReturn = UA_TIMESTAMPSTORETURN_BOTH;
 
     /* Send the request */
     response = UA_Client_Service_createMonitoredItems(client, request);


### PR DESCRIPTION
In the current code, the call to UA_CreateMonitoredItemsRequest_init()
sets timestampsToReturn to 0 which means source timestamp only.
There is currently no way to override the requested timestamps, so
UA_TIMESTAMPSTORETURN_BOTH is a better default.