### PR TITLE
Bugfix: Fix server timestamps

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -358,8 +358,10 @@ ReadWithNode(const UA_Node *node, UA_Server *server, UA_Session *session,
     /* Create server timestamp */
     if(timestampsToReturn == UA_TIMESTAMPSTORETURN_SERVER ||
        timestampsToReturn == UA_TIMESTAMPSTORETURN_BOTH) {
-        v->serverTimestamp = UA_DateTime_now();
-        v->hasServerTimestamp = true;
+        if (!v->hasServerTimestamp) {
+            v->serverTimestamp = UA_DateTime_now();
+            v->hasServerTimestamp = true;
+        }
     }
 
     /* Handle source time stamp */
@@ -1096,9 +1098,15 @@ writeValueAttribute(UA_Server *server, UA_Session *session,
     }
 
     /* Set the source timestamp if there is none */
+    UA_DateTime now = UA_DateTime_now();
     if(!adjustedValue.hasSourceTimestamp) {
-        adjustedValue.sourceTimestamp = UA_DateTime_now();
+        adjustedValue.sourceTimestamp = now;
         adjustedValue.hasSourceTimestamp = true;
+    }
+
+    if(!adjustedValue.hasServerTimestamp) {
+        adjustedValue.serverTimestamp = now;
+        adjustedValue.hasServerTimestamp = true;
     }
 
     /* Ok, do it */


### PR DESCRIPTION
Timestamps from DataValues will never be set on arrival and will be set to now when read.
This is wrong behaviour.

DataValues server timestamps should be set when the values arrive in the server.
While a client read data, the timestamps should not be altered.