### PR TITLE
Use node ID to make sure refcount is updated

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -513,6 +513,13 @@ copyChildNode(UA_Server *server, UA_Session *session,
             return retval;
         }
 
+        /* Add all the children of this child to the new child node to make sure we take
+        * the values from the nearest inherited object first.
+        * The call to addNode_finish will then only add the children from the type and
+        * thus skip the direct children of rd->nodeId.nodeId
+        */
+        copyChildNodes(server, session, &rd->nodeId.nodeId, &newNodeId);
+
         /* Add the parent reference */
         /* we pass the nodeId instead of node to make sure the refcount
          * is increased and other calls can not delete the node in the meantime */

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -55,6 +55,19 @@ UA_Server_setNodeContext(UA_Server *server, UA_NodeId nodeId,
 /* Consistency Checks */
 /**********************/
 
+
+#define UA_PARENT_REFERENCES_COUNT 2
+
+UA_NodeId parentReferences[UA_PARENT_REFERENCES_COUNT] = {
+    {
+        0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASSUBTYPE}
+    },
+    {
+        0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASCOMPONENT}
+    }
+};
+
+
 /* Check if the requested parent node exists, has the right node class and is
  * referenced with an allowed (hierarchical) reference type. For "type" nodes,
  * only hasSubType references are allowed. */
@@ -175,12 +188,11 @@ typeCheckVariableNode(UA_Server *server, UA_Session *session,
     /* If variable node is created below BaseObjectType and has its default valueRank of -2,
      * skip the test */
     const UA_NodeId objectTypes = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE);
-    UA_NodeId refs[2];
-    refs[0] = UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE);
-    refs[1] = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
+
+    // TODO handle subtypes of parent reference types
     if(node->valueRank != vt->valueRank &&
        node->valueRank != UA_VariableAttributes_default.valueRank &&
-       !isNodeInTree(&server->config.nodestore, parentNodeId, &objectTypes, refs, 2)) {
+       !isNodeInTree(&server->config.nodestore, parentNodeId, &objectTypes, parentReferences, UA_PARENT_REFERENCES_COUNT)) {
         /* Check valueRank against the vt */
         if(!compatibleValueRanks(node->valueRank, vt->valueRank))
             return UA_STATUSCODE_BADTYPEMISMATCH;
@@ -422,7 +434,7 @@ static void deleteReferencesSubset(UA_Node *node, size_t referencesSkipSize, UA_
 
 
 static UA_StatusCode
-addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_Node *node, const UA_NodeId *parentNodeId,
+addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId, const UA_NodeId *parentNodeId,
                     const UA_NodeId *referenceTypeId, const UA_NodeId *typeDefinitionId);
 
 static UA_StatusCode
@@ -502,18 +514,15 @@ copyChildNode(UA_Server *server, UA_Session *session,
         }
 
         /* Add the parent reference */
-        retval = addParentAndTypeRef(server, session, node, destinationNodeId,
+        /* we pass the nodeId instead of node to make sure the refcount
+         * is increased and other calls can not delete the node in the meantime */
+        retval = addParentAndTypeRef(server, session, &node->nodeId, destinationNodeId,
                                      &rd->referenceTypeId, typeId);
         if(retval != UA_STATUSCODE_GOOD) {
             UA_Nodestore_delete(server, node);
             UA_Nodestore_release(server, type);
             return retval;
         }
-
-        /* Add all the children of this child to the new child node to make sure we take
-         * the values from the nearest inherited object first.
-         */
-        copyChildNodes(server, session, &rd->nodeId.nodeId, &newNodeId);
 
         /* Call addnode_finish, this recursively adds additional members, the type
          * definition and so on of the base type of this child, if they are not yet
@@ -674,8 +683,12 @@ removeDeconstructedNode(UA_Server *server, UA_Session *session,
 static const UA_NodeId hasSubtype = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASSUBTYPE}};
 
 static UA_StatusCode
-addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_Node *node, const UA_NodeId *parentNodeId,
+addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId, const UA_NodeId *parentNodeId,
                     const UA_NodeId *referenceTypeId, const UA_NodeId *typeDefinitionId) {
+
+    const UA_Node *node = UA_Nodestore_get(server, nodeId);
+    if (!node)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
 
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     const UA_Node *type = NULL;
@@ -705,7 +718,7 @@ addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_Node *node,
         UA_LOG_INFO_SESSION(server->config.logger, session,
                             "AddNodes: The parent reference is invalid");
         UA_Server_deleteNode(server, node->nodeId, true);
-        return retval;
+        goto cleanup;
     }
 
     /* Replace empty typeDefinition with the most permissive default */
@@ -778,11 +791,9 @@ addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_Node *node,
                 const UA_NodeId variableTypes = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE);
                 /* A variable may be of an object type which again is below BaseObjectType */
                 const UA_NodeId objectTypes = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE);
