### PR TITLE
some server have problems with RequestHeader timeoutHint=0

### DIFF
--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -759,6 +759,7 @@ UA_Client_Subscriptions_backgroundPublish(UA_Client *client) {
         if (!request)
             return UA_STATUSCODE_BADOUTOFMEMORY;
 
+        request->requestHeader.timeoutHint=60000;
         UA_StatusCode retval = UA_Client_preparePublishRequest(client, request);
         if(retval != UA_STATUSCODE_GOOD) {
             UA_PublishRequest_delete(request);


### PR DESCRIPTION
if requestHeader timeoutHint is '0' the corresponding server should treat it as no timeout, but some server misbehave and really treat it as zero timeout, which is of course a fault in the server.

To make the client more tolerant a large timeoutHint, i.e. 60000, would help.