### PR TITLE
Properly use target_include_directories to propagate include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,7 @@ GET_PROPERTY(architectures GLOBAL PROPERTY UA_ARCHITECTURES)
 list(SORT architectures)
 set_property(CACHE UA_ARCHITECTURE PROPERTY STRINGS None ${architectures})
 
-GET_PROPERTY(ua_directories_to_include GLOBAL PROPERTY UA_INCLUDE_DIRECTORIES)
-include_directories(${ua_directories_to_include})
+GET_PROPERTY(ua_architecture_directories_to_include GLOBAL PROPERTY UA_INCLUDE_DIRECTORIES)
 
 GET_PROPERTY(ua_architecture_headers GLOBAL PROPERTY UA_ARCHITECTURE_HEADERS)
 
@@ -477,20 +476,6 @@ if(UA_ENABLE_DISCOVERY_MULTICAST)
     set(MDNSD_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported" FORCE)
     configure_file("deps/mdnsd/libmdnsd/mdnsd_config.h.in" "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h")
 endif()
-
-if(UA_ENABLE_DISCOVERY)
-    include_directories(${PROJECT_SOURCE_DIR}/src/client)
-endif()
-
-include_directories(${PROJECT_SOURCE_DIR}/include
-                    ${PROJECT_SOURCE_DIR}/plugins
-                    ${PROJECT_SOURCE_DIR}/plugins/networking
-                    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies
-                    ${PROJECT_SOURCE_DIR}/deps
-                    ${PROJECT_SOURCE_DIR}/src/pubsub
-                    ${PROJECT_BINARY_DIR}
-                    ${PROJECT_BINARY_DIR}/src_generated
-                    ${MBEDTLS_INCLUDE_DIRS})
 
 set(exported_headers ${exported_headers}
                      ${PROJECT_BINARY_DIR}/src_generated/ua_config.h
@@ -871,6 +856,9 @@ assign_source_group(${ua_architecture_sources})
 if(UA_ENABLE_AMALGAMATION)
     add_library(open62541-object OBJECT ${PROJECT_BINARY_DIR}/open62541.c ${PROJECT_BINARY_DIR}/open62541.h)
     target_include_directories(open62541-object PRIVATE ${PROJECT_BINARY_DIR})
+    if(UA_ENABLE_ENCRYPTION)
+        target_include_directories(open62541-object PRIVATE ${MBEDTLS_INCLUDE_DIRS})
+    endif()
 
     # make sure the open62541_amalgamation target builds before so that amalgamation is finished and it is not executed again for open62541-object
     # and thus may overwrite the amalgamation result during multiprocessor compilation
@@ -883,6 +871,9 @@ if(UA_ENABLE_AMALGAMATION)
                      open62541-amalgamation-source)
 
     add_library(open62541 $<TARGET_OBJECTS:open62541-object>)
+    # the only directory that needs to be included if open62541 (amalgameted) target from
+    # the build directory is ${PROJECT_BINARY_DIR}, that contains the generated open62541.h
+    target_include_directories(open62541 PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>)
 
     if(UA_COMPILE_AS_CXX)
         set_source_files_properties(${PROJECT_BINARY_DIR}/open62541.c PROPERTIES LANGUAGE CXX)
@@ -914,6 +905,51 @@ else()
         set_source_files_properties(${default_plugin_sources} ${ua_architecture_sources} PROPERTIES LANGUAGE CXX)
     endif()
 
+    # Declare include directories
+    function(include_directories_private)
+        foreach(_include_dir IN ITEMS ${ARGN})
+            target_include_directories(open62541-object PRIVATE ${_include_dir})
+            target_include_directories(open62541-plugins PRIVATE ${_include_dir})
+        endforeach()
+    endfunction()
+
+    function(include_directories_public)
+        include_directories_private(${ARGN})
+        foreach(_include_dir IN ITEMS ${ARGN})
+            target_include_directories(open62541 PUBLIC $<BUILD_INTERFACE:${_include_dir}>)
+        endforeach()
+    endfunction()
+
+    # Public includes
+    include_directories_public("${ua_architecture_directories_to_include}"
+                               "${PROJECT_BINARY_DIR}/src_generated"
+                               "${PROJECT_SOURCE_DIR}/deps"
+                               "${PROJECT_SOURCE_DIR}/include"
+                               "${PROJECT_SOURCE_DIR}/plugins"
+                               "${PROJECT_SOURCE_DIR}/plugins/securityPolicies")
+
+    # Private includes
+    include_directories_private("${PROJECT_BINARY_DIR}"
+                                "${PROJECT_SOURCE_DIR}/deps"
+                                "${PROJECT_BINARY_DIR}/src_generated")
+    if(UA_ENABLE_ENCRYPTION) 
+        include_directories_private(${MBEDTLS_INCLUDE_DIRS})
+    endif()
+
+    # Option-specific includes
+    if(UA_ENABLE_DISCOVERY)
+        include_directories_private("${PROJECT_SOURCE_DIR}/src/client")
+    endif()
+
+    if(UA_ENABLE_HISTORIZING)
+        include_directories_public("${PROJECT_SOURCE_DIR}/plugins/historydata")
+    endif()
+
+    if(UA_ENABLE_PUBSUB)
+        include_directories_public("${PROJECT_SOURCE_DIR}/plugins/networking"
+                                   "${PROJECT_SOURCE_DIR}/src/pubsub"
+                                   "${PROJECT_BINARY_DIR}")
+    endif()
 endif()
 
 # Export Symbols

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,3 @@
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/plugins)
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR}/examples)
-include_directories(${PROJECT_SOURCE_DIR}/arch)
-include_directories(${PROJECT_SOURCE_DIR}/plugins/historydata)
-
 set(examples_headers
     ${examples_headers}
     ${PROJECT_SOURCE_DIR}/examples/common.h
@@ -123,6 +116,10 @@ if(UA_ENABLE_ENCRYPTION)
     add_example(server_basic128rsa15 encryption/server_basic128rsa15.c)
     add_example(server_basic256sha256 encryption/server_basic256sha256.c)
     add_example(client_encryption encryption/client_encryption.c)
+    # common.h
+    target_include_directories(server_basic128rsa15 PRIVATE "${PROJECT_SOURCE_DIR}/examples")
+    target_include_directories(server_basic256sha256 PRIVATE "${PROJECT_SOURCE_DIR}/examples")
+    target_include_directories(client_encryption PRIVATE "${PROJECT_SOURCE_DIR}/examples")
 endif()
 
 add_example(custom_datatype_client custom_datatype/client_types_custom.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,15 +12,20 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "OpenBSD")
     add_definitions(-Wno-gnu-zero-variadic-macro-arguments)
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/deps)
-include_directories(${PROJECT_SOURCE_DIR}/src)
-include_directories(${PROJECT_SOURCE_DIR}/src/server)
-include_directories(${PROJECT_SOURCE_DIR}/src/pubsub)
-include_directories(${PROJECT_SOURCE_DIR}/plugins)
-include_directories(${PROJECT_SOURCE_DIR}/plugins/historydata)
-include_directories(${PROJECT_BINARY_DIR}/src_generated)
-include_directories(${PROJECT_SOURCE_DIR}/tests/testing-plugins)
+get_property(open62541_BUILD_INCLUDE_DIRS TARGET open62541 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+include_directories(${open62541_BUILD_INCLUDE_DIRS})
+# ua_server_internal.h
+include_directories("${PROJECT_SOURCE_DIR}/src")
+include_directories("${PROJECT_SOURCE_DIR}/src/server")
+# testing_clock.h
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/testing-plugins")
+# #include <src_generated/<...>.h>
+include_directories("${PROJECT_BINARY_DIR}")
+
+if(UA_ENABLE_ENCRYPTION)
+    # mbedtls includes
+    include_directories(${MBEDTLS_INCLUDE_DIRS})
+endif()
 
 add_definitions(-DUA_sleep_ms=UA_comboSleep)
 

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,10 +1,10 @@
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/deps)
-include_directories(${PROJECT_SOURCE_DIR}/src)
-include_directories(${PROJECT_SOURCE_DIR}/src/server)
-include_directories(${PROJECT_SOURCE_DIR}/plugins)
-include_directories(${PROJECT_SOURCE_DIR}/tests/testing-plugins)
-include_directories(${PROJECT_BINARY_DIR}/src_generated)
+get_property(open62541_BUILD_INCLUDE_DIRS TARGET open62541 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+include_directories(${open62541_BUILD_INCLUDE_DIRS})
+# ua_server_internal.h
+include_directories("${PROJECT_SOURCE_DIR}/src")
+include_directories("${PROJECT_SOURCE_DIR}/src/server")
+# testing_clock.h
+include_directories("${PROJECT_SOURCE_DIR}/tests/testing-plugins")
 
 if(NOT MSVC)
     add_definitions(-Wno-deprecated-declarations)


### PR DESCRIPTION
Since CMake ~3.0, the `target_include_directories` can be used to specify the include directories that a are part of the CMake target [`INTERFACE_INCLUDE_DIRECTORIES`](https://cmake.org/cmake/help/v3.0/prop_tgt/INTERFACE_INCLUDE_DIRECTORIES.html), i.e. the include directories that must be used in compilation if another target links to it. See https://cmake.org/cmake/help/v3.10/manual/cmake-buildsystem.7.html#build-specification-and-usage-requirements for more details. 

For the `open62541` target exported in installation tree, setting `INTERFACE_INCLUDE_DIRECTORIES` was handled by [INCLUDE DESTINATION](https://github.com/open62541/open62541/blob/ab04d497b1f2b6edb846926aaf4773033bd8e247/CMakeLists.txt#L1084) option of the `install(TARGETS ..)` command. However, it is also useful to properly set  `INTERFACE_INCLUDE_DIRECTORIES` for the targets defined in the build tree, both for using open62541 with [CMake's FetchContent module](https://cmake.org/cmake/help/v3.11/module/FetchContent.html), and also for reducing the number of `include_directories` necessary to link to a given library. 

In this PR, `target_include_directories` is used as much as possible, but the `include_directories` command is still quite used in the tests, due to the heavy use of `OBJECT` targets, that did not support propagating usage requirements until CMake 3.12 (see https://gitlab.kitware.com/cmake/cmake/issues/18010 for more info. Once CMake 3.12 will be the minimum required version of CMake, it would be possible to simplify the code even more.

This is the main modification required to support using `open62541` with the [CMake's FetchContent module](https://cmake.org/cmake/help/v3.11/module/FetchContent.html), as described in https://github.com/open62541/open62541/issues/2436 .