### PR TITLE
[REVIEW] #1914 - remove binary encoding from namespace generation

### DIFF
--- a/examples/nodeset/CMakeLists.txt
+++ b/examples/nodeset/CMakeLists.txt
@@ -25,6 +25,21 @@ if(UA_COMPILE_AS_CXX)
     set_source_files_properties(${PROJECT_BINARY_DIR}/src_generated/ua_namespace_example.c PROPERTIES LANGUAGE CXX)
 endif()
 
+if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+    ua_generate_nodeset_and_datatypes(
+        NAME "testnodeset"
+        FILE_CSV "${PROJECT_SOURCE_DIR}/examples/nodeset/testnodeset.csv"
+        FILE_BSD "${PROJECT_SOURCE_DIR}/examples/nodeset/testtypes.bsd"
+        NAMESPACE_IDX 2
+        FILE_NS "${PROJECT_SOURCE_DIR}/examples/nodeset/testnodeset.xml"
+        INTERNAL
+    )
+    add_example(server_testnodeset server_testnodeset.c 
+        ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_testnodeset.c
+        ${PROJECT_BINARY_DIR}/src_generated/ua_types_testnodeset_generated.c)
+    add_dependencies(server_testnodeset open62541-generator-ns-testnodeset)
+endif()
+
 ###################
 # PLCopen Nodeset #
 ###################
@@ -57,6 +72,6 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
                 ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_di.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_plc.c)
     add_dependencies(server_nodeset_plcopen open62541-generator-ns-plc)
-    target_include_directories(server_nodeset_plcopen PRIVATE ${PROJECT_SOURCE_DIR}/src) # needs an internal header
+    
 
 endif()

--- a/examples/nodeset/server_testnodeset.c
+++ b/examples/nodeset/server_testnodeset.c
@@ -1,0 +1,54 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
+ */
+
+#include <ua_client_highlevel.h>
+#include <ua_config_default.h>
+#include <ua_log_stdout.h>
+#include <ua_server.h>
+
+#include <signal.h>
+
+#include "ua_namespace_testnodeset.h"
+
+UA_Boolean running = true;
+
+UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTNODESET_COUNT, UA_TYPES_TESTNODESET};
+
+static void stopHandler(int sign)
+{
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
+    running = false;
+}
+
+int main(int argc, char **argv)
+{
+    signal(SIGINT, stopHandler);
+    signal(SIGTERM, stopHandler);
+    UA_ServerConfig *config = UA_ServerConfig_new_default();
+    config->customDataTypes = &customTypesArray;
+    UA_Server *server = UA_Server_new(config);
+
+    UA_StatusCode retval;
+    /* create nodes from nodeset */
+    if (ua_namespace_testnodeset(server) != UA_STATUSCODE_GOOD)
+    {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+                     "Could not add the example nodeset. "
+                     "Check previous output for any error.");
+        retval = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    }
+    else
+    {
+
+        UA_Variant out;
+        UA_Variant_init(&out);
+        UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 10002), &out);
+        UA_Point *p = (UA_Point *)out.data;
+        printf("point 2d x: %f y: %f \n", p->x, p->y);
+        retval = UA_Server_run(server, &running);
+    }
+    UA_Server_delete(server);
+    UA_ServerConfig_delete(config);
+    return (int)retval;
+}

--- a/examples/nodeset/testnodeset.csv
+++ b/examples/nodeset/testnodeset.csv
@@ -1,0 +1,16 @@
+Structs,5001,Object
+Point_Encoding_DefaultBinary,5002,Object
+BaseDataTypes,5100,Object
+BaseDataTypes_Double,5101,Variable
+BaseDataTypes_Uint32,5102,Variable
+Point,10001,DataType
+Structs_PointA,10002,Variable
+Structs_PointC_Array,10004,Variable
+Structs_PointB,10005,Variable
+Structs_InputArguments,11493,Variable
+Structs_StaticNodeIdTypes,15962,Variable
+Structs_StaticNodeIdTypes,15963,Variable
+BaseDataTypes_String1_scalar,16001,Variable
+BaseDataTypes_ByteString_Scalar,16002,Variable
+PointWithArray,3003,DataType
+NestedPoint,10008,DataType

