### PR TITLE
fix Service_CreateSession after #2013

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -139,8 +139,9 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
     /* Mirror back the endpointUrl */
     for(size_t i = 0; i < response->serverEndpointsSize; ++i) {
         UA_String_deleteMembers(&response->serverEndpoints[i].endpointUrl);
-        UA_String_copy(&request->endpointUrl,
-                       &response->serverEndpoints[i].endpointUrl);
+        response->responseHeader.serviceResult |=
+            UA_String_copy(&request->endpointUrl,
+                           &response->serverEndpoints[i].endpointUrl);
     }
 
     /* Attach the session to the channel. But don't activate for now. */


### PR DESCRIPTION
Hello,

With #2013, ```UA_SessionManager_createSession``` was moved up.

In some cases of errors the session is not removed. This PR fix this problem.

In some other places the value of ```response->responseHeader.serviceResult``` is overwritten. This PR fix this problem.

@pro @jpfr  can you review the code?

@mlang-de can you test this PR with CTT?

