### PR TITLE
Move number of endpoints check to UA_Server_run_startup

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -244,13 +244,6 @@ UA_Server_new(const UA_ServerConfig *config) {
     if(!config)
         return NULL;
 
-    /* At least one endpoint has to be configured */
-    if(config->endpointsSize == 0) {
-        UA_LOG_FATAL(config->logger, UA_LOGCATEGORY_SERVER,
-                     "There has to be at least one endpoint.");
-        return NULL;
-    }
-
     /* Allocate the server */
     UA_Server *server = (UA_Server *)UA_calloc(1, sizeof(UA_Server));
     if(!server)

--- a/src/server/ua_server_worker.c
+++ b/src/server/ua_server_worker.c
@@ -305,6 +305,12 @@ UA_StatusCode
 UA_Server_run_startup(UA_Server *server) {
     UA_Variant var;
     UA_StatusCode result = UA_STATUSCODE_GOOD;
+	
+	/* At least one endpoint has to be configured */
+    if(server->config.endpointsSize == 0) {
+        UA_LOG_WARNING(server->config.logger, UA_LOGCATEGORY_SERVER,
+                       "There has to be at least one endpoint.");
+    }
 
     /* Sample the start time and set it to the Server object */
     server->startTime = UA_DateTime_now();


### PR DESCRIPTION
Some systems (for instance embedded systems) could get there IP-configuration late. This time could be used to create the namespace as well as spend some time to parsing files (e.g. XML for address space).
Other case is that the OPC UA Server is part of a whole system will be started first on request (e.g. after 3 hours runtime), but the address space creation should be done each time at system Startup phase.
All code changes do not change any already available behaviour and do not break any API, since the variable lateEndpointCreate in struct UA_ServerConfig will be initialiazed with 0==false.