### PR TITLE
fix #1522

### DIFF
--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -296,6 +296,8 @@ UA_MonitoredItem_SampleCallback(UA_Server *server,
 
 UA_StatusCode
 MonitoredItem_registerSampleCallback(UA_Server *server, UA_MonitoredItem *mon) {
+    if(mon->sampleCallbackIsRegistered)
+        return UA_STATUSCODE_GOOD;
     UA_StatusCode retval =
         UA_Server_addRepeatedCallback(server, (UA_ServerCallback)UA_MonitoredItem_SampleCallback,
                                       mon, (UA_UInt32)mon->samplingInterval, &mon->sampleCallbackId);


### PR DESCRIPTION
fix #1522 compilation
https://travis-ci.org/open62541/open62541/jobs/345152138#L1849

and 

```
If Operation_SetMonitoringMode is called with

    UA_MONITORINGMODE_REPORTING
    UA_MONITORINGMODE_SAMPLING
    UA_MONITORINGMODE_REPORTING

So the callback is registered twice.
```