--- a/examples/nodeset/testnodeset.xml
+++ b/examples/nodeset/testnodeset.xml
@@ -1,0 +1,492 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-->A more complete example can be found in tools/test/nodeset_compiler<-->
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:s1="http://yourorganisation.org/test/Types.xsd" xmlns:ua="http://unifiedautomation.com/Configuration/NodeSet.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://yourorganisation.org/test/</Uri>
+    </NamespaceUris>
+    <Aliases>
+        <Alias Alias="Int32">i=6</Alias>
+        <Alias Alias="UInt32">i=7</Alias>
+        <Alias Alias="Double">i=11</Alias>
+        <Alias Alias="Organizes">i=35</Alias>
+        <Alias Alias="HasModellingRule">i=37</Alias>
+        <Alias Alias="HasEncoding">i=38</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+        <Alias Alias="IdType">i=256</Alias>
+        <Alias Alias="Argument">i=296</Alias>
+        <Alias Alias="Point3D">ns=1;i=3002</Alias>
+        <Alias Alias="Point">ns=1;i=10001</Alias>
+    </Aliases>
+    <Extensions>
+        <Extension>
+            <ua:ModelInfo Tool="UaModeler" Hash="NY/CbF6sk/OjLXFpjvfTAA==" Version="1.6.2"/>
+        </Extension>
+    </Extensions>
+    <!-->Struct with builtin members<-->
+    <UADataType NodeId="ns=1;i=10001" BrowseName="1:Point">
+        <DisplayName>Point</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:Point">
+            <Field DataType="Double" Name="x"/>
+            <Field DataType="Double" Name="y"/>
+        </Definition>
+    </UADataType>
+    <UADataType NodeId="ns=1;i=10008" BrowseName="1:NestedPoint">
+        <DisplayName>NestedPoint</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:Point">
+            <Field DataType="Double" Name="x"/>
+            <Field DataType="Double" Name="y"/>
+            <Field DataType="ns=1;i=10001" Name="Point1" />
+        </Definition>
+    </UADataType>
+    <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5002" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=10001</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>    
+    <UAObject NodeId="ns=1;i=5100" BrowseName="1:BuiltinTypes">
+        <DisplayName>BuiltinTypes</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+        </References>
+    </UAObject>
+    <UAVariable DataType="ByteString" NodeId="ns=1;i=16002" BrowseName="1:ByteString_scalar_init" AccessLevel="3">
+        <DisplayName>ByteString_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ByteString>SGVsbG9Xb3JsZA==</ByteString>
+        </Value>
+    </UAVariable>
+    <!--ValueRank>
+    OPC UA spec part 3, NodeClass Variable
+    -3: Scalar or 1-dim
+    -2: Any, value can be a scalar or an array with any number of dimensions
+    -1: scalar
+     0: value is array with one or more dimensions
+     1: array with one dimension
+     n>1: array with with the specified numbers of dimensions
+    <-->
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8001" BrowseName="1:Int32_scalar_noInit_withoutValueRank" AccessLevel="3">
+        <DisplayName>Int32_scalar_noInit_withoutValueRank</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8002" BrowseName="1:Int32_scalar_Init_ValueRank=-3" AccessLevel="3" ValueRank="-3">
+        <DisplayName>Int32_scalar_Init_ValueRank=-3</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>            
+            <Int32>1</Int32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8003" BrowseName="1:Int32_1dim_Init_ValueRank=-3" AccessLevel="3" ValueRank="-3">
+        <DisplayName>Int32_1dim_Init_ValueRank=-3</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ListOfInt32>
+                <Int32>1</Int32>
+                <Int32>2</Int32>
+            </ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8004" BrowseName="1:Int32_scalar_noInit_ValueRank=-2" AccessLevel="3" ValueRank="-2">
+        <DisplayName>Int32_scalar_noInit_ValueRank=-2</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8005" BrowseName="1:Int32_scalar_noInit_ValueRank=-1" AccessLevel="3" ValueRank="-1">
+        <DisplayName>Int32_scalar_noInit_ValueRank=-1</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ListOfInt32>
+                <Int32>1</Int32>
+                <Int32>2</Int32>
+            </ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8006" BrowseName="1:Int32_OneOrMoreDim_noInit_ValueRank=0" AccessLevel="3" ValueRank="0">
+        <DisplayName>Int32_scalar_noInit_ValueRank=0</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8007" BrowseName="1:Int32_1dim_noInit_ValueRank=1" AccessLevel="3" ValueRank="1">
+        <DisplayName>Int32_1dim_noInit_ValueRank=1</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8008" BrowseName="1:Int32_2dim_noInit_ValueRank=2" AccessLevel="3" ValueRank="2">
+        <DisplayName>Int32_2dim_noInit_ValueRank=2</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8009" BrowseName="1:Int32_3dim_noInit_ValueRank=2" AccessLevel="3" ValueRank="3">
+        <DisplayName>Int32_3dim_noInit_ValueRank=2</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="String" NodeId="ns=1;i=16001" BrowseName="1:String_scalar_init" AccessLevel="3">
+        <DisplayName>String_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <uax:String>Hello World</uax:String>
+        </Value>
+    </UAVariable>
+    <UAObject NodeId="ns=1;i=5001" BrowseName="1:NotBuiltinTypes">
+        <DisplayName>NotBuiltinTypes</DisplayName>
+        <References>            
+            <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+        </References>
+    </UAObject>   
+    <UAVariable DataType="Argument" NodeId="ns=1;i=11493" BrowseName="InputArguments_scalar_init">
+        <DisplayName>InputArguments_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>i=297</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <Argument xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                        <Name>argName</Name>
+                        <DataType>
+                            <Identifier>i=1</Identifier>
+                        </DataType>
+                        <ValueRank>-1</ValueRank>                        
+                        <ArrayDimensions>0</ArrayDimensions>
+                        <Description>
+                            <Locale>en</Locale>
+                            <Text>myDescritipon</Text>
+                        </Description>
+                    </Argument>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=10002" BrowseName="1:Point_scalar_init" AccessLevel="3">
+        <DisplayName>Point_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>            
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                        <x>1</x>
+                        <y>2</y>
+                    </Point>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+    <!-->uninitialized scalar point<-->
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="-1" NodeId="ns=1;i=10005" BrowseName="1:Point_scalar_noInit" AccessLevel="3">
+        <DisplayName>Point_scalar_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=10007" BrowseName="1:Point_1dim_noInit" AccessLevel="3">
+        <DisplayName>Point_1dim_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=10004" ArrayDimensions="4" BrowseName="1:Point_1dim_init" AccessLevel="3">
+        <DisplayName>Point_1dim_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>1</x>
+                            <y>2</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>3</x>
+                            <y>4</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>5</x>
+                            <y>6</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>7</x>
+                            <y>8</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="2" NodeId="ns=1;i=10006" ArrayDimensions="2,2" BrowseName="1:Point_2dim_init" AccessLevel="3">
+        <DisplayName>Point_2dim_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>1</x>
+                            <y>2</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>3</x>
+                            <y>4</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>5</x>
+                            <y>6</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>7</x>
+                            <y>8</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>    
+    <UAVariable DataType="Double" ParentNodeId="ns=1;i=5100" NodeId="ns=1;i=5101" BrowseName="1:Double_init" AccessLevel="3">
+        <DisplayName>Double_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+        </References>
+        <Value>
+            <uax:Double>42</uax:Double>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="UInt32" ParentNodeId="ns=1;i=5100" ValueRank="1" NodeId="ns=1;i=5102" ArrayDimensions="3" BrowseName="1:UInt32_init" AccessLevel="3">
+        <DisplayName>UInt32_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+        <Value>
+            <uax:ListOfUInt32>
+                <uax:UInt32>1</uax:UInt32>
+                <uax:UInt32>2</uax:UInt32>
+                <uax:UInt32>3</uax:UInt32>
+            </uax:ListOfUInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="IdType" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=15962" ArrayDimensions="7" BrowseName="Enum_1dim_init">
+        <DisplayName>Enum_init</DisplayName>
+        <Description>A list of IdTypes for nodes which are the same in every server that exposes them.</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfInt32>
+                <uax:Int32>0</uax:Int32>
+                <uax:Int32>1</uax:Int32>
+                <uax:Int32>3</uax:Int32>
+                <uax:Int32>4</uax:Int32>
+                <uax:Int32>5</uax:Int32>
+                <uax:Int32>6</uax:Int32>
+                <uax:Int32>7</uax:Int32>
+            </uax:ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="IdType" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=15963" BrowseName="Enum_scalar_noInit">
+        <DisplayName>Enum_scalar_noInit</DisplayName>
+        <Description>A list of IdTypes for nodes which are the same in every server that exposes them.</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="i=307" NodeId="ns=1;i=16003" BrowseName="1:ApplicationTye_1dim_noInit" UserAccessLevel="3" AccessLevel="3" ValueRank="1">
+        <DisplayName>ApplicationTye_1dim_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ListOfInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                <Int32>0</Int32>
+                <Int32>1</Int32>
+                <Int32>2</Int32>
+                <Int32>3</Int32>
+            </ListOfInt32>
+        </Value>
+    </UAVariable>
+    
+    <UAVariable DataType="Int32" ValueRank="2" NodeId="ns=1;i=6003" ArrayDimensions="3,2" BrowseName="1:Int32_2dim_init" AccessLevel="3">
+        <DisplayName>Int32_2dim_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <uax:ListOfInt32>
+                <uax:Int32>11</uax:Int32>
+                <uax:Int32>21</uax:Int32>
+                <uax:Int32>31</uax:Int32>
+                <uax:Int32>12</uax:Int32>
+                <uax:Int32>22</uax:Int32>
+                <uax:Int32>32</uax:Int32>
+            </uax:ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UADataType NodeId="ns=1;i=3003" BrowseName="1:PointWithArray">
+        <DisplayName>PointWithArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:PointWithArray">
+            <Field DataType="Double" Name="x"/>
+            <Field DataType="Double" Name="y"/>
+            <Field DataType="Double" Name="z"/>
+            <Field DataType="UInt32" Name="array1Size"/>
+            <Field DataType="Double" ValueRank="1" Name="array1"/>
+        </Definition>
+    </UADataType>
+    <UAVariable DataType="ns=1;i=3003" NodeId="ns=1;i=6008" BrowseName="1:PointWithArray_scalar_noInit" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>PointWithArray_scalar_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <!-->
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=3003</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <PointWithArray xmlns="http://yourorganisation.org/exported2/Types.xsd">
+                        <x>1.1</x>
+                        <y>2.2</y>
+                        <z>3.3</z>
+                        <array1Size>1</array1Size>
+                        <array1><Double>1.1</Double></array1>
+                    </PointWithArray>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>-->
+    </UAVariable>
+    <UAVariable DataType="ns=1;i=10008" NodeId="ns=1;i=6009" BrowseName="1:NestedPoint_scalar_noInit" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>NestedPoint_scalar_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <!-->
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=3003</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <PointWithArray xmlns="http://yourorganisation.org/exported2/Types.xsd">
+                        <x>1.1</x>
+                        <y>2.2</y>
+                        <z>3.3</z>
+                        <array1Size>1</array1Size>
+                        <array1><Double>1.1</Double></array1>
+                    </PointWithArray>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>-->
+    </UAVariable>
+</UANodeSet>

