### PR TITLE
fix tests when UA_ENABLE_METHODCALLS is disabled

### DIFF
--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -464,6 +464,10 @@ START_TEST(Client_subscription_async_sub) {
 }
 END_TEST
 
+#endif /* UA_ENABLE_SUBSCRIPTIONS */
+
+#ifdef UA_ENABLE_METHODCALLS
+
 START_TEST(Client_methodcall) {
     UA_Client *client = UA_Client_new(UA_ClientConfig_default);
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
@@ -522,7 +526,7 @@ START_TEST(Client_methodcall) {
 }
 END_TEST
 
-#endif /* UA_ENABLE_SUBSCRIPTIONS */
+#endif /* UA_ENABLE_METHODCALLS */
 
 static Suite* testSuite_Client(void) {
     TCase *tc_client = tcase_create("Client Subscription Basic");
@@ -538,9 +542,9 @@ static Suite* testSuite_Client(void) {
 
     TCase *tc_client2 = tcase_create("Client Subscription + Method Call of GetMonitoredItmes");
     tcase_add_checked_fixture(tc_client2, setup, teardown);
-#ifdef UA_ENABLE_SUBSCRIPTIONS
+#ifdef UA_ENABLE_METHODCALLS
     tcase_add_test(tc_client2, Client_methodcall);
-#endif /* UA_ENABLE_SUBSCRIPTIONS */
+#endif /* UA_ENABLE_METHODCALLS */
 
     Suite *s = suite_create("Client Subscription");
     suite_add_tcase(s,tc_client);

--- a/tests/client/check_client_subscriptions_deprecated.c
+++ b/tests/client/check_client_subscriptions_deprecated.c
@@ -285,6 +285,10 @@ START_TEST(Client_subscription_connectionClose) {
 }
 END_TEST
 
+#endif /* UA_ENABLE_SUBSCRIPTIONS */
+
+#ifdef UA_ENABLE_METHODCALLS
+
 START_TEST(Client_methodcall) {
     UA_Client *client = UA_Client_new(UA_ClientConfig_default);
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
@@ -335,7 +339,7 @@ START_TEST(Client_methodcall) {
 }
 END_TEST
 
-#endif /* UA_ENABLE_SUBSCRIPTIONS */
+#endif /* UA_ENABLE_METHODCALLS */
 
 static Suite* testSuite_Client(void) {
     TCase *tc_client = tcase_create("Client Subscription Basic");
@@ -349,9 +353,9 @@ static Suite* testSuite_Client(void) {
 
     TCase *tc_client2 = tcase_create("Client Subscription + Method Call of GetMonitoredItmes");
     tcase_add_checked_fixture(tc_client2, setup, teardown);
-#ifdef UA_ENABLE_SUBSCRIPTIONS
+#ifdef UA_ENABLE_METHODCALLS
     tcase_add_test(tc_client2, Client_methodcall);
-#endif /* UA_ENABLE_SUBSCRIPTIONS */
+#endif /* UA_ENABLE_METHODCALLS */
 
     Suite *s = suite_create("Client Subscription");
     suite_add_tcase(s,tc_client);


### PR DESCRIPTION
When compiling open62541 with ```UA_ENABLE_METHODCALLS``` disabled, I have the following errors:

```
CMakeFiles/check_client_subscriptions.dir/client/check_client_subscriptions.c.o : Dans la fonction « Client_methodcall » :
/data/open62541/tests/client/check_client_subscriptions.c:496 : référence indéfinie vers « UA_Client_call »
/data/open62541/tests/client/check_client_subscriptions.c:513 : référence indéfinie vers « UA_Client_call »
collect2: error: ld returned 1 exit status
tests/CMakeFiles/check_client_subscriptions.dir/build.make:192 : la recette pour la cible « bin/tests/check_client_subscriptions » a échouée
make[2]: *** [bin/tests/check_client_subscriptions] Erreur 1
CMakeFiles/Makefile2:1479 : la recette pour la cible « tests/CMakeFiles/check_client_subscriptions.dir/all » a échouée
make[1]: *** [tests/CMakeFiles/check_client_subscriptions.dir/all] Erreur 2
Makefile:160 : la recette pour la cible « all » a échouée
make: *** [all] Erreur 2
```