### PR TITLE
fix security policy amalgamation odr violations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,8 @@ if(UA_ENABLE_ENCRYPTION)
     set(default_plugin_headers ${default_plugin_headers}
             ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic256sha256.h)
     set(default_plugin_sources ${default_plugin_sources}
+            ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_common.c)
+    set(default_plugin_sources ${default_plugin_sources}
             ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.c)
     set(default_plugin_sources ${default_plugin_sources}
             ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic256sha256.c)

--- a/plugins/ua_securitypolicy_common.c
+++ b/plugins/ua_securitypolicy_common.c
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mbedtls/sha1.h>
+
+#include "ua_securitypolicy_common.h"
+
+
+void
+sha1(const unsigned char *input, size_t ilen, unsigned char output[20]) {
+    mbedtls_sha1_context sha1Context;
+    mbedtls_sha1_init(&sha1Context);
+    mbedtls_sha1_starts(&sha1Context);
+    mbedtls_sha1_update(&sha1Context, input, ilen);
+    mbedtls_sha1_finish(&sha1Context, output);
+    mbedtls_sha1_free(&sha1Context);
+}

--- a/plugins/ua_securitypolicy_common.h
+++ b/plugins/ua_securitypolicy_common.h
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+ 
+#ifndef UA_SECURITYPOLICY_COMMON_H_
+#define UA_SECURITYPOLICY_COMMON_H_
+
+void
+sha1(const unsigned char *input, size_t ilen, unsigned char output[20]);
+
+#endif // UA_SECURITYPOLICY_COMMON_H_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,9 +21,9 @@ include_directories(${PROJECT_SOURCE_DIR}/tests/testing-plugins)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/tests)
 if (MSVC)
-	set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests/${CMAKE_BUILD_TYPE})
+    set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests/${CMAKE_BUILD_TYPE})
 else()
-	set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests)
+    set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests)
 endif()
 
 
@@ -42,6 +42,8 @@ set(test_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.c
 )
 
 if(UA_ENABLE_ENCRYPTION)
+    set(test_plugin_sources ${test_plugin_sources}
+        ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_common.c)
     set(test_plugin_sources ${test_plugin_sources}
         ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.c)
     set(test_plugin_sources ${test_plugin_sources}

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -65,6 +65,8 @@ set(fuzzing_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.c
 
 if(UA_ENABLE_ENCRYPTION)
     set(fuzzing_plugin_sources ${fuzzing_plugin_sources}
+        ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_common.c)
+    set(fuzzing_plugin_sources ${fuzzing_plugin_sources}
         ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.c)
     set(fuzzing_plugin_sources ${fuzzing_plugin_sources}
         ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic256sha256.c)


### PR DESCRIPTION
Adds two additional files in the plugins directory: ua_securitypolicy_common.h/.c
Pulls out sha1 function into these common files and renames other conflicting functions.
These new files could also be used in the future to reduce code duplication between security policy basic128rsa15 and basic256sha256.
#1643 