### PR TITLE
fix connection closed server log

### DIFF
--- a/plugins/ua_network_tcp.c
+++ b/plugins/ua_network_tcp.c
@@ -664,15 +664,9 @@ ServerNetworkLayerTCP_listen(UA_ServerNetworkLayer *nl, UA_Server *server,
             connection_releaserecvbuffer(&e->connection, &buf);
         } else if(retval == UA_STATUSCODE_BADCONNECTIONCLOSED) {
             /* The socket is shutdown but not closed */
-            if(e->connection.state != UA_CONNECTION_CLOSED) {
-                UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                            "Connection %i | Closed by the client",
-                            e->connection.sockfd);
-            } else {
-                UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                            "Connection %i | Closed by the server",
-                            e->connection.sockfd);
-            }
+            UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
+                        "Connection %i | Closed",
+                        e->connection.sockfd);
             LIST_REMOVE(e, pointers);
             CLOSESOCKET(e->connection.sockfd);
             UA_Server_removeConnection(server, &e->connection);


### PR DESCRIPTION
since https://github.com/open62541/open62541/pull/1417/files the connection is closed in ```UA_SecureChannel_deleteMembersCleanup```.

Then

https://github.com/open62541/open62541/blob/fc2200ad685d9249955c9dc98064fa166732bca7/plugins/ua_network_tcp.c#L667-L675

is now wrong and it can cause interpretation problems as in https://github.com/open62541/open62541/issues/1678