### PR TITLE
Correct Event validity check

### DIFF
--- a/src/server/ua_subscription_events.c
+++ b/src/server/ua_subscription_events.c
@@ -145,11 +145,11 @@ isValidEvent(UA_Server *server, const UA_NodeId *validEventParent, const UA_Node
     }
     
 	/* get the EventType Property Node */
-    const UA_Node* tLeafNode = UA_Nodestore_get(server, &bpr.targets[0].targetId.nodeId);
     UA_Variant tOutVariant;
+    UA_Variant_init(&tOutVariant);
     /* read the Value of EventType Property Node (the Value should be a NodeId) */
-    UA_Server_readValue(server, tLeafNode->nodeId, &tOutVariant);
-    UA_NodeId tEventType = *((UA_NodeId*)tOutVariant.data);
+    UA_Server_readValue(server, bpr.targets[0].targetId.nodeId, &tOutVariant);
+    const UA_NodeId *tEventType = (UA_NodeId*)tOutVariant.data;
 
     /* Make sure the EventType is not a Subtype of CondtionType
      * First check for filter set using UaExpert
@@ -158,23 +158,22 @@ isValidEvent(UA_Server *server, const UA_NodeId *validEventParent, const UA_Node
     UA_NodeId conditionTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_CONDITIONTYPE);
     UA_NodeId hasSubtypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE);
     if(UA_NodeId_equal(validEventParent, &conditionTypeId) ||
-       isNodeInTree(&server->config.nodestore, &tEventType, 
+       isNodeInTree(&server->config.nodestore, tEventType,
     		         &conditionTypeId, &hasSubtypeId, 1)){
         UA_LOG_ERROR(server->config.logger, UA_LOGCATEGORY_USERLAND,
     	         "Alarms and Conditions are not supported yet!");
-        UA_Nodestore_release(server, (const UA_Node *) tLeafNode);
         UA_BrowsePathResult_deleteMembers(&bpr);
         return UA_FALSE;
     }
 
     /* check whether Valid Event other than Conditions */
     UA_NodeId baseEventTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
-    UA_Boolean tmp = isNodeInTree(&server->config.nodestore, &tEventType,
-                                  &baseEventTypeId, &hasSubtypeId, 1);
+    UA_Boolean isSubtypeOfBaseEvent = isNodeInTree(&server->config.nodestore, tEventType,
+                                                   &baseEventTypeId, &hasSubtypeId, 1);
 
-    UA_Nodestore_release(server, (const UA_Node *) tLeafNode);
     UA_BrowsePathResult_deleteMembers(&bpr);
-    return tmp;
+    UA_Variant_deleteMembers(&tOutVariant);
+    return isSubtypeOfBaseEvent;
 }
 
 /* static UA_StatusCode */


### PR DESCRIPTION
Make sure the EventType is not a Subtype of CondtionType (Part 9 not supported yet).
1) The check should ignore the "ConditionId" Clause set by UaExpert and ignore all Events which are Conditions. (However, if a Condition Event was created and UaExpert is used, then all the Fields of that Event except the "ConditionId" will be presenet in the Event View) -> The User should not use Events which are Conditions in that case!
2) The second check is to make sure the Event has a TypeDefinition of an BaseEventType SubType.

Fixes #2027 and fixes #2038 

Cherry-picked from @sqadasi 