### PR TITLE
[Review] PubSub: Only add timer if interval > 0

### DIFF
--- a/src/pubsub/ua_pubsub.c
+++ b/src/pubsub/ua_pubsub.c
@@ -1152,12 +1152,15 @@ UA_WriterGroup_publishCallback(UA_Server *server, UA_WriterGroup *writerGroup) {
  */
 UA_StatusCode
 UA_WriterGroup_addPublishCallback(UA_Server *server, UA_WriterGroup *writerGroup) {
-    UA_StatusCode retval =
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    if (writerGroup->config.publishingInterval > 0) {
+        retval =
             UA_PubSubManager_addRepeatedCallback(server, (UA_ServerCallback) UA_WriterGroup_publishCallback,
                                                  writerGroup, (UA_UInt32) writerGroup->config.publishingInterval,
                                                  &writerGroup->publishCallbackId);
-    if(retval == UA_STATUSCODE_GOOD)
-        writerGroup->publishCallbackIsRegistered = true;
+        if(retval == UA_STATUSCODE_GOOD)
+            writerGroup->publishCallbackIsRegistered = true;
+    }
     //run once after creation
     UA_WriterGroup_publishCallback(server, writerGroup);
     return retval;


### PR DESCRIPTION
The callback should only be added if publishingInterval is set to > 0.

@andreasebner please check

Also note, that the call to `UA_WriterGroup_publishCallback(server, writerGroup);` will do nothing, since the writerGroup does not have a writer right after creation and in the tutorial the writer is added afterwards.

Later on we may need a User-API method which allows to manually publish one single data set (without interval).