### PR TITLE
Enable auto generation for types required by EventFilter

### DIFF
--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -136,6 +136,7 @@ QueryDataSet
 ParsingResult
 ContentFilterElementResult
 ContentFilterResult
+EventFilterResult
 QueryFirstResponse
 QueryNextRequest
 QueryNextResponse
@@ -173,6 +174,9 @@ DeadbandType
 DataChangeFilter
 EventFilter
 FilterOperand
+ElementOperand
+LiteralOperand
+AttributeOperand
 SimpleAttributeOperand
 EventNotificationList
 EventFieldList


### PR DESCRIPTION
There is a working API for event monitoring with event filters, so the operator types for the where clause should be available by default.