### PR TITLE
Fix android build with ndk r16b

### DIFF
--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -281,7 +281,11 @@ extern "C" {
 # define UA_BINARY_OVERLAYABLE_FLOAT 1
 #elif defined(__linux__) /* Linux (including Android) */
 # include <endian.h>
-# if __FLOAT_WORD_ORDER == __LITTLE_ENDIAN
+# if defined(__ANDROID__)
+#  if __BYTE_ORDER == __LITTLE_ENDIAN
+#   define UA_BINARY_OVERLAYABLE_INTEGER 1
+#  endif
+# elif __FLOAT_WORD_ORDER == __LITTLE_ENDIAN
 #  define UA_BINARY_OVERLAYABLE_FLOAT 1
 # endif
 #elif defined(_WRS_KERNEL)

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -131,14 +131,7 @@ encodeWithExchangeBuffer(const void *ptr, encodeBinarySignature encodeFunc, Ctx 
 
 #if !UA_BINARY_OVERLAYABLE_INTEGER
 
-#if defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic warning "-W#warnings"
-#endif
-#warning Integer endianness could not be detected to be little endian. Use slow generic encoding.
-#if defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
+#pragma message Integer endianness could not be detected to be little endian. Use slow generic encoding.
 
 /* These en/decoding functions are only used when the architecture isn't little-endian. */
 static void
@@ -310,14 +303,7 @@ DECODE_BINARY(UInt64) {
 
 #include <math.h>
 
-#if defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic warning "-W#warnings"
-#endif
-# warning No native IEEE 754 format detected. Use slow generic encoding.
-#if defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
+#pragma message "No native IEEE 754 format detected. Use slow generic encoding."
 
 /* Handling of IEEE754 floating point values was taken from Beej's Guide to
  * Network Programming (http://beej.us/guide/bgnet/) and enhanced to cover the


### PR DESCRIPTION
The build failed with the following errors:
- __FLOAT_WORD_ORDER' is not defined, evaluates to 0 [-Werror,-Wundef]
- error: #warning is a language extension [-Werror,-Wpedantic]