### PR TITLE
Fix installation directory of CMake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,7 +913,7 @@ add_custom_target(cpplint cpplint
 # specify install location with `-DCMAKE_INSTALL_PREFIX=xyz`
 # Enable shared library with `-DBUILD_SHARED_LIBS=ON`
 
-set(cmake_configfile_install ${LIB_INSTALL_DIR}/cmake)
+set(cmake_configfile_install ${LIB_INSTALL_DIR}/cmake/open62541)
 set(target_install_dest_name "${cmake_configfile_install}/open62541Targets.cmake")
 set(open62541_tools_dir share/open62541/tools)
 set(open62541_deps_dir include/open62541/deps)


### PR DESCRIPTION
Without this fix if one installed open62541 in the default [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/v3.5/variable/CMAKE_INSTALL_PREFIX.html), or in a custom prefix that was added to pCMAKE_PREFIX_PATH](https://cmake.org/cmake/help/v3.5/variable/CMAKE_PREFIX_PATH.html), `find_package(open62541 REQUIRED)` would still fail. 

This is because the CMake config file was not installed in one of the many directory check by the find_package CMake command: 
https://cmake.org/cmake/help/v3.8/command/find_package.html . 

Before this fix, the only way of actually finding the open62541 CMake package was to directly point `open62541_DIR` or `CMAKE_PREFIX_PATH` to `<prefix>/lib/cmake/open62541` .

See https://cmake.org/cmake/help/v3.10/manual/cmake-packages.7.html#package-configuration-file for a good documentation of CMake packages and config files. 

cc @XB32Z that contributed to the CMake support in https://github.com/open62541/open62541/pull/969 and https://github.com/open62541/open62541/pull/977 .