### PR TITLE
Adds dataEncipherment to key usage extension for initial certificate

### DIFF
--- a/tools/certs/localhost.cnf
+++ b/tools/certs/localhost.cnf
@@ -254,7 +254,7 @@ basicConstraints = CA:false
 # left out by default.
 # keyUsage = cRLSign, keyCertSign
 
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment
 extendedKeyUsage = TLS Web Server Authentication, TLS Web Client Authentication
 
 # Some might want this also


### PR DESCRIPTION
The standard specifies in part 6, p. 41 and part 4, p. 115 that the key usage extension for an Application Instance Certificate shall include
- digitalSignature
- nonRepudiation
- keyEncipherment
- dataEncipherment