### PR TITLE
Add common.h to cmake project

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,12 @@
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/plugins)
 include_directories(${PROJECT_BINARY_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/examples)
+
+set(examples_headers
+    ${examples_headers}
+    ${PROJECT_SOURCE_DIR}/examples/common.h
+    )
 
 #############################
 # Compiled binaries folders #
@@ -9,7 +15,7 @@ include_directories(${PROJECT_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/examples)
 
 macro(add_example EXAMPLE_NAME EXAMPLE_SOURCE)
-  add_executable(${EXAMPLE_NAME} ${STATIC_OBJECTS} ${EXAMPLE_SOURCE} ${ARGN})
+  add_executable(${EXAMPLE_NAME} ${STATIC_OBJECTS} ${EXAMPLE_SOURCE} ${ARGN} ${examples_headers})
   target_link_libraries(${EXAMPLE_NAME} open62541 ${open62541_LIBRARIES})
   assign_source_group(${EXAMPLE_SOURCE})
   add_dependencies(${EXAMPLE_NAME} open62541-amalgamation-header open62541-amalgamation-source)

--- a/examples/common.h
+++ b/examples/common.h
@@ -1,6 +1,8 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
+#include "open62541.h"
+
 /* loadFile parses the certificate file.
  *
  * @param  path               specifies the file name given in argv[]

--- a/examples/encryption/client_basic256sha256.c
+++ b/examples/encryption/client_basic256sha256.c
@@ -5,7 +5,7 @@
 #include <errno.h>
 
 #include "open62541.h"
-#include "../common.h"
+#include "common.h"
 
 #define MIN_ARGS           3
 #define FAILURE            1


### PR DESCRIPTION
This adds the common.h file to the cmake project which is necessary for some IDEs to recognize it for analysis.