### PR TITLE
use GNUInstallDirs to handle multiarch correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ set(open62541_NODESET_DIR ${PROJECT_SOURCE_DIR}/deps/ua-nodeset)
 include(macros_internal)
 include(macros_public)
 
+# GNUInstallDirs handles multiarch lib installation place
+# https://wiki.debian.org/Multiarch/Implementation
+include(GNUInstallDirs)
+
 #############################
 # Compiled binaries folders #
 #############################
@@ -38,9 +42,6 @@ set(OPEN62541_VER_MAJOR 0)
 set(OPEN62541_VER_MINOR 4)
 set(OPEN62541_VER_PATCH 0)
 set(OPEN62541_VER_LABEL "-dev") # Appended to the X.Y.Z version format. For example "-rc1" or an empty string
-
-#  If a relative path is specified, it is treated as relative to the $<INSTALL_PREFIX>
-set(LIB_INSTALL_DIR lib CACHE PATH "Installation path of libraries")
 
 # Set OPEN62541_VER_COMMIT
 if(GIT_FOUND)
@@ -63,7 +64,6 @@ if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "CMAKE_BUILD_TYPE not given; setting to 'Debug'")
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build" FORCE)
 endif()
-
 
 option(UA_ENABLE_AMALGAMATION "Concatenate the library to a single file open62541.h/.c" OFF)
 set(UA_AMALGAMATION_ARCHITECTURES "" CACHE STRING "List of architectures to include in amalgamation")
@@ -1026,7 +1026,7 @@ add_custom_target(cpplint cpplint
 # specify install location with `-DCMAKE_INSTALL_PREFIX=xyz`
 # Enable shared library with `-DBUILD_SHARED_LIBS=ON`
 
-set(cmake_configfile_install ${LIB_INSTALL_DIR}/cmake/open62541)
+set(cmake_configfile_install ${CMAKE_INSTALL_LIBDIR}/cmake/open62541)
 set(target_install_dest_name "${cmake_configfile_install}/open62541Targets.cmake")
 set(macros_install_dest_name "${cmake_configfile_install}/open62541Macros.cmake")
 set(open62541_install_tools_dir share/open62541/tools)
@@ -1078,15 +1078,15 @@ endif()
 if(NOT UA_ENABLE_AMALGAMATION)
 install(TARGETS open62541
         EXPORT open62541Targets
-        LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-        ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
         INCLUDES DESTINATION include/open62541 include)
 else()
 install(TARGETS open62541
         EXPORT open62541Targets
-        LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-        ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}
         INCLUDES DESTINATION include)
 # Our default way of installation is the non-amalgamated version.
@@ -1128,7 +1128,7 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/macros_public.cmake"
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     install(FILES "${PROJECT_BINARY_DIR}/src_generated/open62541.pc"
-            DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 set(UA_install_tools_dirs "tools/certs"


### PR DESCRIPTION
Installing libraries in a multiarch environment requires to set the multiarch tuple (i.e. x86_64-linux-gnu) correctly. CMake provides GNUInstallDirs for this reason. 
See also  https://wiki.debian.org/Multiarch/Implementation#CMake
