### PR TITLE
DatatypeGenerator: Check for valid node id in csv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,7 @@ ua_generate_datatypes(
 
 # transport data types
 ua_generate_datatypes(
+    INTERNAL
     NAME "ua_transport"
     TARGET_SUFFIX "transport"
     NAMESPACE_IDX 1

--- a/examples/nodeset/CMakeLists.txt
+++ b/examples/nodeset/CMakeLists.txt
@@ -80,20 +80,9 @@ endif()
 # POWERLINK requires the full ns0 as basis
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
-    # Generate types and namespace for DI
-    #ua_generate_nodeset_and_datatypes(
-    #    NAME "di"
-    #    FILE_CSV "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/OpcUaDiModel.csv"
-    #    FILE_BSD "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.Types.bsd"
-    #    NAMESPACE_IDX 2
-    #    FILE_NS "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml"
-    #    INTERNAL
-    #)
-
     # generate powerlink namespace which is using DI
     ua_generate_nodeset_and_datatypes(
         NAME "powerlink"
-        # POWERLINK does not define custom types. Only generate the nodeset
         FILE_CSV "${PROJECT_SOURCE_DIR}/deps/ua-nodeset/POWERLINK/Opc.Ua.POWERLINK.NodeIds.csv"
         FILE_BSD "${PROJECT_SOURCE_DIR}/examples/nodeset/Opc.Ua.POWERLINK.NodeSet2.bsd"
         NAMESPACE_IDX 3
@@ -108,7 +97,7 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
                 ${PROJECT_BINARY_DIR}/src_generated/ua_types_powerlink_generated.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_di.c
                 ${PROJECT_BINARY_DIR}/src_generated/ua_namespace_powerlink.c)
-    add_dependencies(server_nodeset_plcopen open62541-generator-ns-powerlink)
+    add_dependencies(server_nodeset_powerlink open62541-generator-ns-powerlink)
     
 
 endif()

--- a/tools/cmake/macros_public.cmake
+++ b/tools/cmake/macros_public.cmake
@@ -79,6 +79,7 @@ endfunction()
 #   Options:
 #
 #   [BUILTIN]       Optional argument. If given, then builtin types will be generated.
+#   [INTERNAL]      Optional argument. If given, then the given types file is seen as internal file (e.g. does not require a .csv)
 #
 #   Arguments taking one value:
 #
@@ -100,7 +101,7 @@ endfunction()
 #
 #
 function(ua_generate_datatypes)
-    set(options BUILTIN)
+    set(options BUILTIN INTERNAL)
     set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX NAMESPACE_IDX OUTPUT_DIR FILE_CSV)
     set(multiValueArgs FILES_BSD FILES_SELECTED)
     cmake_parse_arguments(UA_GEN_DT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
@@ -143,6 +144,11 @@ function(ua_generate_datatypes)
         set(UA_GEN_DT_NO_BUILTIN "")
     endif()
 
+    set(UA_GEN_DT_INTERNAL_ARG "")
+    if (UA_GEN_DT_INTERNAL)
+        set(UA_GEN_DT_INTERNAL_ARG "--internal")
+    endif()
+
 
     set(SELECTED_TYPES_TMP "")
     foreach(f ${UA_GEN_DT_FILES_SELECTED})
@@ -170,6 +176,7 @@ function(ua_generate_datatypes)
         ${BSD_FILES_TMP}
         --type-csv=${UA_GEN_DT_FILE_CSV}
         ${UA_GEN_DT_NO_BUILTIN}
+        ${UA_GEN_DT_INTERNAL_ARG}
         ${UA_GEN_DT_OUTPUT_DIR}/${UA_GEN_DT_NAME}
         DEPENDS ${open62541_TOOLS_DIR}/generate_datatypes.py
         ${UA_GEN_DT_FILES_BSD}


### PR DESCRIPTION
If there's a type definition in the .bsd file, but there is no corresponding
entry in the .csv, then the old code silently set the type id to NODEID_NULL.

This will then cause the server to fail on a later stage. To avoid this,
the datatype generator should check this immediately and inform the user.