### PR TITLE
Fix wrong MSVC version check and avoid redefinition of _CRT_SECURE_NO_WARNINGS

### DIFF
--- a/arch/ua_architecture_definitions.h
+++ b/arch/ua_architecture_definitions.h
@@ -20,7 +20,7 @@
 #ifdef UNDER_CE
 # include "stdint.h"
 #endif
-#if !defined(_MSC_VER) || _MSC_VER >= 1600
+#if !defined(_MSC_VER) || _MSC_VER >= 1800
 # include <stdint.h>
 # include <stdbool.h> /* C99 Boolean */
 #else

--- a/arch/wec7/ua_architecture.h
+++ b/arch/wec7/ua_architecture.h
@@ -16,7 +16,7 @@
 #endif
 
 /* Disable some security warnings on MSVC */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 # define _CRT_SECURE_NO_WARNINGS
 #endif
 

--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -17,7 +17,7 @@
 #endif
 
 /* Disable some security warnings on MSVC */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 # define _CRT_SECURE_NO_WARNINGS
 #endif
 


### PR DESCRIPTION
#2431