### PR TITLE
Ignore null fields in DataValue during binary encoding

### DIFF
--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -1129,14 +1129,21 @@ DECODE_BINARY(Variant) {
 
 /* DataValue */
 ENCODE_BINARY(DataValue) {
+    UA_Boolean hasValue = src->hasValue && src->value.type != NULL;
+    UA_Boolean hasStatus = src->hasStatus && src->status;
+    UA_Boolean hasSourceTimestamp = src->hasSourceTimestamp && src->sourceTimestamp;
+    UA_Boolean hasSourcePicoseconds = src->hasSourcePicoseconds && src->sourcePicoseconds;
+    UA_Boolean hasServerTimestamp = src->hasServerTimestamp && src->serverTimestamp;
+    UA_Boolean hasServerPicoseconds = src->hasServerPicoseconds && src->serverPicoseconds;
+
     /* Set up the encoding mask */
     u8 encodingMask = (u8)
-        (((u8)src->hasValue) |
-         ((u8)src->hasStatus << 1) |
-         ((u8)src->hasSourceTimestamp << 2) |
-         ((u8)src->hasServerTimestamp << 3) |
-         ((u8)src->hasSourcePicoseconds << 4) |
-         ((u8)src->hasServerPicoseconds << 5));
+        (((u8)hasValue) |
+         ((u8)hasStatus << 1) |
+         ((u8)hasSourceTimestamp << 2) |
+         ((u8)hasServerTimestamp << 3) |
+         ((u8)hasSourcePicoseconds << 4) |
+         ((u8)hasServerPicoseconds << 5));
 
     /* Encode the encoding byte */
     status ret = ENCODE_DIRECT(&encodingMask, Byte);
@@ -1144,21 +1151,21 @@ ENCODE_BINARY(DataValue) {
         return ret;
 
     /* Encode the variant. */
-    if(src->hasValue) {
+    if(hasValue) {
         ret = ENCODE_DIRECT(&src->value, Variant);
         if(ret != UA_STATUSCODE_GOOD)
             return ret;
     }
 
-    if(src->hasStatus)
+    if(hasStatus)
         ret |= ENCODE_WITHEXCHANGE(&src->status, UA_TYPES_STATUSCODE);
-    if(src->hasSourceTimestamp)
+    if(hasSourceTimestamp)
         ret |= ENCODE_WITHEXCHANGE(&src->sourceTimestamp, UA_TYPES_DATETIME);
-    if(src->hasSourcePicoseconds)
+    if(hasSourcePicoseconds)
         ret |= ENCODE_WITHEXCHANGE(&src->sourcePicoseconds, UA_TYPES_UINT16);
-    if(src->hasServerTimestamp)
+    if(hasServerTimestamp)
         ret |= ENCODE_WITHEXCHANGE(&src->serverTimestamp, UA_TYPES_DATETIME);
-    if(src->hasServerPicoseconds)
+    if(hasServerPicoseconds)
         ret |= ENCODE_WITHEXCHANGE(&src->serverPicoseconds, UA_TYPES_UINT16);
     return ret;
 }
@@ -1649,17 +1656,17 @@ CALCSIZE_BINARY(Variant) {
 
 CALCSIZE_BINARY(DataValue) {
     size_t s = 1; /* Encoding byte */
-    if(src->hasValue)
+    if(src->hasValue && src->value.type != NULL)
         s += Variant_calcSizeBinary(&src->value, NULL);
-    if(src->hasStatus)
+    if(src->hasStatus && src->status)
         s += 4;
-    if(src->hasSourceTimestamp)
+    if(src->hasSourceTimestamp && src->sourceTimestamp)
         s += 8;
-    if(src->hasSourcePicoseconds)
+    if(src->hasSourcePicoseconds && src->sourcePicoseconds)
         s += 2;
-    if(src->hasServerTimestamp)
+    if(src->hasServerTimestamp && src->serverTimestamp)
         s += 8;
-    if(src->hasServerPicoseconds)
+    if(src->hasServerPicoseconds && src->serverPicoseconds)
         s += 2;
     return s;
 }

--- a/tests/check_types_builtin.c
+++ b/tests/check_types_builtin.c
@@ -904,6 +904,36 @@ START_TEST(UA_ExpandedNodeId_encodeShallWorkOnExample) {
 }
 END_TEST
 
+START_TEST(UA_DataValue_encodeShallWorkOnNullValues) {
+    // given
+    UA_DataValue src;
+    UA_DataValue_init(&src);
+    src.value.type = NULL;
+    src.hasValue = true;
+    src.status = 0;
+    src.hasStatus = true;
+    src.serverTimestamp = 0;
+    src.hasServerTimestamp = true;
+    src.sourceTimestamp = 0;
+    src.hasSourceTimestamp = true;
+
+    UA_Byte data[] = { 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+                       0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+                       0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55 };
+    UA_ByteString dst = { 24, data };
+    UA_Byte *pos = dst.data;
+    const UA_Byte *end = &dst.data[dst.length];
+
+    // when
+    UA_StatusCode retval = UA_DataValue_encodeBinary(&src, &pos, end);
+    // then
+    ck_assert_int_eq((uintptr_t)(pos - dst.data), 1);
+    ck_assert_uint_eq(1, UA_calcSizeBinary(&src, &UA_TYPES[UA_TYPES_DATAVALUE]));
+    ck_assert_int_eq(dst.data[0], 0x00); // encodingMask
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+}
+END_TEST
+
 START_TEST(UA_DataValue_encodeShallWorkOnExampleWithoutVariant) {
     // given
     UA_DataValue src;
@@ -1511,6 +1541,7 @@ static Suite *testSuite_builtin(void) {
     tcase_add_test(tc_encode, UA_Double_encodeShallWorkOnExample);
     tcase_add_test(tc_encode, UA_String_encodeShallWorkOnExample);
     tcase_add_test(tc_encode, UA_ExpandedNodeId_encodeShallWorkOnExample);
+    tcase_add_test(tc_encode, UA_DataValue_encodeShallWorkOnNullValues);
     tcase_add_test(tc_encode, UA_DataValue_encodeShallWorkOnExampleWithoutVariant);
     tcase_add_test(tc_encode, UA_DataValue_encodeShallWorkOnExampleWithVariant);
     tcase_add_test(tc_encode, UA_ExtensionObject_encodeDecodeShallWorkOnExtensionObject);

--- a/tests/pubsub/check_pubsub_encoding.c
+++ b/tests/pubsub/check_pubsub_encoding.c
@@ -698,7 +698,7 @@ START_TEST(UA_PubSub_EnDecode_ShallWorkOn1DS2ValuesDataValueDeltaFrame) {
     ck_assert(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasValue == m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasValue);
     ck_assert_int_eq((uintptr_t)m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.value.type, (uintptr_t)&UA_TYPES[UA_TYPES_INT32]);
     ck_assert_int_eq(*(UA_Int32 *)m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.value.data, iv);
-    ck_assert(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasSourceTimestamp == m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasSourceTimestamp);
+    ck_assert_int_eq(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.sourceTimestamp, m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.sourceTimestamp);
 
     ck_assert_int_eq(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[1].fieldIndex, fieldIndex2);
     ck_assert(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[1].fieldValue.hasValue == m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[1].fieldValue.hasValue);
@@ -1197,7 +1197,7 @@ START_TEST(UA_PubSub_EnDecode_ShallWorkOn1DS2ValuesDataValueDeltaFrameGHProm2) {
     ck_assert(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasValue == m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasValue);
     ck_assert_int_eq((uintptr_t)m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.value.type, (uintptr_t)&UA_TYPES[UA_TYPES_INT32]);
     ck_assert_int_eq(*(UA_Int32 *)m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.value.data, iv);
-    ck_assert(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasSourceTimestamp == m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.hasSourceTimestamp);
+    ck_assert_int_eq(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.sourceTimestamp, m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.sourceTimestamp);
 
     ck_assert_int_eq(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[1].fieldIndex, fieldIndex2);
     ck_assert(m.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[1].fieldValue.hasValue == m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[1].fieldValue.hasValue);


### PR DESCRIPTION
According to the OPC UA specification 1.04 part 6 paragraph 5.2.2.17
fields with all zero content should not be encoded.