### PR TITLE
Add support for EventQueueOverflowEvents

### DIFF
--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -303,14 +303,6 @@ prepareNotificationMessage(UA_Server *server, UA_Subscription *sub,
             UA_EventFieldList_init(&notification->data.event.fields);
             efl->clientHandle = mon->clientHandle;
             enlPos++;
-
-            /* increase the monitoredItem queueSize if an eventOverflow was moved,
-             * so it remains the same when the size is reduced in UA_Notification_delete */
-            UA_NodeId overflowId = UA_NODEID_NUMERIC(0, UA_NS0ID_SIMPLEOVERFLOWEVENTTYPE);
-            if (efl->eventFieldsSize == 1 && efl->eventFields[0].type == &UA_TYPES[UA_TYPES_NODEID]
-                    && UA_NodeId_equal((UA_NodeId *)efl->eventFields[0].data, &overflowId)) {
-                mon->queueSize++;
-            }
         }
 #endif
         else {

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -297,24 +297,20 @@ prepareNotificationMessage(UA_Server *server, UA_Subscription *sub,
         } else if(mon->monitoredItemType == UA_MONITOREDITEMTYPE_EVENTNOTIFY && enl) {
             UA_assert(enl != NULL); /* Have at least one event notification */
 
-            /* TODO: The following lead to crashes when we assumed notifications to be ready... */
-            /* /\* removing an overflowEvent should not reduce the queueSize *\/ */
-            /* UA_NodeId overflowId = UA_NODEID_NUMERIC(0, UA_NS0ID_SIMPLEOVERFLOWEVENTTYPE); */
-            /* if (!(notification->data.event.fields.eventFieldsSize == 1 */
-            /*       && notification->data.event.fields.eventFields->type == &UA_TYPES[UA_TYPES_NODEID] */
-            /*       && UA_NodeId_equal((UA_NodeId *)notification->data.event.fields.eventFields->data, &overflowId))) { */
-            /*     --mon->queueSize; */
-            /*     --sub->notificationQueueSize; */
-            /* } */
-
             /* Move the content to the response */
             UA_EventFieldList *efl = &enl->events[enlPos];
             *efl = notification->data.event.fields;
             UA_EventFieldList_init(&notification->data.event.fields);
             efl->clientHandle = mon->clientHandle;
-            /* EventFilterResult currently isn't being used
-               UA_EventFilterResult_deleteMembers(&notification->data.event.result); */
             enlPos++;
+
+            /* increase the monitoredItem queueSize if an eventOverflow was moved,
+             * so it remains the same when the size is reduced in UA_Notification_delete */
+            UA_NodeId overflowId = UA_NODEID_NUMERIC(0, UA_NS0ID_SIMPLEOVERFLOWEVENTTYPE);
+            if (efl->eventFieldsSize == 1 && efl->eventFields[0].type == &UA_TYPES[UA_TYPES_NODEID]
+                    && UA_NodeId_equal((UA_NodeId *)efl->eventFields[0].data, &overflowId)) {
+                mon->queueSize++;
+            }
         }
 #endif
         else {

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -115,6 +115,8 @@ struct UA_MonitoredItem {
     UA_UInt32 queueSize;
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
     UA_MonitoredItem *next;
+    /* Save the amount of OverflowEvents in a separate counter */
+    UA_UInt32 eventOverflows;
 #endif
 };
 

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -113,10 +113,10 @@ struct UA_MonitoredItem {
     /* Notification Queue */
     NotificationQueue queue;
     UA_UInt32 queueSize;
+     /* Save the amount of OverflowEvents in a separate counter */
+     UA_UInt32 eventOverflows;
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
     UA_MonitoredItem *next;
-    /* Save the amount of OverflowEvents in a separate counter */
-    UA_UInt32 eventOverflows;
 #endif
 };
 

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -131,12 +131,14 @@ MonitoredItem_ensureQueueSpace(UA_Server *server, UA_MonitoredItem *mon) {
          if(mon->monitoredItemType == UA_MONITOREDITEMTYPE_EVENTNOTIFY) {
              /* check if an overflowEvent is being deleted
               * TODO: make sure overflowEvents are never deleted */
+             UA_NodeId overflowBaseId = UA_NODEID_NUMERIC(0, UA_NS0ID_EVENTQUEUEOVERFLOWEVENTTYPE);
              UA_NodeId overflowId = UA_NODEID_NUMERIC(0, UA_NS0ID_SIMPLEOVERFLOWEVENTTYPE);
 
              /* Check if an OverflowEvent is being deleted */
              if (del->data.event.fields.eventFieldsSize == 1
-                   &&  del->data.event.fields.eventFields[0].type == &UA_TYPES[UA_TYPES_NODEID]
-                   &&  UA_NodeId_equal((UA_NodeId *)del->data.event.fields.eventFields[0].data, &overflowId)) {
+                 && del->data.event.fields.eventFields[0].type == &UA_TYPES[UA_TYPES_NODEID]
+                 && isNodeInTree(&server->config.nodestore, (UA_NodeId*)del->data.event.fields.eventFields[0].data,
+                                 &overflowBaseId, &subtypeId, 1)) {
                  /* Don't do anything, since adding and removing an overflow will not change anything */
                  return UA_STATUSCODE_GOOD;
              }


### PR DESCRIPTION
Since the specification only states that the MonitoredItems' queue sizes are unaffected by EventQueueOverflowEvents, an additional counter has been added to MonitoredItems to keep track of the "actual" amount of items in the queue, even if the queueSize only reflects events which aren't overflows.
The subscription queues do not handle OverflowEvents in a special way.

@jpfr Please review.