### PR TITLE
Replace lastSampledValue with UA_DataValue in Monitored Item

### DIFF
--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -564,6 +564,9 @@ UA_Variant_isEmpty(const UA_Variant *v) {
     return v->type == NULL;
 }
 
+UA_Boolean UA_EXPORT
+UA_Variant_isEqual(const UA_Variant *v1, const UA_Variant *v2);
+
 /* Returns true if the variant contains a scalar value. Note that empty variants
  * contain an array of length -1 (undefined).
  *
@@ -727,6 +730,20 @@ typedef struct {
     UA_DateTime   serverTimestamp;
     UA_UInt16     serverPicoseconds;
 } UA_DataValue;
+
+UA_Boolean UA_EXPORT
+UA_DataValue_isEqual(const UA_DataValue * v1, const UA_DataValue * v2);
+
+typedef enum {
+    UA_DATAVALUE_IGNORETYPE_NONE = 0x00,
+    UA_DATAVALUE_IGNORETYPE_SERVERTIMESTAMP = 0x01,
+    UA_DATAVALUE_IGNORETYPE_SOURCETIMESTAMP = 0x02,
+    UA_DATAVALUE_IGNORETYPE_VALUE = 0x04,
+    UA_DATAVALUE_IGNORETYPE_STATUS = 0x08
+} UA_DataValue_IgnoreType;
+
+UA_Boolean UA_EXPORT
+UA_DataValue_isEqualParameterized(const UA_DataValue * v1, const UA_DataValue * v2, UA_DataValue_IgnoreType ignoreType);
 
 /**
  * DiagnosticInfo

--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -26,6 +26,8 @@ extern "C" {
 
 #define UA_BUILTIN_TYPES_COUNT 25U
 
+#define UA_VARIANTENCODING_MAXSTACK 512
+
 /**
  * .. _types:
  *
@@ -565,7 +567,7 @@ UA_Variant_isEmpty(const UA_Variant *v) {
 }
 
 UA_Boolean UA_EXPORT
-UA_Variant_isEqual(const UA_Variant *v1, const UA_Variant *v2);
+UA_Variant_equal(const UA_Variant *v1, const UA_Variant *v2);
 
 /* Returns true if the variant contains a scalar value. Note that empty variants
  * contain an array of length -1 (undefined).
@@ -732,7 +734,7 @@ typedef struct {
 } UA_DataValue;
 
 UA_Boolean UA_EXPORT
-UA_DataValue_isEqual(const UA_DataValue * v1, const UA_DataValue * v2);
+UA_DataValue_equal(const UA_DataValue * v1, const UA_DataValue * v2);
 
 typedef enum {
     UA_DATAVALUE_IGNORETYPE_NONE = 0x00,
@@ -742,8 +744,8 @@ typedef enum {
     UA_DATAVALUE_IGNORETYPE_STATUS = 0x08
 } UA_DataValue_IgnoreType;
 
-UA_Boolean UA_EXPORT
-UA_DataValue_isEqualParameterized(const UA_DataValue * v1, const UA_DataValue * v2, UA_DataValue_IgnoreType ignoreType);
+UA_Boolean
+UA_DataValue_equalParameterized(const UA_DataValue * v1, const UA_DataValue * v2, UA_DataValue_IgnoreType ignoreType);
 
 /**
  * DiagnosticInfo

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -173,11 +173,11 @@ setMonitoredItemSettings(UA_Server *server, UA_MonitoredItem *mon,
         if (filter->deadbandType == UA_DEADBANDTYPE_PERCENT) {
             return UA_STATUSCODE_BADMONITOREDITEMFILTERUNSUPPORTED;
         }
-        if (UA_Variant_isEmpty(&mon->lastValue)) {
+        if (UA_Variant_isEmpty(&mon->lastSampledValue.value)) {
             if (!dataType || !isDataTypeNumeric(dataType))
                 return UA_STATUSCODE_BADFILTERNOTALLOWED;
         } else
-        if (!isDataTypeNumeric(mon->lastValue.type)) {
+        if (!isDataTypeNumeric(mon->lastSampledValue.value.type)) {
             return UA_STATUSCODE_BADFILTERNOTALLOWED;
         }
         UA_DataChangeFilter_copy(filter, &(mon->filter));
@@ -462,8 +462,7 @@ Operation_SetMonitoringMode(UA_Server *server, UA_Session *session,
         mon->queueSize = 0;
 
         /* Initialize lastSampledValue */
