### PR TITLE
Add missing ifdef for compiling namespace externally

### DIFF
--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -491,8 +491,14 @@ printh('''/* Generated from ''' + inname + ''' with script ''' + sys.argv[0] + '
 extern "C" {
 #endif
 
+#ifdef UA_NO_AMALGAMATION
 #include "ua_types.h"
-''' + ('#include "ua_types_generated.h"\n' if outname != "ua_types" else ''))
+''' + ('#include "ua_types_generated.h"\n' if outname != "ua_types" else '') + '''
+#else
+#include "open62541.h"
+#endif
+
+''')
 
 filtered_types = iter_types(types, False)
 filtered_opaque_types = iter_types(types, True)

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -189,19 +189,55 @@ def generateOpen62541Code(nodeset, outfilename, generate_ns0=False, internal_hea
     if internal_headers:
         writeh("""
 #ifdef UA_NO_AMALGAMATION
-#include "ua_server.h"
-#include "ua_types_encoding_binary.h"
-%s
+# include "ua_server.h"
+# include "ua_types_encoding_binary.h"
 #else
-#include "open62541.h"
+# include "open62541.h"
+
+/* The following declarations are in the open62541.c file so here's needed when compiling nodesets externally */
+
+# ifndef UA_Nodestore_remove //this definition is needed to hide this code in the amalgamated .c file
+
+typedef UA_StatusCode (*UA_exchangeEncodeBuffer)(void *handle, UA_Byte **bufPos,
+                                                 const UA_Byte **bufEnd);
+
+UA_StatusCode
+UA_encodeBinary(const void *src, const UA_DataType *type,
+                UA_Byte **bufPos, const UA_Byte **bufEnd,
+                UA_exchangeEncodeBuffer exchangeCallback,
+                void *exchangeHandle) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+
+UA_StatusCode
+UA_decodeBinary(const UA_ByteString *src, size_t *offset, void *dst,
+                const UA_DataType *type, size_t customTypesSize,
+                const UA_DataType *customTypes) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+
+size_t
+UA_calcSizeBinary(void *p, const UA_DataType *type);
+
+const UA_DataType *
+UA_findDataTypeByBinary(const UA_NodeId *typeId);
+
+# endif // UA_Nodestore_remove
+
 #endif
+
+%s
 """ % (additionalHeaders))
     else:
         writeh("""
 #include "open62541.h"
 """)
     writeh("""
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
 extern UA_StatusCode %s(UA_Server *server);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* %s_H_ */""" % \
            (outfilebase, outfilebase.upper()))


### PR DESCRIPTION
I added some namespaces and followed #823 until some point to generate my namespaces files. I wanted to compile these files in my own project in C++ wich uses the open62541 static library. I added then in this PR what's needed for C++ and the big change is that I want to include only the folder where open62541.h file is, so the only thing missing was the ua_types_encoding_binary.h which is not exported so it is only present in the open62541.c file. I added the declarations of it for the namespaces and included a ["hack"](https://github.com/open62541/open62541/compare/master...cabralfortiss:master#diff-36dccac8f1a25167289a84f42ba74460R199) to avoid compiling errors for namespace0 in amalgamation