### PR TITLE
CI: Remove NS0 hardcoded optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,8 +817,13 @@ ua_generate_nodeset(
     DEPENDS_TARGET "open62541-generator-types"
 )
 
-# stack protector and optimization needs to be disabled for the huge ns0 file, otherwise it may take many minutes to compile the file.
-if(NOT MSVC)
+# stack protector and optimization needs to be disabled for the huge ns0 file, otherwise debian packaging fails due to long build times.
+if(UA_PACK_DEBIAN OR (
+        (CMAKE_BUILD_TYPE STREQUAL "MinSizeRel" OR CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo") AND (
+            # List of compilers which have problems with the huge ns0 optimization
+            (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND (CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0))
+        )
+   ))
     set_source_files_properties(${PROJECT_BINARY_DIR}/src_generated/ua_namespace0.c PROPERTIES COMPILE_FLAGS "-fno-stack-protector -O0")
 endif()
 

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -166,20 +166,6 @@ else
     cd .. && rm build -rf
     echo -en 'travis_fold:end:script.build.doc\\r'
 
-    echo -e "\r\n== Full Namespace 0 Generation ==" && echo -en 'travis_fold:start:script.build.ns0\\r'
-    mkdir -p build
-    cd build
-    cmake \
-        -DCMAKE_BUILD_TYPE=Debug \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-        -DUA_BUILD_EXAMPLES=ON \
-        -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
-        -DUA_NAMESPACE_ZERO=FULL ..
-    make -j
-    if [ $? -ne 0 ] ; then exit 1 ; fi
-    cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.ns0\\r'
-
     # cross compilation only with gcc
     if ! [ -z ${MINGW+x} ]; then
         echo -e "\r\n== Cross compile release build for MinGW 32 bit =="  && echo -en 'travis_fold:start:script.build.cross_mingw32\\r'


### PR DESCRIPTION
Remove hardcoded optimization level for NS0 file. Fixes #2315 

This is for now a test to see how fast everything compiles.