### PR TITLE
Remove dependency on python-six

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ matrix:
             - gcc-mingw-w64-x86-64
             - binutils-mingw-w64-i686
             - g++-multilib
-            - python-six
             # debian packaging
             - cmake
             - debhelper
@@ -60,7 +59,6 @@ matrix:
           packages:
             - gcc-8
             - gcc-8-multilib
-            - python-six
             # doc
             - python-sphinx
             - graphviz
@@ -85,7 +83,6 @@ matrix:
           packages:
             - clang-6.0
             - clang-tidy-6.0
-            - python-six
             # doc
             - python-sphinx
             - graphviz
@@ -110,7 +107,6 @@ matrix:
           packages:
             - clang-6.0
             - clang-tidy-6.0
-            - python3-six
             # doc
             - python3-sphinx
             - graphviz
@@ -132,7 +128,6 @@ matrix:
       addons:
         apt:
           packages:
-            - python-six
             # doc
             - python-sphinx
             - graphviz
@@ -156,7 +151,6 @@ matrix:
           packages:
             - clang-6.0
             - clang-tidy-6.0
-            - python3-six
       env:
         - INSTALL=true
         - PYTHON=python3
@@ -212,7 +206,6 @@ matrix:
             - clang-6.0
             - clang-tidy-6.0
             - libfuzzer-6.0-dev
-            - python-six
       env:
         - FUZZER=true
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,6 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER_CASE)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/tools/cmake")
 find_package(PythonInterp REQUIRED)
-# Verify that the six python module is correctly installed 
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"  "import six"
-                RESULT_VARIABLE import_six_return OUTPUT_QUIET ERROR_QUIET)
-if(NOT ${import_six_return} EQUAL 0)
-   message(FATAL_ERROR "Python interpreter found, but required six python module is not installed.")
-endif()
 find_package(Git)
 include(AssignSourceGroup)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.5
-RUN apk add --no-cache cmake gcc g++ musl-dev python py-pip py-six make && rm -rf /var/cache/apk/*
+RUN apk add --no-cache cmake gcc g++ musl-dev python py-pip make && rm -rf /var/cache/apk/*
 ADD . /tmp/open62541
 WORKDIR /tmp/open62541/build
-RUN pip install six
 RUN cmake -DUA_ENABLE_AMALGAMATION=true  \
           -DBUILD_SHARED_LIBS=true \
           /tmp/open62541 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Build-Depends: debhelper (>= 7.0.50~),
  git,
  graphviz,
  python (>= 2.7),
- python-six
 Standards-Version: 4.1.2
 Section: libs
 Homepage: https://open62541.org/

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -22,7 +22,7 @@ Building with CMake on Ubuntu or Debian
 
 .. code-block:: bash
 
-   sudo apt-get install git build-essential gcc pkg-config cmake python python-six
+   sudo apt-get install git build-essential gcc pkg-config cmake python
 
    # enable additional features
    sudo apt-get install cmake-curses-gui # for the ccmake graphical interface
@@ -54,7 +54,6 @@ with MinGW, just replace the compiler selection in the call to CMake.
 - Download and install
 
   - Python 2.7.x (Python 3.x works as well): https://python.org/downloads
-  - Install python-six with the pip package manager (``pip install six``)
   - CMake: http://www.cmake.org/cmake/resources/software.html
   - Microsoft Visual Studio: https://www.visualstudio.com/products/visual-studio-community-vs
 
@@ -85,7 +84,6 @@ Building on OS X
 .. code-block:: bash
 
    brew install cmake
-   pip install six # python 2/3 compatibility workarounds
    pip install sphinx # for documentation generation
    pip install sphinx_rtd_theme # documentation style
    brew install graphviz # for graphics in the documentation

--- a/open62541.spec
+++ b/open62541.spec
@@ -6,7 +6,7 @@ License:  MPLv2.0
 URL:      http://open62541.org
 Source0:  https://github.com/open62541/open62541/archive/%{name}-%{version}.tar.gz
 
-BuildRequires: cmake3, python, python-six
+BuildRequires: cmake3, python
 
 %description
 open62541 is a C-based library (linking with C++ projects is possible)

--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -19,7 +19,8 @@
 import sys
 import logging
 from datetime import datetime
-
+import xml.dom.minidom as dom
+from base64 import *
 
 __all__ = ['valueIsInternalType', 'Value', 'Boolean', 'Number', 'Integer',
            'UInteger', 'Byte', 'SByte',
@@ -29,17 +30,15 @@ __all__ = ['valueIsInternalType', 'Value', 'Boolean', 'Number', 'Integer',
            'DiagnosticInfo', 'Guid']
 
 logger = logging.getLogger(__name__)
-import xml.dom.minidom as dom
-
-from base64 import *
-
-import six
 
 if sys.version_info[0] >= 3:
     # strings are already parsed to unicode
     def unicode(s):
         return s
 
+    string_types = str
+else:
+    string_types = basestring 
 
 def getNextElementNode(xmlvalue):
     if xmlvalue is None:
@@ -187,7 +186,7 @@ class Value(object):
         if len(enc) == 1:
             # 0: ['BuiltinType']          either builtin type
             # 1: [ [ 'Alias', [...], n] ] or single alias for possible multipart
-            if isinstance(enc[0], six.string_types):
+            if isinstance(enc[0], string_types):
                 # 0: 'BuiltinType'
                 if alias is not None:
                     if not xmlvalue.localName == alias and not xmlvalue.localName == enc[0]:
@@ -224,7 +223,7 @@ class Value(object):
                 return self.__parseXMLSingleValue(xmlvalue, parentDataTypeNode, parent,
                                                   namespaceMapping=namespaceMapping,
                                                   alias=alias, encodingPart=enc[0], valueRank=enc[2] if len(enc)>2 else None)
-        elif len(enc) == 3 and isinstance(enc[0], six.string_types):
+        elif len(enc) == 3 and isinstance(enc[0], string_types):
             # [ 'Alias', [...], 0 ]          aliased multipart
             if alias is None:
                 alias = enc[0]

--- a/tools/nodeset_compiler/nodeset.py
+++ b/tools/nodeset_compiler/nodeset.py
@@ -22,20 +22,21 @@ import xml.dom.minidom as dom
 import logging
 import codecs
 import re
-import six
+from datatypes import *
+from nodes import *
+from opaque_type_mapping import opaque_type_mapping
 
 __all__ = ['NodeSet', 'getSubTypesOf']
 
 logger = logging.getLogger(__name__)
 
-from datatypes import *
-from nodes import *
-from opaque_type_mapping import opaque_type_mapping
-
 if sys.version_info[0] >= 3:
     # strings are already parsed to unicode
     def unicode(s):
         return s
+    string_types = str
+else:
+    string_types = basestring 
 
 ####################
 # Helper Functions #
@@ -317,7 +318,7 @@ class NodeSet(object):
         return node
                 
     def getDataTypeNode(self, dataType):
-        if isinstance(dataType, six.string_types):
+        if isinstance(dataType, string_types):
             if not valueIsInternalType(dataType):
                 logger.error("Not a valid dataType string: " + dataType)
                 return None


### PR DESCRIPTION
Python3 is now very common. We can expect it for the dev environments
where code is generated. Remove workarounds and the python-six dependency.