### PR TITLE
Fix name of tutorial_server_variable.c

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -12,7 +12,7 @@ Using the GCC compiler, the following calls build the examples on Linux.
 
    cp /path-to/open62541.* . # copy single-file distribution to the local directory
    cp /path-to/examples/tutorial_server_variable.c . # copy the example server
-   gcc -std=c99 -DUA_ARCHITECTURE_POSIX open62541.c server_variable.c -o server
+   gcc -std=c99 -DUA_ARCHITECTURE_POSIX open62541.c tutorial_server_variable.c -o server
 
 Building the Library
 --------------------

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -11,7 +11,7 @@ Using the GCC compiler, the following calls build the examples on Linux.
 .. code-block:: bash
 
    cp /path-to/open62541.* . # copy single-file distribution to the local directory
-   cp /path-to/examples/server_variable.c . # copy the example server
+   cp /path-to/examples/tutorial_server_variable.c . # copy the example server
    gcc -std=c99 -DUA_ARCHITECTURE_POSIX open62541.c server_variable.c -o server
 
 Building the Library


### PR DESCRIPTION
The example called server_variable.c was removed in https://github.com/open62541/open62541/commit/68402c5ff6e6cfcd1f58b5922dc1df7d865ac697#diff-beb1222a9c51e2083f45b086a9275aa3 .