### PR TITLE
Typo in cmake option: Trailing S missing in BUILD_SHARED_LIBS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,7 @@ endif()
 if(MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3 /WX /w44996") # Compiler warnings, error on warning
 
-  if(NOT BUILD_SHARED_LIB)
+  if(NOT BUILD_SHARED_LIBS)
     set(CompilerFlags CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS
         CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE)
     foreach(CompilerFlag ${CompilerFlags})


### PR DESCRIPTION
This typo introduced the following bug:

When building open62541 against mbedtls, the compiler options
for the C Runtime-Libraries mbedtls is built with do not match
the ones for open62541 anymore resulting in linker errors.
This bug is MSVC-related only.