### PR TITLE
NodesetCompiler: Hide valueRank not supported warning

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -174,7 +174,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, r
     for field in node.encodingRule:
         ptrSym = ""
         # If this is an Array, this is pointer to its contents with a AliasOfFieldSize entry
-        if field[2] != 0:
+        if field[2] != None and field[2] != 0 :
             code.append("  UA_Int32 " + str(field[0]) + "Size;")
             ptrSym = "*"
         if len(field[1]) == 1:
@@ -192,7 +192,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, r
         logger.debug(
             "Encoding of field " + subv.alias + " is " + str(subv.encodingRule) + "defined by " + str(encField))
         # Check if this is an array
-        if encField[2] == 0:
+        if subv.valueRank is None or subv.valueRank == 0:
             valueName = instanceName + "_struct." + subv.alias
             code.append(generateNodeValueCode(valueName + " = " ,
                         subv, instanceName,valueName, global_var_code, asIndirect=False))
@@ -243,7 +243,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, r
     for subv in node.value:
         encField = node.encodingRule[encFieldIdx]
         encFieldIdx = encFieldIdx + 1
-        if encField[2] == 0:
+        if subv.valueRank is None or subv.valueRank == 0:
             code.append(
                 "retVal |= UA_encodeBinary(&" + instanceName + "_struct." + subv.alias + ", " +
                 getTypesArrayForValue(nodeset, subv) + ", &pos" + instanceName + ", &end" + instanceName + ", NULL, NULL);")

--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -55,6 +55,7 @@ class Value(object):
         self.dataType = None
         self.encodingRule = []
         self.isInternal = False
+        self.valueRank = None
         if xmlelement:
             self.parseXML(xmlelement)
 
@@ -163,7 +164,7 @@ class Value(object):
         else:
             self.value = [self.__parseXMLSingleValue(xmlvalue, parentDataTypeNode, parent)]
 
-    def __parseXMLSingleValue(self, xmlvalue, parentDataTypeNode, parent, alias=None, encodingPart=None):
+    def __parseXMLSingleValue(self, xmlvalue, parentDataTypeNode, parent, alias=None, encodingPart=None, valueRank=None):
         # Parse an encoding list such as enc = [[Int32], ['Duration', ['DateTime']]],
         # returning a possibly aliased variable or list of variables.
         # Keep track of aliases, as ['Duration', ['Hawaii', ['UtcTime', ['DateTime']]]]
@@ -193,6 +194,7 @@ class Value(object):
                         t = self.getTypeByString(enc[0], enc)
                         t.alias = alias
                         t.parseXML(xmlvalue)
+                        t.valueRank = valueRank
                         return t
                 else:
                     if not valueIsInternalType(xmlvalue.localName):
@@ -205,7 +207,8 @@ class Value(object):
             else:
                 # 1: ['Alias', [...], n]
                 # Let the next elif handle this
-                return self.__parseXMLSingleValue(xmlvalue, parentDataTypeNode, parent, alias=alias, encodingPart=enc[0])
+                return self.__parseXMLSingleValue(xmlvalue, parentDataTypeNode, parent,
+                                                  alias=alias, encodingPart=enc[0], valueRank=enc[2] if len(enc)>2 else None)
         elif len(enc) == 3 and isinstance(enc[0], six.string_types):
             # [ 'Alias', [...], 0 ]          aliased multipart
             if alias == None:
@@ -214,7 +217,8 @@ class Value(object):
             elif alias != None and len(enc[1]) > 1:
                 alias = enc[0]
             # otherwise drop the alias
-            return self.__parseXMLSingleValue(xmlvalue, parentDataTypeNode, parent, alias=alias, encodingPart=enc[1])
+            return self.__parseXMLSingleValue(xmlvalue, parentDataTypeNode, parent,
+                                              alias=alias, encodingPart=enc[1], valueRank=enc[2] if len(enc)>2 else None)
         else:
             # [ [...], [...], [...]] multifield of unknowns (analyse separately)
             # create an extension object to hold multipart type

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -498,7 +498,7 @@ class DataTypeNode(Node):
                             self.__encodable__ = False
                             break
                         else:
-                            self.__baseTypeEncoding__ = self.__baseTypeEncoding__ + [self.browseName.name, subenc, 0]
+                            self.__baseTypeEncoding__ = self.__baseTypeEncoding__ + [self.browseName.name, subenc, None]
             if len(self.__baseTypeEncoding__) == 0:
                 logger.debug(prefix + "No viable definition for " + str(self.browseName) + " " + str(self.id) + " found.")
                 self.__encodable__ = False
@@ -514,7 +514,6 @@ class DataTypeNode(Node):
 
         isEnum = True
         isSubType = True
-        hasValueRank = 0
 
         # We need to store the definition as ordered data, but can't use orderedDict
         # for backward compatibility with Python 2.6 and 3.4
@@ -527,7 +526,7 @@ class DataTypeNode(Node):
                 fname  = ""
                 fdtype = ""
                 enumVal = ""
-                valueRank = 0
+                valueRank = None
                 for at,av in x.attributes.items():
                     if at == "DataType":
                         fdtype = str(av)
@@ -541,8 +540,6 @@ class DataTypeNode(Node):
                         isSubType = False
                     elif at == "ValueRank":
                         valueRank = int(av)
-                        if valueRank > 0:
-                            logger.warn("Value ranks >0 not fully supported. Further steps may fail")
                     else:
                         logger.warn("Unknown Field Attribute " + str(at))
                 # This can either be an enumeration OR a structure, not both.


### PR DESCRIPTION
The valueRank for data types is currently not used in the nodeset compiler
and thus we can hide the warning. The rest of the code still works.

This valueRank attribute should then later on be used when creating
data type definitions on the fly with fixed array size instead of malloc
arrays.

See also #2137