### PR TITLE
Correctly resolve mDNS SRV announce target

### DIFF
--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -63,7 +63,6 @@ writeInteger(UA_Server *server, const UA_NodeId *sessionId,
 }
 
 char *discovery_url = NULL;
-UA_String *self_discovery_url = NULL;
 
 static void
 serverOnNetworkCallback(const UA_ServerOnNetwork *serverOnNetwork, UA_Boolean isServerAnnounce,
@@ -74,11 +73,6 @@ serverOnNetworkCallback(const UA_ServerOnNetwork *serverOnNetwork, UA_Boolean is
                      "serverOnNetworkCallback called, but discovery URL "
                      "already initialized or is not announcing. Ignoring.");
         return; // we already have everything we need or we only want server announces
-    }
-
-    if(self_discovery_url != NULL && UA_String_equal(&serverOnNetwork->discoveryUrl, self_discovery_url)) {
-        // skip self
-        return;
     }
 
     if(!isTxtReceived)
@@ -280,7 +274,6 @@ int main(int argc, char **argv) {
     //UA_String caps = UA_String_fromChars("LDS");
     //config.serverCapabilities = &caps;
     UA_Server *server = UA_Server_new(config);
-    self_discovery_url = &config->networkLayers[0].discoveryUrl;
 
     /* add a variable node to the address space */
     UA_Int32 myInteger = 42;

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -69,7 +69,7 @@ processACKResponse(void *application, UA_Connection *connection, UA_ByteString *
         UA_Byte *data = (UA_Byte*)&chunk->data[offset + 4+4];
         UA_LOG_ERROR(client->config.logger, UA_LOGCATEGORY_NETWORK,
                     "Received ERR response. %s - %.*s", UA_StatusCode_name(error), len, data);
-        return UA_STATUSCODE_BADTCPMESSAGETYPEINVALID;
+        return error;
     }
     if (chunkType != UA_CHUNKTYPE_FINAL) {
         return UA_STATUSCODE_BADTCPMESSAGETYPEINVALID;
@@ -148,7 +148,7 @@ HelAckHandshake(UA_Client *client) {
                                                  client->config.timeout);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO(client->config.logger, UA_LOGCATEGORY_NETWORK,
-                    "Receiving ACK message failed");
+                    "Receiving ACK message failed with %s", UA_StatusCode_name(retval));
         if(retval == UA_STATUSCODE_BADCONNECTIONCLOSED)
             client->state = UA_CLIENTSTATE_DISCONNECTED;
         UA_Client_close(client);

--- a/src/server/ua_mdns.c
+++ b/src/server/ua_mdns.c
@@ -375,8 +375,8 @@ mdns_is_self_announce(UA_Server *server, struct serverOnNetwork_list_entry *entr
 #else
     /* Clean up */
     freeifaddrs(ifaddr);
-    return isSelf;
 #endif
+    return isSelf;
 
 }
 

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -92,6 +92,18 @@ typedef struct serverOnNetwork_hash_entry {
     struct serverOnNetwork_hash_entry* next;
 } serverOnNetwork_hash_entry;
 
+typedef struct mdnsHostnameToIp_list_entry {
+    LIST_ENTRY(mdnsHostnameToIp_list_entry) pointers;
+    UA_String mdnsHostname;
+    struct in_addr addr;
+} mdnsHostnameToIp_list_entry;
+
+#define MDNS_HOSTNAME_TO_IP_HASH_PRIME 1009
+typedef struct mdnsHostnameToIp_hash_entry {
+    mdnsHostnameToIp_list_entry* entry;
+    struct mdnsHostnameToIp_hash_entry* next;
+} mdnsHostnameToIp_hash_entry;
+
 #endif /* UA_ENABLE_DISCOVERY_MULTICAST */
 #endif /* UA_ENABLE_DISCOVERY */
 
@@ -128,6 +140,11 @@ struct UA_Server {
 
     UA_Server_serverOnNetworkCallback serverOnNetworkCallback;
     void* serverOnNetworkCallbackData;
+
+
+    LIST_HEAD(mdnsHostnameToIp_list, mdnsHostnameToIp_list_entry) mdnsHostnameToIp; // doubly-linked list of hostname to IP mapping (from mDNS)
+    // hash mapping hostname to ip
+    struct mdnsHostnameToIp_hash_entry* mdnsHostnameToIpHash[MDNS_HOSTNAME_TO_IP_HASH_PRIME];
 
 # endif
 #endif

--- a/src/server/ua_services_discovery_multicast.c
+++ b/src/server/ua_services_discovery_multicast.c
@@ -39,7 +39,7 @@ multicastWorkerLoop(UA_Server *server) {
             break;
         } else if (retVal == 2) {
             UA_LOG_SOCKET_ERRNO_WRAP(
-                UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_DEBUG(server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Multicast error: Can not write to socket. %s", errno_str));
             break;
         }
@@ -552,12 +552,12 @@ iterateMulticastDiscoveryServer(UA_Server* server, UA_DateTime *nextRepeat,
                                        processIn, true, &next_sleep);
     if(retval == 1) {
         UA_LOG_SOCKET_ERRNO_WRAP(
-                UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+               UA_LOG_DEBUG(server->config.logger, UA_LOGCATEGORY_SERVER,
                      "Multicast error: Can not read from socket. %s", errno_str));
         return UA_STATUSCODE_BADNOCOMMUNICATION;
     } else if(retval == 2) {
         UA_LOG_SOCKET_ERRNO_WRAP(
-                UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_DEBUG(server->config.logger, UA_LOGCATEGORY_SERVER,
                      "Multicast error: Can not write to socket. %s", errno_str));
         return UA_STATUSCODE_BADNOCOMMUNICATION;
     }


### PR DESCRIPTION
The mDNS SRV announce target was currently just taken for the discovery url.

The specification Part 12 explicitly states:

> The hostname maps onto the SRV record target field.
> If the hostname is an IPAddress then it must be converted to a domain name.
> If this cannot be done then LDS shall report an error

This is solved by using the mDNS 'A' record announces, which map host names to IP addresses.
