### PR TITLE
WIP: Separate SecurityPolicies from Endpoints in the server

### DIFF
--- a/include/ua_plugin_securitypolicy.h
+++ b/include/ua_plugin_securitypolicy.h
@@ -111,11 +111,12 @@ typedef struct {
      * key.
      *
      * @param securityPolicy the securityPolicy the function is invoked on.
-     * @param channelContext the channelContext which contains information about
-     *                       the keys needed to decrypt the message.
+     * @param securityPolicyContext the securityPolicyContext which contains
+     *                              information about the keys needed to decrypt
+     *                              the message.
      * @param data the data to decrypt. The decryption is done in place. */
     UA_StatusCode (*decrypt)(const UA_SecurityPolicy *securityPolicy,
-                             void *channelContext,
+                             void *securityPolicyContext,
                              UA_ByteString *data) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
     /* Returns the length of the key used locally to encrypt messages in bits
@@ -366,11 +367,6 @@ struct UA_SecurityPolicy {
     void (*deleteMembers)(UA_SecurityPolicy *policy);
 };
 
-typedef struct {
-    UA_SecurityPolicy securityPolicy;
-    UA_EndpointDescription endpointDescription;
-} UA_Endpoint;
-
 /* Gets the number of bytes that are needed by the encryption function in
  * addition to the length of the plaintext message. This is needed, since
  * most RSA encryption methods have their own padding mechanism included.
@@ -386,6 +382,14 @@ UA_SecurityPolicy_getRemoteAsymEncryptionBufferLengthOverhead(const UA_SecurityP
                                                               const void *channelContext,
                                                               size_t maxEncryptionLength);
 
+/* Gets the a pointer to the context of a security policy supported by the
+ * server matched by the security policy uri.
+ *
+ * @param server the server context.
+ * @param securityPolicyUri the security policy to get the context of. */
+UA_SecurityPolicy *
+UA_SecurityPolicy_getSecurityPolicyByUri(const UA_Server *server,
+                                         UA_ByteString *securityPolicyUri);
 
 typedef UA_StatusCode
 (*UA_SecurityPolicy_Func)(UA_SecurityPolicy *policy,

--- a/include/ua_plugin_securitypolicy.h
+++ b/include/ua_plugin_securitypolicy.h
@@ -111,12 +111,11 @@ typedef struct {
      * key.
      *
      * @param securityPolicy the securityPolicy the function is invoked on.
-     * @param securityPolicyContext the securityPolicyContext which contains
-     *                              information about the keys needed to decrypt
-     *                              the message.
+     * @param channelContext the channelContext which contains information about
+     *                       the keys needed to decrypt the message.
      * @param data the data to decrypt. The decryption is done in place. */
     UA_StatusCode (*decrypt)(const UA_SecurityPolicy *securityPolicy,
-                             void *securityPolicyContext,
+                             void *channelContext,
                              UA_ByteString *data) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
     /* Returns the length of the key used locally to encrypt messages in bits

--- a/include/ua_server_config.h
+++ b/include/ua_server_config.h
@@ -100,9 +100,13 @@ struct UA_ServerConfig {
     UA_PubSubTransportLayer *pubsubTransportLayers;
 #endif
 
+    /* Available security policies */
+    size_t securityPoliciesSize;
+    UA_SecurityPolicy* securityPolicies;
+
     /* Available endpoints */
     size_t endpointsSize;
-    UA_Endpoint *endpoints;
+    UA_EndpointDescription *endpoints;
 
     /* Node Lifecycle callbacks */
     UA_GlobalNodeLifecycle nodeLifecycle;

--- a/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
@@ -212,13 +212,13 @@ asym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 
 static UA_StatusCode
 asym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                              Basic128Rsa15_PolicyContext *pc,
+                              Basic128Rsa15_ChannelContext *cc,
                               UA_ByteString *data) {
-    if(securityPolicy == NULL || pc == NULL || data == NULL)
+    if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *rsaContext =
-        mbedtls_pk_rsa(pc->localPrivateKey);
+        mbedtls_pk_rsa(cc->policyContext->localPrivateKey);
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, 0);
 
     if(data->length % rsaContext->len != 0)
@@ -234,7 +234,7 @@ asym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
     size_t offset = 0;
     size_t outLength = 0;
     while(lenDataToDecrypt >= rsaContext->len) {
-        int mbedErr = mbedtls_pk_decrypt(&pc->localPrivateKey,
+        int mbedErr = mbedtls_pk_decrypt(&cc->policyContext->localPrivateKey,
                                          data->data + inOffset, rsaContext->len,
                                          decrypted.data + offset, &outLength,
                                          decrypted.length - offset, NULL, NULL);

--- a/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
  */
@@ -212,13 +212,13 @@ asym_encrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
 
 static UA_StatusCode
 asym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
-                              Basic128Rsa15_ChannelContext *cc,
+                              Basic128Rsa15_PolicyContext *pc,
                               UA_ByteString *data) {
-    if(securityPolicy == NULL || cc == NULL || data == NULL)
+    if(securityPolicy == NULL || pc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *rsaContext =
-        mbedtls_pk_rsa(cc->policyContext->localPrivateKey);
+        mbedtls_pk_rsa(pc->localPrivateKey);
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, 0);
 
     if(data->length % rsaContext->len != 0)
@@ -234,7 +234,7 @@ asym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
     size_t offset = 0;
     size_t outLength = 0;
     while(lenDataToDecrypt >= rsaContext->len) {
-        int mbedErr = mbedtls_pk_decrypt(&cc->policyContext->localPrivateKey,
+        int mbedErr = mbedtls_pk_decrypt(&pc->localPrivateKey,
                                          data->data + inOffset, rsaContext->len,
                                          decrypted.data + offset, &outLength,
                                          decrypted.length - offset, NULL, NULL);
@@ -927,7 +927,7 @@ UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy,
 
     UA_SecurityPolicyEncryptionAlgorithm *asym_encryptionAlgorithm =
         &asymmetricModule->cryptoModule.encryptionAlgorithm;
-    asym_encryptionAlgorithm->uri = UA_STRING("TODO: ALG URI");
+    asym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#rsa-1_5");
     asym_encryptionAlgorithm->encrypt =
         (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))asym_encrypt_sp_basic128rsa15;
     asym_encryptionAlgorithm->decrypt =

--- a/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
@@ -227,13 +227,13 @@ asym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
 asym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                               Basic256Sha256_PolicyContext *pc,
+                               Basic256Sha256_ChannelContext *cc,
                                UA_ByteString *data) {
-    if(securityPolicy == NULL || pc == NULL || data == NULL)
+    if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *rsaContext =
-        mbedtls_pk_rsa(pc->localPrivateKey);
+        mbedtls_pk_rsa(cc->policyContext->localPrivateKey);
 
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
 
@@ -250,6 +250,7 @@ asym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
     size_t offset = 0;
     size_t outLength = 0;
     const unsigned char *label = NULL;
+    Basic256Sha256_PolicyContext *pc = cc->policyContext;
 
     while(lenDataToDecrypt >= rsaContext->len) {
         int mbedErr = mbedtls_rsa_rsaes_oaep_decrypt(rsaContext, mbedtls_ctr_drbg_random,

--- a/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
@@ -227,13 +227,13 @@ asym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
 asym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                               Basic256Sha256_ChannelContext *cc,
+                               Basic256Sha256_PolicyContext *pc,
                                UA_ByteString *data) {
-    if(securityPolicy == NULL || cc == NULL || data == NULL)
+    if(securityPolicy == NULL || pc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *rsaContext =
-        mbedtls_pk_rsa(cc->policyContext->localPrivateKey);
+        mbedtls_pk_rsa(pc->localPrivateKey);
 
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
 
@@ -250,7 +250,6 @@ asym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
     size_t offset = 0;
     size_t outLength = 0;
     const unsigned char *label = NULL;
-    Basic256Sha256_PolicyContext *pc = cc->policyContext;
 
     while(lenDataToDecrypt >= rsaContext->len) {
         int mbedErr = mbedtls_rsa_rsaes_oaep_decrypt(rsaContext, mbedtls_ctr_drbg_random,

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -282,7 +282,7 @@ UA_ServerConfig_new_customBuffer(UA_UInt16 portNumber,
     if(certificate)
         localCertificate = *certificate;
     retval =
-        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
+        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -361,7 +361,7 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
 
     ++conf->securityPoliciesSize;
     retval =
-        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
+        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -461,7 +461,7 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
        localPrivateKey = *privateKey;
     ++conf->securityPoliciesSize;
     retval =
-        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
+        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -561,7 +561,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
        localPrivateKey = *privateKey;
     ++conf->securityPoliciesSize;
     retval =
-        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
+        UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -501,7 +501,7 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
     }
 
     ++conf->endpointsSize;
-    retval = createEndpoint(conf, &conf->endpoints[1], &conf->securityPolicies[1],
+    retval = createEndpoint(conf, &conf->endpoints[2], &conf->securityPolicies[1],
                             UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -281,7 +281,7 @@ UA_ServerConfig_new_customBuffer(UA_UInt16 portNumber,
     UA_ByteString localCertificate = UA_BYTESTRING_NULL;
     if(certificate)
         localCertificate = *certificate;
-    retVal =
+    retval =
         UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
@@ -289,7 +289,7 @@ UA_ServerConfig_new_customBuffer(UA_UInt16 portNumber,
     }
 
     /* Allocate the endpoint */
-    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint));
+    conf->endpoints = (UA_EndpointDescription *)UA_malloc(sizeof(UA_EndpointDescription));
     if(!conf->endpoints) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -359,7 +359,7 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
     if(privateKey)
        localPrivateKey = *privateKey;
 
-    retVal =
+    retval =
         UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
@@ -375,7 +375,7 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
 
     /* Allocate the endpoints */
     conf->endpointsSize = 0;
-    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint) * 3);
+    conf->endpoints = (UA_EndpointDescription *)UA_malloc(sizeof(UA_EndpointDescription) * 3);
     if(!conf->endpoints) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -457,7 +457,7 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
         localCertificate = *certificate;
     if(privateKey)
        localPrivateKey = *privateKey;
-    retVal =
+    retval =
         UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
@@ -473,7 +473,7 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
 
     /* Allocate the endpoints */
     conf->endpointsSize = 0;
-    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint) * 3);
+    conf->endpoints = (UA_EndpointDescription *)UA_malloc(sizeof(UA_EndpointDescription) * 3);
     if(!conf->endpoints) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -489,7 +489,7 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
     }
 
     ++conf->endpointsSize;
-    retval = createEndpoint(conf, &conf->endpoints[1], &conf->securityPolicies[1]
+    retval = createEndpoint(conf, &conf->endpoints[1], &conf->securityPolicies[1],
                             UA_MESSAGESECURITYMODE_SIGN);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
@@ -497,7 +497,7 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
     }
 
     ++conf->endpointsSize;
-    retval = createEndpoint(conf, &conf->endpoints[1], &conf->securityPolicies[1]
+    retval = createEndpoint(conf, &conf->endpoints[1], &conf->securityPolicies[1],
                             UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
@@ -555,7 +555,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
         localCertificate = *certificate;
     if(privateKey)
        localPrivateKey = *privateKey;
-    retVal =
+    retval =
         UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
@@ -578,7 +578,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
 
     /* Allocate the endpoints */
     conf->endpointsSize = 0;
-    conf->endpoints = (UA_Endpoint *)UA_malloc(sizeof(UA_Endpoint) * 5);
+    conf->endpoints = (UA_EndpointDescription *)UA_malloc(sizeof(UA_EndpointDescription) * 5);
     if(!conf->endpoints) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -593,7 +593,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
         return NULL;
     }
 
-    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[1]
+    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[1],
                             UA_MESSAGESECURITYMODE_SIGN);
     ++conf->endpointsSize;
     if(retval != UA_STATUSCODE_GOOD) {
@@ -601,7 +601,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
         return NULL;
     }
 
-    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[1]
+    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[1],
                             UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
     ++conf->endpointsSize;
     if(retval != UA_STATUSCODE_GOOD) {
@@ -609,7 +609,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
         return NULL;
     }
 
-    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[2]
+    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[2],
                             UA_MESSAGESECURITYMODE_SIGN);
     ++conf->endpointsSize;
     if(retval != UA_STATUSCODE_GOOD) {
@@ -617,7 +617,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
         return NULL;
     }
 
-    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[2]
+    retval = createEndpoint(conf, &conf->endpoints[conf->endpointsSize], &conf->securityPolicies[2],
                             UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
     ++conf->endpointsSize;
     if(retval != UA_STATUSCODE_GOOD) {

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -369,7 +369,7 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
     ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic128Rsa15(&conf->securityPolicies[1], &conf->certificateVerification,
-                                        localCertificate, localPrivateKey, conf->logger);
+                                        localCertificate, localPrivateKey, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -469,7 +469,7 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
     ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic256Sha256(&conf->securityPolicies[1], &conf->certificateVerification,
-                                         localCertificate, localPrivateKey, conf->logger);
+                                         localCertificate, localPrivateKey, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -569,7 +569,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
     ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic128Rsa15(&conf->securityPolicies[1], &conf->certificateVerification,
-                                        localCertificate, localPrivateKey, conf->logger);
+                                        localCertificate, localPrivateKey, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
@@ -577,7 +577,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
     ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic256Sha256(&conf->securityPolicies[2], &conf->certificateVerification,
-                                         localCertificate, localPrivateKey, conf->logger);
+                                         localCertificate, localPrivateKey, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -359,12 +359,14 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
     if(privateKey)
        localPrivateKey = *privateKey;
 
+    ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
     }
+    ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic128Rsa15(&conf->securityPolicies[1], &conf->certificateVerification,
                                         localCertificate, localPrivateKey, conf->logger);
@@ -457,12 +459,14 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
         localCertificate = *certificate;
     if(privateKey)
        localPrivateKey = *privateKey;
+    ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
     }
+    ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic256Sha256(&conf->securityPolicies[1], &conf->certificateVerification,
                                          localCertificate, localPrivateKey, conf->logger);
@@ -555,12 +559,14 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
         localCertificate = *certificate;
     if(privateKey)
        localPrivateKey = *privateKey;
+    ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_None(&conf->securityPolicies[0], NULL, localCertificate, conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
     }
+    ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic128Rsa15(&conf->securityPolicies[1], &conf->certificateVerification,
                                         localCertificate, localPrivateKey, conf->logger);
@@ -568,6 +574,7 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
         UA_ServerConfig_delete(conf);
         return NULL;
     }
+    ++conf->securityPoliciesSize;
     retval =
         UA_SecurityPolicy_Basic256Sha256(&conf->securityPolicies[2], &conf->certificateVerification,
                                          localCertificate, localPrivateKey, conf->logger);

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -68,7 +68,7 @@ createEndpoint(UA_ServerConfig *conf, UA_EndpointDescription *endpoint,
     UA_EndpointDescription_init(endpoint);
 
     endpoint->securityMode = securityMode;
-    endpoint->securityPolicyUri = securityPolicy->policyUri;
+    UA_String_copy(&securityPolicy->policyUri, &endpoint->securityPolicyUri);
     endpoint->transportProfileUri =
         UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
 

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -333,6 +333,8 @@ UA_Server_updateCertificate(UA_Server *server,
             UA_String_deleteMembers(&ed->serverCertificate);
             UA_String_copy(newCertificate, &ed->serverCertificate);
             UA_SecurityPolicy *sp = UA_SecurityPolicy_getSecurityPolicyByUri(server, &server->config.endpoints[i].securityPolicyUri);
+            if(!sp)
+                return UA_STATUSCODE_BADINTERNALERROR;
             sp->updateCertificateAndPrivateKey(sp, *newCertificate, *newPrivateKey);
         }
         i++;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -332,7 +332,7 @@ UA_Server_updateCertificate(UA_Server *server,
         if (UA_ByteString_equal(&ed->serverCertificate, oldCertificate)) {
             UA_String_deleteMembers(&ed->serverCertificate);
             UA_String_copy(newCertificate, &ed->serverCertificate);
-            UA_SecurityPolicy *sp = UA_SecurityPolicy_getSecurityPolicyByUri(&server->config.endpoints[i].securityPolicyUri);
+            UA_SecurityPolicy *sp = UA_SecurityPolicy_getSecurityPolicyByUri(server, &server->config.endpoints[i].securityPolicyUri);
             sp->updateCertificateAndPrivateKey(sp, *newCertificate, *newPrivateKey);
         }
         i++;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -341,6 +341,23 @@ UA_Server_updateCertificate(UA_Server *server,
     return UA_STATUSCODE_GOOD;
 }
 
+/***************************/
+/* Server lookup functions */
+/***************************/
+
+UA_SecurityPolicy *
+UA_SecurityPolicy_getSecurityPolicyByUri(const UA_Server *server,
+                                         UA_ByteString *securityPolicyUri)
+{
+    for(size_t i = 0; i < server->config.securityPoliciesSize; i++) {
+        UA_SecurityPolicy *securityPolicyCandidate = &server->config.securityPolicies[i];
+        if(UA_ByteString_equal(securityPolicyUri,
+                               &securityPolicyCandidate->policyUri))
+            return securityPolicyCandidate;
+    }
+    return NULL;
+}
+
 /********************/
 /* Main Server Loop */
 /********************/

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -328,11 +328,11 @@ UA_Server_updateCertificate(UA_Server *server,
 
     size_t i = 0;
     while (i < server->config.endpointsSize) {
-        UA_EndpointDescription *ed = &server->config.endpoints[i].endpointDescription;
+        UA_EndpointDescription *ed = &server->config.endpoints[i];
         if (UA_ByteString_equal(&ed->serverCertificate, oldCertificate)) {
             UA_String_deleteMembers(&ed->serverCertificate);
             UA_String_copy(newCertificate, &ed->serverCertificate);
-            UA_SecurityPolicy *sp = &server->config.endpoints[i].securityPolicy;
+            UA_SecurityPolicy *sp = UA_SecurityPolicy_getSecurityPolicyByUri(&server->config.endpoints[i].securityPolicyUri);
             sp->updateCertificateAndPrivateKey(sp, *newCertificate, *newPrivateKey);
         }
         i++;

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -648,15 +648,18 @@ createSecureChannel(void *application, UA_Connection *connection,
     UA_Server *server = (UA_Server*)application;
 
     /* Iterate over available endpoints and choose the correct one */
-    UA_Endpoint *endpoint = NULL;
+    UA_EndpointDescription *endpoint = NULL;
+    UA_SecurityPolicy *securityPolicy = NULL;
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     for(size_t i = 0; i < server->config.endpointsSize; ++i) {
-        UA_Endpoint *endpointCandidate = &server->config.endpoints[i];
+        UA_EndpointDescription *endpointCandidate = &server->config.endpoints[i];
         if(!UA_ByteString_equal(&asymHeader->securityPolicyUri,
-                                &endpointCandidate->securityPolicy.policyUri))
+                                &endpointCandidate->securityPolicyUri))
             continue;
-        retval = endpointCandidate->securityPolicy.asymmetricModule.
-            compareCertificateThumbprint(&endpointCandidate->securityPolicy,
+        securityPolicy = UA_SecurityPolicy_getSecurityPolicyByUri(server,
+                                                                  (UA_ByteString*)&endpointCandidate->securityPolicyUri);
+        retval = securityPolicy->asymmetricModule.
+            compareCertificateThumbprint(securityPolicy,
                                          &asymHeader->receiverCertificateThumbprint);
         if(retval != UA_STATUSCODE_GOOD)
             continue;
@@ -673,7 +676,7 @@ createSecureChannel(void *application, UA_Connection *connection,
 
     /* Create a new channel */
     return UA_SecureChannelManager_create(&server->secureChannelManager, connection,
-                                          &endpoint->securityPolicy, asymHeader);
+                                          securityPolicy, asymHeader);
 }
 
 static UA_StatusCode

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -658,6 +658,9 @@ createSecureChannel(void *application, UA_Connection *connection,
             continue;
         securityPolicy = UA_SecurityPolicy_getSecurityPolicyByUri(server,
                                                                   (UA_ByteString*)&endpointCandidate->securityPolicyUri);
+        if(!securityPolicy)
+            return UA_STATUSCODE_BADINTERNALERROR;
+
         retval = securityPolicy->asymmetricModule.
             compareCertificateThumbprint(securityPolicy,
                                          &asymHeader->receiverCertificateThumbprint);

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -238,7 +238,7 @@ Service_GetEndpoints(UA_Server *server, UA_Session *session,
         for(size_t j = 0; j < server->config.endpointsSize; ++j) {
             for(size_t i = 0; i < request->profileUrisSize; ++i) {
                 if(!UA_String_equal(&request->profileUris[i],
-                                    &server->config.endpoints[j].endpointDescription.transportProfileUri))
+                                    &server->config.endpoints[j].transportProfileUri))
                     continue;
                 relevant_endpoints[j] = true;
                 ++relevant_count;
@@ -277,7 +277,7 @@ Service_GetEndpoints(UA_Server *server, UA_Session *session,
         for(size_t j = 0; j < server->config.endpointsSize; ++j) {
             if(!relevant_endpoints[j])
                 continue;
-            retval = UA_EndpointDescription_copy(&server->config.endpoints[j].endpointDescription,
+            retval = UA_EndpointDescription_copy(&server->config.endpoints[j],
                                                  &response->endpoints[k]);
             if(retval != UA_STATUSCODE_GOOD)
                 goto error;

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -135,7 +135,7 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
     /* Copy the server's endpointdescriptions into the response */
     for(size_t i = 0; i < server->config.endpointsSize; ++i)
         response->responseHeader.serviceResult |=
-            UA_EndpointDescription_copy(&server->config.endpoints[i].endpointDescription,
+            UA_EndpointDescription_copy(&server->config.endpoints[i],
                                         &response->serverEndpoints[i]);
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         UA_SessionManager_removeSession(&server->sessionManager,

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -277,20 +277,20 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
     /* Find the matching endpoint */
     const UA_EndpointDescription *ed = NULL;
     for(size_t i = 0; ed == NULL && i < server->config.endpointsSize; ++i) {
-        const UA_Endpoint *e = &server->config.endpoints[i];
+        const UA_EndpointDescription *e = &server->config.endpoints[i];
 
         /* Match the Security Mode */
-        if(e->endpointDescription.securityMode != channel->securityMode)
+        if(e->securityMode != channel->securityMode)
             continue;
 
         /* Match the SecurityPolicy */
-        if(!UA_String_equal(&e->securityPolicy.policyUri,
+        if(!UA_String_equal(&e->securityPolicyUri,
                             &channel->securityPolicy->policyUri))
             continue;
 
         /* Match the UserTokenType */
-        for(size_t j = 0; j < e->endpointDescription.userIdentityTokensSize; j++) {
-            const UA_UserTokenPolicy *u = &e->endpointDescription.userIdentityTokens[j];
+        for(size_t j = 0; j < e->userIdentityTokensSize; j++) {
+            const UA_UserTokenPolicy *u = &e->userIdentityTokens[j];
             if(u->tokenType == UA_USERTOKENTYPE_ANONYMOUS) {
                 if(request->userIdentityToken.content.decoded.type != &UA_TYPES[UA_TYPES_ANONYMOUSIDENTITYTOKEN])
                     continue;
@@ -309,7 +309,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
             }
 
             /* Match found */
-            ed = &e->endpointDescription;
+            ed = e;
             break;
         }
 


### PR DESCRIPTION
Currently the SecurityPolicies supported by the server are strongly
tied together with the endpoints. To be able to reuse the
SecurityPolicy instances of the server also in the Access Control
plugin to handle encrypted passwords the SecurityPolicies are moved
to the server config struct.