### PR TITLE
[Review] Fix/cleanup unsafe c names

### DIFF
--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -67,14 +67,16 @@ def getTypeName(xmlTypeName):
 class StructMember(object):
     def __init__(self, name, memberType, isArray):
         self.name = name
+        self.cSafeName = re.sub(r'[^\w]', '', self.name)
         self.memberType = memberType
         self.isArray = isArray
 
 class Type(object):
     def __init__(self, outname, xml, namespace):
         self.name = xml.get("Name")
+        self.cSafeName = re.sub(r'[^\w]', '', self.name)
         self.ns0 = ("true" if namespace == 0 else "false")
-        self.typeIndex = outname.upper() + "_" + self.name.upper()
+        self.typeIndex = outname.upper() + "_" + self.cSafeName.upper()
         self.outname = outname
         self.description = ""
         self.pointerfree = "false"
@@ -99,44 +101,44 @@ class Type(object):
             binaryEncodingId = description.binaryEncodingId
         else:
             typeid = "{0, UA_NODEIDTYPE_NUMERIC, {0}}"
-        return "{\n    UA_TYPENAME(\"%s\") /* .typeName */\n" % self.name + \
+        return "{\n    UA_TYPENAME(\"%s\") /* .typeName */\n" % self.cSafeName + \
             "    " + typeid + ", /* .typeId */\n" + \
-            "    sizeof(UA_" + self.name + "), /* .memSize */\n" + \
+            "    sizeof(UA_" + self.cSafeName + "), /* .memSize */\n" + \
             "    " + self.typeIndex + ", /* .typeIndex */\n" + \
             "    " + str(len(self.members)) + ", /* .membersSize */\n" + \
             "    " + self.builtin + ", /* .builtin */\n" + \
             "    " + self.pointerfree + ", /* .pointerFree */\n" + \
             "    " + self.overlayable + ", /* .overlayable */\n" + \
             "    " + binaryEncodingId + ", /* .binaryEncodingId */\n" + \
-            "    %s_members" % self.name + " /* .members */\n}"
+            "    %s_members" % self.cSafeName + " /* .members */\n}"
 
     def members_c(self):
         if len(self.members)==0:
-            return "#define %s_members NULL" % (self.name)
-        members = "static UA_DataTypeMember %s_members[%s] = {" % (self.name, len(self.members))
+            return "#define %s_members NULL" % (self.cSafeName)
+        members = "static UA_DataTypeMember %s_members[%s] = {" % (self.cSafeName, len(self.members))
         before = None
         i = 0
         size = len(self.members)
         for index, member in enumerate(self.members):
             i += 1
-            membername = member.name
+            membername = member.cSafeName
             if len(membername) > 0:
-                membername = member.name[0].upper() + member.name[1:]
+                membername = member.cSafeName[0].upper() + member.cSafeName[1:]
             m = "\n{\n    UA_TYPENAME(\"%s\") /* .memberName */\n" % membername
-            m += "    %s_%s, /* .memberTypeIndex */\n" % (member.memberType.outname.upper(), member.memberType.name.upper())
+            m += "    %s_%s, /* .memberTypeIndex */\n" % (member.memberType.outname.upper(), member.memberType.cSafeName.upper())
             m += "    "
             if not before:
                 m += "0,"
             else:
                 if member.isArray:
-                    m += "offsetof(UA_%s, %sSize)" % (self.name, member.name)
+                    m += "offsetof(UA_%s, %sSize)" % (self.cSafeName, member.cSafeName)
                 else:
-                    m += "offsetof(UA_%s, %s)" % (self.name, member.name)
-                m += " - offsetof(UA_%s, %s)" % (self.name, before.name)
+                    m += "offsetof(UA_%s, %s)" % (self.cSafeName, member.cSafeName)
+                m += " - offsetof(UA_%s, %s)" % (self.cSafeName, before.cSafeName)
                 if before.isArray:
                     m += " - sizeof(void*),"
                 else:
