### PR TITLE
Elaborate on "mandatory" event fields

### DIFF
--- a/examples/tutorial_server_events.c
+++ b/examples/tutorial_server_events.c
@@ -41,8 +41,8 @@ addNewEventType(UA_Server *server) {
  * All we need for this is our `EventType`. Once we have our event node, which is saved internally as an `ObjectNode`,
  * we can define the attributes the event has the same way we would define the attributes of an object node. It is not
  * necessary to define the attributes `EventId`, `ReceiveTime`, `SourceNode` or `EventType` since these are set
- * automatically by the server. In this example, we will be setting all the rest mandatory EventFields of the BaseEventType: 
- * `Time` (to make the example UaExpert compliant), `Severity`, `Message` and `SourceName`.
+ * automatically by the server. In this example, we will be setting the fields 'Message' and 'Severity' in addition
+ * to `Time` which is needed to make the example UaExpert compliant.
  */
 static UA_StatusCode
 setUpEvent(UA_Server *server, UA_NodeId *outId) {
@@ -54,6 +54,7 @@ setUpEvent(UA_Server *server, UA_NodeId *outId) {
     }
 
     /* Set the Event Attributes */
+    /* Setting the Time is required or else the event will not show up in UAExpert! */
     UA_DateTime eventTime = UA_DateTime_now();
     UA_Server_writeObjectProperty_scalar(server, *outId, UA_QUALIFIEDNAME(0, "Time"),
                                          &eventTime, &UA_TYPES[UA_TYPES_DATETIME]);

--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -1204,8 +1204,10 @@ UA_Server_deleteReference(UA_Server *server, const UA_NodeId sourceNodeId,
  * The method ``UA_Server_createEvent`` creates an event and represents it as node. The node receives a unique `EventId`
  * which is automatically added to the node.
  * The method returns a `NodeId` to the object node which represents the event through ``outNodeId``. The `NodeId` can
- * be used to set the attributes of the event. The generated `NodeId` is always numeric. ``outNodeId`` cannot be 
+ * be used to set the attributes of the event. The generated `NodeId` is always numeric. ``outNodeId`` cannot be
  * ``NULL``.
+ *
+ * Note: In order to see an event in UAExpert, the field `Time` must be given a value!
  *
  * The method ``UA_Server_triggerEvent`` "triggers" an event by adding it to all monitored items of the specified
  * origin node and those of all its parents. Any filters specified by the monitored items are automatically applied.


### PR DESCRIPTION
Change a few lines in documentation and example to point out the necessity of the Time field if events should be monitored using UAExpert.