### PR TITLE
Travis clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ matrix:
             - xutils-dev
             - zip
       env:
-        - ANALYZE=false
         - CC=gcc-4.8
         - CXX=g++-4.8
         - PYTHON=python2
@@ -73,7 +72,6 @@ matrix:
             - texlive-latex-recommended
             - valgrind
       env:
-        - ANALYZE=false
         - CC=gcc-8
         - CXX=g++-8
         - PYTHON=python2
@@ -96,7 +94,6 @@ matrix:
             - texlive-latex-recommended
             - valgrind
       env:
-        - ANALYZE=false
         - CC=clang-6.0
         - CXX=clang++-6.0
         - PYTHON=python2
@@ -119,7 +116,6 @@ matrix:
             - texlive-latex-recommended
             - valgrind
       env:
-        - ANALYZE=false
         - CC=clang-6.0
         - CXX=clang++-6.0
         - PYTHON=python3
@@ -137,7 +133,6 @@ matrix:
             - texlive-latex-extra
             - texlive-latex-recommended
       env:
-        - ANALYZE=false
         - CC=tcc
         - PYTHON=python2
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   global:
     # GITAUTH:
     - secure: nSunY54Wp5HkQCHHbKwlwpbaKyqRVIu/0EnhaoJSwhM1wqerQV/E5d/2JelO9/tZgbungAO7wk/fjutRMVc7d378RTIPwS8vHpvZfEoGhCFsLoTOlqESzsZFBup2H5t1lpQ23jRHDOxlLdJy2lz5U+zd1YnYgDXqdDFjegsIYdo=
+    - PYTHON=python2
 
 dist: trusty
 
@@ -12,31 +13,27 @@ matrix:
   fast_finish: true
   include:
 #
-# gcc-4.8 (trusty) full host and cross build:
+# gcc-4.8 (trusty) full host and cross build with tests:
 # doc, cert, cross-mingw32, cross-mingw64, cross-linux32, cross-raspi, linux64,
 # amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal, debian-package
     - os: linux
+      compiler: gcc-4.8
       addons:
         apt:
           sources:
             # see https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
             - ubuntu-toolchain-r-test
           packages:
-            - check
-            # cross-mingw
             - mingw-w64
-            - g++-mingw-w64-i686
-            - g++-mingw-w64-x86-64
+            - gcc-mingw-w64-i686
+            - gcc-mingw-w64-x86-64
             - binutils-mingw-w64-i686
+            - g++-multilib
+            - python-six
             # debian packaging
+            - cmake
             - debhelper
             - fakeroot
-            #
-            - gcc-multilib
-            - g++-multilib
-            - libsubunit-dev
-            - libx11-dev
-            - python-six
             # doc
             - python-sphinx
             - graphviz
@@ -44,34 +41,25 @@ matrix:
             - texlive-fonts-recommended
             - texlive-latex-extra
             - latexmk
-            #
+            # tests
+            - check
             - valgrind
-            - wget
-            - xutils-dev
-            - zip
       env:
-#        - CC=gcc-4.8
-#        - CXX=g++-4.8
-        - PYTHON=python2
         - MINGW=true
         - DEBIAN=true
 #
-# gcc-8 full host build:
+# gcc-8 full host build with tests:
 # doc, cert, linux64,
 # amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
+      compiler: gcc-8
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - check
             - gcc-8
             - gcc-8-multilib
-            - g++-8
-            - g++-8-multilib
-            - graphviz
-            - linux-libc-dev:i386
             - python-six
             # doc
             - python-sphinx
@@ -80,26 +68,24 @@ matrix:
             - texlive-fonts-recommended
             - texlive-latex-extra
             - latexmk
-            #
+            # tests
+            - check
             - valgrind
-      env:
-        - CC=gcc-8
-        - CXX=g++-8
-        - PYTHON=python2
 #
-# clang-6 full host build:
+# clang-6 full host build with tests:
 # doc, cert, linux64,
 # amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
+      compiler: clang-6.0
       addons:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
             - ubuntu-toolchain-r-test
           packages:
-            - check
             - clang-6.0
             - clang-tidy-6.0
+            - python-six
             # doc
             - python-sphinx
             - graphviz
@@ -107,24 +93,21 @@ matrix:
             - texlive-fonts-recommended
             - texlive-latex-extra
             - latexmk
-            #
+            # tests
+            - check
             - valgrind
-      env:
-        - CC=clang-6.0
-        - CXX=clang++-6.0
-        - PYTHON=python2
 #
-# clang-6 python-3 full host build:
+# clang-6 python-3 full host build with tests:
 # doc, cert, linux64,
 # amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
+      compiler: clang-6.0
       addons:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
             - ubuntu-toolchain-r-test
           packages:
-            - check
             - clang-6.0
             - clang-tidy-6.0
             - python3-six
@@ -135,37 +118,36 @@ matrix:
             - texlive-fonts-recommended
             - texlive-latex-extra
             - latexmk
-            #
+            # tests
+            - check
             - valgrind
       env:
