### PR TITLE
Added highlevel API for historical access

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -56,6 +56,8 @@ add_example(server server.c)
 
 add_example(client client.c)
 
+add_example(client_historical client_historical.c)
+
 add_example(client_connect_loop client_connect_loop.c)
 
 if(UA_ENABLE_SUBSCRIPTIONS)

--- a/examples/client_historical.c
+++ b/examples/client_historical.c
@@ -128,11 +128,11 @@ int main(int argc, char *argv[]) {
     /* Read historical values */
     printf("\nStart historical read (4, \"Demo.History.ByteWithHistory\"):\n");
     retval = UA_Client_readHistorical(client, UA_NODEID_STRING(4, "Demo.History.ByteWithHistory"), readHist,
-        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_FALSE);
+        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), false, 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_FALSE);
 
     printf("\nStart historical read (4, \"Demo.History.DoubleWithHistory\"):\n");
     retval = UA_Client_readHistorical(client, UA_NODEID_STRING(4, "Demo.History.DoubleWithHistory"), readHist,
-        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_TRUE);
+        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), false, 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_TRUE);
 
 cleanup:
     UA_Client_disconnect(client);

--- a/examples/client_historical.c
+++ b/examples/client_historical.c
@@ -1,0 +1,141 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <stdio.h>
+#include "open62541.h"
+
+#ifdef _WIN32
+# include <windows.h>
+# define UA_sleep_ms(X) Sleep(X)
+#else
+# include <unistd.h>
+# define UA_sleep_ms(X) usleep(X * 1000)
+#endif
+
+static UA_Boolean
+readHist(const UA_NodeId nodeId, const UA_Boolean isInverse,
+         const UA_Boolean moreDataAvailable,
+         const UA_HistoryData *data, void *isDouble) {
+
+    printf("\nRead historical callback:\n");
+    printf("\tValue count:\t%d\n", data->dataValuesSize);
+    printf("\tIs inverse:\t%d\n", isInverse);
+    printf("\tHas more data:\t%d\n\n", moreDataAvailable);
+
+    /* Iterate over all values */
+    for (size_t i = 0; i < data->dataValuesSize; ++i)
+    {
+        UA_DataValue val = data->dataValues[i];
+        
+        /* If there is no value, we are out of bounds or something bad hapened */
+        if (!val.hasValue) {
+            if (val.hasStatus) {
+                if (val.status == UA_STATUSCODE_BADBOUNDNOTFOUND)
+                    printf("Skipping bounds (i=%d)\n\n", i);
+                else
+                    printf("Skipping (i=%d) (status=%08x -> %s)\n\n", i, val.status, UA_StatusCode_name(val.status));
+            }
+
+            continue;
+        }
+        
+        /* The handle is used to determine double and byte request */
+        if ((UA_Boolean)isDouble) {
+            UA_Double hrValue = *(UA_Double *)val.value.data;
+            printf("ByteValue (i=%d) %f\n", i, hrValue);
+        }
+        else {
+            UA_Byte hrValue = *(UA_Byte *)val.value.data;
+            printf("DoubleValue (i=%d) %d\n", i, hrValue);
+        }
+
+        /* Print status and timestamps */
+        if (val.hasStatus)
+            printf("Status %u\n", val.status);
+        if (val.hasServerTimestamp) {
+            UA_DateTimeStruct dts = UA_DateTime_toStruct(val.serverTimestamp);
+            printf("ServerTime: %02u-%02u-%04u %02u:%02u:%02u.%03u\n",
+                dts.day, dts.month, dts.year, dts.hour, dts.min, dts.sec, dts.milliSec);
+        }
+        if (val.hasSourceTimestamp) {
+            UA_DateTimeStruct dts = UA_DateTime_toStruct(val.sourceTimestamp);
+            printf("ServerTime: %02u-%02u-%04u %02u:%02u:%02u.%03u\n",
+                dts.day, dts.month, dts.year, dts.hour, dts.min, dts.sec, dts.milliSec);
+        }
+        printf("\n");
+    }
+
+    /* We want more data! */
+    return true;
+}
+
+int main(int argc, char *argv[]) {
+    UA_Client *client = UA_Client_new(UA_ClientConfig_default);
+
+    /* Listing endpoints */
+    UA_EndpointDescription* endpointArray = NULL;
+    size_t endpointArraySize = 0;
+
+    /* Connect to the Unified Automation demo server */
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:48020");
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_Client_delete(client);
+        return (int)retval;
+    }
+
+    /* Read, if data logging is active */
+    UA_Boolean active = UA_FALSE;
+    printf("Reading, if data logging is active (4, \"Demo.History.DataLoggerActive\"):\n");
+    UA_Variant *val = UA_Variant_new();
+    retval = UA_Client_readValueAttribute(client, UA_NODEID_STRING(4, "Demo.History.DataLoggerActive"), val);
+    if (retval == UA_STATUSCODE_GOOD && UA_Variant_isScalar(val) &&
+        val->type == &UA_TYPES[UA_TYPES_BOOLEAN]) {
+        active = *(UA_Boolean*)val->data;
+        if (active) 
+            printf("The data logging is active. Continue.\n");
+        else
+            printf("The data logging is not active!\n");
+    }
+    else {
+        printf("Failed to read data logging status.\n");
+        UA_Variant_delete(val);
+        goto cleanup;
+    }
+    UA_Variant_delete(val);
+
+#ifdef UA_ENABLE_METHODCALLS
+    /* Active server side data logging via remote method call */
+    if (!active) {
+        printf("Activate data logging.\n");
+        retval = UA_Client_call(client, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+            UA_NODEID_STRING(4, "Demo.History.StartLogging"), 0, NULL, NULL, NULL);
+        if (retval != UA_STATUSCODE_GOOD) {
+            printf("Start method call failed.\n");
+            goto cleanup;
+        }
+
+        /* The server logs a value every 50ms by default */
+        printf("Successfully started data logging. Let the server collect data for 2000ms..\n");
+        UA_sleep_ms(2000);
+    }
+#else
+    if (!active) {
+        printf("Method calling is not allowed, you have to active the data logging manually.\n");
+        goto cleanup;
+    }
+#endif
+
+    /* Read historical values */
+    printf("\nStart historical read (4, \"Demo.History.ByteWithHistory\"):\n");
+    retval = UA_Client_readHistorical(client, UA_NODEID_STRING(4, "Demo.History.ByteWithHistory"), readHist,
+        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_FALSE);
+
+    printf("\nStart historical read (4, \"Demo.History.DoubleWithHistory\"):\n");
+    retval = UA_Client_readHistorical(client, UA_NODEID_STRING(4, "Demo.History.DoubleWithHistory"), readHist,
+        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_TRUE);
+
+cleanup:
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+    return (int) retval;
+}

