### PR TITLE
Use EXIT_SUCCESS/FAILURE for the examples

### DIFF
--- a/examples/access_control/client_access_control.c
+++ b/examples/access_control/client_access_control.c
@@ -9,6 +9,8 @@
 #include <ua_config_default.h>
 #include <ua_client_highlevel.h>
 
+#include <stdlib.h>
+
 int main(void) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));
@@ -16,7 +18,7 @@ int main(void) {
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
     if(retval != UA_STATUSCODE_GOOD) {
         UA_Client_delete(client);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
 
     UA_NodeId newVariableIdRequest = UA_NODEID_NUMERIC(1, 1001);
@@ -63,5 +65,5 @@ int main(void) {
     /* Clean up */
     UA_VariableAttributes_clear(&newVariableAttributes);
     UA_Client_delete(client); /* Disconnects the client internally */
-    return UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/access_control/server_access_control.c
+++ b/examples/access_control/server_access_control.c
@@ -7,6 +7,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 static UA_Boolean
 allowAddNode(UA_Server *server, UA_AccessControl *ac,
@@ -63,5 +64,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/client.c
+++ b/examples/client.c
@@ -6,6 +6,8 @@
 #include <ua_config_default.h>
 #include <ua_log_stdout.h>
 
+#include <stdlib.h>
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static void
 handler_TheAnswerChanged(UA_Client *client, UA_UInt32 subId, void *subContext,
@@ -38,7 +40,7 @@ int main(int argc, char *argv[]) {
     if(retval != UA_STATUSCODE_GOOD) {
         UA_Array_delete(endpointArray, endpointArraySize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
         UA_Client_delete(client);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
     printf("%i endpoints found\n", (int)endpointArraySize);
     for(size_t i=0;i<endpointArraySize;i++) {
@@ -53,7 +55,7 @@ int main(int argc, char *argv[]) {
     retval = UA_Client_connect_username(client, "opc.tcp://localhost:4840", "user1", "password");
     if(retval != UA_STATUSCODE_GOOD) {
         UA_Client_delete(client);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
 
     /* Browse some objects */
@@ -255,5 +257,5 @@ int main(int argc, char *argv[]) {
 
     UA_Client_disconnect(client);
     UA_Client_delete(client);
-    return (int) UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/client_async.c
+++ b/examples/client_async.c
@@ -6,6 +6,8 @@
 #include <ua_log_stdout.h>
 #include <ua_client_highlevel_async.h>
 
+#include <stdlib.h>
+
 #define NODES_EXIST
 /* async connection callback, it only gets called after the completion of the whole
  * connection process*/
@@ -198,5 +200,5 @@ main(int argc, char *argv[]) {
     UA_Client_disconnect(client);
     UA_Client_delete(client);
 
-    return (int) UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/client_connect_loop.c
+++ b/examples/client_connect_loop.c
@@ -16,6 +16,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 
@@ -78,5 +79,5 @@ int main(void) {
     /* Clean up */
     UA_Variant_clear(&value);
     UA_Client_delete(client); /* Disconnects the client internally */
-    return UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/client_connectivitycheck_loop.c
+++ b/examples/client_connectivitycheck_loop.c
@@ -6,6 +6,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 
@@ -49,5 +50,5 @@ int main(void) {
 
     /* Clean up */
     UA_Client_delete(client); /* Disconnects the client internally */
-    return UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/client_historical.c
+++ b/examples/client_historical.c
@@ -1,10 +1,12 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
-#include <stdio.h>
 #include <ua_client_highlevel.h>
 #include <ua_client.h>
 #include <ua_config_default.h>
+
+#include <stdio.h>
+#include <stdlib.h>
 
 #ifdef UA_ENABLE_EXPERIMENTAL_HISTORIZING
 static void
@@ -140,7 +142,7 @@ int main(int argc, char *argv[]) {
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:53530/OPCUA/SimulationServer");
     if(retval != UA_STATUSCODE_GOOD) {
         UA_Client_delete(client);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
 
     /* Read historical values (uint32) */
@@ -175,5 +177,5 @@ int main(int argc, char *argv[]) {
 #endif
     UA_Client_disconnect(client);
     UA_Client_delete(client);
-    return (int) retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/client_subscription_loop.c
+++ b/examples/client_subscription_loop.c
@@ -15,6 +15,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 
@@ -136,5 +137,5 @@ main(void) {
 
     /* Clean up */
     UA_Client_delete(client); /* Disconnects the client internally */
-    return UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/custom_datatype/client_types_custom.c
+++ b/examples/custom_datatype/client_types_custom.c
@@ -5,6 +5,8 @@
 #include <ua_config_default.h>
 #include "custom_datatype.h"
 
+#include <stdlib.h>
+
 int main(void) {
     /* Make your custom datatype known to the stack */
     UA_DataType types[1];
@@ -41,5 +43,5 @@ int main(void) {
     /* Clean up */
     UA_Variant_clear(&value);
     UA_Client_delete(client); /* Disconnects the client internally */
-    return UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/custom_datatype/server_types_custom.c
+++ b/examples/custom_datatype/server_types_custom.c
@@ -7,6 +7,7 @@
 #include "custom_datatype.h"
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 
@@ -86,5 +87,5 @@ int main(void) {
 
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/examples/discovery/client_find_servers.c
+++ b/examples/discovery/client_find_servers.c
@@ -9,6 +9,8 @@
 #include <ua_config_default.h>
 #include <ua_log_stdout.h>
 
+#include <stdlib.h>
+
 #define DISCOVERY_SERVER_ENDPOINT "opc.tcp://localhost:4840"
 
 int main(void) {
@@ -31,7 +33,7 @@ int main(void) {
                          "Is the discovery server started? StatusCode %s",
                          UA_StatusCode_name(retval));
             UA_Client_delete(client);
-            return (int) retval;
+            return EXIT_FAILURE;
         }
 
         // output all the returned/registered servers
@@ -69,7 +71,7 @@ int main(void) {
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Could not call FindServers service. "
                 "Is the discovery server started? StatusCode %s", UA_StatusCode_name(retval));
-        return (int) retval;
+        return EXIT_FAILURE;
     }
 
     // output all the returned/registered servers
@@ -184,5 +186,5 @@ int main(void) {
     UA_Array_delete(applicationDescriptionArray, applicationDescriptionArraySize,
                     &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
 
-    return (int) UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }

--- a/examples/discovery/server_lds.c
+++ b/examples/discovery/server_lds.c
@@ -10,6 +10,7 @@
 #include <ua_config_default.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sig) {
@@ -43,5 +44,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -15,6 +15,7 @@
 #include <ua_securitypolicies.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 const UA_ByteString UA_SECURITY_POLICY_BASIC128_URI =
     {56, (UA_Byte *)"http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15"};
@@ -309,7 +310,7 @@ int main(int argc, char **argv) {
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
         UA_free(discovery_url);
-        return 1;
+        return EXIT_FAILURE;
     }
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                 "Server started. Waiting for announce of LDS Server.");
@@ -319,7 +320,7 @@ int main(int argc, char **argv) {
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
         UA_free(discovery_url);
-        return 1;
+        return EXIT_FAILURE;
     }
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "LDS-ME server found on %s", discovery_url);
 
@@ -333,7 +334,7 @@ int main(int argc, char **argv) {
                      "Could not find any suitable endpoints on discovery server");
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return 1;
+        return EXIT_FAILURE;
     }
 
     UA_Client *clientRegister = getRegisterClient(endpointRegister, argc, argv);
@@ -342,7 +343,7 @@ int main(int argc, char **argv) {
                      "Could not create the client for remote registering");
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Connect the client */
@@ -360,7 +361,7 @@ int main(int argc, char **argv) {
         UA_Client_delete(clientRegister);
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return 1;
+        return EXIT_FAILURE;
     }
 
     while (running)
@@ -380,5 +381,5 @@ int main(int argc, char **argv) {
     UA_Client_delete(clientRegister);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -10,6 +10,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 #define DISCOVERY_SERVER_ENDPOINT "opc.tcp://localhost:4840"
 
@@ -107,7 +108,7 @@ int main(int argc, char **argv) {
         UA_Client_delete(clientRegister);
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
 
     retval = UA_Server_run(server, &running);
@@ -119,7 +120,7 @@ int main(int argc, char **argv) {
         UA_Client_delete(clientRegister);
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
 
     // Unregister the server from the discovery server.
@@ -134,5 +135,5 @@ int main(int argc, char **argv) {
     UA_Client_delete(clientRegister);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;;
 }

--- a/examples/encryption/client_encryption.c
+++ b/examples/encryption/client_encryption.c
@@ -8,8 +8,9 @@
 #include <ua_client_highlevel.h>
 #include "common.h"
 
+#include <stdlib.h>
+
 #define MIN_ARGS 4
-#define FAILURE  1
 
 int main(int argc, char* argv[]) {
     if(argc < MIN_ARGS) {
@@ -18,7 +19,7 @@ int main(int argc, char* argv[]) {
                      "<opc.tcp://host:port> "
                      "<client-certificate.der> <client-private-key.der> "
                      "[<trustlist1.crl>, ...]");
-        return FAILURE;
+        return EXIT_FAILURE;
     }
 
     const char *endpointUrl = argv[1];
@@ -55,7 +56,7 @@ int main(int argc, char* argv[]) {
     UA_StatusCode retval = UA_Client_connect(client, endpointUrl);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_Client_delete(client);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
 
     UA_Variant value;
@@ -76,5 +77,5 @@ int main(int argc, char* argv[]) {
     /* Clean up */
     UA_Variant_clear(&value);
     UA_Client_delete(client);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/encryption/server_basic128rsa15.c
+++ b/examples/encryption/server_basic128rsa15.c
@@ -9,6 +9,7 @@
 #include "common.h"
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sig) {
@@ -25,7 +26,7 @@ int main(int argc, char* argv[]) {
                      "Missing arguments. Arguments are "
                      "<server-certificate.der> <private-key.der> "
                      "[<trustlist1.crl>, ...]");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Load certificate and private key */
@@ -56,12 +57,12 @@ int main(int argc, char* argv[]) {
     if(!config) {
         UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                      "Could not create the server config");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     UA_Server *server = UA_Server_new(config);
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/encryption/server_basic256sha256.c
+++ b/examples/encryption/server_basic256sha256.c
@@ -9,6 +9,7 @@
 #include "common.h"
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sig) {
@@ -25,7 +26,7 @@ int main(int argc, char* argv[]) {
                      "Missing arguments. Arguments are "
                      "<server-certificate.der> <private-key.der> "
                      "[<trustlist1.crl>, ...]");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Load certificate and private key */
@@ -56,12 +57,12 @@ int main(int argc, char* argv[]) {
     if(!config) {
         UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                      "Could not create the server config");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     UA_Server *server = UA_Server_new(config);
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;;
 }

--- a/examples/nodeset/server_nodeset.c
+++ b/examples/nodeset/server_nodeset.c
@@ -6,6 +6,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 /* Files example_namespace.h and example_namespace.c are created from server_nodeset.xml in the
  * /src_generated directory by CMake */
@@ -49,5 +50,5 @@ int main(int argc, char** argv) {
 
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/nodeset/server_nodeset_plcopen.c
+++ b/examples/nodeset/server_nodeset_plcopen.c
@@ -10,6 +10,7 @@
 #endif
 
 #include <signal.h>
+#include <stdlib.h>
 
 #include "ua_namespace_di.h"
 #include "ua_namespace_plc.h"
@@ -34,18 +35,18 @@ int main(int argc, char** argv) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Adding the DI namespace failed. Please check previous error output.");
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return (int)UA_STATUSCODE_BADUNEXPECTEDERROR;
+        return EXIT_FAILURE;
     }
     retval |= ua_namespace_plc(server);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Adding the PLCopen namespace failed. Please check previous error output.");
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return (int)UA_STATUSCODE_BADUNEXPECTEDERROR;
+        return EXIT_FAILURE;
     }
 
     retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/nodeset/server_nodeset_powerlink.c
+++ b/examples/nodeset/server_nodeset_powerlink.c
@@ -10,6 +10,7 @@
 #endif
 
 #include <signal.h>
+#include <stdlib.h>
 
 #include "ua_namespace_di.h"
 #include "ua_namespace_powerlink.h"
@@ -34,18 +35,18 @@ int main(int argc, char** argv) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Adding the DI namespace failed. Please check previous error output.");
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return (int)UA_STATUSCODE_BADUNEXPECTEDERROR;
+        return EXIT_FAILURE;
     }
     retval |= ua_namespace_powerlink(server);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Adding the Powerlink namespace failed. Please check previous error output.");
         UA_Server_delete(server);
         UA_ServerConfig_delete(config);
-        return (int)UA_STATUSCODE_BADUNEXPECTEDERROR;
+        return EXIT_FAILURE;
     }
 
     retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/nodeset/server_testnodeset.c
+++ b/examples/nodeset/server_testnodeset.c
@@ -8,6 +8,7 @@
 #include <ua_server.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 #include "ua_namespace_testnodeset.h"
 
@@ -49,5 +50,5 @@ int main(int argc, char **argv)
     }
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/pubsub/tutorial_pubsub_connection.c
+++ b/examples/pubsub/tutorial_pubsub_connection.c
@@ -8,6 +8,7 @@
 #include <ua_network_pubsub_udp.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sign) {
@@ -85,5 +86,5 @@ int main(void) {
     retval |= UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/pubsub/tutorial_pubsub_publish.c
+++ b/examples/pubsub/tutorial_pubsub_publish.c
@@ -167,7 +167,7 @@ static int run(UA_String *transportProfile,
         (UA_PubSubTransportLayer *) UA_calloc(2, sizeof(UA_PubSubTransportLayer));
     if(!config->pubsubTransportLayers) {
         UA_ServerConfig_delete(config);
-        return -1;
+        return EXIT_FAILURE;
     }
     config->pubsubTransportLayers[0] = UA_PubSubTransportLayerUDPMP();
     config->pubsubTransportLayersSize++;
@@ -186,7 +186,7 @@ static int run(UA_String *transportProfile,
     retval |= UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 static void
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
     if (argc > 1) {
         if (strcmp(argv[1], "-h") == 0) {
             usage(argv[0]);
-            return 0;
+            return EXIT_SUCCESS;
         } else if (strncmp(argv[1], "opc.udp://", 10) == 0) {
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else if (strncmp(argv[1], "opc.eth://", 10) == 0) {
@@ -211,13 +211,13 @@ int main(int argc, char **argv) {
                 UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
             if (argc < 3) {
                 printf("Error: UADP/ETH needs an interface name\n");
-                return 1;
+                return EXIT_FAILURE;
             }
             networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf("Error: unknown URI\n");
-            return 1;
+            return EXIT_FAILURE;
         }
     }
 

--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -19,8 +19,10 @@
 #include "ua_network_pubsub_ethernet.h"
 #endif
 #include "src_generated/ua_types_generated.h"
+
 #include <stdio.h>
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sign) {
@@ -108,7 +110,7 @@ run(UA_String *transportProfile, UA_NetworkAddressUrlDataType *networkAddressUrl
         UA_calloc(2, sizeof(UA_PubSubTransportLayer));
     if (!config->pubsubTransportLayers) {
         UA_ServerConfig_delete(config);
-        return -1;
+        return EXIT_FAILURE;
     }
     config->pubsubTransportLayers[0] = UA_PubSubTransportLayerUDPMP();
     config->pubsubTransportLayersSize++;
@@ -152,7 +154,7 @@ run(UA_String *transportProfile, UA_NetworkAddressUrlDataType *networkAddressUrl
     retval |= UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;;
 }
 
 
@@ -170,7 +172,7 @@ int main(int argc, char **argv) {
     if (argc > 1) {
         if (strcmp(argv[1], "-h") == 0) {
             usage(argv[0]);
-            return 0;
+            return EXIT_SUCCESS;
         } else if (strncmp(argv[1], "opc.udp://", 10) == 0) {
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else if (strncmp(argv[1], "opc.eth://", 10) == 0) {
@@ -178,13 +180,13 @@ int main(int argc, char **argv) {
                 UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
             if (argc < 3) {
                 printf("Error: UADP/ETH needs an interface name\n");
-                return 1;
+                return EXIT_FAILURE;
             }
             networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf("Error: unknown URI\n");
-            return 1;
+            return EXIT_FAILURE;
         }
     }
 

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -1,8 +1,10 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
-# include "open62541.h"
+#include "open62541.h"
+
 #include <signal.h>
+#include <stdlib.h>
 
 /* Build Instructions (Linux)
  * - gcc -std=c99 -c open62541.c
@@ -46,5 +48,5 @@ int main() {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/server_certificate.c
+++ b/examples/server_certificate.c
@@ -10,7 +10,9 @@
 #include <ua_log_stdout.h>
 
 #include "common.h"
+
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 
@@ -39,5 +41,5 @@ int main(int argc, char** argv) {
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
 
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/server_ctt.c
+++ b/examples/server_ctt.c
@@ -16,6 +16,7 @@
 # include "common.h"
 
 #include <signal.h>
+#include <stdlib.h>
 
 /* This server is configured to the Compliance Testing Tools (CTT) against. The
  * corresponding CTT configuration is available at
@@ -459,13 +460,13 @@ int main(int argc, char **argv) {
         if(certificate.length == 0) {
             UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                            "Unable to load file %s.", argv[1]);
-            return 1;
+            return EXIT_FAILURE;
         }
         UA_ByteString privateKey = loadFile(argv[2]);
         if(privateKey.length == 0) {
             UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                            "Unable to load file %s.", argv[2]);
-            return 1;
+            return EXIT_FAILURE;
         }
 
         /* Load the trustlist */
@@ -503,7 +504,7 @@ int main(int argc, char **argv) {
     if(!config) {
         UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                      "Could not create the server config");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /* Override with a custom access control policy */
@@ -514,7 +515,7 @@ int main(int argc, char **argv) {
 
     UA_Server *server = UA_Server_new(config);
     if(server == NULL)
-        return 1;
+        return EXIT_FAILURE;
 
     setInformationModel(server);
 
@@ -522,5 +523,5 @@ int main(int argc, char **argv) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/server_inheritance.c
+++ b/examples/server_inheritance.c
@@ -6,6 +6,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sig) {
@@ -260,5 +261,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/server_instantiation.c
+++ b/examples/server_instantiation.c
@@ -6,6 +6,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sig) {
@@ -82,5 +83,5 @@ int main(void) {
     retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/server_mainloop.c
+++ b/examples/server_mainloop.c
@@ -8,6 +8,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sign) {
@@ -56,5 +57,5 @@ int main(int argc, char** argv) {
  cleanup:
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/server_repeated_job.c
+++ b/examples/server_repeated_job.c
@@ -6,6 +6,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 static void
 testCallback(UA_Server *server, void *data) {
@@ -31,5 +32,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
 
     if(argc < 2) {
         printf("Usage: tutorial_client_events <opc.tcp://server-url>\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     UA_Client *client = UA_Client_new();
@@ -110,7 +110,7 @@ int main(int argc, char *argv[]) {
     UA_StatusCode retval = UA_Client_connect(client, argv[1]);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_Client_delete(client);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
     if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         UA_Client_disconnect(client);
         UA_Client_delete(client);
-        return (int)retval;
+        return EXIT_FAILURE;
     }
     UA_UInt32 subId = response.subscriptionId;
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Create subscription succeeded, id %u", subId);
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
     monId = result.monitoredItemId;
 
     while(running)
-        UA_Client_run_iterate(client, 100);
+        retval = UA_Client_run_iterate(client, 100);
 
     /* Delete the subscription */
  cleanup:
@@ -172,5 +172,5 @@ int main(int argc, char *argv[]) {
 
     UA_Client_disconnect(client);
     UA_Client_delete(client);
-    return (int) retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_client_firststeps.c
+++ b/examples/tutorial_client_firststeps.c
@@ -12,6 +12,8 @@
 #include <ua_config_default.h>
 #include <ua_log_stdout.h>
 
+#include <stdlib.h>
+
 int main(void) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));
@@ -41,7 +43,7 @@ int main(void) {
     /* Clean up */
     UA_Variant_clear(&value);
     UA_Client_delete(client); /* Disconnects the client internally */
-    return UA_STATUSCODE_GOOD;
+    return EXIT_SUCCESS;
 }
 
 /**

--- a/examples/tutorial_datatypes.c
+++ b/examples/tutorial_datatypes.c
@@ -20,6 +20,7 @@
 #include <ua_config_default.h>
 #include <ua_log_stdout.h>
 
+#include <stdlib.h>
 
 static void
 variables_basic(void) {
@@ -135,5 +136,5 @@ int main(void) {
     variables_basic();
     variables_nodeids();
     variables_variants();
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/examples/tutorial_server_datasource.c
+++ b/examples/tutorial_server_datasource.c
@@ -30,6 +30,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 static void
 updateCurrentTime(UA_Server *server) {
@@ -172,5 +173,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_server_events.c
+++ b/examples/tutorial_server_events.c
@@ -6,6 +6,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 /**
  * Generating events
@@ -154,10 +155,8 @@ int main (void) {
     addNewEventType(server);
     addGenerateEventMethod(server);
 
-    /* return value */
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-
-    return (int) retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_server_firststeps.c
+++ b/examples/tutorial_server_firststeps.c
@@ -25,6 +25,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 UA_Boolean running = true;
 static void stopHandler(int sig) {
@@ -42,7 +43,7 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 /**

--- a/examples/tutorial_server_historicaldata.c
+++ b/examples/tutorial_server_historicaldata.c
@@ -12,7 +12,9 @@
 #include <ua_historydatagathering_default.h>
 #include <ua_historydatabase_default.h>
 #include <ua_historydatabackend_memory.h>
+
 #include <signal.h>
+#include <stdlib.h>
 
 static UA_Boolean running = true;
 static void stopHandler(int sign) {
@@ -20,7 +22,6 @@ static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
     running = false;
 }
-
 
 int main(void) {
     signal(SIGINT, stopHandler);
@@ -137,5 +138,5 @@ int main(void) {
     UA_Server_run_shutdown(server);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_server_method.c
+++ b/examples/tutorial_server_method.c
@@ -35,6 +35,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 static UA_StatusCode
 helloWorldMethodCallback(UA_Server *server,
@@ -181,5 +182,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_server_monitoreditems.c
+++ b/examples/tutorial_server_monitoreditems.c
@@ -25,6 +25,7 @@
 #include <ua_client_subscriptions.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 static void
 dataChangeNotificationCallback(UA_Server *server, UA_UInt32 monitoredItemId,
@@ -65,5 +66,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_server_object.c
+++ b/examples/tutorial_server_object.c
@@ -332,5 +332,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_server_variable.c
+++ b/examples/tutorial_server_variable.c
@@ -19,7 +19,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
-
+#include <stdlib.h>
 
 static void
 addVariable(UA_Server *server) {
@@ -119,5 +119,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/tutorial_server_variabletype.c
+++ b/examples/tutorial_server_variabletype.c
@@ -23,6 +23,7 @@
 #include <ua_log_stdout.h>
 
 #include <signal.h>
+#include <stdlib.h>
 
 static UA_NodeId pointTypeId;
 
@@ -137,5 +138,5 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
     UA_Server_delete(server);
     UA_ServerConfig_delete(config);
-    return (int)retval;
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
Make use of EXIT_SUCCESS and EXIT_FAILURE from stdlib.h.
The previous approach of returning a value from UA_StatusCode
was often broken as an exit code can (portably) only be between 0 and 125.