### PR TITLE
Fix wrong local include in amalgamated file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,14 +830,16 @@ GET_PROPERTY(ua_architecture_add_definitions GLOBAL PROPERTY UA_ARCHITECTURE_ADD
 add_definitions(${ua_architecture_add_definitions})
 
 GET_PROPERTY(ua_architecture_remove_definitions GLOBAL PROPERTY UA_ARCHITECTURE_REMOVE_DEFINITIONS)
-remove_definitions(${ua_architecture_remove_definitions})
+if (NOT "${ua_architecture_remove_definitions}" STREQUAL "")
+  string(REPLACE " " ";" ua_architecture_remove_definitions_list ${ua_architecture_remove_definitions})
+  remove_definitions(${ua_architecture_remove_definitions_list})
+endif(NOT "${ua_architecture_remove_definitions}" STREQUAL "")
 
 GET_PROPERTY(ua_architecture_append_to_library GLOBAL PROPERTY UA_ARCHITECTURE_APPEND_TO_LIBRARY)
 list(APPEND open62541_LIBRARIES ${ua_architecture_append_to_library})
 
 # DLL requires linking to dependencies
 target_link_libraries(open62541 ${open62541_LIBRARIES})
-
 
 ##########################
 # Build Selected Targets #

--- a/arch/eCos/CMakeLists.txt
+++ b/arch/eCos/CMakeLists.txt
@@ -12,15 +12,6 @@ if (${_index} GREATER -1 OR "${UA_ARCHITECTURE}" STREQUAL "eCos")
     if("${UA_ARCHITECTURE}" STREQUAL "eCos")
 
         ua_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
-        ua_architecture_remove_definitions(-Wpedantic -Wno-static-in-inline -Wc++-compat)
-        ua_architecture_add_definitions(-Wno-sign-conversion -fdata-sections -fno-exceptions -ffunction-sections -DSYSTEM_BUS_WIDTH=32  -mhw-mul -mno-hw-mulx -mhw-div -Wa,-relax-all -W -Wall -Wextra -D_KERNEL -D__ECOS -nostdlib -Wl,--gc-sections -Wl,-static)
-
-        ua_architecture_append_to_library("-L${UA_ECOS_INCLUDES}/lib -Wl,-T,${UA_ECOS_INCLUDES}/lib/target.ld -nostartfiles") #for examples
-
-        SET(UA_ECOS_INCLUDES "" CACHE STRING "Folders to include from the eCos OS")
-
-        ua_include_directories(${UA_ECOS_INCLUDES}/include)
         
         set(UA_ECOS_HOSTNAME "eCos-host" CACHE STRING "Define a custom hostname/ip for the endpoint.")
         ua_architecture_add_definitions(-DUA_ECOS_HOSTNAME="${UA_ECOS_HOSTNAME}")

--- a/arch/eCos/ua_architecture.h
+++ b/arch/eCos/ua_architecture.h
@@ -5,10 +5,8 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  */
 
-#ifndef PLUGINS_ARCH_POSIX_UA_ARCHITECTURE_H_
-#define PLUGINS_ARCH_POSIX_UA_ARCHITECTURE_H_
-
-#include <../deps/queue.h>  //TODO: in some compilers there's already a _SYS_QUEUE_H_ who is included first and doesn't have all functions
+#ifndef PLUGINS_ARCH_ECOS_UA_ARCHITECTURE_H_
+#define PLUGINS_ARCH_ECOS_UA_ARCHITECTURE_H_
 
 #include <pkgconf/system.h>
 #include <cyg/kernel/kapi.h>
@@ -85,4 +83,32 @@ int gethostname_ecos(char* name, size_t len);
 
 #include "../ua_architecture_functions.h"
 
-#endif /* PLUGINS_ARCH_POSIX_UA_ARCHITECTURE_H_ */
+#undef SLIST_EMPTY
+#undef SLIST_FOREACH
+#undef SLIST_INIT
+#undef SLIST_REMOVE
+
+#undef LIST_EMPTY
+#undef LIST_FOREACH
+#undef LIST_INIT
+#undef LIST_REMOVE
+
+#undef TAILQ_EMPTY
+#undef TAILQ_FOREACH
+#undef TAILQ_INIT
+#undef TAILQ_REMOVE
+#undef TAILQ_FOREACH_REVERSE
+
+#undef CIRCLEQ_EMPTY
+#undef CIRCLEQ_FOREACH
+#undef CIRCLEQ_INIT
+#undef CIRCLEQ_FOREACH_REVERSE
+#undef CIRCLEQ_REMOVE
+#undef CIRCLEQ_INSERT_TAIL
+#undef CIRCLEQ_INSERT_HEAD
+#undef CIRCLEQ_INSERT_AFTER
+#undef CIRCLEQ_INSERT_BEFORE
+
+#undef _SYS_QUEUE_H_
+
+#endif /* PLUGINS_ARCH_ECOS_UA_ARCHITECTURE_H_ */

--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -23,8 +23,6 @@
 # define _BSD_SOURCE
 #endif
 
-#include <../deps/queue.h>  //in some compilers there's already a _SYS_QUEUE_H_ who is included first and doesn't have all functions
-
 #include <errno.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -131,6 +129,34 @@ void UA_sleep_ms(size_t ms);
 }
 
 #include "../ua_architecture_functions.h"