--- a/examples/nodeset/testtypes.bsd
+++ b/examples/nodeset/testtypes.bsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+-->
+
+<opc:TypeDictionary
+  xmlns:opc="http://opcfoundation.org/BinarySchema/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ua="http://opcfoundation.org/UA/"
+  xmlns:tns="http://yourorganisation.org/test/"
+  DefaultByteOrder="LittleEndian"
+  TargetNamespace="http://yourorganisation.org/test/"
+>
+  <opc:Import Namespace="http://opcfoundation.org/UA/" Location="Opc.Ua.BinarySchema.bsd"/>
+
+  <opc:StructuredType Name="Point" BaseType="ua:ExtensionObject">
+    <opc:Field Name="x" TypeName="opc:Double" />
+    <opc:Field Name="y" TypeName="opc:Double" />
+  </opc:StructuredType>
+
+  <opc:StructuredType Name="NestedPoint" BaseType="ua:ExtensionObject">
+    <opc:Field Name="x" TypeName="opc:Double" />
+    <opc:Field Name="y" TypeName="opc:Double" />
+    <opc:Field Name="point1" TypeName="tns:Point" />
+  </opc:StructuredType>
+
+   <opc:StructuredType Name="PointWithArray" BaseType="ua:ExtensionObject">
+    <opc:Field Name="x" TypeName="opc:Double" />
+    <opc:Field Name="y" TypeName="opc:Double" />
+    <opc:Field Name="z" TypeName="opc:Double" />
+    <opc:Field Name="array1Size" TypeName="opc:UInt32" />
+    <opc:Field Name="array1" TypeName="opc:Double" LengthField="array1Size" />
+  </opc:StructuredType>
+
+</opc:TypeDictionary>

--- a/src/ua_types_encoding_binary.h
+++ b/src/ua_types_encoding_binary.h
@@ -37,8 +37,7 @@ typedef UA_StatusCode (*UA_exchangeEncodeBuffer)(void *handle, UA_Byte **bufPos,
           Is ignored if NULL.
  * @param exchangeHandle Custom data passed into the exchangeCallback.
  * @return Returns a statuscode whether encoding succeeded. */
-//TODO remove UA_EXPORT after we fix issue #1914
-UA_StatusCode UA_EXPORT
+UA_StatusCode 
 UA_encodeBinary(const void *src, const UA_DataType *type,
                 UA_Byte **bufPos, const UA_Byte **bufEnd,
                 UA_exchangeEncodeBuffer exchangeCallback,

--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -87,4 +87,38 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     add_dependencies(check_nodeset_compiler_plc open62541-generator-ns-tests-plc)
     target_link_libraries(check_nodeset_compiler_plc ${LIBS})
     add_test_valgrind(nodeset_compiler_plc ${TESTS_BINARY_DIR}/check_nodeset_compiler_plc)
+
+    
+endif()
+
+#generate testnodeset
+if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+    
+    ua_generate_datatypes(
+        NAME "ua_types_testnodeset"
+        TARGET_SUFFIX "tests-types-testnodeset"
+        NAMESPACE_IDX 2
+        OUTPUT_DIR "${PROJECT_BINARY_DIR}/src_generated/tests"
+        FILE_CSV "${PROJECT_SOURCE_DIR}/tests/nodeset-compiler/testnodeset.csv"
+        FILES_BSD "${PROJECT_SOURCE_DIR}/tests/nodeset-compiler/testtypes.bsd"
+    )
+   
+    ua_generate_nodeset(
+        NAME "tests-testnodeset"
+        FILE "${PROJECT_SOURCE_DIR}/tests/nodeset-compiler/testnodeset.xml"
+        TYPES_ARRAY "UA_TYPES_TESTNODESET"
+        INTERNAL
+        OUTPUT_DIR "${PROJECT_BINARY_DIR}/src_generated/tests"
+        DEPENDS_TYPES "UA_TYPES"
+        DEPENDS_NS    "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml"
+        DEPENDS_TARGET "open62541-generator-tests-types-testnodeset"
+    )   
+
+    add_executable(check_nodeset_compiler_testnodeset check_nodeset_compiler_testnodeset.c
+                ${PROJECT_BINARY_DIR}/src_generated/tests/ua_namespace_tests_testnodeset.c
+                ${PROJECT_BINARY_DIR}/src_generated/tests/ua_types_testnodeset_generated.c
+                $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+    add_dependencies(check_nodeset_compiler_testnodeset open62541-generator-ns-tests-testnodeset)
+    target_link_libraries(check_nodeset_compiler_testnodeset ${LIBS})
+    add_test_valgrind(nodeset_compiler_testnodeset ${TESTS_BINARY_DIR}/check_nodeset_compiler_testnodeset)
 endif()

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "check.h"
+#include "testing_clock.h"
+#include "tests/ua_namespace_tests_testnodeset.h"
+#include "ua_config_default.h"
+#include "ua_server.h"
+#include "ua_types.h"
+#include "unistd.h"
+
+UA_Server *server = NULL;
+UA_ServerConfig *config = NULL;
+
+UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTNODESET_COUNT, UA_TYPES_TESTNODESET};
+
+static void setup(void) {
+    config = UA_ServerConfig_new_default();
+    config->customDataTypes = &customTypesArray;
+    server = UA_Server_new(config);
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+    UA_ServerConfig_delete(config);
+}
+
+START_TEST(Server_addTestNodeset) {
+    UA_StatusCode retval = ua_namespace_tests_testnodeset(server);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+}
+END_TEST
+
+START_TEST(checkScalarValues) {
+    UA_Variant out;
+    UA_Variant_init(&out);
+    // Point_scalar_Init
+    UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 10002), &out);
+    ck_assert(UA_Variant_isScalar(&out));
+    UA_Point *p = (UA_Point *)out.data;
+    ck_assert(p->x == (UA_Double)1.0);
+    ck_assert(p->y == (UA_Double)2.0);
+    UA_Variant_clear(&out);
+    // Point_scalar_noInit
+    UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 10005), &out);
+    p = (UA_Point *)out.data;
+    ck_assert(UA_Variant_isScalar(&out));
+    ck_assert(p->x == (UA_Double)0.0);
+    ck_assert(p->y == (UA_Double)0.0);
+    UA_Variant_clear(&out);
+}
+END_TEST
+
+START_TEST(check1dimValues) {
+    UA_Variant out;
+    UA_Variant_init(&out);
+    // Point_1dim_noInit
+    UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 10007), &out);
+    ck_assert(!UA_Variant_isScalar(&out));
+    ck_assert(out.arrayDimensionsSize == 0);
+    UA_Variant_clear(&out);
+    // Point_1dim_init
+    UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 10004), &out);
+    UA_Point *p = (UA_Point *)out.data;
+    ck_assert(!UA_Variant_isScalar(&out));
+    ck_assert(out.arrayLength == 4);
+    ck_assert(p[0].x == (UA_Double)1.0);
+    ck_assert(p[3].y == (UA_Double)8.0);
+    UA_Variant_clear(&out);
+}
+END_TEST
+
+START_TEST(readValueRank) {
+    UA_Int32 rank;
+    UA_Variant dims;
+    // scalar
+    UA_Server_readValueRank(server, UA_NODEID_NUMERIC(2, 10002), &rank);
+    ck_assert_int_eq(rank, -1);
+    UA_Server_readValueRank(server, UA_NODEID_NUMERIC(2, 10002), &rank);
+    ck_assert_int_eq(rank, -1);
+    UA_Variant_init(&dims);
+    UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(2, 10002), &dims);
+    ck_assert_int_eq(dims.arrayLength, 0);
+    UA_Variant_clear(&dims);
+    // 1-dim
+    UA_Server_readValueRank(server, UA_NODEID_NUMERIC(2, 10007), &rank);
+    ck_assert_int_eq(rank, 1);
+    UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(2, 10007), &dims);
+    ck_assert_int_eq(dims.arrayLength, 1);
+    ck_assert_int_eq(*((UA_UInt32 *)dims.data), 0);
+    UA_Variant_clear(&dims);
+    UA_Server_readValueRank(server, UA_NODEID_NUMERIC(2, 10004), &rank);
+    ck_assert_int_eq(rank, 1);
+    UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(2, 10004), &dims);
+    ck_assert_int_eq(dims.arrayLength, 1);
+    ck_assert_int_eq(*((UA_UInt32 *)dims.data), 4);
+    UA_Variant_clear(&dims);
+    // 2-dim
+    UA_Server_readValueRank(server, UA_NODEID_NUMERIC(2, 10006), &rank);
+    ck_assert_int_eq(rank, 2);
+    UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(2, 10006), &dims);
+    ck_assert_int_eq(dims.arrayLength, 2);
+    UA_UInt32 *dimensions = (UA_UInt32 *)dims.data;
+    ck_assert_int_eq(dimensions[0], 2);
+    ck_assert_int_eq(dimensions[1], 2);
+    UA_Variant_clear(&dims);
+}
+END_TEST
+
+static Suite *testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Compiler");
+    TCase *tc_server = tcase_create("Server Testnodeset");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_addTestNodeset);
+    tcase_add_test(tc_server, checkScalarValues);
+    tcase_add_test(tc_server, check1dimValues);
+    tcase_add_test(tc_server, readValueRank);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-compiler/testnodeset.csv
+++ b/tests/nodeset-compiler/testnodeset.csv
@@ -1,0 +1,16 @@
+Structs,5001,Object
+Point_Encoding_DefaultBinary,5002,Object
+BaseDataTypes,5100,Object
+BaseDataTypes_Double,5101,Variable
+BaseDataTypes_Uint32,5102,Variable
+Point,10001,DataType
+Structs_PointA,10002,Variable
+Structs_PointC_Array,10004,Variable
+Structs_PointB,10005,Variable
+Structs_InputArguments,11493,Variable
+Structs_StaticNodeIdTypes,15962,Variable
+Structs_StaticNodeIdTypes,15963,Variable
+BaseDataTypes_String1_scalar,16001,Variable
+BaseDataTypes_ByteString_Scalar,16002,Variable
+PointWithArray,3003,DataType
+NestedPoint,10008,DataType