-                UA_NodeId refs[2];
-                refs[0] = UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE);
-                refs[1] = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
-                if(!isNodeInTree(&server->config.nodestore, parentNodeId, &variableTypes, refs, 2) &&
-                   !isNodeInTree(&server->config.nodestore, parentNodeId, &objectTypes, refs, 2)) {
+                // TODO handle subtypes of parent reference types
+                if(!isNodeInTree(&server->config.nodestore, parentNodeId, &variableTypes, parentReferences, UA_PARENT_REFERENCES_COUNT) &&
+                   !isNodeInTree(&server->config.nodestore, parentNodeId, &objectTypes, parentReferences, UA_PARENT_REFERENCES_COUNT)) {
                     UA_LOG_INFO_SESSION(server->config.logger, session,
                                         "AddNodes: Type of variable node must "
                                             "be VariableType and not cannot be abstract");
@@ -796,10 +807,8 @@ addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_Node *node,
             if(((const UA_ObjectTypeNode*)type)->isAbstract) {
                 /* Object node created of an abstract ObjectType. Only allowed if within BaseObjectType folder */
                 const UA_NodeId objectTypes = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE);
-                UA_NodeId refs[2];
-                refs[0] = UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE);
-                refs[1] = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
-                if(!isNodeInTree(&server->config.nodestore, parentNodeId, &objectTypes, refs, 2)) {
+                // TODO handle subtypes of parent reference types
+                if(!isNodeInTree(&server->config.nodestore, parentNodeId, &objectTypes, parentReferences, UA_PARENT_REFERENCES_COUNT)) {
                     UA_LOG_INFO_SESSION(server->config.logger, session,
                                         "AddNodes: Type of object node must "
                                             "be ObjectType and not be abstract");
@@ -862,6 +871,7 @@ addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_Node *node,
     }
 
  cleanup:
+    UA_Nodestore_release(server, node);
     if(type)
         UA_Nodestore_release(server, type);
     if(retval != UA_STATUSCODE_GOOD)
@@ -951,7 +961,9 @@ Operation_addNode_begin(UA_Server *server, UA_Session *session, void *nodeContex
         return retval;
     }
 
-    retval = addParentAndTypeRef(server, session, node, parentNodeId, referenceTypeId, &item->typeDefinition.nodeId);
+    /* we pass the nodeId instead of node to make sure the refcount is
+     * increased and other calls can not delete the node in the meantime */
+    retval = addParentAndTypeRef(server, session, &node->nodeId, parentNodeId, referenceTypeId, &item->typeDefinition.nodeId);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO_SESSION(server->config.logger, session,
                             "AddNodes: Node could add parent references with error code %s",

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -724,7 +724,6 @@ addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_NodeId *nod
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO_SESSION(server->config.logger, session,
                             "AddNodes: The parent reference is invalid");
-        UA_Server_deleteNode(server, node->nodeId, true);
         goto cleanup;
     }
 
@@ -882,7 +881,7 @@ addParentAndTypeRef(UA_Server *server, UA_Session *session, const UA_NodeId *nod
     if(type)
         UA_Nodestore_release(server, type);
     if(retval != UA_STATUSCODE_GOOD)
-        removeDeconstructedNode(server, session, node, true);
+        UA_Server_deleteNode(server, *nodeId, UA_TRUE);
     return retval;
 }
 
@@ -976,7 +975,7 @@ Operation_addNode_begin(UA_Server *server, UA_Session *session, void *nodeContex
         UA_LOG_INFO_SESSION(server->config.logger, session,
                             "AddNodes: Node could add parent references with error code %s",
                             UA_StatusCode_name(retval));
-        UA_Nodestore_delete(server, node);
+        // the node is already deleted within addParentAndTypeRef
     }
 
     return retval;

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -58,7 +58,7 @@ UA_Server_setNodeContext(UA_Server *server, UA_NodeId nodeId,
 
 #define UA_PARENT_REFERENCES_COUNT 2
 
-UA_NodeId parentReferences[UA_PARENT_REFERENCES_COUNT] = {
+const UA_NodeId parentReferences[UA_PARENT_REFERENCES_COUNT] = {
     {
         0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASSUBTYPE}
     },
@@ -523,7 +523,7 @@ copyChildNode(UA_Server *server, UA_Session *session,
         /* Add the parent reference */
         /* we pass the nodeId instead of node to make sure the refcount
          * is increased and other calls can not delete the node in the meantime */
-        retval = addParentAndTypeRef(server, session, &node->nodeId, destinationNodeId,
+        retval = addParentAndTypeRef(server, session, &newNodeId, destinationNodeId,
                                      &rd->referenceTypeId, typeId);
         if(retval != UA_STATUSCODE_GOOD) {
             UA_Nodestore_delete(server, node);
@@ -970,6 +970,7 @@ Operation_addNode_begin(UA_Server *server, UA_Session *session, void *nodeContex
 
     /* we pass the nodeId instead of node to make sure the refcount is
      * increased and other calls can not delete the node in the meantime */
+    // TODO on multithreading `node` may already have been deleted
     retval = addParentAndTypeRef(server, session, &node->nodeId, parentNodeId, referenceTypeId, &item->typeDefinition.nodeId);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO_SESSION(server->config.logger, session,


### PR DESCRIPTION
This addresses the comment here:
https://github.com/open62541/open62541/pull/1603#issuecomment-368455022

Additionally, @janitza-thbe requested an additional method which allows to get the parent of a specific node.
@jpfr Should we add it as a public API?
```c
static UA_StatusCode
UA_Server_getNodeParent(UA_Server *server, const UA_Node *node, UA_NodeId **parentNodeId, UA_NodeId **parentReferenceId) {
    for (size_t i=0; i< node->referencesSize; i++) {
        if (node->references[i].isInverse == UA_TRUE) {
            for (uint8_t r =0; r<UA_PARENT_REFERENCES_COUNT; r++) {
                // TODO handle subtypes of parent reference types
                if (UA_NodeId_equal(&node->references[i].referenceTypeId, &parentReferences[r])) {
                    *parentNodeId = &node->references[i].targetIds[0].nodeId;
                    *parentReferenceId = &parentReferences[r];
                    return UA_STATUSCODE_GOOD;
                }
            }
        }
    }

    return UA_STATUSCODE_BADNOTFOUND;
}
```