### PR TITLE
Run clang-format check for PR diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -182,6 +182,22 @@ matrix:
         - ANALYZE=true
         - PYTHON=python3
 #
+# clang-format code analysis
+    - os: linux
+      compiler: clang-6.0
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-6.0
+            - clang-tidy-6.0
+            - clang-format-6.0
+      env:
+        - CLANG_FORMAT=true
+        - PYTHON=python3
+#
 # cpplint checking
     #- os: linux
     #  compiler: gcc

--- a/tools/travis/travis_linux_after_success.sh
+++ b/tools/travis/travis_linux_after_success.sh
@@ -2,7 +2,7 @@
 set -ev
 
 # We only want to push the docs once, so we just take the travis run where MINGW=true which is only enabled once
-if [ $MINGW = "true" ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+if [ "$MINGW" = "true" ] && [ "${TRAVIS_REPO_SLUG}" = "open62541/open62541" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     echo "=== Executing after_success scripts ==="
     # List branches where the doc should be pushed to the webpage
     if [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "0.3" ]; then

--- a/tools/travis/travis_linux_before_install.sh
+++ b/tools/travis/travis_linux_before_install.sh
@@ -6,6 +6,11 @@ if [ -z ${LOCAL_PKG+x} ] || [ -z "$LOCAL_PKG" ]; then
     exit 1
 fi
 
+if ! [ -z ${CLANG_FORMAT+x} ]; then
+    echo "CLANG_FORMAT does not need any dependencies. Done."
+    exit 0
+fi
+
 if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
 	# Only on non-docker builds required
 


### PR DESCRIPTION
Hey,

since #2559 focuses on a more convenient way by adding comment support,
this is a pre-stage and just breaks the CI if the code format does not align with
the specified clang-format style.
