### PR TITLE
Fix value rank compatibility check

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -665,7 +665,7 @@ compatibleValueRankValue(UA_Int32 valueRank, const UA_Variant *value) {
         return true;
 
     size_t arrayDims = value->arrayDimensionsSize;
-    if(!UA_Variant_isScalar(value))
+    if(!arrayDims && !UA_Variant_isScalar(value))
         arrayDims = 1; /* array but no arraydimensions -> implicit array dimension 1 */
 
     /* We cannot simply use compatibleValueRankArrayDimensions since we can have


### PR DESCRIPTION
The number of array dimensions must be set to 1 only if the value is not scalar and if the array dimensions size is 0. Omitting the second check breaks the compatibility check for arrays with more than one dimension.