### PR TITLE
[0.3] Backport and further CMake install improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,12 +801,21 @@ if(UA_ENABLE_DISCOVERY_MULTICAST)
 endif()
 
 # export library (either static or shared depending on BUILD_SHARED_LIBS)
+if(NOT UA_ENABLE_AMALGAMATION)
 install(TARGETS open62541
         EXPORT open62541Targets
         LIBRARY DESTINATION ${LIB_INSTALL_DIR}
         ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
         INCLUDES DESTINATION include/open62541 include)
+else()
+install(TARGETS open62541
+        EXPORT open62541Targets
+        LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+        ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
+        INCLUDES DESTINATION include)
+endif()
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/open62541Config.cmake.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -860,8 +860,6 @@ set(UA_install_tools_files "tools/generate_datatypes.py"
 install(DIRECTORY ${UA_install_tools_dirs} DESTINATION ${open62541_install_tools_dir} USE_SOURCE_PERMISSIONS)
 install(FILES ${UA_install_tools_files} DESTINATION ${open62541_install_tools_dir})
 
-install(FILES ${PROJECT_BINARY_DIR}/open62541.h DESTINATION include)
-# Export amalgamated header open62541.h which is generated due to build of open62541-object
 if(NOT UA_ENABLE_AMALGAMATION)
     # Assume no files have identical names and place everything in the include folder
     install(FILES ${internal_headers}
@@ -869,6 +867,10 @@ if(NOT UA_ENABLE_AMALGAMATION)
                   ${default_plugin_headers}
                   ${historizing_default_plugin_headers}
             DESTINATION ${open62541_install_include_dir})
+else()
+    # Export amalgamated header open62541.h which is generated due to build of 
+    # open62541-object
+    install(FILES ${PROJECT_BINARY_DIR}/open62541.h DESTINATION include)
 endif()
 
 add_subdirectory(tools/packaging)


### PR DESCRIPTION
Backport of #2292 and documentation on how to install open62541.

This emphasizes that we recommend installing without amalgamation, as discussed here https://github.com/open62541/open62541/pull/2292#discussion_r241106424