### PR TITLE
Debian install doc excluding temp build files

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -112,3 +112,28 @@ add_dependencies(doc open62541)
 
 set_target_properties(doc doc_latex doc_pdf PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE)
 set_target_properties(doc doc_latex doc_pdf PROPERTIES FOLDER "open62541/doc")
+
+if (UA_PACK_DEBIAN)
+    set(open62541_install_debdoc_html_dir share/doc/open62541/open62541.html)
+    set(open62541_install_debdoc_dir share/doc/open62541)
+
+    set(open62541_debdoc_pdf_files "${DOC_LATEX_DIR}/open62541.pdf")
+
+    install(DIRECTORY ${DOC_HTML_DIR}/
+        COMPONENT htmldoc 
+        DESTINATION ${open62541_install_debdoc_dir}/open62541.html 
+        USE_SOURCE_PERMISSIONS
+        FILES_MATCHING 
+        PATTERN "*.*"
+        PATTERN ".doctrees" EXCLUDE
+        PATTERN ".buildinfo" EXCLUDE
+        PATTERN "CMakeFiles" EXCLUDE
+        PATTERN "CMakeLists.txt" EXCLUDE
+        PATTERN "Makefile" EXCLUDE
+        PATTERN "*.map" EXCLUDE
+        PATTERN "*.cmake" EXCLUDE
+        PATTERN "*.inv" EXCLUDE
+        PATTERN "*.py" EXCLUDE
+        )
+    install(FILES ${open62541_debdoc_pdf_files} COMPONENT pdfdoc DESTINATION ${open62541_install_debdoc_dir})
+endif()


### PR DESCRIPTION
When packaging for Debian this installs the needed stuff for the `HTML` at `/usr/share/doc/open62541/open62541.html` and `PDF` at `/usr/share/doc/open62541` which is the Debian standard location. Installation of the temp build files will be excluded.
