### PR TITLE
change port used by Server and Client examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ int main(int argc, char** argv)
 {
     signal(SIGINT, signalHandler); /* catch ctrl-c */
 
-    /* Create a server with one network layer listening on port 4840 */
+    /* Create a server with one network layer listening on port 16664 */
     UA_ServerConfig config = UA_ServerConfig_standard;
-    UA_ServerNetworkLayer nl = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 4840);
+    UA_ServerNetworkLayer nl = UA_ServerNetworkLayerTCP(UA_ConnectionConfig_standard, 16664);
     config.networkLayers = &nl;
     config.networkLayersSize = 1;
     UA_Server *server = UA_Server_new(config);

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
 {
     /* Create a client and connect */
     UA_Client *client = UA_Client_new(UA_ClientConfig_standard);
-    UA_StatusCode status = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    UA_StatusCode status = UA_Client_connect(client, "opc.tcp://localhost:16664");
     if(status != UA_STATUSCODE_GOOD) {
         UA_Client_delete(client);
         return status;


### PR DESCRIPTION
Readme.md contains **Example Server Implementation** and **Example Client Implementation** that uses a default port.
Port 4840 is the standard one for the OPC UA server discovery.
I think it's better to use 16664 that is the one used in
https://github.com/open62541/open62541/blob/7b3824f8d451f7b1025bee774efbbe81e350b370/examples/server.c#L116

Using port 4840 brings to an issue like the one described in #1092 
`warning/network Error during binding of the server socket`