### PR TITLE
Fix stack-use-after-scope in ua_network_tcp.c

### DIFF
--- a/arch/ua_network_tcp.c
+++ b/arch/ua_network_tcp.c
@@ -320,20 +320,19 @@ ServerNetworkLayerTCP_start(UA_ServerNetworkLayer *nl, const UA_String *customHo
 
     /* Get the discovery url from the hostname */
     UA_String du = UA_STRING_NULL;
+    char discoveryUrlBuffer[256];
+    char hostnameBuffer[256];
     if (customHostname->length) {
-        char discoveryUrl[256];
-        du.length = (size_t)UA_snprintf(discoveryUrl, 255, "opc.tcp://%.*s:%d/",
+        du.length = (size_t)UA_snprintf(discoveryUrlBuffer, 255, "opc.tcp://%.*s:%d/",
                                      (int)customHostname->length,
                                      customHostname->data,
                                      layer->port);
-        du.data = (UA_Byte*)discoveryUrl;
+        du.data = (UA_Byte*)discoveryUrlBuffer;
     }else{
-        char hostname[256];
-        if(UA_gethostname(hostname, 255) == 0) {
-            char discoveryUrl[256];
-            du.length = (size_t)UA_snprintf(discoveryUrl, 255, "opc.tcp://%s:%d/",
-                                         hostname, layer->port);
-            du.data = (UA_Byte*)discoveryUrl;
+        if(UA_gethostname(hostnameBuffer, 255) == 0) {
+            du.length = (size_t)UA_snprintf(discoveryUrlBuffer, 255, "opc.tcp://%s:%d/",
+                                         hostnameBuffer, layer->port);
+            du.data = (UA_Byte*)discoveryUrlBuffer;
         } else {
             UA_LOG_ERROR(layer->logger, UA_LOGCATEGORY_NETWORK, "Could not get the hostname");
         }


### PR DESCRIPTION
open62541 applications built with clang with ASAN enabled fail with
>==25154==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffd3812dac0 at pc 0x0000004ddc8d bp 0x7ffd3812d380 sp 0x7ffd3812cb30

This patch fixes the issue. For more details, see https://github.com/google/sanitizers/wiki/AddressSanitizerUseAfterScope