### PR TITLE
CI: Disable NS0 optimization on appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,7 +825,8 @@ ua_generate_nodeset(
 )
 
 # stack protector and optimization needs to be disabled for the huge ns0 file, otherwise debian packaging fails due to long build times.
-if(UA_PACK_DEBIAN OR (
+# We also disable optimization on Appveyor builds, since they take almost an hour otherwise
+if(UA_PACK_DEBIAN OR (NOT "$ENV{APPVEYOR}" STREQUAL "") OR (
         (CMAKE_BUILD_TYPE STREQUAL "MinSizeRel" OR CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo") AND (
             # List of compilers which have problems with the huge ns0 optimization
             (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND (CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0))


### PR DESCRIPTION
Follow up of #2320

We need to disable NS0 optimization on appveyor, otherwise these builds take too long (almost an hour).