### PR TITLE
CI: Use debug symbols for check to avoid missing .pdb warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -224,7 +224,24 @@ cache:
 
 # combine all the commands into one single command. See https://github.com/travis-ci/travis-ci/issues/1066
 before_install: |
- set -e
+ set -eE
+
+ errorTrap() {
+   last_rv=$?
+
+   if [ $last_rv -ne 0 ] ; then
+      echo ""
+      echo ""
+      echo "----------------- Error -----------------"
+      echo ""
+      echo "---- Check additional output above!! ----"
+      # Wait a bit until the stdout is flushed
+      for i in 1 2 3 4 5 6 7 8 9 10; do echo "."; sleep 1; done
+   fi
+
+   exit $last_rv
+ }
+ trap errorTrap 0
 
  # set paths for locally installed libs (like liburcu)
  export LOCAL_PKG=$HOME/install
@@ -248,11 +265,48 @@ before_install: |
  if [ ${TRAVIS_OS_NAME} == "osx" ]; then sh ./tools/travis/travis_osx_before_install.sh; fi
 
 script: |
- set -e
+ set -eE
+
+ errorTrap() {
+   last_rv=$?
+
+   if [ $last_rv -ne 0 ] ; then
+      echo ""
+      echo ""
+      echo "----------------- Error -----------------"
+      echo ""
+      echo "---- Check additional output above!! ----"
+      # Wait a bit until the stdout is flushed
+      for i in 1 2 3 4 5 6 7 8 9 10; do echo "."; sleep 1; done
+   fi
+
+   exit $last_rv
+ }
+ trap errorTrap 0
+
  if [ ${TRAVIS_OS_NAME} == "linux" ]; then sh ./tools/travis/travis_linux_script.sh; fi
  if [ ${TRAVIS_OS_NAME} == "osx" ]; then sh ./tools/travis/travis_osx_script.sh; fi
 
 after_success: |
+ set -eE
+
+ errorTrap() {
+   last_rv=$?
+
+   if [ $last_rv -ne 0 ] ; then
+     echo ""
+     echo ""
+     echo "----------------- Error -----------------"
+     echo ""
+     echo "---- Check additional output above!! ----"
+     # Wait a bit until the stdout is flushed
+     for i in 1 2 3 4 5 6 7 8 9 10; do echo "."; sleep 1; done
+   fi
+
+   exit $last_rv
+ }
+ trap errorTrap 0
+
  if [ ${TRAVIS_OS_NAME} == "linux" ]; then sh ./tools/travis/travis_linux_after_success.sh; fi
  # Sleep to flush travis output
  echo == Build success ==

--- a/tools/appveyor/install.ps1
+++ b/tools/appveyor/install.ps1
@@ -48,7 +48,7 @@ try {
 
     if ($env:CC_SHORTNAME -eq "vs2015") {
         Write-Host -ForegroundColor Green "`n### Installing libcheck ###`n"
-        & appveyor DownloadFile https://github.com/Pro/check/releases/download/0.12.0_win/check.zip
+        & appveyor DownloadFile https://github.com/Pro/check/releases/download/0.12.0_dbg/check.zip
         & 7z x check.zip -oc:\ -bso0 -bsp0
 
         Write-Host -ForegroundColor Green "`n### Installing DrMemory ###`n"

--- a/tools/travis/travis_linux_before_install.sh
+++ b/tools/travis/travis_linux_before_install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -ev
 
+if [ -z ${LOCAL_PKG+x} ] || [ -z "$LOCAL_PKG" ]; then
+    echo "LOCAL_PKG is not set. Aborting..."
+    exit 1
+fi
 
 if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
 	# Only on non-docker builds required
@@ -25,7 +29,11 @@ if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
     echo "=== The build environment is outdated ==="
 
     # Clean up
-    rm -rf $LOCAL_PKG/*
+    # additional safety measure to avoid rm -rf on root
+    # only execute it on travis
+    if ! [ -z ${TRAVIS+x} ]; then
+        echo "rm -rf $LOCAL_PKG/*"
+    fi
 
 	if [ "$CC" = "tcc" ]; then
 		mkdir tcc_install && cd tcc_install


### PR DESCRIPTION
Appveyor (and windows builds) showed warnings for missing .pdb files in libcheck.

This uses the new release which also includes the .pdb

Also, this includes another fix for travis to try to flush stdout before exiting on error