-        - CC=clang-6.0
-        - CXX=clang++-6.0
         - PYTHON=python3
 #
 # tcc full host build:
 # doc, cert, linux64,
 # amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
+      compiler: tcc
       addons:
         apt:
           packages:
-            - check
-            - python3-six
+            - python-six
             # doc
-            - python3-sphinx
+            - python-sphinx
             - graphviz
             - texlive-generic-extra
             - texlive-fonts-recommended
             - texlive-latex-extra
             - latexmk
-            #
-      env:
-        - CC=tcc
-        - PYTHON=python2
+            # tests
+            - check
+            - valgrind
 #
 # clang-6 python-3 install build and minimal example:
 # linux64, minimal-example
     - os: linux
+      compiler: clang-6.0
       addons:
         apt:
           sources:
@@ -175,51 +157,51 @@ matrix:
             - clang-6.0
             - clang-tidy-6.0
             - python3-six
-            - valgrind
       env:
         - INSTALL=true
-        - CC=clang-6.0
-        - CXX=clang++-6.0
         - PYTHON=python3
+        - CXX=clang-6.0
 #
 # gcc-4.8 static code analysis
     - os: linux
+      compiler: gcc
       addons:
         apt:
           packages:
             - cppcheck
       env:
         - ANALYZE=true
-        - CC=gcc-4.8
-        - CXX=g++-4.8
 #
 # clang-6 static code analysis
     - os: linux
+      compiler: clang-6.0
       addons:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
             - ubuntu-toolchain-r-test
           packages:
-#            - check
+            - check
             - clang-6.0
             - clang-tidy-6.0
       env:
         - ANALYZE=true
         - PYTHON=python3
-        - CC=clang-6.0
-        - CXX=clang++-6.0
+#
+# cpplint checking
     #- os: linux
     #  compiler: gcc
     #  env: LINT=true
 #
 # DOCKER build
     - os: linux
+      compiler: gcc
       env:
         - DOCKER=true
 #
 # clang-6 FUZZER build
     - os: linux
+      compiler: clang-6.0
       addons:
         apt:
           sources:
@@ -230,12 +212,11 @@ matrix:
             - clang-6.0
             - clang-tidy-6.0
             - libfuzzer-6.0-dev
-#            - python-six
-#            - python3-six
+            - python-six
       env:
         - FUZZER=true
 #
-# OSX clang-6 build
+# OSX clang build
     - os: osx
       compiler: clang
       # disable homebrew auto update which takes a lot of time
@@ -246,6 +227,7 @@ matrix:
 #
 # SONAR gcc-4.9 build
     - os: linux
+      compiler: gcc-4.9
       addons:
         sonarcloud:
           organization: open62541
@@ -254,9 +236,6 @@ matrix:
             - sonarcloud
       env:
         - SONAR=true
-        - CC=gcc-4.9
-        - CXX=g++-4.9
-        - PYTHON=python2
       cache:
         directories:
           - '$HOME/.sonar/cache'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-# using c for language overwrites our compilers
-language: generic
-
+language: c
 sudo: required
 
 env:
@@ -13,7 +11,10 @@ dist: trusty
 matrix:
   fast_finish: true
   include:
-    #
+#
+# gcc-4.8 (trusty) full host and cross build:
+# doc, cert, cross-mingw32, cross-mingw64, cross-linux32, cross-raspi, linux64,
+# amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal, debian-package
     - os: linux
       addons:
         apt:
@@ -21,35 +22,43 @@ matrix:
             # see https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
             - ubuntu-toolchain-r-test
           packages:
-            - binutils-mingw-w64-i686
-            - build-essential
             - check
-            - cmake
-            - debhelper
-            - fakeroot
-            - gcc-multilib
+            # cross-mingw
+            - mingw-w64
             - g++-mingw-w64-i686
             - g++-mingw-w64-x86-64
+            - binutils-mingw-w64-i686
+            # debian packaging
+            - debhelper
+            - fakeroot
+            #
+            - gcc-multilib
             - g++-multilib
-            - graphviz
             - libsubunit-dev
             - libx11-dev
-            - mingw-w64
             - python-six
-            - python3-six
+            # doc
+            - python-sphinx
+            - graphviz
+            - texlive-generic-extra
             - texlive-fonts-recommended
             - texlive-latex-extra
-            - texlive-latex-recommended
+            - latexmk
+            #
             - valgrind
             - wget
             - xutils-dev
             - zip
       env:
-        - CC=gcc-4.8
-        - CXX=g++-4.8
+#        - CC=gcc-4.8
+#        - CXX=g++-4.8
         - PYTHON=python2
         - MINGW=true
         - DEBIAN=true
+#
+# gcc-8 full host build:
+# doc, cert, linux64,
+# amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
       addons:
         apt:
@@ -57,8 +66,6 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - check
-            - debhelper
-            - fakeroot
             - gcc-8
             - gcc-8-multilib
             - g++-8
@@ -66,15 +73,23 @@ matrix:
             - graphviz
             - linux-libc-dev:i386
             - python-six
