### PR TITLE
[REVIEW] enable standalone examples build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1132,6 +1132,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 set(UA_install_tools_dirs "tools/certs"
+    "tools/cmake"    
     "tools/nodeset_compiler"
     "tools/schema"
     "deps/ua-nodeset")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,15 +1,52 @@
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/plugins)
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR}/examples)
-include_directories(${PROJECT_SOURCE_DIR}/arch)
-include_directories(${PROJECT_SOURCE_DIR}/plugins/historydata)
-
-set(examples_headers
-    ${examples_headers}
-    ${PROJECT_SOURCE_DIR}/examples/common.h
-    )
-
+if(UA_EXAMPLES_STANDALONE)
+    #
+    # test Debian packaging resp. build only examples
+    #
+    # cp -a /usr/share/open62541/examples .
+    # OR
+    # cp -a <path-to-open62541-src-tree/examples .
+    # cd examples
+    # mkdir build
+    # cd build
+    # cmake -DUA_EXAMPLES_STANDALONE=ON ..
+    # OR
+    # cmake -DUA_EXAMPLES_STANDALONE=ON -DUA_NAMESPACE_ZERO=FULL ..
+    # make
+    cmake_minimum_required(VERSION 3.0)
+    project(open62541)
+    find_package(open62541 0.4.0 REQUIRED)
+    if(UA_TOOLS_DIR)
+        # build with tools from open62541 source_dir
+        # cmake -DUA_EXAMPLES_STANDALONE=ON -DUA_TOOLS_DIR="<path-to-tools-dir>" ..
+        get_filename_component(ABSOLUTE_PATH ${UA_TOOLS_DIR} ABSOLUTE)
+        set(CMAKE_MODULE_PATH "${ABSOLUTE_PATH}/cmake")
+    else()
+        # build with installed tools, i.e. from /usr/share/open62541/tools
+        # cmake -DUA_EXAMPLES_STANDALONE=ON ..
+        set(CMAKE_MODULE_PATH "${open62541_TOOLS_DIR}/cmake")
+        set(UA_TOOLS_DIR ${open62541_TOOLS_DIR})
+    endif()
+    message("I: CMAKE_MODULE_PATH = ${CMAKE_MODULE_PATH}")
+    include(AssignSourceGroup)
+    include_directories(${PROJECT_BINARY_DIR}/src_generated)
+    add_custom_target(open62541-object)
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src_generated")
+    set(examples_headers
+        ${examples_headers}
+        ${PROJECT_SOURCE_DIR}/common.h
+        )
+else()
+    include_directories(${PROJECT_SOURCE_DIR}/include)
+    include_directories(${PROJECT_SOURCE_DIR}/plugins)
+    include_directories(${PROJECT_BINARY_DIR})
+    include_directories(${PROJECT_SOURCE_DIR}/examples)
+    include_directories(${PROJECT_SOURCE_DIR}/arch)
+    include_directories(${PROJECT_SOURCE_DIR}/plugins/historydata)
+    set(examples_headers
+        ${examples_headers}
+        ${PROJECT_SOURCE_DIR}/examples/common.h
+        )
+endif()
 
 if(UA_ENABLE_AMALGAMATION)
     add_definitions(-DUA_ENABLE_AMALGAMATION)

--- a/examples/nodeset/CMakeLists.txt
+++ b/examples/nodeset/CMakeLists.txt
@@ -6,19 +6,30 @@
 # Custom XML      #
 ###################
 
+if(NOT UA_EXAMPLES_STANDALONE)
+    set(FILE_CSV_DIRPREFIX ${PROJECT_SOURCE_DIR}/examples/nodeset)
+    set(FILE_BSD_DIRPREFIX ${PROJECT_SOURCE_DIR}/examples/nodeset)
+    set(FILE_NS_DIRPREFIX ${PROJECT_SOURCE_DIR}/examples/nodeset)
+else()
+    set(FILE_CSV_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+    set(FILE_BSD_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+    set(FILE_NS_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+endif()
+
 # generate namespace from XML file
+
 ua_generate_nodeset_and_datatypes(
     NAME "example"
-    FILE_NS "${PROJECT_SOURCE_DIR}/examples/nodeset/server_nodeset.xml"
-)
+    FILE_NS "${FILE_NS_DIRPREFIX}/server_nodeset.xml"
+    )
 
 # The .csv file can be created from within UaModeler or manually
 ua_generate_nodeid_header(
     NAME "example_nodeids"
     ID_PREFIX "EXAMPLE_NS"
     TARGET_SUFFIX "ids_example"
-    FILE_CSV "${PROJECT_SOURCE_DIR}/examples/nodeset/server_nodeset.csv"
-)
+    FILE_CSV "${FILE_CSV_DIRPREFIX}/server_nodeset.csv"
+    )
 
 add_example(server_nodeset server_nodeset.c ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_example.c ${PROJECT_BINARY_DIR}/src_generated/example_nodeids.h)
 if(UA_COMPILE_AS_CXX)
@@ -28,21 +39,34 @@ endif()
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     ua_generate_nodeset_and_datatypes(
         NAME "testnodeset"
-        FILE_CSV "${PROJECT_SOURCE_DIR}/examples/nodeset/testnodeset.csv"
-        FILE_BSD "${PROJECT_SOURCE_DIR}/examples/nodeset/testtypes.bsd"
+        FILE_CSV "${FILE_CSV_DIRPREFIX}/testnodeset.csv"
+        FILE_BSD "${FILE_BSD_DIRPREFIX}/testtypes.bsd"
         NAMESPACE_IDX 2
-        FILE_NS "${PROJECT_SOURCE_DIR}/examples/nodeset/testnodeset.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/testnodeset.xml"
         INTERNAL
-    )
+        )
     add_example(server_testnodeset server_testnodeset.c 
         ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_testnodeset.c
         ${PROJECT_BINARY_DIR}/src_generated/ua_types_testnodeset_generated.c)
     add_dependencies(server_testnodeset open62541-generator-ns-testnodeset)
 endif()
 
