### PR TITLE
[REVIEW] build examples as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -933,7 +933,7 @@ else()
     include_directories_private("${PROJECT_BINARY_DIR}"
                                 "${PROJECT_SOURCE_DIR}/deps"
                                 "${PROJECT_BINARY_DIR}/src_generated")
-    if(UA_ENABLE_ENCRYPTION) 
+    if(UA_ENABLE_ENCRYPTION)
         include_directories_private(${MBEDTLS_INCLUDE_DIRS})
     endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,57 @@
-set(examples_headers
-    ${examples_headers}
-    ${PROJECT_SOURCE_DIR}/examples/common.h
-    )
+cmake_minimum_required(VERSION 3.0)
+project(open62541-examples)
 
+# This examples folder can also be built standalone.
+# First install open62541 using `make install` then
+# copy this folder to any other location and call CMake directly:
+#
+# cp -r open62541/examples $HOME/open62541_examples
+# cd $HOME/open62541_examples
+# mkdir build && cd build
+# cmake -DUA_NAMESPACE_ZERO=FULL ..
+# make -j
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    # Examples are built standalone.
+
+    find_package(open62541 REQUIRED)
+    if(UA_TOOLS_DIR)
+        # build with cmake tools from open62541 source_dir
+        # cmake -DUA_TOOLS_DIR="<path-to-tools-dir>" ..
+        get_filename_component(ABSOLUTE_PATH ${UA_TOOLS_DIR} ABSOLUTE)
+        set(CMAKE_MODULE_PATH "${ABSOLUTE_PATH}/cmake")
+    else()
+        # build with installed cmake tools, i.e. from /usr/share/open62541/tools/cmake
+        # cmake ..
+        set(CMAKE_MODULE_PATH "${open62541_TOOLS_DIR}/cmake")
+        set(UA_TOOLS_DIR ${open62541_TOOLS_DIR})
+    endif()
+
+    function(assign_source_group)
+        # define empty function. We don't need it in standalone
+    endfunction(assign_source_group)
+
+    include_directories(${PROJECT_BINARY_DIR}/src_generated)
+    add_custom_target(open62541-object)
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src_generated")
+    set(examples_headers
+        ${examples_headers}
+        ${PROJECT_SOURCE_DIR}/common.h
+        )
+else()
+    # Examples are built inside the main repo
+
+    include_directories(${CMAKE_SOURCE_DIR}/include)
+    include_directories(${CMAKE_SOURCE_DIR}/plugins)
+    include_directories(${CMAKE_BINARY_DIR})
+    include_directories(${CMAKE_SOURCE_DIR}/examples)
+    include_directories(${CMAKE_SOURCE_DIR}/arch)
+    include_directories(${CMAKE_SOURCE_DIR}/plugins/historydata)
+    set(examples_headers
+        ${examples_headers}
+        ${PROJECT_SOURCE_DIR}/common.h
+        )
+endif()
 
 if(UA_ENABLE_AMALGAMATION)
     add_definitions(-DUA_ENABLE_AMALGAMATION)
@@ -133,9 +182,9 @@ endif()
 if(UA_BUILD_SELFSIGNED_CERTIFICATE)
   find_package(OpenSSL REQUIRED)
   add_custom_command(OUTPUT server_cert.der
-                     COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py ${CMAKE_CURRENT_BINARY_DIR}
-                     DEPENDS ${PROJECT_SOURCE_DIR}/tools/certs/create_self-signed.py
-                             ${PROJECT_SOURCE_DIR}/tools/certs/localhost.cnf)
+                     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/certs/create_self-signed.py ${CMAKE_CURRENT_BINARY_DIR}
+                     DEPENDS ${CMAKE_SOURCE_DIR}/tools/certs/create_self-signed.py
+                             ${CMAKE_SOURCE_DIR}/tools/certs/localhost.cnf)
   add_custom_target(selfsigned ALL DEPENDS server_cert.der)
   add_executable(server_certificate server_certificate.c ${STATIC_OBJECTS} server_cert.der)
   target_link_libraries(server_certificate open62541 ${open62541_LIBRARIES})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,18 +12,15 @@ project(open62541-examples)
 # make -j
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    # Examples are built standalone.
+    # Examples are built standalone. Find installed open62541
 
-    find_package(open62541 REQUIRED)
-    if(UA_TOOLS_DIR)
-        # build with cmake tools from open62541 source_dir
-        # cmake -DUA_TOOLS_DIR="<path-to-tools-dir>" ..
-        get_filename_component(ABSOLUTE_PATH ${UA_TOOLS_DIR} ABSOLUTE)
-        set(CMAKE_MODULE_PATH "${ABSOLUTE_PATH}/cmake")
+    if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+        find_package(open62541 REQUIRED COMPONENTS FullNamespace)
     else()