--- a/examples/client_historical.c
+++ b/examples/client_historical.c
@@ -127,12 +127,12 @@ int main(int argc, char *argv[]) {
 
     /* Read historical values */
     printf("\nStart historical read (4, \"Demo.History.ByteWithHistory\"):\n");
-    retval = UA_Client_readHistorical(client, UA_NODEID_STRING(4, "Demo.History.ByteWithHistory"), readHist,
-        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), false, 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_FALSE);
+    retval = UA_Client_readHistorical_raw(client, UA_NODEID_STRING(4, "Demo.History.ByteWithHistory"), readHist,
+        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), false, 10, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_FALSE);
 
     printf("\nStart historical read (4, \"Demo.History.DoubleWithHistory\"):\n");
-    retval = UA_Client_readHistorical(client, UA_NODEID_STRING(4, "Demo.History.DoubleWithHistory"), readHist,
-        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), false, 10, false, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_TRUE);
+    retval = UA_Client_readHistorical_raw(client, UA_NODEID_STRING(4, "Demo.History.DoubleWithHistory"), readHist,
+        UA_DateTime_fromUnixTime(0), UA_DateTime_now(), false, 10, UA_TIMESTAMPSTORETURN_BOTH, (void *)UA_TRUE);
 
 cleanup:
     UA_Client_disconnect(client);

--- a/include/ua_client.h
+++ b/include/ua_client.h
@@ -259,6 +259,17 @@ UA_Client_Service_write(UA_Client *client, const UA_WriteRequest request) {
 }
 
 /**
+* Historical Access Service Set
+* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ */
+static UA_INLINE UA_HistoryReadResponse
+UA_Client_Service_history_read(UA_Client *client, const UA_HistoryReadRequest request) {
+    UA_HistoryReadResponse response;
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_HISTORYREADREQUEST],
+        &response, &UA_TYPES[UA_TYPES_HISTORYREADRESPONSE]);
+    return response;
+}
+
+/**
  * Method Service Set
  * ^^^^^^^^^^^^^^^^^^ */
 #ifdef UA_ENABLE_METHODCALLS

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -444,6 +444,13 @@ typedef UA_Boolean
                                  const UA_HistoryData *data, void *handle);
 
 UA_StatusCode UA_EXPORT