+
 ###################
 # PLCopen Nodeset #
 ###################
+
+if(NOT UA_EXAMPLES_STANDALONE)
+    set(FILE_CSV_DIRPREFIX ${PROJECT_SOURCE_DIR}/deps/ua-nodeset)
+    set(FILE_BSD_PLCOPEN_DIRPREFIX ${PROJECT_SOURCE_DIR}/deps/ua-nodeset)
+    set(FILE_BSD_POWERLINK_DIRPREFIX ${PROJECT_SOURCE_DIR}/examples/nodeset)
+    set(FILE_NS_DIRPREFIX ${PROJECT_SOURCE_DIR}/deps/ua-nodeset)
+else()
+    set(FILE_CSV_DIRPREFIX ${UA_TOOLS_DIR}/ua-nodeset)
+    set(FILE_BSD_PLCOPEN_DIRPREFIX ${UA_TOOLS_DIR}/ua-nodeset)
+    set(FILE_BSD_POWERLINK_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+    set(FILE_NS_DIRPREFIX ${UA_TOOLS_DIR}/ua-nodeset)
+endif()
 
 # PLCopen requires the full ns0 as basis
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
@@ -50,22 +74,22 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     # Generate types and namespace for DI
     ua_generate_nodeset_and_datatypes(
         NAME "di"
-        FILE_CSV "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/OpcUaDiModel.csv"
-        FILE_BSD "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.Types.bsd"
+        FILE_CSV "${FILE_CSV_DIRPREFIX}/DI/OpcUaDiModel.csv"
+        FILE_BSD "${FILE_BSD_PLCOPEN_DIRPREFIX}/DI/Opc.Ua.Di.Types.bsd"
         NAMESPACE_IDX 2
-        FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/DI/Opc.Ua.Di.NodeSet2.xml"
         INTERNAL
-    )
-
+        )
+    
     # generate PLCopen namespace which is using DI
     ua_generate_nodeset_and_datatypes(
         NAME "plc"
         # PLCopen does not define custom types. Only generate the nodeset
-        FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/PLCopen/Opc.Ua.Plc.NodeSet2.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/PLCopen/Opc.Ua.Plc.NodeSet2.xml"
         # PLCopen depends on the di nodeset, which must be generated before
         DEPENDS "di"
         INTERNAL
-    )
+        )
 
     add_example(server_nodeset_plcopen server_nodeset_plcopen.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_types_di_generated.c
@@ -77,15 +101,16 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 endif()
 
 # POWERLINK requires the full ns0 as basis
+
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
     # Generate types and namespace for DI
     #ua_generate_nodeset_and_datatypes(
     #    NAME "di"
-    #    FILE_CSV "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/OpcUaDiModel.csv"
-    #    FILE_BSD "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.Types.bsd"
+    #    FILE_CSV "${FILE_CSV_DIRPREFIX}/DI/OpcUaDiModel.csv"
+    #    FILE_BSD "${FILE_BSD_POWERLINK_DIRPREFIX}/DI/Opc.Ua.Di.Types.bsd"
     #    NAMESPACE_IDX 2
-    #    FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml"
+    #    FILE_NS "${FILE_NS_DIRPREFIX}/DI/Opc.Ua.Di.NodeSet2.xml"
     #    INTERNAL
     #)
 
@@ -93,16 +118,16 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     ua_generate_nodeset_and_datatypes(
         NAME "powerlink"
         # POWERLINK does not define custom types. Only generate the nodeset
-        FILE_CSV "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/POWERLINK/Opc.Ua.POWERLINK.NodeIds.csv"
-        FILE_BSD "${PROJECT_SOURCE_DIR}/examples/nodeset/Opc.Ua.POWERLINK.NodeSet2.bsd"
+        FILE_CSV "${FILE_CSV_DIRPREFIX}/POWERLINK/Opc.Ua.POWERLINK.NodeIds.csv"
+        FILE_BSD "${FILE_BSD_POWERLINK_DIRPREFIX}/Opc.Ua.POWERLINK.NodeSet2.bsd"
         NAMESPACE_IDX 3
-        FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml"
         # POWERLINK depends on the di nodeset, which must be generated before
         DEPENDS "di"
         INTERNAL
-    )
+        )
 
-    add_example(server_nodeset_powerlink server_nodeset_powerlink.c
+        add_example(server_nodeset_powerlink server_nodeset_powerlink.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_types_di_generated.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_types_powerlink_generated.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_di.c


### PR DESCRIPTION
**FEATURE please review**
This is my first attempt to enable building the examples standalone.

This PR assumes that open62541 lib, examples  and tools are already installed at a standard place.

With the following workflow one can build the examples standalone
```
    # cd <to-my-local-test-dir>
    # cp -a /usr/share/open62541/examples .
    # OR
    # cp -a <path-to-open62541-src-tree/examples .
    # cd examples
    # mkdir build
    # cd build
    # cmake -DUA_EXAMPLES_STANDALONE=ON ..
    # OR
    # cmake -DUA_EXAMPLES_STANDALONE=ON -DUA_NAMESPACE_ZERO=FULL ..
    # make
``` 
Review, hints and comments are welcome....
