### PR TITLE
Add a new job to AppVeyor that builds with clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library is [available](https://github.com/open62541/open62541/releases) in s
 
 [![Ohloh Project Status](https://www.ohloh.net/p/open62541/widgets/project_thin_badge.gif)](https://www.ohloh.net/p/open62541)
 [![Build Status](https://img.shields.io/travis/open62541/open62541/master.svg)](https://travis-ci.org/open62541/open62541)
-[![MSVS build status](https://img.shields.io/appveyor/ci/open62541/open62541/master.svg)](https://ci.appveyor.com/project/open62541/open62541/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/9e5sw7smlssrmjkl/branch/master?svg=true)](https://ci.appveyor.com/project/escherstair/open62541/branch/master)
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/12248.svg)](https://scan.coverity.com/projects/open62541-open62541)
 [![Coverage Status](https://img.shields.io/coveralls/open62541/open62541/master.svg)](https://coveralls.io/r/open62541/open62541?branch=master)
 [![Overall Downloads](https://img.shields.io/github/downloads/open62541/open62541/total.svg)](https://github.com/open62541/open62541/releases)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
     matrix:
         - CC_NAME: MinGW Makefiles
           CC_SHORTNAME: mingw
+          GENERATOR: MinGW Makefiles
           # We need to redirect stderr to stdout otherwise powershell will fail if there is an output during amalgamation.
           # Only use one thread, otherwise appveyor runs out of memory
           MAKE: mingw32-make -j1 2>&1
@@ -21,22 +22,34 @@ environment:
           OUT_DIR_EXAMPLES: bin\examples
         - CC_NAME: Visual Studio 9 2008
           CC_SHORTNAME: vs2008
+          GENERATOR: Visual Studio 9 2008
           MAKE: msbuild /p:ContinueOnError=false /p:StopOnFirstFailure=true open62541.sln
           FORCE_CXX: ON
           OUT_DIR_LIB: bin\Debug
           OUT_DIR_EXAMPLES: bin\examples\Debug
         - CC_NAME: Visual Studio 12 2013
           CC_SHORTNAME: vs2013
+          GENERATOR: Visual Studio 12 2013
           MAKE: msbuild /p:ContinueOnError=false /p:StopOnFirstFailure=true open62541.sln
           FORCE_CXX: OFF
           OUT_DIR_LIB: bin\Debug
           OUT_DIR_EXAMPLES: bin\examples\Debug
         - CC_NAME: Visual Studio 14 2015
           CC_SHORTNAME: vs2015
+          GENERATOR: Visual Studio 14 2015
           MAKE: msbuild /p:ContinueOnError=false /p:StopOnFirstFailure=true open62541.sln
           FORCE_CXX: OFF
           OUT_DIR_LIB: bin\Debug
           OUT_DIR_EXAMPLES: bin\examples\Debug
+        - CC_NAME: Clang
+          CC_SHORTNAME: clang-mingw
+          GENERATOR: MinGW Makefiles
+          # We need to redirect stderr to stdout otherwise powershell will fail if there is an output during amalgamation.
+          # Only use one thread, otherwise appveyor runs out of memory
+          MAKE: mingw32-make -j1 2>&1
+          FORCE_CXX: OFF
+          OUT_DIR_LIB: bin
+          OUT_DIR_EXAMPLES: bin\examples
 
 cache:
   - C:\ProgramData\chocolatey\bin -> tools/appveyor/install.ps1

--- a/tools/appveyor/build.ps1
+++ b/tools/appveyor/build.ps1
@@ -15,6 +15,14 @@ try {
 
     if ($env:CC_SHORTNAME -eq "mingw") {
 
+    } elseif ($env:CC_SHORTNAME -eq "clang-mingw") {
+        # Workaround for http://llvm.org/bugs/show_bug.cgi?id=28089
+        Copy-Item 'C:\Program Files\LLVM' -destination C:\LLVM -recurse
+        $env:Path = 'C:\LLVM\bin;' + $env:Path
+        # Setup clang
+        $env:CC = "clang --target=x86_64-w64-mingw32"
+        $env:CXX = "clang++ --target=x86_64-w64-mingw32"
+        clang --version
     } else {
         $vcpkg_toolchain = '-DCMAKE_TOOLCHAIN_FILE="C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake"'
         $vcpkg_triplet = '-DVCPKG_TARGET_TRIPLET="x86-windows-static"'
@@ -37,7 +45,7 @@ try {
     # New-Item -ItemType directory -Path build
     # cd build
     # & cmake -DMIKTEX_BINARY_PATH=c:\miktex\texmfs\install\miktex\bin -DCMAKE_BUILD_TYPE=Release `
-    #     -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DUA_BUILD_EXAMPLES:BOOL=OFF -G"$env:CC_NAME" ..
+    #     -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DUA_BUILD_EXAMPLES:BOOL=OFF -G"$env:GENERATOR" ..
     # & cmake --build . --target doc_latex
     # if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
     #     Write-Host -ForegroundColor Red "`n`n*** Make doc_latex. Exiting ... ***"
@@ -57,7 +65,7 @@ try {
     New-Item -ItemType directory -Path "build"
     cd build
     & cmake  $vcpkg_toolchain $vcpkg_triplet -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX `
-        -DUA_ENABLE_ENCRYPTION:BOOL=$build_encryption -G"$env:CC_NAME" ..
+        -DUA_ENABLE_ENCRYPTION:BOOL=$build_encryption -G"$env:GENERATOR" ..
     Invoke-Expression $make_cmd
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
@@ -84,7 +92,7 @@ try {
     New-Item -ItemType directory -Path "build"
     cd build
     & cmake -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_ENABLE_PUBSUB:BOOL=ON -DUA_ENABLE_PUBSUB_INFORMATIONMODEL:BOOL=ON `
-    -DUA_ENABLE_PUBSUB_DELTAFRAMES:BOOL=ON  -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -G"$env:CC_NAME"  ..
+    -DUA_ENABLE_PUBSUB_DELTAFRAMES:BOOL=ON  -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -G"$env:GENERATOR"  ..
     Invoke-Expression $make_cmd
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
@@ -98,7 +106,7 @@ try {
     New-Item -ItemType directory -Path "build"
     cd build
     & cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_BUILD_EXAMPLES:BOOL=ON -DUA_ENABLE_AMALGAMATION:BOOL=ON `
-     -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DBUILD_SHARED_LIBS:BOOL=OFF -G"$env:CC_NAME" ..
+     -DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX -DBUILD_SHARED_LIBS:BOOL=OFF -G"$env:GENERATOR" ..
     Invoke-Expression $make_cmd
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"

--- a/tools/appveyor/install.ps1
+++ b/tools/appveyor/install.ps1
@@ -31,7 +31,7 @@ try {
 
     Write-Host -ForegroundColor Green "`n### Installing mbedtls ###`n"
 
-    if ($env:CC_SHORTNAME -eq "mingw") {
+    if ($env:CC_SHORTNAME -eq "mingw" -or $env:CC_SHORTNAME -eq "clang-mingw") {
         # pacman may complain that the directory does not exist, thus create it.
         # See https://github.com/open62541/open62541/issues/2068
         & C:\msys64\usr\bin\mkdir -p /var/cache/pacman/pkg


### PR DESCRIPTION
This PR adds a new job to AppVeyor so that it builds using clang on Windows