### PR TITLE
FIX return value if a node isn't found.

### DIFF
--- a/src/server/ua_services_call.c
+++ b/src/server/ua_services_call.c
@@ -245,7 +245,7 @@ Operation_CallMethod(UA_Server *server, UA_Session *session, void *context,
         server->config.nodestore.getNode(server->config.nodestore.context,
                                          &request->objectId);
     if(!object) {
-        result->statusCode = UA_STATUSCODE_BADNODEIDINVALID;
+        result->statusCode = UA_STATUSCODE_BADNODEIDUNKNOWN;
         server->config.nodestore.releaseNode(server->config.nodestore.context,
                                              (const UA_Node*)method);
         return;


### PR DESCRIPTION
STATUSCODE_BADNODEIDINVALID is for a node id with in invalid syntax.

Another indication that UA_STATUSCODE_BADNODEIDUNKNOWN is correct
is that a few lines up, this value is return in another case where
a node store lookup fails.