### PR TITLE
Add NAMESPACE open62541:: to exported CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -916,6 +916,9 @@ else()
 
 endif()
 
+# Ensure that the open62541::open62541 alias can be used inside open62541's build
+add_library(open62541::open62541 ALIAS open62541)
+
 # Export Symbols
 target_compile_definitions(open62541-object PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
 target_compile_definitions(open62541 PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
@@ -1114,7 +1117,8 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/open62541ConfigVer
 
 install(EXPORT open62541Targets
         FILE open62541Targets.cmake
-        DESTINATION "${cmake_configfile_install}")
+        DESTINATION "${cmake_configfile_install}"
+        NAMESPACE open62541::)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/open62541Config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/open62541ConfigVersion.cmake"

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -50,7 +50,7 @@ In your own CMake project you can then include the open62541 library using:
 
    find_package(open62541 0.3.0 REQUIRED COMPONENTS FullNamespace DiscoveryMulticast)
    add_executable(main main.cpp)
-   target_link_libraries(main open62541)
+   target_link_libraries(main open62541::open62541)
 
 
 A full list of enabled features during build time is stored in the CMake Variable ``open62541_COMPONENTS_ALL``

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -83,7 +83,7 @@ cmake_minimum_required(VERSION 2.8)
 project(install-test)
 find_package(open62541 REQUIRED COMPONENTS FullNamespace)
 add_executable(install-test-example ../examples/tutorial_server_firststeps.c)
-target_link_libraries(install-test-example open62541)
+target_link_libraries(install-test-example open62541::open62541)
 EOM
     cmake \
         -DCMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/open62541_install .


### PR DESCRIPTION
Fix https://github.com/open62541/open62541/issues/2415 . 

I also added a `add_library(open62541::open62541 ALIAS open62541)` command to make sure that `open62541::open62541` is also available in the open62541's build itself. This is useful when `open62541` is part of a bigger project by being vendored (or fetched via [CMake's FetchContent module](https://cmake.org/cmake/help/v3.11/module/FetchContent.html)) and included with `add_subdirectory`. See https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1#using-a-library-defined-in-the-same-cmake-tree-should-look-the-same-as-using-an-external-library for more details.  