### PR TITLE
Process normal services before initalizing the message context

### DIFF
--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2014-2017 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2014-2016 (c) Sten Grüner
@@ -559,9 +559,7 @@ processMSG(UA_Server *server, UA_SecureChannel *channel,
      * layers only providing one send buffer, only one message context can be
      * initialized concurrently. */
     if(serviceType == UA_SERVICETYPE_NORMAL)
-    {
         service(server, session, request, response);
-    }
 
     /* Start the message */
     UA_NodeId typeId = UA_NODEID_NUMERIC(0, responseType->binaryEncodingId);


### PR DESCRIPTION
To support network layers that only provides 1 send buffer only one
message context can be initialized at once. Some services, e.g.
Delete Subscriptions, also initializes message contexts when they
are processed. To only have 1 message context active concurrently,
the normal services are now processed before the message context are
initialized.