### PR TITLE
Fix PC-lint warning: Unreachable code at token ';'

### DIFF
--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -90,7 +90,7 @@ browseReferences(UA_Server *server, const UA_Node *node,
     /* If the node has no references, just return */
     if(node->referencesSize == 0) {
         result->referencesSize = 0;
-        return true;;
+        return true;
     }
 
     /* Follow all references? */


### PR DESCRIPTION
remove dupclicated ';'