### PR TITLE
support data types that are different from (nsIndex==0)

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -41,13 +41,29 @@ const UA_ExpandedNodeId UA_EXPANDEDNODEID_NULL = {{0, UA_NODEIDTYPE_NUMERIC, {0}
  * more efficient. */
 const UA_DataType *
 UA_findDataType(const UA_NodeId *typeId) {
-    if(typeId->identifierType != UA_NODEIDTYPE_NUMERIC ||
-       typeId->namespaceIndex != 0)
+    if(typeId->identifierType != UA_NODEIDTYPE_NUMERIC)
         return NULL;
+
+    /* Always look in built-in types first
+     * (may contain data types from all namespaces) */
     for(size_t i = 0; i < UA_TYPES_COUNT; ++i) {
-        if(UA_TYPES[i].typeId.identifier.numeric == typeId->identifier.numeric)
+        if(UA_TYPES[i].typeId.identifier.numeric == typeId->identifier.numeric
+           && UA_TYPES[i].typeId.namespaceIndex == typeId->namespaceIndex)
             return &UA_TYPES[i];
     }
+
+    /* TODO When other namespace look in custom types, too, requires access to custom types array here! */
+    /*if(typeId->namespaceIndex != 0) {
+        size_t customTypesArraySize;
+        const UA_DataType *customTypesArray;
+        UA_getCustomTypes(&customTypesArraySize, &customTypesArray);
+        for(size_t i = 0; i < customTypesArraySize; ++i) {
+            if(customTypesArray[i].typeId.identifier.numeric == typeId->identifier.numeric
+               && customTypesArray[i].typeId.namespaceIndex == typeId->namespaceIndex)
+                return &customTypesArray[i];
+        }
+    }*/
+
     return NULL;
 }
 
@@ -281,15 +297,14 @@ UA_NodeId_isNull(const UA_NodeId *p) {
 
 UA_Boolean
 UA_NodeId_equal(const UA_NodeId *n1, const UA_NodeId *n2) {
+    if(n1 == NULL || n2 == NULL)
+        return false;
     if(n1->namespaceIndex != n2->namespaceIndex ||
        n1->identifierType!=n2->identifierType)
         return false;
     switch(n1->identifierType) {
     case UA_NODEIDTYPE_NUMERIC:
-        if(n1->identifier.numeric == n2->identifier.numeric)
-            return true;
-        else
-            return false;
+        return (n1->identifier.numeric == n2->identifier.numeric);
     case UA_NODEIDTYPE_STRING:
         return UA_String_equal(&n1->identifier.string,
                                &n2->identifier.string);

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -803,16 +803,16 @@ UA_findDataTypeByBinaryInternal(const UA_NodeId *typeId, Ctx *ctx) {
     /* Always look in built-in types first
      * (may contain data types from all namespaces) */
     for(size_t i = 0; i < UA_TYPES_COUNT; ++i) {
-        if(UA_TYPES[i].binaryEncodingId == typeId->identifier.numeric
-           && UA_TYPES[i].typeId.namespaceIndex == typeId->namespaceIndex)
+        if(UA_TYPES[i].binaryEncodingId == typeId->identifier.numeric &&
+           UA_TYPES[i].typeId.namespaceIndex == typeId->namespaceIndex)
             return &UA_TYPES[i];
     }
 
     /* When other namespace look in custom types, too */
     if(typeId->namespaceIndex != 0) {
         for(size_t i = 0; i < ctx->customTypesArraySize; ++i) {
-            if(ctx->customTypesArray[i].binaryEncodingId == typeId->identifier.numeric
-               && UA_TYPES[i].typeId.namespaceIndex == typeId->namespaceIndex)
+            if(ctx->customTypesArray[i].binaryEncodingId == typeId->identifier.numeric &&
+               ctx->customTypesArray[i].typeId.namespaceIndex == typeId->namespaceIndex)
                 return &ctx->customTypesArray[i];
         }
     }


### PR DESCRIPTION
This pull request adds support for built-in data types (UA_TYPES) with a namespace index that is different from ns==0.

The lookup algorithms of `UA_findDataType` and `UA_findDataTypeByBinaryInternal` are adapted.
`UA_findDataType` has still a ToDo since the custom data types are not known in `ua_types.c` yet.