### PR TITLE
[WIP] Remove OR'ing statuscodes

### DIFF
--- a/plugins/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/ua_securitypolicy_basic128rsa15.c
@@ -520,7 +520,7 @@ sym_generateKey_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
         if(offset + hashLen > out->length) {
             outSegment.data = NULL;
             outSegment.length = 0;
-            retval |= UA_ByteString_allocBuffer(&outSegment, hashLen);
+            retval = UA_ByteString_allocBuffer(&outSegment, hashLen);
             if(retval != UA_STATUSCODE_GOOD) {
                 UA_ByteString_deleteMembers(&A_and_seed);
                 UA_ByteString_deleteMembers(&ANext_and_seed);

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -23,11 +23,14 @@ static UA_StatusCode
 setApplicationDescriptionFromRegisteredServer(const UA_FindServersRequest *request,
                                               UA_ApplicationDescription *target,
                                               const UA_RegisteredServer *registeredServer) {
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
-
     UA_ApplicationDescription_init(target);
-    retval |= UA_String_copy(&registeredServer->serverUri, &target->applicationUri);
-    retval |= UA_String_copy(&registeredServer->productUri, &target->productUri);
+    UA_StatusCode retval = UA_String_copy(&registeredServer->serverUri, &target->applicationUri);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    retval = UA_String_copy(&registeredServer->productUri, &target->productUri);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
 
     // if the client requests a specific locale, select the corresponding server name
     if(request->localeIdsSize) {
@@ -35,8 +38,10 @@ setApplicationDescriptionFromRegisteredServer(const UA_FindServersRequest *reque
         for(size_t i =0; i<request->localeIdsSize && !appNameFound; i++) {
             for(size_t j =0; j<registeredServer->serverNamesSize; j++) {
                 if(UA_String_equal(&request->localeIds[i], &registeredServer->serverNames[j].locale)) {
-                    retval |= UA_LocalizedText_copy(&registeredServer->serverNames[j],
-                                                    &target->applicationName);
+                    retval = UA_LocalizedText_copy(&registeredServer->serverNames[j],
+                                                   &target->applicationName);
+                    if(retval != UA_STATUSCODE_GOOD)
+                        return retval;
                     appNameFound = UA_TRUE;
                     break;
                 }
@@ -45,16 +50,23 @@ setApplicationDescriptionFromRegisteredServer(const UA_FindServersRequest *reque
 
         // server does not have the requested local, therefore we can select the
         // most suitable one
-        if(!appNameFound && registeredServer->serverNamesSize)
-            retval |= UA_LocalizedText_copy(&registeredServer->serverNames[0],
-                                            &target->applicationName);
+        if(!appNameFound && registeredServer->serverNamesSize) {
+            retval = UA_LocalizedText_copy(&registeredServer->serverNames[0],
+                                           &target->applicationName);
+            if(retval != UA_STATUSCODE_GOOD)
+                return retval;
+        }
     } else if(registeredServer->serverNamesSize) {
         // just take the first name
-        retval |= UA_LocalizedText_copy(&registeredServer->serverNames[0], &target->applicationName);
+        retval = UA_LocalizedText_copy(&registeredServer->serverNames[0], &target->applicationName);
+        if(retval != UA_STATUSCODE_GOOD)
+            return retval;
     }
 
     target->applicationType = registeredServer->serverType;
-    retval |= UA_String_copy(&registeredServer->gatewayServerUri, &target->gatewayServerUri);
+    retval = UA_String_copy(&registeredServer->gatewayServerUri, &target->gatewayServerUri);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
     // TODO where do we get the discoveryProfileUri for application data?
 
     target->discoveryUrlsSize = registeredServer->discoveryUrlsSize;
@@ -63,8 +75,11 @@ setApplicationDescriptionFromRegisteredServer(const UA_FindServersRequest *reque
         target->discoveryUrls = (UA_String *)UA_malloc(duSize);
         if(!target->discoveryUrls)
             return UA_STATUSCODE_BADOUTOFMEMORY;
-        for(size_t i = 0; i<registeredServer->discoveryUrlsSize; i++)
-            retval |= UA_String_copy(&registeredServer->discoveryUrls[i], &target->discoveryUrls[i]);
+        for(size_t i = 0; i < registeredServer->discoveryUrlsSize; i++) {
+            retval = UA_String_copy(&registeredServer->discoveryUrls[i], &target->discoveryUrls[i]);
+            if(retval != UA_STATUSCODE_GOOD)
+                return retval;
+        }
     }
 
     return retval;
@@ -195,9 +210,10 @@ void Service_FindServers(UA_Server *server, UA_Session *session,
 #endif
 }
 
-void Service_GetEndpoints(UA_Server *server, UA_Session *session,
-                          const UA_GetEndpointsRequest *request,
-                          UA_GetEndpointsResponse *response) {
+void
+Service_GetEndpoints(UA_Server *server, UA_Session *session,
+                     const UA_GetEndpointsRequest *request,
+                     UA_GetEndpointsResponse *response) {
     /* If the client expects to see a specific endpointurl, mirror it back. If
        not, clone the endpoints with the discovery url of all networklayers. */
     const UA_String *endpointUrl = &request->endpointUrl;
@@ -255,28 +271,31 @@ void Service_GetEndpoints(UA_Server *server, UA_Session *session,
     response->endpointsSize = relevant_count * clone_times;
 
     size_t k = 0;
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    UA_StatusCode retval;
     for(size_t i = 0; i < clone_times; ++i) {
         if(nl_endpointurl)
             endpointUrl = &server->config.networkLayers[i].discoveryUrl;
         for(size_t j = 0; j < server->config.endpointsSize; ++j) {
             if(!relevant_endpoints[j])
                 continue;
-            retval |= UA_EndpointDescription_copy(&server->config.endpoints[j].endpointDescription,
-                                                  &response->endpoints[k]);
-            retval |= UA_String_copy(endpointUrl, &response->endpoints[k].endpointUrl);
+            retval = UA_EndpointDescription_copy(&server->config.endpoints[j].endpointDescription,
+                                                 &response->endpoints[k]);
+            if(retval != UA_STATUSCODE_GOOD)
+                goto error;
+            retval = UA_String_copy(endpointUrl, &response->endpoints[k].endpointUrl);
+            if(retval != UA_STATUSCODE_GOOD)
+                goto error;
             ++k;
         }
     }
 
-    if(retval != UA_STATUSCODE_GOOD) {
-        response->responseHeader.serviceResult = retval;
-        UA_Array_delete(response->endpoints, response->endpointsSize,
-                        &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-        response->endpoints = NULL;
-        response->endpointsSize = 0;
-        return;
-    }
+    return;
+error:
+    response->responseHeader.serviceResult = retval;
+    UA_Array_delete(response->endpoints, response->endpointsSize,
+                    &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
+    response->endpoints = NULL;
+    response->endpointsSize = 0;
 }
 
 #ifdef UA_ENABLE_DISCOVERY


### PR DESCRIPTION
By OR'ing statuscodes we lose information in some cases and in those cases where they don't overlap it complicates getting the actual statuscodes.
Also in some cases we only check at the end of a function if we encountered an error. If the error happens at the beginning of the function the rest is still executed which might lead to other problems.