### PR TITLE
Fix PC-lint warning: Declaration of symbol 'index' hides symbol 'index(...)'

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -397,16 +397,16 @@ UA_Server_updateCertificate(UA_Server *server,
         }
     }
 
-    size_t index = 0;
-    while (index < server->config.endpointsSize) {
-        UA_EndpointDescription *ed = &server->config.endpoints[index].endpointDescription;
+    size_t i = 0;
+    while (i < server->config.endpointsSize) {
+        UA_EndpointDescription *ed = &server->config.endpoints[i].endpointDescription;
         if (UA_ByteString_equal(&ed->serverCertificate, oldCertificate)) {
             UA_String_deleteMembers(&ed->serverCertificate);
             UA_String_copy(newCertificate, &ed->serverCertificate);
-            UA_SecurityPolicy *sp = &server->config.endpoints[index].securityPolicy;
+            UA_SecurityPolicy *sp = &server->config.endpoints[i].securityPolicy;
             sp->updateCertificateAndPrivateKey(sp, *newCertificate, *newPrivateKey);
         }
-        index++;
+        i++;
     }
 
     return UA_STATUSCODE_GOOD;

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -20,47 +20,47 @@
 #define ABS_SUBTRACT_TYPE_INDEPENDENT(a,b) ((a)>(b)?(a)-(b):(b)-(a))
 
 static UA_Boolean
-outOfDeadBand(const void *data1, const void *data2, const size_t arrayIndex,
+outOfDeadBand(const void *data1, const void *data2, const size_t arrayPos,
               const UA_DataType *type, const UA_Double deadbandValue) {
     if(type == &UA_TYPES[UA_TYPES_SBYTE]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_SByte*)data1)[arrayIndex],
-                                         ((const UA_SByte*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_SByte*)data1)[arrayPos],
+                                         ((const UA_SByte*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_BYTE]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Byte*)data1)[arrayIndex],
-                                         ((const UA_Byte*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Byte*)data1)[arrayPos],
+                                         ((const UA_Byte*)data2)[arrayPos]) <= deadbandValue)
                 return false;
     } else if(type == &UA_TYPES[UA_TYPES_INT16]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int16*)data1)[arrayIndex],
-                                          ((const UA_Int16*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int16*)data1)[arrayPos],
+                                          ((const UA_Int16*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_UINT16]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt16*)data1)[arrayIndex],
-                                          ((const UA_UInt16*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt16*)data1)[arrayPos],
+                                          ((const UA_UInt16*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_INT32]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int32*)data1)[arrayIndex],
-                                         ((const UA_Int32*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int32*)data1)[arrayPos],
+                                         ((const UA_Int32*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_UINT32]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt32*)data1)[arrayIndex],
-                                         ((const UA_UInt32*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt32*)data1)[arrayPos],
+                                         ((const UA_UInt32*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_INT64]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int64*)data1)[arrayIndex],
-                                         ((const UA_Int64*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int64*)data1)[arrayPos],
+                                         ((const UA_Int64*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_UINT64]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt64*)data1)[arrayIndex],
-                                         ((const UA_UInt64*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt64*)data1)[arrayPos],
+                                         ((const UA_UInt64*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_FLOAT]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Float*)data1)[arrayIndex],
-                                         ((const UA_Float*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Float*)data1)[arrayPos],
+                                         ((const UA_Float*)data2)[arrayPos]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_DOUBLE]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Double*)data1)[arrayIndex],
-                                         ((const UA_Double*)data2)[arrayIndex]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Double*)data1)[arrayPos],
+                                         ((const UA_Double*)data2)[arrayPos]) <= deadbandValue)
             return false;
     }
     return true;

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -20,47 +20,47 @@
 #define ABS_SUBTRACT_TYPE_INDEPENDENT(a,b) ((a)>(b)?(a)-(b):(b)-(a))
 
 static UA_Boolean
-outOfDeadBand(const void *data1, const void *data2, const size_t index,
+outOfDeadBand(const void *data1, const void *data2, const size_t arrayIndex,
               const UA_DataType *type, const UA_Double deadbandValue) {
     if(type == &UA_TYPES[UA_TYPES_SBYTE]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_SByte*)data1)[index],
-                                         ((const UA_SByte*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_SByte*)data1)[arrayIndex],
+                                         ((const UA_SByte*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_BYTE]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Byte*)data1)[index],
-                                         ((const UA_Byte*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Byte*)data1)[arrayIndex],
+                                         ((const UA_Byte*)data2)[arrayIndex]) <= deadbandValue)
                 return false;
     } else if(type == &UA_TYPES[UA_TYPES_INT16]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int16*)data1)[index],
-                                          ((const UA_Int16*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int16*)data1)[arrayIndex],
+                                          ((const UA_Int16*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_UINT16]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt16*)data1)[index],
-                                          ((const UA_UInt16*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt16*)data1)[arrayIndex],
+                                          ((const UA_UInt16*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_INT32]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int32*)data1)[index],
-                                         ((const UA_Int32*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int32*)data1)[arrayIndex],
+                                         ((const UA_Int32*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_UINT32]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt32*)data1)[index],
-                                         ((const UA_UInt32*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt32*)data1)[arrayIndex],
+                                         ((const UA_UInt32*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_INT64]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int64*)data1)[index],
-                                         ((const UA_Int64*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Int64*)data1)[arrayIndex],
+                                         ((const UA_Int64*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_UINT64]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt64*)data1)[index],
-                                         ((const UA_UInt64*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_UInt64*)data1)[arrayIndex],
+                                         ((const UA_UInt64*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_FLOAT]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Float*)data1)[index],
-                                         ((const UA_Float*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Float*)data1)[arrayIndex],
+                                         ((const UA_Float*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     } else if(type == &UA_TYPES[UA_TYPES_DOUBLE]) {
-        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Double*)data1)[index],
-                                         ((const UA_Double*)data2)[index]) <= deadbandValue)
+        if(ABS_SUBTRACT_TYPE_INDEPENDENT(((const UA_Double*)data1)[arrayIndex],
+                                         ((const UA_Double*)data2)[arrayIndex]) <= deadbandValue)
             return false;
     }
     return true;


### PR DESCRIPTION
PC-lint complains about the naming:
Declaration of symbol 'index' hides symbol 'index(const char *, int)' (file ..\arm-none-eabi-gcc\4.5.2\arm-none-eabi\include\string.h)