### PR TITLE
Fix the missing message detection in the client subscription

### DIFF
--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -649,7 +649,12 @@ UA_Client_Subscriptions_processPublishResponse(UA_Client *client, UA_PublishRequ
         /* UA_Client_close(client);
            return; */
     }
-    sub->sequenceNumber = msg->sequenceNumber;
+    /* According to f), a keep-alive message contains no notifications and has the sequence number
+     * of the next NotificationMessage that is to be sent => More than one consecutive keep-alive
+     * message or a NotificationMessage following a keep-alive message will share the same sequence
+     * number. */
+    if (msg->notificationDataSize)
+        sub->sequenceNumber = msg->sequenceNumber;
 
     /* Process the notification messages */
     for(size_t k = 0; k < msg->notificationDataSize; ++k)


### PR DESCRIPTION
More than one consecutive keepalive message and the first notification message after a keepalive message share the same sequence number.
Don't print a warning for these cases.

This is related to https://github.com/open62541/open62541/commit/792cade2c6d9b05c2d1c69af7ad61a9131ab26c7