### PR TITLE
Compare end certificates of channel and CreateSessionRequest

### DIFF
--- a/plugins/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/ua_securitypolicy_basic128rsa15.c
@@ -718,6 +718,7 @@ channelContext_compareCertificate_sp_basic128rsa15(const Basic128Rsa15_ChannelCo
     const UA_SecurityPolicy *securityPolicy = cc->policyContext->securityPolicy;
 
     mbedtls_x509_crt cert;
+    mbedtls_x509_crt_init(&cert);
     int mbedErr = mbedtls_x509_crt_parse(&cert, certificate->data, certificate->length);
     UA_MBEDTLS_ERRORHANDLING_RETURN(UA_STATUSCODE_BADSECURITYCHECKSFAILED);
 

--- a/plugins/ua_securitypolicy_basic256sha256.c
+++ b/plugins/ua_securitypolicy_basic256sha256.c
@@ -741,6 +741,7 @@ channelContext_compareCertificate_sp_basic256sha256(const Basic256Sha256_Channel
     const UA_SecurityPolicy *securityPolicy = cc->policyContext->securityPolicy;
 
     mbedtls_x509_crt cert;
+    mbedtls_x509_crt_init(&cert);
     int mbedErr = mbedtls_x509_crt_parse(&cert, certificate->data, certificate->length);
     UA_MBEDTLS_ERRORHANDLING_RETURN(UA_STATUSCODE_BADSECURITYCHECKSFAILED);
 

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -73,8 +73,15 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
 
     if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
        channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT) {
-        if(!UA_ByteString_equal(&request->clientCertificate,
-                                &channel->remoteCertificate)) {
+        /* Compare the clientCertificate with the remoteCertificate of the channel.
+         * Both the clientCertificate of this request and the remoteCertificate
+         * of the channel may contain a partial or a complete certificate chain.
+         * The compareCertificate function of the channelModule will compare the 
+         * first certificate of each chain. The end certificate shall be located
+         * first in the chain according to the OPC UA specification Part 6 (1.04),
+         * chapter 6.2.3.*/
+        if(channel->securityPolicy->channelModule.compareCertificate(channel->channelContext,
+                                                                     &request->clientCertificate) != UA_STATUSCODE_GOOD) {
             response->responseHeader.serviceResult = UA_STATUSCODE_BADCERTIFICATEINVALID;
             return;
         }


### PR DESCRIPTION
A client are allowed to include a partitial or a complete certificate
chain both in the OpenSecureChannelRequest and in the
CreateSessionRequest. When comparing the certificates while
processing the CreateSessionRequest this must be considered.
The comparition has been updated to use the compareCertificate
function of the channelModule of the SecurityPolicy plugin API.