### PR TITLE
Extend function UA_NodeId_isNull

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -259,9 +259,19 @@ NodeId_copy(UA_NodeId const *src, UA_NodeId *dst, const UA_DataType *_) {
 
 UA_Boolean
 UA_NodeId_isNull(const UA_NodeId *p) {
-    return p->namespaceIndex == 0 &&
-        p->identifierType == UA_NODEIDTYPE_NUMERIC &&
-        p->identifier.numeric == 0;
+    if(p->namespaceIndex != 0)
+        return false;
+    switch (p->identifierType) {
+    case UA_NODEIDTYPE_NUMERIC:
+        return (p->identifier.numeric == 0);
+    case UA_NODEIDTYPE_STRING:
+        return UA_String_equal(&p->identifier.string, &UA_STRING_NULL);
+    case UA_NODEIDTYPE_GUID:
+        return UA_Guid_equal(&p->identifier.guid, &UA_GUID_NULL);
+    case UA_NODEIDTYPE_BYTESTRING:
+        return UA_ByteString_equal(&p->identifier.byteString, &UA_BYTESTRING_NULL);
+    }
+    return false;
 }
 
 UA_Boolean


### PR DESCRIPTION
CTT scripts "View TranslateBrowsePath/011 + Err-020" requires the check for all NodeId types against being NULL.