### PR TITLE
fix missing types during compilation with UA_ENABLE_MULTITHREADING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,7 +594,7 @@ if(UA_ENABLE_ENCRYPTION)
 endif()
 
 if(UA_ENABLE_DISCOVERY)
-    list(INSERT internal_headers 5 ${PROJECT_SOURCE_DIR}/src/server/ua_discovery_manager.h)
+    list(INSERT internal_headers 13 ${PROJECT_SOURCE_DIR}/src/server/ua_discovery_manager.h)
     list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_discovery_manager.c)
 endif()
 


### PR DESCRIPTION
Compiling the `open62541  v0.4` with `UA_ENABLE_MULTITHREADING=ON`  gives errors like
`open62541.c:4965:5: error: unknown type name 'UA_DelayedCallback'
     UA_DelayedCallback delayedCleanup;` 

With both options UA_ENABLE_DISCOVERY=ON and UA_ENABLE_MULTITHREADING=ON the open62541 library doesn't compile anymore because the `ua_discovery_manager.h` file will be inserted at position `5` into internal_headers and that is to early.
inserting `ua_discovery_manager.h` at position `13` works, but I don't know if this has other unwanted side effects?!
