### PR TITLE
Feature/remove const qualifier from data variable in edit node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ mark_as_advanced(UA_ENABLE_DETERMINISTIC_RNG)
 option(UA_ENABLE_VALGRIND_INTERACTIVE "Enable dumping valgrind every iteration. CAUTION! SLOWDOWN!" OFF)
 mark_as_advanced(UA_ENABLE_VALGRIND_INTERACTIVE)
 
+option(UA_MSVC_FORCE_STATIC_CRT "Force linking with the static C-runtime library when compiling to static library with MSVC" ON)
+mark_as_advanced(UA_MSVC_FORCE_STATIC_CRT)
+
 option(UA_ENABLE_FULL_NS0 "Use the full NS0 instead of a minimal Namespace 0 nodeset" OFF)
 if (MSVC AND UA_ENABLE_FULL_NS0)
     # For the full NS0 we need a stack size of 8MB (as it is default on linux)
@@ -300,7 +303,7 @@ endif()
 if(MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W3 /WX /w44996") # Compiler warnings, error on warning
 
-  if(NOT BUILD_SHARED_LIBS)
+  if(UA_MSVC_FORCE_STATIC_CRT AND NOT BUILD_SHARED_LIBS)
     set(CompilerFlags CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS
         CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE)
     foreach(CompilerFlag ${CompilerFlags})
@@ -436,8 +439,14 @@ set(default_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.c
 if(UA_ENABLE_ENCRYPTION)
     set(default_plugin_headers ${default_plugin_headers}
             ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.h)
+    set(default_plugin_headers ${default_plugin_headers}
+            ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic256sha256.h)
+    set(default_plugin_sources ${default_plugin_sources}
+            ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_common.c)
     set(default_plugin_sources ${default_plugin_sources}
             ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.c)
+    set(default_plugin_sources ${default_plugin_sources}
+            ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic256sha256.c)
 endif()
 
 if(UA_DEBUG_DUMP_PKGS)

--- a/examples/access_control/server_access_control.c
+++ b/examples/access_control/server_access_control.c
@@ -7,33 +7,33 @@
 #include "open62541.h"
 
 static UA_Boolean
-allowAddNode(const UA_NodeId *sessionId, void *sessionContext,
-    const UA_AddNodesItem *item)
-{
+allowAddNode(UA_Server *server, UA_AccessControl *ac,
+             const UA_NodeId *sessionId, void *sessionContext,
+             const UA_AddNodesItem *item) {
     printf("Called allowAddNode\n");
     return UA_TRUE;
 }
 
 static UA_Boolean
-allowAddReference(const UA_NodeId *sessionId, void *sessionContext,
-    const UA_AddReferencesItem *item)
-{
+allowAddReference(UA_Server *server, UA_AccessControl *ac,
+                  const UA_NodeId *sessionId, void *sessionContext,
+                  const UA_AddReferencesItem *item) {
     printf("Called allowAddReference\n");
     return UA_TRUE;
 }
 
 static UA_Boolean
-allowDeleteNode(const UA_NodeId *sessionId, void *sessionContext,
-    const UA_DeleteNodesItem *item)
-{
+allowDeleteNode(UA_Server *server, UA_AccessControl *ac,
+                const UA_NodeId *sessionId, void *sessionContext,
+                const UA_DeleteNodesItem *item) {
     printf("Called allowDeleteNode\n");
     return UA_FALSE; // Do not allow deletion from client
 }
 
 static UA_Boolean
-allowDeleteReference(const UA_NodeId *sessionId, void *sessionContext,
-    const UA_DeleteReferencesItem *item)
-{
+allowDeleteReference(UA_Server *server, UA_AccessControl *ac,
+                     const UA_NodeId *sessionId, void *sessionContext,
+                     const UA_DeleteReferencesItem *item) {
     printf("Called allowDeleteReference\n");
     return UA_TRUE;
 }

--- a/examples/server.c
+++ b/examples/server.c
@@ -34,7 +34,7 @@ loadFile(const char *const path) {
     /* Get the file length, allocate the data and read */
     fseek(fp, 0, SEEK_END);
     fileContents.length = (size_t)ftell(fp);
-    fileContents.data = (UA_Byte*)UA_malloc(fileContents.length * sizeof(UA_Byte));
+    fileContents.data = (UA_Byte *)UA_malloc(fileContents.length * sizeof(UA_Byte));
     if(fileContents.data) {
         fseek(fp, 0, SEEK_SET);
         size_t read = fread(fileContents.data, sizeof(UA_Byte), fileContents.length, fp);
@@ -87,11 +87,11 @@ helloWorld(UA_Server *server,
            size_t inputSize, const UA_Variant *input,
            size_t outputSize, UA_Variant *output) {
     /* input is a scalar string (checked by the server) */
-    UA_String *name = (UA_String *) input[0].data;
+    UA_String *name = (UA_String *)input[0].data;
     UA_String hello = UA_STRING("Hello ");
     UA_String greet;
     greet.length = hello.length + name->length;
-    greet.data = (UA_Byte *) UA_malloc(greet.length);
+    greet.data = (UA_Byte *)UA_malloc(greet.length);
     memcpy(greet.data, hello.data, hello.length);
     memcpy(greet.data + hello.length, name->data, name->length);
     UA_Variant_setScalarCopy(output, &greet, &UA_TYPES[UA_TYPES_STRING]);
@@ -132,8 +132,8 @@ main(int argc, char **argv) {
     if(argc < 3) {
         UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                      "Missing arguments for encryption support. "
-                     "Arguments are <server-certificate.der> "
-                     "<private-key.der> [<trustlist1.crl>, ...]");
+                         "Arguments are <server-certificate.der> "
+                         "<private-key.der> [<trustlist1.crl>, ...]");
         return 1;
     }
 
@@ -145,21 +145,21 @@ main(int argc, char **argv) {
     UA_ByteString *trustList = NULL;
     size_t trustListSize = 0;
     if(argc > 3) {
-        trustListSize = (size_t)argc-3;
-        trustList = (UA_ByteString*)
+        trustListSize = (size_t)argc - 3;
+        trustList = (UA_ByteString *)
             UA_alloca(sizeof(UA_ByteString) * trustListSize);
         for(size_t i = 0; i < trustListSize; i++)
-            trustList[i] = loadFile(argv[i+3]);
+            trustList[i] = loadFile(argv[i + 3]);
     }
 
-    /* Loading of a revocation list currentlu unsupported */
+    /* Loading of a revocation list currently unsupported */
     UA_ByteString *revocationList = NULL;
     size_t revocationListSize = 0;
 
     UA_ServerConfig *config =
-        UA_ServerConfig_new_basic128rsa15(4840, &certificate, &privateKey,
-                                          trustList, trustListSize,
-                                          revocationList, revocationListSize);
+        UA_ServerConfig_new_allSecurityPolicies(4840, &certificate, &privateKey,
+                                                trustList, trustListSize,
+                                                revocationList, revocationListSize);
     UA_ByteString_deleteMembers(&certificate);
     UA_ByteString_deleteMembers(&privateKey);
     for(size_t i = 0; i < trustListSize; i++)
@@ -329,7 +329,7 @@ main(int argc, char **argv) {
 
         /* add an matrix node for every built-in type */
         void *myMultiArray = UA_Array_new(9, &UA_TYPES[type]);
-        attr.value.arrayDimensions = (UA_UInt32 *) UA_Array_new(2, &UA_TYPES[UA_TYPES_INT32]);
+        attr.value.arrayDimensions = (UA_UInt32 *)UA_Array_new(2, &UA_TYPES[UA_TYPES_INT32]);
         attr.value.arrayDimensions[0] = 3;
         attr.value.arrayDimensions[1] = 3;
         attr.value.arrayDimensionsSize = 2;
@@ -458,5 +458,5 @@ main(int argc, char **argv) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int) retval;
+    return (int)retval;
 }

--- a/include/ua_plugin_access_control.h
+++ b/include/ua_plugin_access_control.h
@@ -23,55 +23,70 @@ extern "C" {
  * The access control callback is used to authenticate sessions and grant access
  * rights accordingly. */
 
-typedef struct {
-    /* These booleans are used to create endpoints for the possible
-     * authentication methods */
-    UA_Boolean enableAnonymousLogin;
-    UA_Boolean enableUsernamePasswordLogin;
+struct UA_AccessControl;
+typedef struct UA_AccessControl UA_AccessControl;
+
+struct UA_AccessControl {
+    void *context;
+    void (*deleteMembers)(UA_AccessControl *ac);
+
+    /* Supported login mechanisms. The server endpoints are created from here. */
+    size_t userTokenPoliciesSize;
+    UA_UserTokenPolicy *userTokenPolicies;
 
     /* Authenticate a session. The session context is attached to the session and
      * later passed into the node-based access control callbacks. */
-    UA_StatusCode (*activateSession)(const UA_NodeId *sessionId,
+    UA_StatusCode (*activateSession)(UA_Server *server, UA_AccessControl *ac,
+                                     const UA_NodeId *sessionId,
                                      const UA_ExtensionObject *userIdentityToken,
                                      void **sessionContext);
 
     /* Deauthenticate a session and cleanup */
-    void (*closeSession)(const UA_NodeId *sessionId, void *sessionContext);
+    void (*closeSession)(UA_Server *server, UA_AccessControl *ac,
+                         const UA_NodeId *sessionId, void *sessionContext);
 
     /* Access control for all nodes*/
-    UA_UInt32 (*getUserRightsMask)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_UInt32 (*getUserRightsMask)(UA_Server *server, UA_AccessControl *ac,
+                                   const UA_NodeId *sessionId, void *sessionContext,
                                    const UA_NodeId *nodeId, void *nodeContext);
 
     /* Additional access control for variable nodes */
-    UA_Byte (*getUserAccessLevel)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_Byte (*getUserAccessLevel)(UA_Server *server, UA_AccessControl *ac,
+                                  const UA_NodeId *sessionId, void *sessionContext,
                                   const UA_NodeId *nodeId, void *nodeContext);
 
     /* Additional access control for method nodes */
-    UA_Boolean (*getUserExecutable)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_Boolean (*getUserExecutable)(UA_Server *server, UA_AccessControl *ac,
+                                    const UA_NodeId *sessionId, void *sessionContext,
                                     const UA_NodeId *methodId, void *methodContext);
 
     /* Additional access control for calling a method node in the context of a
      * specific object */
-    UA_Boolean (*getUserExecutableOnObject)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_Boolean (*getUserExecutableOnObject)(UA_Server *server, UA_AccessControl *ac,
+                                            const UA_NodeId *sessionId, void *sessionContext,
                                             const UA_NodeId *methodId, void *methodContext,
                                             const UA_NodeId *objectId, void *objectContext);
 
     /* Allow adding a node */
-    UA_Boolean (*allowAddNode)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_Boolean (*allowAddNode)(UA_Server *server, UA_AccessControl *ac,
+                               const UA_NodeId *sessionId, void *sessionContext,
                                const UA_AddNodesItem *item);
 
     /* Allow adding a reference */
-    UA_Boolean (*allowAddReference)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_Boolean (*allowAddReference)(UA_Server *server, UA_AccessControl *ac,
+                                    const UA_NodeId *sessionId, void *sessionContext,
                                     const UA_AddReferencesItem *item);
 
     /* Allow deleting a node */
-    UA_Boolean (*allowDeleteNode)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_Boolean (*allowDeleteNode)(UA_Server *server, UA_AccessControl *ac,
+                                  const UA_NodeId *sessionId, void *sessionContext,
                                   const UA_DeleteNodesItem *item);
 
     /* Allow deleting a reference */
-    UA_Boolean (*allowDeleteReference)(const UA_NodeId *sessionId, void *sessionContext,
+    UA_Boolean (*allowDeleteReference)(UA_Server *server, UA_AccessControl *ac,
+                                       const UA_NodeId *sessionId, void *sessionContext,
                                        const UA_DeleteReferencesItem *item);
-} UA_AccessControl;
+};
 
 #ifdef __cplusplus
 }

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -10,44 +10,54 @@
 /* Example access control management. Anonymous and username / password login.
  * The access rights are maximally permissive. */
 
+typedef struct {
+    UA_Boolean allowAnonymous;
+    size_t usernamePasswordLoginSize;
+    UA_UsernamePasswordLogin *usernamePasswordLogin;
+} AccessControlContext;
+
 #define ANONYMOUS_POLICY "open62541-anonymous-policy"
 #define USERNAME_POLICY "open62541-username-policy"
-
-// TODO: There should be one definition of these strings in the endpoint.
-// Put the endpoint definition in the access control struct?
-#define UA_STRING_STATIC(s) {sizeof(s)-1, (UA_Byte*)s}
 const UA_String anonymous_policy = UA_STRING_STATIC(ANONYMOUS_POLICY);
 const UA_String username_policy = UA_STRING_STATIC(USERNAME_POLICY);
 
-typedef struct {
-    UA_String username;
-    UA_String password;
-} UA_UsernamePasswordLogin;
+/************************/
+/* Access Control Logic */
+/************************/
 
-const size_t usernamePasswordsSize = 2;
-UA_UsernamePasswordLogin usernamePasswords[2] = {
-    { UA_STRING_STATIC("user1"), UA_STRING_STATIC("password") },
-    { UA_STRING_STATIC("user2"), UA_STRING_STATIC("password1") } };
-
-UA_StatusCode
-activateSession_default(const UA_NodeId *sessionId,
+static UA_StatusCode
+activateSession_default(UA_Server *server, UA_AccessControl *ac,
+                        const UA_NodeId *sessionId,
                         const UA_ExtensionObject *userIdentityToken,
                         void **sessionContext) {
+    AccessControlContext *context = (AccessControlContext*)ac->context;
+
+    /* The empty token is interpreted as anonymous */
+    if(userIdentityToken->encoding == UA_EXTENSIONOBJECT_ENCODED_NOBODY) {
+        if(!context->allowAnonymous)
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+
+        /* No userdata atm */
+        *sessionContext = NULL;
+        return UA_STATUSCODE_GOOD;
+    }
+
     /* Could the token be decoded? */
     if(userIdentityToken->encoding < UA_EXTENSIONOBJECT_DECODED)
         return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 
     /* Anonymous login */
-    if(userIdentityToken->content.decoded.type ==
-       &UA_TYPES[UA_TYPES_ANONYMOUSIDENTITYTOKEN]) {
-        const UA_AnonymousIdentityToken *token =
-            (UA_AnonymousIdentityToken*)userIdentityToken->content.decoded.data;
+    if(userIdentityToken->content.decoded.type == &UA_TYPES[UA_TYPES_ANONYMOUSIDENTITYTOKEN]) {
+        if(!context->allowAnonymous)
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+
+        const UA_AnonymousIdentityToken *token = (UA_AnonymousIdentityToken*)
+            userIdentityToken->content.decoded.data;
 
         /* Compatibility notice: Siemens OPC Scout v10 provides an empty
          * policyId. This is not compliant. For compatibility, assume that empty
          * policyId == ANONYMOUS_POLICY */
-        if(token->policyId.data &&
-           !UA_String_equal(&token->policyId, &anonymous_policy))
+        if(token->policyId.data && !UA_String_equal(&token->policyId, &anonymous_policy))
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 
         /* No userdata atm */
@@ -56,28 +66,26 @@ activateSession_default(const UA_NodeId *sessionId,
     }
 
     /* Username and password */
-    if(userIdentityToken->content.decoded.type ==
-       &UA_TYPES[UA_TYPES_USERNAMEIDENTITYTOKEN]) {
-        const UA_UserNameIdentityToken *token =
+    if(userIdentityToken->content.decoded.type == &UA_TYPES[UA_TYPES_USERNAMEIDENTITYTOKEN]) {
+        const UA_UserNameIdentityToken *userToken =
             (UA_UserNameIdentityToken*)userIdentityToken->content.decoded.data;
-        if(!UA_String_equal(&token->policyId, &username_policy))
+
+        if(!UA_String_equal(&userToken->policyId, &username_policy))
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 
         /* TODO: Support encrypted username/password over unencrypted SecureChannels */
-        if(token->encryptionAlgorithm.length > 0)
+        if(userToken->encryptionAlgorithm.length > 0)
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 
         /* Empty username and password */
-        if(token->userName.length == 0 && token->password.length == 0)
+        if(userToken->userName.length == 0 && userToken->password.length == 0)
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 
         /* Try to match username/pw */
         UA_Boolean match = false;
-        for(size_t i = 0; i < usernamePasswordsSize; i++) {
-            const UA_String *user = &usernamePasswords[i].username;
-            const UA_String *pw = &usernamePasswords[i].password;
-            if(UA_String_equal(&token->userName, user) &&
-               UA_String_equal(&token->password, pw)) {
+        for(size_t i = 0; i < context->usernamePasswordLoginSize; i++) {
+            if(UA_String_equal(&userToken->userName, &context->usernamePasswordLogin[i].username) &&
+               UA_String_equal(&userToken->password, &context->usernamePasswordLogin[i].password)) {
                 match = true;
                 break;
             }
@@ -94,56 +102,151 @@ activateSession_default(const UA_NodeId *sessionId,
     return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 }
 
-void
-closeSession_default(const UA_NodeId *sessionId, void *sessionContext) {
+static void
+closeSession_default(UA_Server *server, UA_AccessControl *ac,
+                     const UA_NodeId *sessionId, void *sessionContext) {
     /* no context to clean up */
 }
 
-UA_UInt32
-getUserRightsMask_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_UInt32
+getUserRightsMask_default(UA_Server *server, UA_AccessControl *ac,
+                          const UA_NodeId *sessionId, void *sessionContext,
                           const UA_NodeId *nodeId, void *nodeContext) {
     return 0xFFFFFFFF;
 }
 
-UA_Byte
-getUserAccessLevel_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_Byte
+getUserAccessLevel_default(UA_Server *server, UA_AccessControl *ac,
+                           const UA_NodeId *sessionId, void *sessionContext,
                            const UA_NodeId *nodeId, void *nodeContext) {
     return 0xFF;
 }
 
-UA_Boolean
-getUserExecutable_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_Boolean
+getUserExecutable_default(UA_Server *server, UA_AccessControl *ac,
+                          const UA_NodeId *sessionId, void *sessionContext,
                           const UA_NodeId *methodId, void *methodContext) {
     return true;
 }
 
-UA_Boolean
-getUserExecutableOnObject_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_Boolean
+getUserExecutableOnObject_default(UA_Server *server, UA_AccessControl *ac,
+                                  const UA_NodeId *sessionId, void *sessionContext,
                                   const UA_NodeId *methodId, void *methodContext,
                                   const UA_NodeId *objectId, void *objectContext) {
     return true;
 }
 
-UA_Boolean
-allowAddNode_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_Boolean
+allowAddNode_default(UA_Server *server, UA_AccessControl *ac,
+                     const UA_NodeId *sessionId, void *sessionContext,
                      const UA_AddNodesItem *item) {
     return true;
 }
 
-UA_Boolean
-allowAddReference_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_Boolean
+allowAddReference_default(UA_Server *server, UA_AccessControl *ac,
+                          const UA_NodeId *sessionId, void *sessionContext,
                           const UA_AddReferencesItem *item) {
     return true;
 }
 
-UA_Boolean
-allowDeleteNode_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_Boolean
+allowDeleteNode_default(UA_Server *server, UA_AccessControl *ac,
+                        const UA_NodeId *sessionId, void *sessionContext,
                         const UA_DeleteNodesItem *item) {
     return true;
 }
 
-UA_Boolean
-allowDeleteReference_default(const UA_NodeId *sessionId, void *sessionContext,
+static UA_Boolean
+allowDeleteReference_default(UA_Server *server, UA_AccessControl *ac,
+                             const UA_NodeId *sessionId, void *sessionContext,
                              const UA_DeleteReferencesItem *item) {
     return true;
+}
+
+/***************************************/
+/* Create Delete Access Control Plugin */
+/***************************************/
+
+static void deleteMembers_default(UA_AccessControl *ac) {
+    UA_Array_delete((void*)(uintptr_t)ac->userTokenPolicies,
+                    ac->userTokenPoliciesSize,
+                    &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
+
+    AccessControlContext *context = (AccessControlContext*)ac->context;
+    for(size_t i = 0; i < context->usernamePasswordLoginSize; i++) {
+        UA_String_deleteMembers(&context->usernamePasswordLogin[i].username);
+        UA_String_deleteMembers(&context->usernamePasswordLogin[i].password);
+    }
+    if(context->usernamePasswordLoginSize > 0)
+        UA_free(context->usernamePasswordLogin);
+    UA_free(ac->context);
+}
+
+UA_AccessControl
+UA_AccessControl_default(UA_Boolean allowAnonymous, size_t usernamePasswordLoginSize,
+                         const UA_UsernamePasswordLogin *usernamePasswordLogin) {
+    AccessControlContext *context = (AccessControlContext*)
+        UA_malloc(sizeof(AccessControlContext));
+
+    UA_AccessControl ac;
+    memset(&ac, 0, sizeof(ac));
+    ac.context = context;
+    ac.deleteMembers = deleteMembers_default;
+    ac.activateSession = activateSession_default;
+    ac.closeSession = closeSession_default;
+    ac.getUserRightsMask = getUserRightsMask_default;
+    ac.getUserAccessLevel = getUserAccessLevel_default;
+    ac.getUserExecutable = getUserExecutable_default;
+    ac.getUserExecutableOnObject = getUserExecutableOnObject_default;
+    ac.allowAddNode = allowAddNode_default;
+    ac.allowAddReference = allowAddReference_default;
+    ac.allowDeleteNode = allowDeleteNode_default;
+    ac.allowDeleteReference = allowDeleteReference_default;
+
+    /* Allow anonymous? */
+    context->allowAnonymous = allowAnonymous;
+
+    /* Copy username/password to the access control plugin */
+    if(usernamePasswordLoginSize > 0) {
+        context->usernamePasswordLogin = (UA_UsernamePasswordLogin*)
+            UA_malloc(usernamePasswordLoginSize * sizeof(UA_UsernamePasswordLogin));
+        if(!context->usernamePasswordLogin)
+            return ac;
+        context->usernamePasswordLoginSize = usernamePasswordLoginSize;
+        for(size_t i = 0; i < usernamePasswordLoginSize; i++) {
+            UA_String_copy(&usernamePasswordLogin[i].username, &context->usernamePasswordLogin[i].username);
+            UA_String_copy(&usernamePasswordLogin[i].password, &context->usernamePasswordLogin[i].password);
+        }
+    }
+
+    /* Set the allowed policies */
+    size_t policies = 0;
+    if(allowAnonymous)
+        policies++;
+    if(usernamePasswordLoginSize > 0)
+        policies++;
+    ac.userTokenPoliciesSize = 0;
+    ac.userTokenPolicies = (UA_UserTokenPolicy *)
+        UA_Array_new(policies, &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
+    if(!ac.userTokenPolicies)
+        return ac;
+    ac.userTokenPoliciesSize = policies;
+
+    policies = 0;
+    if(allowAnonymous) {
+        ac.userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_ANONYMOUS;
+        ac.userTokenPolicies[policies].policyId = UA_STRING_ALLOC(ANONYMOUS_POLICY);
+        policies++;
+    }
+
+    if(usernamePasswordLoginSize > 0) {
+        ac.userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_USERNAME;
+        ac.userTokenPolicies[policies].policyId = UA_STRING_ALLOC(USERNAME_POLICY);
+        /* No encryption of username/password supported at the moment */
+        ac.userTokenPolicies[policies].securityPolicyUri =
+            UA_STRING_ALLOC("http://opcfoundation.org/UA/SecurityPolicy#None");
+    }
+    return ac;
 }

--- a/plugins/ua_accesscontrol_default.h
+++ b/plugins/ua_accesscontrol_default.h
@@ -9,51 +9,23 @@
 #define UA_ACCESSCONTROL_DEFAULT_H_
 
 #include "ua_server.h"
+#include "ua_plugin_access_control.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-UA_StatusCode UA_EXPORT
-activateSession_default(const UA_NodeId *sessionId,
-                        const UA_ExtensionObject *userIdentityToken,
-                        void **sessionContext);
+typedef struct {
+    UA_String username;
+    UA_String password;
+} UA_UsernamePasswordLogin;
 
-void UA_EXPORT
-closeSession_default(const UA_NodeId *sessionId, void *sessionContext);
-
-UA_UInt32 UA_EXPORT
-getUserRightsMask_default(const UA_NodeId *sessionId, void *sessionContext,
-                          const UA_NodeId *nodeId, void *nodeContext);
-
-UA_Byte UA_EXPORT
-getUserAccessLevel_default(const UA_NodeId *sessionId, void *sessionContext,
-                          const UA_NodeId *nodeId, void *nodeContext);
-
-UA_Boolean UA_EXPORT
-getUserExecutable_default(const UA_NodeId *sessionId, void *sessionContext,
-                          const UA_NodeId *methodId, void *methodContext);
-
-UA_Boolean UA_EXPORT
-getUserExecutableOnObject_default(const UA_NodeId *sessionId, void *sessionContext,
-                                  const UA_NodeId *methodId, void *methodContext,
-                                  const UA_NodeId *objectId, void *objectContext);
-
-UA_Boolean UA_EXPORT
-allowAddNode_default(const UA_NodeId *sessionId, void *sessionContext,
-                     const UA_AddNodesItem *item);
-
-UA_Boolean UA_EXPORT
-allowAddReference_default(const UA_NodeId *sessionId, void *sessionContext,
-                          const UA_AddReferencesItem *item);
-
-UA_Boolean UA_EXPORT
-allowDeleteNode_default(const UA_NodeId *sessionId, void *sessionContext,
-                        const UA_DeleteNodesItem *item);
-
-UA_Boolean UA_EXPORT
-allowDeleteReference_default(const UA_NodeId *sessionId, void *sessionContext,
-                             const UA_DeleteReferencesItem *item);
+/* Default access control. The log-in can be anonymous or username-password. A
+ * logged-in user has all access rights. */
+UA_EXPORT UA_AccessControl
+UA_AccessControl_default(UA_Boolean allowAnonymous,
+                         size_t usernamePasswordLoginSize,
+                         const UA_UsernamePasswordLogin *usernamePasswordLogin);
 
 #ifdef __cplusplus
 }

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -6,6 +6,7 @@
  *    Copyright 2017-2018 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Thomas Stalder, Blue Time Concept SA
+ *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  */
 
 #include "ua_plugin_securitypolicy.h"
@@ -20,14 +21,12 @@
 
 #ifdef UA_ENABLE_ENCRYPTION
 #include "ua_securitypolicy_basic128rsa15.h"
+#include "ua_securitypolicy_basic256sha256.h"
 #endif
 
 #include "ua_types.h"
 #include "ua_types_generated_handling.h"
 #include "ua_client_subscriptions.h"
-
-#define ANONYMOUS_POLICY "open62541-anonymous-policy"
-#define USERNAME_POLICY "open62541-username-policy"
 
 /* Struct initialization works across ANSI C/C99/C++ if it is done when the
  * variable is first declared. Assigning values to existing structs is
@@ -82,26 +81,17 @@ createSecurityPolicyNoneEndpoint(UA_ServerConfig *conf, UA_Endpoint *endpoint,
     endpoint->endpointDescription.transportProfileUri =
         UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
 
-    /* enable anonymous and username/password */
-    size_t policies = 2;
-    endpoint->endpointDescription.userIdentityTokens = (UA_UserTokenPolicy *)
-        UA_Array_new(policies, &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
-    if(!endpoint->endpointDescription.userIdentityTokens)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-    endpoint->endpointDescription.userIdentityTokensSize = policies;
-
-    endpoint->endpointDescription.userIdentityTokens[0].tokenType =
-        UA_USERTOKENTYPE_ANONYMOUS;
-    endpoint->endpointDescription.userIdentityTokens[0].policyId =
-        UA_STRING_ALLOC(ANONYMOUS_POLICY);
-
-    endpoint->endpointDescription.userIdentityTokens[1].tokenType =
-        UA_USERTOKENTYPE_USERNAME;
-    endpoint->endpointDescription.userIdentityTokens[1].policyId =
-        UA_STRING_ALLOC(USERNAME_POLICY);
+    /* Enable all login mechanisms from the access control plugin  */
+    UA_StatusCode retval = UA_Array_copy(conf->accessControl.userTokenPolicies,
+                                         conf->accessControl.userTokenPoliciesSize,
+                                         (void **)&endpoint->endpointDescription.userIdentityTokens,
+                                         &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+    endpoint->endpointDescription.userIdentityTokensSize =
+        conf->accessControl.userTokenPoliciesSize;
 
     UA_String_copy(&localCertificate, &endpoint->endpointDescription.serverCertificate);
-
     UA_ApplicationDescription_copy(&conf->applicationDescription,
                                    &endpoint->endpointDescription.server);
 
@@ -127,8 +117,8 @@ createSecurityPolicyBasic128Rsa15Endpoint(UA_ServerConfig *const conf,
     UA_EndpointDescription_init(&endpoint->endpointDescription);
 
     UA_StatusCode retval =
-        UA_SecurityPolicy_Basic128Rsa15(&endpoint->securityPolicy, &conf->certificateVerification, localCertificate,
-                                        localPrivateKey, conf->logger);
+        UA_SecurityPolicy_Basic128Rsa15(&endpoint->securityPolicy, &conf->certificateVerification,
+                                        localCertificate, localPrivateKey, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         endpoint->securityPolicy.deleteMembers(&endpoint->securityPolicy);
         return retval;
@@ -140,23 +130,58 @@ createSecurityPolicyBasic128Rsa15Endpoint(UA_ServerConfig *const conf,
     endpoint->endpointDescription.transportProfileUri =
         UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
 
-    /* enable anonymous and username/password */
-    size_t policies = 1;
-    endpoint->endpointDescription.userIdentityTokens = (UA_UserTokenPolicy *)
-        UA_Array_new(policies, &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
-    if(!endpoint->endpointDescription.userIdentityTokens)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-    endpoint->endpointDescription.userIdentityTokensSize = policies;
+    /* Enable all login mechanisms from the access control plugin  */
+    retval = UA_Array_copy(conf->accessControl.userTokenPolicies,
+                           conf->accessControl.userTokenPoliciesSize,
+                           (void **)&endpoint->endpointDescription.userIdentityTokens,
+                           &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+    endpoint->endpointDescription.userIdentityTokensSize =
+        conf->accessControl.userTokenPoliciesSize;
 
-    endpoint->endpointDescription.userIdentityTokens[0].tokenType =
-        UA_USERTOKENTYPE_ANONYMOUS;
-    endpoint->endpointDescription.userIdentityTokens[0].policyId =
-        UA_STRING_ALLOC(ANONYMOUS_POLICY);
-    /*
-    endpoint->endpointDescription.userIdentityTokens[1].tokenType =
-        UA_USERTOKENTYPE_USERNAME;
-    endpoint->endpointDescription.userIdentityTokens[1].policyId =
-        UA_STRING_ALLOC(USERNAME_POLICY);*/
+    UA_String_copy(&localCertificate, &endpoint->endpointDescription.serverCertificate);
+    UA_ApplicationDescription_copy(&conf->applicationDescription,
+                                   &endpoint->endpointDescription.server);
+
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+createSecurityPolicyBasic256Sha256Endpoint(UA_ServerConfig *const conf,
+                                           UA_Endpoint *endpoint,
+                                           UA_MessageSecurityMode securityMode,
+                                           const UA_ByteString localCertificate,
+                                           const UA_ByteString localPrivateKey) {
+    UA_EndpointDescription_init(&endpoint->endpointDescription);
+
+    UA_StatusCode retval =
+        UA_SecurityPolicy_Basic256Sha256(&endpoint->securityPolicy, &conf->certificateVerification, localCertificate,
+                                         localPrivateKey, conf->logger);
+    if(retval != UA_STATUSCODE_GOOD) {
+        endpoint->securityPolicy.deleteMembers(&endpoint->securityPolicy);
+        return retval;
+    }
+
+    endpoint->endpointDescription.securityMode = securityMode;
+    endpoint->endpointDescription.securityPolicyUri =
+        UA_STRING_ALLOC("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
+    endpoint->endpointDescription.transportProfileUri =
+        UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
+
+    /* Enable all login mechanisms from the access control plugin  */
+    retval = UA_Array_copy(conf->accessControl.userTokenPolicies,
+                           conf->accessControl.userTokenPoliciesSize,
+                           (void **)&endpoint->endpointDescription.userIdentityTokens,
+                           &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+    endpoint->endpointDescription.userIdentityTokensSize =
+        conf->accessControl.userTokenPoliciesSize;
+
+    UA_String_copy(&localCertificate, &endpoint->endpointDescription.serverCertificate);
+    UA_ApplicationDescription_copy(&conf->applicationDescription,
+                                   &endpoint->endpointDescription.server);
 
     UA_String_copy(&localCertificate, &endpoint->endpointDescription.serverCertificate);
 
@@ -168,9 +193,14 @@ createSecurityPolicyBasic128Rsa15Endpoint(UA_ServerConfig *const conf,
 
 #endif
 
+const size_t usernamePasswordsSize = 2;
+UA_UsernamePasswordLogin usernamePasswords[2] = {
+    {UA_STRING_STATIC("user1"), UA_STRING_STATIC("password")},
+    {UA_STRING_STATIC("user2"), UA_STRING_STATIC("password1")}};
+
 static UA_ServerConfig *
 createDefaultConfig(void) {
-    UA_ServerConfig *conf = (UA_ServerConfig *) UA_malloc(sizeof(UA_ServerConfig));
+    UA_ServerConfig *conf = (UA_ServerConfig *)UA_malloc(sizeof(UA_ServerConfig));
     if(!conf)
         return NULL;
 
@@ -188,7 +218,9 @@ createDefaultConfig(void) {
     conf->buildInfo.softwareVersion =
         UA_STRING_ALLOC(VERSION(UA_OPEN62541_VER_MAJOR, UA_OPEN62541_VER_MINOR,
                                 UA_OPEN62541_VER_PATCH, UA_OPEN62541_VER_LABEL));
-    conf->buildInfo.buildNumber = UA_STRING_ALLOC(__DATE__ " " __TIME__);
+    conf->buildInfo.buildNumber = UA_STRING_ALLOC(__DATE__
+                                                      " "
+                                                      __TIME__);
     conf->buildInfo.buildDate = 0;
 
     conf->applicationDescription.applicationUri = UA_STRING_ALLOC(APPLICATION_URI);
@@ -227,19 +259,8 @@ createDefaultConfig(void) {
     conf->nodeLifecycle.constructor = NULL;
     conf->nodeLifecycle.destructor = NULL;
 
-    /* Access Control */
-    conf->accessControl.enableAnonymousLogin = true;
-    conf->accessControl.enableUsernamePasswordLogin = true;
-    conf->accessControl.activateSession = activateSession_default;
-    conf->accessControl.closeSession = closeSession_default;
-    conf->accessControl.getUserRightsMask = getUserRightsMask_default;
-    conf->accessControl.getUserAccessLevel = getUserAccessLevel_default;
-    conf->accessControl.getUserExecutable = getUserExecutable_default;
-    conf->accessControl.getUserExecutableOnObject = getUserExecutableOnObject_default;
-    conf->accessControl.allowAddNode = allowAddNode_default;
-    conf->accessControl.allowAddReference = allowAddReference_default;
-    conf->accessControl.allowDeleteNode = allowDeleteNode_default;
-    conf->accessControl.allowDeleteReference = allowDeleteReference_default;
+    /* Access Control. Anonymous Login only. */
+    conf->accessControl = UA_AccessControl_default(true, usernamePasswordsSize, usernamePasswords);
 
     /* Limits for SecureChannels */
     conf->maxSecureChannels = 40;
@@ -302,7 +323,7 @@ UA_ServerConfig_new_minimal(UA_UInt16 portNumber,
 
     /* Allocate the endpoint */
     conf->endpointsSize = 1;
-    conf->endpoints = (UA_Endpoint *) UA_malloc(sizeof(UA_Endpoint));
+    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint));
     if(!conf->endpoints) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -359,7 +380,7 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
 
     /* Allocate the endpoints */
     conf->endpointsSize = 0;
-    conf->endpoints = (UA_Endpoint *) UA_malloc(sizeof(UA_Endpoint) * 3);
+    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint) * 3);
     if(!conf->endpoints) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -393,6 +414,235 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
 
     return conf;
 }
+
+UA_ServerConfig *
+UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
+                                   const UA_ByteString *certificate,
+                                   const UA_ByteString *privateKey,
+                                   const UA_ByteString *trustList,
+                                   size_t trustListSize,
+                                   const UA_ByteString *revocationList,
+                                   size_t revocationListSize) {
+    UA_ServerConfig *conf = createDefaultConfig();
+
+    UA_StatusCode retval = UA_CertificateVerification_Trustlist(&conf->certificateVerification,
+                                                                trustList, trustListSize,
+                                                                revocationList, revocationListSize);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    retval = UA_Nodestore_default_new(&conf->nodestore);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    if(addDefaultNetworkLayers(conf, portNumber) != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    if(trustListSize == 0)
+        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                       "No CA trust-list provided. Any remote certificate will be accepted.");
+
+    /* Allocate the endpoints */
+    conf->endpointsSize = 0;
+    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint) * 3);
+    if(!conf->endpoints) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    /* Populate the endpoints */
+    ++conf->endpointsSize;
+    retval = createSecurityPolicyNoneEndpoint(conf, &conf->endpoints[0], *certificate);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    ++conf->endpointsSize;
+    retval = createSecurityPolicyBasic256Sha256Endpoint(conf, &conf->endpoints[1],
+                                                        UA_MESSAGESECURITYMODE_SIGN, *certificate,
+                                                        *privateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    ++conf->endpointsSize;
+    retval = createSecurityPolicyBasic256Sha256Endpoint(conf, &conf->endpoints[2],
+                                                        UA_MESSAGESECURITYMODE_SIGNANDENCRYPT, *certificate,
+                                                        *privateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    return conf;
+}
+
+UA_ServerConfig *
+UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
+                                   const UA_ByteString *certificate,
+                                   const UA_ByteString *privateKey,
+                                   const UA_ByteString *trustList,
+                                   size_t trustListSize,
+                                   const UA_ByteString *revocationList,
+                                   size_t revocationListSize) {
+    UA_ServerConfig *conf = createDefaultConfig();
+
+    UA_StatusCode retval = UA_CertificateVerification_Trustlist(&conf->certificateVerification,
+                                                                trustList, trustListSize,
+                                                                revocationList, revocationListSize);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    retval = UA_Nodestore_default_new(&conf->nodestore);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    if(addDefaultNetworkLayers(conf, portNumber) != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    if(trustListSize == 0)
+        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                       "No CA trust-list provided. Any remote certificate will be accepted.");
+
+    /* Allocate the endpoints */
+    conf->endpointsSize = 0;
+    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint) * 3);
+    if(!conf->endpoints) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    /* Populate the endpoints */
+    ++conf->endpointsSize;
+    retval = createSecurityPolicyNoneEndpoint(conf, &conf->endpoints[0], *certificate);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    ++conf->endpointsSize;
+    retval = createSecurityPolicyBasic256Sha256Endpoint(conf, &conf->endpoints[1],
+                                                        UA_MESSAGESECURITYMODE_SIGN, *certificate,
+                                                        *privateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    ++conf->endpointsSize;
+    retval = createSecurityPolicyBasic256Sha256Endpoint(conf, &conf->endpoints[2],
+                                                        UA_MESSAGESECURITYMODE_SIGNANDENCRYPT, *certificate,
+                                                        *privateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    return conf;
+}
+
+UA_ServerConfig *
+UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
+                                        const UA_ByteString *certificate,
+                                        const UA_ByteString *privateKey,
+                                        const UA_ByteString *trustList,
+                                        size_t trustListSize,
+                                        const UA_ByteString *revocationList,
+                                        size_t revocationListSize) {
+    UA_ServerConfig *conf = createDefaultConfig();
+
+    UA_StatusCode retval = UA_CertificateVerification_Trustlist(&conf->certificateVerification,
+                                                                trustList, trustListSize,
+                                                                revocationList, revocationListSize);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    retval = UA_Nodestore_default_new(&conf->nodestore);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    if(addDefaultNetworkLayers(conf, portNumber) != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    if(trustListSize == 0)
+        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                       "No CA trust-list provided. Any remote certificate will be accepted.");
+
+    /* Allocate the endpoints */
+    conf->endpointsSize = 0;
+    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint) * 5);
+    if(!conf->endpoints) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    /* Populate the endpoints */
+    retval = createSecurityPolicyNoneEndpoint(conf, &conf->endpoints[conf->endpointsSize], *certificate);
+    ++conf->endpointsSize;
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    retval = createSecurityPolicyBasic128Rsa15Endpoint(conf, &conf->endpoints[conf->endpointsSize],
+                                                       UA_MESSAGESECURITYMODE_SIGN, *certificate,
+                                                       *privateKey);
+    ++conf->endpointsSize;
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    retval = createSecurityPolicyBasic128Rsa15Endpoint(conf, &conf->endpoints[conf->endpointsSize],
+                                                       UA_MESSAGESECURITYMODE_SIGNANDENCRYPT, *certificate,
+                                                       *privateKey);
+    ++conf->endpointsSize;
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    retval = createSecurityPolicyBasic256Sha256Endpoint(conf, &conf->endpoints[conf->endpointsSize],
+                                                        UA_MESSAGESECURITYMODE_SIGN, *certificate,
+                                                        *privateKey);
+    ++conf->endpointsSize;
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    retval = createSecurityPolicyBasic256Sha256Endpoint(conf, &conf->endpoints[conf->endpointsSize],
+                                                        UA_MESSAGESECURITYMODE_SIGNANDENCRYPT, *certificate,
+                                                        *privateKey);
+    ++conf->endpointsSize;
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    return conf;
+}
+
 
 #endif
 
@@ -443,6 +693,9 @@ UA_ServerConfig_delete(UA_ServerConfig *config) {
 
     /* Certificate Validation */
     config->certificateVerification.deleteMembers(&config->certificateVerification);
+
+    /* Access Control */
+    config->accessControl.deleteMembers(&config->accessControl);
 
     UA_free(config);
 }

--- a/plugins/ua_config_default.h
+++ b/plugins/ua_config_default.h
@@ -40,6 +40,7 @@ UA_EXPORT UA_ServerConfig *
 UA_ServerConfig_new_minimal(UA_UInt16 portNumber, const UA_ByteString *certificate);
 
 #ifdef UA_ENABLE_ENCRYPTION
+
 UA_EXPORT UA_ServerConfig *
 UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
                                   const UA_ByteString *certificate,
@@ -48,6 +49,25 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
                                   size_t trustListSize,
                                   const UA_ByteString *revocationList,
                                   size_t revocationListSize);
+
+UA_EXPORT UA_ServerConfig *
+UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
+                                   const UA_ByteString *certificate,
+                                   const UA_ByteString *privateKey,
+                                   const UA_ByteString *trustList,
+                                   size_t trustListSize,
+                                   const UA_ByteString *revocationList,
+                                   size_t revocationListSize);
+
+UA_EXPORT UA_ServerConfig *
+UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
+                                        const UA_ByteString *certificate,
+                                        const UA_ByteString *privateKey,
+                                        const UA_ByteString *trustList,
+                                        size_t trustListSize,
+                                        const UA_ByteString *revocationList,
+                                        size_t revocationListSize);
+
 #endif
 
 /* Creates a server config on the default port 4840 with no server

--- a/plugins/ua_securitypolicy_basic256sha256.c
+++ b/plugins/ua_securitypolicy_basic256sha256.c
@@ -1,12 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
+ *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  */
 
 #include <mbedtls/aes.h>
 #include <mbedtls/md.h>
+#include <mbedtls/sha256.h>
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
@@ -16,7 +18,7 @@
 #include "ua_plugin_pki.h"
 #include "ua_plugin_securitypolicy.h"
 #include "ua_securitypolicy_common.h"
-#include "ua_securitypolicy_basic128rsa15.h"
+#include "ua_securitypolicy_basic256sha256.h"
 #include "ua_types.h"
 #include "ua_types_generated_handling.h"
 
@@ -26,14 +28,15 @@
  * https://tls.mbed.org/discussions/generic/in-place-decryption-with-aes256-same-input-output-buffer
  */
 
-#define UA_SECURITYPOLICY_BASIC128RSA15_RSAPADDING_LEN 11
+#define UA_SECURITYPOLICY_BASIC256SHA256_RSAPADDING_LEN 42
 #define UA_SHA1_LENGTH 20
-#define UA_SECURITYPOLICY_BASIC128RSA15_SYM_KEY_LENGTH 16
-#define UA_BASIC128RSA15_SYM_SIGNING_KEY_LENGTH 16
-#define UA_SECURITYPOLICY_BASIC128RSA15_SYM_ENCRYPTION_BLOCK_SIZE 16
-#define UA_SECURITYPOLICY_BASIC128RSA15_SYM_PLAIN_TEXT_BLOCK_SIZE 16
-#define UA_SECURITYPOLICY_BASIC128RSA15_MINASYMKEYLENGTH 128
-#define UA_SECURITYPOLICY_BASIC128RSA15_MAXASYMKEYLENGTH 256
+#define UA_SHA256_LENGTH 32
+#define UA_BASIC256SHA256_SYM_SIGNING_KEY_LENGTH 32
+#define UA_SECURITYPOLICY_BASIC256SHA256_SYM_KEY_LENGTH 32
+#define UA_SECURITYPOLICY_BASIC256SHA256_SYM_ENCRYPTION_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_BASIC256SHA256_SYM_PLAIN_TEXT_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH 256
+#define UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH 512
 
 #define UA_LOG_MBEDERR                                                  \
     char errBuff[300];                                                  \
@@ -59,12 +62,12 @@ typedef struct {
 
     mbedtls_ctr_drbg_context drbgContext;
     mbedtls_entropy_context entropyContext;
-    mbedtls_md_context_t sha1MdContext;
+    mbedtls_md_context_t sha256MdContext;
     mbedtls_pk_context localPrivateKey;
-} Basic128Rsa15_PolicyContext;
+} Basic256Sha256_PolicyContext;
 
 typedef struct {
-    Basic128Rsa15_PolicyContext *policyContext;
+    Basic256Sha256_PolicyContext *policyContext;
 
     UA_ByteString localSymSigningKey;
     UA_ByteString localSymEncryptingKey;
@@ -75,56 +78,66 @@ typedef struct {
     UA_ByteString remoteSymIv;
 
     mbedtls_x509_crt remoteCertificate;
-} Basic128Rsa15_ChannelContext;
-
+} Basic256Sha256_ChannelContext;
 
 /********************/
 /* AsymmetricModule */
 /********************/
 
+/* VERIFY AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_verify_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                             Basic128Rsa15_ChannelContext *cc,
-                             const UA_ByteString *message,
-                             const UA_ByteString *signature) {
+asym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                              Basic256Sha256_ChannelContext *cc,
+                              const UA_ByteString *message,
+                              const UA_ByteString *signature) {
     if(securityPolicy == NULL || message == NULL || signature == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    /* Compute the sha1 hash */
-    unsigned char hash[UA_SHA1_LENGTH];
-    sha1(message->data, message->length, hash);
+    unsigned char hash[UA_SHA256_LENGTH];
+    mbedtls_sha256(message->data, message->length, hash, 0);
 
     /* Set the RSA settings */
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, 0);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256);
 
-    /* Verify */
+    /* For RSA keys, the default padding type is PKCS#1 v1.5 in mbedtls_pk_verify() */
+    /* Alternatively, use more specific function mbedtls_rsa_rsassa_pkcs1_v15_verify(), i.e. */
+    /* int mbedErr = mbedtls_rsa_rsassa_pkcs1_v15_verify(rsaContext, NULL, NULL,
+                                                         MBEDTLS_RSA_PUBLIC, MBEDTLS_MD_SHA256,
+                                                         UA_SHA256_LENGTH, hash,
+                                                         signature->data); */
+
     int mbedErr = mbedtls_pk_verify(&cc->remoteCertificate.pk,
-                                    MBEDTLS_MD_SHA1, hash, UA_SHA1_LENGTH,
+                                    MBEDTLS_MD_SHA256, hash, UA_SHA256_LENGTH,
                                     signature->data, signature->length);
+
     UA_MBEDTLS_ERRORHANDLING_RETURN(UA_STATUSCODE_BADSECURITYCHECKSFAILED);
     return UA_STATUSCODE_GOOD;
 }
 
+/* AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_sign_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                           Basic128Rsa15_ChannelContext *cc,
-                           const UA_ByteString *message,
-                           UA_ByteString *signature) {
+asym_sign_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                            Basic256Sha256_ChannelContext *cc,
+                            const UA_ByteString *message,
+                            UA_ByteString *signature) {
     if(securityPolicy == NULL || message == NULL || signature == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    unsigned char hash[UA_SHA1_LENGTH];
-    sha1(message->data, message->length, hash);
+    unsigned char hash[UA_SHA256_LENGTH];
+    mbedtls_sha256(message->data, message->length, hash, 0);
 
-    Basic128Rsa15_PolicyContext *pc = cc->policyContext;
+    Basic256Sha256_PolicyContext *pc = cc->policyContext;
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(pc->localPrivateKey);
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, 0);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256);
 
     size_t sigLen = 0;
+
+    /* For RSA keys, the default padding type is PKCS#1 v1.5 in mbedtls_pk_sign */
+    /* Alternatively use more specific function mbedtls_rsa_rsassa_pkcs1_v15_sign() */
     int mbedErr = mbedtls_pk_sign(&pc->localPrivateKey,
-                                  MBEDTLS_MD_SHA1, hash,
-                                  UA_SHA1_LENGTH, signature->data,
+                                  MBEDTLS_MD_SHA256, hash,
+                                  UA_SHA256_LENGTH, signature->data,
                                   &sigLen, mbedtls_ctr_drbg_random,
                                   &pc->drbgContext);
     UA_MBEDTLS_ERRORHANDLING_RETURN(UA_STATUSCODE_BADINTERNALERROR);
@@ -132,8 +145,8 @@ asym_sign_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 }
 
 static size_t
-asym_getLocalSignatureSize_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                            const Basic128Rsa15_ChannelContext *cc) {
+asym_getLocalSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                             const Basic256Sha256_ChannelContext *cc) {
     if(securityPolicy == NULL || cc == NULL)
         return 0;
 
@@ -141,18 +154,19 @@ asym_getLocalSignatureSize_sp_basic128rsa15(const UA_SecurityPolicy *securityPol
 }
 
 static size_t
-asym_getRemoteSignatureSize_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                             const Basic128Rsa15_ChannelContext *cc) {
+asym_getRemoteSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                              const Basic256Sha256_ChannelContext *cc) {
     if(securityPolicy == NULL || cc == NULL)
         return 0;
 
     return mbedtls_pk_rsa(cc->remoteCertificate.pk)->len;
 }
 
+/* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                              Basic128Rsa15_ChannelContext *cc,
-                              UA_ByteString *data) {
+asym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                               Basic256Sha256_ChannelContext *cc,
+                               UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -163,7 +177,7 @@ asym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *remoteRsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    mbedtls_rsa_set_padding(remoteRsaContext, MBEDTLS_RSA_PKCS_V15, 0);
+    mbedtls_rsa_set_padding(remoteRsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
 
     UA_ByteString encrypted;
     const size_t bufferOverhead =
@@ -176,20 +190,21 @@ asym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
     size_t inOffset = 0;
     size_t offset = 0;
     size_t outLength = 0;
-    Basic128Rsa15_PolicyContext *pc = cc->policyContext;
+    const unsigned char *label = NULL;
+    Basic256Sha256_PolicyContext *pc = cc->policyContext;
     while(lenDataToEncrypt >= plainTextBlockSize) {
-        int mbedErr = mbedtls_pk_encrypt(&cc->remoteCertificate.pk,
-                                         data->data + inOffset, plainTextBlockSize,
-                                         encrypted.data + offset, &outLength,
-                                         encrypted.length - offset,
-                                         mbedtls_ctr_drbg_random,
-                                         &pc->drbgContext);
+        int mbedErr = mbedtls_rsa_rsaes_oaep_encrypt(remoteRsaContext, mbedtls_ctr_drbg_random,
+                                                     &pc->drbgContext, MBEDTLS_RSA_PUBLIC,
+                                                     label, 0, plainTextBlockSize,
+                                                     data->data + inOffset, encrypted.data + offset);
+
         UA_MBEDTLS_ERRORHANDLING(UA_STATUSCODE_BADINTERNALERROR);
         if(retval != UA_STATUSCODE_GOOD) {
             UA_ByteString_deleteMembers(&encrypted);
             return retval;
         }
 
+        outLength += remoteRsaContext->len;
         inOffset += plainTextBlockSize;
         offset += outLength;
         lenDataToEncrypt -= plainTextBlockSize;
@@ -201,15 +216,18 @@ asym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
     return UA_STATUSCODE_GOOD;
 }
 
+/* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                              Basic128Rsa15_ChannelContext *cc,
-                              UA_ByteString *data) {
+asym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                               Basic256Sha256_ChannelContext *cc,
+                               UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *rsaContext =
         mbedtls_pk_rsa(cc->policyContext->localPrivateKey);
+
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
 
     if(data->length % rsaContext->len != 0)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -223,11 +241,16 @@ asym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
     size_t inOffset = 0;
     size_t offset = 0;
     size_t outLength = 0;
+    const unsigned char *label = NULL;
+    Basic256Sha256_PolicyContext *pc = cc->policyContext;
+
     while(lenDataToDecrypt >= rsaContext->len) {
-        int mbedErr = mbedtls_pk_decrypt(&cc->policyContext->localPrivateKey,
-                                         data->data + inOffset, rsaContext->len,
-                                         decrypted.data + offset, &outLength,
-                                         decrypted.length - offset, NULL, NULL);
+        int mbedErr = mbedtls_rsa_rsaes_oaep_decrypt(rsaContext, mbedtls_ctr_drbg_random,
+                                                     &pc->drbgContext, MBEDTLS_RSA_PRIVATE,
+                                                     label, 0, &outLength,
+                                                     data->data + inOffset,
+                                                     decrypted.data + offset,
+                                                     decrypted.length - offset);
         if(mbedErr)
             UA_ByteString_deleteMembers(&decrypted); // TODO: Maybe change error macro to jump to cleanup?
         UA_MBEDTLS_ERRORHANDLING_RETURN(UA_STATUSCODE_BADSECURITYCHECKSFAILED);
@@ -249,29 +272,29 @@ asym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 }
 
 static size_t
-asym_getRemoteEncryptionKeyLength_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                                   const Basic128Rsa15_ChannelContext *cc) {
+asym_getRemoteEncryptionKeyLength_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                                    const Basic256Sha256_ChannelContext *cc) {
     return mbedtls_pk_get_len(&cc->remoteCertificate.pk) * 8;
 }
 
 static size_t
-asym_getRemoteBlockSize_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                         const Basic128Rsa15_ChannelContext *cc) {
+asym_getRemoteBlockSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                          const Basic256Sha256_ChannelContext *cc) {
     mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
     return rsaContext->len;
 }
 
 static size_t
-asym_getRemotePlainTextBlockSize_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                                  const Basic128Rsa15_ChannelContext *cc) {
+asym_getRemotePlainTextBlockSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                                   const Basic256Sha256_ChannelContext *cc) {
     mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    return rsaContext->len - UA_SECURITYPOLICY_BASIC128RSA15_RSAPADDING_LEN;
+    return rsaContext->len - UA_SECURITYPOLICY_BASIC256SHA256_RSAPADDING_LEN;
 }
 
 static UA_StatusCode
-asym_makeThumbprint_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                     const UA_ByteString *certificate,
-                                     UA_ByteString *thumbprint) {
+asym_makeThumbprint_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                      const UA_ByteString *certificate,
+                                      UA_ByteString *thumbprint) {
     if(securityPolicy == NULL || certificate == NULL || thumbprint == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -281,17 +304,18 @@ asym_makeThumbprint_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
     if(thumbprint->length != UA_SHA1_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
+    /* The certificate thumbprint is always a 20 bit sha1 hash, see Part 4 of the Specification. */
     sha1(certificate->data, certificate->length, thumbprint->data);
     return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-asymmetricModule_compareCertificateThumbprint_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                                               const UA_ByteString *certificateThumbprint) {
+asymmetricModule_compareCertificateThumbprint_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                                                const UA_ByteString *certificateThumbprint) {
     if(securityPolicy == NULL || certificateThumbprint == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic128Rsa15_PolicyContext *pc = (Basic128Rsa15_PolicyContext *)securityPolicy->policyContext;
+    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
     if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
         return UA_STATUSCODE_BADCERTIFICATEINVALID;
 
@@ -303,87 +327,87 @@ asymmetricModule_compareCertificateThumbprint_sp_basic128rsa15(const UA_Security
 /*******************/
 
 static void
-md_hmac(mbedtls_md_context_t *context, const UA_ByteString *key,
-        const UA_ByteString *in, unsigned char out[20]) {
+md_hmac_Basic256Sha256(mbedtls_md_context_t *context, const UA_ByteString *key,
+                       const UA_ByteString *in, unsigned char out[32]) {
     mbedtls_md_hmac_starts(context, key->data, key->length);
     mbedtls_md_hmac_update(context, in->data, in->length);
     mbedtls_md_hmac_finish(context, out);
 }
 
 static UA_StatusCode
-sym_verify_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                            Basic128Rsa15_ChannelContext *cc,
-                            const UA_ByteString *message,
-                            const UA_ByteString *signature) {
+sym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                             Basic256Sha256_ChannelContext *cc,
+                             const UA_ByteString *message,
+                             const UA_ByteString *signature) {
     if(securityPolicy == NULL || cc == NULL || message == NULL || signature == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* Compute MAC */
-    if(signature->length != UA_SHA1_LENGTH) {
+    if(signature->length != UA_SHA256_LENGTH) {
         UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                      "Signature size does not have the desired size defined by the security policy");
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     }
 
-    Basic128Rsa15_PolicyContext *pc =
-        (Basic128Rsa15_PolicyContext *)securityPolicy->policyContext;
+    Basic256Sha256_PolicyContext *pc =
+        (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
 
-    unsigned char mac[UA_SHA1_LENGTH];
-    md_hmac(&pc->sha1MdContext, &cc->remoteSymSigningKey, message, mac);
+    unsigned char mac[UA_SHA256_LENGTH];
+    md_hmac_Basic256Sha256(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
 
     /* Compare with Signature */
-    if(memcmp(signature->data, mac, UA_SHA1_LENGTH) != 0)
+    if(memcmp(signature->data, mac, UA_SHA256_LENGTH) != 0)
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-sym_sign_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                          const Basic128Rsa15_ChannelContext *cc,
-                          const UA_ByteString *message,
-                          UA_ByteString *signature) {
-    if(signature->length != UA_SHA1_LENGTH)
+sym_sign_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                           const Basic256Sha256_ChannelContext *cc,
+                           const UA_ByteString *message,
+                           UA_ByteString *signature) {
+    if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    md_hmac(&cc->policyContext->sha1MdContext, &cc->localSymSigningKey,
-            message, signature->data);
+    md_hmac_Basic256Sha256(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
+                           message, signature->data);
     return UA_STATUSCODE_GOOD;
 }
 
 static size_t
-sym_getSignatureSize_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                      const void *channelContext) {
-    return UA_SHA1_LENGTH;
+sym_getSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                       const void *channelContext) {
+    return UA_SHA256_LENGTH;
 }
 
 static size_t
-sym_getSigningKeyLength_sp_basic128rsa15(const UA_SecurityPolicy *const securityPolicy,
-                                         const void *const channelContext) {
-    return UA_BASIC128RSA15_SYM_SIGNING_KEY_LENGTH;
+sym_getSigningKeyLength_sp_basic256sha256(const UA_SecurityPolicy *const securityPolicy,
+                                          const void *const channelContext) {
+    return UA_BASIC256SHA256_SYM_SIGNING_KEY_LENGTH;
 }
 
 static size_t
-sym_getEncryptionKeyLength_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                            const void *channelContext) {
-    return UA_SECURITYPOLICY_BASIC128RSA15_SYM_KEY_LENGTH;
+sym_getEncryptionKeyLength_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                             const void *channelContext) {
+    return UA_SECURITYPOLICY_BASIC256SHA256_SYM_KEY_LENGTH;
 }
 
 static size_t
-sym_getEncryptionBlockSize_sp_basic128rsa15(const UA_SecurityPolicy *const securityPolicy,
+sym_getEncryptionBlockSize_sp_basic256sha256(const UA_SecurityPolicy *const securityPolicy,
+                                             const void *const channelContext) {
+    return UA_SECURITYPOLICY_BASIC256SHA256_SYM_ENCRYPTION_BLOCK_SIZE;
+}
+
+static size_t
+sym_getPlainTextBlockSize_sp_basic256sha256(const UA_SecurityPolicy *const securityPolicy,
                                             const void *const channelContext) {
-    return UA_SECURITYPOLICY_BASIC128RSA15_SYM_ENCRYPTION_BLOCK_SIZE;
-}
-
-static size_t
-sym_getPlainTextBlockSize_sp_basic128rsa15(const UA_SecurityPolicy *const securityPolicy,
-                                           const void *const channelContext) {
-    return UA_SECURITYPOLICY_BASIC128RSA15_SYM_PLAIN_TEXT_BLOCK_SIZE;
+    return UA_SECURITYPOLICY_BASIC256SHA256_SYM_PLAIN_TEXT_BLOCK_SIZE;
 }
 
 static UA_StatusCode
-sym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                             const Basic128Rsa15_ChannelContext *cc,
-                             UA_ByteString *data) {
+sym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                              const Basic256Sha256_ChannelContext *cc,
+                              UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -420,9 +444,9 @@ sym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 }
 
 static UA_StatusCode
-sym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                             const Basic128Rsa15_ChannelContext *cc,
-                             UA_ByteString *data) {
+sym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                              const Basic256Sha256_ChannelContext *cc,
+                              UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -456,24 +480,24 @@ sym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 }
 
 static void
-swapBuffers(UA_ByteString *const bufA, UA_ByteString *const bufB) {
+swapBuffers_Basic256Sha256(UA_ByteString *const bufA, UA_ByteString *const bufB) {
     UA_ByteString tmp = *bufA;
     *bufA = *bufB;
     *bufB = tmp;
 }
 
 static UA_StatusCode
-sym_generateKey_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                 const UA_ByteString *secret, const UA_ByteString *seed,
-                                 UA_ByteString *out) {
+sym_generateKey_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                  const UA_ByteString *secret, const UA_ByteString *seed,
+                                  UA_ByteString *out) {
     if(securityPolicy == NULL || secret == NULL || seed == NULL || out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic128Rsa15_PolicyContext *pc =
-        (Basic128Rsa15_PolicyContext *)securityPolicy->policyContext;
+    Basic256Sha256_PolicyContext *pc =
+        (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
 
     size_t hashLen = 0;
-    const mbedtls_md_info_t *mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
+    const mbedtls_md_info_t *mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     hashLen = (size_t)mbedtls_md_get_size(mdInfo);
 
     UA_ByteString A_and_seed;
@@ -494,7 +518,7 @@ sym_generateKey_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
         ANext_and_seed.data
     };
 
-    md_hmac(&pc->sha1MdContext, secret, seed, A.data);
+    md_hmac_Basic256Sha256(&pc->sha256MdContext, secret, seed, A.data);
 
     UA_StatusCode retval = 0;
     for(size_t offset = 0; offset < out->length; offset += hashLen) {
@@ -516,8 +540,8 @@ sym_generateKey_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
             bufferAllocated = UA_TRUE;
         }
 
-        md_hmac(&pc->sha1MdContext, secret, &A_and_seed, outSegment.data);
-        md_hmac(&pc->sha1MdContext, secret, &A, ANext.data);
+        md_hmac_Basic256Sha256(&pc->sha256MdContext, secret, &A_and_seed, outSegment.data);
+        md_hmac_Basic256Sha256(&pc->sha256MdContext, secret, &A, ANext.data);
 
         if(retval != UA_STATUSCODE_GOOD) {
             if(bufferAllocated)
@@ -532,8 +556,8 @@ sym_generateKey_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
             UA_ByteString_deleteMembers(&outSegment);
         }
 
-        swapBuffers(&ANext_and_seed, &A_and_seed);
-        swapBuffers(&ANext, &A);
+        swapBuffers_Basic256Sha256(&ANext_and_seed, &A_and_seed);
+        swapBuffers_Basic256Sha256(&ANext, &A);
     }
 
     UA_ByteString_deleteMembers(&A_and_seed);
@@ -542,13 +566,13 @@ sym_generateKey_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 }
 
 static UA_StatusCode
-sym_generateNonce_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                   UA_ByteString *out) {
+sym_generateNonce_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                    UA_ByteString *out) {
     if(securityPolicy == NULL || securityPolicy->policyContext == NULL || out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic128Rsa15_PolicyContext *data =
-        (Basic128Rsa15_PolicyContext *)securityPolicy->policyContext;
+    Basic256Sha256_PolicyContext *data =
+        (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
 
     int mbedErr = mbedtls_ctr_drbg_random(&data->drbgContext, out->data, out->length);
     UA_MBEDTLS_ERRORHANDLING_RETURN(UA_STATUSCODE_BADUNEXPECTEDERROR);
@@ -562,8 +586,8 @@ sym_generateNonce_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 
 /* Assumes that the certificate has been verified externally */
 static UA_StatusCode
-parseRemoteCertificate_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
-                                        const UA_ByteString *remoteCertificate) {
+parseRemoteCertificate_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+                                         const UA_ByteString *remoteCertificate) {
     if(remoteCertificate == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -576,15 +600,15 @@ parseRemoteCertificate_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
 
     /* Check the key length */
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    if(rsaContext->len < UA_SECURITYPOLICY_BASIC128RSA15_MINASYMKEYLENGTH ||
-       rsaContext->len > UA_SECURITYPOLICY_BASIC128RSA15_MAXASYMKEYLENGTH)
+    if(rsaContext->len < UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH ||
+       rsaContext->len > UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH)
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
 
     return UA_STATUSCODE_GOOD;
 }
 
 static void
-channelContext_deleteContext_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc) {
+channelContext_deleteContext_sp_basic256sha256(Basic256Sha256_ChannelContext *cc) {
     UA_ByteString_deleteMembers(&cc->localSymSigningKey);
     UA_ByteString_deleteMembers(&cc->localSymEncryptingKey);
     UA_ByteString_deleteMembers(&cc->localSymIv);
@@ -599,21 +623,21 @@ channelContext_deleteContext_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc) 
 }
 
 static UA_StatusCode
-channelContext_newContext_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                                           const UA_ByteString *remoteCertificate,
-                                           void **pp_contextData) {
+channelContext_newContext_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                            const UA_ByteString *remoteCertificate,
+                                            void **pp_contextData) {
     if(securityPolicy == NULL || remoteCertificate == NULL || pp_contextData == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* Allocate the channel context */
-    *pp_contextData = UA_malloc(sizeof(Basic128Rsa15_ChannelContext));
+    *pp_contextData = UA_malloc(sizeof(Basic256Sha256_ChannelContext));
     if(*pp_contextData == NULL)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    Basic128Rsa15_ChannelContext *cc = (Basic128Rsa15_ChannelContext *)*pp_contextData;
+    Basic256Sha256_ChannelContext *cc = (Basic256Sha256_ChannelContext *)*pp_contextData;
 
     /* Initialize the channel context */
-    cc->policyContext = (Basic128Rsa15_PolicyContext *)securityPolicy->policyContext;
+    cc->policyContext = (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
 
     UA_ByteString_init(&cc->localSymSigningKey);
     UA_ByteString_init(&cc->localSymEncryptingKey);
@@ -626,17 +650,17 @@ channelContext_newContext_sp_basic128rsa15(const UA_SecurityPolicy *securityPoli
     mbedtls_x509_crt_init(&cc->remoteCertificate);
 
     // TODO: this can be optimized so that we dont allocate memory before parsing the certificate
-    UA_StatusCode retval = parseRemoteCertificate_sp_basic128rsa15(cc, remoteCertificate);
+    UA_StatusCode retval = parseRemoteCertificate_sp_basic256sha256(cc, remoteCertificate);
     if(retval != UA_STATUSCODE_GOOD) {
-        channelContext_deleteContext_sp_basic128rsa15(cc);
+        channelContext_deleteContext_sp_basic256sha256(cc);
         *pp_contextData = NULL;
     }
     return retval;
 }
 
 static UA_StatusCode
-channelContext_setLocalSymEncryptingKey_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
-                                                         const UA_ByteString *key) {
+channelContext_setLocalSymEncryptingKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+                                                          const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -645,8 +669,8 @@ channelContext_setLocalSymEncryptingKey_sp_basic128rsa15(Basic128Rsa15_ChannelCo
 }
 
 static UA_StatusCode
-channelContext_setLocalSymSigningKey_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
-                                                      const UA_ByteString *key) {
+channelContext_setLocalSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+                                                       const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -656,8 +680,8 @@ channelContext_setLocalSymSigningKey_sp_basic128rsa15(Basic128Rsa15_ChannelConte
 
 
 static UA_StatusCode
-channelContext_setLocalSymIv_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
-                                              const UA_ByteString *iv) {
+channelContext_setLocalSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+                                               const UA_ByteString *iv) {
     if(iv == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -666,8 +690,8 @@ channelContext_setLocalSymIv_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymEncryptingKey_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
-                                                          const UA_ByteString *key) {
+channelContext_setRemoteSymEncryptingKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+                                                           const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -676,8 +700,8 @@ channelContext_setRemoteSymEncryptingKey_sp_basic128rsa15(Basic128Rsa15_ChannelC
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymSigningKey_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
-                                                       const UA_ByteString *key) {
+channelContext_setRemoteSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+                                                        const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -686,8 +710,8 @@ channelContext_setRemoteSymSigningKey_sp_basic128rsa15(Basic128Rsa15_ChannelCont
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymIv_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
-                                               const UA_ByteString *iv) {
+channelContext_setRemoteSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+                                                const UA_ByteString *iv) {
     if(iv == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -696,8 +720,8 @@ channelContext_setRemoteSymIv_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
 }
 
 static UA_StatusCode
-channelContext_compareCertificate_sp_basic128rsa15(const Basic128Rsa15_ChannelContext *cc,
-                                                   const UA_ByteString *certificate) {
+channelContext_compareCertificate_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
+                                                    const UA_ByteString *certificate) {
     if(cc == NULL || certificate == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -717,7 +741,7 @@ channelContext_compareCertificate_sp_basic128rsa15(const Basic128Rsa15_ChannelCo
 }
 
 static void
-deleteMembers_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy) {
+deleteMembers_sp_basic256sha256(UA_SecurityPolicy *securityPolicy) {
     if(securityPolicy == NULL)
         return;
 
@@ -727,31 +751,31 @@ deleteMembers_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy) {
     UA_ByteString_deleteMembers(&securityPolicy->localCertificate);
 
     /* delete all allocated members in the context */
-    Basic128Rsa15_PolicyContext *pc = (Basic128Rsa15_PolicyContext *)
+    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)
         securityPolicy->policyContext;
 
     mbedtls_ctr_drbg_free(&pc->drbgContext);
     mbedtls_entropy_free(&pc->entropyContext);
     mbedtls_pk_free(&pc->localPrivateKey);
-    mbedtls_md_free(&pc->sha1MdContext);
+    mbedtls_md_free(&pc->sha256MdContext);
     UA_ByteString_deleteMembers(&pc->localCertThumbprint);
 
     UA_LOG_DEBUG(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                 "Deleted members of EndpointContext for sp_basic128rsa15");
+                 "Deleted members of EndpointContext for sp_basic256sha256");
 
     UA_free(pc);
     securityPolicy->policyContext = NULL;
 }
 
 static UA_StatusCode
-policyContext_newContext_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
-                                          const UA_ByteString localPrivateKey) {
+policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
+                                           const UA_ByteString localPrivateKey) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(securityPolicy == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic128Rsa15_PolicyContext *pc = (Basic128Rsa15_PolicyContext *)
-        UA_malloc(sizeof(Basic128Rsa15_PolicyContext));
+    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)
+        UA_malloc(sizeof(Basic256Sha256_PolicyContext));
     securityPolicy->policyContext = (void *)pc;
     if(!pc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -759,16 +783,16 @@ policyContext_newContext_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
     }
 
     /* Initialize the PolicyContext */
-    memset(pc, 0, sizeof(Basic128Rsa15_PolicyContext));
+    memset(pc, 0, sizeof(Basic256Sha256_PolicyContext));
     mbedtls_ctr_drbg_init(&pc->drbgContext);
     mbedtls_entropy_init(&pc->entropyContext);
     mbedtls_pk_init(&pc->localPrivateKey);
-    mbedtls_md_init(&pc->sha1MdContext);
+    mbedtls_md_init(&pc->sha256MdContext);
     pc->securityPolicy = securityPolicy;
 
     /* Initialized the message digest */
-    const mbedtls_md_info_t *const mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
-    int mbedErr = mbedtls_md_setup(&pc->sha1MdContext, mdInfo, MBEDTLS_MD_SHA1);
+    const mbedtls_md_info_t *const mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    int mbedErr = mbedtls_md_setup(&pc->sha256MdContext, mdInfo, MBEDTLS_MD_SHA256);
     UA_MBEDTLS_ERRORHANDLING(UA_STATUSCODE_BADOUTOFMEMORY);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
@@ -802,7 +826,7 @@ policyContext_newContext_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
     retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
-    retval = asym_makeThumbprint_sp_basic128rsa15(pc->securityPolicy,
+    retval = asym_makeThumbprint_sp_basic256sha256(pc->securityPolicy,
                                                   &securityPolicy->localCertificate,
                                                   &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
@@ -814,18 +838,18 @@ error:
     UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Could not create securityContext");
     if(securityPolicy->policyContext != NULL)
-        deleteMembers_sp_basic128rsa15(securityPolicy);
+        deleteMembers_sp_basic256sha256(securityPolicy);
     return retval;
 }
 
 UA_StatusCode
-UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy, UA_CertificateVerification *certificateVerification,
-                                const UA_ByteString localCertificate, const UA_ByteString localPrivateKey,
-                                UA_Logger logger) {
+UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, UA_CertificateVerification *certificateVerification,
+                                 const UA_ByteString localCertificate, const UA_ByteString localPrivateKey,
+                                 UA_Logger logger) {
     memset(policy, 0, sizeof(UA_SecurityPolicy));
     policy->logger = logger;
 
-    policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+    policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
 
     UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
@@ -848,14 +872,14 @@ UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy, UA_CertificateVerific
         UA_STRING("http://www.w3.org/2000/09/xmldsig#rsa-sha1\0");
     asym_signatureAlgorithm->verify =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *,
-                           const UA_ByteString *, const UA_ByteString *))asym_verify_sp_basic128rsa15;
+                           const UA_ByteString *, const UA_ByteString *))asym_verify_sp_basic256sha256;
     asym_signatureAlgorithm->sign =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *,
-                           const UA_ByteString *, UA_ByteString *))asym_sign_sp_basic128rsa15;
+                           const UA_ByteString *, UA_ByteString *))asym_sign_sp_basic256sha256;
     asym_signatureAlgorithm->getLocalSignatureSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getLocalSignatureSize_sp_basic128rsa15;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getLocalSignatureSize_sp_basic256sha256;
     asym_signatureAlgorithm->getRemoteSignatureSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteSignatureSize_sp_basic128rsa15;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteSignatureSize_sp_basic256sha256;
     asym_signatureAlgorithm->getLocalKeyLength = NULL; // TODO: Write function
     asym_signatureAlgorithm->getRemoteKeyLength = NULL; // TODO: Write function
 
@@ -863,27 +887,27 @@ UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy, UA_CertificateVerific
         &asymmetricModule->cryptoModule.encryptionAlgorithm;
     asym_encryptionAlgorithm->uri = UA_STRING("TODO: ALG URI");
     asym_encryptionAlgorithm->encrypt =
-        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))asym_encrypt_sp_basic128rsa15;
+        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))asym_encrypt_sp_basic256sha256;
     asym_encryptionAlgorithm->decrypt =
         (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))
-            asym_decrypt_sp_basic128rsa15;
+            asym_decrypt_sp_basic256sha256;
     asym_encryptionAlgorithm->getLocalKeyLength = NULL; // TODO: Write function
     asym_encryptionAlgorithm->getRemoteKeyLength =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteEncryptionKeyLength_sp_basic128rsa15;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteEncryptionKeyLength_sp_basic256sha256;
     asym_encryptionAlgorithm->getLocalBlockSize = NULL; // TODO: Write function
     asym_encryptionAlgorithm->getRemoteBlockSize = (size_t (*)(const UA_SecurityPolicy *,
-                                                               const void *))asym_getRemoteBlockSize_sp_basic128rsa15;
+                                                               const void *))asym_getRemoteBlockSize_sp_basic256sha256;
     asym_encryptionAlgorithm->getLocalPlainTextBlockSize = NULL; // TODO: Write function
     asym_encryptionAlgorithm->getRemotePlainTextBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemotePlainTextBlockSize_sp_basic128rsa15;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemotePlainTextBlockSize_sp_basic256sha256;
 
-    asymmetricModule->makeCertificateThumbprint = asym_makeThumbprint_sp_basic128rsa15;
+    asymmetricModule->makeCertificateThumbprint = asym_makeThumbprint_sp_basic256sha256;
     asymmetricModule->compareCertificateThumbprint =
-        asymmetricModule_compareCertificateThumbprint_sp_basic128rsa15;
+        asymmetricModule_compareCertificateThumbprint_sp_basic256sha256;
 
     /* SymmetricModule */
-    symmetricModule->generateKey = sym_generateKey_sp_basic128rsa15;
-    symmetricModule->generateNonce = sym_generateNonce_sp_basic128rsa15;
+    symmetricModule->generateKey = sym_generateKey_sp_basic256sha256;
+    symmetricModule->generateNonce = sym_generateNonce_sp_basic256sha256;
 
     UA_SecurityPolicySignatureAlgorithm *sym_signatureAlgorithm =
         &symmetricModule->cryptoModule.signatureAlgorithm;
@@ -891,64 +915,64 @@ UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy, UA_CertificateVerific
         UA_STRING("http://www.w3.org/2000/09/xmldsig#hmac-sha1\0");
     sym_signatureAlgorithm->verify =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *, const UA_ByteString *,
-                           const UA_ByteString *))sym_verify_sp_basic128rsa15;
+                           const UA_ByteString *))sym_verify_sp_basic256sha256;
     sym_signatureAlgorithm->sign =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *,
-                           const UA_ByteString *, UA_ByteString *))sym_sign_sp_basic128rsa15;
-    sym_signatureAlgorithm->getLocalSignatureSize = sym_getSignatureSize_sp_basic128rsa15;
-    sym_signatureAlgorithm->getRemoteSignatureSize = sym_getSignatureSize_sp_basic128rsa15;
+                           const UA_ByteString *, UA_ByteString *))sym_sign_sp_basic256sha256;
+    sym_signatureAlgorithm->getLocalSignatureSize = sym_getSignatureSize_sp_basic256sha256;
+    sym_signatureAlgorithm->getRemoteSignatureSize = sym_getSignatureSize_sp_basic256sha256;
     sym_signatureAlgorithm->getLocalKeyLength =
         (size_t (*)(const UA_SecurityPolicy *,
-                    const void *))sym_getSigningKeyLength_sp_basic128rsa15;
+                    const void *))sym_getSigningKeyLength_sp_basic256sha256;
     sym_signatureAlgorithm->getRemoteKeyLength =
         (size_t (*)(const UA_SecurityPolicy *,
-                    const void *))sym_getSigningKeyLength_sp_basic128rsa15;
+                    const void *))sym_getSigningKeyLength_sp_basic256sha256;
 
     UA_SecurityPolicyEncryptionAlgorithm *sym_encryptionAlgorithm =
         &symmetricModule->cryptoModule.encryptionAlgorithm;
     sym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#aes128-cbc");
     sym_encryptionAlgorithm->encrypt =
-        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_encrypt_sp_basic128rsa15;
+        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_encrypt_sp_basic256sha256;
     sym_encryptionAlgorithm->decrypt =
-        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_decrypt_sp_basic128rsa15;
-    sym_encryptionAlgorithm->getLocalKeyLength = sym_getEncryptionKeyLength_sp_basic128rsa15;
-    sym_encryptionAlgorithm->getRemoteKeyLength = sym_getEncryptionKeyLength_sp_basic128rsa15;
+        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_decrypt_sp_basic256sha256;
+    sym_encryptionAlgorithm->getLocalKeyLength = sym_getEncryptionKeyLength_sp_basic256sha256;
+    sym_encryptionAlgorithm->getRemoteKeyLength = sym_getEncryptionKeyLength_sp_basic256sha256;
     sym_encryptionAlgorithm->getLocalBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_basic128rsa15;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_basic256sha256;
     sym_encryptionAlgorithm->getRemoteBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_basic128rsa15;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_basic256sha256;
     sym_encryptionAlgorithm->getLocalPlainTextBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_basic128rsa15;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_basic256sha256;
     sym_encryptionAlgorithm->getRemotePlainTextBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_basic128rsa15;
-    symmetricModule->secureChannelNonceLength = 16;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_basic256sha256;
+    symmetricModule->secureChannelNonceLength = 32;
 
     // Use the same signature algorithm as the asymmetric component for certificate signing (see standard)
     policy->certificateSigningAlgorithm = policy->asymmetricModule.cryptoModule.signatureAlgorithm;
 
     /* ChannelModule */
-    channelModule->newContext = channelContext_newContext_sp_basic128rsa15;
+    channelModule->newContext = channelContext_newContext_sp_basic256sha256;
     channelModule->deleteContext = (void (*)(void *))
-        channelContext_deleteContext_sp_basic128rsa15;
+        channelContext_deleteContext_sp_basic256sha256;
 
     channelModule->setLocalSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymEncryptingKey_sp_basic128rsa15;
+        channelContext_setLocalSymEncryptingKey_sp_basic256sha256;
     channelModule->setLocalSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymSigningKey_sp_basic128rsa15;
+        channelContext_setLocalSymSigningKey_sp_basic256sha256;
     channelModule->setLocalSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymIv_sp_basic128rsa15;
+        channelContext_setLocalSymIv_sp_basic256sha256;
 
     channelModule->setRemoteSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymEncryptingKey_sp_basic128rsa15;
+        channelContext_setRemoteSymEncryptingKey_sp_basic256sha256;
     channelModule->setRemoteSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymSigningKey_sp_basic128rsa15;
+        channelContext_setRemoteSymSigningKey_sp_basic256sha256;
     channelModule->setRemoteSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymIv_sp_basic128rsa15;
+        channelContext_setRemoteSymIv_sp_basic256sha256;
 
     channelModule->compareCertificate = (UA_StatusCode (*)(const void *, const UA_ByteString *))
-        channelContext_compareCertificate_sp_basic128rsa15;
+        channelContext_compareCertificate_sp_basic256sha256;
 
-    policy->deleteMembers = deleteMembers_sp_basic128rsa15;
+    policy->deleteMembers = deleteMembers_sp_basic256sha256;
 
-    return policyContext_newContext_sp_basic128rsa15(policy, localPrivateKey);
+    return policyContext_newContext_sp_basic256sha256(policy, localPrivateKey);
 }

