### PR TITLE
Client performance issue on large responses

### DIFF
--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -47,7 +47,9 @@ typedef struct UA_SessionHeader {
 struct ChunkEntry {
     LIST_ENTRY(ChunkEntry) pointers;
     UA_UInt32 requestId;
-    UA_ByteString bytes;
+    UA_Byte* bytes;
+    size_t size;
+    size_t count;
 };
 
 typedef enum {


### PR DESCRIPTION
## Problem:
Large responses on server are divided into 64k chunks.  
Client for every received chunk increases (UA_realloc) complete message size for one chunk size(64k). On large responses this means a lot of memory allocating for increasing buffer size just for 64k.

## Solution:
Increase memory size for more than just newly arrived chunk.