### PR TITLE
Don't prepare NodeIds for logging when the loglevel is too high

### DIFF
--- a/plugins/historydata/ua_historydatabackend_memory.h
+++ b/plugins/historydata/ua_historydatabackend_memory.h
@@ -10,12 +10,9 @@
 
 #include "ua_plugin_history_data_backend.h"
 
+_UA_BEGIN_DECLS
+
 #define INITIAL_MEMORY_STORE_SIZE 1000
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 UA_HistoryDataBackend UA_EXPORT
 UA_HistoryDataBackend_Memory(size_t initialNodeIdStoreSize, size_t initialDataStoreSize);
@@ -23,8 +20,6 @@ UA_HistoryDataBackend_Memory(size_t initialNodeIdStoreSize, size_t initialDataSt
 void UA_EXPORT
 UA_HistoryDataBackend_Memory_deleteMembers(UA_HistoryDataBackend *backend);
 
-#ifdef __cplusplus
-}
-#endif
+_UA_END_DECLS
 
 #endif /* UA_HISTORYDATABACKEND_MEMORY_H_ */

--- a/plugins/historydata/ua_historydatabase_default.h
+++ b/plugins/historydata/ua_historydatabase_default.h
@@ -12,15 +12,11 @@
 #include "ua_plugin_historydatabase.h"
 #include "ua_plugin_history_data_gathering.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+_UA_BEGIN_DECLS
 
 UA_HistoryDatabase UA_EXPORT
 UA_HistoryDatabase_default(UA_HistoryDataGathering gathering);
 
-#ifdef __cplusplus
-}
-#endif
+_UA_END_DECLS
 
 #endif /* UA_HISTORYDATASERVICE_DEFAULT_H_ */

--- a/plugins/historydata/ua_historydatagathering_default.h
+++ b/plugins/historydata/ua_historydatagathering_default.h
@@ -10,16 +10,11 @@
 
 #include "ua_plugin_history_data_gathering.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+_UA_BEGIN_DECLS
 
 UA_HistoryDataGathering UA_EXPORT
 UA_HistoryDataGathering_Default(size_t initialNodeIdStoreSize);
 
-#ifdef __cplusplus
-}
-#endif
+_UA_END_DECLS
 
 #endif /* UA_HISTORYDATAGATHERING_DEFAULT_H_ */

--- a/plugins/historydata/ua_plugin_history_data_backend.h
+++ b/plugins/historydata/ua_plugin_history_data_backend.h
@@ -8,12 +8,10 @@
 #ifndef UA_PLUGIN_HISTORY_DATA_BACKEND_H_
 #define UA_PLUGIN_HISTORY_DATA_BACKEND_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_types.h"
 #include "ua_server.h"