-        # build with installed cmake tools, i.e. from /usr/share/open62541/tools/cmake
-        # cmake ..
-        set(CMAKE_MODULE_PATH "${open62541_TOOLS_DIR}/cmake")
+        find_package(open62541 REQUIRED)
+    endif()
+
+    if(NOT UA_TOOLS_DIR)
         set(UA_TOOLS_DIR ${open62541_TOOLS_DIR})
     endif()
 
@@ -32,26 +29,10 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     endfunction(assign_source_group)
 
     include_directories(${PROJECT_BINARY_DIR}/src_generated)
-    add_custom_target(open62541-object)
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src_generated")
-    set(examples_headers
-        ${examples_headers}
-        ${PROJECT_SOURCE_DIR}/common.h
-        )
-else()
-    # Examples are built inside the main repo
-
-    include_directories(${CMAKE_SOURCE_DIR}/include)
-    include_directories(${CMAKE_SOURCE_DIR}/plugins)
-    include_directories(${CMAKE_BINARY_DIR})
-    include_directories(${CMAKE_SOURCE_DIR}/examples)
-    include_directories(${CMAKE_SOURCE_DIR}/arch)
-    include_directories(${CMAKE_SOURCE_DIR}/plugins/historydata)
-    set(examples_headers
-        ${examples_headers}
-        ${PROJECT_SOURCE_DIR}/common.h
-        )
 endif()
+
+# Required for common.h header file used in examples
+include_directories(${CMAKE_CURRENT_LIST_DIR})
 
 if(UA_ENABLE_AMALGAMATION)
     add_definitions(-DUA_ENABLE_AMALGAMATION)
@@ -68,14 +49,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_BINARY_DIR}/bin/exampl
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_BINARY_DIR}/bin/examples)
 
 macro(add_example EXAMPLE_NAME EXAMPLE_SOURCE)
-  add_executable(${EXAMPLE_NAME} ${STATIC_OBJECTS} ${EXAMPLE_SOURCE} ${ARGN} ${examples_headers})
-  target_link_libraries(${EXAMPLE_NAME} open62541 ${open62541_LIBRARIES})
+  add_executable(${EXAMPLE_NAME} ${STATIC_OBJECTS} ${EXAMPLE_SOURCE} ${ARGN} ${PROJECT_SOURCE_DIR}/common.h)
+  target_link_libraries(${EXAMPLE_NAME} open62541::open62541)
   assign_source_group(${EXAMPLE_SOURCE})
