### PR TITLE
Async monitored items

### DIFF
--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -69,28 +69,32 @@ UA_Client_Subscriptions_create(UA_Client *client,
                                UA_Client_StatusChangeNotificationCallback statusChangeCallback,
                                UA_Client_DeleteSubscriptionCallback deleteCallback);
 
-UA_StatusCode UA_EXPORT UA_Client_Subscriptions_create_async(
-    UA_Client *client, const UA_CreateSubscriptionRequest request, void *subscriptionContext,
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_create_async(
+    UA_Client *client, const UA_CreateSubscriptionRequest request,
+    void *subscriptionContext,
     UA_Client_StatusChangeNotificationCallback statusChangeCallback,
-    UA_Client_DeleteSubscriptionCallback deleteCallback, UA_ClientAsyncServiceCallback callback, void *userdata,
-    UA_UInt32 *requestId);
+    UA_Client_DeleteSubscriptionCallback deleteCallback,
+    UA_ClientAsyncServiceCallback callback, void *userdata, UA_UInt32 *requestId);
 
 UA_ModifySubscriptionResponse UA_EXPORT
 UA_Client_Subscriptions_modify(UA_Client *client, const UA_ModifySubscriptionRequest request);
 
-UA_StatusCode UA_EXPORT UA_Client_Subscriptions_modify_async(UA_Client *client,
-                                                             const UA_ModifySubscriptionRequest request,
-                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
-                                                             UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_modify_async(UA_Client *client,
+                                     const UA_ModifySubscriptionRequest request,
+                                     UA_ClientAsyncServiceCallback callback,
+                                     void *userdata, UA_UInt32 *requestId);
 
 UA_DeleteSubscriptionsResponse UA_EXPORT
 UA_Client_Subscriptions_delete(UA_Client *client,
                                const UA_DeleteSubscriptionsRequest request);
 
-UA_StatusCode UA_EXPORT UA_Client_Subscriptions_delete_async(UA_Client *client,
-                                                             const UA_DeleteSubscriptionsRequest request,
-                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
-                                                             UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_delete_async(UA_Client *client,
+                                     const UA_DeleteSubscriptionsRequest request,
+                                     UA_ClientAsyncServiceCallback callback,
+                                     void *userdata, UA_UInt32 *requestId);
 
 /* Delete a single subscription */
 UA_StatusCode UA_EXPORT
@@ -160,9 +164,11 @@ UA_Client_MonitoredItems_createDataChanges(UA_Client *client,
             UA_Client_DataChangeNotificationCallback *callbacks,
             UA_Client_DeleteMonitoredItemCallback *deleteCallbacks);
 
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createDataChanges_async(
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_createDataChanges_async(
     UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
-    UA_Client_DataChangeNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_Client_DataChangeNotificationCallback *callbacks,
+    UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
     UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId);
 
 UA_MonitoredItemCreateResult UA_EXPORT
@@ -179,9 +185,11 @@ UA_Client_MonitoredItems_createEvents(UA_Client *client,
             UA_Client_DeleteMonitoredItemCallback *deleteCallback);
 
 /* Monitor the EventNotifier attribute only */
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createEvents_async(
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_createEvents_async(
     UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
-    UA_Client_EventNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_Client_EventNotificationCallback *callbacks,
+    UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
     UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId);
 
 UA_MonitoredItemCreateResult UA_EXPORT
@@ -193,13 +201,15 @@ UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId
 UA_DeleteMonitoredItemsResponse UA_EXPORT
 UA_Client_MonitoredItems_delete(UA_Client *client, const UA_DeleteMonitoredItemsRequest);
 
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_delete_async(UA_Client *client,
-                                                              const UA_DeleteMonitoredItemsRequest request,
-                                                              UA_ClientAsyncServiceCallback callback, void *userdata,
-                                                              UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_delete_async(UA_Client *client,
+                                      const UA_DeleteMonitoredItemsRequest request,
+                                      UA_ClientAsyncServiceCallback callback,
+                                      void *userdata, UA_UInt32 *requestId);
 
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId,
-                                                              UA_UInt32 monitoredItemId);
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId,
+                                      UA_UInt32 monitoredItemId);
 
 /* The clientHandle parameter will be filled automatically */
 UA_ModifyMonitoredItemsResponse UA_EXPORT
@@ -230,27 +240,33 @@ UA_Client_MonitoredItems_setTriggering(UA_Client *client,
     return response;
 }
 
-static UA_INLINE UA_StatusCode UA_Client_MonitoredItems_modify_async(UA_Client *client,
-                                                                     const UA_ModifyMonitoredItemsRequest request,
-                                                                     UA_ClientAsyncServiceCallback callback,
-                                                                     void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST], callback,
-                                    &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE], userdata, requestId);
+static UA_INLINE UA_StatusCode
+UA_Client_MonitoredItems_modify_async(UA_Client *client,
+                                      const UA_ModifyMonitoredItemsRequest request,
+                                      UA_ClientAsyncServiceCallback callback,
+                                      void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(
+        client, &request, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST], callback,
+        &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE], userdata, requestId);
 }
 
-static UA_INLINE UA_StatusCode UA_Client_MonitoredItems_setMonitoringMode_async(
-    UA_Client *client, const UA_SetMonitoringModeRequest request, UA_ClientAsyncServiceCallback callback,
-    void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_SETMONITORINGMODEREQUEST], callback,
-                                    &UA_TYPES[UA_TYPES_SETMONITORINGMODERESPONSE], userdata, requestId);
+static UA_INLINE UA_StatusCode
+UA_Client_MonitoredItems_setMonitoringMode_async(
+    UA_Client *client, const UA_SetMonitoringModeRequest request,
+    UA_ClientAsyncServiceCallback callback, void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(
+        client, &request, &UA_TYPES[UA_TYPES_SETMONITORINGMODEREQUEST], callback,
+        &UA_TYPES[UA_TYPES_SETMONITORINGMODERESPONSE], userdata, requestId);
 }
 
-static UA_INLINE UA_StatusCode UA_Client_MonitoredItems_setTriggering_async(UA_Client *client,
-                                                                            const UA_SetTriggeringRequest request,
-                                                                            UA_ClientAsyncServiceCallback callback,
-                                                                            void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_SETTRIGGERINGREQUEST], callback,
-                                    &UA_TYPES[UA_TYPES_SETTRIGGERINGRESPONSE], userdata, requestId);
+static UA_INLINE UA_StatusCode
+UA_Client_MonitoredItems_setTriggering_async(UA_Client *client,
+                                             const UA_SetTriggeringRequest request,
+                                             UA_ClientAsyncServiceCallback callback,
+                                             void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(
+        client, &request, &UA_TYPES[UA_TYPES_SETTRIGGERINGREQUEST], callback,
+        &UA_TYPES[UA_TYPES_SETTRIGGERINGRESPONSE], userdata, requestId);
 }
 
 #endif

--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -69,33 +69,28 @@ UA_Client_Subscriptions_create(UA_Client *client,
                                UA_Client_StatusChangeNotificationCallback statusChangeCallback,
                                UA_Client_DeleteSubscriptionCallback deleteCallback);
 
-UA_StatusCode UA_EXPORT
-UA_Client_Subscriptions_create_async(UA_Client *client,
-                                     const UA_CreateSubscriptionRequest request,
-                                     void *subscriptionContext,
-                                     UA_Client_StatusChangeNotificationCallback statusChangeCallback,
-                                     UA_Client_DeleteSubscriptionCallback deleteCallback,
-                                     UA_ClientAsyncServiceCallback callback,
-                                     void *userdata, UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT UA_Client_Subscriptions_create_async(
+    UA_Client *client, const UA_CreateSubscriptionRequest request, void *subscriptionContext,
+    UA_Client_StatusChangeNotificationCallback statusChangeCallback,
+    UA_Client_DeleteSubscriptionCallback deleteCallback, UA_ClientAsyncServiceCallback callback, void *userdata,
+    UA_UInt32 *requestId);
 
 UA_ModifySubscriptionResponse UA_EXPORT
 UA_Client_Subscriptions_modify(UA_Client *client, const UA_ModifySubscriptionRequest request);
 
-UA_StatusCode UA_EXPORT
-UA_Client_Subscriptions_modify_async(UA_Client *client, const UA_ModifySubscriptionRequest request,
-                                     UA_ClientAsyncServiceCallback callback, void *userdata,
-                                     UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT UA_Client_Subscriptions_modify_async(UA_Client *client,
+                                                             const UA_ModifySubscriptionRequest request,
+                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
+                                                             UA_UInt32 *requestId);
 
 UA_DeleteSubscriptionsResponse UA_EXPORT
 UA_Client_Subscriptions_delete(UA_Client *client,
                                const UA_DeleteSubscriptionsRequest request);
 
-UA_StatusCode UA_EXPORT
-UA_Client_Subscriptions_delete_async(UA_Client *client,
-                                     const UA_DeleteSubscriptionsRequest request,
-                                     UA_ClientAsyncServiceCallback callback, void *userdata,
-                                     UA_UInt32 *requestId);
-
+UA_StatusCode UA_EXPORT UA_Client_Subscriptions_delete_async(UA_Client *client,
+                                                             const UA_DeleteSubscriptionsRequest request,
+                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
+                                                             UA_UInt32 *requestId);
 
 /* Delete a single subscription */
 UA_StatusCode UA_EXPORT
@@ -165,13 +160,10 @@ UA_Client_MonitoredItems_createDataChanges(UA_Client *client,
             UA_Client_DataChangeNotificationCallback *callbacks,
             UA_Client_DeleteMonitoredItemCallback *deleteCallbacks);
 
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
-            const UA_CreateMonitoredItemsRequest request, void **contexts,
-            UA_Client_DataChangeNotificationCallback *callbacks,
-            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
-            UA_ClientAsyncServiceCallback createCallback,
-            void *userdata, UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createDataChanges_async(
+    UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
+    UA_Client_DataChangeNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId);
 
 UA_MonitoredItemCreateResult UA_EXPORT
 UA_Client_MonitoredItems_createDataChange(UA_Client *client, UA_UInt32 subscriptionId,
@@ -187,13 +179,10 @@ UA_Client_MonitoredItems_createEvents(UA_Client *client,
             UA_Client_DeleteMonitoredItemCallback *deleteCallback);
 
 /* Monitor the EventNotifier attribute only */
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_createEvents_async(UA_Client *client,
-            const UA_CreateMonitoredItemsRequest request, void **contexts,
-            UA_Client_EventNotificationCallback *callbacks,
-            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
-            UA_ClientAsyncServiceCallback createCallback,
-            void *userdata, UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createEvents_async(
+    UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
+    UA_Client_EventNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId);
 
 UA_MonitoredItemCreateResult UA_EXPORT
 UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId,
@@ -204,13 +193,13 @@ UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId
 UA_DeleteMonitoredItemsResponse UA_EXPORT
 UA_Client_MonitoredItems_delete(UA_Client *client, const UA_DeleteMonitoredItemsRequest);
 
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_delete_async(UA_Client *client, const UA_DeleteMonitoredItemsRequest request,
-                                      UA_ClientAsyncServiceCallback callback,
-                                      void *userdata, UA_UInt32 *requestId);
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_delete_async(UA_Client *client,
+                                                              const UA_DeleteMonitoredItemsRequest request,
+                                                              UA_ClientAsyncServiceCallback callback, void *userdata,
+                                                              UA_UInt32 *requestId);
 
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId, UA_UInt32 monitoredItemId);
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId,
+                                                              UA_UInt32 monitoredItemId);
 
 /* The clientHandle parameter will be filled automatically */
 UA_ModifyMonitoredItemsResponse UA_EXPORT
@@ -241,37 +230,27 @@ UA_Client_MonitoredItems_setTriggering(UA_Client *client,
     return response;
 }
 
-static UA_INLINE UA_StatusCode
-UA_Client_MonitoredItems_modify_async(UA_Client *client,
-                                      const UA_ModifyMonitoredItemsRequest request,
-                                      UA_ClientAsyncServiceCallback callback,
-                                      void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_AsyncService(client,
-                                    &request, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST],
-                                    callback, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE],
-                                    userdata, requestId);
+static UA_INLINE UA_StatusCode UA_Client_MonitoredItems_modify_async(UA_Client *client,
+                                                                     const UA_ModifyMonitoredItemsRequest request,
+                                                                     UA_ClientAsyncServiceCallback callback,
+                                                                     void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST], callback,
+                                    &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE], userdata, requestId);
 }
 
-static UA_INLINE UA_StatusCode
-UA_Client_MonitoredItems_setMonitoringMode_async(UA_Client *client,
-                                                 const UA_SetMonitoringModeRequest request,
-                                                 UA_ClientAsyncServiceCallback callback,
-                                                 void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_AsyncService(client,
-                                    &request, &UA_TYPES[UA_TYPES_SETMONITORINGMODEREQUEST],
-                                    callback, &UA_TYPES[UA_TYPES_SETMONITORINGMODERESPONSE],
-                                    userdata, requestId);
+static UA_INLINE UA_StatusCode UA_Client_MonitoredItems_setMonitoringMode_async(
+    UA_Client *client, const UA_SetMonitoringModeRequest request, UA_ClientAsyncServiceCallback callback,
+    void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_SETMONITORINGMODEREQUEST], callback,
+                                    &UA_TYPES[UA_TYPES_SETMONITORINGMODERESPONSE], userdata, requestId);
 }
 
-static UA_INLINE UA_StatusCode
-UA_Client_MonitoredItems_setTriggering_async(UA_Client *client,
-                                             const UA_SetTriggeringRequest request,
-                                             UA_ClientAsyncServiceCallback callback,
-                                             void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_AsyncService(client,
-                                    &request, &UA_TYPES[UA_TYPES_SETTRIGGERINGREQUEST],
-                                    callback, &UA_TYPES[UA_TYPES_SETTRIGGERINGRESPONSE],
-                                    userdata, requestId);
+static UA_INLINE UA_StatusCode UA_Client_MonitoredItems_setTriggering_async(UA_Client *client,
+                                                                            const UA_SetTriggeringRequest request,
+                                                                            UA_ClientAsyncServiceCallback callback,
+                                                                            void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_SETTRIGGERINGREQUEST], callback,
+                                    &UA_TYPES[UA_TYPES_SETTRIGGERINGRESPONSE], userdata, requestId);
 }
 
 #endif

--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -69,12 +69,33 @@ UA_Client_Subscriptions_create(UA_Client *client,
                                UA_Client_StatusChangeNotificationCallback statusChangeCallback,
                                UA_Client_DeleteSubscriptionCallback deleteCallback);
 
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_create_async(UA_Client *client,
+                                     const UA_CreateSubscriptionRequest request,
+                                     void *subscriptionContext,
+                                     UA_Client_StatusChangeNotificationCallback statusChangeCallback,
+                                     UA_Client_DeleteSubscriptionCallback deleteCallback,
+                                     UA_ClientAsyncServiceCallback callback,
+                                     void *userdata, UA_UInt32 *requestId);
+
 UA_ModifySubscriptionResponse UA_EXPORT
 UA_Client_Subscriptions_modify(UA_Client *client, const UA_ModifySubscriptionRequest request);
+
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_modify_async(UA_Client *client, const UA_ModifySubscriptionRequest request,
+                                     UA_ClientAsyncServiceCallback callback, void *userdata,
+                                     UA_UInt32 *requestId);
 
 UA_DeleteSubscriptionsResponse UA_EXPORT
 UA_Client_Subscriptions_delete(UA_Client *client,
                                const UA_DeleteSubscriptionsRequest request);
+
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_delete_async(UA_Client *client,
+                                     const UA_DeleteSubscriptionsRequest request,
+                                     UA_ClientAsyncServiceCallback callback, void *userdata,
+                                     UA_UInt32 *requestId);
+
 
 /* Delete a single subscription */
 UA_StatusCode UA_EXPORT
@@ -144,6 +165,14 @@ UA_Client_MonitoredItems_createDataChanges(UA_Client *client,
             UA_Client_DataChangeNotificationCallback *callbacks,
             UA_Client_DeleteMonitoredItemCallback *deleteCallbacks);
 
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
+            const UA_CreateMonitoredItemsRequest request, void **contexts,
+            UA_Client_DataChangeNotificationCallback *callbacks,
+            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+            UA_ClientAsyncServiceCallback createCallback,
+            void *userdata, UA_UInt32 *requestId);
+
 UA_MonitoredItemCreateResult UA_EXPORT
 UA_Client_MonitoredItems_createDataChange(UA_Client *client, UA_UInt32 subscriptionId,
           UA_TimestampsToReturn timestampsToReturn, const UA_MonitoredItemCreateRequest item,
@@ -157,6 +186,15 @@ UA_Client_MonitoredItems_createEvents(UA_Client *client,
             UA_Client_EventNotificationCallback *callback,
             UA_Client_DeleteMonitoredItemCallback *deleteCallback);
 
+/* Monitor the EventNotifier attribute only */
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_createEvents_async(UA_Client *client,
+            const UA_CreateMonitoredItemsRequest request, void **contexts,
+            UA_Client_EventNotificationCallback *callbacks,
+            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+            UA_ClientAsyncServiceCallback createCallback,
+            void *userdata, UA_UInt32 *requestId);
+
 UA_MonitoredItemCreateResult UA_EXPORT
 UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId,
           UA_TimestampsToReturn timestampsToReturn, const UA_MonitoredItemCreateRequest item,
@@ -165,6 +203,11 @@ UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId
 
 UA_DeleteMonitoredItemsResponse UA_EXPORT
 UA_Client_MonitoredItems_delete(UA_Client *client, const UA_DeleteMonitoredItemsRequest);
+
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_delete_async(UA_Client *client, const UA_DeleteMonitoredItemsRequest request,
+                                      UA_ClientAsyncServiceCallback callback,
+                                      void *userdata, UA_UInt32 *requestId);
 
 UA_StatusCode UA_EXPORT
 UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId, UA_UInt32 monitoredItemId);
@@ -196,6 +239,39 @@ UA_Client_MonitoredItems_setTriggering(UA_Client *client,
                         &request, &UA_TYPES[UA_TYPES_SETTRIGGERINGREQUEST],
                         &response, &UA_TYPES[UA_TYPES_SETTRIGGERINGRESPONSE]);
     return response;
