### PR TITLE
Fix-gcc-V4.9.x-warning -maybe-uninitialized

### DIFF
--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -526,7 +526,7 @@ UA_SecureChannel_sendAsymmetricOPNMessage(UA_SecureChannel *channel, UA_UInt32 r
 
     /* The total message length is known here which is why we */
     /* encode the headers at this step and not earlier. */
-    size_t finalLength;
+    size_t finalLength = 0;
     retval = prependHeadersAsym(channel, buf.data, buf_end, total_length,
                                 securityHeaderLength, requestId, &finalLength);
     if(retval != UA_STATUSCODE_GOOD)


### PR DESCRIPTION
GCC version 4.9.x complains about variable finalLength (compiler setting -Wmaybe-uninitialized)