-  add_dependencies(${EXAMPLE_NAME} open62541-object)
   set_target_properties(${EXAMPLE_NAME} PROPERTIES FOLDER "open62541/examples")
   set_target_properties(${EXAMPLE_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
   if(UA_COMPILE_AS_CXX)
-    set_source_files_properties(${EXAMPLE_SOURCE} PROPERTIES LANGUAGE CXX)
+      set_source_files_properties(${EXAMPLE_SOURCE} PROPERTIES LANGUAGE CXX)
   endif()
 endmacro()
 
@@ -92,7 +72,7 @@ add_example(tutorial_server_variable tutorial_server_variable.c)
 add_example(tutorial_server_datasource tutorial_server_datasource.c)
 
 if(UA_ENABLE_SUBSCRIPTIONS)
-add_example(tutorial_server_monitoreditems tutorial_server_monitoreditems.c)
+    add_example(tutorial_server_monitoreditems tutorial_server_monitoreditems.c)
 endif()
 
 add_example(tutorial_server_variabletype tutorial_server_variabletype.c)
@@ -100,7 +80,7 @@ add_example(tutorial_server_variabletype tutorial_server_variabletype.c)
 add_example(tutorial_server_object tutorial_server_object.c)
 
 if(UA_ENABLE_METHODCALLS)
-  add_example(tutorial_server_method tutorial_server_method.c)
+    add_example(tutorial_server_method tutorial_server_method.c)
 endif()
 
 add_example(tutorial_client_firststeps tutorial_client_firststeps.c)
@@ -108,7 +88,7 @@ add_example(tutorial_client_firststeps tutorial_client_firststeps.c)
 add_example(tutorial_client_events tutorial_client_events.c)
 
 if(UA_ENABLE_SUBSCRIPTIONS_EVENTS)
-  add_example(tutorial_server_events tutorial_server_events.c)
+    add_example(tutorial_server_events tutorial_server_events.c)
 endif()
 
 ##################
@@ -142,7 +122,7 @@ add_example(client_connect_loop client_connect_loop.c)
 add_example(client_connectivitycheck_loop client_connectivitycheck_loop.c)
 
 if(UA_ENABLE_SUBSCRIPTIONS)
-add_example(client_subscription_loop client_subscription_loop.c)
+    add_example(client_subscription_loop client_subscription_loop.c)
 endif()
 
 ####################

--- a/examples/nodeset/CMakeLists.txt
+++ b/examples/nodeset/CMakeLists.txt
@@ -6,19 +6,36 @@
 # Custom XML      #
 ###################
 
+set(FILE_CSV_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+set(FILE_BSD_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+set(FILE_NS_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+
+if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    # needed or cmake doesn't recognize dependencies of generated files
+    set(PROJECT_BINARY_DIR ${CMAKE_BINARY_DIR})
+endif()
+
 # generate namespace from XML file
-ua_generate_nodeset_and_datatypes(
-    NAME "example"
-    FILE_NS "${PROJECT_SOURCE_DIR}/examples/nodeset/server_nodeset.xml"
-    DEPENDS "${PROJECT_SOURCE_DIR}/tools/schema/Opc.Ua.NodeSet2.Minimal.xml"
-)
+if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    ua_generate_nodeset_and_datatypes(
+        NAME "example"
+        FILE_NS "${FILE_NS_DIRPREFIX}/server_nodeset.xml"
+        DEPENDS "${CMAKE_SOURCE_DIR}/tools/schema/Opc.Ua.NodeSet2.Minimal.xml"
+    )
+else()
+    # standalone examples build expects already installed Opc.Ua.NodeSet2.Minimal.xml
+    ua_generate_nodeset_and_datatypes(
+        NAME "example"
+        FILE_NS "${FILE_NS_DIRPREFIX}/server_nodeset.xml"
+    )
+endif()
 
 # The .csv file can be created from within UaModeler or manually
 ua_generate_nodeid_header(
     NAME "example_nodeids"
     ID_PREFIX "EXAMPLE_NS"
     TARGET_SUFFIX "ids_example"
-    FILE_CSV "${PROJECT_SOURCE_DIR}/examples/nodeset/server_nodeset.csv"
+    FILE_CSV "${FILE_CSV_DIRPREFIX}/server_nodeset.csv"
 )
 
 add_example(server_nodeset server_nodeset.c ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_example.c ${PROJECT_BINARY_DIR}/src_generated/example_nodeids.h)
@@ -29,10 +46,10 @@ endif()
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     ua_generate_nodeset_and_datatypes(
         NAME "testnodeset"
-        FILE_CSV "${PROJECT_SOURCE_DIR}/examples/nodeset/testnodeset.csv"
-        FILE_BSD "${PROJECT_SOURCE_DIR}/examples/nodeset/testtypes.bsd"
+        FILE_CSV "${FILE_CSV_DIRPREFIX}/testnodeset.csv"
+        FILE_BSD "${FILE_BSD_DIRPREFIX}/testtypes.bsd"
         NAMESPACE_IDX 2
-        FILE_NS "${PROJECT_SOURCE_DIR}/examples/nodeset/testnodeset.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/testnodeset.xml"
         INTERNAL
     )
     add_example(server_testnodeset server_testnodeset.c 
@@ -41,9 +58,22 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     add_dependencies(server_testnodeset open62541-generator-ns-testnodeset)
 endif()
 
+
 ###################
 # PLCopen Nodeset #
 ###################
+
+if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    set(FILE_CSV_DIRPREFIX ${CMAKE_SOURCE_DIR}/deps/ua-nodeset)
+    set(FILE_BSD_PLCOPEN_DIRPREFIX ${CMAKE_SOURCE_DIR}/deps/ua-nodeset)
+    set(FILE_BSD_POWERLINK_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+    set(FILE_NS_DIRPREFIX ${CMAKE_SOURCE_DIR}/deps/ua-nodeset)
+else()
+    set(FILE_CSV_DIRPREFIX ${UA_TOOLS_DIR}/ua-nodeset)
+    set(FILE_BSD_PLCOPEN_DIRPREFIX ${UA_TOOLS_DIR}/ua-nodeset)
+    set(FILE_BSD_POWERLINK_DIRPREFIX ${PROJECT_SOURCE_DIR}/nodeset)
+    set(FILE_NS_DIRPREFIX ${UA_TOOLS_DIR}/ua-nodeset)
+endif()
 
 # PLCopen requires the full ns0 as basis
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
@@ -51,10 +81,10 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     # Generate types and namespace for DI
     ua_generate_nodeset_and_datatypes(
         NAME "di"
-        FILE_CSV "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/OpcUaDiModel.csv"
-        FILE_BSD "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.Types.bsd"
+        FILE_CSV "${FILE_CSV_DIRPREFIX}/DI/OpcUaDiModel.csv"
+        FILE_BSD "${FILE_BSD_PLCOPEN_DIRPREFIX}/DI/Opc.Ua.Di.Types.bsd"
         NAMESPACE_IDX 2
-        FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/DI/Opc.Ua.Di.NodeSet2.xml"
         INTERNAL
     )
 
@@ -62,7 +92,7 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     ua_generate_nodeset_and_datatypes(
         NAME "plc"
         # PLCopen does not define custom types. Only generate the nodeset
-        FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/PLCopen/Opc.Ua.Plc.NodeSet2.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/PLCopen/Opc.Ua.Plc.NodeSet2.xml"
         # PLCopen depends on the di nodeset, which must be generated before
         DEPENDS "di"
         INTERNAL
@@ -78,15 +108,16 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 endif()
 
 # POWERLINK requires the full ns0 as basis
+
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
     # generate powerlink namespace which is using DI
     ua_generate_nodeset_and_datatypes(
         NAME "powerlink"
-        FILE_CSV "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/POWERLINK/Opc.Ua.POWERLINK.NodeIds.csv"
-        FILE_BSD "${PROJECT_SOURCE_DIR}/examples/nodeset/Opc.Ua.POWERLINK.NodeSet2.bsd"
+        FILE_CSV "${FILE_CSV_DIRPREFIX}/POWERLINK/Opc.Ua.POWERLINK.NodeIds.csv"
+        FILE_BSD "${FILE_BSD_POWERLINK_DIRPREFIX}/Opc.Ua.POWERLINK.NodeSet2.bsd"
         NAMESPACE_IDX 3
-        FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml"
         # POWERLINK depends on the di nodeset, which must be generated before
         DEPENDS "di"
         INTERNAL
@@ -98,6 +129,5 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
                 ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_di.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_powerlink.c)
     add_dependencies(server_nodeset_powerlink open62541-generator-ns-powerlink)
-    
 
 endif()

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -60,8 +60,8 @@ fi
 
 # INSTALL build test
 if ! [ -z ${INSTALL+x} ]; then
-echo "=== Install build, then compile minimal example ===" && echo -en 'travis_fold:start:script.build.install\\r'
-    # Use make install to deploy files and then test if we can build an example based on the installed files
+echo "=== Install build, then compile examples ===" && echo -en 'travis_fold:start:script.build.install\\r'
+    # Use make install to deploy files and then test if we can build the examples based on the installed files
     mkdir -p build
     cd build
     cmake \
@@ -79,19 +79,14 @@ echo "=== Install build, then compile minimal example ===" && echo -en 'travis_f
 
     echo -en 'travis_fold:start:script.build.mini-example\\r'
     # Now create a simple CMake Project which uses the installed file
-    mkdir compile && cd compile
-    cat > CMakeLists.txt << EOM
-cmake_minimum_required(VERSION 2.8)
-project(install-test)
-find_package(open62541 REQUIRED COMPONENTS FullNamespace)
-add_executable(install-test-example ../examples/tutorial_server_firststeps.c)
-target_link_libraries(install-test-example open62541::open62541)
-EOM
+    mkdir compile
+    cp -r examples compile/examples && cd compile/examples
     cmake \
-        -DCMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/open62541_install .
+        -DCMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/open62541_install \
+        -DUA_NAMESPACE_ZERO=FULL .
     make -j
     if [ $? -ne 0 ] ; then exit 1 ; fi
-    cd ..
+    cd ../..
     rm -rf compile
     echo -en 'travis_fold:end:script.build.mini-example\\r'
     exit 0


### PR DESCRIPTION
In this PR the examples are defined as subproject to open62541. One can build the examples  standalone or, as before, during the build of the whole open62541 project.

It's assumed that open62541 lib, examples and tools are already installed at a standard place.
The following workflow builds the examples standalone
```
    # cp -a /usr/share/open62541/examples .
    # OR
    # cp -a <path-to-open62541-src-tree>/examples .
    # cd examples
    # mkdir build
    # cd build
    # cmake ..
    # OR
    # cmake -DUA_NAMESPACE_ZERO=FULL  ..
    # make
```
@Pro @ralphlange 
I've decided to make a new PR instead modifying #2451 

Please review and/or comment ...