### PR TITLE
Added support for server to descrypt passwords

### DIFF
--- a/examples/access_control/server_access_control.c
+++ b/examples/access_control/server_access_control.c
@@ -59,7 +59,8 @@ int main(void) {
     UA_ServerConfig *config = UA_ServerConfig_new_default();
     // disable anonymous logins, enable two user/password logins
     config->accessControl.deleteMembers(&config->accessControl);
-    if (UA_AccessControl_default(&config->accessControl, false, 2, logins) != UA_STATUSCODE_GOOD) {
+    if (UA_AccessControl_default(&config->accessControl, false, 2, logins,
+                                 config->securityPoliciesSize, config->securityPolicies) != UA_STATUSCODE_GOOD) {
         return EXIT_FAILURE;
     }
 

--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -13,6 +13,11 @@
 
 _UA_BEGIN_DECLS
 
+/* Internal UserIdentityToken policy ID set by the stack when an
+ * UsernameIdentityToken has been decrypted before passing it to the
+ * access control plugin */
+#define UA_ACCESS_CONTROL_DECRYPTED_PASSWORD_POLICY_ID "open62541-internal-decrypted"
+
 struct UA_AccessControl;
 typedef struct UA_AccessControl UA_AccessControl;
 

--- a/plugins/include/open62541/plugin/accesscontrol_default.h
+++ b/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -10,7 +10,7 @@
 
 #include <open62541/plugin/accesscontrol.h>
 #include <open62541/server.h>
-#include "ua_plugin_securitypolicy.h"
+#include <open62541/plugin/securitypolicy.h>
 
 _UA_BEGIN_DECLS
 

--- a/plugins/include/open62541/plugin/accesscontrol_default.h
+++ b/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -10,6 +10,7 @@
 
 #include <open62541/plugin/accesscontrol.h>
 #include <open62541/server.h>
+#include "ua_plugin_securitypolicy.h"
 
 _UA_BEGIN_DECLS
 
@@ -23,7 +24,9 @@ typedef struct {
 UA_EXPORT UA_StatusCode
 UA_AccessControl_default(UA_AccessControl *ac, UA_Boolean allowAnonymous,
                          size_t usernamePasswordLoginSize,
-                         const UA_UsernamePasswordLogin *usernamePasswordLogin);
+                         const UA_UsernamePasswordLogin *usernamePasswordLogin,
+                         size_t securityPoliciesSize,
+                         const UA_SecurityPolicy *securityPolicies);
 
 _UA_END_DECLS
 

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -165,12 +165,6 @@ createDefaultConfig(void) {
     conf->nodeLifecycle.constructor = NULL;
     conf->nodeLifecycle.destructor = NULL;
 
-    if (UA_AccessControl_default(&conf->accessControl, true, usernamePasswordsSize,
-            usernamePasswords) != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_delete(conf);
-        return NULL;
-    }
-
     /* Relax constraints for the InformationModel */
     conf->relaxEmptyValueConstraint = true; /* Allow empty values */
 
@@ -293,6 +287,13 @@ UA_ServerConfig_new_customBuffer(UA_UInt16 portNumber,
         return NULL;
     }
 
+    /* Access Control */
+    if (UA_AccessControl_default(&conf->accessControl, true, usernamePasswordsSize,
+           usernamePasswords, conf->securityPoliciesSize, conf->securityPolicies) != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
     /* Allocate the endpoint */
     conf->endpoints = (UA_EndpointDescription *)UA_malloc(sizeof(UA_EndpointDescription));
     if(!conf->endpoints) {
@@ -381,6 +382,13 @@ UA_ServerConfig_new_basic128rsa15(UA_UInt16 portNumber,
                                              localCertificate, localPrivateKey,
                                              &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    /* Access Control */
+    if (UA_AccessControl_default(&conf->accessControl, true, usernamePasswordsSize,
+           usernamePasswords, conf->securityPoliciesSize, conf->securityPolicies) != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
     }
@@ -487,6 +495,13 @@ UA_ServerConfig_new_basic256sha256(UA_UInt16 portNumber,
                                               localCertificate, localPrivateKey,
                                               &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    /* Access Control */
+    if (UA_AccessControl_default(&conf->accessControl, true, usernamePasswordsSize,
+           usernamePasswords, conf->securityPoliciesSize, conf->securityPolicies) != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
     }
@@ -612,6 +627,13 @@ UA_ServerConfig_new_allSecurityPolicies(UA_UInt16 portNumber,
                                               &conf->certificateVerification,
                                               localCertificate, localPrivateKey, &conf->logger);
     if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_delete(conf);
+        return NULL;
+    }
+
+    /* Access Control */
+    if (UA_AccessControl_default(&conf->accessControl, true, usernamePasswordsSize,
+           usernamePasswords, conf->securityPoliciesSize, conf->securityPolicies) != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_delete(conf);
         return NULL;
     }

--- a/tests/server/check_accesscontrol.c
+++ b/tests/server/check_accesscontrol.c
@@ -69,7 +69,7 @@ START_TEST(Client_user_fail) {
     UA_StatusCode retval =
         UA_Client_connect_username(client, "opc.tcp://localhost:4840", "user0", "password");
 
-    ck_assert_uint_eq(retval, UA_STATUSCODE_BADUSERACCESSDENIED);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADIDENTITYTOKENREJECTED);
 
     UA_Client_disconnect(client);
     UA_Client_delete(client);
@@ -81,7 +81,7 @@ START_TEST(Client_pass_fail) {
     UA_StatusCode retval =
         UA_Client_connect_username(client, "opc.tcp://localhost:4840", "user1", "secret");
 
-    ck_assert_uint_eq(retval, UA_STATUSCODE_BADUSERACCESSDENIED);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADIDENTITYTOKENREJECTED);
 
     UA_Client_disconnect(client);
     UA_Client_delete(client);


### PR DESCRIPTION
This PR contains an update of the accesscontrol plugin implementation to handle encrypted passwords. This example access control plugin will create one UserIdentityToken per SecurityPolicy supported by the server.

To be able to decrypt the passwords the issue #2350 needs to be solved. The asymmetric encryption API must be updated to not depend on the channel context.