--- a/tests/nodeset-compiler/testnodeset.xml
+++ b/tests/nodeset-compiler/testnodeset.xml
@@ -1,0 +1,491 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:s1="http://yourorganisation.org/test/Types.xsd" xmlns:ua="http://unifiedautomation.com/Configuration/NodeSet.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://yourorganisation.org/test/</Uri>
+    </NamespaceUris>
+    <Aliases>
+        <Alias Alias="Int32">i=6</Alias>
+        <Alias Alias="UInt32">i=7</Alias>
+        <Alias Alias="Double">i=11</Alias>
+        <Alias Alias="Organizes">i=35</Alias>
+        <Alias Alias="HasModellingRule">i=37</Alias>
+        <Alias Alias="HasEncoding">i=38</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+        <Alias Alias="IdType">i=256</Alias>
+        <Alias Alias="Argument">i=296</Alias>
+        <Alias Alias="Point3D">ns=1;i=3002</Alias>
+        <Alias Alias="Point">ns=1;i=10001</Alias>
+    </Aliases>
+    <Extensions>
+        <Extension>
+            <ua:ModelInfo Tool="UaModeler" Hash="NY/CbF6sk/OjLXFpjvfTAA==" Version="1.6.2"/>
+        </Extension>
+    </Extensions>
+    <!-->Struct with builtin members<-->
+    <UADataType NodeId="ns=1;i=10001" BrowseName="1:Point">
+        <DisplayName>Point</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:Point">
+            <Field DataType="Double" Name="x"/>
+            <Field DataType="Double" Name="y"/>
+        </Definition>
+    </UADataType>
+    <UADataType NodeId="ns=1;i=10008" BrowseName="1:NestedPoint">
+        <DisplayName>NestedPoint</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:Point">
+            <Field DataType="Double" Name="x"/>
+            <Field DataType="Double" Name="y"/>
+            <Field DataType="ns=1;i=10001" Name="Point1" />
+        </Definition>
+    </UADataType>
+    <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5002" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=10001</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>    
+    <UAObject NodeId="ns=1;i=5100" BrowseName="1:BuiltinTypes">
+        <DisplayName>BuiltinTypes</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+        </References>
+    </UAObject>
+    <UAVariable DataType="ByteString" NodeId="ns=1;i=16002" BrowseName="1:ByteString_scalar_init" AccessLevel="3">
+        <DisplayName>ByteString_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ByteString>SGVsbG9Xb3JsZA==</ByteString>
+        </Value>
+    </UAVariable>
+    <!--ValueRank>
+    OPC UA spec part 3, NodeClass Variable
+    -3: Scalar or 1-dim
+    -2: Any, value can be a scalar or an array with any number of dimensions
+    -1: scalar
+     0: value is array with one or more dimensions
+     1: array with one dimension
+     n>1: array with with the specified numbers of dimensions
+    <-->
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8001" BrowseName="1:Int32_scalar_noInit_withoutValueRank" AccessLevel="3">
+        <DisplayName>Int32_scalar_noInit_withoutValueRank</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8002" BrowseName="1:Int32_scalar_Init_ValueRank=-3" AccessLevel="3" ValueRank="-3">
+        <DisplayName>Int32_scalar_Init_ValueRank=-3</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>            
+            <Int32>1</Int32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8003" BrowseName="1:Int32_1dim_Init_ValueRank=-3" AccessLevel="3" ValueRank="-3">
+        <DisplayName>Int32_1dim_Init_ValueRank=-3</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ListOfInt32>
+                <Int32>1</Int32>
+                <Int32>2</Int32>
+            </ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8004" BrowseName="1:Int32_scalar_noInit_ValueRank=-2" AccessLevel="3" ValueRank="-2">
+        <DisplayName>Int32_scalar_noInit_ValueRank=-2</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8005" BrowseName="1:Int32_scalar_noInit_ValueRank=-1" AccessLevel="3" ValueRank="-1">
+        <DisplayName>Int32_scalar_noInit_ValueRank=-1</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ListOfInt32>
+                <Int32>1</Int32>
+                <Int32>2</Int32>
+            </ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8006" BrowseName="1:Int32_OneOrMoreDim_noInit_ValueRank=0" AccessLevel="3" ValueRank="0">
+        <DisplayName>Int32_scalar_noInit_ValueRank=0</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8007" BrowseName="1:Int32_1dim_noInit_ValueRank=1" AccessLevel="3" ValueRank="1">
+        <DisplayName>Int32_1dim_noInit_ValueRank=1</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8008" BrowseName="1:Int32_2dim_noInit_ValueRank=2" AccessLevel="3" ValueRank="2">
+        <DisplayName>Int32_2dim_noInit_ValueRank=2</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=8009" BrowseName="1:Int32_3dim_noInit_ValueRank=2" AccessLevel="3" ValueRank="3">
+        <DisplayName>Int32_3dim_noInit_ValueRank=2</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>        
+    </UAVariable>
+    <UAVariable DataType="String" NodeId="ns=1;i=16001" BrowseName="1:String_scalar_init" AccessLevel="3">
+        <DisplayName>String_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <uax:String>Hello World</uax:String>
+        </Value>
+    </UAVariable>
+    <UAObject NodeId="ns=1;i=5001" BrowseName="1:NotBuiltinTypes">
+        <DisplayName>NotBuiltinTypes</DisplayName>
+        <References>            
+            <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+        </References>
+    </UAObject>   
+    <UAVariable DataType="Argument" NodeId="ns=1;i=11493" BrowseName="InputArguments_scalar_init">
+        <DisplayName>InputArguments_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>i=297</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <Argument xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                        <Name>argName</Name>
+                        <DataType>
+                            <Identifier>i=1</Identifier>
+                        </DataType>
+                        <ValueRank>-1</ValueRank>                        
+                        <ArrayDimensions>0</ArrayDimensions>
+                        <Description>
+                            <Locale>en</Locale>
+                            <Text>myDescritipon</Text>
+                        </Description>
+                    </Argument>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=10002" BrowseName="1:Point_scalar_init" AccessLevel="3">
+        <DisplayName>Point_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>            
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                        <x>1</x>
+                        <y>2</y>
+                    </Point>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+    <!-->uninitialized scalar point<-->
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="-1" NodeId="ns=1;i=10005" BrowseName="1:Point_scalar_noInit" AccessLevel="3">
+        <DisplayName>Point_scalar_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=10007" BrowseName="1:Point_1dim_noInit" AccessLevel="3">
+        <DisplayName>Point_1dim_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=10004" ArrayDimensions="4" BrowseName="1:Point_1dim_init" AccessLevel="3">
+        <DisplayName>Point_1dim_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>1</x>
+                            <y>2</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>3</x>
+                            <y>4</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>5</x>
+                            <y>6</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=0</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>7</x>
+                            <y>8</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Point" ParentNodeId="ns=1;i=5001" ValueRank="2" NodeId="ns=1;i=10006" ArrayDimensions="2,2" BrowseName="1:Point_2dim_init" AccessLevel="3">
+        <DisplayName>Point_2dim_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>1</x>
+                            <y>2</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>3</x>
+                            <y>4</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>5</x>
+                            <y>6</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>ns=1;i=10001</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <Point xmlns="http://yourorganisation.org/test/Types.xsd">
+                            <x>7</x>
+                            <y>8</y>
+                        </Point>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>    
+    <UAVariable DataType="Double" ParentNodeId="ns=1;i=5100" NodeId="ns=1;i=5101" BrowseName="1:Double_init" AccessLevel="3">
+        <DisplayName>Double_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+        </References>
+        <Value>
+            <uax:Double>42</uax:Double>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="UInt32" ParentNodeId="ns=1;i=5100" ValueRank="1" NodeId="ns=1;i=5102" ArrayDimensions="3" BrowseName="1:UInt32_init" AccessLevel="3">
+        <DisplayName>UInt32_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+        <Value>
+            <uax:ListOfUInt32>
+                <uax:UInt32>1</uax:UInt32>
+                <uax:UInt32>2</uax:UInt32>
+                <uax:UInt32>3</uax:UInt32>
+            </uax:ListOfUInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="IdType" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=15962" ArrayDimensions="7" BrowseName="Enum_1dim_init">
+        <DisplayName>Enum_init</DisplayName>
+        <Description>A list of IdTypes for nodes which are the same in every server that exposes them.</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfInt32>
+                <uax:Int32>0</uax:Int32>
+                <uax:Int32>1</uax:Int32>
+                <uax:Int32>3</uax:Int32>
+                <uax:Int32>4</uax:Int32>
+                <uax:Int32>5</uax:Int32>
+                <uax:Int32>6</uax:Int32>
+                <uax:Int32>7</uax:Int32>
+            </uax:ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="IdType" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=15963" BrowseName="Enum_scalar_noInit">
+        <DisplayName>Enum_scalar_noInit</DisplayName>
+        <Description>A list of IdTypes for nodes which are the same in every server that exposes them.</Description>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="i=307" NodeId="ns=1;i=16003" BrowseName="1:ApplicationTye_1dim_noInit" UserAccessLevel="3" AccessLevel="3" ValueRank="1">
+        <DisplayName>ApplicationTye_1dim_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <ListOfInt32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+                <Int32>0</Int32>
+                <Int32>1</Int32>
+                <Int32>2</Int32>
+                <Int32>3</Int32>
+            </ListOfInt32>
+        </Value>
+    </UAVariable>
+    
+    <UAVariable DataType="Int32" ValueRank="2" NodeId="ns=1;i=6003" ArrayDimensions="3,2" BrowseName="1:Int32_2dim_init" AccessLevel="3">
+        <DisplayName>Int32_2dim_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5100</Reference>
+        </References>
+        <Value>
+            <uax:ListOfInt32>
+                <uax:Int32>11</uax:Int32>
+                <uax:Int32>21</uax:Int32>
+                <uax:Int32>31</uax:Int32>
+                <uax:Int32>12</uax:Int32>
+                <uax:Int32>22</uax:Int32>
+                <uax:Int32>32</uax:Int32>
+            </uax:ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UADataType NodeId="ns=1;i=3003" BrowseName="1:PointWithArray">
+        <DisplayName>PointWithArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:PointWithArray">
+            <Field DataType="Double" Name="x"/>
+            <Field DataType="Double" Name="y"/>
+            <Field DataType="Double" Name="z"/>
+            <Field DataType="UInt32" Name="array1Size"/>
+            <Field DataType="Double" ValueRank="1" Name="array1"/>
+        </Definition>
+    </UADataType>
+    <UAVariable DataType="ns=1;i=3003" NodeId="ns=1;i=6008" BrowseName="1:PointWithArray_scalar_noInit" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>PointWithArray_scalar_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <!-->
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=3003</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <PointWithArray xmlns="http://yourorganisation.org/exported2/Types.xsd">
+                        <x>1.1</x>
+                        <y>2.2</y>
+                        <z>3.3</z>
+                        <array1Size>1</array1Size>
+                        <array1><Double>1.1</Double></array1>
+                    </PointWithArray>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>-->
+    </UAVariable>
+    <UAVariable DataType="ns=1;i=10008" NodeId="ns=1;i=6009" BrowseName="1:NestedPoint_scalar_noInit" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>NestedPoint_scalar_noInit</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+        <!-->
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=3003</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <PointWithArray xmlns="http://yourorganisation.org/exported2/Types.xsd">
+                        <x>1.1</x>
+                        <y>2.2</y>
+                        <z>3.3</z>
+                        <array1Size>1</array1Size>
+                        <array1><Double>1.1</Double></array1>
+                    </PointWithArray>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>-->
+    </UAVariable>
+</UANodeSet>

