### PR TITLE
CI: Remove VS2015 from Appveyor builds to save build time

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,13 +34,6 @@ environment:
           FORCE_CXX: OFF
           OUT_DIR_LIB: bin\Debug
           OUT_DIR_EXAMPLES: bin\examples\Debug
-        - CC_NAME: Visual Studio 14 2015
-          CC_SHORTNAME: vs2015
-          GENERATOR: Visual Studio 14 2015
-          MAKE: msbuild /p:ContinueOnError=false /p:StopOnFirstFailure=true open62541.sln
-          FORCE_CXX: OFF
-          OUT_DIR_LIB: bin\Debug
-          OUT_DIR_EXAMPLES: bin\examples\Debug
         - CC_NAME: Visual Studio 15 2017
           CC_SHORTNAME: vs2017
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/tools/appveyor/build.ps1
+++ b/tools/appveyor/build.ps1
@@ -131,8 +131,8 @@ try {
     Remove-Item -Path pack_tmp -Recurse -Force
     Remove-Item -Path build -Recurse -Force
 
-    # Only execute unit tests on vs2015 and vs2017 to save compilation time
-    if ($env:CC_SHORTNAME -eq "vs2015" -or $env:CC_SHORTNAME -eq "vs2017") {
+    # Only execute unit tests on vs2017 to save compilation time
+    if ($env:CC_SHORTNAME -eq "vs2017") {
         Write-Host -ForegroundColor Green "`n###################################################################"
         Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with unit tests #####`n"
         New-Item -ItemType directory -Path "build"


### PR DESCRIPTION
As discussed in #2218