--- a/plugins/ua_securitypolicy_basic256sha256.h
+++ b/plugins/ua_securitypolicy_basic256sha256.h
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
+ *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
+ */
+
+#ifndef UA_SECURITYPOLICY_BASIC256SHA256_H_
+#define UA_SECURITYPOLICY_BASIC256SHA256_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ua_plugin_securitypolicy.h"
+#include "ua_plugin_log.h"
+
+UA_EXPORT UA_StatusCode
+UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy,
+                                 UA_CertificateVerification *certificateVerification,
+                                 const UA_ByteString localCertificate,
+                                 const UA_ByteString localPrivateKey,
+                                 UA_Logger logger);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UA_SECURITYPOLICY_BASIC256SHA256_H_

--- a/plugins/ua_securitypolicy_common.c
+++ b/plugins/ua_securitypolicy_common.c
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mbedtls/sha1.h>
+
+#include "ua_securitypolicy_common.h"
+
+
+void
+sha1(const unsigned char *input, size_t ilen, unsigned char output[20]) {
+    mbedtls_sha1_context sha1Context;
+    mbedtls_sha1_init(&sha1Context);
+    mbedtls_sha1_starts(&sha1Context);
+    mbedtls_sha1_update(&sha1Context, input, ilen);
+    mbedtls_sha1_finish(&sha1Context, output);
+    mbedtls_sha1_free(&sha1Context);
+}