--- a/tests/nodeset-compiler/testtypes.bsd
+++ b/tests/nodeset-compiler/testtypes.bsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ * 
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+-->
+
+<opc:TypeDictionary
+  xmlns:opc="http://opcfoundation.org/BinarySchema/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ua="http://opcfoundation.org/UA/"
+  xmlns:tns="http://yourorganisation.org/test/"
+  DefaultByteOrder="LittleEndian"
+  TargetNamespace="http://yourorganisation.org/test/"
+>
+  <opc:Import Namespace="http://opcfoundation.org/UA/" Location="Opc.Ua.BinarySchema.bsd"/>
+
+  <opc:StructuredType Name="Point" BaseType="ua:ExtensionObject">
+    <opc:Field Name="x" TypeName="opc:Double" />
+    <opc:Field Name="y" TypeName="opc:Double" />
+  </opc:StructuredType>
+
+  <opc:StructuredType Name="NestedPoint" BaseType="ua:ExtensionObject">
+    <opc:Field Name="x" TypeName="opc:Double" />
+    <opc:Field Name="y" TypeName="opc:Double" />
+    <opc:Field Name="point1" TypeName="tns:Point" />
+  </opc:StructuredType>
+
+   <opc:StructuredType Name="PointWithArray" BaseType="ua:ExtensionObject">
+    <opc:Field Name="x" TypeName="opc:Double" />
+    <opc:Field Name="y" TypeName="opc:Double" />
+    <opc:Field Name="z" TypeName="opc:Double" />
+    <opc:Field Name="array1Size" TypeName="opc:UInt32" />
+    <opc:Field Name="array1" TypeName="opc:Double" LengthField="array1Size" />
+  </opc:StructuredType>
+
+</opc:TypeDictionary>

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -189,7 +189,6 @@ UA_findDataTypeByBinary(const UA_NodeId *typeId);
 
 #else // UA_ENABLE_AMALGAMATION
 # include "ua_server.h"