+}
+
+static UA_INLINE UA_StatusCode
+UA_Client_MonitoredItems_modify_async(UA_Client *client,
+                                      const UA_ModifyMonitoredItemsRequest request,
+                                      UA_ClientAsyncServiceCallback callback,
+                                      void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(client,
+                                    &request, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST],
+                                    callback, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE],
+                                    userdata, requestId);
+}
+
+static UA_INLINE UA_StatusCode
+UA_Client_MonitoredItems_setMonitoringMode_async(UA_Client *client,
+                                                 const UA_SetMonitoringModeRequest request,
+                                                 UA_ClientAsyncServiceCallback callback,
+                                                 void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(client,
+                                    &request, &UA_TYPES[UA_TYPES_SETMONITORINGMODEREQUEST],
+                                    callback, &UA_TYPES[UA_TYPES_SETMONITORINGMODERESPONSE],
+                                    userdata, requestId);
+}
+
+static UA_INLINE UA_StatusCode
+UA_Client_MonitoredItems_setTriggering_async(UA_Client *client,
+                                             const UA_SetTriggeringRequest request,
+                                             UA_ClientAsyncServiceCallback callback,
+                                             void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_AsyncService(client,
+                                    &request, &UA_TYPES[UA_TYPES_SETTRIGGERINGREQUEST],
+                                    callback, &UA_TYPES[UA_TYPES_SETTRIGGERINGRESPONSE],
+                                    userdata, requestId);
 }
 
 #endif

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -753,6 +753,11 @@ cleanup:
 
 /* Async Functions */
 
+typedef struct {
+    UA_AttributeId attributeId;
+    const UA_DataType *outDataType;
+} AsyncReadData;
+
 static
 void ValueAttributeRead(UA_Client *client, void *userdata,
                         UA_UInt32 requestId, void *response) {
@@ -760,28 +765,25 @@ void ValueAttributeRead(UA_Client *client, void *userdata,
         return;
 
     /* Find the callback for the response */
-    CustomCallback *cc;
-    LIST_FOREACH(cc, &client->customCallbacks, pointers) {
-        if(cc->callbackId == requestId)
-            break;
-    }
+    CustomCallback *cc = UA_Client_findCustomCallback(client, requestId);
     if(!cc)
         return;
 
     UA_ReadResponse *rr = (UA_ReadResponse *) response;
     UA_DataValue *res = rr->results;
     UA_Boolean done = false;
+    AsyncReadData *data = (AsyncReadData *)cc->clientData;
     if(rr->resultsSize == 1 && res != NULL && res->hasValue) {
-        if(cc->attributeId == UA_ATTRIBUTEID_VALUE) {
+        if(data->attributeId == UA_ATTRIBUTEID_VALUE) {
             /* Call directly with the variant */
-            cc->callback(client, userdata, requestId, &res->value);
+            cc->userCallback(client, cc->userData, requestId, &res->value);
             done = true;
         } else if(UA_Variant_isScalar(&res->value) &&
-                  res->value.type == cc->outDataType) {
+                  res->value.type == data->outDataType) {
             /* Unpack the value */
-            UA_STACKARRAY(UA_Byte, value, cc->outDataType->memSize);
-            memcpy(&value, res->value.data, cc->outDataType->memSize);
-            cc->callback(client, userdata, requestId, &value);
+            UA_STACKARRAY(UA_Byte, value, data->outDataType->memSize);
+            memcpy(&value, res->value.data, data->outDataType->memSize);
+            cc->userCallback(client, cc->userData, requestId, &value);
             done = true;
         }
     }
@@ -792,8 +794,7 @@ void ValueAttributeRead(UA_Client *client, void *userdata,
                     "Cannot process the response to the async read "
                     "request %u", requestId);
 
-    LIST_REMOVE(cc, pointers);
-    UA_free(cc);
+    CustomCallback_remove(cc, true);
 }
 
 /*Read Attributes*/
@@ -812,16 +813,25 @@ UA_StatusCode __UA_Client_readAttribute_async(UA_Client *client,
 
     __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_READREQUEST],
                              ValueAttributeRead, &UA_TYPES[UA_TYPES_READRESPONSE],
-                             userdata, reqId);
+                             NULL, reqId);
 
     CustomCallback *cc = (CustomCallback*) UA_malloc(sizeof(CustomCallback));
     if (!cc)
         return UA_STATUSCODE_BADOUTOFMEMORY;
-    cc->callback = callback;
+    memset(cc, 0, sizeof(CustomCallback));
+    cc->userCallback = callback;
+    cc->userData = userdata;
     cc->callbackId = *reqId;
 
