### PR TITLE
Remove wrong incompleteChunk assert

### DIFF
--- a/src/ua_connection.c
+++ b/src/ua_connection.c
@@ -160,9 +160,6 @@ UA_StatusCode
 UA_Connection_processChunks(UA_Connection *connection, void *application,
                             UA_Connection_processChunk processCallback,
                             const UA_ByteString *packet) {
-    /* The connection has already prepended any incomplete chunk during recv */
-    UA_assert(connection->incompleteChunk.length == 0);
-
     /* Loop over the received chunks. pos is increased with each chunk. */
     const UA_Byte *pos = packet->data;
     const UA_Byte *end = &packet->data[packet->length];


### PR DESCRIPTION
I think 94a1651 introduced a wrong assert around incompleteChunk.

If running `UA_Client_run_iterate` in a tight loop and/or being on a slow network can wrongfully trigger the assert.

- `connection_recv` reads incompleteChunk
- `UA_Connection_processChunks` stores in `connection->incompleteChunk`
- tight loop
- no new data arrived - `connection_recv` will read nothing and because of that will not clear `connection->incompleteChunk`
- `UA_Connection_processChunks` gets called with `connection->incompleteChunk` still present
- assert triggers

I'm not sure why the assert is present in the first place. There is probably a good reason which I'm missing. If we want to keep the assert `connection_recv` could copy the incompleteChunk unconditionally (playing memcpy ping-pong doesn't feel quite right to me though).