-# include "ua_types_encoding_binary.h"
 #endif
 
 %s
@@ -201,7 +200,8 @@ UA_findDataTypeByBinary(const UA_NodeId *typeId);
 #else
 # include "ua_server.h"
 #endif
-""")
+%s
+""" % (additionalHeaders))
     writeh("""
 _UA_BEGIN_DECLS
 

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -35,8 +35,8 @@ def generateNodeIdPrintable(node):
 
     return re.sub('[^0-9a-z_]+', '_', CodePrintable.lower())
 
-def generateNodeValueInstanceName(node, parent, recursionDepth, arrayIndex):
-    return generateNodeIdPrintable(parent) + "_" + str(node.alias) + "_" + str(arrayIndex) + "_" + str(recursionDepth)
+def generateNodeValueInstanceName(node, parent, arrayIndex):
+    return generateNodeIdPrintable(parent) + "_" + str(node.alias) + "_" + str(arrayIndex)
 
 def generateReferenceCode(reference):
     if reference.isForward:
@@ -86,15 +86,14 @@ def generateVariableNodeCode(node, nodeset, encode_binary_size):
     code.append("attr.valueRank = %d;" % node.valueRank)
     if node.valueRank > 0:
         code.append("attr.arrayDimensionsSize = %d;" % node.valueRank)
-        code.append("attr.arrayDimensions = (UA_UInt32 *)UA_Array_new({}, &UA_TYPES[UA_TYPES_UINT32]);".format(node.valueRank))
-        code.append("if (!attr.arrayDimensions) return UA_STATUSCODE_BADOUTOFMEMORY;")
-        codeCleanup.append("UA_Array_delete(attr.arrayDimensions, {}, &UA_TYPES[UA_TYPES_UINT32]);".format(node.valueRank))
+        code.append("UA_UInt32 arrayDimensions[{}];".format(node.valueRank))
         if len(node.arrayDimensions) == node.valueRank:
             for idx, v in enumerate(node.arrayDimensions):
-                code.append("attr.arrayDimensions[{}] = {};".format(idx, int(unicode(v))))
+                code.append("arrayDimensions[{}] = {};".format(idx, int(str(v))))
         else:
             for dim in range(0, node.valueRank):
-                code.append("attr.arrayDimensions[{}] = 0;".format(dim))
+                code.append("arrayDimensions[{}] = 0;".format(dim))
+        code.append("attr.arrayDimensions = &arrayDimensions[0];")
 
     if node.dataType is not None:
         if isinstance(node.dataType, NodeId) and node.dataType.ns == 0 and node.dataType.i == 0:
@@ -110,7 +109,7 @@ def generateVariableNodeCode(node, nodeset, encode_binary_size):
 
             if dataTypeNode.isEncodable():
                 if node.value is not None:
-                    [code1, codeCleanup1, codeGlobal1] = generateValueCode(node.value, nodeset.nodes[node.id], nodeset, encode_binary_size=encode_binary_size)
+                    [code1, codeCleanup1, codeGlobal1] = generateValueCode(node.value, nodeset.nodes[node.id], nodeset)
                     code += code1
                     codeCleanup += codeCleanup1
                     codeGlobal += codeGlobal1
@@ -123,6 +122,10 @@ def generateVariableNodeCode(node, nodeset, encode_binary_size):
                         code.append("attr.value.arrayDimensions = attr.arrayDimensions;")
                 else:
                     code += generateValueCodeDummy(dataTypeNode, nodeset.nodes[node.id], nodeset)
+            else:
+                #TODO: take a look on this
+                #logger.error("cannot encode: " + node.browseName.name)
+                pass
     return [code, codeCleanup, codeGlobal]
 
 def generateVariableTypeNodeCode(node, nodeset, encode_binary_size):
@@ -145,7 +148,7 @@ def generateVariableTypeNodeCode(node, nodeset, encode_binary_size):
             code.append("attr.dataType = %s;" % generateNodeIdCode(dataTypeNode.id))
             if dataTypeNode.isEncodable():
                 if node.value is not None:
-                    [code1, codeCleanup1, codeGlobal1] = generateValueCode(node.value, nodeset.nodes[node.id], nodeset, encode_binary_size)
+                    [code1, codeCleanup1, codeGlobal1] = generateValueCode(node.value, nodeset.nodes[node.id], nodeset)
                     code += code1
                     codeCleanup += codeCleanup1
                     codeGlobal += codeGlobal1
@@ -153,7 +156,10 @@ def generateVariableTypeNodeCode(node, nodeset, encode_binary_size):
                     code += generateValueCodeDummy(dataTypeNode, nodeset.nodes[node.id], nodeset)
     return [code, codeCleanup, codeGlobal]
 
-def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, recursionDepth=0, arrayIndex=0, encode_binary_size=32000):
+def lowerFirstChar(inputString):
+    return inputString[0].lower() + inputString[1:]
+
+def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, instanceName=None, isArrayElement=False):
     code = [""]
     codeCleanup = [""]
 
@@ -161,30 +167,32 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, r
     logger.debug("Value    " + str(node.value))
     logger.debug("Encoding " + str(node.encodingRule))
 
-    instanceName = generateNodeValueInstanceName(node, parent, recursionDepth, arrayIndex)
-    # If there are any ExtensionObjects instide this ExtensionObject, we need to
+    # If there are any ExtensionObjects inside this ExtensionObject, we need to
     # generate one-time-structs for them too before we can proceed;
     for subv in node.value:
         if isinstance(subv, list):
             logger.error("ExtensionObject contains an ExtensionObject, which is currently not encodable!")
+            return
 
-    code.append("struct {")
-    for field in node.encodingRule:
-        ptrSym = ""
-        # If this is an Array, this is pointer to its contents with a AliasOfFieldSize entry
-        if field[2] != None and field[2] != 0 :
-            code.append("  UA_Int32 " + str(field[0]) + "Size;")
-            ptrSym = "*"
-        if len(field[1]) == 1:
-            code.append("  UA_" + str(field[1][0]) + " " + ptrSym + str(field[0]) + ";")
-        else:
-            code.append("  UA_ExtensionObject " + " " + ptrSym + str(field[0]) + ";")
-    code.append("} " + instanceName + "_struct;")
 
-    # Allocate some memory
-    code.append("UA_ExtensionObject *" + instanceName + " =  UA_ExtensionObject_new();")
-    code.append("if (!" + instanceName + ") return UA_STATUSCODE_BADOUTOFMEMORY;")
-    codeCleanup.append("UA_ExtensionObject_delete(" + instanceName + ");")
+    typeBrowseNode = makeCIdentifier(nodeset.getDataTypeNode(parent.dataType).browseName.name)
+    #TODO: review this
+    if typeBrowseNode == "NumericRange":
+        # in the stack we define a separate structure for the numeric range, but
+        # the value itself is just a string
+        typeBrowseNode = "String"
+
+
+    typeString = "UA_" + typeBrowseNode
+    if instanceName is None:
+        instanceName = generateNodeValueInstanceName(node, parent, 0)
+        code.append("UA_STACKARRAY(" + typeString + ", " + instanceName + ", 1);")
+    typeArr = nodeset.getDataTypeNode(parent.dataType).typesArray
+    typeString = nodeset.getDataTypeNode(parent.dataType).browseName.name.upper()
+    typeArrayString = typeArr + "[" + typeArr + "_" + typeString + "]"
+    code.append("UA_init({ref}{instanceName}, &{typeArrayString});".format(ref="&" if isArrayElement else "",
+                                                                           instanceName=instanceName,
+                                                                           typeArrayString=typeArrayString))
 
     # Assign data to the struct contents
     # Track the encoding rule definition to detect arrays and/or ExtensionObjects
@@ -192,104 +200,41 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, r
     for subv in node.value:
         encField = node.encodingRule[encFieldIdx]
         encFieldIdx = encFieldIdx + 1
+        memberName= lowerFirstChar(encField[0])
         logger.debug(
-            "Encoding of field " + subv.alias + " is " + str(subv.encodingRule) + "defined by " + str(encField))
+            "Encoding of field " + memberName + " is " + str(subv.encodingRule) + "defined by " + str(encField))
         # Check if this is an array
+        accessor = "." if isArrayElement else "->"
+
+
         if subv.valueRank is None or subv.valueRank == 0:
-            valueName = instanceName + "_struct." + subv.alias
+            valueName = instanceName + accessor + memberName
             code.append(generateNodeValueCode(valueName + " = " ,
                         subv, instanceName,valueName, global_var_code, asIndirect=False))
         else:
-            if isinstance(subv, list):
-                # this is an array
-                code.append(instanceName + "_struct." + subv.alias + "Size = " + str(len(subv)) + ";")
-                code.append(
-                     "{0}_struct.{1} = (UA_{2}*) UA_malloc(sizeof(UA_{2})*{3});".format(
-                         instanceName, subv.alias, subv.__class__.__name__, str(len(subv))))
-                code.append("if (!{0}_struct.{1}) return UA_STATUSCODE_BADOUTOFMEMORY;".format(
-                    instanceName, subv.alias))
-                codeCleanup.append("UA_free({0}_struct.{1});".format(instanceName, subv.alias))
-                logger.debug("Encoding included array of " + str(len(subv)) + " values.")
-                for subvidx in range(0, len(subv)):
-                    subvv = subv[subvidx]
-                    logger.debug("  " + str(subvidx) + " " + str(subvv))
-                    valueName = instanceName + "_struct." + subv.alias + "[" + str(
-                        subvidx) + "]"
-                    code.append(generateNodeValueCode(valueName + " = ", subvv, instanceName, valueName, global_var_code))
-                code.append("}")
-            else:
-                code.append(instanceName + "_struct." + subv.alias + "Size = 1;")
-                code.append(
-                    "{0}_struct.{1} = (UA_{2}*) UA_malloc(sizeof(UA_{2}));".format(
-                        instanceName, subv.alias, subv.__class__.__name__))
-                code.append("if (!{0}_struct.{1}) return UA_STATUSCODE_BADOUTOFMEMORY;".format(
-                    instanceName, subv.alias))
-                codeCleanup.append("UA_free({0}_struct.{1});".format(instanceName, subv.alias))
-                valueName = instanceName + "_struct." + subv.alias + "[0]"
-                code.append(generateNodeValueCode(valueName + " = ",
-                            subv, instanceName, valueName, global_var_code, asIndirect=True))
+            memberName = lowerFirstChar(encField[0])
+            code.append(generateNodeValueCode(instanceName + accessor + memberName + "Size = ", subv, instanceName,valueName, global_var_code, asIndirect=False))
 
-    code.append(instanceName + "->encoding = UA_EXTENSIONOBJECT_ENCODED_BYTESTRING;")
-    #if parent.dataType.ns == 0:
+    if not isArrayElement:
+        code.append("UA_Variant_setScalar(&attr.value, " + instanceName + ", &" + typeArrayString + ");")
 
-    binaryEncodingId = nodeset.getBinaryEncodingIdForNode(parent.dataType)
-    code.append(
-        instanceName + "->content.encoded.typeId = UA_NODEID_NUMERIC(" + str(binaryEncodingId.ns) + ", " +
-        str(binaryEncodingId.i) + ");")
-    code.append(
-        "retVal |= UA_ByteString_allocBuffer(&" + instanceName + "->content.encoded.body, " + str(encode_binary_size) + ");")
-
-    # Encode each value as a bytestring separately.
-    code.append("UA_Byte *pos" + instanceName + " = " + instanceName + "->content.encoded.body.data;")
-    code.append("const UA_Byte *end" + instanceName + " = &" + instanceName + "->content.encoded.body.data[" + str(encode_binary_size) + "];")
-    encFieldIdx = 0
-    code.append("{")
-    for subv in node.value:
-        # encField = node.encodingRule[encFieldIdx]
-        encFieldIdx = encFieldIdx + 1
-        if subv.valueRank is None or subv.valueRank == 0:
-            code.append(
-                "retVal |= UA_encodeBinary(&" + instanceName + "_struct." + subv.alias + ", " +
-                getTypesArrayForValue(nodeset, subv) + ", &pos" + instanceName + ", &end" + instanceName + ", NULL, NULL);")
-        else:
-            if isinstance(subv, list):
-                for subvidx in range(0, len(subv)):
-                    code.append("retVal |= UA_encodeBinary(&" + instanceName + "_struct." + subv.alias + "[" +
-                                str(subvidx) + "], " + getTypesArrayForValue(nodeset, subv) + ", &pos" +
-                                instanceName + ", &end" + instanceName + ", NULL, NULL);")
-            else:
-                code.append(
-                    "retVal |= UA_encodeBinary(&" + instanceName + "_struct." + subv.alias + "[0], " +
-                    getTypesArrayForValue(nodeset, subv) + ", &pos" + instanceName + ", &end" + instanceName + ", NULL, NULL);")
-
-    code.append("}")
-    # Reallocate the memory by swapping the 65k Bytestring for a new one
-    code.append("size_t " + instanceName + "_encOffset = (uintptr_t)(" +
-                "pos" + instanceName + "-" + instanceName + "->content.encoded.body.data);")
-    code.append(instanceName + "->content.encoded.body.length = " + instanceName + "_encOffset;")
-    code.append("UA_Byte *" + instanceName + "_newBody = (UA_Byte *) UA_malloc(" + instanceName + "_encOffset);")
-    code.append("if (!" + instanceName + "_newBody) return UA_STATUSCODE_BADOUTOFMEMORY;")
-    code.append("memcpy(" + instanceName + "_newBody, " + instanceName + "->content.encoded.body.data, " +
-                instanceName + "_encOffset);")
-    code.append("UA_Byte *" + instanceName + "_oldBody = " + instanceName + "->content.encoded.body.data;")
-    code.append(instanceName + "->content.encoded.body.data = " + instanceName + "_newBody;")
-    code.append("UA_free(" + instanceName + "_oldBody);")
-    code.append("")
     return [code, codeCleanup]
 
+def getTypeBrowseName(dataTypeNode):
+    typeBrowseName = makeCIdentifier(dataTypeNode.browseName.name)
+    #TODO: review this
+    if typeBrowseName == "NumericRange":
+        # in the stack we define a separate structure for the numeric range, but
+        # the value itself is just a string
+        typeBrowseName = "String"
+    return typeBrowseName
 
 def generateValueCodeDummy(dataTypeNode, parentNode, nodeset):
     code = []
     valueName = generateNodeIdPrintable(parentNode) + "_variant_DataContents"
-
-    typeBrowseNode = makeCIdentifier(dataTypeNode.browseName.name)
-    if typeBrowseNode == "NumericRange":
-        # in the stack we define a separate structure for the numeric range, but
-        # the value itself is just a string
-        typeBrowseNode = "String"
-
-    typeArr = dataTypeNode.typesArray + "[" + dataTypeNode.typesArray + "_" + typeBrowseNode.upper() + "]"
-    typeStr = "UA_" + typeBrowseNode
+    typeBrowseName = getTypeBrowseName(dataTypeNode)
+    typeArr = dataTypeNode.typesArray + "[" + dataTypeNode.typesArray + "_" + typeBrowseName.upper() + "]"
+    typeStr = "UA_" + typeBrowseName
 
     if parentNode.valueRank > 0:
         for i in range(0, parentNode.valueRank):
@@ -298,7 +243,6 @@ def generateValueCodeDummy(dataTypeNode, parentNode, nodeset):
         code.append("UA_STACKARRAY(" + typeStr + ", " + valueName + ", 1);")
         code.append("UA_init(" + valueName + ", &" + typeArr + ");")
         code.append("UA_Variant_setScalar(&attr.value, " + valueName + ", &" + typeArr + ");")
-
     return code
 
 def getTypesArrayForValue(nodeset, value):
@@ -307,10 +251,16 @@ def getTypesArrayForValue(nodeset, value):
         typesArray = "UA_TYPES"
     else:
         typesArray = typeNode.typesArray
-    return "&" + typesArray + "[" + typesArray + "_" + \
-            makeCIdentifier(value.__class__.__name__.upper()) + "]"
+    typeName = makeCIdentifier(value.__class__.__name__.upper())
+    return "&" + typesArray + "[" + typesArray + "_" + typeName + "]"
 
-def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_binary_size=32000):
+
+def isArrayVariableNode(node, parentNode):
+    return parentNode.valueRank != -1 and (parentNode.valueRank >= 0
+                                       or (len(node.value) > 1
+                                           and (parentNode.valueRank != -2 or parentNode.valueRank != -3)))
+
+def generateValueCode(node, parentNode, nodeset, bootstrapping=True):
     code = []
     codeCleanup = []
     codeGlobal = []
@@ -332,9 +282,9 @@ def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_bina
     if not isinstance(node.value[0], Value):
         return ["", ""]
 
-    if parentNode.valueRank != -1 and (parentNode.valueRank >= 0
-                                       or (len(node.value) > 1
-                                           and (parentNode.valueRank != -2 or parentNode.valueRank != -3))):
+    dataTypeNode = nodeset.getDataTypeNode(parentNode.dataType)
+
+    if isArrayVariableNode(node, parentNode):
         # User the following strategy for all directly mappable values a la 'UA_Type MyInt = (UA_Type) 23;'
         if isinstance(node.value[0], Guid):
             logger.warn("Don't know how to print array of GUID in node " + str(parentNode.id))
@@ -344,29 +294,25 @@ def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_bina
             logger.warn("Don't know how to print array of StatusCode in node " + str(parentNode.id))
         else:
             if isinstance(node.value[0], ExtensionObject):
+                code.append("UA_" + getTypeBrowseName(dataTypeNode) + " " + valueName + "[" + str(len(node.value)) + "];")
                 for idx, v in enumerate(node.value):
                     logger.debug("Building extObj array index " + str(idx))
-                    [code1, codeCleanup1] = generateExtensionObjectSubtypeCode(v, parent=parentNode, nodeset=nodeset, arrayIndex=idx,
-                                                                               encode_binary_size=encode_binary_size, global_var_code=codeGlobal)
+                    instanceName = valueName + "[" + str(idx) + "]"
+                    [code1, codeCleanup1] = generateExtensionObjectSubtypeCode(v, parent=parentNode, nodeset=nodeset,
+                                                                                global_var_code=codeGlobal, instanceName=instanceName,
+                                                                               isArrayElement=True)
                     code = code + code1
                     codeCleanup = codeCleanup + codeCleanup1
-            code.append("UA_" + node.value[0].__class__.__name__ + " " + valueName + "[" + str(len(node.value)) + "];")
-            if isinstance(node.value[0], ExtensionObject):
-                for idx, v in enumerate(node.value):
-                    logger.debug("Printing extObj array index " + str(idx))
-                    instanceName = generateNodeValueInstanceName(v, parentNode, 0, idx)
-                    code.append(generateNodeValueCode(
-                        valueName + "[" + str(idx) + "] = ",
-                        v, instanceName, valueName, codeGlobal))
-                    # code.append("UA_free(&" +valueName + "[" + str(idx) + "]);")
             else:
+                code.append("UA_" + node.value[0].__class__.__name__ + " " + valueName + "[" + str(len(node.value)) + "];")
                 for idx, v in enumerate(node.value):
-                    instanceName = generateNodeValueInstanceName(v, parentNode, 0, idx)
+                    instanceName = generateNodeValueInstanceName(v, parentNode, idx)
                     code.append(generateNodeValueCode(
                         valueName + "[" + str(idx) + "] = " , v, instanceName, valueName, codeGlobal))
             code.append("UA_Variant_setArray(&attr.value, &" + valueName +
-                        ", (UA_Int32) " + str(len(node.value)) + ", " +
-                        getTypesArrayForValue(nodeset, node.value[0]) + ");")
+                        ", (UA_Int32) " + str(len(node.value)) + ", " + "&" +
+                        dataTypeNode.typesArray + "["+dataTypeNode.typesArray + "_" + getTypeBrowseName(dataTypeNode).upper() +"]);")
+    #scalar value
     else:
         # User the following strategy for all directly mappable values a la 'UA_Type MyInt = (UA_Type) 23;'
         if isinstance(node.value[0], Guid):
@@ -378,21 +324,11 @@ def generateValueCode(node, parentNode, nodeset, bootstrapping=True, encode_bina
         else:
             # The following strategy applies to all other types, in particular strings and numerics.
             if isinstance(node.value[0], ExtensionObject):
-                [code1, codeCleanup1] = generateExtensionObjectSubtypeCode(node.value[0], parent=parentNode, nodeset=nodeset,
-                                                                           encode_binary_size=encode_binary_size, global_var_code=codeGlobal)
+                [code1, codeCleanup1] = generateExtensionObjectSubtypeCode(node.value[0], parent=parentNode, nodeset=nodeset, global_var_code=codeGlobal, isArrayElement=False)
                 code = code + code1
                 codeCleanup = codeCleanup + codeCleanup1
-            instanceName = generateNodeValueInstanceName(node.value[0], parentNode, 0, 0)
-            if isinstance(node.value[0], ExtensionObject):
-                code.append(generateNodeValueCode("UA_" + node.value[0].__class__.__name__ + " *" + valueName + " = " ,
-                            node.value[0], instanceName, valueName, codeGlobal, asIndirect=True ))
-                code.append(
-                    "UA_Variant_setScalar(&attr.value, " + valueName + ", " +
-                    getTypesArrayForValue(nodeset, node.value[0]) + ");")
-
-                # FIXME: There is no membership definition for extensionObjects generated in this function.
-                # code.append("UA_" + node.value[0].__class__.__name__ + "_deleteMembers(" + valueName + ");")
-            else:
+            instanceName = generateNodeValueInstanceName(node.value[0], parentNode, 0)
+            if not(isinstance(node.value[0], ExtensionObject)):
                 code.append("UA_" + node.value[0].__class__.__name__ + " *" + valueName + " =  UA_" + node.value[
                     0].__class__.__name__ + "_new();")
                 code.append("if (!" + valueName + ") return UA_STATUSCODE_BADOUTOFMEMORY;")

--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -115,3 +115,4 @@ UtcTime
 LocaleId
 RedundancySupport
 ServerDiagnosticsSummaryDataType
+EnumValueType


### PR DESCRIPTION
This pr shold remove the necessity of calling ua_encodebinary during namespace generation with the nodeset compiler.

I have added a testnodeset in examples/nodeset. I will move this to tests folder and write some tests.