### PR TITLE
Added HistoryServerCapabilities to ServerCapabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 
 # Options
 set(UA_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported")
+option(UA_ENABLE_HISTORIZING "Enable server to provide historical access." ON)
 option(UA_ENABLE_METHODCALLS "Enable the Method service set" ON)
 option(UA_ENABLE_NODEMANAGEMENT "Enable dynamic addition and removal of nodes at runtime" ON)
 option(UA_ENABLE_SUBSCRIPTIONS "Enable subscriptions support." ON)

--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -31,6 +31,7 @@ extern "C" {
 #cmakedefine UA_ENABLE_PUBSUB_DELTAFRAMES
 #cmakedefine UA_ENABLE_PUBSUB_INFORMATIONMODEL
 #cmakedefine UA_ENABLE_ENCRYPTION
+#cmakedefine UA_ENABLE_HISTORIZING
 #cmakedefine UA_ENABLE_SUBSCRIPTIONS_EVENTS
 
 /* Multithreading */

--- a/include/ua_server_config.h
+++ b/include/ua_server_config.h
@@ -5,6 +5,7 @@
  *    Copyright 2017 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Henrik Norrman
+ *    Copyright 2018 (c) Fabian Arndt, Root-Core
  */
 
 #ifndef UA_SERVER_CONFIG_H_

--- a/include/ua_server_config.h
+++ b/include/ua_server_config.h
@@ -165,6 +165,29 @@ struct UA_ServerConfig {
      * state of the semaphore file. */
     UA_UInt32 discoveryCleanupTimeout;
 #endif
+
+    /* Historical Access */
+#ifdef UA_ENABLE_HISTORIZING
+    UA_Boolean accessHistoryDataCapability;
+    UA_UInt32  maxReturnDataValues; /* 0 -> unlimited size */
+    
+    UA_Boolean accessHistoryEventsCapability;
+    UA_UInt32  maxReturnEventValues; /* 0 -> unlimited size */
+
+    UA_Boolean insertDataCapability;
+    UA_Boolean insertEventCapability;
+    UA_Boolean insertAnnotationsCapability;
+
+    UA_Boolean replaceDataCapability;
+    UA_Boolean replaceEventCapability;
+    
+    UA_Boolean updateDataCapability;
+    UA_Boolean updateEventCapability;
+    
+    UA_Boolean deleteRawCapability;
+    UA_Boolean deleteEventCapability;
+    UA_Boolean deleteAtTimeDataCapability;
+#endif
 };
 
 #ifdef __cplusplus

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -7,6 +7,7 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Thomas Stalder, Blue Time Concept SA
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
+ *    Copyright 2018 (c) Fabian Arndt, Root-Core
  */
 
 #include "ua_plugin_securitypolicy.h"

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -280,6 +280,28 @@ createDefaultConfig(void) {
     conf->discoveryCleanupTimeout = 60 * 60;
 #endif
 
+#ifdef UA_ENABLE_HISTORIZING
+    /* conf->accessHistoryDataCapability = UA_FALSE; */
+    /* conf->maxReturnDataValues = 0; */
+
+    /* conf->accessHistoryEventsCapability = UA_FALSE; */
+    /* conf->maxReturnEventValues = 0; */
+
+    /* conf->insertDataCapability = UA_FALSE; */
+    /* conf->insertEventCapability = UA_FALSE; */
+    /* conf->insertAnnotationsCapability = UA_FALSE; */
+
+    /* conf->replaceDataCapability = UA_FALSE; */
+    /* conf->replaceEventCapability = UA_FALSE; */
+
+    /* conf->updateDataCapability = UA_FALSE; */
+    /* conf->updateEventCapability = UA_FALSE; */
+
+    /* conf->deleteRawCapability = UA_FALSE; */
+    /* conf->deleteEventCapability = UA_FALSE; */
+    /* conf->deleteAtTimeDataCapability = UA_FALSE; */
+#endif
+
     /* --> Finish setting the default static config <-- */
 
     return conf;

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -7,6 +7,7 @@
  *    Copyright 2017 (c) Thomas Bender
  *    Copyright 2017 (c) Julian Grothoff
  *    Copyright 2017 (c) Henrik Norrman
+ *    Copyright 2018 (c) Fabian Arndt, Root-Core
  */
 
 #include "ua_server_internal.h"

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -583,7 +583,7 @@ UA_Server_initNS0(UA_Server *server) {
                                &maxBrowseContinuationPoints, &UA_TYPES[UA_TYPES_UINT16]);
 
     /* ServerProfileArray */
-    UA_String profileArray[4];
+    UA_String profileArray[5];
     UA_UInt16 profileArraySize = 0;
 #define ADDPROFILEARRAY(x) profileArray[profileArraySize++] = UA_STRING_ALLOC(x)
     ADDPROFILEARRAY("http://opcfoundation.org/UA-Profile/Server/NanoEmbeddedDevice");
@@ -595,6 +595,9 @@ UA_Server_initNS0(UA_Server *server) {
 #endif
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     ADDPROFILEARRAY("http://opcfoundation.org/UA-Profile/Server/EmbeddedDataChangeSubscription");
+#endif
+#ifdef UA_ENABLE_HISTORIZING
+    ADDPROFILEARRAY("http://opcfoundation.org/UA-Profile/Server/HistoricalRawData");
 #endif
 
     retVal |= writeNs0VariableArray(server, UA_NS0ID_SERVER_SERVERCAPABILITIES_SERVERPROFILEARRAY,
@@ -736,6 +739,64 @@ UA_Server_initNS0(UA_Server *server) {
     /* ServerCapabilities - OperationLimits - MaxMonitoredItemsPerCall */
     retVal |= writeNs0Variable(server, UA_NS0ID_SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXMONITOREDITEMSPERCALL,
                                &server->config.maxMonitoredItemsPerCall, &UA_TYPES[UA_TYPES_UINT32]);
+
+#ifdef UA_ENABLE_HISTORIZING
+    /* ServerCapabilities - HistoryServerCapabilities - AccessHistoryDataCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_ACCESSHISTORYDATACAPABILITY,
+                               &server->config.accessHistoryDataCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - MaxReturnDataValues */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_MAXRETURNDATAVALUES,
+                               &server->config.maxReturnDataValues, &UA_TYPES[UA_TYPES_UINT32]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - AccessHistoryEventsCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_ACCESSHISTORYEVENTSCAPABILITY,
+                               &server->config.accessHistoryEventsCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - MaxReturnEventValues */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_MAXRETURNEVENTVALUES,
+                               &server->config.maxReturnEventValues, &UA_TYPES[UA_TYPES_UINT32]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - InsertDataCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_INSERTDATACAPABILITY,
+                               &server->config.insertDataCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - InsertEventCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_INSERTEVENTCAPABILITY,
+                               &server->config.insertEventCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - InsertAnnotationsCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_INSERTANNOTATIONCAPABILITY,
+                               &server->config.insertAnnotationsCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - ReplaceDataCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_REPLACEDATACAPABILITY,
+                               &server->config.replaceDataCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - ReplaceEventCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_REPLACEEVENTCAPABILITY,
+                               &server->config.replaceEventCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - UpdateDataCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_UPDATEDATACAPABILITY,
+                               &server->config.updateDataCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - UpdateEventCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_UPDATEEVENTCAPABILITY,
+                               &server->config.updateEventCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - DeleteRawCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_DELETERAWCAPABILITY,
+                               &server->config.deleteRawCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - DeleteEventCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_DELETEEVENTCAPABILITY,
+                               &server->config.deleteEventCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    /* ServerCapabilities - HistoryServerCapabilities - DeleteAtTimeDataCapability */
+    retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_DELETEATTIMECAPABILITY,
+                               &server->config.deleteAtTimeDataCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
+#endif
 
 #if defined(UA_ENABLE_METHODCALLS) && defined(UA_ENABLE_SUBSCRIPTIONS)
     retVal |= UA_Server_setMethodNode_callback(server,

--- a/tools/schema/Opc.Ua.NodeSet2.Minimal.xml
+++ b/tools/schema/Opc.Ua.NodeSet2.Minimal.xml
@@ -1202,6 +1202,7 @@
       <Reference ReferenceType="HasProperty">i=3704</Reference>
       <Reference ReferenceType="HasComponent">i=2996</Reference>
       <Reference ReferenceType="HasComponent">i=2997</Reference>
+      <Reference ReferenceType="HasComponent">i=11192</Reference>
       <Reference ReferenceType="HasTypeDefinition">i=2013</Reference>
       <Reference ReferenceType="HasComponent" IsForward="false">i=2253</Reference>
     </References>
@@ -2059,4 +2060,137 @@ PC9vcGM6VHlwZURpY3Rpb25hcnk+</ByteString>
       <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">EnumValueType</String>
     </Value>
   </UAVariable>
+  <UAObjectType NodeId="i=2330" BrowseName="HistoryServerCapabilitiesType">
+    <DisplayName>HistoryServerCapabilitiesType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="i=11192" BrowseName="HistoryServerCapabilities">
+    <DisplayName>HistoryServerCapabilities</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">i=11193</Reference>
+      <Reference ReferenceType="HasProperty">i=11242</Reference>
+      <Reference ReferenceType="HasProperty">i=11273</Reference>
+      <Reference ReferenceType="HasProperty">i=11274</Reference>
+      <Reference ReferenceType="HasProperty">i=11196</Reference>
+      <Reference ReferenceType="HasProperty">i=11197</Reference>
+      <Reference ReferenceType="HasProperty">i=11198</Reference>
+      <Reference ReferenceType="HasProperty">i=11199</Reference>
+      <Reference ReferenceType="HasProperty">i=11200</Reference>
+      <Reference ReferenceType="HasProperty">i=11281</Reference>
+      <Reference ReferenceType="HasProperty">i=11282</Reference>
+      <Reference ReferenceType="HasProperty">i=11283</Reference>
+      <Reference ReferenceType="HasProperty">i=11502</Reference>
+      <Reference ReferenceType="HasProperty">i=11275</Reference>
+      <Reference ReferenceType="HasComponent">i=11201</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=2268</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=2330</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="i=11193" BrowseName="AccessHistoryDataCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>AccessHistoryDataCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11242" BrowseName="AccessHistoryEventsCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>AccessHistoryEventsCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11273" BrowseName="MaxReturnDataValues" ParentNodeId="i=11192" DataType="UInt32">
+    <DisplayName>MaxReturnDataValues</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11274" BrowseName="MaxReturnEventValues" ParentNodeId="i=11192" DataType="UInt32">
+    <DisplayName>MaxReturnEventValues</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11196" BrowseName="InsertDataCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>InsertDataCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11197" BrowseName="ReplaceDataCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>ReplaceDataCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11198" BrowseName="UpdateDataCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>UpdateDataCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11199" BrowseName="DeleteRawCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>DeleteRawCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11200" BrowseName="DeleteAtTimeCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>DeleteAtTimeCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11281" BrowseName="InsertEventCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>InsertEventCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11282" BrowseName="ReplaceEventCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>ReplaceEventCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11283" BrowseName="UpdateEventCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>UpdateEventCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11502" BrowseName="DeleteEventCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>DeleteEventCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=11275" BrowseName="InsertAnnotationCapability" ParentNodeId="i=11192" DataType="Boolean">
+    <DisplayName>InsertAnnotationCapability</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=11192</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="i=11201" BrowseName="AggregateFunctions" ParentNodeId="i=11192">
+    <DisplayName>AggregateFunctions</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=11192</Reference>
+    </References>
+  </UAObject>
 </UANodeSet>


### PR DESCRIPTION
OPC Spec Part 11 - 5.4.2: 
> The ServerCapabilitiesType Objects for any OPC UA Server supporting Historical Access shall contain a Reference to a HistoryServerCapabilitiesType Object.

I made the capabilities configurable via the server config file. This could also help the regarding implementation, as we could quickly check, if the implementation supports the requested feature.
It only gets applied, if `UA_ENABLE_HISTORIZING` is enabled.

The problem: The `HistoryServerCapabilities` are added to `ServerCapabilities` regardless if `UA_ENABLE_HISTORIZING` is set. I don't know how one would get the node compiler to do this dynamically, without creating a new NodeSet containing Minimal and Part 11.

Also adding `HistoricalRawData` Profile, if `UA_ENABLE_HISTORIZING` is enabled.
This could get a bit messy in the future, as the Historical Profiles are split into features.
It could be better to get some dynamic into the "profile system", regarding to the servers configuration.
This could easily done by checking the server config and setting the profile array late in `UA_Server_initNS0()`.