-    cc->attributeId = attributeId;
-    cc->outDataType = outDataType;
+    cc->clientData = UA_malloc(sizeof(AsyncReadData));
+    if (!cc->clientData) {
+      UA_free(cc);
+      return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    cc->clientDataDeleter = UA_free;
+    AsyncReadData *rd = (AsyncReadData *)cc->clientData;
+    rd->attributeId = attributeId;
+    rd->outDataType = outDataType;
 
     LIST_INSERT_HEAD(&client->customCallbacks, cc, pointers);
 

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -774,12 +774,11 @@ void ValueAttributeRead(UA_Client *client, void *userdata,
     UA_Boolean done = false;
     AsyncReadData *data = (AsyncReadData *)cc->clientData;
     if(rr->resultsSize == 1 && res != NULL && res->hasValue) {
-        if(data->attributeId == UA_ATTRIBUTEID_VALUE) {
+        if (data->attributeId == UA_ATTRIBUTEID_VALUE) {
             /* Call directly with the variant */
             cc->userCallback(client, cc->userData, requestId, &res->value);
             done = true;
-        } else if(UA_Variant_isScalar(&res->value) &&
-                  res->value.type == data->outDataType) {
+        } else if (UA_Variant_isScalar(&res->value) && res->value.type == data->outDataType) {
             /* Unpack the value */
             UA_STACKARRAY(UA_Byte, value, data->outDataType->memSize);
             memcpy(&value, res->value.data, data->outDataType->memSize);
@@ -811,9 +810,8 @@ UA_StatusCode __UA_Client_readAttribute_async(UA_Client *client,
     request.nodesToRead = &item;
     request.nodesToReadSize = 1;
 
-    __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_READREQUEST],
-                             ValueAttributeRead, &UA_TYPES[UA_TYPES_READRESPONSE],
-                             NULL, reqId);
+    __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_READREQUEST], ValueAttributeRead,
+                             &UA_TYPES[UA_TYPES_READRESPONSE], NULL, reqId);
 
     CustomCallback *cc = (CustomCallback*) UA_malloc(sizeof(CustomCallback));
     if (!cc)
@@ -825,8 +823,8 @@ UA_StatusCode __UA_Client_readAttribute_async(UA_Client *client,
 
     cc->clientData = UA_malloc(sizeof(AsyncReadData));
     if (!cc->clientData) {
-      UA_free(cc);
-      return UA_STATUSCODE_BADOUTOFMEMORY;
+        UA_free(cc);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     cc->clientDataDeleter = UA_free;
     AsyncReadData *rd = (AsyncReadData *)cc->clientData;

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -774,11 +774,12 @@ void ValueAttributeRead(UA_Client *client, void *userdata,
     UA_Boolean done = false;
     AsyncReadData *data = (AsyncReadData *)cc->clientData;
     if(rr->resultsSize == 1 && res != NULL && res->hasValue) {
-        if (data->attributeId == UA_ATTRIBUTEID_VALUE) {
+        if(data->attributeId == UA_ATTRIBUTEID_VALUE) {
             /* Call directly with the variant */
             cc->userCallback(client, cc->userData, requestId, &res->value);
             done = true;
-        } else if (UA_Variant_isScalar(&res->value) && res->value.type == data->outDataType) {
+        } else if(UA_Variant_isScalar(&res->value) &&
+                  res->value.type == data->outDataType) {
             /* Unpack the value */
             UA_STACKARRAY(UA_Byte, value, data->outDataType->memSize);
             memcpy(&value, res->value.data, data->outDataType->memSize);
@@ -810,8 +811,9 @@ UA_StatusCode __UA_Client_readAttribute_async(UA_Client *client,
     request.nodesToRead = &item;
     request.nodesToReadSize = 1;
 
-    __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_READREQUEST], ValueAttributeRead,
-                             &UA_TYPES[UA_TYPES_READRESPONSE], NULL, reqId);
+    __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_READREQUEST],
+                             ValueAttributeRead, &UA_TYPES[UA_TYPES_READRESPONSE], NULL,
+                             reqId);
 
     CustomCallback *cc = (CustomCallback*) UA_malloc(sizeof(CustomCallback));
     if (!cc)
@@ -822,7 +824,7 @@ UA_StatusCode __UA_Client_readAttribute_async(UA_Client *client,
     cc->callbackId = *reqId;
 
     cc->clientData = UA_malloc(sizeof(AsyncReadData));
-    if (!cc->clientData) {
+    if(!cc->clientData) {
         UA_free(cc);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -794,7 +794,9 @@ void ValueAttributeRead(UA_Client *client, void *userdata,
                     "Cannot process the response to the async read "
                     "request %u", requestId);
 
-    CustomCallback_remove(cc, true);
+    UA_free(cc->clientData);
+    LIST_REMOVE(cc, pointers);
+    UA_free(cc);
 }
 
 /*Read Attributes*/
@@ -828,7 +830,6 @@ UA_StatusCode __UA_Client_readAttribute_async(UA_Client *client,
         UA_free(cc);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    cc->clientDataDeleter = UA_free;
     AsyncReadData *rd = (AsyncReadData *)cc->clientData;
     rd->attributeId = attributeId;
     rd->outDataType = outDataType;

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -172,26 +172,30 @@ struct UA_Client {
     UA_Boolean pendingConnectivityCheck;
 };
 
-static UA_INLINE CustomCallback *CustomCallback_new(void) {
+static UA_INLINE CustomCallback *
+CustomCallback_new(void) {
     CustomCallback *cc = (CustomCallback *)UA_malloc(sizeof(CustomCallback));
-    if (cc)
+    if(cc)
         memset(cc, 0, sizeof(CustomCallback));
     return cc;
 }
 
-// removes the callback from the client and frees it and its clientData (if clientDataDeleter is set)
-static UA_INLINE void CustomCallback_remove(CustomCallback *cc, bool removeList) {
-    if (removeList)
+// removes the callback from the client and frees it and its clientData (if
+// clientDataDeleter is set)
+static UA_INLINE void
+CustomCallback_remove(CustomCallback *cc, bool removeList) {
+    if(removeList)
         LIST_REMOVE(cc, pointers);
-    if (cc->clientDataDeleter && cc->clientData)
+    if(cc->clientDataDeleter && cc->clientData)
         cc->clientDataDeleter(cc->clientData);
     UA_free(cc);
 }
 
-static UA_INLINE CustomCallback *UA_Client_findCustomCallback(UA_Client *client, UA_UInt32 requestId) {
+static UA_INLINE CustomCallback *
+UA_Client_findCustomCallback(UA_Client *client, UA_UInt32 requestId) {
     CustomCallback *cc;
-    LIST_FOREACH (cc, &client->customCallbacks, pointers) {
-        if (cc->callbackId == requestId)
+    LIST_FOREACH(cc, &client->customCallbacks, pointers) {
+        if(cc->callbackId == requestId)
             break;
     }
     return cc;

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -112,8 +112,6 @@ void UA_Client_AsyncService_cancel(UA_Client *client, AsyncServiceCall *ac,
 
 void UA_Client_AsyncService_removeAll(UA_Client *client, UA_StatusCode statusCode);
 
-typedef void (*CustomCallbackDataDeleter)(void *);
-
 typedef struct CustomCallback {
     LIST_ENTRY(CustomCallback)
     pointers;
@@ -123,8 +121,8 @@ typedef struct CustomCallback {
     UA_ClientAsyncServiceCallback userCallback;
     void *userData;
 
+    bool isAsync;
     void *clientData;
-    CustomCallbackDataDeleter clientDataDeleter;
 } CustomCallback;
 
 struct UA_Client {
@@ -171,17 +169,6 @@ struct UA_Client {
     UA_DateTime lastConnectivityCheck;
     UA_Boolean pendingConnectivityCheck;
 };
-
-// removes the callback from the client and frees it and its clientData (if
-// clientDataDeleter is set)
-static UA_INLINE void
-CustomCallback_remove(CustomCallback *cc, bool removeList) {
-    if(removeList)
-        LIST_REMOVE(cc, pointers);
-    if(cc->clientDataDeleter && cc->clientData)
-        cc->clientDataDeleter(cc->clientData);
-    UA_free(cc);
-}
 
 static UA_INLINE CustomCallback *
 UA_Client_findCustomCallback(UA_Client *client, UA_UInt32 requestId) {

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -172,8 +172,7 @@ struct UA_Client {
     UA_Boolean pendingConnectivityCheck;
 };
 
-static UA_INLINE CustomCallback *
-CustomCallback_new(void) {
+static UA_INLINE CustomCallback *CustomCallback_new(void) {
     CustomCallback *cc = (CustomCallback *)UA_malloc(sizeof(CustomCallback));
     if (cc)
         memset(cc, 0, sizeof(CustomCallback));
@@ -181,20 +180,18 @@ CustomCallback_new(void) {
 }
 
 // removes the callback from the client and frees it and its clientData (if clientDataDeleter is set)
-static UA_INLINE void
-CustomCallback_remove(CustomCallback *cc, bool removeList) {
-    if(removeList)
+static UA_INLINE void CustomCallback_remove(CustomCallback *cc, bool removeList) {
+    if (removeList)
         LIST_REMOVE(cc, pointers);
-    if(cc->clientDataDeleter && cc->clientData)
+    if (cc->clientDataDeleter && cc->clientData)
         cc->clientDataDeleter(cc->clientData);
     UA_free(cc);
 }
 
-static UA_INLINE CustomCallback *
-UA_Client_findCustomCallback(UA_Client *client, UA_UInt32 requestId) {
+static UA_INLINE CustomCallback *UA_Client_findCustomCallback(UA_Client *client, UA_UInt32 requestId) {
     CustomCallback *cc;
-    LIST_FOREACH(cc, &client->customCallbacks, pointers) {
-        if(cc->callbackId == requestId)
+    LIST_FOREACH (cc, &client->customCallbacks, pointers) {
+        if (cc->callbackId == requestId)
             break;
     }
     return cc;

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -172,14 +172,6 @@ struct UA_Client {
     UA_Boolean pendingConnectivityCheck;
 };
 
-static UA_INLINE CustomCallback *
-CustomCallback_new(void) {
-    CustomCallback *cc = (CustomCallback *)UA_malloc(sizeof(CustomCallback));
-    if(cc)
-        memset(cc, 0, sizeof(CustomCallback));
-    return cc;
-}
-
 // removes the callback from the client and frees it and its clientData (if
 // clientDataDeleter is set)
 static UA_INLINE void

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -666,6 +666,7 @@ __UA_Client_MonitoredItems_createDataChanges_async(
         __MonitoredItems_create_handler, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE],
         cc, requestId);
 cleanup:
+    MonitoredItems_CreateData_deleteItems(data, client);
     MonitoredItems_CreateData_free(data);
     UA_free(cc);
     return retval;

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -598,12 +598,11 @@ __UA_Client_MonitoredItems_createDataChanges_async(
     cc->userCallback = createCallback;
     cc->userData = userdata;
     MonitoredItems_CreateData *data =
-        (MonitoredItems_CreateData *)UA_malloc(sizeof(MonitoredItems_CreateData));
+        (MonitoredItems_CreateData *)UA_calloc(1, sizeof(MonitoredItems_CreateData));
     if(!data) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
-    memset(data, 0, sizeof(MonitoredItems_CreateData));
     data->asyncData = true;
     cc->clientData = data;
     cc->clientDataDeleter =

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -72,7 +72,7 @@ cleanup:
     }
 }
 
-UA_CreateSubscriptionResponse UA_EXPORT
+UA_CreateSubscriptionResponse
 UA_Client_Subscriptions_create(UA_Client *client,
                                const UA_CreateSubscriptionRequest request,
                                void *subscriptionContext,
@@ -101,7 +101,7 @@ UA_Client_Subscriptions_create(UA_Client *client,
     return response;
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_Subscriptions_create_async(
     UA_Client *client, const UA_CreateSubscriptionRequest request,
     void *subscriptionContext,
@@ -162,7 +162,7 @@ __Subscriptions_modify_handler(UA_Client *client, void *data, UA_UInt32 requestI
     }
 }
 
-UA_ModifySubscriptionResponse UA_EXPORT
+UA_ModifySubscriptionResponse
 UA_Client_Subscriptions_modify(UA_Client *client, const UA_ModifySubscriptionRequest request) {
     UA_ModifySubscriptionResponse response;
     UA_ModifySubscriptionResponse_init(&response);
@@ -185,7 +185,7 @@ UA_Client_Subscriptions_modify(UA_Client *client, const UA_ModifySubscriptionReq
     return response;
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_Subscriptions_modify_async(UA_Client *client,
                                      const UA_ModifySubscriptionRequest request,
                                      UA_ClientAsyncServiceCallback callback,
@@ -307,7 +307,7 @@ cleanup:
     }
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_Subscriptions_delete_async(UA_Client *client,
                                      const UA_DeleteSubscriptionsRequest request,
                                      UA_ClientAsyncServiceCallback callback,
@@ -346,7 +346,7 @@ cleanup:
     return UA_STATUSCODE_BADOUTOFMEMORY;
 }
 
-UA_DeleteSubscriptionsResponse UA_EXPORT
+UA_DeleteSubscriptionsResponse
 UA_Client_Subscriptions_delete(UA_Client *client,
                                const UA_DeleteSubscriptionsRequest request) {
     UA_STACKARRAY(UA_Client_Subscription *, subs, request.subscriptionIdsSize);
@@ -372,7 +372,7 @@ UA_Client_Subscriptions_delete(UA_Client *client,
     return response;
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_Subscriptions_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId) {
     UA_DeleteSubscriptionsRequest request;
     UA_DeleteSubscriptionsRequest_init(&request);
@@ -662,7 +662,7 @@ cleanup:
     return retval;
 }
 
-UA_CreateMonitoredItemsResponse UA_EXPORT
+UA_CreateMonitoredItemsResponse
 UA_Client_MonitoredItems_createDataChanges(UA_Client *client,
             const UA_CreateMonitoredItemsRequest request, void **contexts,
             UA_Client_DataChangeNotificationCallback *callbacks,
@@ -673,7 +673,7 @@ UA_Client_MonitoredItems_createDataChanges(UA_Client *client,
     return response;
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_MonitoredItems_createDataChanges_async(
     UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
     UA_Client_DataChangeNotificationCallback *callbacks,
@@ -684,7 +684,7 @@ UA_Client_MonitoredItems_createDataChanges_async(
         createCallback, userdata, requestId);
 }
 
-UA_MonitoredItemCreateResult UA_EXPORT
+UA_MonitoredItemCreateResult
 UA_Client_MonitoredItems_createDataChange(UA_Client *client, UA_UInt32 subscriptionId,
           UA_TimestampsToReturn timestampsToReturn, const UA_MonitoredItemCreateRequest item,
           void *context, UA_Client_DataChangeNotificationCallback callback,
@@ -713,7 +713,7 @@ UA_Client_MonitoredItems_createDataChange(UA_Client *client, UA_UInt32 subscript
     return result;
 }
 
-UA_CreateMonitoredItemsResponse UA_EXPORT
+UA_CreateMonitoredItemsResponse
 UA_Client_MonitoredItems_createEvents(UA_Client *client,
             const UA_CreateMonitoredItemsRequest request, void **contexts,
             UA_Client_EventNotificationCallback *callback,
@@ -725,7 +725,7 @@ UA_Client_MonitoredItems_createEvents(UA_Client *client,
 }
 
 /* Monitor the EventNotifier attribute only */
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_MonitoredItems_createEvents_async(
     UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
     UA_Client_EventNotificationCallback *callbacks,
@@ -736,7 +736,7 @@ UA_Client_MonitoredItems_createEvents_async(
         createCallback, userdata, requestId);
 }
 
-UA_MonitoredItemCreateResult UA_EXPORT
+UA_MonitoredItemCreateResult
 UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId,
           UA_TimestampsToReturn timestampsToReturn, const UA_MonitoredItemCreateRequest item,
           void *context, UA_Client_EventNotificationCallback callback,
@@ -809,7 +809,7 @@ cleanup:
     }
 }
 
-UA_DeleteMonitoredItemsResponse UA_EXPORT
+UA_DeleteMonitoredItemsResponse
 UA_Client_MonitoredItems_delete(UA_Client *client,
                                 const UA_DeleteMonitoredItemsRequest request) {
     /* Send the request */
@@ -825,7 +825,7 @@ UA_Client_MonitoredItems_delete(UA_Client *client,
     return response;
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_MonitoredItems_delete_async(UA_Client *client,
                                       const UA_DeleteMonitoredItemsRequest request,
                                       UA_ClientAsyncServiceCallback callback,
@@ -852,7 +852,7 @@ UA_Client_MonitoredItems_delete_async(UA_Client *client,
         cc, requestId);
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId,
                                       UA_UInt32 monitoredItemId) {
     UA_DeleteMonitoredItemsRequest request;

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -247,9 +247,8 @@ __Subscriptions_delete_prepare(UA_Client *client,
     CustomCallback *cc = CustomCallback_new();
     if (!cc)
         goto cleanup;
-    Subscriptions_DeleteData *data = NULL;
-
-    data = (Subscriptions_DeleteData *)UA_calloc(1, sizeof(Subscriptions_DeleteData));
+    Subscriptions_DeleteData *data =
+        (Subscriptions_DeleteData *)UA_calloc(1, sizeof(Subscriptions_DeleteData));
     if (!data)
         goto cleanup;
 
@@ -622,7 +621,8 @@ __UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
     memcpy(data->contexts, contexts, request.itemsToCreateSize * sizeof(void*));
     data->deleteCallbacks = (UA_Client_DeleteMonitoredItemCallback *)
         (array + (2 * request.itemsToCreateSize));
-    memcpy(data->deleteCallbacks, deleteCallbacks, request.itemsToCreateSize * sizeof(void*));
+    memcpy(data->deleteCallbacks, deleteCallbacks,
+           request.itemsToCreateSize * sizeof(UA_Client_DeleteMonitoredItemCallback));
     data->handlingCallbacks = array + (3 * request.itemsToCreateSize);
     memcpy(data->handlingCallbacks, callbacks, request.itemsToCreateSize * sizeof(void*));
 

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -83,6 +83,9 @@ UA_Client_Subscriptions_create(UA_Client *client,
 
     CustomCallback cc;
     memset(&cc, 0, sizeof(CustomCallback));
+#ifdef __clang_analyzer__
+    cc.isAsync = false;
+#endif
 
     UA_StatusCode retval = __Subscriptions_create_prepare(
         &cc, &request, subscriptionContext, statusChangeCallback, deleteCallback);
@@ -354,6 +357,9 @@ UA_Client_Subscriptions_delete(UA_Client *client,
 
     CustomCallback cc;
     memset(&cc, 0, sizeof(CustomCallback));
+#ifdef __clang_analyzer__
+    cc.isAsync = false;
+#endif
 
     Subscriptions_DeleteData data;
     cc.clientData = &data;
@@ -552,6 +558,9 @@ __UA_Client_MonitoredItems_create(UA_Client *client,
     }
     CustomCallback cc;
     memset(&cc, 0, sizeof(CustomCallback));
+#ifdef __clang_analyzer__
+    cc.isAsync = false;
+#endif
 
     /* Fix clang warning */
     size_t itemsToCreateSize = request->itemsToCreateSize;
@@ -816,6 +825,9 @@ UA_Client_MonitoredItems_delete(UA_Client *client,
     UA_DeleteMonitoredItemsResponse response;
     CustomCallback cc;
     memset(&cc, 0, sizeof(CustomCallback));
+#ifdef __clang_analyzer__
+    cc.isAsync = false;
+#endif
     cc.clientData = (void *)(uintptr_t)&request;
 
     __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST],

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -22,14 +22,17 @@
 /* Subscriptions */
 /*****************/
 
-static UA_StatusCode __Subscriptions_create_prepare(CustomCallback *cc, const UA_CreateSubscriptionRequest *request,
-                                                    void *subscriptionContext,
-                                                    UA_Client_StatusChangeNotificationCallback statusChangeCallback,
-                                                    UA_Client_DeleteSubscriptionCallback deleteCallback) {
+static UA_StatusCode
+__Subscriptions_create_prepare(
+    CustomCallback *cc, const UA_CreateSubscriptionRequest *request,
+    void *subscriptionContext,
+    UA_Client_StatusChangeNotificationCallback statusChangeCallback,
+    UA_Client_DeleteSubscriptionCallback deleteCallback) {
     UA_Client_Subscription *sub =
-        (UA_Client_Subscription *)(cc->clientData = UA_malloc(sizeof(UA_Client_Subscription)));
+        (UA_Client_Subscription *)(cc->clientData =
+                                       UA_malloc(sizeof(UA_Client_Subscription)));
     cc->clientDataDeleter = UA_free;
-    if (!sub)
+    if(!sub)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     sub->context = subscriptionContext;
     sub->statusChangeCallback = statusChangeCallback;
@@ -37,10 +40,12 @@ static UA_StatusCode __Subscriptions_create_prepare(CustomCallback *cc, const UA
     return UA_STATUSCODE_GOOD;
 }
 
-static void __Subscriptions_create_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
+static void
+__Subscriptions_create_handler(UA_Client *client, void *data, UA_UInt32 requestId,
+                               void *r) {
     UA_CreateSubscriptionResponse *response = (UA_CreateSubscriptionResponse *)r;
     CustomCallback *cc = (CustomCallback *)data;
-    if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         goto cleanup;
     }
 
@@ -58,7 +63,7 @@ static void __Subscriptions_create_handler(UA_Client *client, void *data, UA_UIn
     LIST_INSERT_HEAD(&client->subscriptions, newSub, listEntry);
 
 cleanup:
-    if (cc->userCallback)
+    if(cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
@@ -73,14 +78,14 @@ UA_Client_Subscriptions_create(UA_Client *client,
     UA_CreateSubscriptionResponse_init(&response);
 
     CustomCallback *cc = CustomCallback_new();
-    if (!cc) {
+    if(!cc) {
         response.responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
 
-    UA_StatusCode retval =
-        __Subscriptions_create_prepare(cc, &request, subscriptionContext, statusChangeCallback, deleteCallback);
-    if (retval != UA_STATUSCODE_GOOD) {
+    UA_StatusCode retval = __Subscriptions_create_prepare(
+        cc, &request, subscriptionContext, statusChangeCallback, deleteCallback);
+    if(retval != UA_STATUSCODE_GOOD) {
         response.responseHeader.serviceResult = retval;
         goto cleanup;
     }
@@ -98,29 +103,33 @@ cleanup:
     return response;
 }
 
-UA_StatusCode UA_EXPORT UA_Client_Subscriptions_create_async(
-    UA_Client *client, const UA_CreateSubscriptionRequest request, void *subscriptionContext,
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_create_async(
+    UA_Client *client, const UA_CreateSubscriptionRequest request,
+    void *subscriptionContext,
     UA_Client_StatusChangeNotificationCallback statusChangeCallback,
-    UA_Client_DeleteSubscriptionCallback deleteCallback, UA_ClientAsyncServiceCallback createCallback, void *userdata,
-    UA_UInt32 *requestId) {
+    UA_Client_DeleteSubscriptionCallback deleteCallback,
+    UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     CustomCallback *cc = CustomCallback_new();
-    if (!cc) {
+    if(!cc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
     cc->userCallback = createCallback;
     cc->userData = userdata;
 
-    retval = __Subscriptions_create_prepare(cc, &request, subscriptionContext, statusChangeCallback, deleteCallback);
-    if (retval != UA_STATUSCODE_GOOD) {
+    retval = __Subscriptions_create_prepare(cc, &request, subscriptionContext,
+                                            statusChangeCallback, deleteCallback);
+    if(retval != UA_STATUSCODE_GOOD) {
         goto cleanup;
     }
 
     /* Send the request as asynchronous service call */
-    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONREQUEST],
-                                    __Subscriptions_create_handler, &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONRESPONSE], cc,
-                                    requestId);
+    return __UA_Client_AsyncService(
+        client, &request, &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONREQUEST],
+        __Subscriptions_create_handler, &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONRESPONSE],
+        cc, requestId);
 
 cleanup:
     CustomCallback_remove(cc, false);
@@ -137,7 +146,9 @@ findSubscription(const UA_Client *client, UA_UInt32 subscriptionId) {
     return sub;
 }
 
-static void __Subscriptions_modify_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
+static void
+__Subscriptions_modify_handler(UA_Client *client, void *data, UA_UInt32 requestId,
+                               void *r) {
     UA_ModifySubscriptionResponse *response = (UA_ModifySubscriptionResponse *)r;
     CustomCallback *cc = (CustomCallback *)data;
     UA_Client_Subscription *sub = (UA_Client_Subscription *)cc->clientData;
@@ -145,7 +156,7 @@ static void __Subscriptions_modify_handler(UA_Client *client, void *data, UA_UIn
     sub->publishingInterval = response->revisedPublishingInterval;
     sub->maxKeepAliveCount = response->revisedMaxKeepAliveCount;
 
-    if (cc->userCallback)
+    if(cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
@@ -173,26 +184,28 @@ UA_Client_Subscriptions_modify(UA_Client *client, const UA_ModifySubscriptionReq
     return response;
 }
 
-UA_StatusCode UA_EXPORT UA_Client_Subscriptions_modify_async(UA_Client *client,
-                                                             const UA_ModifySubscriptionRequest request,
-                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
-                                                             UA_UInt32 *requestId) {
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_modify_async(UA_Client *client,
+                                     const UA_ModifySubscriptionRequest request,
+                                     UA_ClientAsyncServiceCallback callback,
+                                     void *userdata, UA_UInt32 *requestId) {
     /* Find the internal representation */
     UA_Client_Subscription *sub = findSubscription(client, request.subscriptionId);
-    if (!sub)
+    if(!sub)
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
 
     CustomCallback *cc = CustomCallback_new();
-    if (!cc)
+    if(!cc)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
     cc->clientData = sub;
     cc->userData = userdata;
     cc->userCallback = callback;
 
-    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONREQUEST],
-                                    __Subscriptions_modify_handler, &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONRESPONSE], cc,
-                                    requestId);
+    return __UA_Client_AsyncService(
+        client, &request, &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONREQUEST],
+        __Subscriptions_modify_handler, &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONRESPONSE],
+        cc, requestId);
 }
 
 static void
@@ -216,42 +229,48 @@ typedef struct {
     UA_Client_Subscription **subs;
 } Subscriptions_DeleteData;
 
-static void __Subscriptions_DeleteData_free(Subscriptions_DeleteData *data) {
-    if (!data)
+static void
+__Subscriptions_DeleteData_free(Subscriptions_DeleteData *data) {
+    if(!data)
         return;
-    if (data->subs)
+    if(data->subs)
         UA_free(data->subs);
-    if (data->request)
+    if(data->request)
         UA_delete(data->request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST]);
     UA_free(data);
 }
 
 static UA_INLINE CustomCallback *
-__Subscriptions_delete_prepare(UA_Client *client, const UA_DeleteSubscriptionsRequest *request, UA_StatusCode *retval) {
+__Subscriptions_delete_prepare(UA_Client *client,
+                               const UA_DeleteSubscriptionsRequest *request,
+                               UA_StatusCode *retval) {
     CustomCallback *cc = CustomCallback_new();
-    if (!cc)
+    if(!cc)
         goto cleanup;
-    Subscriptions_DeleteData *data = (Subscriptions_DeleteData *)UA_calloc(1, sizeof(Subscriptions_DeleteData));
-    if (!data)
+    Subscriptions_DeleteData *data =
+        (Subscriptions_DeleteData *)UA_calloc(1, sizeof(Subscriptions_DeleteData));
+    if(!data)
         goto cleanup;
 
     cc->clientData = data;
-    cc->clientDataDeleter = (CustomCallbackDataDeleter)(uintptr_t)__Subscriptions_DeleteData_free;
+    cc->clientDataDeleter =
+        (CustomCallbackDataDeleter)(uintptr_t)__Subscriptions_DeleteData_free;
 
     data->request = UA_DeleteSubscriptionsRequest_new();
-    if (!data->request)
+    if(!data->request)
         goto cleanup;
-    data->subs = (UA_Client_Subscription **)UA_calloc(request->subscriptionIdsSize, sizeof(UA_Client_Subscription *));
-    if (!data->subs)
+    data->subs = (UA_Client_Subscription **)UA_calloc(request->subscriptionIdsSize,
+                                                      sizeof(UA_Client_Subscription *));
+    if(!data->subs)
         goto cleanup;
 
     /* the async handler needs a copy of the request parameters */
     UA_DeleteSubscriptionsRequest_copy(request, data->request);
 
     /* temporary remove the subscriptions from the list */
-    for (size_t i = 0; i < request->subscriptionIdsSize; i++) {
+    for(size_t i = 0; i < request->subscriptionIdsSize; i++) {
         data->subs[i] = findSubscription(client, request->subscriptionIds[i]);
-        if (data->subs[i])
+        if(data->subs[i])
             LIST_REMOVE(data->subs[i], listEntry);
     }
     *retval = UA_STATUSCODE_GOOD;
@@ -262,25 +281,27 @@ cleanup:
     return NULL;
 }
 
-static void __Subscriptions_delete_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
+static void
+__Subscriptions_delete_handler(UA_Client *client, void *data, UA_UInt32 requestId,
+                               void *r) {
     UA_DeleteSubscriptionsResponse *response = (UA_DeleteSubscriptionsResponse *)r;
     CustomCallback *cc = (CustomCallback *)data;
     Subscriptions_DeleteData *delData = (Subscriptions_DeleteData *)cc->clientData;
     UA_DeleteSubscriptionsRequest *request = delData->request;
     UA_Client_Subscription **subs = delData->subs;
 
-    if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
+    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    if (request->subscriptionIdsSize != response->resultsSize) {
+    if(request->subscriptionIdsSize != response->resultsSize) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         goto cleanup;
     }
 
     /* Loop over the removed subscriptions and remove internally */
-    for (size_t i = 0; i < request->subscriptionIdsSize; i++) {
-        if (response->results[i] != UA_STATUSCODE_GOOD &&
-            response->results[i] != UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID) {
+    for(size_t i = 0; i < request->subscriptionIdsSize; i++) {
+        if(response->results[i] != UA_STATUSCODE_GOOD &&
+           response->results[i] != UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID) {
             /* Something was wrong, reinsert the subscription in the list */
             if (subs[i])
                 LIST_INSERT_HEAD(&client->subscriptions, subs[i], listEntry);
@@ -289,7 +310,8 @@ static void __Subscriptions_delete_handler(UA_Client *client, void *data, UA_UIn
         }
 
         if(!subs[i]) {
-            UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT, "No internal representation of subscription %u",
+            UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
+                        "No internal representation of subscription %u",
                         delData->request->subscriptionIds[i]);
             continue;
         }
@@ -300,42 +322,46 @@ static void __Subscriptions_delete_handler(UA_Client *client, void *data, UA_UIn
     }
 
 cleanup:
-    for (size_t i = 0; i < request->subscriptionIdsSize; i++) {
+    for(size_t i = 0; i < request->subscriptionIdsSize; i++) {
         if (subs[i]) {
             LIST_INSERT_HEAD(&client->subscriptions, subs[i], listEntry);
         }
     }
-    if (cc->userCallback)
+    if(cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
 
-UA_StatusCode UA_EXPORT UA_Client_Subscriptions_delete_async(UA_Client *client,
-                                                             const UA_DeleteSubscriptionsRequest request,
-                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
-                                                             UA_UInt32 *requestId) {
+UA_StatusCode UA_EXPORT
+UA_Client_Subscriptions_delete_async(UA_Client *client,
+                                     const UA_DeleteSubscriptionsRequest request,
+                                     UA_ClientAsyncServiceCallback callback,
+                                     void *userdata, UA_UInt32 *requestId) {
     UA_StatusCode retval;
     CustomCallback *cc = __Subscriptions_delete_prepare(client, &request, &retval);
-    if (retval != UA_STATUSCODE_GOOD)
+    if(retval != UA_STATUSCODE_GOOD)
         return retval;
     cc->userCallback = callback;
     cc->userData = userdata;
 
-    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],
-                                    __Subscriptions_delete_handler, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE], cc,
-                                    requestId);
+    return __UA_Client_AsyncService(
+        client, &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],
+        __Subscriptions_delete_handler, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE],
+        cc, requestId);
 }
 
-UA_DeleteSubscriptionsResponse UA_EXPORT UA_Client_Subscriptions_delete(UA_Client *client,
-                                                                        const UA_DeleteSubscriptionsRequest request) {
+UA_DeleteSubscriptionsResponse UA_EXPORT
+UA_Client_Subscriptions_delete(UA_Client *client,
+                               const UA_DeleteSubscriptionsRequest request) {
     /* Send the request */
     UA_DeleteSubscriptionsResponse response;
-    CustomCallback *cc = __Subscriptions_delete_prepare(client, &request, &response.responseHeader.serviceResult);
-    if (response.responseHeader.serviceResult != UA_STATUSCODE_GOOD)
+    CustomCallback *cc = __Subscriptions_delete_prepare(
+        client, &request, &response.responseHeader.serviceResult);
+    if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         return response;
 
-    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST], &response,
-                        &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE]);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE]);
 
     __Subscriptions_delete_handler(client, cc, 0, &response);
     return response;
@@ -395,16 +421,18 @@ typedef struct {
     UA_CreateMonitoredItemsRequest *request;
 } MonitoredItems_CreateData;
 
-static void MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_Client *client) {
-    if (!data)
+static void
+MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_Client *client) {
+    if(!data)
         return;
 
-    if (data->request && data->mis && data->deleteCallbacks && data->contexts) {
-        for (size_t i = 0; i < data->request->itemsToCreateSize; i++) {
-            if (data->mis[i]) {
-                if (data->deleteCallbacks[i]) {
-                    if (data->sub)
-                        data->deleteCallbacks[i](client, data->sub->subscriptionId, data->sub->context, 0,
+    if(data->request && data->mis && data->deleteCallbacks && data->contexts) {
+        for(size_t i = 0; i < data->request->itemsToCreateSize; i++) {
+            if(data->mis[i]) {
+                if(data->deleteCallbacks[i]) {
+                    if(data->sub)
+                        data->deleteCallbacks[i](client, data->sub->subscriptionId,
+                                                 data->sub->context, 0,
                                                  data->contexts[i]);
                     else
                         data->deleteCallbacks[i](client, 0, NULL, 0, data->contexts[i]);
@@ -414,16 +442,18 @@ static void MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_C
         }
     }
 
-    if (data->asyncData) {
-        if (data->mis)
+    if(data->asyncData) {
+        if(data->mis)
             UA_free(data->mis);
-        if (data->request)
+        if(data->request)
             UA_CreateMonitoredItemsRequest_delete(data->request);
         UA_free(data);
     }
 }
 
-static void __MonitoredItems_create_handler(UA_Client *client, void *d, UA_UInt32 requestId, void *r) {
+static void
+__MonitoredItems_create_handler(UA_Client *client, void *d, UA_UInt32 requestId,
+                                void *r) {
     UA_CreateMonitoredItemsResponse *response = (UA_CreateMonitoredItemsResponse *)r;
     CustomCallback *cc = (CustomCallback *)d;
     MonitoredItems_CreateData *data = (MonitoredItems_CreateData *)cc->clientData;
@@ -440,13 +470,13 @@ static void __MonitoredItems_create_handler(UA_Client *client, void *d, UA_UInt3
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    if (response->resultsSize != request->itemsToCreateSize) {
+    if(response->resultsSize != request->itemsToCreateSize) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         goto cleanup;
     }
 
     /* Add internally */
-    for (size_t i = 0; i < request->itemsToCreateSize; i++) {
+    for(size_t i = 0; i < request->itemsToCreateSize; i++) {
         if(response->results[i].statusCode != UA_STATUSCODE_GOOD) {
             if (deleteCallbacks[i])
                 deleteCallbacks[i](client, sub->subscriptionId, sub->context, 0, contexts[i]);
@@ -472,39 +502,44 @@ static void __MonitoredItems_create_handler(UA_Client *client, void *d, UA_UInt3
         mis[i] = NULL;
     }
 cleanup:
-    if (cc->userCallback)
+    if(cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
 
-static UA_StatusCode MonitoredItems_CreateData_prepare(MonitoredItems_CreateData *data, UA_Client *client) {
+static UA_StatusCode
+MonitoredItems_CreateData_prepare(MonitoredItems_CreateData *data, UA_Client *client) {
     /* Allocate the memory for internal representations */
-    for (size_t i = 0; i < data->request->itemsToCreateSize; i++) {
-        data->mis[i] = (UA_Client_MonitoredItem *)UA_malloc(sizeof(UA_Client_MonitoredItem));
-        if (!data->mis[i]) {
+    for(size_t i = 0; i < data->request->itemsToCreateSize; i++) {
+        data->mis[i] =
+            (UA_Client_MonitoredItem *)UA_malloc(sizeof(UA_Client_MonitoredItem));
+        if(!data->mis[i]) {
             return UA_STATUSCODE_BADOUTOFMEMORY;
         }
     }
 
     /* Set the clientHandle */
-    for (size_t i = 0; i < data->request->itemsToCreateSize; i++)
-        data->request->itemsToCreate[i].requestedParameters.clientHandle = ++(client->monitoredItemHandles);
+    for(size_t i = 0; i < data->request->itemsToCreateSize; i++)
+        data->request->itemsToCreate[i].requestedParameters.clientHandle =
+            ++(client->monitoredItemHandles);
 
     return UA_STATUSCODE_GOOD;
 }
 
-static void __UA_Client_MonitoredItems_create(UA_Client *client, const UA_CreateMonitoredItemsRequest *request,
-                                              void **contexts, void **handlingCallbacks,
-                                              UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
-                                              UA_CreateMonitoredItemsResponse *response) {
+static void
+__UA_Client_MonitoredItems_create(UA_Client *client,
+                                  const UA_CreateMonitoredItemsRequest *request,
+                                  void **contexts, void **handlingCallbacks,
+                                  UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+                                  UA_CreateMonitoredItemsResponse *response) {
     UA_CreateMonitoredItemsResponse_init(response);
 
-    if (!request->itemsToCreateSize) {
+    if(!request->itemsToCreateSize) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         return;
     }
     CustomCallback *cc = CustomCallback_new();
-    if (!cc) {
+    if(!cc) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return;
     }
@@ -523,24 +558,25 @@ static void __UA_Client_MonitoredItems_create(UA_Client *client, const UA_Create
     data.mis = mis;
 
     cc->clientData = &data;
-    cc->clientDataDeleter = (CustomCallbackDataDeleter)(uintptr_t)MonitoredItems_CreateData_free;
+    cc->clientDataDeleter =
+        (CustomCallbackDataDeleter)(uintptr_t)MonitoredItems_CreateData_free;
 
     /* Get the subscription */
     data.sub = findSubscription(client, request->subscriptionId);
-    if (!data.sub) {
+    if(!data.sub) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         goto cleanup;
     }
 
     UA_StatusCode retval = MonitoredItems_CreateData_prepare(&data, client);
-    if (retval != UA_STATUSCODE_GOOD) {
+    if(retval != UA_STATUSCODE_GOOD) {
         response->responseHeader.serviceResult = retval;
         goto cleanup;
     }
 
     /* Call the service */
-    __UA_Client_Service(client, request, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST], response,
-                        &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE]);
+    __UA_Client_Service(client, request, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST],
+                        response, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE]);
 
     __MonitoredItems_create_handler(client, cc, 0, response);
     return;
@@ -548,66 +584,75 @@ cleanup:
     CustomCallback_remove(cc, false);
 }
 
-static UA_StatusCode __UA_Client_MonitoredItems_createDataChanges_async(
-    UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts, void **callbacks,
-    UA_Client_DeleteMonitoredItemCallback *deleteCallbacks, UA_ClientAsyncServiceCallback createCallback,
-    void *userdata, UA_UInt32 *requestId) {
+static UA_StatusCode
+__UA_Client_MonitoredItems_createDataChanges_async(
+    UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
+    void **callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     CustomCallback *cc = CustomCallback_new();
-    if (!cc) {
+    if(!cc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
     cc->userCallback = createCallback;
     cc->userData = userdata;
-    MonitoredItems_CreateData *data = (MonitoredItems_CreateData *)UA_malloc(sizeof(MonitoredItems_CreateData));
-    if (!data) {
+    MonitoredItems_CreateData *data =
+        (MonitoredItems_CreateData *)UA_malloc(sizeof(MonitoredItems_CreateData));
+    if(!data) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
     memset(data, 0, sizeof(MonitoredItems_CreateData));
     data->asyncData = true;
     cc->clientData = data;
-    cc->clientDataDeleter = (CustomCallbackDataDeleter)(uintptr_t)MonitoredItems_CreateData_free;
+    cc->clientDataDeleter =
+        (CustomCallbackDataDeleter)(uintptr_t)MonitoredItems_CreateData_free;
 
     data->sub = findSubscription(client, request.subscriptionId);
-    if (!data->sub) {
+    if(!data->sub) {
         retval = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         goto cleanup;
     }
 
     /* create a big array that holds the monitored items and parameters */
     void **array = (void **)UA_calloc(4 * request.itemsToCreateSize, sizeof(void *));
-    if (!array) {
+    if(!array) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
     data->mis = (UA_Client_MonitoredItem **)array;
-    data->contexts = (void **)((uintptr_t)array + (sizeof(void *) * request.itemsToCreateSize));
+    data->contexts =
+        (void **)((uintptr_t)array + (sizeof(void *) * request.itemsToCreateSize));
     memcpy(data->contexts, contexts, request.itemsToCreateSize * sizeof(void *));
     data->deleteCallbacks =
-        (UA_Client_DeleteMonitoredItemCallback *)((uintptr_t)array + (2 * request.itemsToCreateSize * sizeof(void *)));
+        (UA_Client_DeleteMonitoredItemCallback *)((uintptr_t)array +
+                                                  (2 * request.itemsToCreateSize *
+                                                   sizeof(void *)));
     memcpy(data->deleteCallbacks, deleteCallbacks,
            request.itemsToCreateSize * sizeof(UA_Client_DeleteMonitoredItemCallback));
-    data->handlingCallbacks = (void **)((uintptr_t)array + (3 * request.itemsToCreateSize * sizeof(void *)));
-    memcpy(data->handlingCallbacks, callbacks, request.itemsToCreateSize * sizeof(void *));
+    data->handlingCallbacks =
+        (void **)((uintptr_t)array + (3 * request.itemsToCreateSize * sizeof(void *)));
+    memcpy(data->handlingCallbacks, callbacks,
+           request.itemsToCreateSize * sizeof(void *));
 
     data->request = UA_CreateMonitoredItemsRequest_new();
-    if (!data->request) {
+    if(!data->request) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
     retval = UA_CreateMonitoredItemsRequest_copy(&request, data->request);
-    if (retval != UA_STATUSCODE_GOOD)
+    if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 
     retval = MonitoredItems_CreateData_prepare(data, client);
-    if (retval != UA_STATUSCODE_GOOD)
+    if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    return __UA_Client_AsyncService(client, data->request, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST],
-                                    __MonitoredItems_create_handler, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE],
-                                    cc, requestId);
+    return __UA_Client_AsyncService(
+        client, data->request, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST],
+        __MonitoredItems_create_handler, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE],
+        cc, requestId);
 cleanup:
     CustomCallback_remove(cc, false);
     return retval;
@@ -624,12 +669,15 @@ UA_Client_MonitoredItems_createDataChanges(UA_Client *client,
     return response;
 }
 
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createDataChanges_async(
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_createDataChanges_async(
     UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
-    UA_Client_DataChangeNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_Client_DataChangeNotificationCallback *callbacks,
+    UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
     UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_MonitoredItems_createDataChanges_async(client, request, contexts, (void **)(uintptr_t)callbacks,
-                                                              deleteCallbacks, createCallback, userdata, requestId);
+    return __UA_Client_MonitoredItems_createDataChanges_async(
+        client, request, contexts, (void **)(uintptr_t)callbacks, deleteCallbacks,
+        createCallback, userdata, requestId);
 }
 
 UA_MonitoredItemCreateResult UA_EXPORT
@@ -673,12 +721,15 @@ UA_Client_MonitoredItems_createEvents(UA_Client *client,
 }
 
 /* Monitor the EventNotifier attribute only */
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createEvents_async(
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_createEvents_async(
     UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
-    UA_Client_EventNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_Client_EventNotificationCallback *callbacks,
+    UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
     UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_MonitoredItems_createDataChanges_async(client, request, contexts, (void **)(uintptr_t)callbacks,
-                                                              deleteCallbacks, createCallback, userdata, requestId);
+    return __UA_Client_MonitoredItems_createDataChanges_async(
+        client, request, contexts, (void **)(uintptr_t)callbacks, deleteCallbacks,
+        createCallback, userdata, requestId);
 }
 
 UA_MonitoredItemCreateResult UA_EXPORT
@@ -708,24 +759,28 @@ UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId
     return result;
 }
 
-static void __MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt32 requestId, void *r) {
+static void
+__MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt32 requestId,
+                                void *r) {
     UA_DeleteMonitoredItemsResponse *response = (UA_DeleteMonitoredItemsResponse *)r;
     CustomCallback *cc = (CustomCallback *)d;
-    UA_DeleteMonitoredItemsRequest *request = (UA_DeleteMonitoredItemsRequest *)cc->clientData;
-    if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
+    UA_DeleteMonitoredItemsRequest *request =
+        (UA_DeleteMonitoredItemsRequest *)cc->clientData;
+    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         goto cleanup;
 
     UA_Client_Subscription *sub = findSubscription(client, request->subscriptionId);
     if(!sub) {
-        UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT, "No internal representation of subscription %u",
+        UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
+                    "No internal representation of subscription %u",
                     request->subscriptionId);
         goto cleanup;
     }
 
     /* Loop over deleted MonitoredItems */
-    for (size_t i = 0; i < response->resultsSize; i++) {
-        if (response->results[i] != UA_STATUSCODE_GOOD &&
-            response->results[i] != UA_STATUSCODE_BADMONITOREDITEMIDINVALID) {
+    for(size_t i = 0; i < response->resultsSize; i++) {
+        if(response->results[i] != UA_STATUSCODE_GOOD &&
+           response->results[i] != UA_STATUSCODE_BADMONITOREDITEMIDINVALID) {
             continue;
         }
 
@@ -734,7 +789,7 @@ static void __MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt3
         UA_Client_MonitoredItem *mon;
         LIST_FOREACH(mon, &sub->monitoredItems, listEntry) {
             // NOLINTNEXTLINE
-            if (mon->monitoredItemId == request->monitoredItemIds[i]) {
+            if(mon->monitoredItemId == request->monitoredItemIds[i]) {
                 UA_Client_MonitoredItem_remove(client, sub, mon);
                 break;
             }
@@ -742,56 +797,61 @@ static void __MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt3
 #endif
     }
 cleanup:
-    if (cc->userCallback)
+    if(cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
 
 UA_DeleteMonitoredItemsResponse UA_EXPORT
-UA_Client_MonitoredItems_delete(UA_Client *client, const UA_DeleteMonitoredItemsRequest request) {
+UA_Client_MonitoredItems_delete(UA_Client *client,
+                                const UA_DeleteMonitoredItemsRequest request) {
     /* Send the request */
     UA_DeleteMonitoredItemsResponse response;
     CustomCallback *cc = CustomCallback_new();
-    if (!cc) {
+    if(!cc) {
         response.responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return response;
     }
     cc->clientData = (void *)(uintptr_t)&request;
 
-    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST], &response,
-                        &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE]);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE]);
 
     __MonitoredItems_delete_handler(client, cc, 0, &response);
     return response;
 }
 
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_delete_async(UA_Client *client,
-                                                              const UA_DeleteMonitoredItemsRequest request,
-                                                              UA_ClientAsyncServiceCallback callback, void *userdata,
-                                                              UA_UInt32 *requestId) {
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_delete_async(UA_Client *client,
+                                      const UA_DeleteMonitoredItemsRequest request,
+                                      UA_ClientAsyncServiceCallback callback,
+                                      void *userdata, UA_UInt32 *requestId) {
     /* Send the request */
     CustomCallback *cc = CustomCallback_new();
-    if (!cc)
+    if(!cc)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
     UA_DeleteMonitoredItemsRequest *req_copy = UA_DeleteMonitoredItemsRequest_new();
-    if (!req_copy) {
+    if(!req_copy) {
         UA_free(cc);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     UA_DeleteMonitoredItemsRequest_copy(&request, req_copy);
     cc->clientData = req_copy;
-    cc->clientDataDeleter = (CustomCallbackDataDeleter)(uintptr_t)UA_DeleteMonitoredItemsRequest_delete;
+    cc->clientDataDeleter =
+        (CustomCallbackDataDeleter)(uintptr_t)UA_DeleteMonitoredItemsRequest_delete;
     cc->userCallback = callback;
     cc->userData = userdata;
 
-    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST],
-                                    __MonitoredItems_delete_handler, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE],
-                                    cc, requestId);
+    return __UA_Client_AsyncService(
+        client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST],
+        __MonitoredItems_delete_handler, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE],
+        cc, requestId);
 }
 
-UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId,
-                                                              UA_UInt32 monitoredItemId) {
+UA_StatusCode UA_EXPORT
+UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId,
+                                      UA_UInt32 monitoredItemId) {
     UA_DeleteMonitoredItemsRequest request;
     UA_DeleteMonitoredItemsRequest_init(&request);
     request.subscriptionId = subscriptionId;

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -22,16 +22,14 @@
 /* Subscriptions */
 /*****************/
 
-static UA_StatusCode
-__Subscriptions_create_prepare(CustomCallback *cc,
-                               const UA_CreateSubscriptionRequest *request,
-                               void *subscriptionContext,
-                               UA_Client_StatusChangeNotificationCallback statusChangeCallback,
-                               UA_Client_DeleteSubscriptionCallback deleteCallback) {
-    UA_Client_Subscription *sub = (UA_Client_Subscription *)
-        (cc->clientData = UA_malloc(sizeof(UA_Client_Subscription)));
+static UA_StatusCode __Subscriptions_create_prepare(CustomCallback *cc, const UA_CreateSubscriptionRequest *request,
+                                                    void *subscriptionContext,
+                                                    UA_Client_StatusChangeNotificationCallback statusChangeCallback,
+                                                    UA_Client_DeleteSubscriptionCallback deleteCallback) {
+    UA_Client_Subscription *sub =
+        (UA_Client_Subscription *)(cc->clientData = UA_malloc(sizeof(UA_Client_Subscription)));
     cc->clientDataDeleter = UA_free;
-    if(!sub)
+    if (!sub)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     sub->context = subscriptionContext;
     sub->statusChangeCallback = statusChangeCallback;
@@ -39,11 +37,10 @@ __Subscriptions_create_prepare(CustomCallback *cc,
     return UA_STATUSCODE_GOOD;
 }
 
-static void
-__Subscriptions_create_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
+static void __Subscriptions_create_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
     UA_CreateSubscriptionResponse *response = (UA_CreateSubscriptionResponse *)r;
     CustomCallback *cc = (CustomCallback *)data;
-    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+    if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         goto cleanup;
     }
 
@@ -60,8 +57,8 @@ __Subscriptions_create_handler(UA_Client *client, void *data, UA_UInt32 requestI
     LIST_INIT(&newSub->monitoredItems);
     LIST_INSERT_HEAD(&client->subscriptions, newSub, listEntry);
 
-  cleanup:
-    if(cc->userCallback)
+cleanup:
+    if (cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
@@ -82,8 +79,7 @@ UA_Client_Subscriptions_create(UA_Client *client,
     }
 
     UA_StatusCode retval =
-        __Subscriptions_create_prepare(cc, &request, subscriptionContext,
-                                       statusChangeCallback, deleteCallback);
+        __Subscriptions_create_prepare(cc, &request, subscriptionContext, statusChangeCallback, deleteCallback);
     if (retval != UA_STATUSCODE_GOOD) {
         response.responseHeader.serviceResult = retval;
         goto cleanup;
@@ -97,19 +93,16 @@ UA_Client_Subscriptions_create(UA_Client *client,
     __Subscriptions_create_handler(client, cc, 0, &response);
 
     return response;
-  cleanup:
+cleanup:
     CustomCallback_remove(cc, false);
     return response;
 }
 
-UA_StatusCode UA_EXPORT
-UA_Client_Subscriptions_create_async(UA_Client *client,
-                                     const UA_CreateSubscriptionRequest request,
-                                     void *subscriptionContext,
-                                     UA_Client_StatusChangeNotificationCallback statusChangeCallback,
-                                     UA_Client_DeleteSubscriptionCallback deleteCallback,
-                                     UA_ClientAsyncServiceCallback createCallback,
-                                     void *userdata, UA_UInt32 *requestId) {
+UA_StatusCode UA_EXPORT UA_Client_Subscriptions_create_async(
+    UA_Client *client, const UA_CreateSubscriptionRequest request, void *subscriptionContext,
+    UA_Client_StatusChangeNotificationCallback statusChangeCallback,
+    UA_Client_DeleteSubscriptionCallback deleteCallback, UA_ClientAsyncServiceCallback createCallback, void *userdata,
+    UA_UInt32 *requestId) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     CustomCallback *cc = CustomCallback_new();
     if (!cc) {
@@ -119,20 +112,17 @@ UA_Client_Subscriptions_create_async(UA_Client *client,
     cc->userCallback = createCallback;
     cc->userData = userdata;
 
-    retval = __Subscriptions_create_prepare(cc, &request, subscriptionContext,
-                                            statusChangeCallback, deleteCallback);
+    retval = __Subscriptions_create_prepare(cc, &request, subscriptionContext, statusChangeCallback, deleteCallback);
     if (retval != UA_STATUSCODE_GOOD) {
         goto cleanup;
     }
 
     /* Send the request as asynchronous service call */
-    return __UA_Client_AsyncService(client, &request,
-                                    &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONREQUEST],
-                                    __Subscriptions_create_handler,
-                                    &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONRESPONSE],
-                                    cc, requestId);
+    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONREQUEST],
+                                    __Subscriptions_create_handler, &UA_TYPES[UA_TYPES_CREATESUBSCRIPTIONRESPONSE], cc,
+                                    requestId);
 
-  cleanup:
+cleanup:
     CustomCallback_remove(cc, false);
     return retval;
 }
@@ -147,8 +137,7 @@ findSubscription(const UA_Client *client, UA_UInt32 subscriptionId) {
     return sub;
 }
 
-static void
-__Subscriptions_modify_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
+static void __Subscriptions_modify_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
     UA_ModifySubscriptionResponse *response = (UA_ModifySubscriptionResponse *)r;
     CustomCallback *cc = (CustomCallback *)data;
     UA_Client_Subscription *sub = (UA_Client_Subscription *)cc->clientData;
@@ -156,7 +145,7 @@ __Subscriptions_modify_handler(UA_Client *client, void *data, UA_UInt32 requestI
     sub->publishingInterval = response->revisedPublishingInterval;
     sub->maxKeepAliveCount = response->revisedMaxKeepAliveCount;
 
-    if(cc->userCallback)
+    if (cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
@@ -184,13 +173,13 @@ UA_Client_Subscriptions_modify(UA_Client *client, const UA_ModifySubscriptionReq
     return response;
 }
 
-UA_StatusCode UA_EXPORT
-UA_Client_Subscriptions_modify_async(UA_Client *client, const UA_ModifySubscriptionRequest request,
-                                     UA_ClientAsyncServiceCallback callback, void *userdata,
-                                     UA_UInt32 *requestId) {
+UA_StatusCode UA_EXPORT UA_Client_Subscriptions_modify_async(UA_Client *client,
+                                                             const UA_ModifySubscriptionRequest request,
+                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
+                                                             UA_UInt32 *requestId) {
     /* Find the internal representation */
     UA_Client_Subscription *sub = findSubscription(client, request.subscriptionId);
-    if(!sub)
+    if (!sub)
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
 
     CustomCallback *cc = CustomCallback_new();
@@ -201,11 +190,9 @@ UA_Client_Subscriptions_modify_async(UA_Client *client, const UA_ModifySubscript
     cc->userData = userdata;
     cc->userCallback = callback;
 
-    return __UA_Client_AsyncService(client, &request,
-                                    &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONREQUEST],
-                                    __Subscriptions_modify_handler,
-                                    &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONRESPONSE],
-                                    cc, requestId);
+    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONREQUEST],
+                                    __Subscriptions_modify_handler, &UA_TYPES[UA_TYPES_MODIFYSUBSCRIPTIONRESPONSE], cc,
+                                    requestId);
 }
 
 static void
@@ -229,8 +216,7 @@ typedef struct {
     UA_Client_Subscription **subs;
 } Subscriptions_DeleteData;
 
-static void
-__Subscriptions_DeleteData_free(Subscriptions_DeleteData *data) {
+static void __Subscriptions_DeleteData_free(Subscriptions_DeleteData *data) {
     if (!data)
         return;
     if (data->subs)
@@ -241,65 +227,60 @@ __Subscriptions_DeleteData_free(Subscriptions_DeleteData *data) {
 }
 
 static UA_INLINE CustomCallback *
-__Subscriptions_delete_prepare(UA_Client *client,
-                               const UA_DeleteSubscriptionsRequest *request,
-                               UA_StatusCode *retval) {
+__Subscriptions_delete_prepare(UA_Client *client, const UA_DeleteSubscriptionsRequest *request, UA_StatusCode *retval) {
     CustomCallback *cc = CustomCallback_new();
     if (!cc)
         goto cleanup;
-    Subscriptions_DeleteData *data =
-        (Subscriptions_DeleteData *)UA_calloc(1, sizeof(Subscriptions_DeleteData));
+    Subscriptions_DeleteData *data = (Subscriptions_DeleteData *)UA_calloc(1, sizeof(Subscriptions_DeleteData));
     if (!data)
         goto cleanup;
 
     cc->clientData = data;
-    cc->clientDataDeleter = (CustomCallbackDataDeleter) (uintptr_t) __Subscriptions_DeleteData_free;
+    cc->clientDataDeleter = (CustomCallbackDataDeleter)(uintptr_t)__Subscriptions_DeleteData_free;
 
     data->request = UA_DeleteSubscriptionsRequest_new();
     if (!data->request)
         goto cleanup;
-    data->subs = (UA_Client_Subscription **)
-        UA_calloc(request->subscriptionIdsSize, sizeof(UA_Client_Subscription*));
-    if(!data->subs)
+    data->subs = (UA_Client_Subscription **)UA_calloc(request->subscriptionIdsSize, sizeof(UA_Client_Subscription *));
+    if (!data->subs)
         goto cleanup;
 
     /* the async handler needs a copy of the request parameters */
     UA_DeleteSubscriptionsRequest_copy(request, data->request);
 
     /* temporary remove the subscriptions from the list */
-    for(size_t i = 0; i < request->subscriptionIdsSize; i++) {
+    for (size_t i = 0; i < request->subscriptionIdsSize; i++) {
         data->subs[i] = findSubscription(client, request->subscriptionIds[i]);
         if (data->subs[i])
             LIST_REMOVE(data->subs[i], listEntry);
     }
     *retval = UA_STATUSCODE_GOOD;
     return cc;
-  cleanup:
+cleanup:
     *retval = UA_STATUSCODE_BADOUTOFMEMORY;
     CustomCallback_remove(cc, false);
     return NULL;
 }
 
-static void
-__Subscriptions_delete_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
+static void __Subscriptions_delete_handler(UA_Client *client, void *data, UA_UInt32 requestId, void *r) {
     UA_DeleteSubscriptionsResponse *response = (UA_DeleteSubscriptionsResponse *)r;
     CustomCallback *cc = (CustomCallback *)data;
     Subscriptions_DeleteData *delData = (Subscriptions_DeleteData *)cc->clientData;
     UA_DeleteSubscriptionsRequest *request = delData->request;
     UA_Client_Subscription **subs = delData->subs;
 
-    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
+    if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    if(request->subscriptionIdsSize != response->resultsSize) {
+    if (request->subscriptionIdsSize != response->resultsSize) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         goto cleanup;
     }
 
     /* Loop over the removed subscriptions and remove internally */
-    for(size_t i = 0; i < request->subscriptionIdsSize; i++) {
-        if(response->results[i] != UA_STATUSCODE_GOOD &&
-           response->results[i] != UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID) {
+    for (size_t i = 0; i < request->subscriptionIdsSize; i++) {
+        if (response->results[i] != UA_STATUSCODE_GOOD &&
+            response->results[i] != UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID) {
             /* Something was wrong, reinsert the subscription in the list */
             if (subs[i])
                 LIST_INSERT_HEAD(&client->subscriptions, subs[i], listEntry);
@@ -308,8 +289,7 @@ __Subscriptions_delete_handler(UA_Client *client, void *data, UA_UInt32 requestI
         }
 
         if(!subs[i]) {
-            UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
-                        "No internal representation of subscription %u",
+            UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT, "No internal representation of subscription %u",
                         delData->request->subscriptionIds[i]);
             continue;
         }
@@ -320,21 +300,20 @@ __Subscriptions_delete_handler(UA_Client *client, void *data, UA_UInt32 requestI
     }
 
 cleanup:
-    for(size_t i = 0; i < request->subscriptionIdsSize; i++) {
+    for (size_t i = 0; i < request->subscriptionIdsSize; i++) {
         if (subs[i]) {
             LIST_INSERT_HEAD(&client->subscriptions, subs[i], listEntry);
         }
     }
-    if(cc->userCallback)
+    if (cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
 
-UA_StatusCode UA_EXPORT
-UA_Client_Subscriptions_delete_async(UA_Client *client,
-                                     const UA_DeleteSubscriptionsRequest request,
-                                     UA_ClientAsyncServiceCallback callback, void *userdata,
-                                     UA_UInt32 *requestId) {
+UA_StatusCode UA_EXPORT UA_Client_Subscriptions_delete_async(UA_Client *client,
+                                                             const UA_DeleteSubscriptionsRequest request,
+                                                             UA_ClientAsyncServiceCallback callback, void *userdata,
+                                                             UA_UInt32 *requestId) {
     UA_StatusCode retval;
     CustomCallback *cc = __Subscriptions_delete_prepare(client, &request, &retval);
     if (retval != UA_STATUSCODE_GOOD)
@@ -342,25 +321,21 @@ UA_Client_Subscriptions_delete_async(UA_Client *client,
     cc->userCallback = callback;
     cc->userData = userdata;
 
-    return __UA_Client_AsyncService(client, &request,
-                                    &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],
-                                    __Subscriptions_delete_handler,
-                                    &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE],
-                                    cc, requestId);
+    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],
+                                    __Subscriptions_delete_handler, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE], cc,
+                                    requestId);
 }
 
-UA_DeleteSubscriptionsResponse UA_EXPORT
-UA_Client_Subscriptions_delete(UA_Client *client, const UA_DeleteSubscriptionsRequest request) {
+UA_DeleteSubscriptionsResponse UA_EXPORT UA_Client_Subscriptions_delete(UA_Client *client,
+                                                                        const UA_DeleteSubscriptionsRequest request) {
     /* Send the request */
     UA_DeleteSubscriptionsResponse response;
-    CustomCallback *cc =
-        __Subscriptions_delete_prepare(client, &request, &response.responseHeader.serviceResult);
+    CustomCallback *cc = __Subscriptions_delete_prepare(client, &request, &response.responseHeader.serviceResult);
     if (response.responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         return response;
 
-    __UA_Client_Service(client,
-                        &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],
-                        &response, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE]);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST], &response,
+                        &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE]);
 
     __Subscriptions_delete_handler(client, cc, 0, &response);
     return response;
@@ -420,18 +395,17 @@ typedef struct {
     UA_CreateMonitoredItemsRequest *request;
 } MonitoredItems_CreateData;
 
-static void
-MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_Client *client) {
+static void MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_Client *client) {
     if (!data)
         return;
 
     if (data->request && data->mis && data->deleteCallbacks && data->contexts) {
-        for(size_t i = 0; i < data->request->itemsToCreateSize; i++) {
+        for (size_t i = 0; i < data->request->itemsToCreateSize; i++) {
             if (data->mis[i]) {
                 if (data->deleteCallbacks[i]) {
-                    if(data->sub)
-                        data->deleteCallbacks[i](client, data->sub->subscriptionId,
-                                                 data->sub->context, 0, data->contexts[i]);
+                    if (data->sub)
+                        data->deleteCallbacks[i](client, data->sub->subscriptionId, data->sub->context, 0,
+                                                 data->contexts[i]);
                     else
                         data->deleteCallbacks[i](client, 0, NULL, 0, data->contexts[i]);
                 }
@@ -440,7 +414,7 @@ MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_Client *clien
         }
     }
 
-    if(data->asyncData) {
+    if (data->asyncData) {
         if (data->mis)
             UA_free(data->mis);
         if (data->request)
@@ -449,9 +423,7 @@ MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_Client *clien
     }
 }
 
-static void
-__MonitoredItems_create_handler(UA_Client *client, void *d,
-                                UA_UInt32 requestId, void *r) {
+static void __MonitoredItems_create_handler(UA_Client *client, void *d, UA_UInt32 requestId, void *r) {
     UA_CreateMonitoredItemsResponse *response = (UA_CreateMonitoredItemsResponse *)r;
     CustomCallback *cc = (CustomCallback *)d;
     MonitoredItems_CreateData *data = (MonitoredItems_CreateData *)cc->clientData;
@@ -468,13 +440,13 @@ __MonitoredItems_create_handler(UA_Client *client, void *d,
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    if(response->resultsSize != request->itemsToCreateSize) {
+    if (response->resultsSize != request->itemsToCreateSize) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         goto cleanup;
     }
 
     /* Add internally */
-    for(size_t i = 0; i < request->itemsToCreateSize; i++) {
+    for (size_t i = 0; i < request->itemsToCreateSize; i++) {
         if(response->results[i].statusCode != UA_STATUSCODE_GOOD) {
             if (deleteCallbacks[i])
                 deleteCallbacks[i](client, sub->subscriptionId, sub->context, 0, contexts[i]);
@@ -499,38 +471,32 @@ __MonitoredItems_create_handler(UA_Client *client, void *d,
                      sub->subscriptionId, newMon->clientHandle);
         mis[i] = NULL;
     }
- cleanup:
+cleanup:
     if (cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
 }
 
-static UA_StatusCode
-MonitoredItems_CreateData_prepare(MonitoredItems_CreateData *data, UA_Client *client)
-{
+static UA_StatusCode MonitoredItems_CreateData_prepare(MonitoredItems_CreateData *data, UA_Client *client) {
     /* Allocate the memory for internal representations */
-    for(size_t i = 0; i < data->request->itemsToCreateSize; i++) {
-        data->mis[i] = (UA_Client_MonitoredItem*)UA_malloc(sizeof(UA_Client_MonitoredItem));
-        if(!data->mis[i]) {
+    for (size_t i = 0; i < data->request->itemsToCreateSize; i++) {
+        data->mis[i] = (UA_Client_MonitoredItem *)UA_malloc(sizeof(UA_Client_MonitoredItem));
+        if (!data->mis[i]) {
             return UA_STATUSCODE_BADOUTOFMEMORY;
         }
     }
 
     /* Set the clientHandle */
-    for(size_t i = 0; i < data->request->itemsToCreateSize; i++)
-        data->request->itemsToCreate[i].requestedParameters.clientHandle =
-            ++(client->monitoredItemHandles);
+    for (size_t i = 0; i < data->request->itemsToCreateSize; i++)
+        data->request->itemsToCreate[i].requestedParameters.clientHandle = ++(client->monitoredItemHandles);
 
     return UA_STATUSCODE_GOOD;
 }
 
-static void
-__UA_Client_MonitoredItems_create(UA_Client *client,
-                                  const UA_CreateMonitoredItemsRequest *request,
-                                  void **contexts,
-                                  void **handlingCallbacks,
-                                  UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
-                                  UA_CreateMonitoredItemsResponse *response) {
+static void __UA_Client_MonitoredItems_create(UA_Client *client, const UA_CreateMonitoredItemsRequest *request,
+                                              void **contexts, void **handlingCallbacks,
+                                              UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+                                              UA_CreateMonitoredItemsResponse *response) {
     UA_CreateMonitoredItemsResponse_init(response);
 
     if (!request->itemsToCreateSize) {
@@ -538,15 +504,15 @@ __UA_Client_MonitoredItems_create(UA_Client *client,
         return;
     }
     CustomCallback *cc = CustomCallback_new();
-    if(!cc) {
+    if (!cc) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return;
     }
 
     /* Fix clang warning */
     size_t itemsToCreateSize = request->itemsToCreateSize;
-    UA_STACKARRAY(UA_Client_MonitoredItem*, mis, itemsToCreateSize);
-    memset(mis, 0, sizeof(void*) * itemsToCreateSize);
+    UA_STACKARRAY(UA_Client_MonitoredItem *, mis, itemsToCreateSize);
+    memset(mis, 0, sizeof(void *) * itemsToCreateSize);
 
     MonitoredItems_CreateData data;
     memset(&data, 0, sizeof(MonitoredItems_CreateData));
@@ -561,7 +527,7 @@ __UA_Client_MonitoredItems_create(UA_Client *client,
 
     /* Get the subscription */
     data.sub = findSubscription(client, request->subscriptionId);
-    if(!data.sub) {
+    if (!data.sub) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         goto cleanup;
     }
@@ -573,33 +539,29 @@ __UA_Client_MonitoredItems_create(UA_Client *client,
     }
 
     /* Call the service */
-    __UA_Client_Service(client, request, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST],
-                        response, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE]);
+    __UA_Client_Service(client, request, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST], response,
+                        &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE]);
 
     __MonitoredItems_create_handler(client, cc, 0, response);
     return;
-  cleanup:
+cleanup:
     CustomCallback_remove(cc, false);
 }
 
-static UA_StatusCode
-__UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
-            const UA_CreateMonitoredItemsRequest request, void **contexts,
-            void **callbacks,
-            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
-            UA_ClientAsyncServiceCallback createCallback,
-            void *userdata, UA_UInt32 *requestId) {
+static UA_StatusCode __UA_Client_MonitoredItems_createDataChanges_async(
+    UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts, void **callbacks,
+    UA_Client_DeleteMonitoredItemCallback *deleteCallbacks, UA_ClientAsyncServiceCallback createCallback,
+    void *userdata, UA_UInt32 *requestId) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     CustomCallback *cc = CustomCallback_new();
-    if(!cc) {
+    if (!cc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
     cc->userCallback = createCallback;
     cc->userData = userdata;
-    MonitoredItems_CreateData *data =
-        (MonitoredItems_CreateData *)UA_malloc(sizeof(MonitoredItems_CreateData));
-    if(!data) {
+    MonitoredItems_CreateData *data = (MonitoredItems_CreateData *)UA_malloc(sizeof(MonitoredItems_CreateData));
+    if (!data) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
@@ -609,29 +571,29 @@ __UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
     cc->clientDataDeleter = (CustomCallbackDataDeleter)(uintptr_t)MonitoredItems_CreateData_free;
 
     data->sub = findSubscription(client, request.subscriptionId);
-    if(!data->sub) {
+    if (!data->sub) {
         retval = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         goto cleanup;
     }
 
     /* create a big array that holds the monitored items and parameters */
-    void **array = (void**)UA_calloc(4 * request.itemsToCreateSize, sizeof(void*));
-    if(!array) {
+    void **array = (void **)UA_calloc(4 * request.itemsToCreateSize, sizeof(void *));
+    if (!array) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
     data->mis = (UA_Client_MonitoredItem **)array;
-    data->contexts = (void **) ((uintptr_t) array + (sizeof(void*) * request.itemsToCreateSize));
-    memcpy(data->contexts, contexts, request.itemsToCreateSize * sizeof(void*));
-    data->deleteCallbacks = (UA_Client_DeleteMonitoredItemCallback *)
-      ((uintptr_t) array + (2 * request.itemsToCreateSize * sizeof(void*)));
+    data->contexts = (void **)((uintptr_t)array + (sizeof(void *) * request.itemsToCreateSize));
+    memcpy(data->contexts, contexts, request.itemsToCreateSize * sizeof(void *));
+    data->deleteCallbacks =
+        (UA_Client_DeleteMonitoredItemCallback *)((uintptr_t)array + (2 * request.itemsToCreateSize * sizeof(void *)));
     memcpy(data->deleteCallbacks, deleteCallbacks,
            request.itemsToCreateSize * sizeof(UA_Client_DeleteMonitoredItemCallback));
-    data->handlingCallbacks = (void **) ((uintptr_t) array + (3 * request.itemsToCreateSize * sizeof(void*)));
-    memcpy(data->handlingCallbacks, callbacks, request.itemsToCreateSize * sizeof(void*));
+    data->handlingCallbacks = (void **)((uintptr_t)array + (3 * request.itemsToCreateSize * sizeof(void *)));
+    memcpy(data->handlingCallbacks, callbacks, request.itemsToCreateSize * sizeof(void *));
 
     data->request = UA_CreateMonitoredItemsRequest_new();
-    if(!data->request) {
+    if (!data->request) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }
@@ -640,15 +602,13 @@ __UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
         goto cleanup;
 
     retval = MonitoredItems_CreateData_prepare(data, client);
-    if(retval != UA_STATUSCODE_GOOD)
+    if (retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    return __UA_Client_AsyncService(client, data->request,
-                                    &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST],
-                                    __MonitoredItems_create_handler,
-                                    &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE],
+    return __UA_Client_AsyncService(client, data->request, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSREQUEST],
+                                    __MonitoredItems_create_handler, &UA_TYPES[UA_TYPES_CREATEMONITOREDITEMSRESPONSE],
                                     cc, requestId);
-  cleanup:
+cleanup:
     CustomCallback_remove(cc, false);
     return retval;
 }
@@ -664,16 +624,12 @@ UA_Client_MonitoredItems_createDataChanges(UA_Client *client,
     return response;
 }
 
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
-            const UA_CreateMonitoredItemsRequest request, void **contexts,
-            UA_Client_DataChangeNotificationCallback *callbacks,
-            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
-            UA_ClientAsyncServiceCallback createCallback,
-            void *userdata, UA_UInt32 *requestId) {
-    return __UA_Client_MonitoredItems_createDataChanges_async(
-            client, request, contexts, (void**)(uintptr_t) callbacks,
-            deleteCallbacks, createCallback, userdata, requestId);
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createDataChanges_async(
+    UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
+    UA_Client_DataChangeNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_MonitoredItems_createDataChanges_async(client, request, contexts, (void **)(uintptr_t)callbacks,
+                                                              deleteCallbacks, createCallback, userdata, requestId);
 }
 
 UA_MonitoredItemCreateResult UA_EXPORT
@@ -717,17 +673,12 @@ UA_Client_MonitoredItems_createEvents(UA_Client *client,
 }
 
 /* Monitor the EventNotifier attribute only */
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_createEvents_async(UA_Client *client,
-            const UA_CreateMonitoredItemsRequest request, void **contexts,
-            UA_Client_EventNotificationCallback *callbacks,
-            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
-            UA_ClientAsyncServiceCallback createCallback,
-            void *userdata, UA_UInt32 *requestId)
-{
-    return __UA_Client_MonitoredItems_createDataChanges_async(
-            client, request, contexts, (void**)(uintptr_t) callbacks,
-            deleteCallbacks, createCallback, userdata, requestId);
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_createEvents_async(
+    UA_Client *client, const UA_CreateMonitoredItemsRequest request, void **contexts,
+    UA_Client_EventNotificationCallback *callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
+    UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
+    return __UA_Client_MonitoredItems_createDataChanges_async(client, request, contexts, (void **)(uintptr_t)callbacks,
+                                                              deleteCallbacks, createCallback, userdata, requestId);
 }
 
 UA_MonitoredItemCreateResult UA_EXPORT
@@ -757,27 +708,24 @@ UA_Client_MonitoredItems_createEvent(UA_Client *client, UA_UInt32 subscriptionId
     return result;
 }
 
-static void
-__MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt32 requestId, void *r) {
+static void __MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt32 requestId, void *r) {
     UA_DeleteMonitoredItemsResponse *response = (UA_DeleteMonitoredItemsResponse *)r;
     CustomCallback *cc = (CustomCallback *)d;
-    UA_DeleteMonitoredItemsRequest *request =
-        (UA_DeleteMonitoredItemsRequest *)cc->clientData;
-    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
+    UA_DeleteMonitoredItemsRequest *request = (UA_DeleteMonitoredItemsRequest *)cc->clientData;
+    if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
         goto cleanup;
 
     UA_Client_Subscription *sub = findSubscription(client, request->subscriptionId);
     if(!sub) {
-        UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
-                    "No internal representation of subscription %u",
+        UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT, "No internal representation of subscription %u",
                     request->subscriptionId);
         goto cleanup;
     }
 
     /* Loop over deleted MonitoredItems */
-    for(size_t i = 0; i < response->resultsSize; i++) {
-        if(response->results[i] != UA_STATUSCODE_GOOD &&
-           response->results[i] != UA_STATUSCODE_BADMONITOREDITEMIDINVALID) {
+    for (size_t i = 0; i < response->resultsSize; i++) {
+        if (response->results[i] != UA_STATUSCODE_GOOD &&
+            response->results[i] != UA_STATUSCODE_BADMONITOREDITEMIDINVALID) {
             continue;
         }
 
@@ -786,14 +734,14 @@ __MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt32 requestId,
         UA_Client_MonitoredItem *mon;
         LIST_FOREACH(mon, &sub->monitoredItems, listEntry) {
             // NOLINTNEXTLINE
-            if(mon->monitoredItemId == request->monitoredItemIds[i]) {
+            if (mon->monitoredItemId == request->monitoredItemIds[i]) {
                 UA_Client_MonitoredItem_remove(client, sub, mon);
                 break;
             }
         }
 #endif
     }
-  cleanup:
+cleanup:
     if (cc->userCallback)
         cc->userCallback(client, cc->userData, requestId, response);
     CustomCallback_remove(cc, false);
@@ -804,28 +752,27 @@ UA_Client_MonitoredItems_delete(UA_Client *client, const UA_DeleteMonitoredItems
     /* Send the request */
     UA_DeleteMonitoredItemsResponse response;
     CustomCallback *cc = CustomCallback_new();
-    if(!cc) {
+    if (!cc) {
         response.responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return response;
     }
-    cc->clientData = (void*)(uintptr_t)&request;
+    cc->clientData = (void *)(uintptr_t)&request;
 
-    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST],
-                        &response, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE]);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST], &response,
+                        &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE]);
 
     __MonitoredItems_delete_handler(client, cc, 0, &response);
     return response;
 }
 
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_delete_async(UA_Client *client, const UA_DeleteMonitoredItemsRequest request,
-                                      UA_ClientAsyncServiceCallback callback,
-                                      void *userdata, UA_UInt32 *requestId) {
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_delete_async(UA_Client *client,
+                                                              const UA_DeleteMonitoredItemsRequest request,
+                                                              UA_ClientAsyncServiceCallback callback, void *userdata,
+                                                              UA_UInt32 *requestId) {
     /* Send the request */
     CustomCallback *cc = CustomCallback_new();
-    if(!cc)
+    if (!cc)
         return UA_STATUSCODE_BADOUTOFMEMORY;
-
 
     UA_DeleteMonitoredItemsRequest *req_copy = UA_DeleteMonitoredItemsRequest_new();
     if (!req_copy) {
@@ -838,15 +785,13 @@ UA_Client_MonitoredItems_delete_async(UA_Client *client, const UA_DeleteMonitore
     cc->userCallback = callback;
     cc->userData = userdata;
 
-    return __UA_Client_AsyncService(client, &request,
-                                    &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST],
-                                    __MonitoredItems_delete_handler,
-                                    &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE],
+    return __UA_Client_AsyncService(client, &request, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSREQUEST],
+                                    __MonitoredItems_delete_handler, &UA_TYPES[UA_TYPES_DELETEMONITOREDITEMSRESPONSE],
                                     cc, requestId);
 }
 
-UA_StatusCode UA_EXPORT
-UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId, UA_UInt32 monitoredItemId) {
+UA_StatusCode UA_EXPORT UA_Client_MonitoredItems_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId,
+                                                              UA_UInt32 monitoredItemId) {
     UA_DeleteMonitoredItemsRequest request;
     UA_DeleteMonitoredItemsRequest_init(&request);
     request.subscriptionId = subscriptionId;

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -423,16 +423,18 @@ MonitoredItems_CreateData_free(MonitoredItems_CreateData *data, UA_Client *clien
     if (!data)
         return;
 
-    for(size_t i = 0; i < data->request->itemsToCreateSize; i++) {
-        if (data->mis[i]) {
-            if (data->deleteCallbacks[i]) {
-                if(data->sub)
-                    data->deleteCallbacks[i](client, data->sub->subscriptionId,
-                                             data->sub->context, 0, data->contexts[i]);
-                else
-                    data->deleteCallbacks[i](client, 0, NULL, 0, data->contexts[i]);
+    if (data->request && data->mis && data->deleteCallbacks && data->contexts) {
+        for(size_t i = 0; i < data->request->itemsToCreateSize; i++) {
+            if (data->mis[i]) {
+                if (data->deleteCallbacks[i]) {
+                    if(data->sub)
+                        data->deleteCallbacks[i](client, data->sub->subscriptionId,
+                                                 data->sub->context, 0, data->contexts[i]);
+                    else
+                        data->deleteCallbacks[i](client, 0, NULL, 0, data->contexts[i]);
+                }
+                UA_free(data->mis[i]);
             }
-            UA_free(data->mis[i]);
         }
     }
 

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -824,7 +824,14 @@ UA_Client_MonitoredItems_delete_async(UA_Client *client, const UA_DeleteMonitore
     if(!cc)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    cc->clientData = (void*)(uintptr_t)&request;
+
+    UA_DeleteMonitoredItemsRequest *req_copy = UA_DeleteMonitoredItemsRequest_new();
+    if (!req_copy) {
+        UA_free(cc);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    UA_DeleteMonitoredItemsRequest_copy(&request, req_copy);
+    cc->clientData = req_copy;
     cc->clientDataDeleter = (CustomCallbackDataDeleter)(uintptr_t)UA_DeleteMonitoredItemsRequest_delete;
     cc->userCallback = callback;
     cc->userData = userdata;

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -619,13 +619,13 @@ __UA_Client_MonitoredItems_createDataChanges_async(UA_Client *client,
         goto cleanup;
     }
     data->mis = (UA_Client_MonitoredItem **)array;
-    data->contexts = array + (request.itemsToCreateSize);
+    data->contexts = (void **) ((uintptr_t) array + (sizeof(void*) * request.itemsToCreateSize));
     memcpy(data->contexts, contexts, request.itemsToCreateSize * sizeof(void*));
     data->deleteCallbacks = (UA_Client_DeleteMonitoredItemCallback *)
-        (array + (2 * request.itemsToCreateSize));
+      ((uintptr_t) array + (2 * request.itemsToCreateSize * sizeof(void*)));
     memcpy(data->deleteCallbacks, deleteCallbacks,
            request.itemsToCreateSize * sizeof(UA_Client_DeleteMonitoredItemCallback));
-    data->handlingCallbacks = array + (3 * request.itemsToCreateSize);
+    data->handlingCallbacks = (void **) ((uintptr_t) array + (3 * request.itemsToCreateSize * sizeof(void*)));
     memcpy(data->handlingCallbacks, callbacks, request.itemsToCreateSize * sizeof(void*));
 
     data->request = UA_CreateMonitoredItemsRequest_new();

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -302,7 +302,7 @@ cleanup:
     if(cc->isAsync) {
         if(cc->userCallback)
             cc->userCallback(client, cc->userData, requestId, response);
-        __Subscriptions_DeleteData_free(cc->clientData);
+        __Subscriptions_DeleteData_free(delData);
         UA_free(cc);
     }
 }
@@ -341,7 +341,7 @@ UA_Client_Subscriptions_delete_async(UA_Client *client,
         __Subscriptions_delete_handler, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE],
         cc, requestId);
 cleanup:
-    __Subscriptions_DeleteData_free(cc->clientData);
+    __Subscriptions_DeleteData_free(data);
     UA_free(cc);
     return UA_STATUSCODE_BADOUTOFMEMORY;
 }
@@ -512,11 +512,11 @@ __MonitoredItems_create_handler(UA_Client *client, void *d, UA_UInt32 requestId,
         mis[i] = NULL;
     }
 cleanup:
-    MonitoredItems_CreateData_deleteItems(cc->clientData, client);
+    MonitoredItems_CreateData_deleteItems(data, client);
     if (cc->isAsync) {
         if(cc->userCallback)
             cc->userCallback(client, cc->userData, requestId, response);
-        MonitoredItems_CreateData_free(cc->clientData);
+        MonitoredItems_CreateData_free(data);
         UA_free(cc);
     }
 }
@@ -806,7 +806,7 @@ cleanup:
     if (cc->isAsync) {
         if(cc->userCallback)
             cc->userCallback(client, cc->userData, requestId, response);
-        UA_DeleteMonitoredItemsRequest_delete(cc->clientData);
+        UA_DeleteMonitoredItemsRequest_delete(request);
         UA_free(cc);
     }
 }

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -339,6 +339,8 @@ UA_Client_Subscriptions_delete_async(UA_Client *client,
     CustomCallback *cc = __Subscriptions_delete_prepare(client, &request, &retval);
     if (retval != UA_STATUSCODE_GOOD)
         return retval;
+    cc->userCallback = callback;
+    cc->userData = userdata;
 
     return __UA_Client_AsyncService(client, &request,
                                     &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -436,10 +436,17 @@ MonitoredItems_CreateData_deleteItems(MonitoredItems_CreateData *data,
     if(!data)
         return;
 
-    if(data->request && data->mis && data->deleteCallbacks && data->contexts) {
+#ifdef __clang_analyzer__
+    /* The clang analyzer requires the information that the loop below is executed
+       which is already checked in the __UA_Client_MonitoredItems_create */
+    assert(data->request->itemsToCreateSize);
+#endif
+
+    bool hasCallbacks = data->deleteCallbacks != NULL && data->contexts != NULL;
+    if(data->request && data->mis) {
         for(size_t i = 0; i < data->request->itemsToCreateSize; i++) {
             if(data->mis[i]) {
-                if(data->deleteCallbacks[i]) {
+                if(hasCallbacks && data->deleteCallbacks[i]) {
                     if(data->sub)
                         data->deleteCallbacks[i](client, data->sub->subscriptionId,
                                                  data->sub->context, 0,

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -428,7 +428,8 @@ typedef struct {
 } MonitoredItems_CreateData;
 
 static void
-MonitoredItems_CreateData_deleteItems(MonitoredItems_CreateData *data, UA_Client *client) {
+MonitoredItems_CreateData_deleteItems(MonitoredItems_CreateData *data,
+                                      UA_Client *client) {
     if(!data)
         return;
 
@@ -513,7 +514,7 @@ __MonitoredItems_create_handler(UA_Client *client, void *d, UA_UInt32 requestId,
     }
 cleanup:
     MonitoredItems_CreateData_deleteItems(data, client);
-    if (cc->isAsync) {
+    if(cc->isAsync) {
         if(cc->userCallback)
             cc->userCallback(client, cc->userData, requestId, response);
         MonitoredItems_CreateData_free(data);
@@ -803,7 +804,7 @@ __MonitoredItems_delete_handler(UA_Client *client, void *d, UA_UInt32 requestId,
 #endif
     }
 cleanup:
-    if (cc->isAsync) {
+    if(cc->isAsync) {
         if(cc->userCallback)
             cc->userCallback(client, cc->userData, requestId, response);
         UA_DeleteMonitoredItemsRequest_delete(request);

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -360,13 +360,10 @@ UA_Client_Subscriptions_delete(UA_Client *client,
     data.request = (UA_DeleteSubscriptionsRequest *)(uintptr_t)&request;
     data.subs = subs;
 
-    /* Send the request */
-    UA_DeleteSubscriptionsResponse response;
-
     __Subscriptions_delete_prepare(client, &data);
 
-    if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD)
-        return response;
+    /* Send the request */
+    UA_DeleteSubscriptionsResponse response;
 
     __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSREQUEST],
                         &response, &UA_TYPES[UA_TYPES_DELETESUBSCRIPTIONSRESPONSE]);

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -77,7 +77,7 @@ UA_Client_Subscriptions_create(UA_Client *client,
     UA_CreateSubscriptionResponse response;
     UA_CreateSubscriptionResponse_init(&response);
 
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc) {
         response.responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
@@ -111,7 +111,7 @@ UA_Client_Subscriptions_create_async(
     UA_Client_DeleteSubscriptionCallback deleteCallback,
     UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
@@ -194,7 +194,7 @@ UA_Client_Subscriptions_modify_async(UA_Client *client,
     if(!sub)
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
 
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
@@ -244,7 +244,7 @@ static UA_INLINE CustomCallback *
 __Subscriptions_delete_prepare(UA_Client *client,
                                const UA_DeleteSubscriptionsRequest *request,
                                UA_StatusCode *retval) {
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc)
         goto cleanup;
     Subscriptions_DeleteData *data =
@@ -538,7 +538,7 @@ __UA_Client_MonitoredItems_create(UA_Client *client,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         return;
     }
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return;
@@ -590,7 +590,7 @@ __UA_Client_MonitoredItems_createDataChanges_async(
     void **callbacks, UA_Client_DeleteMonitoredItemCallback *deleteCallbacks,
     UA_ClientAsyncServiceCallback createCallback, void *userdata, UA_UInt32 *requestId) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
@@ -807,7 +807,7 @@ UA_Client_MonitoredItems_delete(UA_Client *client,
                                 const UA_DeleteMonitoredItemsRequest request) {
     /* Send the request */
     UA_DeleteMonitoredItemsResponse response;
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc) {
         response.responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return response;
@@ -827,7 +827,7 @@ UA_Client_MonitoredItems_delete_async(UA_Client *client,
                                       UA_ClientAsyncServiceCallback callback,
                                       void *userdata, UA_UInt32 *requestId) {
     /* Send the request */
-    CustomCallback *cc = CustomCallback_new();
+    CustomCallback *cc = (CustomCallback *)UA_calloc(1, sizeof(CustomCallback));
     if(!cc)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -58,27 +58,37 @@ dataChangeHandler(UA_Client *client, UA_UInt32 subId, void *subContext,
     countNotificationReceived++;
 }
 
-static void createSubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+static void
+createSubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                           void *r) {
     UA_CreateSubscriptionResponse_copy((const UA_CreateSubscriptionResponse *)r,
                                        (UA_CreateSubscriptionResponse *)userdata);
 }
 
-static void modifySubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+static void
+modifySubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                           void *r) {
     UA_ModifySubscriptionResponse_copy((const UA_ModifySubscriptionResponse *)r,
                                        (UA_ModifySubscriptionResponse *)userdata);
 }
 
-static void createDataChangesCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+static void
+createDataChangesCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                          void *r) {
     UA_CreateMonitoredItemsResponse_copy((const UA_CreateMonitoredItemsResponse *)r,
                                          (UA_CreateMonitoredItemsResponse *)userdata);
 }
 
-static void deleteMonitoredItemsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+static void
+deleteMonitoredItemsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                             void *r) {
     UA_DeleteMonitoredItemsResponse_copy((const UA_DeleteMonitoredItemsResponse *)r,
                                          (UA_DeleteMonitoredItemsResponse *)userdata);
 }
 
-static void deleteSubscriptionsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+static void
+deleteSubscriptionsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                            void *r) {
     UA_DeleteSubscriptionsResponse_copy((const UA_DeleteSubscriptionsResponse *)r,
                                         (UA_DeleteSubscriptionsResponse *)userdata);
 }
@@ -158,11 +168,12 @@ START_TEST(Client_subscription_async) {
 
     UA_UInt32 requestId = 0;
     UA_CreateSubscriptionResponse response;
-    retval = UA_Client_Subscriptions_create_async(client, request, NULL, NULL, NULL, createSubscriptionCallback,
-                                                  &response, &requestId);
+    retval = UA_Client_Subscriptions_create_async(client, request, NULL, NULL, NULL,
+                                                  createSubscriptionCallback, &response,
+                                                  &requestId);
 
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    UA_realSleep(50); // wait until response is
+    UA_realSleep(50);  // wait until response is
     UA_Client_run_iterate(client, 0);
 
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
@@ -171,23 +182,28 @@ START_TEST(Client_subscription_async) {
     UA_ModifySubscriptionRequest modifySubscriptionRequest;
     UA_ModifySubscriptionRequest_init(&modifySubscriptionRequest);
     modifySubscriptionRequest.subscriptionId = response.subscriptionId;
-    modifySubscriptionRequest.requestedPublishingInterval = response.revisedPublishingInterval;
+    modifySubscriptionRequest.requestedPublishingInterval =
+        response.revisedPublishingInterval;
     modifySubscriptionRequest.requestedLifetimeCount = response.revisedLifetimeCount;
-    modifySubscriptionRequest.requestedMaxKeepAliveCount = response.revisedMaxKeepAliveCount;
+    modifySubscriptionRequest.requestedMaxKeepAliveCount =
+        response.revisedMaxKeepAliveCount;
     UA_ModifySubscriptionResponse modifySubscriptionResponse;
 
-    retval = UA_Client_Subscriptions_modify_async(client, modifySubscriptionRequest, modifySubscriptionCallback,
-                                                  &modifySubscriptionResponse, &requestId);
+    retval = UA_Client_Subscriptions_modify_async(
+        client, modifySubscriptionRequest, modifySubscriptionCallback,
+        &modifySubscriptionResponse, &requestId);
 
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    UA_realSleep(50); // need to wait until response is at the client
+    UA_realSleep(50);  // need to wait until response is at the client
     retval = UA_Client_run_iterate(client, 0);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(modifySubscriptionResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(modifySubscriptionResponse.responseHeader.serviceResult,
+                     UA_STATUSCODE_GOOD);
 
     /* monitor the server state */
     UA_MonitoredItemCreateRequest singleMonRequest =
-        UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE));
+        UA_MonitoredItemCreateRequest_default(
+            UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE));
     void *contexts = NULL;
     UA_Client_DataChangeNotificationCallback notifications = dataChangeHandler;
     UA_Client_DeleteMonitoredItemCallback deleteCallbacks = NULL;
@@ -198,11 +214,11 @@ START_TEST(Client_subscription_async) {
     monRequest.itemsToCreate = &singleMonRequest;
     monRequest.itemsToCreateSize = 1;
     UA_CreateMonitoredItemsResponse monResponse;
-    retval = UA_Client_MonitoredItems_createDataChanges_async(client, monRequest, &contexts, &notifications,
-                                                              &deleteCallbacks, createDataChangesCallback, &monResponse,
-                                                              &requestId);
+    retval = UA_Client_MonitoredItems_createDataChanges_async(
+        client, monRequest, &contexts, &notifications, &deleteCallbacks,
+        createDataChangesCallback, &monResponse, &requestId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    UA_realSleep(50); // need to wait until response is at the client
+    UA_realSleep(50);  // need to wait until response is at the client
     retval = UA_Client_run_iterate(client, 0);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -226,10 +242,11 @@ START_TEST(Client_subscription_async) {
     monDeleteRequest.monitoredItemIdsSize = 1;
     UA_DeleteMonitoredItemsResponse monDeleteResponse;
 
-    retval = UA_Client_MonitoredItems_delete_async(client, monDeleteRequest, deleteMonitoredItemsCallback,
+    retval = UA_Client_MonitoredItems_delete_async(client, monDeleteRequest,
+                                                   deleteMonitoredItemsCallback,
                                                    &monDeleteResponse, &requestId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    UA_realSleep(50); // need to wait until response is at the client
+    UA_realSleep(50);  // need to wait until response is at the client
     retval = UA_Client_run_iterate(client, 0);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -243,11 +260,12 @@ START_TEST(Client_subscription_async) {
     subDeleteRequest.subscriptionIdsSize = 1;
     UA_DeleteSubscriptionsResponse subDeleteResponse;
     printf("will delete\n");
-    retval = UA_Client_Subscriptions_delete_async(client, subDeleteRequest, deleteSubscriptionsCallback,
+    retval = UA_Client_Subscriptions_delete_async(client, subDeleteRequest,
+                                                  deleteSubscriptionsCallback,
                                                   &subDeleteResponse, &requestId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-    UA_realSleep(50); // need to wait until response is at the client
+    UA_realSleep(50);  // need to wait until response is at the client
     retval = UA_Client_run_iterate(client, 0);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -380,7 +398,8 @@ START_TEST(Client_subscription_createDataChanges_async) {
     // Async subscription creation is tested in Client_subscription_async
     // simplify test case using synchronous here
     UA_CreateSubscriptionRequest request = UA_CreateSubscriptionRequest_default();
-    UA_CreateSubscriptionResponse response = UA_Client_Subscriptions_create(client, request, NULL, NULL, NULL);
+    UA_CreateSubscriptionResponse response =
+        UA_Client_Subscriptions_create(client, request, NULL, NULL, NULL);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     UA_UInt32 subId = response.subscriptionId;
 
@@ -391,7 +410,8 @@ START_TEST(Client_subscription_createDataChanges_async) {
     void *contexts[3];
 
     /* monitor the server state */
-    items[0] = UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE));
+    items[0] = UA_MonitoredItemCreateRequest_default(
+        UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE));
     callbacks[0] = dataChangeHandler;
     contexts[0] = NULL;
     deleteCallbacks[0] = NULL;
@@ -403,7 +423,8 @@ START_TEST(Client_subscription_createDataChanges_async) {
     deleteCallbacks[1] = NULL;
 
     /* monitor current time */
-    items[2] = UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME));
+    items[2] = UA_MonitoredItemCreateRequest_default(
+        UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME));
     callbacks[2] = dataChangeHandler;
     contexts[2] = NULL;
     deleteCallbacks[2] = NULL;
@@ -416,9 +437,9 @@ START_TEST(Client_subscription_createDataChanges_async) {
     createRequest.itemsToCreateSize = 3;
     UA_CreateMonitoredItemsResponse createResponse;
 
-    retval =
-        UA_Client_MonitoredItems_createDataChanges_async(client, createRequest, contexts, callbacks, deleteCallbacks,
-                                                         createDataChangesCallback, &createResponse, &reqId);
+    retval = UA_Client_MonitoredItems_createDataChanges_async(
+        client, createRequest, contexts, callbacks, deleteCallbacks,
+        createDataChangesCallback, &createResponse, &reqId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     UA_realSleep(50);
     retval = UA_Client_run_iterate(client, 0);
@@ -428,7 +449,8 @@ START_TEST(Client_subscription_createDataChanges_async) {
     ck_assert_uint_eq(createResponse.resultsSize, 3);
     ck_assert_uint_eq(createResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
     newMonitoredItemIds[0] = createResponse.results[0].monitoredItemId;
-    ck_assert_uint_eq(createResponse.results[1].statusCode, UA_STATUSCODE_BADNODEIDUNKNOWN);
+    ck_assert_uint_eq(createResponse.results[1].statusCode,
+                      UA_STATUSCODE_BADNODEIDUNKNOWN);
     newMonitoredItemIds[1] = createResponse.results[1].monitoredItemId;
     ck_assert_uint_eq(newMonitoredItemIds[1], 0);
     ck_assert_uint_eq(createResponse.results[2].statusCode, UA_STATUSCODE_GOOD);
@@ -459,17 +481,19 @@ START_TEST(Client_subscription_createDataChanges_async) {
         deleteRequest.monitoredItemIdsSize = 3;
 
         UA_DeleteMonitoredItemsResponse deleteResponse;
-        retval = UA_Client_MonitoredItems_delete_async(client, deleteRequest, deleteMonitoredItemsCallback,
-                                                       &deleteResponse, &reqId);
+        retval = UA_Client_MonitoredItems_delete_async(
+            client, deleteRequest, deleteMonitoredItemsCallback, &deleteResponse, &reqId);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-        UA_realSleep(50); // need to wait until response is at the client
+        UA_realSleep(50);  // need to wait until response is at the client
         retval = UA_Client_run_iterate(client, 0);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-        ck_assert_uint_eq(deleteResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(deleteResponse.responseHeader.serviceResult,
+                          UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(deleteResponse.resultsSize, 3);
         ck_assert_uint_eq(deleteResponse.results[0], UA_STATUSCODE_GOOD);
-        ck_assert_uint_eq(deleteResponse.results[1], UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
+        ck_assert_uint_eq(deleteResponse.results[1],
+                          UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
         ck_assert_uint_eq(deleteResponse.results[2], UA_STATUSCODE_GOOD);
 
         UA_DeleteMonitoredItemsResponse_deleteMembers(&deleteResponse);

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -59,23 +59,28 @@ dataChangeHandler(UA_Client *client, UA_UInt32 subId, void *subContext,
 }
 
 static void createSubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
-    UA_CreateSubscriptionResponse_copy(r, userdata);
+    UA_CreateSubscriptionResponse_copy((const UA_CreateSubscriptionResponse *)r,
+                                       (UA_CreateSubscriptionResponse *)userdata);
 }
 
 static void modifySubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
-    UA_ModifySubscriptionResponse_copy(r, userdata);
+    UA_ModifySubscriptionResponse_copy((const UA_ModifySubscriptionResponse *)r,
+                                       (UA_ModifySubscriptionResponse *)userdata);
 }
 
 static void createDataChangesCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
-    UA_CreateMonitoredItemsResponse_copy(r, userdata);
+    UA_CreateMonitoredItemsResponse_copy((const UA_CreateMonitoredItemsResponse *)r,
+                                         (UA_CreateMonitoredItemsResponse *)userdata);
 }
 
 static void deleteMonitoredItemsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
-    UA_DeleteMonitoredItemsResponse_copy(r, userdata);
+    UA_DeleteMonitoredItemsResponse_copy((const UA_DeleteMonitoredItemsResponse *)r,
+                                         (UA_DeleteMonitoredItemsResponse *)userdata);
 }
 
 static void deleteSubscriptionsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
-    UA_DeleteSubscriptionsResponse_copy(r, userdata);
+    UA_DeleteSubscriptionsResponse_copy((const UA_DeleteSubscriptionsResponse *)r,
+                                        (UA_DeleteSubscriptionsResponse *)userdata);
 }
 
 START_TEST(Client_subscription) {

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -158,9 +158,8 @@ START_TEST(Client_subscription_async) {
 
     UA_UInt32 requestId = 0;
     UA_CreateSubscriptionResponse response;
-    retval = UA_Client_Subscriptions_create_async(client, request, NULL, NULL, NULL,
-                                                  createSubscriptionCallback, &response,
-                                                  &requestId);
+    retval = UA_Client_Subscriptions_create_async(client, request, NULL, NULL, NULL, createSubscriptionCallback,
+                                                  &response, &requestId);
 
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     UA_realSleep(50); // wait until response is
@@ -177,8 +176,7 @@ START_TEST(Client_subscription_async) {
     modifySubscriptionRequest.requestedMaxKeepAliveCount = response.revisedMaxKeepAliveCount;
     UA_ModifySubscriptionResponse modifySubscriptionResponse;
 
-    retval = UA_Client_Subscriptions_modify_async(client, modifySubscriptionRequest,
-                                                  modifySubscriptionCallback,
+    retval = UA_Client_Subscriptions_modify_async(client, modifySubscriptionRequest, modifySubscriptionCallback,
                                                   &modifySubscriptionResponse, &requestId);
 
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
@@ -200,9 +198,8 @@ START_TEST(Client_subscription_async) {
     monRequest.itemsToCreate = &singleMonRequest;
     monRequest.itemsToCreateSize = 1;
     UA_CreateMonitoredItemsResponse monResponse;
-    retval = UA_Client_MonitoredItems_createDataChanges_async(client, monRequest,
-                                                              &contexts, &notifications, &deleteCallbacks,
-                                                              createDataChangesCallback, &monResponse,
+    retval = UA_Client_MonitoredItems_createDataChanges_async(client, monRequest, &contexts, &notifications,
+                                                              &deleteCallbacks, createDataChangesCallback, &monResponse,
                                                               &requestId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     UA_realSleep(50); // need to wait until response is at the client
@@ -217,7 +214,7 @@ START_TEST(Client_subscription_async) {
     UA_fakeSleep((UA_UInt32)publishingInterval + 1);
     notificationReceived = false;
 
-    retval = UA_Client_run_iterate(client, (UA_UInt16)(publishingInterval +1));
+    retval = UA_Client_run_iterate(client, (UA_UInt16)(publishingInterval + 1));
 
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(notificationReceived, true);
@@ -229,9 +226,8 @@ START_TEST(Client_subscription_async) {
     monDeleteRequest.monitoredItemIdsSize = 1;
     UA_DeleteMonitoredItemsResponse monDeleteResponse;
 
-    retval = UA_Client_MonitoredItems_delete_async(client, monDeleteRequest,
-                                                   deleteMonitoredItemsCallback, &monDeleteResponse,
-                                                   &requestId);
+    retval = UA_Client_MonitoredItems_delete_async(client, monDeleteRequest, deleteMonitoredItemsCallback,
+                                                   &monDeleteResponse, &requestId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     UA_realSleep(50); // need to wait until response is at the client
     retval = UA_Client_run_iterate(client, 0);
@@ -247,9 +243,8 @@ START_TEST(Client_subscription_async) {
     subDeleteRequest.subscriptionIdsSize = 1;
     UA_DeleteSubscriptionsResponse subDeleteResponse;
     printf("will delete\n");
-    retval = UA_Client_Subscriptions_delete_async(client, subDeleteRequest,
-                                                  deleteSubscriptionsCallback, &subDeleteResponse,
-                                                  &requestId);
+    retval = UA_Client_Subscriptions_delete_async(client, subDeleteRequest, deleteSubscriptionsCallback,
+                                                  &subDeleteResponse, &requestId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_realSleep(50); // need to wait until response is at the client
@@ -385,8 +380,7 @@ START_TEST(Client_subscription_createDataChanges_async) {
     // Async subscription creation is tested in Client_subscription_async
     // simplify test case using synchronous here
     UA_CreateSubscriptionRequest request = UA_CreateSubscriptionRequest_default();
-    UA_CreateSubscriptionResponse response = UA_Client_Subscriptions_create(client, request,
-                                                                            NULL, NULL, NULL);
+    UA_CreateSubscriptionResponse response = UA_Client_Subscriptions_create(client, request, NULL, NULL, NULL);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     UA_UInt32 subId = response.subscriptionId;
 
@@ -422,10 +416,9 @@ START_TEST(Client_subscription_createDataChanges_async) {
     createRequest.itemsToCreateSize = 3;
     UA_CreateMonitoredItemsResponse createResponse;
 
-    retval = UA_Client_MonitoredItems_createDataChanges_async(client, createRequest, contexts,
-                                                              callbacks, deleteCallbacks,
-                                                              createDataChangesCallback,
-                                                              &createResponse, &reqId);
+    retval =
+        UA_Client_MonitoredItems_createDataChanges_async(client, createRequest, contexts, callbacks, deleteCallbacks,
+                                                         createDataChangesCallback, &createResponse, &reqId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     UA_realSleep(50);
     retval = UA_Client_run_iterate(client, 0);
@@ -466,9 +459,8 @@ START_TEST(Client_subscription_createDataChanges_async) {
         deleteRequest.monitoredItemIdsSize = 3;
 
         UA_DeleteMonitoredItemsResponse deleteResponse;
-        retval = UA_Client_MonitoredItems_delete_async(client, deleteRequest,
-                                                       deleteMonitoredItemsCallback, &deleteResponse,
-                                                       &reqId);
+        retval = UA_Client_MonitoredItems_delete_async(client, deleteRequest, deleteMonitoredItemsCallback,
+                                                       &deleteResponse, &reqId);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
         UA_realSleep(50); // need to wait until response is at the client
         retval = UA_Client_run_iterate(client, 0);

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -58,6 +58,26 @@ dataChangeHandler(UA_Client *client, UA_UInt32 subId, void *subContext,
     countNotificationReceived++;
 }
 
+static void createSubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+    UA_CreateSubscriptionResponse_copy(r, userdata);
+}
+
+static void modifySubscriptionCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+    UA_ModifySubscriptionResponse_copy(r, userdata);
+}
+
+static void createDataChangesCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+    UA_CreateMonitoredItemsResponse_copy(r, userdata);
+}
+
+static void deleteMonitoredItemsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+    UA_DeleteMonitoredItemsResponse_copy(r, userdata);
+}
+
+static void deleteSubscriptionsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId, void *r) {
+    UA_DeleteSubscriptionsResponse_copy(r, userdata);
+}
+
 START_TEST(Client_subscription) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));
@@ -113,6 +133,133 @@ START_TEST(Client_subscription) {
 
     retval = UA_Client_Subscriptions_deleteSingle(client, subId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_subscription_async) {
+    UA_Client *client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Client_recv = client->connection.recv;
+    client->connection.recv = UA_Client_recvTesting;
+
+    UA_CreateSubscriptionRequest request = UA_CreateSubscriptionRequest_default();
+
+    UA_UInt32 requestId = 0;
+    UA_CreateSubscriptionResponse response;
+    retval = UA_Client_Subscriptions_create_async(client, request, NULL, NULL, NULL,
+                                                  createSubscriptionCallback, &response,
+                                                  &requestId);
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_realSleep(50); // wait until response is
+    UA_Client_run_iterate(client, 0);
+
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    UA_UInt32 subId = response.subscriptionId;
+
+    UA_ModifySubscriptionRequest modifySubscriptionRequest;
+    UA_ModifySubscriptionRequest_init(&modifySubscriptionRequest);
+    modifySubscriptionRequest.subscriptionId = response.subscriptionId;
+    modifySubscriptionRequest.requestedPublishingInterval = response.revisedPublishingInterval;
+    modifySubscriptionRequest.requestedLifetimeCount = response.revisedLifetimeCount;
+    modifySubscriptionRequest.requestedMaxKeepAliveCount = response.revisedMaxKeepAliveCount;
+    UA_ModifySubscriptionResponse modifySubscriptionResponse;
+
+    retval = UA_Client_Subscriptions_modify_async(client, modifySubscriptionRequest,
+                                                  modifySubscriptionCallback,
+                                                  &modifySubscriptionResponse, &requestId);
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_realSleep(50); // need to wait until response is at the client
+    retval = UA_Client_run_iterate(client, 0);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(modifySubscriptionResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+
+    /* monitor the server state */
+    UA_MonitoredItemCreateRequest singleMonRequest =
+        UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE));
+    void *contexts = NULL;
+    UA_Client_DataChangeNotificationCallback notifications = dataChangeHandler;
+    UA_Client_DeleteMonitoredItemCallback deleteCallbacks = NULL;
+
+    UA_CreateMonitoredItemsRequest monRequest;
+    UA_CreateMonitoredItemsRequest_init(&monRequest);
+    monRequest.subscriptionId = subId;
+    monRequest.itemsToCreate = &singleMonRequest;
+    monRequest.itemsToCreateSize = 1;
+    UA_CreateMonitoredItemsResponse monResponse;
+    retval = UA_Client_MonitoredItems_createDataChanges_async(client, monRequest,
+                                                              &contexts, &notifications, &deleteCallbacks,
+                                                              createDataChangesCallback, &monResponse,
+                                                              &requestId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_realSleep(50); // need to wait until response is at the client
+    retval = UA_Client_run_iterate(client, 0);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(monResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(monResponse.resultsSize, 1);
+    ck_assert_uint_eq(monResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
+    UA_UInt32 monId = monResponse.results[0].monitoredItemId;
+
+    UA_fakeSleep((UA_UInt32)publishingInterval + 1);
+    notificationReceived = false;
+
+    retval = UA_Client_run_iterate(client, (UA_UInt16)(publishingInterval +1));
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(notificationReceived, true);
+
+    UA_DeleteMonitoredItemsRequest monDeleteRequest;
+    UA_DeleteMonitoredItemsRequest_init(&monDeleteRequest);
+    monDeleteRequest.subscriptionId = subId;
+    monDeleteRequest.monitoredItemIds = &monId;
+    monDeleteRequest.monitoredItemIdsSize = 1;
+    UA_DeleteMonitoredItemsResponse monDeleteResponse;
+
+    retval = UA_Client_MonitoredItems_delete_async(client, monDeleteRequest,
+                                                   deleteMonitoredItemsCallback, &monDeleteResponse,
+                                                   &requestId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_realSleep(50); // need to wait until response is at the client
+    retval = UA_Client_run_iterate(client, 0);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(monDeleteResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(monDeleteResponse.resultsSize, 1);
+    ck_assert_uint_eq(monDeleteResponse.results[0], UA_STATUSCODE_GOOD);
+
+    UA_DeleteSubscriptionsRequest subDeleteRequest;
+    UA_DeleteSubscriptionsRequest_init(&subDeleteRequest);
+    subDeleteRequest.subscriptionIds = &monId;
+    subDeleteRequest.subscriptionIdsSize = 1;
+    UA_DeleteSubscriptionsResponse subDeleteResponse;
+    printf("will delete\n");
+    retval = UA_Client_Subscriptions_delete_async(client, subDeleteRequest,
+                                                  deleteSubscriptionsCallback, &subDeleteResponse,
+                                                  &requestId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_realSleep(50); // need to wait until response is at the client
+    retval = UA_Client_run_iterate(client, 0);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(subDeleteResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(subDeleteResponse.resultsSize, 1);
+    ck_assert_uint_eq(subDeleteResponse.results[0], UA_STATUSCODE_GOOD);
+
+    UA_CreateSubscriptionResponse_deleteMembers(&response);
+    UA_ModifySubscriptionResponse_deleteMembers(&modifySubscriptionResponse);
+    UA_CreateMonitoredItemsResponse_deleteMembers(&monResponse);
+    UA_DeleteMonitoredItemsResponse_deleteMembers(&monDeleteResponse);
+    UA_DeleteSubscriptionsResponse_deleteMembers(&subDeleteResponse);
 
     UA_Client_disconnect(client);
     UA_Client_delete(client);
@@ -212,6 +359,127 @@ START_TEST(Client_subscription_createDataChanges) {
 
     UA_DeleteMonitoredItemsResponse_deleteMembers(&deleteResponse);
 
+    retval = UA_Client_Subscriptions_deleteSingle(client, subId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_subscription_createDataChanges_async) {
+    UA_UInt32 reqId = 0;
+    UA_Client *client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Client_recv = client->connection.recv;
+    client->connection.recv = UA_Client_recvTesting;
+
+    // Async subscription creation is tested in Client_subscription_async
+    // simplify test case using synchronous here
+    UA_CreateSubscriptionRequest request = UA_CreateSubscriptionRequest_default();
+    UA_CreateSubscriptionResponse response = UA_Client_Subscriptions_create(client, request,
+                                                                            NULL, NULL, NULL);
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    UA_UInt32 subId = response.subscriptionId;
+
+    UA_MonitoredItemCreateRequest items[3];
+    UA_UInt32 newMonitoredItemIds[3];
+    UA_Client_DataChangeNotificationCallback callbacks[3];
+    UA_Client_DeleteMonitoredItemCallback deleteCallbacks[3];
+    void *contexts[3];
+
+    /* monitor the server state */
+    items[0] = UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE));
+    callbacks[0] = dataChangeHandler;
+    contexts[0] = NULL;
+    deleteCallbacks[0] = NULL;
+
+    /* monitor invalid node */
+    items[1] = UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, 999999));
+    callbacks[1] = dataChangeHandler;
+    contexts[1] = NULL;
+    deleteCallbacks[1] = NULL;
+
+    /* monitor current time */
+    items[2] = UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME));
+    callbacks[2] = dataChangeHandler;
+    contexts[2] = NULL;
+    deleteCallbacks[2] = NULL;
+
+    UA_CreateMonitoredItemsRequest createRequest;
+    UA_CreateMonitoredItemsRequest_init(&createRequest);
+    createRequest.subscriptionId = subId;
+    createRequest.timestampsToReturn = UA_TIMESTAMPSTORETURN_BOTH;
+    createRequest.itemsToCreate = items;
+    createRequest.itemsToCreateSize = 3;
+    UA_CreateMonitoredItemsResponse createResponse;
+
+    retval = UA_Client_MonitoredItems_createDataChanges_async(client, createRequest, contexts,
+                                                              callbacks, deleteCallbacks,
+                                                              createDataChangesCallback,
+                                                              &createResponse, &reqId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_realSleep(50);
+    retval = UA_Client_run_iterate(client, 0);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(createResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(createResponse.resultsSize, 3);
+    ck_assert_uint_eq(createResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
+    newMonitoredItemIds[0] = createResponse.results[0].monitoredItemId;
+    ck_assert_uint_eq(createResponse.results[1].statusCode, UA_STATUSCODE_BADNODEIDUNKNOWN);
+    newMonitoredItemIds[1] = createResponse.results[1].monitoredItemId;
+    ck_assert_uint_eq(newMonitoredItemIds[1], 0);
+    ck_assert_uint_eq(createResponse.results[2].statusCode, UA_STATUSCODE_GOOD);
+    newMonitoredItemIds[2] = createResponse.results[2].monitoredItemId;
+    ck_assert_uint_eq(createResponse.results[2].statusCode, UA_STATUSCODE_GOOD);
+    UA_CreateMonitoredItemsResponse_deleteMembers(&createResponse);
+
+    UA_fakeSleep((UA_UInt32)publishingInterval + 1);
+
+    notificationReceived = false;
+    countNotificationReceived = 0;
+    retval = UA_Client_run_iterate(client, (UA_UInt16)(publishingInterval + 1));
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(notificationReceived, true);
+    ck_assert_uint_eq(countNotificationReceived, 2);
+
+    notificationReceived = false;
+    retval = UA_Client_run_iterate(client, (UA_UInt16)(publishingInterval + 1));
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(notificationReceived, true);
+    ck_assert_uint_eq(countNotificationReceived, 3);
+
+    {
+        UA_DeleteMonitoredItemsRequest deleteRequest;
+        UA_DeleteMonitoredItemsRequest_init(&deleteRequest);
+        deleteRequest.subscriptionId = subId;
+        deleteRequest.monitoredItemIds = newMonitoredItemIds;
+        deleteRequest.monitoredItemIdsSize = 3;
+
+        UA_DeleteMonitoredItemsResponse deleteResponse;
+        retval = UA_Client_MonitoredItems_delete_async(client, deleteRequest,
+                                                       deleteMonitoredItemsCallback, &deleteResponse,
+                                                       &reqId);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        UA_realSleep(50); // need to wait until response is at the client
+        retval = UA_Client_run_iterate(client, 0);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+        ck_assert_uint_eq(deleteResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(deleteResponse.resultsSize, 3);
+        ck_assert_uint_eq(deleteResponse.results[0], UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(deleteResponse.results[1], UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
+        ck_assert_uint_eq(deleteResponse.results[2], UA_STATUSCODE_GOOD);
+
+        UA_DeleteMonitoredItemsResponse_deleteMembers(&deleteResponse);
+    }
+
+    // Async subscription deletion is tested in Client_subscription_async
+    // simplify test case using synchronous here
     retval = UA_Client_Subscriptions_deleteSingle(client, subId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -559,8 +827,10 @@ static Suite* testSuite_Client(void) {
     TCase *tc_client = tcase_create("Client Subscription Basic");
     tcase_add_checked_fixture(tc_client, setup, teardown);
     tcase_add_test(tc_client, Client_subscription);
+    tcase_add_test(tc_client, Client_subscription_async);
     tcase_add_test(tc_client, Client_subscription_connectionClose);
     tcase_add_test(tc_client, Client_subscription_createDataChanges);
+    tcase_add_test(tc_client, Client_subscription_createDataChanges_async);
     tcase_add_test(tc_client, Client_subscription_keepAlive);
     tcase_add_test(tc_client, Client_subscription_without_notification);
     tcase_add_test(tc_client, Client_subscription_async_sub);


### PR DESCRIPTION
Implemented client async functions for subscriptions/monitored items.
I tried to reduce the number of modifications of the original code by splitting each synchronous function in separate parts.

Longer explanation what and why it is implemented that way:

Split synchronous function (SFN) into the following parts:
a) prepare the call
b) execute the call synchronously
c) handle the call result

The asynchronous function (AFN) implements the same schema as SFN; it replace
the synchronous call by an asynchronous one.  It appends the c) part as
ClientAsyncCallback to the asynchronous call.  It also receives a user-defined
callback, that has to be executed after part c) of the AFN has run.

The difficulty lays in the memory management of parts a) and c).  In the
synchronous application, the function parameters and the local variables are
(except multithreading) safe and cannot be modified or deleted by the outside.

In the asynchronous case, part c) is executed after the AFN has returned.
Therefore, we must preserve the necessary state (parameters, local variables) on
the heap and manage the memory internally.  Since part c) is not user provided,
we have to ensure that everything is cleaned up appropriately.

I extended the CustomCallback to hold client-internal data along with a deleter
for that data.  The custom callback holds the usercall back and the ptr to its
userdata as well (which is called after the client-internal handler has run).

I updated the CustomCallback usage (read node async functions) according to the
extension.
