### PR TITLE
[Review] Architecture: Allow overriding memory allocation functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include
 
 set(exported_headers ${exported_headers}
                      ${PROJECT_BINARY_DIR}/src_generated/ua_config.h
+                     ${PROJECT_SOURCE_DIR}/arch/ua_architecture_base.h
                      ${ua_architecture_headers_beginning}
                      )
 

--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -10,6 +10,8 @@
 #ifndef PLUGINS_ARCH_POSIX_UA_ARCHITECTURE_H_
 #define PLUGINS_ARCH_POSIX_UA_ARCHITECTURE_H_
 
+#include "ua_architecture_base.h"
+
 /* Enable POSIX features */
 #if !defined(_XOPEN_SOURCE)
 # define _XOPEN_SOURCE 600
@@ -33,10 +35,6 @@
 #include <net/if.h>
 #ifndef UA_sleep_ms
 # define UA_sleep_ms(X) usleep(X * 1000)
-#else /* UA_sleep_ms */
-/* With this one can define its own UA_sleep_ms using a preprocessor define.
-E.g. see unit tests. */
-void UA_sleep_ms(size_t ms);
 #endif
 
 #define OPTVAL_TYPE int
@@ -111,10 +109,18 @@ void UA_sleep_ms(size_t ms);
 #endif
 
 #include <stdlib.h>
+#ifndef UA_free
 #define UA_free free
+#endif
+#ifndef UA_malloc
 #define UA_malloc malloc
+#endif
+#ifndef UA_calloc
 #define UA_calloc calloc
+#endif
+#ifndef UA_realloc
 #define UA_realloc realloc
+#endif
 
 #include <stdio.h>
 #define UA_snprintf snprintf

--- a/arch/ua_architecture_base.h
+++ b/arch/ua_architecture_base.h
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2018 (c) Stefan Profanter, fortiss GmbH
+ */
+
+#ifndef ARCH_UA_ARCHITECTURE_BASE_H
+#define ARCH_UA_ARCHITECTURE_BASE_H
+
+/*
+ * With the following list of defines, one can define its own UA_sleep_ms using a preprocessor define.
+ * E.g. see unit tests.
+ */
+
+#ifdef UA_sleep_ms
+void UA_sleep_ms(unsigned long ms);
+#endif
+
+#ifdef UA_malloc
+void* UA_malloc(unsigned long size);
+#endif
+
+#ifdef UA_calloc
+void* UA_calloc(unsigned long num, unsigned long size); //allocate memory in the heap with size*num bytes and set the memory to zero
+#endif
+
+#ifdef UA_realloc
+void* UA_realloc(void *ptr, unsigned long new_size);//re-allocate memory in the heap with new_size bytes from previously allocated memory ptr
+#endif
+
+#ifdef UA_free
+void UA_free(void* ptr); //de-allocate memory previously allocated with UA_malloc, UA_calloc or UA_realloc
+#endif
+
+#endif //ARCH_UA_ARCHITECTURE_BASE_H

--- a/arch/vxworks/ua_architecture.h
+++ b/arch/vxworks/ua_architecture.h
@@ -10,6 +10,8 @@
 #ifndef PLUGINS_ARCH_VXWORKS_UA_ARCHITECTURE_H_
 #define PLUGINS_ARCH_VXWORKS_UA_ARCHITECTURE_H_
 
+#include "ua_architecture_base.h"
+
 #include <errno.h>
 
 #include <arpa/inet.h>

--- a/arch/wec7/ua_architecture.h
+++ b/arch/wec7/ua_architecture.h
@@ -9,6 +9,8 @@
 #ifndef PLUGINS_ARCH_WEC7_UA_ARCHITECTURE_H_
 #define PLUGINS_ARCH_WEC7_UA_ARCHITECTURE_H_
 
+#include "ua_architecture_base.h"
+
 #ifndef _BSD_SOURCE
 # define _BSD_SOURCE
 #endif
@@ -55,10 +57,6 @@ char *strerror(int errnum);
 #define OPTVAL_TYPE char
 #ifndef UA_sleep_ms
 # define UA_sleep_ms(X) Sleep(X)
-#else /* UA_sleep_ms */
-/* With this one can define its own UA_sleep_ms using a preprocessor define.
-E.g. see unit tests. */
-void UA_sleep_ms(size_t ms);
 #endif
 
 // Windows does not support ansi colors
@@ -111,10 +109,18 @@ void UA_sleep_ms(size_t ms);
 # undef maxStringLength
 #endif
 
+#ifndef UA_free
 #define UA_free free
+#endif
+#ifndef UA_malloc
 #define UA_malloc malloc
+#endif
+#ifndef UA_calloc
 #define UA_calloc calloc
+#endif
+#ifndef UA_realloc
 #define UA_realloc realloc
+#endif
 
 #define UA_snprintf(source, size, string, ...) _snprintf_s(source, size, _TRUNCATE, string, __VA_ARGS__)
 

--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -10,6 +10,8 @@
 #ifndef PLUGINS_ARCH_WIN32_UA_ARCHITECTURE_H_
 #define PLUGINS_ARCH_WIN32_UA_ARCHITECTURE_H_
 
+#include "ua_architecture_base.h"
+
 #ifndef _BSD_SOURCE
 # define _BSD_SOURCE
 #endif
@@ -54,10 +56,6 @@
 #define OPTVAL_TYPE char
 #ifndef UA_sleep_ms
 # define UA_sleep_ms(X) Sleep(X)
-#else /* UA_sleep_ms */
-/* With this one can define its own UA_sleep_ms using a preprocessor define.
-E.g. see unit tests. */
-void UA_sleep_ms(size_t ms);
 #endif
 
 // Windows does not support ansi colors
@@ -117,10 +115,18 @@ void UA_sleep_ms(size_t ms);
 # undef maxStringLength
 #endif
 
+#ifndef UA_free
 #define UA_free free
+#endif
+#ifndef UA_malloc
 #define UA_malloc malloc
+#endif
+#ifndef UA_calloc
 #define UA_calloc calloc
+#endif
+#ifndef UA_realloc
 #define UA_realloc realloc
+#endif
 
 /* 3rd Argument is the string */
 #define UA_snprintf(source, size, ...) _snprintf_s(source, size, _TRUNCATE, __VA_ARGS__)

--- a/tests/testing-plugins/testing_clock.c
+++ b/tests/testing-plugins/testing_clock.c
@@ -42,7 +42,7 @@ UA_realSleep(UA_UInt32 duration) {
 }
 
 void
-UA_comboSleep(size_t duration) {
+UA_comboSleep(unsigned long duration) {
     UA_fakeSleep((UA_UInt32)duration);
     UA_realSleep((UA_UInt32)duration);
 }


### PR DESCRIPTION
With this change someone can override malloc/free/realloc/calloc with his own implementation by using preprocessor defines.

An example usage is found in: #2188