### PR TITLE
WIP: Historical Access Plugin definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,7 @@ set(exported_headers ${PROJECT_BINARY_DIR}/src_generated/ua_config.h
                      ${PROJECT_SOURCE_DIR}/include/ua_server.h
                      ${PROJECT_SOURCE_DIR}/include/ua_plugin_log.h
                      ${PROJECT_SOURCE_DIR}/include/ua_plugin_network.h
+                     ${PROJECT_SOURCE_DIR}/include/ua_plugin_historical_access.h
                      ${PROJECT_SOURCE_DIR}/include/ua_plugin_access_control.h
                      ${PROJECT_SOURCE_DIR}/include/ua_plugin_pki.h
                      ${PROJECT_SOURCE_DIR}/include/ua_plugin_securitypolicy.h

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -29,6 +29,7 @@ generate_rst(${PROJECT_SOURCE_DIR}/include/ua_client.h ${DOC_SRC_DIR}/client.rst
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_client_highlevel.h ${DOC_SRC_DIR}/client_highlevel.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_plugin_log.h ${DOC_SRC_DIR}/plugin_log.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_plugin_network.h ${DOC_SRC_DIR}/plugin_network.rst)
+generate_rst(${PROJECT_SOURCE_DIR}/include/ua_plugin_historical_access.h ${DOC_SRC_DIR}/plugin_historical_access.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_plugin_access_control.h ${DOC_SRC_DIR}/plugin_access_control.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/src/server/ua_services.h ${DOC_SRC_DIR}/services.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/ua_plugin_nodestore.h ${DOC_SRC_DIR}/nodestore.rst)
@@ -57,6 +58,7 @@ add_custom_target(doc_latex ${SPHINX_EXECUTABLE}
           ${DOC_SRC_DIR}/client_highlevel.rst ${DOC_SRC_DIR}/client_config.rst
           ${DOC_SRC_DIR}/plugin_log.rst ${DOC_SRC_DIR}/plugin_network.rst
           ${DOC_SRC_DIR}/services.rst ${DOC_SRC_DIR}/plugin_access_control.rst
+          ${DOC_SRC_DIR}/plugin_historical_access.rst
           ${DOC_SRC_DIR}/nodestore.rst
           ${DOC_SRC_DIR}/tutorials.rst
           ${DOC_SRC_DIR}/tutorial_datatypes.rst
@@ -92,6 +94,7 @@ add_custom_target(doc ${SPHINX_EXECUTABLE}
           ${DOC_SRC_DIR}/client_highlevel.rst ${DOC_SRC_DIR}/client_config.rst
           ${DOC_SRC_DIR}/plugin_log.rst ${DOC_SRC_DIR}/plugin_network.rst
           ${DOC_SRC_DIR}/services.rst ${DOC_SRC_DIR}/plugin_access_control.rst
+          ${DOC_SRC_DIR}/plugin_historical_access.rst
           ${DOC_SRC_DIR}/nodestore.rst
           ${DOC_SRC_DIR}/tutorials.rst
           ${DOC_SRC_DIR}/tutorial_datatypes.rst

--- a/include/ua_plugin_historical_access.h
+++ b/include/ua_plugin_historical_access.h
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ *
+ *    Copyright 2018 (c) basysKom GmbH <opensource@basyskom.com> (Author: Peter Rustler)
+ *    Copyright 2018 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
+ */
+
+#ifndef UA_PLUGIN_HISTORICAL_ACCESS_H_
+#define UA_PLUGIN_HISTORICAL_ACCESS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ua_server.h"
+
+/**
+ * .. _historical-access:
+ *
+ * Historical Access Plugin API
+ * ============================
+ *
+ * Storage and access to historical data is implemented in a user-defined
+ * plugin. The plugin API does not mandate a specific kind of storage backend or
+ * handling of continuation points.
+ *
+ * The plugin is set globally in the server and used by the HistoryRead and
+ * HistoryUpdate services.
+ *
+ * The function pointers in the HistoryAccess plugin can be set to NULL. The
+ * server returns ``UA_STATUSCODE_BADNOTIMPLEMENTED`` if a requested method is
+ * not available.
+ */
+
+typedef struct {
+    void *context;
+    void (*deleteMembers)(void *context);
+
+    /* Is the node historizing? The callback is used by the normal Read service
+     * for the historizing attribute. */
+    UA_Boolean (*isHistorizing)(UA_Server *server, void *haContext,
+                                const UA_NodeId *nodeId);
+
+    /***************/
+    /* HistoryRead */
+    /***************/
+
+    UA_StatusCode
+    (*historyRead_raw)(UA_Server *server, void *haContext,
+                       const UA_NodeId *sessionId, void *sessionContext,
+                       const UA_ReadRawModifiedDetails *details,
+                       const UA_HistoryReadValueId *id,
+                       UA_TimestampsToReturn timestampsToReturn,
+                       UA_Boolean releaseContinuationPoints,
+                       UA_ByteString *outContinuationPoint,
+                       UA_HistoryData *outHistoryData);
+
+    /* UA_StatusCode */
+    /* (*historyRead_modified)(UA_Server *server, void *haContext, */
+    /*                         const UA_NodeId *sessionId, void *sessionContext, */
+    /*                         const UA_ReadRawModifiedDetails *details, */
+    /*                         const UA_HistoryReadValueId *id, */
+    /*                         UA_TimestampsToReturn timestampsToReturn, */
+    /*                         UA_Boolean releaseContinuationPoints, */
+    /*                         UA_ByteString *outContinuationPoint, */
+    /*                         UA_HistoryModifiedData *outHistoryData); */
+
+    /* UA_StatusCode */
+    /* (*historyRead_processed)(UA_Server *server, void *haContext, */
+    /*                          const UA_NodeId *sessionId, void *sessionContext, */
+    /*                          const UA_ReadProcessedDetails *details, */
+    /*                          const UA_HistoryReadValueId *id, */
+    /*                          UA_TimestampsToReturn timestampsToReturn, */
+    /*                          UA_Boolean releaseContinuationPoints, */
+    /*                          UA_ByteString *outContinuationPoint, */
+    /*                          UA_HistoryData *outHistoryData); */
+
+    /* UA_StatusCode */
+    /* (*historyRead_atTime)(UA_Server *server, void *haContext, */
+    /*                       const UA_NodeId *sessionId, void *sessionContext, */
+    /*                       const UA_ReadAtTimeDetails *details, */
+    /*                       const UA_HistoryReadValueId *id, */
+    /*                       UA_TimestampsToReturn timestampsToReturn, */
+    /*                       UA_Boolean releaseContinuationPoints, */
+    /*                       UA_ByteString *outContinuationPoint, */
+    /*                       UA_HistoryData *outHistoryData); */
+    
+    /* UA_StatusCode */
+    /* (*historyRead_event)(UA_Server *server, void *haContext, */
+    /*                      const UA_NodeId *sessionId, void *sessionContext, */
+    /*                      const UA_ReadEventDetails *details, */
+    /*                      const UA_HistoryReadValueId *id, */
+    /*                      UA_TimestampsToReturn timestampsToReturn, */
+    /*                      UA_Boolean releaseContinuationPoints, */
+    /*                      UA_ByteString *outContinuationPoint, */
+    /*                      UA_HistoryEvent *outHistoryEvent); */
+
+    /*****************/
+    /* HistoryUpdate */
+    /*****************/
+
+    /* outResults is pre-allocated to the size of details->updateValue */
+    /* UA_StatusCode */
+    /* (*historyUpdate_updateData)(UA_Server *server, void *haContext, */
+    /*                             const UA_NodeId *sessionId, void *sessionContext, */
+    /*                             const UA_UpdateDataDetails *details, */
+    /*                             UA_StatusCode *outResults); */
+
+    
+    /* outResults is pre-allocated to the size of details->updateValue */
+    /* UA_StatusCode */
+    /* (*historyUpdate_updateStructureData)(UA_Server *server, void *haContext, */
+    /*                                      const UA_NodeId *sessionId, void *sessionContext, */
+    /*                                      const UA_UpdateStructureDataDetails *details, */
+    /*                                      UA_StatusCode *outResults); */
+
+    /* outResults is pre-allocated to the size of details->eventData */
+    /* UA_StatusCode */
+    /* (*historyUpdate_updateEvent)(UA_Server *server, void *haContext, */
+    /*                              const UA_NodeId *sessionId, void *sessionContext, */
+    /*                              const UA_UpdateEventDetails *details, */
+    /*                              UA_StatusCode *outResults); */
+    
+    /* UA_StatusCode */
+    /* (*historyUpdate_deleteRawModified)(UA_Server *server, void *haContext, */
+    /*                                    const UA_NodeId *sessionId, void *sessionContext, */
+    /*                                    const UA_DeleteRawModifiedDetails *details); */
+    
+    /* outResults is pre-allocated to the size of details->reqTimes */
+    /* UA_StatusCode */
+    /* (*historyUpdate_deleteAtTime)(UA_Server *server, void *haContext, */
+    /*                               const UA_NodeId *sessionId, void *sessionContext, */
+    /*                               const UA_DeleteAtTimeDetails *details, */
+    /*                               UA_StatusCode *outResults); */
+
+    /* outResults is pre-allocated to the size of details->eventIds */
+    /* UA_StatusCode */
+    /* (*historyUpdate_deleteEvent)(UA_Server *server, void *haContext, */
+    /*                              const UA_NodeId *sessionId, void *sessionContext, */
+    /*                              const UA_DeleteEventDetails *details, */
+    /*                              UA_StatusCode *outResults); */
+} UA_HistoricalAccess;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UA_PLUGIN_HISTORICAL_ACCESS_H_ */

--- a/include/ua_server_config.h
+++ b/include/ua_server_config.h
@@ -17,6 +17,7 @@ extern "C" {
 #include "ua_server.h"
 #include "ua_plugin_log.h"
 #include "ua_plugin_network.h"
+#include "ua_plugin_historical_access.h"
 #include "ua_plugin_access_control.h"
 #include "ua_plugin_pki.h"
 #include "ua_plugin_securitypolicy.h"

--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -207,3 +207,9 @@ DataSetFieldContentMask
 UadpDataSetMessageContentMask
 UadpNetworkMessageContentMask
 SimpleTypeDescription
+ReadRawModifiedDetails
+HistoryReadValueId
+HistoryReadRequest
+HistoryData
+HistoryReadResult
+HistoryReadResponse


### PR DESCRIPTION
This PR proposes a "complete" plugin definition for Historical Access.
Note that historical data is not directly tied to nodes.
This keeps the node definition simple and the implementation complexity depends on the plugin provider.

@peter-rustler-basyskom 
For discussion in relation with #1740.
The implementation from #1740 would implement a "middle layer" that provides a minimal Historical Access implementation with an exchangeable "low level" API where people can plug in different storage backends.