### PR TITLE
NodesetCompiler: Correctly map namespace for extension object type id

### DIFF
--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -294,7 +294,7 @@ class VariableNode(Node):
             return False
 
         self.value = Value()
-        self.value.parseXMLEncoding(self.xmlValueDef, dataTypeNode, self)
+        self.value.parseXMLEncoding(self.xmlValueDef, dataTypeNode, self, nodeset.namespaceMapping[self.modelUri])
 
         # Array Dimensions must accurately represent the value and will be patched
         # reflect the exaxt dimensions attached binary stream.


### PR DESCRIPTION
This fixes the nodeset compiler for some very special case:

If there's a variable with an ExtensionObject Value, the namespace of the DataType ID was not correctly mapped.

E.g. 

```xml
 <UAVariable NodeId="ns=1;i=15399" BrowseName="InputArguments" ParentNodeId="ns=1;i=15398" DataType="i=296" ValueRank="1">
    <DisplayName>InputArguments</DisplayName>
    <References>
      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=15398</Reference>
    </References>
    <Value>
      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
        <ExtensionObject>
          <TypeId>
            <Identifier>i=297</Identifier>
          </TypeId>
          <Body>
            <Argument>
              <Name>Name</Name>
              <DataType>
                <Identifier>i=12</Identifier>
              </DataType>
              <ValueRank>-1</ValueRank>
              <ArrayDimensions />
              <Description p5:nil="true" xmlns:p5="http://www.w3.org/2001/XMLSchema-instance" />
            </Argument>
          </Body>
        </ExtensionObject>
        <ExtensionObject>
          <TypeId>
            <Identifier>i=297</Identifier>
          </TypeId>
          <Body>
            <Argument>
              <Name>Frame</Name>
              <DataType>
                <Identifier>ns=3;i=3003</Identifier>
              </DataType>
              <ValueRank>-1</ValueRank>
              <ArrayDimensions />
              <Description p5:nil="true" xmlns:p5="http://www.w3.org/2001/XMLSchema-instance" />
            </Argument>
          </Body>
        </ExtensionObject>
      </ListOfExtensionObject>
    </Value>
  </UAVariable>

```

Here the namespace of the id `ns=3;i=3003` needs to be remapped to the new server namespace index.