### PR TITLE
If array length is set to 0 it should also be set in the encoding

### DIFF
--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -468,7 +468,7 @@ Array_encodeBinary(const void *src, size_t length, const UA_DataType *type, Ctx 
         return UA_STATUSCODE_BADINTERNALERROR;
     if(length > 0)
         signed_length = (i32)length;
-    else if(src == UA_EMPTY_ARRAY_SENTINEL)
+    else if(src == UA_EMPTY_ARRAY_SENTINEL || length == 0)
         signed_length = 0;
 
     /* Encode the array length */


### PR DESCRIPTION
We found this issue with the following sample code (i.e., calling a method with no input args)

```
    UA_CallRequest request2;
    UA_CallRequest_init(&request2);
    UA_CallMethodRequest item;
    UA_CallMethodRequest_init(&item);
    item.methodId = UA_NODEID_NUMERIC(0,100);
    item.objectId = UA_NODEID_NUMERIC(0,1000);
    request2.methodsToCall = &item;
    request2.methodsToCallSize = 1;
    UA_Client_Service_call(client, request2);
```

Note that `UA_CallMethodRequest_init(&item)` sets `inputArgumentsSize` to 0.

If the array length is set to 0, the encoding function will use `i32 signed_length = -1;` instead, since none of the ifs match. So the method call above results in the following wireshark:
![image](https://user-images.githubusercontent.com/251973/40185206-5b933550-59f2-11e8-9544-0a307f45116a.png)

Whereas it should be 0 array size, as it is done with UaExpert:

![image](https://user-images.githubusercontent.com/251973/40185256-775459c2-59f2-11e8-98da-3745190ee5a0.png)

The `-1` causes a `BadOutOfMemory` result when called on a B&R OPC UA Server.
