### PR TITLE
NodesetCompiler: Fixed instantiation of user defined structures

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -376,7 +376,7 @@ def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_bina
             instanceName = generateNodeValueInstanceName(node.value[0], parentNode, 0, 0)
             if isinstance(node.value[0], ExtensionObject):
                 code.append(generateNodeValueCode("UA_" + node.value[0].__class__.__name__ + " *" + valueName + " = " ,
-                            node.value[0], instanceName, valueName, codeGlobal))
+                            node.value[0], instanceName, valueName, codeGlobal, asIndirect=True ))
                 code.append(
                     "UA_Variant_setScalar(&attr.value, " + valueName + ", " +
                     getTypesArrayForValue(nodeset, node.value[0]) + ");")


### PR DESCRIPTION
Hello,
I found an issue in NodesetCompiler when instantiating a user defined structure.

Basically the generated code looks like:

```c
UA_ExtensionObject *variablenode_ns_1_i_6008_variant_DataContents = *variablenode_ns_1_i_6008_TestStruct_0_0;
```

while should be

```c
UA_ExtensionObject *variablenode_ns_1_i_6008_variant_DataContents = variablenode_ns_1_i_6008_TestStruct_0_0;
```

See attached nodeset files.

[test.zip](https://github.com/open62541/open62541/files/2281243/test.zip)

