### PR TITLE
Fix memoryleak in certificateVerification_verify

### DIFF
--- a/plugins/ua_pki_certificate.c
+++ b/plugins/ua_pki_certificate.c
@@ -77,6 +77,7 @@ certificateVerification_verify(void *verificationContext,
         /*              UA_LOGCATEGORY_SECURITYPOLICY, */
         /*              "Verifying the certificate failed with error: %s", buff); */
 
+        mbedtls_x509_crt_free(&remoteCertificate);
         if(flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED)
             return UA_STATUSCODE_BADCERTIFICATEUNTRUSTED;
 
@@ -91,6 +92,7 @@ certificateVerification_verify(void *verificationContext,
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     }
 
+    mbedtls_x509_crt_free(&remoteCertificate);
     return UA_STATUSCODE_GOOD;
 }
 


### PR DESCRIPTION
Stumbled across this while implementing valgrind monitoring for fuzzing.