+
+#undef SLIST_EMPTY
+#undef SLIST_FOREACH
+#undef SLIST_INIT
+#undef SLIST_REMOVE
+
+#undef LIST_EMPTY
+#undef LIST_FOREACH
+#undef LIST_INIT
+#undef LIST_REMOVE
+
+#undef TAILQ_EMPTY
+#undef TAILQ_FOREACH
+#undef TAILQ_INIT
+#undef TAILQ_REMOVE
+#undef TAILQ_FOREACH_REVERSE
+
+#undef CIRCLEQ_EMPTY
+#undef CIRCLEQ_FOREACH
+#undef CIRCLEQ_INIT
+#undef CIRCLEQ_FOREACH_REVERSE
+#undef CIRCLEQ_REMOVE
+#undef CIRCLEQ_INSERT_TAIL
+#undef CIRCLEQ_INSERT_HEAD
+#undef CIRCLEQ_INSERT_AFTER
+#undef CIRCLEQ_INSERT_BEFORE
+
+#undef _SYS_QUEUE_H_
 
 #endif /* PLUGINS_ARCH_POSIX_UA_ARCHITECTURE_H_ */
 

--- a/arch/vxworks/ua_architecture.h
+++ b/arch/vxworks/ua_architecture.h
@@ -10,8 +10,6 @@
 #ifndef PLUGINS_ARCH_VXWORKS_UA_ARCHITECTURE_H_
 #define PLUGINS_ARCH_VXWORKS_UA_ARCHITECTURE_H_
 
-#include <../deps/queue.h>  //in some compilers there's already a _SYS_QUEUE_H_ who is included first and doesn't have all functions
-
 #include <errno.h>
 
 #include <arpa/inet.h>
@@ -108,6 +106,34 @@
 }
 
 #include "../ua_architecture_functions.h"
+
+#undef SLIST_EMPTY
+#undef SLIST_FOREACH
+#undef SLIST_INIT
+#undef SLIST_REMOVE
+
+#undef LIST_EMPTY
+#undef LIST_FOREACH
+#undef LIST_INIT
+#undef LIST_REMOVE
+
+#undef TAILQ_EMPTY
+#undef TAILQ_FOREACH
+#undef TAILQ_INIT
+#undef TAILQ_REMOVE
+#undef TAILQ_FOREACH_REVERSE
+
+#undef CIRCLEQ_EMPTY
+#undef CIRCLEQ_FOREACH
+#undef CIRCLEQ_INIT
+#undef CIRCLEQ_FOREACH_REVERSE
+#undef CIRCLEQ_REMOVE
+#undef CIRCLEQ_INSERT_TAIL
+#undef CIRCLEQ_INSERT_HEAD
+#undef CIRCLEQ_INSERT_AFTER
+#undef CIRCLEQ_INSERT_BEFORE
+
+#undef _SYS_QUEUE_H_
 
 #endif /* PLUGINS_ARCH_VXWORKS_UA_ARCHITECTURE_H_ */
 


### PR DESCRIPTION
This fixes the local queue.h being in the amalgamated h file. Also it removes some compiler specifics flags for the eCos OS and uses the general variables for adding/removing flags for the specific architecture