-            - python3-six
+            # doc
+            - python-sphinx
+            - graphviz
+            - texlive-generic-extra
             - texlive-fonts-recommended
             - texlive-latex-extra
-            - texlive-latex-recommended
+            - latexmk
+            #
             - valgrind
       env:
         - CC=gcc-8
         - CXX=g++-8
         - PYTHON=python2
+#
+# clang-6 full host build:
+# doc, cert, linux64,
+# amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
       addons:
         apt:
@@ -85,18 +100,23 @@ matrix:
             - check
             - clang-6.0
             - clang-tidy-6.0
-            - debhelper
-            - fakeroot
+            # doc
+            - python-sphinx
             - graphviz
-            - python-six
+            - texlive-generic-extra
             - texlive-fonts-recommended
             - texlive-latex-extra
-            - texlive-latex-recommended
+            - latexmk
+            #
             - valgrind
       env:
         - CC=clang-6.0
         - CXX=clang++-6.0
         - PYTHON=python2
+#
+# clang-6 python-3 full host build:
+# doc, cert, linux64,
+# amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
       addons:
         apt:
@@ -107,34 +127,44 @@ matrix:
             - check
             - clang-6.0
             - clang-tidy-6.0
-            - debhelper
-            - fakeroot
-            - graphviz
             - python3-six
+            # doc
+            - python3-sphinx
+            - graphviz
+            - texlive-generic-extra
             - texlive-fonts-recommended
             - texlive-latex-extra
-            - texlive-latex-recommended
+            - latexmk
+            #
             - valgrind
       env:
         - CC=clang-6.0
         - CXX=clang++-6.0
         - PYTHON=python3
+#
+# tcc full host build:
+# doc, cert, linux64,
+# amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
     - os: linux
       addons:
         apt:
           packages:
             - check
-            - graphviz
-            - debhelper
-            - fakeroot
-            - python-six
             - python3-six
+            # doc
+            - python3-sphinx
+            - graphviz
+            - texlive-generic-extra
             - texlive-fonts-recommended
             - texlive-latex-extra
-            - texlive-latex-recommended
+            - latexmk
+            #
       env:
         - CC=tcc
         - PYTHON=python2
+#
+# clang-6 python-3 install build and minimal example:
+# linux64, minimal-example
     - os: linux
       addons:
         apt:
@@ -151,6 +181,8 @@ matrix:
         - CC=clang-6.0
         - CXX=clang++-6.0
         - PYTHON=python3
+#
+# gcc-4.8 static code analysis
     - os: linux
       addons:
         apt:
@@ -160,6 +192,8 @@ matrix:
         - ANALYZE=true
         - CC=gcc-4.8
         - CXX=g++-4.8
+#
+# clang-6 static code analysis
     - os: linux
       addons:
         apt:
@@ -167,15 +201,9 @@ matrix:
             - llvm-toolchain-trusty-6.0
             - ubuntu-toolchain-r-test
           packages:
-            - check
+#            - check
             - clang-6.0
             - clang-tidy-6.0
-            - graphviz
-            - python-six
-            - python3-six
-            - texlive-fonts-recommended
-            - texlive-latex-extra
-            - texlive-latex-recommended
       env:
         - ANALYZE=true
         - PYTHON=python3
@@ -184,9 +212,13 @@ matrix:
     #- os: linux
     #  compiler: gcc
     #  env: LINT=true
+#
+# DOCKER build
     - os: linux
       env:
         - DOCKER=true
+#
+# clang-6 FUZZER build
     - os: linux
       addons:
         apt:
@@ -198,10 +230,12 @@ matrix:
             - clang-6.0
             - clang-tidy-6.0
             - libfuzzer-6.0-dev
-            - python-six
-            - python3-six
+#            - python-six
+#            - python3-six
       env:
         - FUZZER=true
+#
+# OSX clang-6 build
     - os: osx
       compiler: clang
       # disable homebrew auto update which takes a lot of time
@@ -209,6 +243,8 @@ matrix:
       cache:
         directories:
           - $HOME/Library/Caches/Homebrew
+#
+# SONAR gcc-4.9 build
     - os: linux
       addons:
         sonarcloud:
@@ -217,9 +253,9 @@ matrix:
             - master
             - sonarcloud
       env:
+        - SONAR=true
         - CC=gcc-4.9
         - CXX=g++-4.9
-        - SONAR=true
         - PYTHON=python2
       cache:
         directories:

--- a/tools/travis/travis_linux_before_install.sh
+++ b/tools/travis/travis_linux_before_install.sh
@@ -58,7 +58,6 @@ if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
 
 	echo "=== Installing python packages ===" && echo -en 'travis_fold:start:before_install.python\\r'
 	pip install --user cpp-coveralls
-	pip install --user 'sphinx==1.7.9'
 	pip install --user sphinx_rtd_theme
 	pip install --user cpplint
 	echo -en 'travis_fold:end:script.before_install.python\\r'

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -71,7 +71,7 @@ echo "=== Install build, then compile minimal example ===" && echo -en 'travis_f
         -DUA_NAMESPACE_ZERO=FULL \
         -DUA_ENABLE_AMALGAMATION=OFF \
         -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/open62541_install ..
