### PR TITLE
Attempt to fix crash in read response

### DIFF
--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -478,6 +478,11 @@ void ValueAttributeRead(UA_Client *client, void *userdata, UA_UInt32 requestId,
         return;
 
     UA_ReadResponse rr = *(UA_ReadResponse *) response;
+    if ((rr.resultsSize == 0) || (rr.results == NULL))
+    {
+        return;
+    }
+
     if (rr.results[0].status != UA_STATUSCODE_GOOD)
         UA_ReadResponse_deleteMembers((UA_ReadResponse*) response);
 

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -478,42 +478,32 @@ void ValueAttributeRead(UA_Client *client, void *userdata, UA_UInt32 requestId,
         return;
 
     UA_ReadResponse rr = *(UA_ReadResponse *) response;
-    if ((rr.resultsSize == 0) || (rr.results == NULL))
-    {
-        return;
+	UA_DataValue *res = rr.results;
+    if ((rr.resultsSize > 0) && (res != NULL) && (res->hasValue)) {
+		UA_Variant out;
+		UA_Variant_init(&out);
+		/*__UA_Client_readAttribute*/
+		memcpy(&out, &res->value, sizeof(UA_Variant));
+		/* Copy value into out */
+		if (cc->attributeId == UA_ATTRIBUTEID_VALUE) {
+			memcpy(&out, &res->value, sizeof(UA_Variant));
+			UA_Variant_init(&res->value);
+		} else if (cc->attributeId == UA_ATTRIBUTEID_NODECLASS) {
+			memcpy(&out, (UA_NodeClass*) res->value.data, sizeof(UA_NodeClass));
+		} else if (UA_Variant_isScalar(&res->value)
+				&& res->value.type == cc->outDataType) {
+			memcpy(&out, res->value.data, res->value.type->memSize);
+			UA_free(res->value.data);
+			res->value.data = NULL;
+		}
+
+		//use callbackId to find the right custom callback
+		cc->callback(client, userdata, requestId, &out);
+		UA_Variant_deleteMembers(&out);
     }
-
-    if (rr.results[0].status != UA_STATUSCODE_GOOD)
-        UA_ReadResponse_deleteMembers((UA_ReadResponse*) response);
-
-    UA_Variant out;
-    UA_Variant_init(&out);
-    UA_DataValue *res = rr.results;
-    if (!res->hasValue) {
-        return;
-    }
-
-    /*__UA_Client_readAttribute*/
-    memcpy(&out, &res->value, sizeof(UA_Variant));
-    /* Copy value into out */
-    if (cc->attributeId == UA_ATTRIBUTEID_VALUE) {
-        memcpy(&out, &res->value, sizeof(UA_Variant));
-        UA_Variant_init(&res->value);
-    } else if (cc->attributeId == UA_ATTRIBUTEID_NODECLASS) {
-        memcpy(&out, (UA_NodeClass*) res->value.data, sizeof(UA_NodeClass));
-    } else if (UA_Variant_isScalar(&res->value)
-            && res->value.type == cc->outDataType) {
-        memcpy(&out, res->value.data, res->value.type->memSize);
-        UA_free(res->value.data);
-        res->value.data = NULL;
-    }
-
-    //use callbackId to find the right custom callback
-    cc->callback(client, userdata, requestId, &out);
     LIST_REMOVE(cc, pointers);
     UA_free(cc);
     UA_ReadResponse_deleteMembers((UA_ReadResponse*) response);
-    UA_Variant_deleteMembers(&out);
 }
 
 /*Read Attributes*/

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -478,28 +478,28 @@ void ValueAttributeRead(UA_Client *client, void *userdata, UA_UInt32 requestId,
         return;
 
     UA_ReadResponse rr = *(UA_ReadResponse *) response;
-	UA_DataValue *res = rr.results;
+    UA_DataValue *res = rr.results;
     if ((rr.resultsSize > 0) && (res != NULL) && (res->hasValue)) {
-		UA_Variant out;
-		UA_Variant_init(&out);
-		/*__UA_Client_readAttribute*/
-		memcpy(&out, &res->value, sizeof(UA_Variant));
-		/* Copy value into out */
-		if (cc->attributeId == UA_ATTRIBUTEID_VALUE) {
-			memcpy(&out, &res->value, sizeof(UA_Variant));
-			UA_Variant_init(&res->value);
-		} else if (cc->attributeId == UA_ATTRIBUTEID_NODECLASS) {
-			memcpy(&out, (UA_NodeClass*) res->value.data, sizeof(UA_NodeClass));
-		} else if (UA_Variant_isScalar(&res->value)
-				&& res->value.type == cc->outDataType) {
-			memcpy(&out, res->value.data, res->value.type->memSize);
-			UA_free(res->value.data);
-			res->value.data = NULL;
-		}
+        UA_Variant out;
+        UA_Variant_init(&out);
+        /*__UA_Client_readAttribute*/
+        memcpy(&out, &res->value, sizeof(UA_Variant));
+        /* Copy value into out */
+        if (cc->attributeId == UA_ATTRIBUTEID_VALUE) {
+            memcpy(&out, &res->value, sizeof(UA_Variant));
+            UA_Variant_init(&res->value);
+        } else if (cc->attributeId == UA_ATTRIBUTEID_NODECLASS) {
+            memcpy(&out, (UA_NodeClass*) res->value.data, sizeof(UA_NodeClass));
+        } else if (UA_Variant_isScalar(&res->value)
+                && res->value.type == cc->outDataType) {
+            memcpy(&out, res->value.data, res->value.type->memSize);
+            UA_free(res->value.data);
+            res->value.data = NULL;
+        }
 
-		//use callbackId to find the right custom callback
-		cc->callback(client, userdata, requestId, &out);
-		UA_Variant_deleteMembers(&out);
+        //use callbackId to find the right custom callback
+        cc->callback(client, userdata, requestId, &out);
+        UA_Variant_deleteMembers(&out);
     }
     LIST_REMOVE(cc, pointers);
     UA_free(cc);


### PR DESCRIPTION
In some cases when server was rebooted during a read, the callback would access NULL results.

This fixes the crash, but doesn't call the registered application callback in case results is empty.