### PR TITLE
Remove invalid free in ua_subscription_events

### DIFF
--- a/src/server/ua_subscription_events.c
+++ b/src/server/ua_subscription_events.c
@@ -28,7 +28,8 @@ UA_MonitoredItem_removeNodeEventCallback(UA_Server *server, UA_Session *session,
             UA_MonitoredItem *iter = ((UA_ObjectNode *) node)->monitoredItemQueue;
             for (; iter->next != entry; iter=iter->next) {}
             iter->next = entry->next;
-            UA_free(entry);
+            /* Unlike SLIST_REMOVE, do not free the entry, since it
+             * is still being worked on in the calling function */
             break;
         }
     }


### PR DESCRIPTION
An invalid free was causing the server to crash when either creating multiple monitored items on a single node or shutting down the client before closing the subscription.