### PR TITLE
Export of UA_Server_getConfig and no const UA_DataTypeArray->next

### DIFF
--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -1283,7 +1283,7 @@ UA_Server_updateCertificate(UA_Server *server,
 /* Add a new namespace to the server. Returns the index of the new namespace */
 UA_UInt16 UA_EXPORT UA_Server_addNamespace(UA_Server *server, const char* name);
 
-UA_ServerConfig*
+UA_ServerConfig* UA_EXPORT
 UA_Server_getConfig(UA_Server *server);
 
 /* Get namespace by name from the server. */

--- a/include/ua_types.h
+++ b/include/ua_types.h
@@ -987,7 +987,7 @@ UA_Guid UA_EXPORT UA_Guid_random(void);     /* no cryptographic entropy */
  * true, the member datatype is looked up in the array of builtin datatypes
  * instead. */
 typedef struct UA_DataTypeArray {
-    const struct UA_DataTypeArray *next;
+    struct UA_DataTypeArray *next;
     const size_t typesSize;
     const UA_DataType *types;
 } UA_DataTypeArray;


### PR DESCRIPTION
# UA_EXPORT for UA_Server_getConfig
Fix for Issue  #2510 

# Delete of const UA_DataTypeArray.next
In order to add (or change) dataTypes during runtime the linked list of UA_DataTypeArray can't be const.
See line:
https://github.com/open62541/open62541/blob/master/include/ua_types.h#L990