### PR TITLE
Remove comments - I felt to be misleading

### DIFF
--- a/examples/encryption/client_basic128rsa15.c
+++ b/examples/encryption/client_basic128rsa15.c
@@ -19,7 +19,7 @@
  * @param  client             client configuration that need to be deleted
  * @param  remoteCertificate  server certificate */
 static void cleanupClient(UA_Client* client, UA_ByteString* remoteCertificate) {
-    UA_ByteString_delete(remoteCertificate); /* Dereference the memory */
+    UA_ByteString_delete(remoteCertificate);
     UA_Client_delete(client); /* Disconnects the client internally */
 }
 
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
                                   revocationList, revocationListSize,
                                   UA_SecurityPolicy_Basic128Rsa15);
     if(client == NULL) {
-        UA_ByteString_delete(remoteCertificate); /* Dereference the memory */
+        UA_ByteString_delete(remoteCertificate);
         return FAILURE;
     }
 

--- a/examples/encryption/client_basic256sha256.c
+++ b/examples/encryption/client_basic256sha256.c
@@ -19,7 +19,7 @@
  * @param  client             client configuration that need to be deleted
  * @param  remoteCertificate  server certificate */
 static void cleanupClient(UA_Client* client, UA_ByteString* remoteCertificate) {
-    UA_ByteString_delete(remoteCertificate); /* Dereference the memory */
+    UA_ByteString_delete(remoteCertificate);
     UA_Client_delete(client); /* Disconnects the client internally */
 }
 
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
                                   revocationList, revocationListSize,
                                   UA_SecurityPolicy_Basic256Sha256);
     if(client == NULL) {
-        UA_ByteString_delete(remoteCertificate); /* Dereference the memory */
+        UA_ByteString_delete(remoteCertificate);
         return FAILURE;
     }
 


### PR DESCRIPTION
UA_ByteStrings aren't refcounted. The call to UA_ByteString_delete()
surely frees the memory. It does not derefence a string.