### PR TITLE
Add '#ifdef __cplusplus extern "C" {...' in ua_client_highlevel_async.h

### DIFF
--- a/include/ua_client_highlevel_async.h
+++ b/include/ua_client_highlevel_async.h
@@ -8,6 +8,10 @@
 #define UA_CLIENT_HIGHLEVEL_ASYNC_H_
 #include "ua_client.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Raw Services
  * ^^^^^^^^^^^^ */
@@ -627,5 +631,8 @@ static UA_INLINE UA_StatusCode UA_Cient_translateBrowsePathsToNodeIds_async(
 			pathSize, (UA_ClientAsyncServiceCallback) callback, userdata, reqId);
 }
 
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* UA_CLIENT_HIGHLEVEL_ASYNC_H_ */


### PR DESCRIPTION
This fixes  `undefined reference to` when using async functions from C++.
