### PR TITLE
NodesetGenerator: CharArray is now considered as String

### DIFF
--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -28,7 +28,7 @@ excluded_types = ["NodeIdType", "InstanceNode", "TypeNode", "Node", "ObjectNode"
                   "UA_SessionDiagnosticsDataType"]
 
 builtin_types = ["Boolean", "SByte", "Byte", "Int16", "UInt16", "Int32", "UInt32",
-                 "Int64", "UInt64", "Float", "Double", "String", "DateTime", "Guid",
+                 "Int64", "UInt64", "Float", "Double", "String", "CharArray", "DateTime", "Guid",
                  "ByteString", "XmlElement", "NodeId", "ExpandedNodeId", "StatusCode",
                  "QualifiedName", "LocalizedText", "ExtensionObject", "DataValue",
                  "Variant", "DiagnosticInfo"]
@@ -163,7 +163,7 @@ class Type(object):
 
 class BuiltinType(Type):
     def __init__(self, name):
-        self.name = name
+        self.name = name if name != "CharArray"  else "String"
         self.ns0 = "true"
         self.typeIndex = "UA_TYPES_" + self.name.upper()
         self.outname = "ua_types"
@@ -462,6 +462,7 @@ def printc(string):
 
 def iter_types(v):
     l = None
+    del v["CharArray"]
     if sys.version_info[0] < 3:
         l = list(v.itervalues())
     else:


### PR DESCRIPTION
Trying to run the script generate_datatypes.py on data type definition (*.bsd) like the following:

```xml
    <opc:StructuredType BaseType="ua:ExtensionObject" Name="ExtendedKeyValuePair">
        <opc:Field TypeName="opc:CharArray" Name="key"/>
        <opc:Field TypeName="ua:Variant" Name="value"/>
        <opc:Field TypeName="ua:LocalizedText" Name="description"/>
    </opc:StructuredType>
```

the script enters an infinite loop, basically because the type `opc:CharArray ` is not recognized as builtin type String. The patch ensures that `opc:CharArray ` is recognized and transformed to String.

Btw, the standard says:

```xml
<opc:StructuredType Name="String">
  <opc:Documentation>A UTF-8 null terminated string value.</opc:Documentation>
  <opc:Field Name="Value" TypeName="Char" Terminator="00" />
</opc:StructuredType>
<opc:StructuredType Name="CharArray">
  <opc:Documentation>A UTF-8 string prefixed by its length in characters.</opc:Documentation>
  <opc:Field Name="Length" TypeName="Int32" />
  <opc:Field Name="Value" TypeName="Char" LengthField="Length" />
</opc:StructuredType>
```

but apparently the library only deals with CharArray calling it String.