-                    m += " - sizeof(UA_%s)," % before.memberType.name
+                    m += " - sizeof(UA_%s)," % before.memberType.cSafeName
             m += " /* .padding */\n"
             m += "    %s, /* .namespaceZero */\n" % member.memberType.ns0
             m += ("    true" if member.isArray else "    false") + " /* .isArray */\n}"
@@ -147,31 +149,32 @@ class Type(object):
         return members + "};"
 
     def datatype_ptr(self):
-        return "&" + self.outname.upper() + "[" + self.outname.upper() + "_" + self.name.upper() + "]"
+        return "&" + self.outname.upper() + "[" + self.outname.upper() + "_" + self.cSafeName.upper() + "]"
 
     def functions_c(self):
-        funcs = "static UA_INLINE void\nUA_%s_init(UA_%s *p) {\n    memset(p, 0, sizeof(UA_%s));\n}\n\n" % (self.name, self.name, self.name)
-        funcs += "static UA_INLINE UA_%s *\nUA_%s_new(void) {\n    return (UA_%s*)UA_new(%s);\n}\n\n" % (self.name, self.name, self.name, self.datatype_ptr())
+        funcs = "static UA_INLINE void\nUA_%s_init(UA_%s *p) {\n    memset(p, 0, sizeof(UA_%s));\n}\n\n" % (self.cSafeName, self.cSafeName, self.cSafeName)
+        funcs += "static UA_INLINE UA_%s *\nUA_%s_new(void) {\n    return (UA_%s*)UA_new(%s);\n}\n\n" % (self.cSafeName, self.cSafeName, self.cSafeName, self.datatype_ptr())
         if self.pointerfree == "true":
-            funcs += "static UA_INLINE UA_StatusCode\nUA_%s_copy(const UA_%s *src, UA_%s *dst) {\n    *dst = *src;\n    return UA_STATUSCODE_GOOD;\n}\n\n" % (self.name, self.name, self.name)
-            funcs += "static UA_INLINE void\nUA_%s_deleteMembers(UA_%s *p) {\n    memset(p, 0, sizeof(UA_%s));\n}\n\n" % (self.name, self.name, self.name)
+            funcs += "static UA_INLINE UA_StatusCode\nUA_%s_copy(const UA_%s *src, UA_%s *dst) {\n    *dst = *src;\n    return UA_STATUSCODE_GOOD;\n}\n\n" % (self.cSafeName, self.cSafeName, self.cSafeName)
+            funcs += "static UA_INLINE void\nUA_%s_deleteMembers(UA_%s *p) {\n    memset(p, 0, sizeof(UA_%s));\n}\n\n" % (self.cSafeName, self.cSafeName, self.cSafeName)
         else:
-            funcs += "static UA_INLINE UA_StatusCode\nUA_%s_copy(const UA_%s *src, UA_%s *dst) {\n    return UA_copy(src, dst, %s);\n}\n\n" % (self.name, self.name, self.name, self.datatype_ptr())
-            funcs += "static UA_INLINE void\nUA_%s_deleteMembers(UA_%s *p) {\n    UA_deleteMembers(p, %s);\n}\n\n" % (self.name, self.name, self.datatype_ptr())
-        funcs += "static UA_INLINE void\nUA_%s_delete(UA_%s *p) {\n    UA_delete(p, %s);\n}" % (self.name, self.name, self.datatype_ptr())
+            funcs += "static UA_INLINE UA_StatusCode\nUA_%s_copy(const UA_%s *src, UA_%s *dst) {\n    return UA_copy(src, dst, %s);\n}\n\n" % (self.cSafeName, self.cSafeName, self.cSafeName, self.datatype_ptr())
+            funcs += "static UA_INLINE void\nUA_%s_deleteMembers(UA_%s *p) {\n    UA_deleteMembers(p, %s);\n}\n\n" % (self.cSafeName, self.cSafeName, self.datatype_ptr())
+        funcs += "static UA_INLINE void\nUA_%s_delete(UA_%s *p) {\n    UA_delete(p, %s);\n}" % (self.cSafeName, self.cSafeName, self.datatype_ptr())
         return funcs
 
     def encoding_h(self):
         enc = "static UA_INLINE size_t\nUA_%s_calcSizeBinary(const UA_%s *src) {\n    return UA_calcSizeBinary(src, %s);\n}\n"
         enc += "static UA_INLINE UA_StatusCode\nUA_%s_encodeBinary(const UA_%s *src, UA_Byte **bufPos, const UA_Byte *bufEnd) {\n    return UA_encodeBinary(src, %s, bufPos, &bufEnd, NULL, NULL);\n}\n"
         enc += "static UA_INLINE UA_StatusCode\nUA_%s_decodeBinary(const UA_ByteString *src, size_t *offset, UA_%s *dst) {\n    return UA_decodeBinary(src, offset, dst, %s, 0, NULL);\n}"