+
+_UA_BEGIN_DECLS
 
 typedef enum {
     MATCH_EQUAL,
@@ -39,8 +37,7 @@ struct UA_HistoryDataBackend {
      * nodeId is the node for which the value shall be stored.
      * value is the value which shall be stored.
      * historizing is the historizing flag of the node identified by nodeId.
-     * If sessionId is NULL, the historizing flag is invalid and must not be used.
-     */
+     * If sessionId is NULL, the historizing flag is invalid and must not be used. */
     UA_StatusCode
     (*serverSetHistoryData)(UA_Server *server,
                             void *hdbContext,
@@ -50,11 +47,12 @@ struct UA_HistoryDataBackend {
                             UA_Boolean historizing,
                             const UA_DataValue *value);
 
-    /* This function is the high level interface for the ReadRaw operation.
-     * Set it to NULL if you use the low level API for your plugin.
-     * It should be used if the low level interface does not suite your database.
-     * It is more complex to implement the high level interface but it also provide more freedom.
-     * If you implement this, then set all low level api function pointer to NULL.
+    /* This function is the high level interface for the ReadRaw operation. Set
+     * it to NULL if you use the low level API for your plugin. It should be
+     * used if the low level interface does not suite your database. It is more
+     * complex to implement the high level interface but it also provide more
+     * freedom. If you implement this, then set all low level api function
+     * pointer to NULL.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
@@ -70,9 +68,9 @@ struct UA_HistoryDataBackend {
      * range is the numeric range the client wants to read.
      * releaseContinuationPoints determines if the continuation points shall be released.
      * continuationPoint is the continuation point the client wants to release or start from.
-     * outContinuationPoint is the continuation point that gets passed to the client by the HistoryRead service.
-     * result contains the result histoy data that gets passed to the client.
-     */
+     * outContinuationPoint is the continuation point that gets passed to the
+     *                      client by the HistoryRead service.
+     * result contains the result histoy data that gets passed to the client. */
     UA_StatusCode
     (*getHistoryData)(UA_Server *server,
                       const UA_NodeId *sessionId,
@@ -91,16 +89,15 @@ struct UA_HistoryDataBackend {
                       UA_ByteString *outContinuationPoint,
                       UA_HistoryData *result);
 
-    /* This function is part of the low level HistoryRead API.
-     * It returns the index of a value in the database which matches certain criteria.
+    /* This function is part of the low level HistoryRead API. It returns the
+     * index of a value in the database which matches certain criteria.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
      * sessionId and sessionContext identify the session that wants to read historical data.
      * nodeId is the node id of the node for which the matching value shall be found.
      * timestamp is the timestamp of the requested index.
-     * strategy is the matching strategy which shall be applied in finding the index.
-     */
+     * strategy is the matching strategy which shall be applied in finding the index. */
     size_t
     (*getDateTimeMatch)(UA_Server *server,
                         void *hdbContext,
@@ -110,14 +107,14 @@ struct UA_HistoryDataBackend {
                         const UA_DateTime timestamp,
                         const MatchStrategy strategy);
 
-    /* This function is part of the low level HistoryRead API.
-     * It returns the index of the element after the last valid entry in the database for a node.
+    /* This function is part of the low level HistoryRead API. It returns the
+     * index of the element after the last valid entry in the database for a
+     * node.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
      * sessionId and sessionContext identify the session that wants to read historical data.
-     * nodeId is the node id of the node for which the end of storage shall be returned.
-     */
+     * nodeId is the node id of the node for which the end of storage shall be returned. */
     size_t
     (*getEnd)(UA_Server *server,
               void *hdbContext,
@@ -125,14 +122,14 @@ struct UA_HistoryDataBackend {
               void *sessionContext,
               const UA_NodeId *nodeId);
 
-    /* This function is part of the low level HistoryRead API.
-     * It returns the index of the last element in the database for a node.
+    /* This function is part of the low level HistoryRead API. It returns the
+     * index of the last element in the database for a node.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
      * sessionId and sessionContext identify the session that wants to read historical data.
-     * nodeId is the node id of the node for which the index of the last element shall be returned.
-     */
+     * nodeId is the node id of the node for which the index of the last element
+     *        shall be returned. */
     size_t
     (*lastIndex)(UA_Server *server,
                  void *hdbContext,
@@ -140,14 +137,14 @@ struct UA_HistoryDataBackend {
                  void *sessionContext,
                  const UA_NodeId *nodeId);
 
-    /* This function is part of the low level HistoryRead API.
-     * It returns the index of the first element in the database for a node.
+    /* This function is part of the low level HistoryRead API. It returns the
+     * index of the first element in the database for a node.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
      * sessionId and sessionContext identify the session that wants to read historical data.
-     * nodeId is the node id of the node for which the index of the first element shall be returned.
-     */
+     * nodeId is the node id of the node for which the index of the first
+     *        element shall be returned. */
     size_t
     (*firstIndex)(UA_Server *server,
                   void *hdbContext,
@@ -155,16 +152,15 @@ struct UA_HistoryDataBackend {
                   void *sessionContext,
                   const UA_NodeId *nodeId);
 
-    /* This function is part of the low level HistoryRead API.
-     * It returns the number of elements between startIndex and endIndex including both.
+    /* This function is part of the low level HistoryRead API. It returns the
+     * number of elements between startIndex and endIndex including both.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
      * sessionId and sessionContext identify the session that wants to read historical data.
      * nodeId is the node id of the node for which the number of elements shall be returned.
      * startIndex is the index of the first element in the range.
-     * endIndex is the index of the last element in the range.
-     */
+     * endIndex is the index of the last element in the range. */
     size_t
     (*resultSize)(UA_Server *server,
                   void *hdbContext,
@@ -174,8 +170,8 @@ struct UA_HistoryDataBackend {
                   size_t startIndex,
                   size_t endIndex);
 
-    /* This function is part of the low level HistoryRead API.
-     * It copies data values inside a certain range into a buffer.
+    /* This function is part of the low level HistoryRead API. It copies data
+     * values inside a certain range into a buffer.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
@@ -190,8 +186,7 @@ struct UA_HistoryDataBackend {
      * continuationPoint is a continuation point the client wants to release or start from.
      * outContinuationPoint is a continuation point which will be passed to the client.
      * providedValues contains the number of values that were copied.
-     * values contains the values that have been copied from the database.
-     */
+     * values contains the values that have been copied from the database. */
     UA_StatusCode
     (*copyDataValues)(UA_Server *server,
                       void *hdbContext,
@@ -209,15 +204,14 @@ struct UA_HistoryDataBackend {
                       size_t *providedValues,
                       UA_DataValue *values);
 
-    /* This function is part of the low level HistoryRead API.
-     * It returns the data value stored at a certain index in the database.
+    /* This function is part of the low level HistoryRead API. It returns the
+     * data value stored at a certain index in the database.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
      * sessionId and sessionContext identify the session that wants to read historical data.
      * nodeId is the node id of the node for which the data value shall be returned.
-     * index is the index in the database for which the data value is requested.
-     */
+     * index is the index in the database for which the data value is requested. */
     const UA_DataValue*
     (*getDataValue)(UA_Server *server,
                     void *hdbContext,
@@ -226,14 +220,15 @@ struct UA_HistoryDataBackend {
                     const UA_NodeId *nodeId,
                     size_t index);
 
-    /* This function returns UA_TRUE if the backend supports returning bounding values for a node.
-     * This function is mandatory.
+    /* This function returns UA_TRUE if the backend supports returning bounding
+     * values for a node. This function is mandatory.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
-     * sessionId and sessionContext identify the session that wants to read historical data.
-     * nodeId is the node id of the node for which the capability to return bounds shall be queried.
-     */
+     * sessionId and sessionContext identify the session that wants to read
+     *           historical data.
+     * nodeId is the node id of the node for which the capability to return
+     *        bounds shall be queried. */
     UA_Boolean
     (*boundSupported)(UA_Server *server,
                       void *hdbContext,
@@ -241,14 +236,14 @@ struct UA_HistoryDataBackend {
                       void *sessionContext,
                       const UA_NodeId *nodeId);
 
-    /* This function returns UA_TRUE if the backend supports returning the requested timestamps for a node.
-     * This function is mandatory.
+    /* This function returns UA_TRUE if the backend supports returning the
+     * requested timestamps for a node. This function is mandatory.
      *
      * server is the server the node lives in.
      * hdbContext is the context of the UA_HistoryDataBackend.
      * sessionId and sessionContext identify the session that wants to read historical data.
-     * nodeId is the node id of the node for which the capability to return certain timestamps shall be queried.
-     */
+     * nodeId is the node id of the node for which the capability to return
+     *        certain timestamps shall be queried. */
     UA_Boolean
     (*timestampsToReturnSupported)(UA_Server *server,
                                    void *hdbContext,
@@ -256,11 +251,8 @@ struct UA_HistoryDataBackend {
                                    void *sessionContext,
                                    const UA_NodeId *nodeId,
                                    const UA_TimestampsToReturn timestampsToReturn);
-
 };
 
-#ifdef __cplusplus
-}
-#endif
+_UA_END_DECLS
 
 #endif /* UA_PLUGIN_HISTORY_DATA_BACKEND_H_ */

--- a/plugins/historydata/ua_plugin_history_data_gathering.h
+++ b/plugins/historydata/ua_plugin_history_data_gathering.h
@@ -8,13 +8,11 @@
 #ifndef UA_PLUGIN_HISTORY_DATA_GATHERING_H_
 #define UA_PLUGIN_HISTORY_DATA_GATHERING_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_types.h"
 #include "ua_server.h"
 #include "ua_plugin_history_data_backend.h"
+
+_UA_BEGIN_DECLS
 
 typedef enum {
     UA_HISTORIZINGUPDATESTRATEGY_USER     = 0x00,
@@ -43,8 +41,7 @@ struct UA_HistoryDataGathering {
      * server is the server the node lives in.
      * hdgContext is the context of the UA_HistoryDataGathering.
      * nodeId is the node id of the node to register.
-     * setting contains the gatering settings for the node to register.
-     */
+     * setting contains the gatering settings for the node to register. */
     UA_StatusCode
     (*registerNodeId)(UA_Server *server,
                       void *hdgContext,
@@ -56,8 +53,7 @@ struct UA_HistoryDataGathering {
      * server is the server the node lives in.
      * hdgContext is the context of the UA_HistoryDataGathering.
      * nodeId is id of the node for which polling shall be stopped.
-     * setting contains the gatering settings for the node.
-     */
+     * setting contains the gatering settings for the node. */
     UA_StatusCode
     (*stopPoll)(UA_Server *server,
                 void *hdgContext,
@@ -67,8 +63,7 @@ struct UA_HistoryDataGathering {
      *
      * server is the server the node lives in.
      * hdgContext is the context of the UA_HistoryDataGathering.
-     * nodeId is the id of the node for which polling shall be started.
-     */
+     * nodeId is the id of the node for which polling shall be started. */
     UA_StatusCode
     (*startPoll)(UA_Server *server,
                  void *hdgContext,
@@ -79,8 +74,7 @@ struct UA_HistoryDataGathering {
      * server is the server the node lives in.
      * hdgContext is the context of the UA_HistoryDataGathering.
      * nodeId is the node id of the node for which gathering shall be modified.
-     * setting contains the new gatering settings for the node.
-     */
+     * setting contains the new gatering settings for the node. */
     UA_Boolean
     (*updateNodeIdSetting)(UA_Server *server,
                            void *hdgContext,
@@ -91,8 +85,8 @@ struct UA_HistoryDataGathering {
      *
      * server is the server the node lives in.
      * hdgContext is the context of the UA_HistoryDataGathering.
-     * nodeId is the node id of the node for which the gathering settings shall be retrieved.
-     */
+     * nodeId is the node id of the node for which the gathering settings shall
+     *        be retrieved. */
     const UA_HistorizingNodeIdSettings*
     (*getHistorizingSetting)(UA_Server *server,
                              void *hdgContext,
@@ -105,8 +99,7 @@ struct UA_HistoryDataGathering {
      * sessionId and sessionContext identify the session which wants to set this value.
      * nodeId is the node id of the node for which a value shall be set.
      * historizing is the historizing flag of the node identified by nodeId.
-     * value is the value to set in the history data storage.
-     */
+     * value is the value to set in the history data storage. */
     void
     (*setValue)(UA_Server *server,
                 void *hdgContext,
@@ -117,8 +110,6 @@ struct UA_HistoryDataGathering {
                 const UA_DataValue *value);
 };
 
-#ifdef __cplusplus
-}
-#endif
+_UA_END_DECLS
 
 #endif /* UA_PLUGIN_HISTORY_DATA_GATHERING_H_ */

--- a/plugins/ua_config_default.h
+++ b/plugins/ua_config_default.h
@@ -25,8 +25,6 @@ extern const UA_EXPORT UA_ConnectionConfig UA_ConnectionConfig_default;
 /* Default Server Config */
 /*************************/
 
-
-
 /* Creates a new server config with one endpoint and custom buffer size.
  *
  * The config will set the tcp network layer to the given port and adds a single
@@ -42,7 +40,8 @@ extern const UA_EXPORT UA_ConnectionConfig UA_ConnectionConfig_default;
  *
  */
 UA_EXPORT UA_ServerConfig *
-UA_ServerConfig_new_customBuffer(UA_UInt16 portNumber, const UA_ByteString *certificate, UA_UInt32 sendBufferSize, UA_UInt32 recvBufferSize);
+UA_ServerConfig_new_customBuffer(UA_UInt16 portNumber, const UA_ByteString *certificate,
+                                 UA_UInt32 sendBufferSize, UA_UInt32 recvBufferSize);
 
 /* Creates a new server config with one endpoint.
  * 

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -19,6 +19,8 @@
 #include "ua_timer.h"
 #include "../../deps/queue.h"
 
+_UA_BEGIN_DECLS
+
 /**************************/
 /* Subscriptions Handling */
 /**************************/
@@ -226,4 +228,7 @@ UA_Client_delayedCallback(UA_Client *client, UA_ClientCallback callback,
                           void *data);
 UA_StatusCode
 UA_Client_connect_iterate (UA_Client *client);
+
+_UA_END_DECLS
+
 #endif /* UA_CLIENT_INTERNAL_H_ */

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -8,15 +8,13 @@
 #ifndef UA_PUBSUB_H_
 #define UA_PUBSUB_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_plugin_pubsub.h"
 #include "ua_pubsub_networkmessage.h"
 #include "ua_server.h"
 #include "ua_server_pubsub.h"
 #include "../deps/queue.h"
+
+_UA_BEGIN_DECLS
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 
@@ -156,8 +154,6 @@ UA_WriterGroup_publishCallback(UA_Server *server, UA_WriterGroup *writerGroup);
 
 #endif /* UA_ENABLE_PUBSUB */
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_PUBSUB_H_ */

--- a/src/pubsub/ua_pubsub_manager.h
+++ b/src/pubsub/ua_pubsub_manager.h
@@ -8,12 +8,10 @@
 #ifndef UA_PUBSUB_MANAGER_H_
 #define UA_PUBSUB_MANAGER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_pubsub.h"
 #include "ua_server_pubsub.h"
+
+_UA_BEGIN_DECLS
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 
@@ -48,8 +46,6 @@ UA_PubSubManager_removeRepeatedPubSubCallback(UA_Server *server, UA_UInt64 callb
 
 #endif /* UA_ENABLE_PUBSUB */
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_PUBSUB_MANAGER_H_ */

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -5,15 +5,13 @@
  * Copyright (c) 2017 - 2018 Fraunhofer IOSB (Author: Tino Bischoff)
  */
 
-#ifndef UA_NETWORKMESSAGE_H_
-#define UA_NETWORKMESSAGE_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#ifndef UA_PUBSUB_NETWORKMESSAGE_H_
+#define UA_PUBSUB_NETWORKMESSAGE_H_
 
 #include "ua_types.h"
 #include "ua_types_generated.h"
+
+_UA_BEGIN_DECLS
 
 /* DataSet Payload Header */
 typedef struct {
@@ -217,9 +215,6 @@ UA_NetworkMessage_deleteMembers(UA_NetworkMessage* p);
 void
 UA_NetworkMessage_delete(UA_NetworkMessage* p);
 
+_UA_END_DECLS
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
-
-#endif /* UA_NETWORKMESSAGE_H_ */
+#endif /* UA_PUBSUB_NETWORKMESSAGE_H_ */

--- a/src/pubsub/ua_pubsub_ns0.h
+++ b/src/pubsub/ua_pubsub_ns0.h
@@ -5,15 +5,13 @@
  * Copyright (c) 2017-2018 Fraunhofer IOSB (Author: Andreas Ebner)
  */
 
-#ifndef OPEN62541_UA_PUBSUB_NS0_H
-#define OPEN62541_UA_PUBSUB_NS0_H
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#ifndef UA_PUBSUB_NS0_H_
+#define UA_PUBSUB_NS0_H_
 
 #include "server/ua_server_internal.h"
 #include "ua_pubsub.h"
+
+_UA_BEGIN_DECLS
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL /* conditional compilation */
 
@@ -46,8 +44,6 @@ removePublishedDataSetRepresentation(UA_Server *server, UA_PublishedDataSet *pub
 
 #endif /* UA_ENABLE_PUBSUB_INFORMATIONMODEL */
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
-#endif //OPEN62541_UA_PUBSUB_NS0_H
+#endif /* UA_PUBSUB_NS0_H_ */

--- a/src/server/ua_mdns_internal.h
+++ b/src/server/ua_mdns_internal.h
@@ -5,10 +5,16 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  */
 
-#ifndef UA_MDNS_INTERNAL_H
-#define UA_MDNS_INTERNAL_H
+#ifndef UA_MDNS_INTERNAL_H_
+#define UA_MDNS_INTERNAL_H_
+
+#include "ua_config.h"
+
+_UA_BEGIN_DECLS
 
 #ifdef UA_ENABLE_DISCOVERY_MULTICAST
+
+#include "mdnsd/libmdnsd/mdnsd.h"
 
 /**
  * TXT record:
@@ -18,12 +24,6 @@
  * [servername]-[hostname]._opcua-tcp._tcp.local. A [ip].
  * [hostname]. A [ip].
  */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "mdnsd/libmdnsd/mdnsd.h"
 
 void mdns_record_received(const struct resource *r, void *data);
 
@@ -45,10 +45,8 @@ UA_Discovery_update_MdnsForDiscoveryUrl(UA_Server *server, const UA_String *serv
                                         const UA_String *discoveryUrl,
                                         UA_Boolean isOnline, UA_Boolean updateTxt);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+#endif /* UA_ENABLE_DISCOVERY_MULTICAST */
 
-#endif // UA_ENABLE_DISCOVERY_MULTICAST
+_UA_END_DECLS
 
-#endif //UA_MDNS_INTERNAL_H
+#endif /* UA_MDNS_INTERNAL_H_ */

--- a/src/server/ua_securechannel_manager.h
+++ b/src/server/ua_securechannel_manager.h
@@ -11,14 +11,12 @@
 #ifndef UA_CHANNEL_MANAGER_H_
 #define UA_CHANNEL_MANAGER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_util_internal.h"
 #include "ua_server.h"
 #include "ua_securechannel.h"
 #include "../../deps/queue.h"
+
+_UA_BEGIN_DECLS
 
 typedef struct channel_entry {
     UA_SecureChannel channel;
@@ -67,8 +65,6 @@ UA_SecureChannelManager_get(UA_SecureChannelManager *cm, UA_UInt32 channelId);
 UA_StatusCode
 UA_SecureChannelManager_close(UA_SecureChannelManager *cm, UA_UInt32 channelId);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_CHANNEL_MANAGER_H_ */

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -14,10 +14,6 @@
 #ifndef UA_SERVER_INTERNAL_H_
 #define UA_SERVER_INTERNAL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_util_internal.h"
 #include "ua_server.h"
 #include "ua_server_config.h"
@@ -25,6 +21,8 @@ extern "C" {
 #include "ua_connection_internal.h"
 #include "ua_session_manager.h"
 #include "ua_securechannel_manager.h"
+
+_UA_BEGIN_DECLS
 
 #ifdef UA_ENABLE_PUBSUB
 #include "ua_pubsub_manager.h"
@@ -448,8 +446,6 @@ AddNode_finish(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId);
 
 UA_StatusCode UA_Server_initNS0(UA_Server *server);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_SERVER_INTERNAL_H_ */

--- a/src/server/ua_services.h
+++ b/src/server/ua_services.h
@@ -15,12 +15,10 @@
 #ifndef UA_SERVICES_H_
 #define UA_SERVICES_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_server.h"
 #include "ua_session.h"
+
+_UA_BEGIN_DECLS
 
 /**
  * .. _services:
@@ -494,8 +492,6 @@ void Service_DeleteSubscriptions(UA_Server *server, UA_Session *session,
 
 #endif /* UA_ENABLE_SUBSCRIPTIONS */
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_SERVICES_H_ */

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -109,23 +109,47 @@ UA_PublishResponseEntry* UA_Session_dequeuePublishReq(UA_Session *session);
         UA_String_deleteMembers(&idString);                             \
     } while(0)
 
+#if UA_LOGLEVEL <= 100
 #define UA_LOG_TRACE_SESSION(LOGGER, SESSION, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_SESSION_INTERNAL(LOGGER, TRACE, SESSION, __VA_ARGS__, ""))
+#else
+#define UA_LOG_TRACE_SESSION(LOGGER, SESSION, ...) do {} while(0)
+#endif
 
+#if UA_LOGLEVEL <= 200
 #define UA_LOG_DEBUG_SESSION(LOGGER, SESSION, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_SESSION_INTERNAL(LOGGER, DEBUG, SESSION, __VA_ARGS__, ""))
+#else
+#define UA_LOG_DEBUG_SESSION(LOGGER, SESSION, ...) do {} while(0)
+#endif
 
+#if UA_LOGLEVEL <= 300
 #define UA_LOG_INFO_SESSION(LOGGER, SESSION, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_SESSION_INTERNAL(LOGGER, INFO, SESSION, __VA_ARGS__, ""))
+#else
+#define UA_LOG_INFO_SESSION(LOGGER, SESSION, ...) do {} while(0)
+#endif
 
+#if UA_LOGLEVEL <= 400
 #define UA_LOG_WARNING_SESSION(LOGGER, SESSION, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_SESSION_INTERNAL(LOGGER, WARNING, SESSION, __VA_ARGS__, ""))
+#else
+#define UA_LOG_WARNING_SESSION(LOGGER, SESSION, ...) do {} while(0)
+#endif
 
+#if UA_LOGLEVEL <= 500
 #define UA_LOG_ERROR_SESSION(LOGGER, SESSION, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_SESSION_INTERNAL(LOGGER, ERROR, SESSION, __VA_ARGS__, ""))
+#else
+#define UA_LOG_ERROR_SESSION(LOGGER, SESSION, ...) do {} while(0)
+#endif
 
+#if UA_LOGLEVEL <= 600
 #define UA_LOG_FATAL_SESSION(LOGGER, SESSION, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_SESSION_INTERNAL(LOGGER, FATAL, SESSION, __VA_ARGS__, ""))
+#else
+#define UA_LOG_FATAL_SESSION(LOGGER, SESSION, ...) do {} while(0)
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -8,12 +8,10 @@
 #ifndef UA_SESSION_H_
 #define UA_SESSION_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_securechannel.h"
 #include "ua_util.h"
+
+_UA_BEGIN_DECLS
 
 #define UA_MAXCONTINUATIONPOINTS 5
 
@@ -168,8 +166,6 @@ UA_Session_dequeuePublishReq(UA_Session *session);
 #define UA_LOG_FATAL_SESSION(LOGGER, SESSION, ...) do {} while(0)
 #endif
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_SESSION_H_ */

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -82,11 +82,25 @@ void UA_Session_updateLifetime(UA_Session *session);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 
-void UA_Session_addSubscription(UA_Session *session, UA_Subscription *newSubscription);
-UA_Subscription * UA_Session_getSubscriptionById(UA_Session *session, UA_UInt32 subscriptionId);
-UA_StatusCode UA_Session_deleteSubscription(UA_Server *server, UA_Session *session, UA_UInt32 subscriptionId);
-void UA_Session_queuePublishReq(UA_Session *session, UA_PublishResponseEntry* entry, UA_Boolean head);
-UA_PublishResponseEntry* UA_Session_dequeuePublishReq(UA_Session *session);
+void
+UA_Session_addSubscription(UA_Session *session,
+                           UA_Subscription *newSubscription);
+
+UA_Subscription *
+UA_Session_getSubscriptionById(UA_Session *session,
+                               UA_UInt32 subscriptionId);
+
+UA_StatusCode
+UA_Session_deleteSubscription(UA_Server *server, UA_Session *session,
+                              UA_UInt32 subscriptionId);
+
+void
+UA_Session_queuePublishReq(UA_Session *session,
+                           UA_PublishResponseEntry* entry,
+                           UA_Boolean head);
+
+UA_PublishResponseEntry *
+UA_Session_dequeuePublishReq(UA_Session *session);
 
 #endif
 
@@ -103,8 +117,11 @@ UA_PublishResponseEntry* UA_Session_dequeuePublishReq(UA_Session *session);
         UA_NodeId_toString(&(SESSION)->sessionId, &idString);           \
         UA_LOG_##LEVEL(LOGGER, UA_LOGCATEGORY_SESSION,                  \
                        "Connection %i | SecureChannel %i | Session %.*s | " MSG "%.0s", \
-                       ((SESSION)->header.channel ? ((SESSION)->header.channel->connection ? (SESSION)->header.channel->connection->sockfd : 0) : 0), \
-                       ((SESSION)->header.channel ? (SESSION)->header.channel->securityToken.channelId : 0), \
+                       ((SESSION)->header.channel ?                     \
+                        ((SESSION)->header.channel->connection ?        \
+                         (SESSION)->header.channel->connection->sockfd : 0) : 0), \
+                       ((SESSION)->header.channel ?                     \
+                        (SESSION)->header.channel->securityToken.channelId : 0), \
                        (int)idString.length, idString.data, __VA_ARGS__); \
         UA_String_deleteMembers(&idString);                             \
     } while(0)

--- a/src/server/ua_session_manager.h
+++ b/src/server/ua_session_manager.h
@@ -12,14 +12,12 @@
 #ifndef UA_SESSION_MANAGER_H_
 #define UA_SESSION_MANAGER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_server.h"
 #include "ua_util_internal.h"
 #include "ua_session.h"
 #include "../../deps/queue.h"
+
+_UA_BEGIN_DECLS
 
 typedef struct session_list_entry {
     LIST_ENTRY(session_list_entry) pointers;
@@ -57,8 +55,6 @@ UA_SessionManager_getSessionByToken(UA_SessionManager *sm, const UA_NodeId *toke
 UA_Session *
 UA_SessionManager_getSessionById(UA_SessionManager *sm, const UA_NodeId *sessionId);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_SESSION_MANAGER_H_ */

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -19,6 +19,8 @@
 #include "ua_types_generated.h"
 #include "ua_session.h"
 
+_UA_BEGIN_DECLS
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 
 /**
@@ -219,5 +221,7 @@ void UA_Subscription_answerPublishRequestsNoSubscription(UA_Server *server, UA_S
 UA_Boolean UA_Subscription_reachedPublishReqLimit(UA_Server *server,  UA_Session *session);
 
 #endif /* UA_ENABLE_SUBSCRIPTIONS */
+
+_UA_END_DECLS
 
 #endif /* UA_SUBSCRIPTION_H_ */

--- a/src/ua_connection_internal.h
+++ b/src/ua_connection_internal.h
@@ -11,12 +11,10 @@
 #ifndef UA_CONNECTION_INTERNAL_H_
 #define UA_CONNECTION_INTERNAL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_plugin_network.h"
 #include "ua_transport_generated.h"
+
+_UA_BEGIN_DECLS
 
 /* Process the remote configuration in the HEL/ACK handshake. The connection
  * config is initialized with the local settings. */
@@ -83,8 +81,6 @@ void UA_Connection_detachSecureChannel(UA_Connection *connection);
 void UA_Connection_attachSecureChannel(UA_Connection *connection,
                                        UA_SecureChannel *channel);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_CONNECTION_INTERNAL_H_ */

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -11,16 +11,14 @@
 #ifndef UA_SECURECHANNEL_H_
 #define UA_SECURECHANNEL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_types.h"
 #include "ua_transport_generated.h"
 #include "ua_connection_internal.h"
 #include "ua_plugin_securitypolicy.h"
 #include "ua_plugin_log.h"
 #include "../deps/queue.h"
+
+_UA_BEGIN_DECLS
 
 #define UA_SECURE_CONVERSATION_MESSAGE_HEADER_LENGTH 12
 #define UA_SECURE_MESSAGE_HEADER_LENGTH 24
@@ -282,8 +280,6 @@ UA_SecureChannel_processCompleteMessages(UA_SecureChannel *channel, void *applic
 #define UA_LOG_FATAL_CHANNEL(LOGGER, CHANNEL, ...)        \
     UA_MACRO_EXPAND(UA_LOG_FATAL_CHANNEL_INTERNAL(LOGGER, CHANNEL, __VA_ARGS__, ""))
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_SECURECHANNEL_H_ */

--- a/src/ua_timer.h
+++ b/src/ua_timer.h
@@ -9,11 +9,9 @@
 #ifndef UA_TIMER_H_
 #define UA_TIMER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_util_internal.h"
+
+_UA_BEGIN_DECLS
 
 /* An (event) timer triggers callbacks with a recurring interval. Adding,
  * removing and changing repeated callbacks can be done from independent
@@ -83,8 +81,6 @@ UA_Timer_process(UA_Timer *t, UA_DateTime nowMonotonic,
 /* Remove all repeated callbacks. Not thread-safe. */
 void UA_Timer_deleteMembers(UA_Timer *t);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_TIMER_H_ */

--- a/src/ua_types_encoding_binary.h
+++ b/src/ua_types_encoding_binary.h
@@ -12,11 +12,9 @@
 #ifndef UA_TYPES_ENCODING_BINARY_H_
 #define UA_TYPES_ENCODING_BINARY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "ua_types.h"
+
+_UA_BEGIN_DECLS
 
 typedef UA_StatusCode (*UA_exchangeEncodeBuffer)(void *handle, UA_Byte **bufPos,
                                                  const UA_Byte **bufEnd);
@@ -77,8 +75,6 @@ UA_calcSizeBinary(const void *p, const UA_DataType *type);
 const UA_DataType *
 UA_findDataTypeByBinary(const UA_NodeId *typeId);
 
-#ifdef __cplusplus
-}
-#endif
+_UA_END_DECLS
 
 #endif /* UA_TYPES_ENCODING_BINARY_H_ */

--- a/src/ua_util_internal.h
+++ b/src/ua_util_internal.h
@@ -14,13 +14,10 @@
 #ifndef UA_UTIL_H_
 #define UA_UTIL_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/* BSD Queue Macros */
 #include "ua_types.h"
 #include "../deps/queue.h"
+
+_UA_BEGIN_DECLS
 
 /* Macro-Expand for MSVC workarounds */
 #define UA_MACRO_EXPAND(x) x
@@ -163,8 +160,6 @@ size_t UA_readNumber(u8 *buf, size_t buflen, u32 *number);
 void UA_EXPORT UA_dump_hex_pkg(UA_Byte* buffer, size_t bufferLen);
 #endif
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+_UA_END_DECLS
 
 #endif /* UA_UTIL_H_ */


### PR DESCRIPTION
Fixes the speed regression reported in #2034.