### PR TITLE
Resolve port conflict

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -144,15 +144,11 @@ if(UA_BUILD_SELFSIGNED_CERTIFICATE)
   target_link_libraries(server_certificate open62541 ${open62541_LIBRARIES})
 endif()
 
-if(UA_ENABLE_DISCOVERY)
+if(UA_ENABLE_DISCOVERY_MULTICAST)
     add_example(discovery_server_lds discovery/server_lds.c)
-
     add_example(discovery_server_register discovery/server_register.c)
-
     add_example(discovery_client_find_servers discovery/client_find_servers.c)
-    if(UA_ENABLE_DISCOVERY_MULTICAST)
-        add_example(discovery_server_multicast discovery/server_multicast.c)
-    endif()
+    add_example(discovery_server_multicast discovery/server_multicast.c)
 endif()
 
 add_subdirectory(nodeset)

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
     signal(SIGINT, stopHandler); /* catches ctrl-c */
     signal(SIGTERM, stopHandler);
 
-    UA_ServerConfig *config = UA_ServerConfig_new_default();
+    UA_ServerConfig *config = UA_ServerConfig_new_minimal(4841, NULL);;
     UA_String_clear(&config->applicationDescription.applicationUri);
     config->applicationDescription.applicationUri =
         UA_String_fromChars("urn:open62541.example.server_register");


### PR DESCRIPTION
Registering server complains that the port 4840 is already in use (as the LDS is
running there).

./discovery_server_register
[...]
[2019-02-04 22:45:20.070 (UTC+0100)] info/userland      Node read the.answer
[2019-02-04 22:45:20.070 (UTC+0100)] info/userland      read value 42
[2019-02-04 22:45:20.070 (UTC+0100)] warn/network       Error binding a server socket: Address already in use
[2019-02-04 22:45:20.070 (UTC+0100)] warn/network       Error binding a server socket: Address already in use
[2019-02-04 22:45:20.070 (UTC+0100)] info/network       TCP network layer listening on opc.tcp://prokyon:4840/