### PR TITLE
Events: Fix registering of monitoreditem callbacks

### DIFF
--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -498,6 +498,11 @@ UA_StatusCode
 UA_MonitoredItem_registerSampleCallback(UA_Server *server, UA_MonitoredItem *mon) {
     if(mon->sampleCallbackIsRegistered)
         return UA_STATUSCODE_GOOD;
+
+    /* Only DataChange MonitoredItems have a callback with a sampling interval */
+    if(mon->monitoredItemType != UA_MONITOREDITEMTYPE_CHANGENOTIFY)
+        return UA_STATUSCODE_GOOD;
+
     UA_StatusCode retval =
         UA_Server_addRepeatedCallback(server, (UA_ServerCallback)UA_MonitoredItem_sampleCallback,
                                       mon, (UA_UInt32)mon->samplingInterval, &mon->sampleCallbackId);


### PR DESCRIPTION
Thanks to Tino Bischoff for finding the root-cause

Co-authored-by: Tino Bischoff <tino.bischoff@iosb.fraunhofer.de>