### PR TITLE
Fix: mdns record when strlen(hostname) + strlen(servername) is 61 or 62

### DIFF
--- a/src/server/ua_services_discovery_multicast.c
+++ b/src/server/ua_services_discovery_multicast.c
@@ -274,13 +274,13 @@ createFullServiceDomain(char *outServiceDomain, size_t maxLen,
 
     size_t offset = 0;
     if (hostnameLen > 0) {
-        UA_snprintf(outServiceDomain, maxLen - 1, "%.*s-%.*s",
+        UA_snprintf(outServiceDomain, maxLen + 1, "%.*s-%.*s",
                     (int) servernameLen, (char *) servername->data,
                     (int) hostnameLen, (char *) hostname->data);
         offset = servernameLen + hostnameLen + 1;
     }
     else {
-        UA_snprintf(outServiceDomain, maxLen - 1, "%.*s",
+        UA_snprintf(outServiceDomain, maxLen + 1, "%.*s",
                     (int) servernameLen, (char *) servername->data);
         offset = servernameLen;
     }


### PR DESCRIPTION
This fixes the case, that servername + hostname have a length of 61 or 62.

outServiceDomain is a buffer of length 63 + 24
so maxLen is 63
When Servername + hostname in total are 61 or 62 UA_snprintf will cut off the last (two) letter(s).

f.e.
servername:
123456789_123456789_123456789_123456789_123456789_123456789
hostname:
abc
will result in 
123456789_123456789_123456789_123456789_123456789_123456789-a\0
and the next UA_snprintf will insert after the \0