### PR TITLE
Avoid encoding dimensions in simple array variants

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -116,6 +116,10 @@ def generateVariableNodeCode(node, nodeset, encode_binary_size):
                     code += code1
                     codeCleanup += codeCleanup1
                     codeGlobal += codeGlobal1
+                    # #1978 Variant arrayDimensions are only required to properly decode multidimensional arrays
+                    # (valueRank >= 2) from data stored as one-dimensional array of arrayLength elements.
+                    # One-dimensional arrays are already completely defined by arraylength attribute so setting
+                    # also arrayDimensions, even if not explicitly forbidden, can confuse clients
                     if node.valueRank > 1 and len(node.arrayDimensions) == node.valueRank:
                         code.append("attr.value.arrayDimensionsSize = attr.arrayDimensionsSize;")
                         code.append("attr.value.arrayDimensions = attr.arrayDimensions;")

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -116,7 +116,7 @@ def generateVariableNodeCode(node, nodeset, encode_binary_size):
                     code += code1
                     codeCleanup += codeCleanup1
                     codeGlobal += codeGlobal1
-                    if node.valueRank > 0 and len(node.arrayDimensions) == node.valueRank:
+                    if node.valueRank > 1 and len(node.arrayDimensions) == node.valueRank:
                         code.append("attr.value.arrayDimensionsSize = attr.arrayDimensionsSize;")
                         code.append("attr.value.arrayDimensions = attr.arrayDimensions;")
                 else:


### PR DESCRIPTION
 I noticed a problem with an enumeration loaded from a generated nodeset. Belowe the EnumStrings property:

```xml
    <UAVariable DataType="LocalizedText" ParentNodeId="ns=1;i=3002" ValueRank="1" NodeId="ns=1;i=6020" ArrayDimensions="3" BrowseName="EnumStrings">
        <DisplayName>EnumStrings</DisplayName>
        <References>
            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=3002</Reference>
            <Reference ReferenceType="HasModellingRule">i=78</Reference>
            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
        </References>
        <Value>
            <uax:ListOfLocalizedText>
                <uax:LocalizedText>
                    <uax:Text>ConnectedNotRunning</uax:Text>
                </uax:LocalizedText>
                <uax:LocalizedText>
                    <uax:Text>ConnectedRunning</uax:Text>
                </uax:LocalizedText>
                <uax:LocalizedText>
                    <uax:Text>Disconnected</uax:Text>
                </uax:LocalizedText>
            </uax:ListOfLocalizedText>
        </Value>
    </UAVariable>
```

The problem was that UAExpert tool was not showing it as enum like any other enum, but as an plain integer. Debugging with wireshark I found that the encoding of EnumStrings was reported not as Array but as Matrix (0xd5 instead of 0x95)

Digging further I found the problem in the commented lines.

```c
UA_VariableAttributes attr = UA_VariableAttributes_default;
attr.minimumSamplingInterval = 0.000000;
attr.userAccessLevel = 1;
attr.accessLevel = 1;
attr.valueRank = 1;
attr.arrayDimensionsSize = 1;
attr.arrayDimensions = (UA_UInt32 *)UA_Array_new(1, &UA_TYPES[UA_TYPES_UINT32]);
attr.arrayDimensions[0] = 3;
attr.dataType = UA_NODEID_NUMERIC(ns[0], 21);
UA_LocalizedText variablenode_ns_1_i_6020_variant_DataContents[3];
variablenode_ns_1_i_6020_variant_DataContents[0] = UA_LOCALIZEDTEXT("", "ConnectedNotRunning");
variablenode_ns_1_i_6020_variant_DataContents[1] = UA_LOCALIZEDTEXT("", "ConnectedRunning");
variablenode_ns_1_i_6020_variant_DataContents[2] = UA_LOCALIZEDTEXT("", "Disconnected");
UA_Variant_setArray(&attr.value, &variablenode_ns_1_i_6020_variant_DataContents, (UA_Int32) 3, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
//attr.value.arrayDimensionsSize = attr.arrayDimensionsSize;
//attr.value.arrayDimensions = attr.arrayDimensions;
attr.displayName = UA_LOCALIZEDTEXT("", "EnumStrings");
```

Basically the dimensions information was reported inside the node attributes and also inside its variant value, even if simple one-dimensional array.

To my understanding of the standard, ArrayDimensions is used to specify maximum dimension sizes as far as the Variable node class is concerned.
On the other end, for Variants, ArrayDimensions are encoded to represent the actual dimensions sizes used to properly decode the, otherwise linear, array, whose total size is arrayLength.

Even if the standard apparently does not explicitly state that, I assume that in practice explicitly encoding ArrayDimensions, if equal 1, is redundant with encoded arrayLength field and can create issues in clients expecting just an array, so should be omitted. Other implementations I tried confirm this understanding.

This patch fixes just the nodeset generator in order to produce variant ArrayDimensions only for real matrixes, not for simple arrays.



