### PR TITLE
Do not include unistd.h on Win32. Fixes #2105

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -15,7 +15,7 @@
 #include "ua_services.h"
 #include "ua_mdns_internal.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 # ifndef UNDER_CE
 #  include <io.h> //access
 #  define access _access


### PR DESCRIPTION
This PR fixes the build with clang under windows as described in #2105 

Does not need to be ported to master since on master we are using architecture definitions which need different handling.