### PR TITLE
NodesetCompiler use Byte array instead of string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,13 +709,6 @@ add_dependencies(open62541-amalgamation-header open62541-generator-types)
 add_dependencies(open62541-amalgamation-source open62541-generator-types
                  open62541-generator-transport open62541-generator-statuscode)
 
-
-set(NODESET_MAX_STR_LEN 0)
-if(MSVC)
-    # Visual Studio has a maximum string length of 65535 bytes
-    set(NODESET_MAX_STR_LEN 65535)
-endif()
-
 if(NOT UA_NODESET_ENCODE_BINARY_SIZE)
     set(UA_NODESET_ENCODE_BINARY_SIZE 32000)
 endif()
@@ -727,7 +720,6 @@ add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src_generated/ua_namespace0.c
                    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/nodeset_compiler/nodeset_compiler.py
                            --generate-ns0
                            --internal-headers
-                           --max-string-length=${NODESET_MAX_STR_LEN}
                            --encode-binary-size=${UA_NODESET_ENCODE_BINARY_SIZE}
                            --ignore ${PROJECT_SOURCE_DIR}/tools/nodeset_compiler/NodeID_NS0_Base.txt
                            --xml ${UA_FILE_NS0}

--- a/doc/nodeset_compiler.rst
+++ b/doc/nodeset_compiler.rst
@@ -212,7 +212,7 @@ Take the previous snippet and save it to a file ``myNS.xml``. To compile this no
                                [--generate-ns0] [--internal-headers]
                                [-b <blacklistFile>] [-i <ignoreFile>]
                                [-t <typesArray>]
-                               [--max-string-length MAX_STRING_LENGTH] [-v]
+                               [-v]
                                <outputFile>
 
     positional arguments:

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -130,7 +130,7 @@ def sortNodes(nodeset):
 # Generate C Code #
 ###################
 
-def generateOpen62541Code(nodeset, outfilename, generate_ns0=False, internal_headers=False, typesArray=[], max_string_length=0, encode_binary_size=32000):
+def generateOpen62541Code(nodeset, outfilename, generate_ns0=False, internal_headers=False, typesArray=[], encode_binary_size=32000):
     outfilebase = basename(outfilename)
     # Printing functions
     outfileh = codecs.open(outfilename + ".h", r"w+", encoding='utf-8')
@@ -234,7 +234,7 @@ extern UA_StatusCode %s(UA_Server *server);
         parentref = node.popParentRef(parentreftypes)
         if not node.hidden:
             writec("\n/* " + str(node.displayName) + " - " + str(node.id) + " */")
-            code = generateNodeCode_begin(node, nodeset, max_string_length, generate_ns0, parentref, encode_binary_size)
+            code = generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary_size)
             if code is None:
                 writec("/* Ignored. No parent */")
                 nodeset.hide_node(node.id)

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -23,6 +23,7 @@ import string
 from os.path import basename
 import logging
 import codecs
+import os
 try:
     from StringIO import StringIO
 except ImportError:
@@ -295,10 +296,15 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
         writec("retVal |= function_" + outfilebase + "_" + str(i) + "_finish(server, ns);")
 
     writec("return retVal;\n}")
+    outfileh.flush()
+    os.fsync(outfileh)
     outfileh.close()
     fullCode = outfilec.getvalue()
     outfilec.close()
 
     outfilec = codecs.open(outfilename + ".c", r"w+", encoding='utf-8')
     outfilec.write(fullCode)
+    outfilec.flush()
+    os.fsync(outfilec)
     outfilec.close()
+

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -235,12 +235,16 @@ extern UA_StatusCode %s(UA_Server *server);
         parentref = node.popParentRef(parentreftypes)
         if not node.hidden:
             writec("\n/* " + str(node.displayName) + " - " + str(node.id) + " */")
-            code = generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary_size)
+            code_global = []
+            code = generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary_size, code_global)
             if code is None:
                 writec("/* Ignored. No parent */")
                 nodeset.hide_node(node.id)
                 continue
             else:
+                if len(code_global) > 0:
+                    writec("\n".join(code_global))
+                    writec("\n")
                 writec("\nstatic UA_StatusCode function_" + outfilebase + "_" + str(functionNumber) + "_begin(UA_Server *server, UA_UInt16* ns) {")
                 if isinstance(node, MethodNode):
                     writec("#ifdef UA_ENABLE_METHODCALLS")

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -185,8 +185,8 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, recursionDepth=0, 
             "Encoding of field " + subv.alias + " is " + str(subv.encodingRule) + "defined by " + str(encField))
         # Check if this is an array
         if encField[2] == 0:
-            code.append(instanceName + "_struct." + subv.alias + " = " +
-                        generateNodeValueCode(subv, instanceName, asIndirect=False, max_string_length=max_string_length) + ";")
+            code.append(generateNodeValueCode(instanceName + "_struct." + subv.alias + " = " ,
+                        subv, instanceName, asIndirect=False, max_string_length=max_string_length))
         else:
             if isinstance(subv, list):
                 # this is an array
@@ -199,8 +199,8 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, recursionDepth=0, 
                 for subvidx in range(0, len(subv)):
                     subvv = subv[subvidx]
                     logger.debug("  " + str(subvidx) + " " + str(subvv))
-                    code.append(instanceName + "_struct." + subv.alias + "[" + str(
-                        subvidx) + "] = " + generateNodeValueCode(subvv, instanceName, max_string_length=max_string_length) + ";")
+                    code.append(generateNodeValueCode(instanceName + "_struct." + subv.alias + "[" + str(
+                        subvidx) + "] = " , subvv, instanceName, max_string_length=max_string_length))
                 code.append("}")
             else:
                 code.append(instanceName + "_struct." + subv.alias + "Size = 1;")
