### PR TITLE
Prepare python script for usage of define UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT

### DIFF
--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -55,6 +55,8 @@ builtin_overlayable = {"Boolean": "true",
                        "offsetof(UA_Guid, data3) == (sizeof(UA_UInt16) + sizeof(UA_UInt32)) && " + \
                        "offsetof(UA_Guid, data4) == (2*sizeof(UA_UInt32)))"}
 
+whitelistFuncAttrWarnUnusedResult = [  ] # for instances [ "String", "ByteString", "LocalizedText" ]
+
 # Type aliases
 type_aliases = { "CharArray" : "String" }
 def getTypeName(xmlTypeName):
@@ -179,6 +181,11 @@ class Type(object):
             funcs += "static UA_INLINE UA_StatusCode\nUA_%s_copy(const UA_%s *src, UA_%s *dst) {\n    *dst = *src;\n    return UA_STATUSCODE_GOOD;\n}\n\n" % (idName, idName, idName)
             funcs += "static UA_INLINE void\nUA_%s_deleteMembers(UA_%s *p) {\n    memset(p, 0, sizeof(UA_%s));\n}\n\n" % (idName, idName, idName)
         else:
+            for entry in whitelistFuncAttrWarnUnusedResult:
+                if idName == entry:
+                    funcs += "UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT "
+                    break;
+            
             funcs += "static UA_INLINE UA_StatusCode\nUA_%s_copy(const UA_%s *src, UA_%s *dst) {\n    return UA_copy(src, dst, %s);\n}\n\n" % (idName, idName, idName, self.datatype_ptr())
             funcs += "static UA_INLINE void\nUA_%s_deleteMembers(UA_%s *p) {\n    UA_deleteMembers(p, %s);\n}\n\n" % (idName, idName, self.datatype_ptr())
         funcs += "static UA_INLINE void\nUA_%s_delete(UA_%s *p) {\n    UA_delete(p, %s);\n}" % (idName, idName, self.datatype_ptr())


### PR DESCRIPTION
Only the inserted dataTypes in list whitelistFuncAttrWarnUnusedResult will be generated with the define UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT in front of the function declaration.
In file ua_types_generated_handling.h, for example:
```C
UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT static UA_INLINE UA_StatusCode
UA_ByteString_copy(const UA_ByteString *src, UA_ByteString *dst) {
    return UA_copy(src, dst, &UA_TYPES[UA_TYPES_BYTESTRING]);
}
```