### PR TITLE
mDNS: Use hostname instead of resolving IP address

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 ---
 Language:        Cpp
 BasedOnStyle:    llvm
+IndentWidth:     4
 ColumnLimit:     120
 ForEachMacros:   [ foreach, LIST_FOREACH, LIST_FOREACH_SAFE ]
 DisableFormat:   false

--- a/src/server/ua_discovery_manager.c
+++ b/src/server/ua_discovery_manager.c
@@ -104,10 +104,6 @@ UA_DiscoveryManager_init(UA_DiscoveryManager *dm, UA_Server *server) {
     memset(dm->serverOnNetworkHash, 0,
            sizeof(struct serverOnNetwork_hash_entry*) * SERVER_ON_NETWORK_HASH_PRIME);
 
-    LIST_INIT(&dm->mdnsHostnameToIp);
-    memset(dm->mdnsHostnameToIpHash, 0,
-           sizeof(struct mdnsHostnameToIp_hash_entry*) * MDNS_HOSTNAME_TO_IP_HASH_PRIME);
-
     dm->serverOnNetworkCallback = NULL;
     dm->serverOnNetworkCallbackData = NULL;
 #endif /* UA_ENABLE_DISCOVERY_MULTICAST */
@@ -150,21 +146,6 @@ UA_DiscoveryManager_deleteMembers(UA_DiscoveryManager *dm, UA_Server *server) {
         }
     }
 
-    mdnsHostnameToIp_list_entry *mhi, *mhi_tmp;
-    LIST_FOREACH_SAFE(mhi, &dm->mdnsHostnameToIp, pointers, mhi_tmp) {
-        LIST_REMOVE(mhi, pointers);
-        UA_String_deleteMembers(&mhi->mdnsHostname);
-        UA_free(mhi);
-    }
-
-    for(size_t i = 0; i < MDNS_HOSTNAME_TO_IP_HASH_PRIME; i++) {
-        mdnsHostnameToIp_hash_entry* currHash = dm->mdnsHostnameToIpHash[i];
-        while(currHash) {
-            mdnsHostnameToIp_hash_entry* nextHash = currHash->next;
-            UA_free(currHash);
-            currHash = nextHash;
-        }
-    }
 # endif /* UA_ENABLE_DISCOVERY_MULTICAST */
 }
 

--- a/src/server/ua_discovery_manager.h
+++ b/src/server/ua_discovery_manager.h
@@ -70,18 +70,6 @@ typedef struct serverOnNetwork_hash_entry {
     struct serverOnNetwork_hash_entry* next;
 } serverOnNetwork_hash_entry;
 
-typedef struct mdnsHostnameToIp_list_entry {
-    LIST_ENTRY(mdnsHostnameToIp_list_entry) pointers;
-    UA_String mdnsHostname;
-    struct in_addr addr;
-} mdnsHostnameToIp_list_entry;
-
-#define MDNS_HOSTNAME_TO_IP_HASH_PRIME 1009
-typedef struct mdnsHostnameToIp_hash_entry {
-    mdnsHostnameToIp_list_entry* entry;
-    struct mdnsHostnameToIp_hash_entry* next;
-} mdnsHostnameToIp_hash_entry;
-
 #endif
 
 typedef struct {
@@ -108,9 +96,6 @@ typedef struct {
     UA_Server_serverOnNetworkCallback serverOnNetworkCallback;
     void* serverOnNetworkCallbackData;
 
-    LIST_HEAD(, mdnsHostnameToIp_list_entry) mdnsHostnameToIp;
-    /* hash mapping hostname to ip */
-    struct mdnsHostnameToIp_hash_entry* mdnsHostnameToIpHash[MDNS_HOSTNAME_TO_IP_HASH_PRIME];
 #  ifdef UA_ENABLE_MULTITHREADING
     pthread_t mdnsThread;
     UA_Boolean mdnsRunning;

--- a/src/server/ua_server_discovery_mdns.c
+++ b/src/server/ua_server_discovery_mdns.c
@@ -279,7 +279,7 @@ mdns_is_self_announce(UA_Server *server, struct serverOnNetwork_list_entry *entr
 
 #ifdef _WIN32
         /* Iterate through all of the adapters */
-        IP_ADAPTER_ADDRESSES* adapter = adapter_addresses->Next;
+        IP_ADAPTER_ADDRESSES* adapter = adapter_addresses;
         for(; adapter != NULL; adapter = adapter->Next) {
             /* Skip loopback adapters */
             if(IF_TYPE_SOFTWARE_LOOPBACK == adapter->IfType)
@@ -705,7 +705,7 @@ void mdns_set_address_record(UA_Server *server, const char *fullServiceDomain,
         return;
 
     /* Iterate through all of the adapters */
-    IP_ADAPTER_ADDRESSES* adapter = adapter_addresses->Next;
+    IP_ADAPTER_ADDRESSES* adapter = adapter_addresses;
     for(; adapter != NULL; adapter = adapter->Next) {
         /* Skip loopback adapters */
         if(IF_TYPE_SOFTWARE_LOOPBACK == adapter->IfType)

--- a/src/server/ua_services_discovery_multicast.c
+++ b/src/server/ua_services_discovery_multicast.c
@@ -343,6 +343,10 @@ UA_Discovery_addRecord(UA_Server *server, const UA_String *servername,
                        const UA_String *path, const UA_DiscoveryProtocol protocol,
                        UA_Boolean createTxt, const UA_String* capabilites,
                        size_t *capabilitiesSize) {
+    // we assume that the hostname is not an IP address, but a valid domain name
+    // It is required by the OPC UA spec (see Part 12, DiscoveryURL to DNS SRV mapping)
+    // to always use the hostname instead of the IP address
+
     if(!capabilitiesSize || (*capabilitiesSize > 0 && !capabilites))
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 


### PR DESCRIPTION
The spec says that mDNS should announce the hostname, and this hostname should be used for the discovery URL.


![image](https://user-images.githubusercontent.com/251973/50690714-a38d5780-102e-11e9-8bca-af929944a958.png)

An IP address for the SRV.hostname is not allowed.

Up to now we took the announced IP address and tried to resolve it to a hostname, which may lead to various issues (e.g. #2322, #2212). This procedure was done for every received mDNS record.