@@ -209,8 +209,8 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, recursionDepth=0, 
                         instanceName, subv.alias, subv.__class__.__name__))
                 codeCleanup.append("UA_free({0}_struct.{1});".format(instanceName, subv.alias))
 
-                code.append(instanceName + "_struct." + subv.alias + "[0]  = " +
-                            generateNodeValueCode(subv, instanceName, asIndirect=True, max_string_length=max_string_length) + ";")
+                code.append(generateNodeValueCode(instanceName + "_struct." + subv.alias + "[0]  = " ,
+                            subv, instanceName, asIndirect=True, max_string_length=max_string_length))
 
     # Allocate some memory
     code.append("UA_ExtensionObject *" + instanceName + " =  UA_ExtensionObject_new();")
@@ -339,15 +339,15 @@ def generateValueCode(node, parentNode, nodeset, bootstrapping=True, max_string_
                 for idx, v in enumerate(node.value):
                     logger.debug("Printing extObj array index " + str(idx))
                     instanceName = generateNodeValueInstanceName(v, parentNode, 0, idx)
-                    code.append(
-                        valueName + "[" + str(idx) + "] = " +
-                        generateNodeValueCode(v, instanceName, max_string_length=max_string_length) + ";")
+                    code.append(generateNodeValueCode(
+                        valueName + "[" + str(idx) + "] = ",
+                        v, instanceName, max_string_length=max_string_length))
                     # code.append("UA_free(&" +valueName + "[" + str(idx) + "]);")
             else:
                 for idx, v in enumerate(node.value):
                     instanceName = generateNodeValueInstanceName(v, parentNode, 0, idx)
-                    code.append(
-                        valueName + "[" + str(idx) + "] = " + generateNodeValueCode(v, instanceName, max_string_length=max_string_length) + ";")
+                    code.append(generateNodeValueCode(
+                        valueName + "[" + str(idx) + "] = " , v, instanceName, max_string_length=max_string_length))
             code.append("UA_Variant_setArray(&attr.value, &" + valueName +
                         ", (UA_Int32) " + str(len(node.value)) + ", " +
                         getTypesArrayForValue(nodeset, node.value[0]) + ");")
@@ -368,8 +368,8 @@ def generateValueCode(node, parentNode, nodeset, bootstrapping=True, max_string_
                 codeCleanup = codeCleanup + codeCleanup1
             instanceName = generateNodeValueInstanceName(node.value[0], parentNode, 0, 0)
             if isinstance(node.value[0], ExtensionObject):
-                code.append("UA_" + node.value[0].__class__.__name__ + " *" + valueName + " = " +
-                            generateNodeValueCode(node.value[0], instanceName, max_string_length=max_string_length) + ";")
+                code.append(generateNodeValueCode("UA_" + node.value[0].__class__.__name__ + " *" + valueName + " = " ,
+                            node.value[0], instanceName, max_string_length=max_string_length))
                 code.append(
                     "UA_Variant_setScalar(&attr.value, " + valueName + ", " +
                     getTypesArrayForValue(nodeset, node.value[0]) + ");")
@@ -379,7 +379,7 @@ def generateValueCode(node, parentNode, nodeset, bootstrapping=True, max_string_
             else:
                 code.append("UA_" + node.value[0].__class__.__name__ + " *" + valueName + " =  UA_" + node.value[
                     0].__class__.__name__ + "_new();")
-                code.append("*" + valueName + " = " + generateNodeValueCode(node.value[0], instanceName, asIndirect=True, max_string_length=max_string_length) + ";")
+                code.append(generateNodeValueCode("*" + valueName + " = " , node.value[0], instanceName, asIndirect=True, max_string_length=max_string_length))
                 code.append(
                         "UA_Variant_setScalar(&attr.value, " + valueName + ", " +
                         getTypesArrayForValue(nodeset, node.value[0]) + ");")
@@ -482,7 +482,7 @@ def generateNodeCode_begin(node, nodeset, max_string_length, generate_ns0, paren
     code.append("(const UA_NodeAttributes*)&attr, &UA_TYPES[UA_TYPES_{}ATTRIBUTES],NULL, NULL);".
                 format(node.__class__.__name__.upper().replace("NODE" ,"")))
     code.extend(codeCleanup)
-    
+
     return "\n".join(code)
 
 def generateNodeCode_finish(node):

--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -82,12 +82,6 @@ parser.add_argument('-t', '--types-array',
                     default=[],
                     help='Types array for the given namespace. Can be used mutliple times to define (in the same order as the .xml files, first for --existing, then --xml) the type arrays')
 
-parser.add_argument('--max-string-length',
-                    type=int,
-                    dest="max_string_length",
-                    default=0,
-                    help='Maximum allowed length of a string literal. If longer, it will be set to an empty string')
-
 parser.add_argument('--encode-binary-size',
                     type=int,
                     dest="encode_binary_size",
@@ -188,5 +182,5 @@ ns.allocateVariables()
 
 # Create the C code with the open62541 backend of the compiler
 logger.info("Generating Code")
-generateOpen62541Code(ns, args.outputFile, args.generate_ns0, args.internal_headers, args.typesArray, args.max_string_length, args.encode_binary_size)
+generateOpen62541Code(ns, args.outputFile, args.generate_ns0, args.internal_headers, args.typesArray, args.encode_binary_size)
 logger.info("NodeSet generation code successfully printed")


### PR DESCRIPTION
Due to issue #1254 : The huge strings are changed as arrays of ASCII values of each element inside for ByteArrays. And also some implementations are done due to task.

Fixes #1254