### PR TITLE
Add flag for interactive valgind dumps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,6 @@ option(UA_ENABLE_DISCOVERY_MULTICAST "Enable Discovery Service with multicast su
 option(UA_ENABLE_AMALGAMATION "Concatenate the library to a single file open62541.h/.c" OFF)
 option(UA_ENABLE_COVERAGE "Enable gcov coverage" OFF)
 option(BUILD_SHARED_LIBS "Enable building of shared libraries (dll/so)" OFF)
-option(UA_ENABLE_VALGRIND_INTERACTIVE "Enable dumping valgrind every iteration. CAUTION! SLOWDOWN!" OFF)
 
 # Encryption Options
 option(UA_ENABLE_ENCRYPTION "Enable encryption support (uses mbedTLS)" OFF)
@@ -96,6 +95,9 @@ mark_as_advanced(UA_ENABLE_TYPENAMES)
 
 option(UA_ENABLE_DETERMINISTIC_RNG "Do not seed the random number generator (e.g. for unit tests)." OFF)
 mark_as_advanced(UA_ENABLE_DETERMINISTIC_RNG)
+
+option(UA_ENABLE_VALGRIND_INTERACTIVE "Enable dumping valgrind every iteration. CAUTION! SLOWDOWN!" OFF)
+mark_as_advanced(UA_ENABLE_VALGRIND_INTERACTIVE)
 
 option(UA_ENABLE_FULL_NS0 "Use the full NS0 instead of a minimal Namespace 0 nodeset" OFF)
 if (MSVC AND UA_ENABLE_FULL_NS0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option(UA_ENABLE_DISCOVERY_MULTICAST "Enable Discovery Service with multicast su
 option(UA_ENABLE_AMALGAMATION "Concatenate the library to a single file open62541.h/.c" OFF)
 option(UA_ENABLE_COVERAGE "Enable gcov coverage" OFF)
 option(BUILD_SHARED_LIBS "Enable building of shared libraries (dll/so)" OFF)
+option(UA_ENABLE_VALGRIND_INTERACTIVE "Enable dumping valgrind every iteration. CAUTION! SLOWDOWN!" OFF)
 
 # Encryption Options
 option(UA_ENABLE_ENCRYPTION "Enable encryption support (uses mbedTLS)" OFF)

--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -28,6 +28,7 @@ extern "C" {
 #cmakedefine UA_ENABLE_SUBSCRIPTIONS
 #cmakedefine UA_ENABLE_MULTITHREADING
 #cmakedefine UA_ENABLE_ENCRYPTION
+#cmakedefine UA_ENABLE_VALGRIND_INTERACTIVE
 
 /* Advanced Options */
 #cmakedefine UA_ENABLE_STATUSCODE_DESCRIPTIONS

--- a/src/server/ua_server_worker.c
+++ b/src/server/ua_server_worker.c
@@ -16,6 +16,9 @@
 
 #include "ua_util.h"
 #include "ua_server_internal.h"
+#ifdef UA_ENABLE_VALGRIND_INTERACTIVE
+#include <valgrind/memcheck.h>
+#endif
 
 #define UA_MAXTIMEOUT 50 /* Max timeout in ms between main-loop iterations */
 
@@ -429,7 +432,11 @@ UA_Server_run(UA_Server *server, volatile UA_Boolean *running) {
     UA_StatusCode retval = UA_Server_run_startup(server);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
-    while(*running)
+    while(*running) {
+#ifdef UA_ENABLE_VALGRIND_INTERACTIVE
+        VALGRIND_DO_LEAK_CHECK;
+#endif
         UA_Server_run_iterate(server, true);
+    }
     return UA_Server_run_shutdown(server);
 }


### PR DESCRIPTION
The PR adds support for enabling valgrind to dump leak checks every iteration of the server loop.
This makes it possible to do interactive checking and using the valgrind dumps to monitor the server while fuzzing for example.