### PR TITLE
[Review] Added possibility to use SecurityPolicy None for discovery only

### DIFF
--- a/include/open62541/server_config.h
+++ b/include/open62541/server_config.h
@@ -140,6 +140,15 @@ struct UA_ServerConfig {
     size_t endpointsSize;
     UA_EndpointDescription *endpoints;
 
+    /* Only allow the following discovery services to be executed on a
+     * SecureChannel with SecurityPolicyNone: GetEndpointsRequest,
+     * FindServersRequest and FindServersOnNetworkRequest.
+     *
+     * Only enable this option if there is no endpoint with SecurityPolicy#None
+     * in the endpoints list. The SecurityPolicy#None must be present in the
+     * securityPolicies list. */
+    UA_Boolean securityPolicyNoneDiscoveryOnly;
+
     /* Node Lifecycle callbacks */
     UA_GlobalNodeLifecycle nodeLifecycle;
 


### PR DESCRIPTION
If no endpoint with SecurityPolicy None is available, it shall be
possible to open a secure channel with SecurityPolicy None to perform
the discovery services GetEndpoints, FindServers and
FindServersOnNetwork. See issue #1936 for details.