+UA_Client_readHistorical_events(UA_Client *client, const UA_NodeId nodeId,
+                                const UA_HistoricalIteratorCallback callback,
+                                const UA_DateTime startTime, const UA_DateTime endTime,
+                                const UA_EventFilter filter, const UA_UInt32 maxItems,
+                                const UA_TimestampsToReturn timestampsToReturn, void* handle);
+
+UA_StatusCode UA_EXPORT
 UA_Client_readHistorical_raw(UA_Client *client, const UA_NodeId nodeId,
                              const UA_HistoricalIteratorCallback callback,
                              const UA_DateTime startTime, const UA_DateTime endTime,

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -447,8 +447,9 @@ UA_StatusCode UA_EXPORT
 UA_Client_readHistorical(UA_Client *client, const UA_NodeId nodeId,
                          const UA_HistoricalIteratorCallback callback,
                          const UA_DateTime startTime, const UA_DateTime endTime,
-                         const UA_UInt32 maxItems, const UA_Boolean returnBounds,
-                         const UA_TimestampsToReturn timestampsToReturn, void *handle);
+                         const UA_Boolean returnBounds, const UA_UInt32 maxItems,
+                         const UA_Boolean readModified, const UA_TimestampsToReturn timestampsToReturn,
+                         void *handle);
 
 /* Don't call this function, use the typed versions */
 UA_StatusCode UA_EXPORT

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -444,12 +444,18 @@ typedef UA_Boolean
                                  const UA_HistoryData *data, void *handle);
 
 UA_StatusCode UA_EXPORT
-UA_Client_readHistorical(UA_Client *client, const UA_NodeId nodeId,
-                         const UA_HistoricalIteratorCallback callback,
-                         const UA_DateTime startTime, const UA_DateTime endTime,
-                         const UA_Boolean returnBounds, const UA_UInt32 maxItems,
-                         const UA_Boolean readModified, const UA_TimestampsToReturn timestampsToReturn,
-                         void *handle);
+UA_Client_readHistorical_raw(UA_Client *client, const UA_NodeId nodeId,
+                             const UA_HistoricalIteratorCallback callback,
+                             const UA_DateTime startTime, const UA_DateTime endTime,
+                             const UA_Boolean returnBounds, const UA_UInt32 maxItems,
+                             const UA_TimestampsToReturn timestampsToReturn, void *handle);
+
+UA_StatusCode UA_EXPORT
+UA_Client_readHistorical_modified(UA_Client *client, const UA_NodeId nodeId,
+                                  const UA_HistoricalIteratorCallback callback,
+                                  const UA_DateTime startTime, const UA_DateTime endTime,
+                                  const UA_Boolean returnBounds, const UA_UInt32 maxItems,
+                                  const UA_TimestampsToReturn timestampsToReturn, void *handle);
 
 /* Don't call this function, use the typed versions */
 UA_StatusCode UA_EXPORT

--- a/include/ua_client_highlevel.h
+++ b/include/ua_client_highlevel.h
@@ -438,6 +438,18 @@ UA_EXPORT extern const UA_DataTypeAttributes UA_DataTypeAttributes_default;
 UA_EXPORT extern const UA_ViewAttributes UA_ViewAttributes_default;
 #endif
 
