### PR TITLE
Add all attributes of VariableType nodes in the nodeset compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -905,16 +905,11 @@ if (UA_ENABLE_AMALGAMATION)
                      open62541-generator-transport open62541-generator-statuscode)
 endif()
 
-if(NOT UA_NODESET_ENCODE_BINARY_SIZE)
-    set(UA_NODESET_ENCODE_BINARY_SIZE 32000)
-endif()
-
 ua_generate_nodeset(
     NAME "ns0"
     FILE ${UA_FILE_NODESETS}
     INTERNAL
     IGNORE "${PROJECT_SOURCE_DIR}/tools/nodeset_compiler/NodeID_NS0_Base.txt"
-    ENCODE_BINARY_SIZE ${UA_NODESET_ENCODE_BINARY_SIZE}
     DEPENDS_TARGET "open62541-generator-types"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,7 +449,7 @@ if(NOT UA_COMPILE_AS_CXX AND (CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID
         if("x${CMAKE_C_COMPILER_ID}" STREQUAL "xClang" AND NOT UA_ENABLE_UNIT_TESTS_MEMCHECK)
             # Add default sanitizer settings when using clang and Debug build.
             # This allows e.g. CLion to find memory locations for SegFaults
-            message("Sanitizer enabled")
+            message(STATUS "Sanitizer enabled")
             set(SANITIZER_FLAGS "-g -fno-omit-frame-pointer -gline-tables-only -fsanitize=address -fsanitize-address-use-after-scope -fsanitize-coverage=trace-pc-guard,trace-cmp -fsanitize=leak -fsanitize=undefined")
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZER_FLAGS}")
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_FLAGS}")

--- a/doc/nodeset_compiler.rst
+++ b/doc/nodeset_compiler.rst
@@ -209,7 +209,7 @@ Take the previous snippet and save it to a file ``myNS.xml``. To compile this no
 
     $ python ./nodeset_compiler.py -h
     usage: nodeset_compiler.py [-h] [-e <existingNodeSetXML>] [-x <nodeSetXML>]
-                               [--generate-ns0] [--internal-headers]
+                               [--internal-headers]
                                [-b <blacklistFile>] [-i <ignoreFile>]
                                [-t <typesArray>]
                                [-v]
@@ -227,9 +227,6 @@ Take the previous snippet and save it to a file ``myNS.xml``. To compile this no
                             on the server.
       -x <nodeSetXML>, --xml <nodeSetXML>
                             NodeSet XML files with nodes that shall be generated.
-      --generate-ns0        Omit some consistency checks for bootstrapping
-                            namespace 0, create references to parents and type
-                            definitions manually
       --internal-headers    Include internal headers instead of amalgamated header
       -b <blacklistFile>, --blacklist <blacklistFile>
                             Loads a list of NodeIDs stored in blacklistFile (one

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -251,6 +251,9 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
                                        const UA_ByteString *certificate,
                                        UA_UInt32 sendBufferSize,
                                        UA_UInt32 recvBufferSize) {
+	if (!config)
+		return UA_STATUSCODE_BADINVALIDARGUMENT;
+
     UA_StatusCode retval = setDefaultConfig(config);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(config);

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -179,8 +179,13 @@ typeCheckVariableNode(UA_Server *server, UA_Session *session,
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
+    UA_NodeId baseDataType = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATATYPE);
+
     /* Check the datatype against the vt */
-    if(!compatibleDataType(server, &node->dataType, &vt->dataType, false)) {
+    /* If the node does not have any value and the dataType is BaseDataType,
+     * then it's also fine. This is the default for empty nodes. */
+    if(!compatibleDataType(server, &node->dataType, &vt->dataType, false) &&
+       (value.hasValue || !UA_NodeId_equal(&node->dataType, &baseDataType))) {
         UA_LOG_NODEID_WRAP(&node->nodeId, UA_LOG_INFO_SESSION(&server->config.logger, session,
                               "AddNodes: The value of %.*s is incompatible with "
                               "the datatype of the VariableType",

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -45,10 +45,7 @@ START_TEST(checkScalarValues) {
     UA_Variant_clear(&out);
     // Point_scalar_noInit
     UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 10005), &out);
-    p = (UA_Point *)out.data;
-    ck_assert(UA_Variant_isScalar(&out));
-    ck_assert(p->x == (UA_Double)0.0);
-    ck_assert(p->y == (UA_Double)0.0);
+    ck_assert(out.data == NULL);
     UA_Variant_clear(&out);
 }
 END_TEST

--- a/tools/cmake/macros_public.cmake
+++ b/tools/cmake/macros_public.cmake
@@ -225,7 +225,6 @@ endfunction()
 #   NAME            Name of the nodeset, e.g. 'di'
 #   [TYPES_ARRAY]   Optional name of the types array containing the custom datatypes of this node set.
 #   [OUTPUT_DIR]    Optional target directory for the generated files. Default is '${PROJECT_BINARY_DIR}/src_generated'
-#   [ENCODE_BINARY_SIZE]    Optional array size for binary encoding extension objects.
 #   [IGNORE]        Optional file containing a list of node ids which should be ignored. The file should have one id per line.
 #   [TARGET_PREFIX] Optional prefix for the resulting target. Default `open62541-generator`
 #
@@ -240,7 +239,7 @@ endfunction()
 function(ua_generate_nodeset)
 
     set(options INTERNAL )
-    set(oneValueArgs NAME TYPES_ARRAY OUTPUT_DIR ENCODE_BINARY_SIZE IGNORE TARGET_PREFIX)
+    set(oneValueArgs NAME TYPES_ARRAY OUTPUT_DIR IGNORE TARGET_PREFIX)
     set(multiValueArgs FILE DEPENDS_TYPES DEPENDS_NS DEPENDS_TARGET)
     cmake_parse_arguments(UA_GEN_NS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -290,12 +289,6 @@ function(ua_generate_nodeset)
     if (UA_GEN_NS_IGNORE)
         set(GEN_IGNORE "--ignore=${UA_GEN_NS_IGNORE}")
     endif()
-
-    set(GEN_BIN_SIZE "")
-    if (UA_GEN_NS_ENCODE_BINARY_SIZE OR "${UA_GEN_NS_ENCODE_BINARY_SIZE}" STREQUAL "0")
-        set(GEN_BIN_SIZE "--encode-binary-size=${UA_GEN_NS_ENCODE_BINARY_SIZE}")
-    endif()
-
 
     set(TYPES_ARRAY_LIST "")
     foreach(f ${UA_GEN_NS_DEPENDS_TYPES})

--- a/tools/cmake/macros_public.cmake
+++ b/tools/cmake/macros_public.cmake
@@ -280,7 +280,6 @@ function(ua_generate_nodeset)
     string(REPLACE "-" "_" FILE_SUFFIX ${FILE_SUFFIX})
 
     if ("${UA_GEN_NS_NAME}" STREQUAL "ns0")
-        set(GEN_NS0 "--generate-ns0")
         set(TARGET_SUFFIX "namespace")
         set(FILE_SUFFIX "0_generated")
     endif()

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -130,7 +130,7 @@ def sortNodes(nodeset):
 # Generate C Code #
 ###################
 
-def generateOpen62541Code(nodeset, outfilename, generate_ns0=False, internal_headers=False, typesArray=[]):
+def generateOpen62541Code(nodeset, outfilename, internal_headers=False, typesArray=[]):
     outfilebase = basename(outfilename)
     # Printing functions
     outfileh = codecs.open(outfilename + ".h", r"w+", encoding='utf-8')
@@ -238,7 +238,7 @@ _UA_END_DECLS
         if not node.hidden:
             writec("\n/* " + str(node.displayName) + " - " + str(node.id) + " */")
             code_global = []
-            code = generateNodeCode_begin(node, nodeset, generate_ns0, parentref, code_global)
+            code = generateNodeCode_begin(node, nodeset, parentref, code_global)
             if code is None:
                 writec("/* Ignored. No parent */")
                 nodeset.hide_node(node.id)

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -130,7 +130,7 @@ def sortNodes(nodeset):
 # Generate C Code #
 ###################
 
-def generateOpen62541Code(nodeset, outfilename, generate_ns0=False, internal_headers=False, typesArray=[], encode_binary_size=32000):
+def generateOpen62541Code(nodeset, outfilename, generate_ns0=False, internal_headers=False, typesArray=[]):
     outfilebase = basename(outfilename)
     # Printing functions
     outfileh = codecs.open(outfilename + ".h", r"w+", encoding='utf-8')
@@ -238,7 +238,7 @@ _UA_END_DECLS
         if not node.hidden:
             writec("\n/* " + str(node.displayName) + " - " + str(node.id) + " */")
             code_global = []
-            code = generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary_size, code_global)
+            code = generateNodeCode_begin(node, nodeset, generate_ns0, parentref, code_global)
             if code is None:
                 writec("/* Ignored. No parent */")
                 nodeset.hide_node(node.id)

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -227,18 +227,14 @@ _UA_END_DECLS
     logger.info("Writing code for nodes and references")
     functionNumber = 0
 
-    parentreftypes = getSubTypesOf(nodeset, nodeset.getNodeByBrowseName("HierarchicalReferences"))
-    parentreftypes = list(map(lambda x: x.id, parentreftypes))
-
     printed_ids = set()
     for node in sorted_nodes:
         printed_ids.add(node.id)
 
-        parentref = node.popParentRef(parentreftypes)
         if not node.hidden:
             writec("\n/* " + str(node.displayName) + " - " + str(node.id) + " */")
             code_global = []
-            code = generateNodeCode_begin(node, nodeset, parentref, code_global)
+            code = generateNodeCode_begin(node, nodeset, code_global)
             if code is None:
                 writec("/* Ignored. No parent */")
                 nodeset.hide_node(node.id)
@@ -257,6 +253,10 @@ _UA_END_DECLS
             if ref.target not in printed_ids:
                 continue
             if node.hidden and nodeset.nodes[ref.target].hidden:
+                continue
+            if node.parent is not None and ref.target == node.parent.id \
+                and ref.referenceType == node.parentReference.id:
+                # Skip parent reference
                 continue
             writec(generateReferenceCode(ref))
 

--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -45,7 +45,15 @@ def generateXmlElementCode(value, alloc=False):
     return u"UA_XMLELEMENT{}({})".format("_ALLOC" if alloc else "", splitStringLiterals(value))
 
 def generateByteStringCode(value, valueName, global_var_code, isPointer):
-    asciiarray = list(value)
+    if isinstance(value, str):
+        # PY3 returns a byte array for b64decode, while PY2 returns a string.
+        # Therefore convert it to bytes
+        asciiarray = bytearray()
+        asciiarray.extend(value)
+        asciiarray = list(asciiarray)
+    else:
+        asciiarray = list(value)
+
     asciiarraystr = str(asciiarray).rstrip(']').lstrip('[')
     cleanValueName = re.sub(r"->", "__", re.sub(r"\.", "_", valueName))
     global_var_code.append("static const UA_Byte {cleanValueName}_byteArray[{len}] = {{{data}}};".format(

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -411,7 +411,7 @@ def generateSubtypeOfDefinitionCode(node):
             return generateNodeIdCode(ref.target)
     return "UA_NODEID_NULL"
 
-def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, code_global):
+def generateNodeCode_begin(node, nodeset, parentref, code_global):
     code = []
     codeCleanup = []
     code.append("UA_StatusCode retVal = UA_STATUSCODE_GOOD;")

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -21,6 +21,12 @@ from backend_open62541_datatypes import *
 import re
 import logging
 
+import sys
+if sys.version_info[0] >= 3:
+    # strings are already parsed to unicode
+    def unicode(s):
+        return s
+
 logger = logging.getLogger(__name__)
 
 #################

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -75,6 +75,39 @@ def generateObjectNodeCode(node):
         code.append("attr.eventNotifier = true;")
     return code
 
+def setNodeDatatypeRecursive(node, nodeset):
+
+    if not isinstance(node, VariableNode) and not isinstance(node, VariableTypeNode):
+        raise RuntimeError("DataType can only be set for VariableNode and VariableTypeNode")
+
+    if node.dataType is not None:
+        return
+
+    # If BaseVariableType
+    if node.id == NodeId("ns=0;i=62"):
+        if node.dataType is None:
+            # Set to default BaseDataType
+            node.dataType = NodeId("ns=0;i=24")
+        return
+
+    if isinstance(node, VariableNode) and not isinstance(node, VariableTypeNode):
+        typeDefNode = nodeset.getNodeTypeDefinition(node)
+        if typeDefNode is None:
+            # Use the parent type.
+            raise RuntimeError("Cannot get node for HasTypeDefinition of VariableNode " + node.browseName.name + " " + str(node.id))
+
+        setNodeDatatypeRecursive(typeDefNode, nodeset)
+
+        node.dataType = typeDefNode.dataType
+    else:
+        # Use the parent type.
+        if node.parent is None:
+            raise RuntimeError("Parent node not defined for " + node.browseName.name + " " + str(node.id))
+
+        setNodeDatatypeRecursive(node.parent, nodeset)
+        node.dataType = node.parent.dataType
+
+
 def generateCommonVariableCode(node, nodeset):
     code = []
     codeCleanup = []
@@ -92,41 +125,49 @@ def generateCommonVariableCode(node, nodeset):
                 for dim in range(0, node.valueRank):
                     code.append("arrayDimensions[{}] = 0;".format(dim))
             code.append("attr.arrayDimensions = &arrayDimensions[0];")
+    else:
+        # Default value for the value rank as defined in the NodeSet2 xsd file
+        code.append("attr.valueRank = -1;")
 
-    if node.dataType is not None:
-        dataTypeNode = nodeset.getBaseDataType(nodeset.getDataTypeNode(node.dataType))
+    if node.dataType is None:
+        # Inherit the datatype from the HasTypeDefinition reference, as stated in the OPC UA Spec:
+        # 6.4.2
+        # "Instances inherit the initial values for the Attributes that they have in common with the
+        # TypeDefinitionNode from which they are instantiated, with the exceptions of the NodeClass and
+        # NodeId."
+        setNodeDatatypeRecursive(node, nodeset)
+        code.append("/* DataType inherited */")
 
-        if dataTypeNode is None:
-            raise RuntimeError("Cannot get BaseDataType for dataType : " + str(node.dataType) + " of node " + node.browseName.name + " " + str(node.id))
+    dataTypeNode = nodeset.getBaseDataType(nodeset.getDataTypeNode(node.dataType))
 
-        code.append("attr.dataType = %s;" % generateNodeIdCode(node.dataType))
+    if dataTypeNode is None:
+        raise RuntimeError("Cannot get BaseDataType for dataType : " + str(node.dataType) + " of node " + node.browseName.name + " " + str(node.id))
 
-        if dataTypeNode.isEncodable():
-            if node.value is not None:
-                [code1, codeCleanup1, codeGlobal1] = generateValueCode(node.value, nodeset.nodes[node.id], nodeset)
-                code += code1
-                codeCleanup += codeCleanup1
-                codeGlobal += codeGlobal1
-                if node.valueRank is not None and node.valueRank > 0 and len(node.arrayDimensions) == node.valueRank and len(node.value.value) > 0:
-                    numElements = 1
-                    hasZero = False
-                    for v in node.arrayDimensions:
-                        dim = int(unicode(v))
-                        if dim > 0:
-                            numElements = numElements * dim
-                        else:
-                            hasZero = True
-                    if hasZero == False and len(node.value.value) == numElements:
-                        code.append("attr.value.arrayDimensionsSize = attr.arrayDimensionsSize;")
-                        code.append("attr.value.arrayDimensions = attr.arrayDimensions;")
-                        logger.warning("printing arrayDimensions")
+    code.append("attr.dataType = %s;" % generateNodeIdCode(node.dataType))
+
+    if dataTypeNode.isEncodable():
+        if node.value is not None:
+            [code1, codeCleanup1, codeGlobal1] = generateValueCode(node.value, nodeset.nodes[node.id], nodeset)
+            code += code1
+            codeCleanup += codeCleanup1
+            codeGlobal += codeGlobal1
+            if node.valueRank is not None and node.valueRank > 0 and len(node.arrayDimensions) == node.valueRank and len(node.value.value) > 0:
+                numElements = 1
+                hasZero = False
+                for v in node.arrayDimensions:
+                    dim = int(unicode(v))
+                    if dim > 0:
+                        numElements = numElements * dim
                     else:
-                        logger.error("Dimension with size 0 or value count mismatch detected, ArrayDimensions won't be copied to the Value attribute.")
-            elif not isinstance(node, VariableTypeNode): # Don't generate a dummy value for VariableType nodes
-                code += generateValueCodeDummy(dataTypeNode, nodeset.nodes[node.id], nodeset)
-        elif node.value is not None:
-            raise RuntimeError("Cannot encode dataTypeNode: " + dataTypeNode.browseName.name + " for value of node " + node.browseName.name + " " + str(node.id))
-
+                        hasZero = True
+                if hasZero == False and len(node.value.value) == numElements:
+                    code.append("attr.value.arrayDimensionsSize = attr.arrayDimensionsSize;")
+                    code.append("attr.value.arrayDimensions = attr.arrayDimensions;")
+                    logger.warning("printing arrayDimensions")
+                else:
+                    logger.error("Dimension with size 0 or value count mismatch detected, ArrayDimensions won't be copied to the Value attribute.")
+    elif node.value is not None:
+        raise RuntimeError("Cannot encode dataTypeNode: " + dataTypeNode.browseName.name + " for value of node " + node.browseName.name + " " + str(node.id))
 
     return [code, codeCleanup, codeGlobal]
 
@@ -144,6 +185,19 @@ def generateVariableNodeCode(node, nodeset):
     # force valueRank = -1 for scalar VariableNode
     if node.valueRank == -2 and node.value is not None and len(node.value.value) == 1:
         node.valueRank = -1
+
+    if node.valueRank is None:
+        # If the VariableNode does not have any valueRank, use the one from the VariableType
+        # The type may define the valueRank to e.g. 1 which is not the default value for the variable itself.
+        # This is e.g. the case for 'ActiveBackground1' of the Adi.NodeSet2.xml
+        variableTypeNode = nodeset.getNodeTypeDefinition(node)
+
+        if variableTypeNode is None:
+            raise RuntimeError("Cannot get node for HasTypeDefinition of VariableNode " + node.browseName.name + " " + str(node.id))
+
+        if variableTypeNode.valueRank is not None and variableTypeNode.valueRank > -2:
+            code.append("attr.valueRank = %d; /* From VariableType */" % variableTypeNode.valueRank)
+
 
     [code1, codeCleanup1, codeGlobal1] = generateCommonVariableCode(node, nodeset)
     code += code1
@@ -250,22 +304,6 @@ def getTypeBrowseName(dataTypeNode):
         # the value itself is just a string
         typeBrowseName = "String"
     return typeBrowseName
-
-def generateValueCodeDummy(dataTypeNode, parentNode, nodeset):
-    code = []
-    valueName = generateNodeIdPrintable(parentNode) + "_variant_DataContents"
-    typeBrowseName = getTypeBrowseName(dataTypeNode)
-    typeArr = dataTypeNode.typesArray + "[" + dataTypeNode.typesArray + "_" + typeBrowseName.upper() + "]"
-    typeStr = "UA_" + typeBrowseName
-
-    if parentNode.valueRank is not None and parentNode.valueRank > 0:
-        for i in range(0, parentNode.valueRank):
-            code.append("UA_Variant_setArray(&attr.value, NULL, (UA_Int32) " + "0, &" + typeArr + ");")
-    elif not dataTypeNode.isAbstract:
-        code.append("UA_STACKARRAY(" + typeStr + ", " + valueName + ", 1);")
-        code.append("UA_init(" + valueName + ", &" + typeArr + ");")
-        code.append("UA_Variant_setScalar(&attr.value, " + valueName + ", &" + typeArr + ");")
-    return code
 
 def getTypesArrayForValue(nodeset, value):
     typeNode = nodeset.getNodeByBrowseName(value.__class__.__name__)
@@ -397,13 +435,6 @@ def generateViewNodeCode(node):
     code.append("attr.eventNotifier = (UA_Byte)%s;" % str(node.eventNotifier))
     return code
 
-def getNodeTypeDefinition(node):
-    for ref in node.references:
-        # 40 = HasTypeDefinition
-        if ref.referenceType.i == 40:
-            return ref.target
-    return None
-
 def generateSubtypeOfDefinitionCode(node):
     for ref in node.inverseReferences:
         # 45 = HasSubtype
@@ -411,7 +442,7 @@ def generateSubtypeOfDefinitionCode(node):
             return generateNodeIdCode(ref.target)
     return "UA_NODEID_NULL"
 
-def generateNodeCode_begin(node, nodeset, parentref, code_global):
+def generateNodeCode_begin(node, nodeset, code_global):
     code = []
     codeCleanup = []
     code.append("UA_StatusCode retVal = UA_STATUSCODE_GOOD;")
@@ -454,8 +485,8 @@ def generateNodeCode_begin(node, nodeset, parentref, code_global):
     code.append("retVal |= UA_Server_addNode_begin(server, UA_NODECLASS_{},".
             format(makeCIdentifier(node.__class__.__name__.upper().replace("NODE" ,""))))
     code.append(generateNodeIdCode(node.id) + ",")
-    code.append(generateNodeIdCode(parentref.target) + ",")
-    code.append(generateNodeIdCode(parentref.referenceType) + ",")
+    code.append(generateNodeIdCode(node.parent.id if node.parent else NodeId()) + ",")
+    code.append(generateNodeIdCode(node.parentReference.id if node.parent else NodeId()) + ",")
     code.append(generateQualifiedNameCode(node.browseName) + ",")
     if isinstance(node, VariableNode) or isinstance(node, ObjectNode):
         typeDefRef = node.popTypeDef()

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -231,8 +231,8 @@ class ObjectNode(Node):
 class VariableNode(Node):
     def __init__(self, xmlelement=None):
         Node.__init__(self)
-        self.dataType = NodeId()
-        self.valueRank = -2
+        self.dataType = None
+        self.valueRank = None
         self.arrayDimensions = []
         # Set access levels to read by default
         self.accessLevel = 1
@@ -295,11 +295,6 @@ class VariableNode(Node):
 
         self.value = Value()
         self.value.parseXMLEncoding(self.xmlValueDef, dataTypeNode, self, nodeset.namespaceMapping[self.modelUri])
-
-        # Array Dimensions must accurately represent the value and will be patched
-        # reflect the exaxt dimensions attached binary stream.
-        if not isinstance(self.value, Value) or len(self.value.value) == 0:
-            self.arrayDimensions = []
         return True
 
 
@@ -311,9 +306,15 @@ class VariableTypeNode(VariableNode):
             VariableTypeNode.parseXML(self, xmlelement)
 
     def parseXML(self, xmlelement):
-        Node.parseXML(self, xmlelement)
+        VariableNode.parseXML(self, xmlelement)
         for (at, av) in xmlelement.attributes.items():
             if at == "IsAbstract":
+                self.isAbstract = "false" not in av.lower()
+
+        for x in xmlelement.childNodes:
+            if x.nodeType != x.ELEMENT_NODE:
+                continue
+            if x.localName == "IsAbstract":
                 self.isAbstract = "false" not in av.lower()
 
 class MethodNode(Node):

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -78,6 +78,8 @@ class Node(object):
         self.references = set()
         self.hidden = False
         self.modelUri = None
+        self.parent = None
+        self.parentReference = None
 
     def __str__(self):
         return self.__class__.__name__ + "(" + str(self.id) + ")"
@@ -142,17 +144,15 @@ class Node(object):
                     forward = not "false" in av.lower()
             self.references.add(Reference(source, reftype, target, forward))
 
-    def popParentRef(self, parentreftypes):
+    def getParentReference(self, parentreftypes):
         # HasSubtype has precedence
         for ref in self.references:
             if ref.referenceType == NodeId("ns=0;i=45") and not ref.isForward:
-                self.references.remove(ref)
                 return ref
         for ref in self.references:
             if ref.referenceType in parentreftypes and not ref.isForward:
-                self.references.remove(ref)
                 return ref
-        return Reference(NodeId(), NodeId(), NodeId(), False)
+        return None
 
     def popTypeDef(self):
         for ref in self.references:

--- a/tools/nodeset_compiler/nodeset.py
+++ b/tools/nodeset_compiler/nodeset.py
@@ -316,7 +316,14 @@ class NodeSet(object):
             if ref.referenceType.i == 45:
                 return self.getBaseDataType(self.nodes[ref.target])
         return node
-                
+
+    def getNodeTypeDefinition(self, node):
+        for ref in node.references:
+            # 40 = HasTypeDefinition
+            if ref.referenceType.i == 40:
+                return self.nodes[ref.target]
+        return None
+
     def getDataTypeNode(self, dataType):
         if isinstance(dataType, string_types):
             if not valueIsInternalType(dataType):
@@ -348,3 +355,13 @@ class NodeSet(object):
             for ref in u.references:
                 back = Reference(ref.target, ref.referenceType, ref.source, not ref.isForward)
                 self.nodes[ref.target].references.add(back) # ref set does not make a duplicate entry
+
+    def setNodeParent(self):
+        parentreftypes = getSubTypesOf(self, self.getNodeByBrowseName("HierarchicalReferences"))
+        parentreftypes = list(map(lambda x: x.id, parentreftypes))
+
+        for node in self.nodes.values():
+            parentref = node.getParentReference(parentreftypes)
+            if parentref is not None:
+                node.parent = self.nodes[parentref.target]
+                node.parentReference = self.nodes[parentref.referenceType]

--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -82,12 +82,6 @@ parser.add_argument('-t', '--types-array',
                     default=[],
                     help='Types array for the given namespace. Can be used mutliple times to define (in the same order as the .xml files, first for --existing, then --xml) the type arrays')
 
-parser.add_argument('--encode-binary-size',
-                    type=int,
-                    dest="encode_binary_size",
-                    default=32000,
-                    help='Size of the temporary array used to encode custom datatypes. If you don\'t know what it is, do not use this option')
-
 parser.add_argument('-v', '--verbose', action='count',
                     default=1,
                     help='Make the script more verbose. Can be applied up to 4 times')
@@ -202,7 +196,7 @@ logger.info("Generating Code for Backend: {}".format(args.backend))
 if args.backend == "open62541":
     # Create the C code with the open62541 backend of the compiler
     from backend_open62541 import generateOpen62541Code
-    generateOpen62541Code(ns, args.outputFile, args.generate_ns0, args.internal_headers, args.typesArray, args.encode_binary_size)
+    generateOpen62541Code(ns, args.outputFile, args.generate_ns0, args.internal_headers, args.typesArray)
 elif args.backend == "graphviz":
     from backend_graphviz import generateGraphvizCode
     generateGraphvizCode(ns, filename=args.outputFile)

--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -186,6 +186,8 @@ ns.allocateVariables()
 
 ns.addInverseReferences()
 
+ns.setNodeParent()
+
 logger.info("Generating Code for Backend: {}".format(args.backend))
 
 if args.backend == "open62541":

--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -48,11 +48,6 @@ parser.add_argument('outputFile',
                     metavar='<outputFile>',
                     help='The path/basename for the <output file>.c and <output file>.h files to be generated. This will also be the function name used in the header and c-file.')
 
-parser.add_argument('--generate-ns0',
-                    action='store_true',
-                    dest="generate_ns0",
-                    help='Omit some consistency checks for bootstrapping namespace 0, create references to parents and type definitions manually')
-
 parser.add_argument('--internal-headers',
                     action='store_true',
                     dest="internal_headers",
@@ -196,7 +191,7 @@ logger.info("Generating Code for Backend: {}".format(args.backend))
 if args.backend == "open62541":
     # Create the C code with the open62541 backend of the compiler
     from backend_open62541 import generateOpen62541Code
-    generateOpen62541Code(ns, args.outputFile, args.generate_ns0, args.internal_headers, args.typesArray)
+    generateOpen62541Code(ns, args.outputFile, args.internal_headers, args.typesArray)
 elif args.backend == "graphviz":
     from backend_graphviz import generateGraphvizCode
     generateGraphvizCode(ns, filename=args.outputFile)

--- a/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
+++ b/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
@@ -1539,7 +1539,7 @@
       <Reference ReferenceType="HasComponent" IsForward="false">i=14643</Reference>
     </References>
   </UAMethod>
-  <UAVariableType NodeId="i=16309" BrowseName="SelectionListType" DataType="i=862" ValueRank="-2">
+  <UAVariableType NodeId="i=16309" BrowseName="SelectionListType" ValueRank="-2">
     <DisplayName>SelectionListType</DisplayName>
     <References>
       <Reference ReferenceType="HasProperty">i=17632</Reference>


### PR DESCRIPTION
This patch extends the nodeset compiler to support all possible attributes of the VariableType node class.

Using the DataType id from the xml description instead of BaseDataType causes an error when adding two nodes from Opc.Ua.NodeSet2.xml (i=17306 and i=17292 fail with "AddNodes: The value is incompatible with the datatype of the VariableType").
Both VariableType nodes use String as DataType attribute and are a subtype of i=16309. i=16309 has DataType i=862 which is a subtype of Struct.

Could there be something wrong with the type checking in ua_services_nodemanagement.c?
Page 30 of part 3 of the spec states "The VariableType NodeClass also defines a set of Attributes that describe the default or initial value of its instance Variables". Doesn't this imply that the DataType attribute can be changed in a variable instance?