--- a/plugins/ua_securitypolicy_common.h
+++ b/plugins/ua_securitypolicy_common.h
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+ 
+#ifndef UA_SECURITYPOLICY_COMMON_H_
+#define UA_SECURITYPOLICY_COMMON_H_
+
+void
+sha1(const unsigned char *input, size_t ilen, unsigned char output[20]);
+
+#endif // UA_SECURITYPOLICY_COMMON_H_

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -720,7 +720,7 @@ UA_Client_Subscriptions_backgroundPublishInactivityCheck(UA_Client *client) {
             if (client->config.subscriptionInactivityCallback)
                 client->config.subscriptionInactivityCallback(client, sub->subscriptionId, sub->context);
             UA_LOG_ERROR(client->config.logger, UA_LOGCATEGORY_CLIENT,
-                         "Inactivity for Subscription %d.", sub->subscriptionId);
+                         "Inactivity for Subscription %u.", sub->subscriptionId);
         }
     }
 }

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -178,7 +178,7 @@ typedef UA_StatusCode (*UA_EditNodeCallback)(UA_Server*, UA_Session*,
 UA_StatusCode UA_Server_editNode(UA_Server *server, UA_Session *session,
                                  const UA_NodeId *nodeId,
                                  UA_EditNodeCallback callback,
-                                 const void *data);
+                                 void *data);
 
 /*************/
 /* Callbacks */

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -353,7 +353,7 @@ getTypeHierarchy(UA_Nodestore *ns, const UA_NodeId *leafType,
 UA_StatusCode
 UA_Server_editNode(UA_Server *server, UA_Session *session,
                    const UA_NodeId *nodeId, UA_EditNodeCallback callback,
-                   const void *data) {
+                   void *data) {
 #ifndef UA_ENABLE_MULTITHREADING
     const UA_Node *node = UA_Nodestore_get(server, nodeId);
     if(!node)

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -32,7 +32,8 @@ getUserWriteMask(UA_Server *server, const UA_Session *session,
     if(session == &adminSession)
         return 0xFFFFFFFF; /* the local admin user has all rights */
     return node->writeMask &
-        server->config.accessControl.getUserRightsMask(&session->sessionId, session->sessionHandle,
+        server->config.accessControl.getUserRightsMask(server, &server->config.accessControl,
+                                                       &session->sessionId, session->sessionHandle,
                                                        &node->nodeId, node->context);
 }
 
@@ -50,7 +51,8 @@ getUserAccessLevel(UA_Server *server, const UA_Session *session,
     if(session == &adminSession)
         return 0xFF; /* the local admin user has all rights */
     return node->accessLevel &
-        server->config.accessControl.getUserAccessLevel(&session->sessionId, session->sessionHandle,
+        server->config.accessControl.getUserAccessLevel(server, &server->config.accessControl,
+                                                        &session->sessionId, session->sessionHandle,
                                                         &node->nodeId, node->context);
 }
 
@@ -60,7 +62,8 @@ getUserExecutable(UA_Server *server, const UA_Session *session,
     if(session == &adminSession)
         return true; /* the local admin user has all rights */
     return node->executable &
-        server->config.accessControl.getUserExecutable(&session->sessionId, session->sessionHandle,
+        server->config.accessControl.getUserExecutable(server, &server->config.accessControl,
+                                                       &session->sessionId, session->sessionHandle,
                                                        &node->nodeId, node->context);
 }
 
@@ -1302,7 +1305,9 @@ UA_StatusCode
 UA_Server_write(UA_Server *server, const UA_WriteValue *value) {
     UA_StatusCode retval =
         UA_Server_editNode(server, &adminSession, &value->nodeId,
-                  (UA_EditNodeCallback)copyAttributeIntoNode, value);
+                  (UA_EditNodeCallback)copyAttributeIntoNode,
+                   /* casting away const qualifier because callback uses const anyway */
+                   (UA_WriteValue *)(uintptr_t)value);
     return retval;
 }
 

--- a/src/server/ua_services_call.c
+++ b/src/server/ua_services_call.c
@@ -159,7 +159,8 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
     UA_Boolean executable = method->executable;
     if(session != &adminSession)
         executable = executable &&
-            server->config.accessControl.getUserExecutableOnObject(&session->sessionId,
+            server->config.accessControl.getUserExecutableOnObject(server,
+                           &server->config.accessControl, &session->sessionId,
                            session->sessionHandle, &request->methodId, method->context,
                            &request->objectId, object->context);
     if(!executable) {

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -239,8 +239,8 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
 
     /* Callback into userland access control */
     response->responseHeader.serviceResult =
-        server->config.accessControl.activateSession(&session->sessionId,
-                                                     &request->userIdentityToken,
+        server->config.accessControl.activateSession(server, &server->config.accessControl,
+                                                     &session->sessionId, &request->userIdentityToken,
                                                      &session->sessionHandle);
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO_SESSION(server->config.logger, session,
@@ -283,8 +283,8 @@ Service_CloseSession(UA_Server *server, UA_Session *session,
     UA_LOG_INFO_SESSION(server->config.logger, session, "CloseSession");
 
     /* Callback into userland access control */
-    server->config.accessControl.closeSession(&session->sessionId,
-                                              session->sessionHandle);
+    server->config.accessControl.closeSession(server, &server->config.accessControl,
+                                              &session->sessionId, session->sessionHandle);
     response->responseHeader.serviceResult =
         UA_SessionManager_removeSession(&server->sessionManager,
                                         &session->header.authenticationToken);

--- a/src/server/ua_session_manager.c
+++ b/src/server/ua_session_manager.c
@@ -72,7 +72,9 @@ UA_SessionManager_cleanupTimedOut(UA_SessionManager *sm,
             continue;
         UA_LOG_INFO_SESSION(sm->server->config.logger, &sentry->session,
                             "Session has timed out");
-        sm->server->config.accessControl.closeSession(&sentry->session.sessionId,
+        sm->server->config.accessControl.closeSession(sm->server,
+                                                      &sm->server->config.accessControl,
+                                                      &sentry->session.sessionId,
                                                       sentry->session.sessionHandle);
         removeSession(sm, sentry);
     }

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -131,7 +131,7 @@ encodeWithExchangeBuffer(const void *ptr, encodeBinarySignature encodeFunc, Ctx 
 
 #if !UA_BINARY_OVERLAYABLE_INTEGER
 
-#pragma message Integer endianness could not be detected to be little endian. Use slow generic encoding.
+#pragma message "Integer endianness could not be detected to be little endian. Use slow generic encoding."
 
 /* These en/decoding functions are only used when the architecture isn't little-endian. */
 static void

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,9 +21,9 @@ include_directories(${PROJECT_SOURCE_DIR}/tests/testing-plugins)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/tests)
 if (MSVC)
-	set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests/${CMAKE_BUILD_TYPE})
+    set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests/${CMAKE_BUILD_TYPE})
 else()
-	set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests)
+    set(TESTS_BINARY_DIR ${CMAKE_BINARY_DIR}/bin/tests)
 endif()
 
 
@@ -43,7 +43,11 @@ set(test_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.c
 
 if(UA_ENABLE_ENCRYPTION)
     set(test_plugin_sources ${test_plugin_sources}
+        ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_common.c)
+    set(test_plugin_sources ${test_plugin_sources}
         ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.c)
+    set(test_plugin_sources ${test_plugin_sources}
+        ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic256sha256.c)
 endif()
 
 add_library(open62541-testplugins OBJECT ${test_plugin_sources})

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -65,7 +65,11 @@ set(fuzzing_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_network_tcp.c
 
 if(UA_ENABLE_ENCRYPTION)
     set(fuzzing_plugin_sources ${fuzzing_plugin_sources}
+        ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_common.c)
+    set(fuzzing_plugin_sources ${fuzzing_plugin_sources}
         ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic128rsa15.c)
+    set(fuzzing_plugin_sources ${fuzzing_plugin_sources}
+        ${PROJECT_SOURCE_DIR}/plugins/ua_securitypolicy_basic256sha256.c)
 endif()
 
 add_library(open62541-fuzzplugins OBJECT ${fuzzing_plugin_sources})

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -491,8 +491,14 @@ printh('''/* Generated from ''' + inname + ''' with script ''' + sys.argv[0] + '
 extern "C" {
 #endif
 
+#ifdef UA_NO_AMALGAMATION
 #include "ua_types.h"
-''' + ('#include "ua_types_generated.h"\n' if outname != "ua_types" else ''))
+''' + ('#include "ua_types_generated.h"\n' if outname != "ua_types" else '') + '''
+#else
+#include "open62541.h"
+#endif
+
+''')
 
 filtered_types = iter_types(types, False)
 filtered_opaque_types = iter_types(types, True)

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -189,19 +189,55 @@ def generateOpen62541Code(nodeset, outfilename, generate_ns0=False, internal_hea
     if internal_headers:
         writeh("""
 #ifdef UA_NO_AMALGAMATION
-#include "ua_server.h"
-#include "ua_types_encoding_binary.h"
-%s
+# include "ua_server.h"
+# include "ua_types_encoding_binary.h"
 #else
-#include "open62541.h"
+# include "open62541.h"
+
+/* The following declarations are in the open62541.c file so here's needed when compiling nodesets externally */
+
+# ifndef UA_Nodestore_remove //this definition is needed to hide this code in the amalgamated .c file
+
+typedef UA_StatusCode (*UA_exchangeEncodeBuffer)(void *handle, UA_Byte **bufPos,
+                                                 const UA_Byte **bufEnd);
+
+UA_StatusCode
+UA_encodeBinary(const void *src, const UA_DataType *type,
+                UA_Byte **bufPos, const UA_Byte **bufEnd,
+                UA_exchangeEncodeBuffer exchangeCallback,
+                void *exchangeHandle) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+
+UA_StatusCode
+UA_decodeBinary(const UA_ByteString *src, size_t *offset, void *dst,
+                const UA_DataType *type, size_t customTypesSize,
+                const UA_DataType *customTypes) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+
+size_t
+UA_calcSizeBinary(void *p, const UA_DataType *type);
+
+const UA_DataType *
+UA_findDataTypeByBinary(const UA_NodeId *typeId);
+
+# endif // UA_Nodestore_remove
+
 #endif
+
+%s
 """ % (additionalHeaders))
     else:
         writeh("""
 #include "open62541.h"
 """)
     writeh("""
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
 extern UA_StatusCode %s(UA_Server *server);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* %s_H_ */""" % \
            (outfilebase, outfilebase.upper()))


### PR DESCRIPTION
The function `UA_Server_editNode` takes a `const void *data`, which does not make a lot of sense because in some cases said data needs to be changed. For example: an element needs to be added to a doubly-linked list which belongs to a node. No matter where you insert it, the reference to the previous and/or next item will have to be edited.
To achieve this while not changing too much all attributes which lose their const qualifier by simply changing the `editNode` function have been edited so that the const is cast away when calling the function but the callback from `editNode` will cast the data back to const.