### PR TITLE
add EventFields 'Time' and 'SourceName' in server events tutorial

### DIFF
--- a/examples/tutorial_server_events.c
+++ b/examples/tutorial_server_events.c
@@ -41,7 +41,8 @@ addNewEventType(UA_Server *server) {
  * All we need for this is our `EventType`. Once we have our event node, which is saved internally as an `ObjectNode`,
  * we can define the attributes the event has the same way we would define the attributes of an object node. It is not
  * necessary to define the attributes `EventId`, `ReceiveTime`, `SourceNode` or `EventType` since these are set
- * automatically by the server. In this example, we will only be setting `Severity` and `Message`.
+ * automatically by the server. In this example, we will be setting all the rest mandatory EventFields of the BaseEventType: 
+ * `Time` (to make the example UaExpert compliant), `Severity`, `Message` and `SourceName`.
  */
 static UA_StatusCode
 setUpEvent(UA_Server *server, UA_NodeId *outId) {
@@ -53,6 +54,10 @@ setUpEvent(UA_Server *server, UA_NodeId *outId) {
     }
 
     /* Set the Event Attributes */
+    UA_DateTime eventTime = UA_DateTime_now();
+    UA_Server_writeObjectProperty_scalar(server, *outId, UA_QUALIFIEDNAME(0, "Time"),
+                                         &eventTime, &UA_TYPES[UA_TYPES_DATETIME]);
+												 
     UA_UInt16 eventSeverity = 100;
     UA_Server_writeObjectProperty_scalar(server, *outId, UA_QUALIFIEDNAME(0, "Severity"),
                                          &eventSeverity, &UA_TYPES[UA_TYPES_UINT16]);
@@ -60,6 +65,10 @@ setUpEvent(UA_Server *server, UA_NodeId *outId) {
     UA_LocalizedText eventMessage = UA_LOCALIZEDTEXT("en-US", "An event has been generated.");
     UA_Server_writeObjectProperty_scalar(server, *outId, UA_QUALIFIEDNAME(0, "Message"),
                                          &eventMessage, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+
+    UA_String eventSourceName = UA_STRING("Server");
+    UA_Server_writeObjectProperty_scalar(server, *outId, UA_QUALIFIEDNAME(0, "SourceName"),
+										 &eventSourceName, &UA_TYPES[UA_TYPES_STRING]);
 
     return UA_STATUSCODE_GOOD;
 }

--- a/examples/tutorial_server_events.c
+++ b/examples/tutorial_server_events.c
@@ -68,7 +68,7 @@ setUpEvent(UA_Server *server, UA_NodeId *outId) {
 
     UA_String eventSourceName = UA_STRING("Server");
     UA_Server_writeObjectProperty_scalar(server, *outId, UA_QUALIFIEDNAME(0, "SourceName"),
-										 &eventSourceName, &UA_TYPES[UA_TYPES_STRING]);
+                                         &eventSourceName, &UA_TYPES[UA_TYPES_STRING]);
 
     return UA_STATUSCODE_GOOD;
 }


### PR DESCRIPTION
I extended the example to add the rest mandatory EventFields 'Time' and 'SourceName'.
UaExpert Client needs the EventField 'Time' to show the events on Event View.

That fixes #1995 and maybe relevant to issue #1839.

@Pro and @aDogCalledSpot please check it:)
