### PR TITLE
[0.3 Backport] NodesetCompiler: Hide valueRank not supported warning

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -193,7 +193,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, recursionDepth=0, 
     for field in node.encodingRule:
         ptrSym = ""
         # If this is an Array, this is pointer to its contents with a AliasOfFieldSize entry
-        if field[2] != 0:
+        if field[2] != None and field[2] != 0 :
             code.append("  UA_Int32 " + str(field[0]) + "Size;")
             ptrSym = "*"
         if len(field[1]) == 1:
@@ -211,7 +211,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, recursionDepth=0, 
         logger.debug(
             "Encoding of field " + subv.alias + " is " + str(subv.encodingRule) + "defined by " + str(encField))
         # Check if this is an array
-        if encField[2] == 0:
+        if subv.valueRank is None or subv.valueRank == 0:
             code.append(instanceName + "_struct." + subv.alias + " = " +
                         generateNodeValueCode(subv, instanceName, asIndirect=False, max_string_length=max_string_length) + ";")
         else:
@@ -260,7 +260,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, recursionDepth=0, 
     for subv in node.value:
         encField = node.encodingRule[encFieldIdx]
         encFieldIdx = encFieldIdx + 1
-        if encField[2] == 0:
+        if subv.valueRank is None or subv.valueRank == 0:
             code.append(
                 "retVal |= UA_encodeBinary(&" + instanceName + "_struct." + subv.alias + ", " +
                 getTypesArrayForValue(nodeset, subv) + ", &pos" + instanceName + ", &end" + instanceName + ", NULL, NULL);")
@@ -516,7 +516,7 @@ def generateNodeCode_begin(node, nodeset, max_string_length, generate_ns0, paren
         code.append("UA_NODEID_NULL,")
     code.append("(const UA_NodeAttributes*)&attr, &UA_TYPES[UA_TYPES_{}ATTRIBUTES],NULL, NULL);".format(node.__class__.__name__.upper().replace("NODE" ,"")))
     code.extend(codeCleanup)
-    
+
     return "\n".join(code)
 
 def generateNodeCode_finish(node):

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -504,7 +504,7 @@ class DataTypeNode(Node):
                             self.__encodable__ = False
                             break
                         else:
-                            self.__baseTypeEncoding__ = self.__baseTypeEncoding__ + [self.browseName.name, subenc, 0]
+                            self.__baseTypeEncoding__ = self.__baseTypeEncoding__ + [self.browseName.name, subenc, None]
             if len(self.__baseTypeEncoding__) == 0:
                 logger.debug(prefix + "No viable definition for " + str(self.browseName) + " " + str(self.id) + " found.")
                 self.__encodable__ = False
@@ -520,7 +520,6 @@ class DataTypeNode(Node):
 
         isEnum = True
         isSubType = True
-        hasValueRank = 0
 
         # We need to store the definition as ordered data, but can't use orderedDict
         # for backward compatibility with Python 2.6 and 3.4
@@ -533,7 +532,7 @@ class DataTypeNode(Node):
                 fname  = ""
                 fdtype = ""
                 enumVal = ""
-                valueRank = 0
+                valueRank = None
                 for at,av in x.attributes.items():
                     if at == "DataType":
                         fdtype = str(av)
@@ -547,8 +546,6 @@ class DataTypeNode(Node):
                         isSubType = False
                     elif at == "ValueRank":
                         valueRank = int(av)
-                        if valueRank > 0:
-                            logger.warn("Value ranks >0 not fully supported. Further steps may fail")
                     else:
                         logger.warn("Unknown Field Attribute " + str(at))
                 # This can either be an enumeration OR a structure, not both.


### PR DESCRIPTION
The valueRank for data types is currently not used in the nodeset compiler
and thus we can hide the warning. The rest of the code still works.

This valueRank attribute should then later on be used when creating
data type definitions on the fly with fixed array size instead of malloc
arrays.

See also #2137