### PR TITLE
Free all allocations before exiting

### DIFF
--- a/examples/custom_datatype/server_types_custom.c
+++ b/examples/custom_datatype/server_types_custom.c
@@ -86,6 +86,8 @@ int main(void) {
     UA_Server_run(server, &running);
 
     UA_Server_delete(server);
+    UA_free(members);
+    UA_free(types);
     UA_ServerConfig_delete(config);
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Makes this example run valgrind clean.

==7424== HEAP SUMMARY:
==7424==     in use at exit: 0 bytes in 0 blocks
==7424==   total heap usage: 96,908 allocs, 96,908 frees, 190,708,768 bytes allocated

vs.

==5408== HEAP SUMMARY:
==5408==     in use at exit: 96 bytes in 2 blocks
==5408==   total heap usage: 96,908 allocs, 96,906 frees, 190,708,768 bytes allocated
==5408==
==5408== 96 (48 direct, 48 indirect) bytes in 1 blocks are definitely lost in loss record 2 of 2
==5408==    at 0x4C2DBF6: malloc (vg_replace_malloc.c:299)
==5408==    by 0x40312A: main (server_types_custom.c:68)
==5408==
==5408== LEAK SUMMARY:
==5408==    definitely lost: 48 bytes in 1 blocks
==5408==    indirectly lost: 48 bytes in 1 blocks

before