### PR TITLE
Correctly check for gcc compiler. Fixes #2039

### DIFF
--- a/tools/travis/travis_linux_after_success.sh
+++ b/tools/travis/travis_linux_after_success.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 set -ev
 
-if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
-	# Only on non-docker builds required
-
-	if [ "$ANALYZE" = "false" ] && [ "$CC" = "gcc" ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ]; then
-		echo "=== Executing after_success scripts ==="
-		# List branches where the doc should be pushed to the webpage
-		if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && (
-		    [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "0.3" ]); then
-			sh ./tools/travis/travis_push_doc.sh
-			sh ./tools/travis/travis_push_coverity.sh
-		fi
-		sh ./tools/travis/travis_push_release.sh;
-	else
-		echo "=== Not in the main repository or not the main build; Skip release scripts ==="
-	fi
+# We only want to push the docs once, so we just take the travis run where MINGW=true which is only enabled once
+if [ -z ${MINGW+x} ]; then
+    echo "=== Executing after_success scripts ==="
+    # List branches where the doc should be pushed to the webpage
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && (
+        [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "0.3" ]); then
+        sh ./tools/travis/travis_push_doc.sh
+        sh ./tools/travis/travis_push_coverity.sh
+    fi
+    sh ./tools/travis/travis_push_release.sh;
+else
+    echo "=== Not in the main repository or not the main build; Skip release scripts ==="
+    exit 0;
 fi

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -258,9 +258,10 @@ else
         if [ $? -ne 0 ] ; then exit 1 ; fi
         echo -en 'travis_fold:end:script.build.unit_test_ns0_minimal\\r'
 
-        # only run coveralls on main repo, otherwise it fails uploading the files
+        # only run coveralls on main repo and when MINGW=true
+        # We only want to build coveralls once, so we just take the travis run where MINGW=true which is only enabled once
         echo -e "\r\n== -> Current repo: ${TRAVIS_REPO_SLUG} =="
-        if [ "$CC" = "gcc" ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ]; then
+        if [ -z ${MINGW+x} ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ]; then
             echo -en "\r\n==   Building coveralls for ${TRAVIS_REPO_SLUG} ==" && echo -en 'travis_fold:start:script.build.coveralls\\r'
             coveralls -E '.*/build/CMakeFiles/.*' -E '.*/examples/.*' -E '.*/tests/.*' -E '.*\.h' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -r ../ || true # ignore result since coveralls is unreachable from time to time
             echo -en 'travis_fold:end:script.build.coveralls\\r'


### PR DESCRIPTION
We changed the `CC` define from the default `gcc` to `gcc-4.8` thus we can not use normal string compare, but would need to use beginswith (https://stackoverflow.com/questions/2172352/in-bash-how-can-i-check-if-a-string-begins-with-some-value).