-    make install
+    make -j install
     if [ $? -ne 0 ] ; then exit 1 ; fi
 
     cd .. && rm build -rf

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -261,7 +261,7 @@ else
     rm build -rf
     echo -en 'travis_fold:end:script.build.linux_64\\r'
 
-    echo -e "\r\n== Building the C++ example =="  && echo -en 'travis_fold:start:script.build.example\\r'
+    echo -e "\r\n== Compile with amalgamation =="  && echo -en 'travis_fold:start:script.build.amalgamate\\r'
     mkdir -p build && cd build
     cmake \
         -DBUILD_SHARED_LIBS=ON \
@@ -277,7 +277,7 @@ else
     g++ ../examples/server.cpp -I./ open62541.o -lrt -o cpp-server
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.example\\r'
+    echo -en 'travis_fold:end:script.build.amalgamate\\r'
 
     echo "Compile as shared lib version" && echo -en 'travis_fold:start:script.build.shared_libs\\r'
     mkdir -p build && cd build

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -60,7 +60,7 @@ fi
 
 # INSTALL build test
 if ! [ -z ${INSTALL+x} ]; then
-
+echo "=== Install build, then compile minimal example ===" && echo -en 'travis_fold:start:script.build.install\\r'
     # Use make install to deploy files and then test if we can build an example based on the installed files
     mkdir -p build
     cd build
@@ -75,10 +75,12 @@ if ! [ -z ${INSTALL+x} ]; then
     if [ $? -ne 0 ] ; then exit 1 ; fi
 
     cd .. && rm build -rf
+    echo -en 'travis_fold:end:script.build.install\\r'
 
+    echo -en 'travis_fold:start:script.build.mini-example\\r'
     # Now create a simple CMake Project which uses the installed file
     mkdir compile && cd compile
-cat > CMakeLists.txt <<- EOM
+    cat > CMakeLists.txt << EOM
 cmake_minimum_required(VERSION 2.8)
 project(install-test)
 find_package(open62541 REQUIRED COMPONENTS FullNamespace)
@@ -91,10 +93,11 @@ EOM
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd ..
     rm -rf compile
+    echo -en 'travis_fold:end:script.build.mini-example\\r'
     exit 0
 fi
 
-if [ $ANALYZE = "true" ]; then
+if ! [ -z ${ANALYZE+x} ]; then
     echo "=== Running static code analysis ===" && echo -en 'travis_fold:start:script.analyze\\r'
     if ! case $CC in clang*) false;; esac; then
         mkdir -p build
@@ -146,110 +149,37 @@ if [ $ANALYZE = "true" ]; then
         fi
     fi
     echo -en 'travis_fold:end:script.analyze\\r'
-else
-    echo -en "\r\n=== Building ===\r\n"
+    exit 0
+fi
 
-    echo -e "\r\n== Documentation and certificate build =="  && echo -en 'travis_fold:start:script.build.doc\\r'
-    mkdir -p build
-    cd build
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-        -DUA_BUILD_EXAMPLES=ON \
-        -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
-    make doc
-    make doc_pdf
-    make selfsigned
-    cp -r doc ../../
-    cp -r doc_latex ../../
-    cp ./examples/server_cert.der ../../
-    cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.doc\\r'
+echo -en "\r\n=== Building ===\r\n"
 
