### PR TITLE
Fix read attribute EventNotifier from Object or View since Events support

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -262,12 +262,12 @@ Read(const UA_Node *node, UA_Server *server, UA_Session *session,
     case UA_ATTRIBUTEID_EVENTNOTIFIER:
         CHECK_NODECLASS(UA_NODECLASS_VIEW | UA_NODECLASS_OBJECT);
         if(node->nodeClass == UA_NODECLASS_VIEW) {
-          setScalarNoDelete(&v->value, &((const UA_ViewNode*)node)->eventNotifier,
-                                    &UA_TYPES[UA_TYPES_BYTE]);
+            setScalarNoDelete(&v->value, &((const UA_ViewNode*)node)->eventNotifier,
+                              &UA_TYPES[UA_TYPES_BYTE]);
         }
         else{
-          setScalarNoDelete(&v->value, &((const UA_ObjectNode*)node)->eventNotifier,
-                                    &UA_TYPES[UA_TYPES_BYTE]);
+            setScalarNoDelete(&v->value, &((const UA_ObjectNode*)node)->eventNotifier,
+                              &UA_TYPES[UA_TYPES_BYTE]);
         }
         break;
     case UA_ATTRIBUTEID_VALUE: {


### PR DESCRIPTION
The View and Object node structures are not equal anymore if UA Events support is enabled.