### PR TITLE
Add Sonar static code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,6 @@ matrix:
         - ANALYZE=false
         - PYTHON=python2
     - os: linux
-      compiler: gcc
-      env: ANALYZE=true
-    - os: linux
-      compiler: gcc
-      env: DOCKER=true
-      services:
-        - docker
-    - os: linux
       compiler: clang
       env:
         - ANALYZE=false
@@ -45,14 +37,22 @@ matrix:
         - ANALYZE=false
         - PYTHON=python2
     - os: linux
-      compiler: clang
+      compiler: gcc
       env: ANALYZE=true
     - os: linux
       compiler: clang
-      env: FUZZER=true
+      env: ANALYZE=true
     #- os: linux
     #  compiler: gcc
     #  env: LINT=true
+    - os: linux
+      compiler: gcc
+      env: DOCKER=true
+      services:
+        - docker
+    - os: linux
+      compiler: clang
+      env: FUZZER=true
     - os: osx
       compiler: clang
       # disable homebrew auto update which takes a lot of time
@@ -60,7 +60,20 @@ matrix:
       cache:
         directories:
           - $HOME/Library/Caches/Homebrew
-
+    - os: linux
+      compiler: gcc
+      addons:
+        sonarcloud:
+          organization: open62541
+          branches:
+            - master
+            - sonarcloud
+      env:
+        - SONAR=true
+        - PYTHON=python2
+      cache:
+        directories:
+          - '$HOME/.sonar/cache'
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The library is [available](https://github.com/open62541/open62541/releases) in s
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/12248.svg)](https://scan.coverity.com/projects/open62541-open62541)
 [![Coverage Status](https://img.shields.io/coveralls/open62541/open62541/master.svg)](https://coveralls.io/r/open62541/open62541?branch=master)
 [![Overall Downloads](https://img.shields.io/github/downloads/open62541/open62541/total.svg)](https://github.com/open62541/open62541/releases)
+[![Quality Gate](https://sonarcloud.io/api/badges/gate?key=open62541-main:master)](https://sonarcloud.io/dashboard/index/open62541-main:master)
+[![SonarCloud Lines of Code (excl comments)](https://sonarcloud.io/api/badges/measure?key=open62541-main%3Amaster&metric=ncloc)](https://sonarcloud.io/component_measures/metric/security_rating/list?id=open62541-main%3Amaster)
+[![SonarCloud Duplicated lines](https://sonarcloud.io/api/badges/measure?key=open62541-main%3Amaster&metric=duplicated_lines_density)](https://sonarcloud.io/component_measures/metric/security_rating/list?id=open62541-main%3Amaster)
+[![SonarCloud Percentage of comments](https://sonarcloud.io/api/badges/measure?key=open62541-main%3Amaster&metric=comment_lines_density)](https://sonarcloud.io/component_measures/metric/security_rating/list?id=open62541-main%3Amaster)
 
 ### Features
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,29 @@
+sonar.projectKey=open62541-main
+sonar.projectName=open62541
+sonar.projectVersion=0.4
+
+sonar.log.level=INFO
+
+sonar.exclusions=deps/**/*,build/open62541.c,build/open62541.h,CMakeFiles/**/*
+
+
+# =====================================================
+#   Meta-data for the project
+# =====================================================
+
+sonar.links.homepage=https://github.com/open62541/open62541
+sonar.links.ci=https://travis-ci.org/open62541/open62541
+sonar.links.scm=https://github.com/open62541/open62541
+sonar.links.issue=https://github.com/open62541/open62541/issues
+
+
+# =====================================================
+#   Properties that will be shared amongst all modules
+# =====================================================
+
+# SQ standard properties
+sonar.sources=.
+
+# Properties specific to the C/C++ analyzer:
+sonar.cfamily.build-wrapper-output=bw-output
+sonar.cfamily.gcov.reportsPath=.

--- a/tools/travis/travis_linux_after_success.sh
+++ b/tools/travis/travis_linux_after_success.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ev
 
-if [ -z ${DOCKER+x} ]; then
+if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
 	# Only on non-docker builds required
 
 	if [ "$ANALYZE" = "false" ] && [ "$CC" = "gcc" ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ]; then

--- a/tools/travis/travis_linux_before_install.sh
+++ b/tools/travis/travis_linux_before_install.sh
@@ -2,7 +2,7 @@
 set -ev
 
 
-if [ -z ${DOCKER+x} ]; then
+if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
 	# Only on non-docker builds required
 
 	echo "=== Installing from external package sources ===" && echo -en 'travis_fold:start:before_install.external\\r'

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -e
 
+
+# Sonar code quality
+if ! [ -z ${SONAR+x} ]; then
+    git fetch --unshallow
+	mkdir -p build && cd build
+	build-wrapper-linux-x86-64 --out-dir ../bw-output cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DCMAKE_BUILD_TYPE=Debug -DUA_BUILD_EXAMPLES=ON -DUA_ENABLE_DISCOVERY=ON -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
+    -DUA_ENABLE_ENCRYPTION .. \
+    && make -j
+	cd ..
+	sonar-scanner
+	exit 0
+fi
+
 # Docker build test
 if ! [ -z ${DOCKER+x} ]; then
     docker build -t open62541 .


### PR DESCRIPTION
This PR adds additional static code analysis provided by sonar cloud. It especially shows duplicated code measurements.

All open62541 Github admins should have access to the analytics here:
https://sonarcloud.io/organizations/open62541/projects