### PR TITLE
Bugfix: delete subscriptions that are closed by the server

### DIFF
--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -619,6 +619,9 @@ UA_Client_Subscriptions_processPublishResponse(UA_Client *client, UA_PublishRequ
             UA_LOG_WARNING(&client->config.logger, UA_LOGCATEGORY_CLIENT,
                            "Received Publish Response with code %s",
                             UA_StatusCode_name(response->responseHeader.serviceResult));
+            UA_Client_Subscription* sub = findSubscription(client, response->subscriptionId);
+            if (sub != NULL)
+              UA_Client_Subscription_deleteInternal(client, sub);
         }
         return;
     }


### PR DESCRIPTION
If the OPC-UA server has closed the session without the client knowing, the
subscription should be deleted.

We observed this behavior with open62541 UA Client against a Beckhoff twincat OPC-UA server when the connection was lost (briefly). The bugfix simply checks if the subscription is already removed on the open62541 client side (and some outstanding publish background checks are coming in) or if the subscription is still active on the client but closed on the server.