-    # cross compilation only with gcc
-    if ! [ -z ${MINGW+x} ]; then
-        echo -e "\r\n== Cross compile release build for MinGW 32 bit =="  && echo -en 'travis_fold:start:script.build.cross_mingw32\\r'
-        mkdir -p build && cd build
-        cmake \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-win32 \
-            -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw32.cmake \
-            -DUA_BUILD_EXAMPLES=ON \
-            -DUA_ENABLE_AMALGAMATION=OFF ..
-        make -j
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        make install
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        cd ..
-        zip -r open62541-win32.zip ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-win32/*
-        rm build -rf
-        echo -en 'travis_fold:end:script.build.cross_mingw32\\r'
+echo -e "\r\n== Documentation and certificate build =="  && echo -en 'travis_fold:start:script.build.doc\\r'
+mkdir -p build
+cd build
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=ON \
+    -DUA_BUILD_SELFSIGNED_CERTIFICATE=ON ..
+make doc
+make doc_pdf
+make selfsigned
+cp -r doc ../../
+cp -r doc_latex ../../
+cp ./examples/server_cert.der ../../
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.doc\\r'
 
-        echo -e "\r\n== Cross compile release build for MinGW 64 bit =="  && echo -en 'travis_fold:start:script.build.cross_mingw64\\r'
-        mkdir -p build && cd build
-        cmake \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-win64 \
-            -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw64.cmake \
-            -DUA_BUILD_EXAMPLES=ON \
-            -DUA_ENABLE_AMALGAMATION=OFF ..
-        make -j
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        make install
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        cd ..
-        zip -r open62541-win64.zip ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-win64/*
-        rm build -rf
-        echo -en 'travis_fold:end:script.build.cross_mingw64\\r'
-
-        echo -e "\r\n== Cross compile release build for 32-bit linux =="  && echo -en 'travis_fold:start:script.build.cross_linux\\r'
-        mkdir -p build && cd build
-        cmake \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-linux32 \
-            -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-gcc-m32.cmake \
-            -DUA_BUILD_EXAMPLES=ON \
-            -DUA_ENABLE_AMALGAMATION=OFF ..
-        make -j
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        make install
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        cd ..
-        tar -pczf open62541-linux32.tar.gz ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-linux32/*
-        rm build -rf
-        echo -en 'travis_fold:end:script.build.cross_linux\\r'
-
-        echo -e "\r\n== Cross compile release build for RaspberryPi =="  && echo -en 'travis_fold:start:script.build.cross_raspi\\r'
-        mkdir -p build && cd build
-        git clone https://github.com/raspberrypi/tools
-        export PATH=$PATH:./tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/
-        cmake \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-raspberrypi \
-            -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-rpi64.cmake \
-            -DUA_BUILD_EXAMPLES=ON \
-            -DUA_ENABLE_AMALGAMATION=OFF ..
-        make -j
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        make install
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        cd ..
-        tar -pczf open62541-raspberrypi.tar.gz ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-raspberrypi/*
-        rm build -rf
-        echo -en 'travis_fold:end:script.build.cross_raspi\\r'
-    fi
-
-    echo -e "\r\n== Compile release build for 64-bit linux =="  && echo -en 'travis_fold:start:script.build.linux_64\\r'
+# cross compilation only with gcc
+if ! [ -z ${MINGW+x} ]; then
+    echo -e "\r\n== Cross compile release build for MinGW 32 bit =="  && echo -en 'travis_fold:start:script.build.cross_mingw32\\r'
     mkdir -p build && cd build
     cmake \
         -DBUILD_SHARED_LIBS=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-linux64 \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-win32 \
+        -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw32.cmake \
         -DUA_BUILD_EXAMPLES=ON \
         -DUA_ENABLE_AMALGAMATION=OFF ..
     make -j
@@ -257,186 +187,260 @@ else
     make install
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd ..
-    tar -pczf open62541-linux64.tar.gz ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-linux64/*
+    zip -r open62541-win32.zip ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-win32/*
     rm build -rf
-    echo -en 'travis_fold:end:script.build.linux_64\\r'
+    echo -en 'travis_fold:end:script.build.cross_mingw32\\r'
 
-    echo -e "\r\n== Compile with amalgamation =="  && echo -en 'travis_fold:start:script.build.amalgamate\\r'
+    echo -e "\r\n== Cross compile release build for MinGW 64 bit =="  && echo -en 'travis_fold:start:script.build.cross_mingw64\\r'
     mkdir -p build && cd build
     cmake \
         -DBUILD_SHARED_LIBS=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-linux64 \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-        -DUA_BUILD_EXAMPLES=OFF \
-        -DUA_ENABLE_AMALGAMATION=ON ..
-    make -j
-    cp open62541.h ../.. # copy single file-release
-    cp open62541.c ../.. # copy single file-release
-    gcc -std=c99 -c open62541.c
-    g++ ../examples/server.cpp -I./ open62541.o -lrt -o cpp-server
-    if [ $? -ne 0 ] ; then exit 1 ; fi
-    cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.amalgamate\\r'
-
-    echo "Compile as shared lib version" && echo -en 'travis_fold:start:script.build.shared_libs\\r'
-    mkdir -p build && cd build
-    cmake \
-        -DBUILD_SHARED_LIBS=ON \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-win64 \
+        -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-mingw64.cmake \
         -DUA_BUILD_EXAMPLES=ON \
         -DUA_ENABLE_AMALGAMATION=OFF ..
     make -j
     if [ $? -ne 0 ] ; then exit 1 ; fi
-    cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.shared_libs\\r'
+    make install
+    if [ $? -ne 0 ] ; then exit 1 ; fi
+    cd ..
+    zip -r open62541-win64.zip ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-win64/*
+    rm build -rf
+    echo -en 'travis_fold:end:script.build.cross_mingw64\\r'
 
-    echo "Compile as shared lib version with amalgamation" && echo -en 'travis_fold:start:script.build.shared_libs_amalgamate\\r'
+    echo -e "\r\n== Cross compile release build for 32-bit linux =="  && echo -en 'travis_fold:start:script.build.cross_linux\\r'
     mkdir -p build && cd build
     cmake \
         -DBUILD_SHARED_LIBS=ON \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-        -DUA_BUILD_EXAMPLES=OFF \
-        -DUA_ENABLE_AMALGAMATION=ON ..
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-linux32 \
+        -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-gcc-m32.cmake \
+        -DUA_BUILD_EXAMPLES=ON \
+        -DUA_ENABLE_AMALGAMATION=OFF ..
+    make -j
+    if [ $? -ne 0 ] ; then exit 1 ; fi
+    make install
+    if [ $? -ne 0 ] ; then exit 1 ; fi
+    cd ..
+    tar -pczf open62541-linux32.tar.gz ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-linux32/*
+    rm build -rf
+    echo -en 'travis_fold:end:script.build.cross_linux\\r'
+
+    echo -e "\r\n== Cross compile release build for RaspberryPi =="  && echo -en 'travis_fold:start:script.build.cross_raspi\\r'
+    mkdir -p build && cd build
+    git clone https://github.com/raspberrypi/tools
+    export PATH=$PATH:./tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/
+    cmake \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-raspberrypi \
+        -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-rpi64.cmake \
+        -DUA_BUILD_EXAMPLES=ON \
+        -DUA_ENABLE_AMALGAMATION=OFF ..
+    make -j
+    if [ $? -ne 0 ] ; then exit 1 ; fi
+    make install
+    if [ $? -ne 0 ] ; then exit 1 ; fi
+    cd ..
+    tar -pczf open62541-raspberrypi.tar.gz ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-raspberrypi/*
+    rm build -rf
+    echo -en 'travis_fold:end:script.build.cross_raspi\\r'
+fi
+
+echo -e "\r\n== Compile release build for 64-bit linux =="  && echo -en 'travis_fold:start:script.build.linux_64\\r'
+mkdir -p build && cd build
+cmake \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-linux64 \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=ON \
+    -DUA_ENABLE_AMALGAMATION=OFF ..
+make -j
+if [ $? -ne 0 ] ; then exit 1 ; fi
+make install
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd ..
+tar -pczf open62541-linux64.tar.gz ../doc_latex/open62541.pdf LICENSE AUTHORS README.md open62541-linux64/*
+rm build -rf
+echo -en 'travis_fold:end:script.build.linux_64\\r'
+
+echo -e "\r\n== Compile with amalgamation =="  && echo -en 'travis_fold:start:script.build.amalgamate\\r'
+mkdir -p build && cd build
+cmake \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/open62541-linux64 \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=OFF \
+    -DUA_ENABLE_AMALGAMATION=ON ..
+make -j
+cp open62541.h ../.. # copy single file-release
+cp open62541.c ../.. # copy single file-release
+gcc -std=c99 -c open62541.c
+g++ ../examples/server.cpp -I./ open62541.o -lrt -o cpp-server
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.amalgamate\\r'
+
+echo "Compile as shared lib version" && echo -en 'travis_fold:start:script.build.shared_libs\\r'
+mkdir -p build && cd build
+cmake \
+    -DBUILD_SHARED_LIBS=ON \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=ON \
+    -DUA_ENABLE_AMALGAMATION=OFF ..
+make -j
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.shared_libs\\r'
+
+echo "Compile as shared lib version with amalgamation" && echo -en 'travis_fold:start:script.build.shared_libs_amalgamate\\r'
+mkdir -p build && cd build
+cmake \
+    -DBUILD_SHARED_LIBS=ON \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=OFF \
+    -DUA_ENABLE_AMALGAMATION=ON ..
+make -j
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.shared_libs_amalgamate\\r'
+
+if [ "$CC" != "tcc" ]; then
+    echo -e "\r\n==Compile multithreaded version==" && echo -en 'travis_fold:start:script.build.multithread\\r'
+    mkdir -p build && cd build
+    cmake \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=ON \
+    -DUA_ENABLE_MULTITHREADING=ON ..
     make -j
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.shared_libs_amalgamate\\r'
+    echo -en 'travis_fold:end:script.build.multithread\\r'
+fi
 
-    if [ "$CC" != "tcc" ]; then
-        echo -e "\r\n==Compile multithreaded version==" && echo -en 'travis_fold:start:script.build.multithread\\r'
-        mkdir -p build && cd build
-        cmake \
+echo -e "\r\n== Compile with encryption ==" && echo -en 'travis_fold:start:script.build.encryption\\r'
+mkdir -p build && cd build
+cmake \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=ON \
+    -DUA_ENABLE_ENCRYPTION=ON ..
+make -j
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.encryption\\r'
+
+echo -e "\r\n== Compile without discovery version ==" && echo -en 'travis_fold:start:script.build.discovery\\r'
+mkdir -p build && cd build
+cmake \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=ON \
+    -DUA_ENABLE_DISCOVERY=OFF \
+    -DUA_ENABLE_DISCOVERY_MULTICAST=OFF ..
+make -j
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.discovery\\r'
+
+if [ "$CC" != "tcc" ]; then
+    echo -e "\r\n== Compile multithreaded version with discovery ==" && echo -en 'travis_fold:start:script.build.multithread_discovery\\r'
+    mkdir -p build && cd build
+    cmake \
         -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
         -DUA_BUILD_EXAMPLES=ON \
+        -DUA_ENABLE_DISCOVERY=ON \
+        -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
         -DUA_ENABLE_MULTITHREADING=ON ..
-        make -j
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        cd .. && rm build -rf
-        echo -en 'travis_fold:end:script.build.multithread\\r'
-    fi
-
-    echo -e "\r\n== Compile with encryption ==" && echo -en 'travis_fold:start:script.build.encryption\\r'
-    mkdir -p build && cd build
-    cmake \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-        -DUA_BUILD_EXAMPLES=ON \
-        -DUA_ENABLE_ENCRYPTION=ON ..
     make -j
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.encryption\\r'
+    echo -en 'travis_fold:end:script.build.multithread_discovery\\r'
+fi
 
-    echo -e "\r\n== Compile without discovery version ==" && echo -en 'travis_fold:start:script.build.discovery\\r'
-    mkdir -p build && cd build
-    cmake \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-        -DUA_BUILD_EXAMPLES=ON \
-        -DUA_ENABLE_DISCOVERY=OFF \
-        -DUA_ENABLE_DISCOVERY_MULTICAST=OFF ..
-    make -j
+echo -e "\r\n== Compile JSON encoding ==" && echo -en 'travis_fold:start:script.build.json\\r'
+mkdir -p build && cd build
+cmake \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_ENABLE_JSON_ENCODING=ON ..
+make -j
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.json\\r'
+
+echo -e "\r\n== Unit tests (full NS0) ==" && echo -en 'travis_fold:start:script.build.unit_test_ns0_full\\r'
+mkdir -p build && cd build
+# Valgrind cannot handle the full NS0 because the generated file is too big. Thus run NS0 full without valgrind
+cmake \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
+    -DUA_BUILD_EXAMPLES=ON \
+    -DUA_BUILD_UNIT_TESTS=ON \
+    -DUA_ENABLE_COVERAGE=OFF \
+    -DUA_ENABLE_DA=ON \
+    -DUA_ENABLE_DISCOVERY=ON \
+    -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
+    -DUA_ENABLE_ENCRYPTION=ON \
+    -DUA_ENABLE_JSON_ENCODING=ON \
+    -DUA_ENABLE_PUBSUB=ON \
+    -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
+    -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
+    -DUA_ENABLE_SUBSCRIPTIONS=ON \
+    -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+    -DUA_ENABLE_UNIT_TESTS_MEMCHECK=OFF \
+    -DUA_NAMESPACE_ZERO=FULL ..
+make -j && make test ARGS="-V"
+if [ $? -ne 0 ] ; then exit 1 ; fi
+cd .. && rm build -rf
+echo -en 'travis_fold:end:script.build.unit_test_ns0_full\\r'
+
+if ! [ -z ${DEBIAN+x} ]; then
+    echo -e "\r\n== Building the Debian package =="  && echo -en 'travis_fold:start:script.build.debian\\r'
+    dpkg-buildpackage -b
     if [ $? -ne 0 ] ; then exit 1 ; fi
-    cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.discovery\\r'
+    cp ../open62541*.deb .
+    # Copy for github release script
+    cp ../open62541*.deb ../..
+    echo -en 'travis_fold:end:script.build.debian\\r'
+fi
 
-    if [ "$CC" != "tcc" ]; then
-        echo -e "\r\n== Compile multithreaded version with discovery ==" && echo -en 'travis_fold:start:script.build.multithread_discovery\\r'
-        mkdir -p build && cd build
-        cmake \
-            -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-            -DUA_BUILD_EXAMPLES=ON \
-            -DUA_ENABLE_DISCOVERY=ON \
-            -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
-            -DUA_ENABLE_MULTITHREADING=ON ..
-        make -j
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        cd .. && rm build -rf
-        echo -en 'travis_fold:end:script.build.multithread_discovery\\r'
-    fi
 
-    echo -e "\r\n== Compile JSON encoding ==" && echo -en 'travis_fold:start:script.build.json\\r'
+if [ "$CC" != "tcc" ]; then
+    echo -e "\r\n== Unit tests (minimal NS0) ==" && echo -en 'travis_fold:start:script.build.unit_test_ns0_minimal\\r'
     mkdir -p build && cd build
-    cmake \
-        -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-        -DUA_ENABLE_JSON_ENCODING=ON ..
-    make -j
-    if [ $? -ne 0 ] ; then exit 1 ; fi
-    cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.json\\r'
-
-    echo -e "\r\n== Unit tests (full NS0) ==" && echo -en 'travis_fold:start:script.build.unit_test_ns0_full\\r'
-    mkdir -p build && cd build
-    # Valgrind cannot handle the full NS0 because the generated file is too big. Thus run NS0 full without valgrind
     cmake \
         -DCMAKE_BUILD_TYPE=Debug \
         -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
         -DUA_BUILD_EXAMPLES=ON \
         -DUA_BUILD_UNIT_TESTS=ON \
-        -DUA_ENABLE_COVERAGE=OFF \
+        -DUA_ENABLE_COVERAGE=ON \
         -DUA_ENABLE_DA=ON \
         -DUA_ENABLE_DISCOVERY=ON \
         -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
         -DUA_ENABLE_ENCRYPTION=ON \
-        -DUA_ENABLE_JSON_ENCODING=ON \
         -DUA_ENABLE_PUBSUB=ON \
         -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
         -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
-        -DUA_ENABLE_SUBSCRIPTIONS=ON \
-        -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
-        -DUA_ENABLE_UNIT_TESTS_MEMCHECK=OFF \
-        -DUA_NAMESPACE_ZERO=FULL ..
+        -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
     make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then exit 1 ; fi
+    echo -en 'travis_fold:end:script.build.unit_test_ns0_minimal\\r'
+
+    # only run coveralls on main repo and when MINGW=true
+    # We only want to build coveralls once, so we just take the travis run where MINGW=true which is only enabled once
+    echo -e "\r\n== -> Current repo: ${TRAVIS_REPO_SLUG} =="
+    if [ $MINGW = "true" ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ]; then
+        echo -en "\r\n==   Building codecov.io for ${TRAVIS_REPO_SLUG} ==" && echo -en 'travis_fold:start:script.build.codecov\\r'
+        cd ..
+        /bin/bash -c "bash <(curl -s https://codecov.io/bash)"
+        if [ $? -ne 0 ] ; then exit 1 ; fi
+        cd build
+        echo -en 'travis_fold:end:script.build.codecov\\r'
+
+        echo -en "\r\n==   Building coveralls for ${TRAVIS_REPO_SLUG} ==" && echo -en 'travis_fold:start:script.build.coveralls\\r'
+        coveralls -E '.*/build/CMakeFiles/.*' -E '.*/examples/.*' -E '.*/tests/.*' -E '.*\.h' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -r ../ || true # ignore result since coveralls is unreachable from time to time
+        echo -en 'travis_fold:end:script.build.coveralls\\r'
+    fi
     cd .. && rm build -rf
