### PR TITLE
Client performance issue on large responses

### DIFF
--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -110,7 +110,7 @@ UA_SecureChannel_deleteMembersCleanup(UA_SecureChannel *channel) {
     /* Remove the buffered chunks */
     struct ChunkEntry *ch, *temp_ch;
     LIST_FOREACH_SAFE(ch, &channel->chunks, pointers, temp_ch) {
-        UA_ByteString_deleteMembers(&ch->bytes);
+        UA_free(ch->bytes);
         LIST_REMOVE(ch, pointers);
         UA_free(ch);
     }
@@ -722,7 +722,7 @@ UA_SecureChannel_removeChunks(UA_SecureChannel *channel, UA_UInt32 requestId) {
     struct ChunkEntry *ch;
     LIST_FOREACH(ch, &channel->chunks, pointers) {
         if(ch->requestId == requestId) {
-            UA_ByteString_deleteMembers(&ch->bytes);
+            UA_free(ch->bytes);
             LIST_REMOVE(ch, pointers);
             UA_free(ch);
             return;
@@ -732,15 +732,22 @@ UA_SecureChannel_removeChunks(UA_SecureChannel *channel, UA_UInt32 requestId) {
 
 static UA_StatusCode
 appendChunk(struct ChunkEntry *chunkEntry, const UA_ByteString *chunkBody) {
-    UA_Byte *new_bytes = (UA_Byte *)
-        UA_realloc(chunkEntry->bytes.data, chunkEntry->bytes.length + chunkBody->length);
-    if(!new_bytes) {
-        UA_ByteString_deleteMembers(&chunkEntry->bytes);
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    size_t new_size = chunkEntry->count + chunkBody->length;
+    if (new_size > chunkEntry->size) {
+        size_t capacity = 3 * new_size / 2;
+        UA_Byte *new_bytes = (UA_Byte *)
+            UA_realloc(chunkEntry->bytes, capacity);
+        if (!new_bytes) {
+            UA_free(chunkEntry->bytes);
+            chunkEntry->size = 0;
+            chunkEntry->count = 0;
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
+        chunkEntry->bytes = new_bytes;
+        chunkEntry->size = capacity;
     }
-    chunkEntry->bytes.data = new_bytes;
-    memcpy(&chunkEntry->bytes.data[chunkEntry->bytes.length], chunkBody->data, chunkBody->length);
-    chunkEntry->bytes.length += chunkBody->length;
+    memcpy(&chunkEntry->bytes[chunkEntry->count], chunkBody->data, chunkBody->length);
+    chunkEntry->count += chunkBody->length;
     return UA_STATUSCODE_GOOD;
 }
 
@@ -758,8 +765,8 @@ UA_SecureChannel_appendChunk(UA_SecureChannel *channel, UA_UInt32 requestId,
         ch = (struct ChunkEntry *)UA_malloc(sizeof(struct ChunkEntry));
         if(!ch)
             return UA_STATUSCODE_BADOUTOFMEMORY;
+        memset(ch, 0, sizeof(struct ChunkEntry));
         ch->requestId = requestId;
-        UA_ByteString_init(&ch->bytes);
         LIST_INSERT_HEAD(&channel->chunks, ch, pointers);
     }
 
@@ -783,7 +790,11 @@ UA_SecureChannel_finalizeChunk(UA_SecureChannel *channel, UA_UInt32 requestId,
         UA_StatusCode retval = appendChunk(chunkEntry, chunkBody);
         if(retval != UA_STATUSCODE_GOOD)
             return retval;
-        bytes = chunkEntry->bytes;
+        
+        UA_ByteString_init(&bytes);
+        bytes.data = chunkEntry->bytes;
+        bytes.length = chunkEntry->count;
+
         LIST_REMOVE(chunkEntry, pointers);
         UA_free(chunkEntry);
     }

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -44,12 +44,16 @@ typedef struct UA_SessionHeader {
 } UA_SessionHeader;
 
 /* For chunked requests */
+struct ChunkData {
+    SIMPLEQ_ENTRY(ChunkData) pointers;
+    UA_ByteString bytes;
+};
+
 struct ChunkEntry {
     LIST_ENTRY(ChunkEntry) pointers;
     UA_UInt32 requestId;
-    UA_Byte* bytes;
-    size_t size;
-    size_t count;
+    SIMPLEQ_HEAD(chunkdata_pointerlist, ChunkData) chunkData;
+    size_t chunkDataSize;
 };
 
 typedef enum {

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -47,7 +47,9 @@ typedef struct UA_SessionHeader {
 struct ChunkEntry {
     LIST_ENTRY(ChunkEntry) pointers;
     UA_UInt32 requestId;
-    UA_ByteString bytes;
+    UA_Byte* bytes;
+    size_t size;
+    size_t count;
 };
 
 typedef enum {


### PR DESCRIPTION
## Problem:
Large responses on server are divided into 64k chunks.
Client for every received chunk increases (UA_realloc) complete message size for one chunk size(64k). On large responses this means a lot of memory allocating for increasing buffer size just for 64k.

## Solution:
Increase memory size for more than just newly arrived chunk.