### PR TITLE
Fix null read and duplicate node IDs

### DIFF
--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -495,6 +495,8 @@ readMonitoredItems(UA_Server *server, const UA_NodeId *sessionId, void *sessionC
     UA_Session *session = UA_SessionManager_getSessionById(&server->sessionManager, sessionId);
     if(!session)
         return UA_STATUSCODE_BADINTERNALERROR;
+    if (inputSize == 0 || !input[0].data)
+        return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
     UA_UInt32 subscriptionId = *((UA_UInt32*)(input[0].data));
     UA_Subscription* subscription = UA_Session_getSubscriptionById(session, subscriptionId);
     if(!subscription)


### PR DESCRIPTION
These issues were found by oss-fuzz.

@jpfr please check my second commit in the nodestore. That bug was really hard to find.
Summarized the following was the case:
1. Some nodes were created and stored in the hash map `ns->entries` (for simplicity let's assume it's an array with node IDs, and the `idx += hash2` is just an iterator `i++`): `[27, 100, 50074]`
2. The node `100` is deleted, so the hashmap will then be `[27, thombstone, 50074]`
3. `findFreeSlot(ns, 50074)` iterates over the array, finds the thombstone on second position and returns that slot since it's the first free slot for that node id. 
4. `UA_NodeMap_insertNode` then assumes that the "random" node id is ok, since there is a free slot.

The problem here is that `findFreeSlot`stops at the first thombstone, but the corresponding node ID could still be somewhere in the nodeset. I added an additional `findOccupiedSlot` which checks if the node ID is really not used.