-    echo -en 'travis_fold:end:script.build.unit_test_ns0_full\\r'
-
-    if ! [ -z ${DEBIAN+x} ]; then
-        echo -e "\r\n== Building the Debian package =="  && echo -en 'travis_fold:start:script.build.debian\\r'
-        dpkg-buildpackage -b
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        cp ../open62541*.deb .
-        # Copy for github release script
-        cp ../open62541*.deb ../..
-        echo -en 'travis_fold:end:script.build.debian\\r'
-    fi
-
-
-    if [ "$CC" != "tcc" ]; then
-        echo -e "\r\n== Unit tests (minimal NS0) ==" && echo -en 'travis_fold:start:script.build.unit_test_ns0_minimal\\r'
-        mkdir -p build && cd build
-        cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/$PYTHON \
-            -DUA_BUILD_EXAMPLES=ON \
-            -DUA_BUILD_UNIT_TESTS=ON \
-            -DUA_ENABLE_COVERAGE=ON \
-            -DUA_ENABLE_DA=ON \
-            -DUA_ENABLE_DISCOVERY=ON \
-            -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
-            -DUA_ENABLE_ENCRYPTION=ON \
-            -DUA_ENABLE_PUBSUB=ON \
-            -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
-            -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
-            -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
-        make -j && make test ARGS="-V"
-        if [ $? -ne 0 ] ; then exit 1 ; fi
-        echo -en 'travis_fold:end:script.build.unit_test_ns0_minimal\\r'
-
-        # only run coveralls on main repo and when MINGW=true
-        # We only want to build coveralls once, so we just take the travis run where MINGW=true which is only enabled once
-        echo -e "\r\n== -> Current repo: ${TRAVIS_REPO_SLUG} =="
-        if [ $MINGW = "true" ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ]; then
-            echo -en "\r\n==   Building codecov.io for ${TRAVIS_REPO_SLUG} ==" && echo -en 'travis_fold:start:script.build.codecov\\r'
-            cd ..
-            /bin/bash -c "bash <(curl -s https://codecov.io/bash)"
-            if [ $? -ne 0 ] ; then exit 1 ; fi
-            cd build
-            echo -en 'travis_fold:end:script.build.codecov\\r'
-
-            echo -en "\r\n==   Building coveralls for ${TRAVIS_REPO_SLUG} ==" && echo -en 'travis_fold:start:script.build.coveralls\\r'
-            coveralls -E '.*/build/CMakeFiles/.*' -E '.*/examples/.*' -E '.*/tests/.*' -E '.*\.h' -E '.*CMakeCXXCompilerId\.cpp' -E '.*CMakeCCompilerId\.c' -r ../ || true # ignore result since coveralls is unreachable from time to time
-            echo -en 'travis_fold:end:script.build.coveralls\\r'
-        fi
-        cd .. && rm build -rf
-    fi
 fi


### PR DESCRIPTION
A bunch of small changes to the Travis build, trying to make things more obvious without changing the actual builds too much:
- fix some misleading output in the build script
- make the static code analysis build a special build like the others
- group the pre-installs in .travis.yml by the feature they are needed for and remove unnecessary ones
- use Travis variables for setting compilers (reduce number of specific env variables for jobs)
- only set env variables for jobs that are needed (i.e. differ from default)

Things that still could be done (considered too disruptive for this PR):
- rename MINGW to CROSS (as it also activates cross builds for linux and raspi)
- create documentation only in the build(s) that actually use it (reduces pre-installs)

Note: The lower part of the diff (below) is misleading - the indentation of a huge block was removed (the analysis build if clause became short) which shows every line of that block as changed.