### PR TITLE
Correctly cast third argument of recv in win32

### DIFF
--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -86,7 +86,7 @@
 
 #define UA_getnameinfo getnameinfo
 #define UA_send(sockfd, buf, len, flags) send(sockfd, buf, (int)(len), flags)
-#define UA_recv recv
+#define UA_recv(sockfd, buf, len, flags) recv(sockfd, buf, (int)(len), flags)
 #define UA_sendto(sockfd, buf, len, flags, dest_addr, addrlen) sendto(sockfd, (const char*)(buf), (int)(len), flags, dest_addr, (int) (addrlen))
 #define UA_recvfrom(sockfd, buf, len, flags, src_addr, addrlen) recvfrom(sockfd, (char*)(buf), (int)(len), flags, src_addr, addrlen)
 #define UA_htonl htonl


### PR DESCRIPTION
Fix https://github.com/open62541/open62541/issues/2406