-        UA_ByteString_deleteMembers(&mon->lastSampledValue);
-        UA_Variant_deleteMembers(&mon->lastValue);
+        UA_DataValue_deleteMembers(&mon->lastSampledValue);
     }
 }
 

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -160,7 +160,6 @@ setMonitoredItemSettings(UA_Server *server, UA_MonitoredItem *mon,
                          // This parameter is optional and used only if mon->lastValue is not set yet.
                          // Then numeric type will be detected from this value. Set null as defaut.
                          const UA_DataType* dataType) {
-
     /* Filter */
     if(params->filter.encoding != UA_EXTENSIONOBJECT_DECODED) {
         UA_DataChangeFilter_init(&(mon->filter));

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -82,11 +82,10 @@ struct UA_MonitoredItem {
     UA_Boolean discardOldest;
     // TODO: dataEncoding is hardcoded to UA binary
     UA_DataChangeFilter filter;
-    UA_Variant lastValue;
 
     /* Sample Callback */
     UA_UInt64 sampleCallbackId;
-    UA_ByteString lastSampledValue;
+    UA_DataValue lastSampledValue;
     UA_Boolean sampleCallbackIsRegistered;
 
     /* Notification Queue */

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -9,11 +9,8 @@
 
 #include "ua_subscription.h"
 #include "ua_server_internal.h"
-#include "ua_types_encoding_binary.h"
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS /* conditional compilation */
-
-#define UA_VALUENCODING_MAXSTACK 512
 
 UA_MonitoredItem *
 UA_MonitoredItem_new(UA_MonitoredItemType monType) {
@@ -212,6 +209,8 @@ updateNeededForFilteredValue(const UA_Variant *value, const UA_Variant *oldValue
     return false;
 }
 
+#include <stdio.h>
+
 /* Errors are returned as no change detected */
 static UA_Boolean
 detectValueChangeWithFilter(UA_MonitoredItem *mon, UA_DataValue *value) {
@@ -235,7 +234,7 @@ detectValueChangeWithFilter(UA_MonitoredItem *mon, UA_DataValue *value) {
     if(mon->filter.trigger < UA_DATACHANGETRIGGER_STATUSVALUETIMESTAMP)
         ignoreType = (UA_DataValue_IgnoreType)(ignoreType | UA_DATAVALUE_IGNORETYPE_SOURCETIMESTAMP);
 
-    return !UA_DataValue_isEqualParameterized(&mon->lastSampledValue, value, ignoreType);
+    return !UA_DataValue_equalParameterized(&mon->lastSampledValue, value, ignoreType);
 }
 
 /* Returns whether a new sample was created */

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1250,7 +1250,7 @@ UA_DataValue_equalParameterized(const UA_DataValue *v1, const UA_DataValue *v2, 
         && (v1->hasServerPicoseconds != v2->hasServerPicoseconds
             || v1->hasServerTimestamp != v2->hasServerTimestamp
             || (v1->hasServerPicoseconds && v1->serverPicoseconds != v2->serverPicoseconds)
-            || (v1->hasServerTimestamp && v1->hasServerTimestamp != v2->serverTimestamp)))
+            || (v1->hasServerTimestamp && v1->serverTimestamp != v2->serverTimestamp)))
         return false;
     if (!(ignoreType & UA_DATAVALUE_IGNORETYPE_SOURCETIMESTAMP)
             && (v1->hasSourcePicoseconds != v2->hasSourcePicoseconds

--- a/tests/server/check_services_subscriptions.c
+++ b/tests/server/check_services_subscriptions.c
@@ -333,21 +333,21 @@ START_TEST(Server_overflow) {
     notification = TAILQ_LAST(&mon->queue, NotificationQueue);
     ck_assert_uint_eq(notification->data.value.hasStatus, false);
 
-    UA_ByteString_deleteMembers(&mon->lastSampledValue);
+    UA_DataValue_deleteMembers(&mon->lastSampledValue);
     UA_MonitoredItem_SampleCallback(server, mon);
     ck_assert_uint_eq(mon->queueSize, 2); 
     ck_assert_uint_eq(mon->maxQueueSize, 3); 
     notification = TAILQ_LAST(&mon->queue, NotificationQueue);
     ck_assert_uint_eq(notification->data.value.hasStatus, false);
 
-    UA_ByteString_deleteMembers(&mon->lastSampledValue);
+    UA_DataValue_deleteMembers(&mon->lastSampledValue);
     UA_MonitoredItem_SampleCallback(server, mon);
     ck_assert_uint_eq(mon->queueSize, 3); 
     ck_assert_uint_eq(mon->maxQueueSize, 3); 
     notification = TAILQ_LAST(&mon->queue, NotificationQueue);
     ck_assert_uint_eq(notification->data.value.hasStatus, false);
 
-    UA_ByteString_deleteMembers(&mon->lastSampledValue);
+    UA_DataValue_deleteMembers(&mon->lastSampledValue);
     UA_MonitoredItem_SampleCallback(server, mon);
     ck_assert_uint_eq(mon->queueSize, 3); 
     ck_assert_uint_eq(mon->maxQueueSize, 3); 


### PR DESCRIPTION
This is a optimazion followup patch for absolute numeric filter handling.
The following advantages are included:
 * lastSampledValue removed and lastValue renamed to lastSampledValue (size improvement)
 * lastSampledValue is compared to last one without hacky encoding and string compare (easier code without hack)
 * response encoding is done when changes are there, only (performance improvement)
 * UA_DataValue has a isEqual function, so does UA_Variant. Both do not encode or copy data. (update) UA_Variant do encode for complex types. For all usual types there are special equal handling.

See also #1726