### PR TITLE
Make default connection configurable

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -751,11 +751,7 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     config->logger.context = NULL;
     config->logger.clear = UA_Log_Stdout_clear;
 
-    config->localConnectionConfig.protocolVersion = 0;
-    config->localConnectionConfig.sendBufferSize = 65535;
-    config->localConnectionConfig.recvBufferSize = 65535;
-    config->localConnectionConfig.maxMessageSize = 0; /* 0 -> unlimited */
-    config->localConnectionConfig.maxChunkCount = 0; /* 0 -> unlimited */
+    config->localConnectionConfig = UA_ConnectionConfig_default;
 
     /* Certificate Verification that accepts every certificate. Can be
      * overwritten when the policy is specialized. */


### PR DESCRIPTION
The default configuration of a connection is hardcoded to 65535. In some devices with low memory this is a problem. 

This PR adds the possibility to set the default values as preprocessor variables, and if not provided, use the old ones.

Also, the client connection uses the default connection variable instead of setting it field by field