### PR TITLE
access_control: Add missing ua_server.h include.

### DIFF
--- a/include/ua_plugin_access_control.h
+++ b/include/ua_plugin_access_control.h
@@ -10,6 +10,7 @@
 #define UA_PLUGIN_ACCESS_CONTROL_H_
 
 #include "ua_types.h"
+#include "ua_server.h"
 
 _UA_BEGIN_DECLS
 


### PR DESCRIPTION
Every header should stand for itself. 
Otherwise include order in other locations mater.