### PR TITLE
Fix #2544

### DIFF
--- a/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
@@ -442,7 +442,7 @@ sym_decrypt_sp_basic128rsa15(const UA_SecurityPolicy *securityPolicy,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     size_t encryptionBlockSize =
-        securityPolicy->symmetricModule.cryptoModule.encryptionAlgorithm.getLocalBlockSize(securityPolicy, cc);
+        securityPolicy->symmetricModule.cryptoModule.encryptionAlgorithm.getRemoteBlockSize(securityPolicy, cc);
 
     if(cc->remoteSymIv.length != encryptionBlockSize)
         return UA_STATUSCODE_BADINTERNALERROR;

--- a/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
@@ -364,7 +364,7 @@ sym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 
     Basic256Sha256_PolicyContext *pc =
         (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
-
+    
     unsigned char mac[UA_SHA256_LENGTH];
     md_hmac_Basic256Sha256(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
 
@@ -464,7 +464,7 @@ sym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     size_t encryptionBlockSize =
-        securityPolicy->symmetricModule.cryptoModule.encryptionAlgorithm.getLocalBlockSize(securityPolicy, cc);
+        securityPolicy->symmetricModule.cryptoModule.encryptionAlgorithm.getRemoteBlockSize(securityPolicy, cc);
 
     if(cc->remoteSymIv.length != encryptionBlockSize)
         return UA_STATUSCODE_BADINTERNALERROR;

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -1299,7 +1299,14 @@ checkSymHeader(UA_SecureChannel *const channel,
             else
                 return UA_STATUSCODE_BADSECURECHANNELTOKENUNKNOWN;
         }
-        return UA_SecureChannel_revolveTokens(channel);
+        UA_StatusCode retval = UA_SecureChannel_revolveTokens(channel);
+        if(retval != UA_STATUSCODE_GOOD)
+            return retval;
+        if(channel->securityToken.tokenId == tokenId) {
+            retval = UA_SecureChannel_generateRemoteKeys(channel, channel->securityPolicy);
+            UA_ChannelSecurityToken_deleteMembers(&channel->previousSecurityToken);
+            return retval;
+        }
     }
 
     if(channel->previousSecurityToken.tokenId != 0) {


### PR DESCRIPTION
The problem was that the remote keys were not regenerated if the next message already used the new token id.