+typedef UA_Boolean
+(*UA_HistoricalIteratorCallback)(const UA_NodeId nodeId, const UA_Boolean isInverse,
+                                 const UA_Boolean moreDataAvailable,
+                                 const UA_HistoryData *data, void *handle);
+
+UA_StatusCode UA_EXPORT
+UA_Client_readHistorical(UA_Client *client, const UA_NodeId nodeId,
+                         const UA_HistoricalIteratorCallback callback,
+                         const UA_DateTime startTime, const UA_DateTime endTime,
+                         const UA_UInt32 maxItems, const UA_Boolean returnBounds,
+                         const UA_TimestampsToReturn timestampsToReturn, void *handle);
+
 /* Don't call this function, use the typed versions */
 UA_StatusCode UA_EXPORT
 __UA_Client_addNode(UA_Client *client, const UA_NodeClass nodeClass,

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -564,7 +564,7 @@ UA_Client_readHistorical_events(UA_Client *client, const UA_NodeId nodeId,
     details.endTime = endTime;
 
     UA_Boolean isInverse = !startTime || (endTime && (startTime > endTime));
-    UA_StatusCode retval = __UA_Client_readHistorical_service(client, nodeId, callback, &details,
+    return __UA_Client_readHistorical_service(client, nodeId, callback, &details,
                                               timestampsToReturn, isInverse, 0, handle);
 
     UA_ReadEventDetails_deleteMembers(&details);
@@ -591,11 +591,8 @@ __UA_Client_readHistorical_service_rawMod(UA_Client *client, const UA_NodeId nod
     details.endTime = endTime;
 
     UA_Boolean isInverse = !startTime || (endTime && (startTime > endTime));
-    UA_StatusCode retval = __UA_Client_readHistorical_service(client, nodeId, callback, &details,
-                                                              timestampsToReturn, isInverse, maxItems, handle);
-
-    UA_ReadRawModifiedDetails_deleteMembers(&details);
-    return retval;
+    return __UA_Client_readHistorical_service(client, nodeId, callback, &details,
+                                              timestampsToReturn, isInverse, maxItems, handle);
 }
 
 UA_StatusCode

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -459,31 +459,19 @@ UA_Client_readArrayDimensionsAttribute(UA_Client *client, const UA_NodeId nodeId
 /* Historical Access */
 /*********************/
 
+// FIXME: Function for ReadProcessedDetails is missing
 UA_HistoryReadResponse
 __UA_Client_readHistorical(UA_Client *client, const UA_NodeId nodeId,
-                           const UA_DateTime startTime, const UA_DateTime endTime,
-                           const UA_Boolean returnBounds, const UA_UInt32 maxItems,
-                           const UA_Boolean readModified, const UA_TimestampsToReturn timestampsToReturn,
+                           void* details, const UA_TimestampsToReturn timestampsToReturn,
                            const UA_ByteString continuationPoint, const UA_Boolean releaseConti) {
 
     UA_HistoryReadValueId item;
     UA_HistoryReadValueId_init(&item);
 
     item.nodeId = nodeId;
-    item.indexRange = UA_STRING_NULL; // TODO: UA_Client_readHistorical_array with NumericRange (?)
+    item.indexRange = UA_STRING_NULL; // TODO: NumericRange (?)
     item.continuationPoint = continuationPoint;
     item.dataEncoding = UA_QUALIFIEDNAME(0, "Default Binary");
-
-    // TODO: ReadEventDetails / ReadProcessedDetails / ReadAtTimeDetails
-    UA_ReadRawModifiedDetails details;
-    UA_ReadRawModifiedDetails_init(&details);
-    details.isReadModified = readModified; // Return only modified values
-    details.returnBounds = returnBounds;   // Return values pre / post given range
-
-    // At least two of the following parameters must be set
-    details.numValuesPerNode = maxItems; // 0 = return all / max server is capable of
-    details.startTime = startTime;
-    details.endTime = endTime;
 
     UA_HistoryReadRequest request;
     UA_HistoryReadRequest_init(&request);
@@ -495,19 +483,60 @@ __UA_Client_readHistorical(UA_Client *client, const UA_NodeId nodeId,
 
     /* Build ReadDetails */
     request.historyReadDetails.content.decoded.type = &UA_TYPES[UA_TYPES_READRAWMODIFIEDDETAILS];
-    request.historyReadDetails.content.decoded.data = &details;
+    request.historyReadDetails.content.decoded.data = details;
     request.historyReadDetails.encoding = UA_EXTENSIONOBJECT_DECODED;
 
     return UA_Client_Service_history_read(client, request);
 }
 
+UA_HistoryReadResponse
+__UA_Client_readHistorical_events(UA_Client *client, const UA_NodeId nodeId,
+                                  const UA_DateTime startTime, const UA_DateTime endTime,
+                                  const UA_EventFilter filter, const UA_UInt32 maxItems,
+                                  const UA_TimestampsToReturn timestampsToReturn,
+                                  const UA_ByteString continuationPoint, const UA_Boolean releaseConti) {
+
+    // TODO: ReadProcessedDetails / ReadAtTimeDetails
+    UA_ReadEventDetails details;
+    UA_ReadEventDetails_init(&details);
+    details.filter = filter;
+    
+    // At least two of the following parameters must be set
+    details.numValuesPerNode = maxItems; // 0 = return all / max server is capable of
+    details.startTime = startTime;
+    details.endTime = endTime;
+
+    return __UA_Client_readHistorical(client, nodeId, &details, timestampsToReturn, continuationPoint, releaseConti);
+}
+
+UA_HistoryReadResponse
+__UA_Client_readHistorical_rawModified(UA_Client *client, const UA_NodeId nodeId,
+    const UA_DateTime startTime, const UA_DateTime endTime,
+    const UA_Boolean returnBounds, const UA_UInt32 maxItems,
+    const UA_Boolean readModified, const UA_TimestampsToReturn timestampsToReturn,
+    const UA_ByteString continuationPoint, const UA_Boolean releaseConti) {
+
+    // TODO: ReadProcessedDetails / ReadAtTimeDetails
+    UA_ReadRawModifiedDetails details;
+    UA_ReadRawModifiedDetails_init(&details);
+    details.isReadModified = readModified; // Return only modified values
+    details.returnBounds = returnBounds;   // Return values pre / post given range
+
+                                           // At least two of the following parameters must be set
+    details.numValuesPerNode = maxItems; // 0 = return all / max server is capable of
+    details.startTime = startTime;
+    details.endTime = endTime;
+
+    return __UA_Client_readHistorical(client, nodeId, &details, timestampsToReturn, continuationPoint, releaseConti);
+}
+
 UA_StatusCode
-UA_Client_readHistorical(UA_Client *client, const UA_NodeId nodeId,
-                         const UA_HistoricalIteratorCallback callback,
-                         const UA_DateTime startTime, const UA_DateTime endTime,
-                         const UA_Boolean returnBounds, const UA_UInt32 maxItems,
-                         const UA_Boolean readModified, const UA_TimestampsToReturn timestampsToReturn,
-                         void *handle) {
+__UA_Client_readHistorical_service(UA_Client *client, const UA_NodeId nodeId,
+                                   const UA_HistoricalIteratorCallback callback,
+                                   const UA_DateTime startTime, const UA_DateTime endTime,
+                                   const UA_Boolean returnBounds, const UA_UInt32 maxItems,
+                                   const UA_Boolean readModified, const UA_TimestampsToReturn timestampsToReturn,
+                                   void *handle) {
 
     UA_Boolean isInverse = !startTime || (startTime > endTime);
     UA_ByteString continuationPoint = UA_BYTESTRING_NULL;
@@ -519,8 +548,8 @@ UA_Client_readHistorical(UA_Client *client, const UA_NodeId nodeId,
         /* We release the continuation point, if no more data is requested by the user */
         UA_Boolean cleanup = !fetchMore && continuationAvail;
         UA_HistoryReadResponse response =
-            __UA_Client_readHistorical(client, nodeId, startTime, endTime, returnBounds, maxItems,
-                                       readModified, timestampsToReturn, continuationPoint, cleanup);
+            __UA_Client_readHistorical_rawModified(client, nodeId, startTime, endTime, returnBounds, maxItems,
+                                                   readModified, timestampsToReturn, continuationPoint, cleanup);
 
         if (cleanup) {
             retval = response.responseHeader.serviceResult;
@@ -560,4 +589,26 @@ cleanup:    UA_HistoryReadResponse_deleteMembers(&response);
     } while (continuationAvail);
 
     return retval;
+}
+
+UA_StatusCode
+UA_Client_readHistorical_raw(UA_Client *client, const UA_NodeId nodeId,
+                             const UA_HistoricalIteratorCallback callback,
+                             const UA_DateTime startTime, const UA_DateTime endTime,
+                             const UA_Boolean returnBounds, const UA_UInt32 maxItems,
+                             const UA_TimestampsToReturn timestampsToReturn, void *handle) {
+
+    return __UA_Client_readHistorical_service(client, nodeId, callback, startTime, endTime,
+                                              returnBounds, maxItems, UA_FALSE, timestampsToReturn, handle);
+}
+
+UA_StatusCode
+UA_Client_readHistorical_modified(UA_Client *client, const UA_NodeId nodeId,
+                                  const UA_HistoricalIteratorCallback callback,
+                                  const UA_DateTime startTime, const UA_DateTime endTime,
+                                  const UA_Boolean returnBounds, const UA_UInt32 maxItems,
+                                  const UA_TimestampsToReturn timestampsToReturn, void *handle) {
+
+    return __UA_Client_readHistorical_service(client, nodeId, callback, startTime, endTime,
+                                              returnBounds, maxItems, UA_TRUE, timestampsToReturn, handle);
 }

--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -197,3 +197,10 @@ AggregateConfiguration
 AggregateFilter
 SetTriggeringRequest
 SetTriggeringResponse
+HistoryReadValueId
+HistoryReadResult
+HistoryReadDetails
+ReadRawModifiedDetails
+HistoryData
+HistoryReadRequest
+HistoryReadResponse

--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -201,6 +201,7 @@ HistoryReadValueId
 HistoryReadResult
 HistoryReadDetails
 ReadRawModifiedDetails
+ReadEventDetails
 HistoryData
 HistoryReadRequest
 HistoryReadResponse


### PR DESCRIPTION
At the moment, it allows to read a single node historically.
It could be altered to support multiple nodes if desired, but this could make the API slightly more complex.

The `readAtTime` function is "missing", as I havn't found a server supporting it to test against.

An example is included, which relies on `Unified Automations OPC UA ANSI C Demo Server` atm, but as I'm working on server side historical access this could change.

Regards.