### PR TITLE
Changes in the OS-9 part of ua_network_tcp.c after the move to arch/

### DIFF
--- a/arch/ua_network_tcp.c
+++ b/arch/ua_network_tcp.c
@@ -652,10 +652,10 @@ UA_StatusCode UA_ClientConnectionTCP_poll(UA_Client *client, void *data) {
 
             _os_sleep(&time,&sig);
             error = connect(clientsockfd, tcpConnection->server->ai_addr,
-                        WIN32_INT tcpConnection->server->ai_addrlen);
-            if ((error == -1 && errno__ == EISCONN) || (error == 0))
+                        tcpConnection->server->ai_addrlen);
+            if ((error == -1 && errno == EISCONN) || (error == 0))
                 resultsize = 1;
-            if (error == -1 && errno__ != EALREADY && errno__ != EINPROGRESS)
+            if (error == -1 && errno != EALREADY && errno != EINPROGRESS)
                 break;
         }
         while(resultsize == 0);
@@ -912,10 +912,10 @@ UA_ClientConnectionTCP(UA_ConnectionConfig conf,
                     break;
 
                 _os_sleep(&time,&sig);
-                error = connect(clientsockfd, server->ai_addr, WIN32_INT server->ai_addrlen);
-                if ((error == -1 && errno__ == EISCONN) || (error == 0))
+                error = connect(clientsockfd, server->ai_addr, server->ai_addrlen);
+                if ((error == -1 && errno == EISCONN) || (error == 0))
                     resultsize = 1;
-                if (error == -1 && errno__ != EALREADY && errno__ != EINPROGRESS)
+                if (error == -1 && errno != EALREADY && errno != EINPROGRESS)
                     break;
             }
             while(resultsize == 0);


### PR DESCRIPTION
After the ua_network_tcp.c has been moved to the arch/ directory, there are a few small modifications needed in the ifdef _OS9000 part. Before, it was errno__ which is not longer existing here and therefore errno again. And a remove of WIN32_INT as a casting. That's all to get the project compiling for OS-9 again.

Signed-off-by: Kei-Thomsen <thomsen@microsys.de>