### PR TITLE
Disable PDF generation on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,12 +56,12 @@ before_build:
   - set PATH=C:\Python27;C:\msys64\mingw64\bin;C:\Program Files (x86)\Dr. Memory\bin;C:\Program Files\CMake\bin;%PATH%
   # Workaround for CMake not wanting sh.exe on PATH for MinGW
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-  # Miktex
-  - set "PATH=%PATH%;c:\miktex\texmfs\install\miktex\bin;%APPDATA%\Python\Scripts"
-  # autoinstall latex packages (0=no, 1=autoinstall, 2=ask)
-  # this adds this to the registry!
-  - initexmf --set-config-value [MPM]AutoInstall=1
-  - initexmf --update-fndb
+  ## Miktex
+  #- set "PATH=%PATH%;c:\miktex\texmfs\install\miktex\bin;%APPDATA%\Python\Scripts"
+  ## autoinstall latex packages (0=no, 1=autoinstall, 2=ask)
+  ## this adds this to the registry!
+  #- initexmf --set-config-value [MPM]AutoInstall=1
+  #- initexmf --update-fndb
 
 build_script:
 - ps: '& "./tools/appveyor/build.ps1"'

--- a/tools/appveyor/build.ps1
+++ b/tools/appveyor/build.ps1
@@ -32,25 +32,25 @@ try {
     Copy-Item AUTHORS pack
     Copy-Item README.md pack
 
-    Write-Host -ForegroundColor Green "`n###################################################################"
-    Write-Host -ForegroundColor Green "`n##### Building Documentation on $env:CC_NAME #####`n"
-    New-Item -ItemType directory -Path build
-    cd build
-    & cmake -DMIKTEX_BINARY_PATH=c:\miktex\texmfs\install\miktex\bin -DCMAKE_BUILD_TYPE=Release `
-        -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DUA_BUILD_EXAMPLES:BOOL=OFF -G"$env:CC_NAME" ..
-    & cmake --build . --target doc_latex
-    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-        Write-Host -ForegroundColor Red "`n`n*** Make doc_latex. Exiting ... ***"
-        exit $LASTEXITCODE
-    }
-    & cmake --build . --target doc_pdf
-    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-        Write-Host -ForegroundColor Red "`n`n*** Make doc_pdf. Exiting ... ***"
-        exit $LASTEXITCODE
-    }
-    cd ..
-    Move-Item -Path "build\doc_latex\open62541.pdf" -Destination pack\
-    Remove-Item -Path build -Recurse -Force
+    # Write-Host -ForegroundColor Green "`n###################################################################"
+    # Write-Host -ForegroundColor Green "`n##### Building Documentation on $env:CC_NAME #####`n"
+    # New-Item -ItemType directory -Path build
+    # cd build
+    # & cmake -DMIKTEX_BINARY_PATH=c:\miktex\texmfs\install\miktex\bin -DCMAKE_BUILD_TYPE=Release `
+    #     -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DUA_BUILD_EXAMPLES:BOOL=OFF -G"$env:CC_NAME" ..
+    # & cmake --build . --target doc_latex
+    # if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    #     Write-Host -ForegroundColor Red "`n`n*** Make doc_latex. Exiting ... ***"
+    #     exit $LASTEXITCODE
+    # }
+    # & cmake --build . --target doc_pdf
+    # if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    #     Write-Host -ForegroundColor Red "`n`n*** Make doc_pdf. Exiting ... ***"
+    #     exit $LASTEXITCODE
+    # }
+    # cd ..
+    # Move-Item -Path "build\doc_latex\open62541.pdf" -Destination pack\
+    # Remove-Item -Path build -Recurse -Force
 
     Write-Host -ForegroundColor Green "`n###################################################################"
     Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME #####`n"
@@ -169,8 +169,8 @@ try {
         }
     }
 
-    # do not cache log
-    Remove-Item -Path c:\miktex\texmfs\data\miktex\log -Recurse -Force
+    # # do not cache log
+    # Remove-Item -Path c:\miktex\texmfs\data\miktex\log -Recurse -Force
 
 } catch {
     # Print a detailed error message

--- a/tools/appveyor/install.ps1
+++ b/tools/appveyor/install.ps1
@@ -11,23 +11,23 @@ try {
     Write-Host -ForegroundColor Green "`n### Installing sphinx ###`n"
     & C:\Python27\Scripts\pip.exe install --user sphinx sphinx_rtd_theme
 
-    Write-Host -ForegroundColor Green "`n### Installing Miktex ###`n"
-    if (-not (Test-Path "c:\miktex\texmfs\install\miktex\bin\pdflatex.exe")) {
-        & appveyor DownloadFile https://ftp.uni-erlangen.de/mirrors/CTAN/systems/win32/miktex/setup/windows-x86/miktex-portable-2.9.6753.exe
-        & 7z x miktex-portable-2.9.6753.exe -oc:\miktex -bso0 -bsp0
+    # Write-Host -ForegroundColor Green "`n### Installing Miktex ###`n"
+    # if (-not (Test-Path "c:\miktex\texmfs\install\miktex\bin\pdflatex.exe")) {
+    #     & appveyor DownloadFile https://ftp.uni-erlangen.de/mirrors/CTAN/systems/win32/miktex/setup/windows-x86/miktex-portable-2.9.6753.exe
+    #     & 7z x miktex-portable-2.9.6753.exe -oc:\miktex -bso0 -bsp0
 
-        # Remove some big files to reduce size to be cached
-        Remove-Item -Path c:\miktex\texmfs\install\doc -Recurse
-        Remove-Item -Path c:\miktex\texmfs\install\miktex\bin\biber.exe
-        Remove-Item -Path c:\miktex\texmfs\install\miktex\bin\a5toa4.exe
-    }
+    #     # Remove some big files to reduce size to be cached
+    #     Remove-Item -Path c:\miktex\texmfs\install\doc -Recurse
+    #     Remove-Item -Path c:\miktex\texmfs\install\miktex\bin\biber.exe
+    #     Remove-Item -Path c:\miktex\texmfs\install\miktex\bin\a5toa4.exe
+    # }
 
-    Write-Host -ForegroundColor Green "`n### Installing graphviz ###`n"
-    & cinst --no-progress graphviz
-    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-        Write-Host -ForegroundColor Red "`n`n*** Installing graphviz failed. Exiting ... ***"
-        exit $LASTEXITCODE
-    }
+    # Write-Host -ForegroundColor Green "`n### Installing graphviz ###`n"
+    # & cinst --no-progress graphviz
+    # if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+    #     Write-Host -ForegroundColor Red "`n`n*** Installing graphviz failed. Exiting ... ***"
+    #     exit $LASTEXITCODE
+    # }
 
     Write-Host -ForegroundColor Green "`n### Installing mbedtls ###`n"
 


### PR DESCRIPTION
This regularly breaks.
And we use the pdfs from appveyor only for releases.
And we have to manually edit the release zips anyway.