### PR TITLE
[Review] Fix removal of 'uax:' namespaces from elements

### DIFF
--- a/tools/nodeset_compiler/nodeset.py
+++ b/tools/nodeset_compiler/nodeset.py
@@ -205,7 +205,7 @@ class NodeSet(object):
             fileContent = fileContent.decode("utf-8")
 
         # Remove the uax namespace from tags. UaModeler adds this namespace to some elements
-        fileContent = re.sub(r"<([/]?)uax:(\w+)([/]?)>", "<\g<1>\g<2>\g<3>>", fileContent)
+        fileContent = re.sub(r"<([/]?)uax:(.+?)([/]?)>", "<\g<1>\g<2>\g<3>>", fileContent)
 
         nodesets = dom.parseString(fileContent).getElementsByTagName("UANodeSet")
         if len(nodesets) == 0 or len(nodesets) > 1:


### PR DESCRIPTION
The regexp in nodeset.py that is used to remove references to the 'uax:' namespace from the XML did not match all cases, causing it to corrupt the XML that is fed to the parser. This lead to Expat 'mismatched tag' errors.

Examples which did not match:
`<uax:Description />`
(because of the space)
`<uax:test property="/test">`
(the space and the special characters). Note that I didn't find actual usage of attributes in my XML, so the second example may not really be an issue in practice..

The modified regexp should match anything up to the first `/>` or `>`, which would convert the above examples into:
`<Description />
<test property="/test">`
The non-greedy match is applied to prevent consuming multiple XML elements, when they occur on the same line (for example: `<uax:Text>NoPower</uax:Text>`)

Before merging this PR, please confirm that this is the intended behavior of this part of the code.