### PR TITLE
Add filter support for numeric absolute filters

### DIFF
--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -814,6 +814,8 @@ struct UA_DataType {
     UA_DataTypeMember *members;
 };
 
+UA_Boolean isDataTypeNumeric(const UA_DataType *type);
+
 /* The following is used to exclude type names in the definition of UA_DataType
  * structures if the feature is disabled. */
 #ifdef UA_ENABLE_TYPENAMES

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -81,7 +81,8 @@ struct UA_MonitoredItem {
     UA_UInt32 maxQueueSize;
     UA_Boolean discardOldest;
     // TODO: dataEncoding is hardcoded to UA binary
-    UA_DataChangeTrigger trigger;
+    UA_DataChangeFilter filter;
+    UA_Variant lastValue;
 
     /* Sample Callback */
     UA_UInt64 sampleCallbackId;

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1114,3 +1114,12 @@ UA_Array_delete(void *p, size_t size, const UA_DataType *type) {
     }
     UA_free((void*)((uintptr_t)p & ~(uintptr_t)UA_EMPTY_ARRAY_SENTINEL));
 }
+
+UA_Boolean
+isDataTypeNumeric(const UA_DataType *type) {
+    // All data types ids between UA_TYPES_SBYTE and UA_TYPES_DOUBLE are numeric
+    for (int i = UA_TYPES_SBYTE; i <= UA_TYPES_DOUBLE; ++i)
+        if (&UA_TYPES[i] == type)
+            return true;
+    return false;
+}


### PR DESCRIPTION
The following changes are made for server support:
 * Creating an DEADBANDTYPE_ABSOLUTE filter for non numeric data type from client fail with BADFILTERNOTALLOWED
 * Creating a DEADBANDTYPE_PERCENT filter will fail with BADNOTIMPLEMENTED (impementing it is not possible as long we do not have the EURange)
 * Updates to clients will be filtered for DEADBANDTYPE_ABSOLUTE filters for numeric scalar and array types

If this is also code which should go into 0.3 release, I can also do a pull request for 0.3 branch. In my opinion the first 2 bullet points fixes bugs, because we do always report GOOD when applying filters by clients, but do not handle them right.