-        return enc % tuple(list(itertools.chain(*itertools.repeat([self.name, self.name, self.datatype_ptr()], 3))))
+        return enc % tuple(list(itertools.chain(*itertools.repeat([self.cSafeName, self.cSafeName, self.datatype_ptr()], 3))))
 
 class BuiltinType(Type):
     def __init__(self, name):
         self.name = name
+        self.cSafeName = re.sub(r'[^\w]', '', self.name)
         self.ns0 = "true"
-        self.typeIndex = "UA_TYPES_" + self.name.upper()
+        self.typeIndex = "UA_TYPES_" + self.cSafeName.upper()
         self.outname = "ua_types"
         self.description = ""
         self.pointerfree = "false"
@@ -201,10 +204,10 @@ class EnumerationType(Type):
             values = self.elements.iteritems()
         else:
             values = self.elements.items()
-        return "typedef enum {\n    " + ",\n    ".join(map(lambda kv : "UA_" + self.name.upper() + "_" + kv[0].upper() + \
+        return "typedef enum {\n    " + ",\n    ".join(map(lambda kv : "UA_" + self.cSafeName.upper() + "_" + kv[0].upper() + \
                                                            " = " + kv[1], values)) + \
-               ",\n    __UA_{0}_FORCE32BIT = 0x7fffffff\n".format(self.name.upper()) + "} " + \
-               "UA_{0};\nUA_STATIC_ASSERT(sizeof(UA_{0}) == sizeof(UA_Int32), enum_must_be_32bit);".format(self.name)
+               ",\n    __UA_{0}_FORCE32BIT = 0x7fffffff\n".format(self.cSafeName.upper()) + "} " + \
+               "UA_{0};\nUA_STATIC_ASSERT(sizeof(UA_{0}) == sizeof(UA_Int32), enum_must_be_32bit);".format(self.cSafeName)
 
 class OpaqueType(Type):
     def __init__(self, outname, xml, namespace, baseType):
@@ -246,22 +249,22 @@ class StructType(Type):
                 self.overlayable += " && " + m.memberType.overlayable
                 if before:
                     self.overlayable += " && offsetof(UA_%s, %s) == (offsetof(UA_%s, %s) + sizeof(UA_%s))" % \
-                                        (self.name, m.name, self.name, before.name, before.memberType.name)
+                                        (self.cSafeName, m.cSafeName, self.cSafeName, before.cSafeName, before.memberType.cSafeName)
             if "false" in self.overlayable:
                 self.overlayable = "false"
             before = m
 
     def typedef_h(self):
         if len(self.members) == 0:
-            return "typedef void * UA_%s;" % self.name
+            return "typedef void * UA_%s;" % self.cSafeName
         returnstr =  "typedef struct {\n"
         for member in self.members:
             if member.isArray:
-                returnstr += "    size_t %sSize;\n" % member.name
-                returnstr += "    UA_%s *%s;\n" % (member.memberType.name, member.name)
+                returnstr += "    size_t %sSize;\n" % member.cSafeName
+                returnstr += "    UA_%s *%s;\n" % (member.memberType.cSafeName, member.cSafeName)
             else:
-                returnstr += "    UA_%s %s;\n" % (member.memberType.name, member.name)
-        return returnstr + "} UA_%s;" % self.name
+                returnstr += "    UA_%s %s;\n" % (member.memberType.cSafeName, member.cSafeName)
+        return returnstr + "} UA_%s;" % self.cSafeName
 
 #########################
 # Parse Typedefinitions #
@@ -534,7 +537,7 @@ for t in filtered_types:
         printh(" * " + t.description + " */")
     if type(t) != BuiltinType:
         printh(t.typedef_h() + "\n")
-    printh("#define " + outname.upper() + "_" + t.name.upper() + " " + str(i))
+    printh("#define " + outname.upper() + "_" + t.cSafeName.upper() + " " + str(i))
     i += 1
 
 printh('''

--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -65,7 +65,7 @@ def generateNodeIdCode(value):
     if value.i != None:
         return "UA_NODEID_NUMERIC(ns[%s], %s)" % (value.ns, value.i)
     elif value.s != None:
-        v = makeCLiteral(value.s)
+        v = re.sub(r'(?<!\\)"', r'\\"', makeCLiteral(value.s))
         return u"UA_NODEID_STRING(ns[%s], \"%s\")" % (value.ns, v)
     raise Exception(str(value) + " no NodeID generation for bytestring and guid..")
 
@@ -73,7 +73,7 @@ def generateExpandedNodeIdCode(value):
     if value.i != None:
         return "UA_EXPANDEDNODEID_NUMERIC(ns[%s], %s)" % (str(value.ns), str(value.i))
     elif value.s != None:
-        vs = makeCLiteral(value.s)
+        vs = re.sub(r'(?<!\\)"', r'\\"', makeCLiteral(value.s))
         return u"UA_EXPANDEDNODEID_STRING(ns[%s], \"%s\")" % (str(value.ns), vs)
     raise Exception(str(value) + " no NodeID generation for bytestring and guid..")
 

--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -12,7 +12,7 @@ def generateBooleanCode(value):
     return "false"
 
 def makeCLiteral(value):
-    return value.replace('\\', r'\\\\').replace('\n', r'\\n').replace('\r', r'')
+    return re.sub(r'(?<!\\)"', r'\\"', value.replace('\\', r'\\\\').replace('\n', r'\\n').replace('\r', r''))
 
 def splitStringLiterals(value, splitLength=500):
     """
@@ -22,13 +22,13 @@ def splitStringLiterals(value, splitLength=500):
     """
     value = value.strip()
     if len(value) < splitLength or splitLength == 0:
-        return "\"" + value.replace('"', r'\"') + "\""
+        return "\"" + re.sub(r'(?<!\\)"', r'\\"', value) + "\""
     ret = ""
     tmp = value
     while len(tmp) > splitLength:
         ret += "\"" + tmp[:splitLength].replace('"', r'\"') + "\" "
         tmp = tmp[splitLength:]
-    ret += "\"" + tmp.replace('"', r'\"') + "\" "
+    ret += "\"" + re.sub(r'(?<!\\)"', r'\\"', tmp) + "\" "
     return ret
 
 def generateStringCode(value, alloc=False):
@@ -65,7 +65,7 @@ def generateNodeIdCode(value):
     if value.i != None:
         return "UA_NODEID_NUMERIC(ns[%s], %s)" % (value.ns, value.i)
     elif value.s != None:
-        v = re.sub(r'(?<!\\)"', r'\\"', makeCLiteral(value.s))
+        v = makeCLiteral(value.s)
         return u"UA_NODEID_STRING(ns[%s], \"%s\")" % (value.ns, v)
     raise Exception(str(value) + " no NodeID generation for bytestring and guid..")
 
@@ -73,7 +73,7 @@ def generateExpandedNodeIdCode(value):
     if value.i != None:
         return "UA_EXPANDEDNODEID_NUMERIC(ns[%s], %s)" % (str(value.ns), str(value.i))
     elif value.s != None:
-        vs = re.sub(r'(?<!\\)"', r'\\"', makeCLiteral(value.s))
+        vs = makeCLiteral(value.s)
         return u"UA_EXPANDEDNODEID_STRING(ns[%s], \"%s\")" % (str(value.ns), vs)
     raise Exception(str(value) + " no NodeID generation for bytestring and guid..")
 

--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -11,6 +11,11 @@ def generateBooleanCode(value):
         return "true"
     return "false"
 
+# Strip invalid characters to create valid C identifiers (variable names etc):
+def makeCIdentifier(value):
+    return re.sub(r'[^\w]', '', value)
+
+# Escape C strings:
 def makeCLiteral(value):
     return re.sub(r'(?<!\\)"', r'\\"', value.replace('\\', r'\\\\').replace('\n', r'\\n').replace('\r', r''))
 

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -277,7 +277,7 @@ def generateValueCodeDummy(dataTypeNode, parentNode, nodeset):
     code = []
     valueName = generateNodeIdPrintable(parentNode) + "_variant_DataContents"
 
-    typeBrowseNode = dataTypeNode.browseName.name
+    typeBrowseNode = re.sub(r'[^\w]', '', dataTypeNode.browseName.name)
     if typeBrowseNode == "NumericRange":
         # in the stack we define a separate structure for the numeric range, but
         # the value itself is just a string
@@ -303,7 +303,7 @@ def getTypesArrayForValue(nodeset, value):
     else:
         typesArray = typeNode.typesArray
     return "&" + typesArray + "[" + typesArray + "_" + \
-                    value.__class__.__name__.upper() + "]"
+            re.sub(r'[^\w]', '', value.__class__.__name__.upper()) + "]"
 
 def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_binary_size=32000):
     code = []
@@ -484,7 +484,7 @@ def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary
 
     # AddNodes call
     code.append("retVal |= UA_Server_addNode_begin(server, UA_NODECLASS_{},".
-                format(node.__class__.__name__.upper().replace("NODE" ,"")))
+            format(re.sub(r'[^\w]', '', node.__class__.__name__.upper().replace("NODE" ,""))))
     code.append(generateNodeIdCode(node.id) + ",")
     code.append(generateNodeIdCode(parentref.target) + ",")
     code.append(generateNodeIdCode(parentref.referenceType) + ",")
@@ -495,7 +495,7 @@ def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary
     else:
         code.append(" UA_NODEID_NULL,")
     code.append("(const UA_NodeAttributes*)&attr, &UA_TYPES[UA_TYPES_{}ATTRIBUTES],NULL, NULL);".
-                format(node.__class__.__name__.upper().replace("NODE" ,"")))
+            format(re.sub(r'[^\w]', '', node.__class__.__name__.upper().replace("NODE" ,""))))
     code.extend(codeCleanup)
 
     return "\n".join(code)

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -277,7 +277,7 @@ def generateValueCodeDummy(dataTypeNode, parentNode, nodeset):
     code = []
     valueName = generateNodeIdPrintable(parentNode) + "_variant_DataContents"
 
-    typeBrowseNode = re.sub(r'[^\w]', '', dataTypeNode.browseName.name)
+    typeBrowseNode = makeCLiteral(dataTypeNode.browseName.name)
     if typeBrowseNode == "NumericRange":
         # in the stack we define a separate structure for the numeric range, but
         # the value itself is just a string
@@ -303,7 +303,7 @@ def getTypesArrayForValue(nodeset, value):
     else:
         typesArray = typeNode.typesArray
     return "&" + typesArray + "[" + typesArray + "_" + \
-            re.sub(r'[^\w]', '', value.__class__.__name__.upper()) + "]"
+            makeCLiteral(value.__class__.__name__.upper()) + "]"
 
 def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_binary_size=32000):
     code = []
@@ -484,7 +484,7 @@ def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary
 
     # AddNodes call
     code.append("retVal |= UA_Server_addNode_begin(server, UA_NODECLASS_{},".
-            format(re.sub(r'[^\w]', '', node.__class__.__name__.upper().replace("NODE" ,""))))
+            format(makeCLiteral(node.__class__.__name__.upper().replace("NODE" ,""))))
     code.append(generateNodeIdCode(node.id) + ",")
     code.append(generateNodeIdCode(parentref.target) + ",")
     code.append(generateNodeIdCode(parentref.referenceType) + ",")
@@ -495,7 +495,7 @@ def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary
     else:
         code.append(" UA_NODEID_NULL,")
     code.append("(const UA_NodeAttributes*)&attr, &UA_TYPES[UA_TYPES_{}ATTRIBUTES],NULL, NULL);".
-            format(re.sub(r'[^\w]', '', node.__class__.__name__.upper().replace("NODE" ,""))))
+            format(makeCLiteral(node.__class__.__name__.upper().replace("NODE" ,""))))
     code.extend(codeCleanup)
 
     return "\n".join(code)
@@ -515,4 +515,3 @@ def generateNodeCode_finish(node):
         code.append(");")
 
     return "\n".join(code)
-

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -277,7 +277,7 @@ def generateValueCodeDummy(dataTypeNode, parentNode, nodeset):
     code = []
     valueName = generateNodeIdPrintable(parentNode) + "_variant_DataContents"
 
-    typeBrowseNode = makeCLiteral(dataTypeNode.browseName.name)
+    typeBrowseNode = makeCIdentifier(dataTypeNode.browseName.name)
     if typeBrowseNode == "NumericRange":
         # in the stack we define a separate structure for the numeric range, but
         # the value itself is just a string
@@ -303,7 +303,7 @@ def getTypesArrayForValue(nodeset, value):
     else:
         typesArray = typeNode.typesArray
     return "&" + typesArray + "[" + typesArray + "_" + \
-            makeCLiteral(value.__class__.__name__.upper()) + "]"
+            makeCIdentifier(value.__class__.__name__.upper()) + "]"
 
 def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_binary_size=32000):
     code = []
@@ -484,7 +484,7 @@ def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary
 
     # AddNodes call
     code.append("retVal |= UA_Server_addNode_begin(server, UA_NODECLASS_{},".
-            format(makeCLiteral(node.__class__.__name__.upper().replace("NODE" ,""))))
+            format(makeCIdentifier(node.__class__.__name__.upper().replace("NODE" ,""))))
     code.append(generateNodeIdCode(node.id) + ",")
     code.append(generateNodeIdCode(parentref.target) + ",")
     code.append(generateNodeIdCode(parentref.referenceType) + ",")
@@ -495,7 +495,7 @@ def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary
     else:
         code.append(" UA_NODEID_NULL,")
     code.append("(const UA_NodeAttributes*)&attr, &UA_TYPES[UA_TYPES_{}ATTRIBUTES],NULL, NULL);".
-            format(makeCLiteral(node.__class__.__name__.upper().replace("NODE" ,""))))
+            format(makeCIdentifier(node.__class__.__name__.upper().replace("NODE" ,""))))
     code.extend(codeCleanup)
 
     return "\n".join(code)


### PR DESCRIPTION
Apparently, OPC-UA identifiers may contain a wide range of special characters, including quotation marks, dots and spaces.
For example, this is a fragment from an UANodeSet XML exported from Siemens TIA Portal V15:
```
<UAVariable NodeId="ns=3;s=&quot;dbCounters_748&quot;.&quot;AllData&quot;.&quot;Element&quot;[11].&quot;CountData&quot;.&quot;Product&quot;[0]" BrowseName="3:0" ParentNodeId="ns=3;s=&quot;dbCounters_748&quot;.&quot;AllData&quot;.&quot;Element&quot;[11].&quot;CountData&quot;.&quot;Product&quot;" DataType="ns=3;s=DT_&quot;udtCounter_627&quot;" AccessLevel="3">
    <DisplayName>0</DisplayName>
    <References>
        <Reference ReferenceType="HasTypeDefinition">ns=3;s=VT_"udtCounter_627"</Reference>
        <Reference ReferenceType="HasComponent" IsForward="false">ns=3;s="dbCounters_748"."AllData"."Element"[11]."CountData"."Product"</Reference>
    </References>
</UAVariable>
```
When these identifiers end up in the generated C files, the result is no longer valid C code.

This PR tries to address these problems.
The code in tools/nodeset_compiler only requires a few fixes, most of the code was already handling this issue correctly.
The script tools/generate_datatypes.py requires more work. I have chosen to keep the `.name` properties intact, and create separate 'C-safe' name properties on the various classes. I'm not sure if this is your preferred way to solve this issue.

Note: unfortunately, this PR alone is not sufficient to compile the above mentioned UANodeSet file error-free, but it is a start...