### PR TITLE
AccessControlContext not initialized

### DIFF
--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -189,7 +189,7 @@ UA_AccessControl_default(UA_Boolean allowAnonymous, size_t usernamePasswordLogin
                          const UA_UsernamePasswordLogin *usernamePasswordLogin) {
     AccessControlContext *context = (AccessControlContext*)
         UA_malloc(sizeof(AccessControlContext));
-    
+    memset(&context, 0, sizeof(context));
     UA_AccessControl ac;
     memset(&ac, 0, sizeof(ac));
     ac.context = context;


### PR DESCRIPTION
When calling UA_AccessControl_default with no username password (usernamePasswordLoginSize = 0) context->usernamePasswordLoginSize is not initialized. This causes a crash when deleteMembers_default is called.