### PR TITLE
Types: Ensure booleans are 1 byte long for overlayed encoding

### DIFF
--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -284,6 +284,12 @@ extern "C" {
 # define UA_BINARY_OVERLAYABLE_INTEGER 0
 #endif
 
+/* Some platforms (e.g. QNX) have sizeof(bool) > 1. Disable overlayed integer
+ * encoding if that is the case. */
+#if UA_BINARY_OVERLAYABLE_INTEGER == 1
+UA_STATIC_ASSERT(sizeof(bool) == 1, cannot_overlay_integers_with_large_bool);
+#endif
+
 /**
  * Float Endianness
  * ^^^^^^^^^^^^^^^^

--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -75,7 +75,7 @@ extern "C" {
 #else
 # include "ms_stdint.h"
 # if !defined(__bool_true_false_are_defined)
-#  define bool short
+#  define bool unsigned char
 #  define true 1
 #  define false 0
 #  define __bool_true_false_are_defined


### PR DESCRIPTION
Fix the default encoding (no overlays) for longer bool definitions.

This fixes #1840. Thanks to @HamidMapna for uncovering the root cause
for issues on QNX.