### PR TITLE
Include time.h when struct timespec is used

### DIFF
--- a/arch/vxworks/ua_architecture.h
+++ b/arch/vxworks/ua_architecture.h
@@ -13,6 +13,7 @@
 #include "ua_architecture_base.h"
 
 #include <errno.h>
+#include <time.h>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>


### PR DESCRIPTION
In both the POSIX ( http://pubs.opengroup.org/onlinepubs/009695299/basedefs/time.h.html ) and C11 ( https://en.cppreference.com/w/c/chrono/timespec ) standards, the struct timespec structure and the nanosleep function are defined in the time.h header. 

Depending on the specific VxWorks version, the time.h header could be already transitively included by one of the other headers,  but explicitly adding the time.h include makes sure the `UA_sleep_ms` macro will work correctly on all possible versions.