### PR TITLE
Fix: Build with UA_ENABLE_DISCOVERY_MULTICAST

### DIFF
--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -122,7 +122,8 @@ void UA_sleep_ms(size_t ms);
 #define UA_calloc calloc
 #define UA_realloc realloc
 
-#define UA_snprintf(source, size, string, ...) _snprintf_s(source, size, _TRUNCATE, string, __VA_ARGS__)
+/* 3rd Argument is the string */
+#define UA_snprintf(source, size, ...) _snprintf_s(source, size, _TRUNCATE, __VA_ARGS__)
 
 #define UA_LOG_SOCKET_ERRNO_WRAP(LOG) { \
     char *errno_str = NULL; \


### PR DESCRIPTION
When Building with UA_ENABLE_DISCOVERY_MULTICAST, the build failes with the following error:
`open62541.c:44080:73: error: ISO C99 requires at least one argument for the "..." in a variadic macro [-Werror]      UA_snprintf(&outServiceDomain[offset], 24, "._opcua-tcp._tcp.local.");`

Corresponding codeline:
https://github.com/open62541/open62541/blob/06834b9f1ecc869fe2eda70738fd5bc1b85c5d39/src/server/ua_services_discovery_multicast.c#L348

I do not like my solution that much, but it seems the easiest way to solve it...