### PR TITLE
Stack: Various small reformatting to fix build after running clang-format

### DIFF
--- a/arch/posix/ua_architecture_functions.c
+++ b/arch/posix/ua_architecture_functions.c
@@ -23,11 +23,9 @@ unsigned int UA_socket_set_nonblocking(UA_SOCKET sockfd){
 }
 
 void UA_initialize_architecture_network(void){
-  return;
 }
 
 void UA_deinitialize_architecture_network(void){
-  return;
 }
 
 #endif /* UA_ARCHITECTURE_POSIX */

--- a/arch/ua_network_tcp.h
+++ b/arch/ua_network_tcp.h
@@ -14,17 +14,17 @@
 _UA_BEGIN_DECLS
 
 UA_ServerNetworkLayer UA_EXPORT
-UA_ServerNetworkLayerTCP(UA_ConnectionConfig conf, UA_UInt16 port, UA_Logger *logger);
+UA_ServerNetworkLayerTCP(UA_ConnectionConfig config, UA_UInt16 port, UA_Logger *logger);
 
 UA_Connection UA_EXPORT
-UA_ClientConnectionTCP(UA_ConnectionConfig conf, const UA_String endpointUrl,
+UA_ClientConnectionTCP(UA_ConnectionConfig config, const UA_String endpointUrl,
                        UA_UInt32 timeout, UA_Logger *logger);
 
 UA_StatusCode UA_EXPORT
 UA_ClientConnectionTCP_poll(UA_Client *client, void *data);
 
 UA_Connection UA_EXPORT
-UA_ClientConnectionTCP_init(UA_ConnectionConfig conf, const UA_String endpointUrl,
+UA_ClientConnectionTCP_init(UA_ConnectionConfig config, const UA_String endpointUrl,
                             UA_UInt32 timeout, UA_Logger *logger);
 
 _UA_END_DECLS

--- a/deps/ziptree.h
+++ b/deps/ziptree.h
@@ -186,11 +186,11 @@ __##name##_ZIP_FIND(struct type *root, const keytype *key) {            \
     enum ZIP_CMP eq = (cmp)(key, &(root)->keyfield);                    \
     if(eq == ZIP_CMP_EQ) {                                              \
         return root;                                                    \
-    } else if(eq == ZIP_CMP_LESS) {                                     \
-        return __##name##_ZIP_FIND(ZIP_LEFT(root, field), key);         \
-    } else {                                                            \
-        return __##name##_ZIP_FIND(ZIP_RIGHT(root, field), key);        \
     }                                                                   \
+    if(eq == ZIP_CMP_LESS) {                                            \
+        return __##name##_ZIP_FIND(ZIP_LEFT(root, field), key);         \
+    }                                                                   \
+    return __##name##_ZIP_FIND(ZIP_RIGHT(root, field), key);            \
 }                                                                       \
                                                                         \
 struct type *                                                           \

--- a/include/ua_client.h
+++ b/include/ua_client.h
@@ -96,7 +96,7 @@ UA_Client_connect(UA_Client *client, const char *endpointUrl);
 UA_StatusCode UA_EXPORT
 UA_Client_connect_async(UA_Client *client, const char *endpointUrl,
                         UA_ClientAsyncServiceCallback callback,
-                        void *connected);
+                        void *userdata);
 
 /* Connect to the server without creating a session
  *

--- a/include/ua_client_subscriptions.h
+++ b/include/ua_client_subscriptions.h
@@ -150,7 +150,7 @@ UA_Client_MonitoredItems_createDataChange(UA_Client *client, UA_UInt32 subscript
 UA_CreateMonitoredItemsResponse UA_EXPORT
 UA_Client_MonitoredItems_createEvents(UA_Client *client,
             const UA_CreateMonitoredItemsRequest request, void **contexts,
-            UA_Client_EventNotificationCallback *callbacks,
+            UA_Client_EventNotificationCallback *callback,
             UA_Client_DeleteMonitoredItemCallback *deleteCallback);
 
 UA_MonitoredItemCreateResult UA_EXPORT

--- a/include/ua_server.h
+++ b/include/ua_server.h
@@ -53,7 +53,7 @@ void UA_EXPORT UA_Server_delete(UA_Server *server);
  *        Otherwise, the server shuts down.
  * @return Returns the statuscode of the UA_Server_run_shutdown method */
 UA_StatusCode UA_EXPORT
-UA_Server_run(UA_Server *server, volatile UA_Boolean *running);
+UA_Server_run(UA_Server *server, const volatile UA_Boolean *running);
 
 /* The prologue part of UA_Server_run (no need to use if you call
  * UA_Server_run) */

--- a/include/ua_util.h
+++ b/include/ua_util.h
@@ -61,7 +61,7 @@ UA_parseEndpointUrlEthernet(const UA_String *endpointUrl, UA_String *target,
 size_t UA_readNumber(UA_Byte *buf, size_t buflen, UA_UInt32 *number);
 
 /* Same as UA_ReadNumber but with a base parameter */
-size_t UA_readNumberWithBase(UA_Byte *buf, size_t buflen, UA_UInt32 *number, UA_Byte base);
+size_t UA_readNumberWithBase(const UA_Byte *buf, size_t buflen, UA_UInt32 *number, UA_Byte base);
 
 #ifndef UA_MIN
 #define UA_MIN(A,B) (A > B ? B : A)

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -347,7 +347,7 @@ client_processChunk(void *application, UA_Connection *connection, UA_ByteString 
  * timout finishes */
 UA_StatusCode
 receiveServiceResponse(UA_Client *client, void *response, const UA_DataType *responseType,
-                       UA_DateTime maxDate, UA_UInt32 *synchronousRequestId) {
+                       UA_DateTime maxDate, const UA_UInt32 *synchronousRequestId) {
     /* Prepare the response and the structure we give into processServiceResponse */
     SyncResponseDescription rd = { client, false, 0, response, responseType };
 

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -206,7 +206,7 @@ openSecureChannel(UA_Client *client, UA_Boolean renew);
 UA_StatusCode
 receiveServiceResponse(UA_Client *client, void *response,
                        const UA_DataType *responseType, UA_DateTime maxDate,
-                       UA_UInt32 *synchronousRequestId);
+                       const UA_UInt32 *synchronousRequestId);
 
 UA_StatusCode
 receiveServiceResponseAsync(UA_Client *client, void *response,

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -151,10 +151,9 @@ UA_Client_Subscriptions_delete(UA_Client *client, const UA_DeleteSubscriptionsRe
                         "No internal representation of subscription %u",
                         request.subscriptionIds[i]);
             continue;
-        } else {
-            LIST_INSERT_HEAD(&client->subscriptions, subs[i], listEntry);
         }
-
+        
+        LIST_INSERT_HEAD(&client->subscriptions, subs[i], listEntry);
         UA_Client_Subscription_deleteInternal(client, subs[i]);
     }
 
@@ -202,6 +201,7 @@ UA_Client_Subscriptions_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId
 void
 UA_Client_MonitoredItem_remove(UA_Client *client, UA_Client_Subscription *sub,
                                UA_Client_MonitoredItem *mon) {
+    // NOLINTNEXTLINE
     LIST_REMOVE(mon, listEntry);
     if(mon->deleteCallback)
         mon->deleteCallback(client, sub->subscriptionId, sub->context,
@@ -343,11 +343,11 @@ UA_Client_MonitoredItems_createDataChange(UA_Client *client, UA_UInt32 subscript
 UA_CreateMonitoredItemsResponse UA_EXPORT
 UA_Client_MonitoredItems_createEvents(UA_Client *client,
             const UA_CreateMonitoredItemsRequest request, void **contexts,
-            UA_Client_EventNotificationCallback *callbacks,
-            UA_Client_DeleteMonitoredItemCallback *deleteCallbacks) {
+            UA_Client_EventNotificationCallback *callback,
+            UA_Client_DeleteMonitoredItemCallback *deleteCallback) {
     UA_CreateMonitoredItemsResponse response;
     __UA_Client_MonitoredItems_create(client, &request, contexts,
-                (void**)(uintptr_t)callbacks, deleteCallbacks, &response);
+                (void**)(uintptr_t)callback, deleteCallback, &response);
     return response;
 }
 
@@ -399,7 +399,8 @@ UA_Client_MonitoredItems_delete(UA_Client *client, const UA_DeleteMonitoredItems
         /* Delete the internal representation */
         UA_Client_MonitoredItem *mon;
         LIST_FOREACH(mon, &sub->monitoredItems, listEntry) {
-            if(mon->monitoredItemId == request.monitoredItemIds[i]) {
+            // NOLINTNEXTLINE
+            if (mon->monitoredItemId == request.monitoredItemIds[i]) {
                 UA_Client_MonitoredItem_remove(client, sub, mon);
                 break;
             }

--- a/src/client/ua_client_worker.c
+++ b/src/client/ua_client_worker.c
@@ -116,9 +116,7 @@ UA_StatusCode UA_Client_run_iterate(UA_Client *client, UA_UInt16 timeout) {
         retval = receiveServiceResponse(client, NULL, NULL, maxDate, NULL);
         if(retval == UA_STATUSCODE_GOODNONCRITICALTIMEOUT)
             retval = UA_STATUSCODE_GOOD;
-    }
-
-    else{
+    } else {
         UA_DateTime now = UA_DateTime_nowMonotonic();
         UA_Timer_process(&client->timer, now,
                          (UA_TimerExecutionCallback)clientExecuteRepeatedCallback, client);

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -145,7 +145,7 @@ onRead(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
             if(!publishedDataSet)
                 return;
             switch(((UA_NodePropertyContext *) nodeContext)->elementClassiefier) {
-                case UA_NS0ID_PUBLISHEDDATAITEMSTYPE_PUBLISHEDDATA:;
+                case UA_NS0ID_PUBLISHEDDATAITEMSTYPE_PUBLISHEDDATA:
                     pvd = (UA_PublishedVariableDataType *)
                             UA_calloc(publishedDataSet->fieldSize, sizeof(UA_PublishedVariableDataType));
                     UA_DataSetField *field;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -71,8 +71,8 @@ UA_Server_getConfig(UA_Server *server)
 {
   if(!server)
     return NULL;
-  else
-    return &server->config;
+
+  return &server->config;
 }
 
 UA_StatusCode
@@ -504,7 +504,7 @@ UA_Server_run_shutdown(UA_Server *server) {
 }
 
 UA_StatusCode
-UA_Server_run(UA_Server *server, volatile UA_Boolean *running) {
+UA_Server_run(UA_Server *server, const volatile UA_Boolean *running) {
     UA_StatusCode retval = UA_Server_run_startup(server);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -250,7 +250,7 @@ UA_Boolean
 compatibleValueRanks(UA_Int32 valueRank, UA_Int32 constraintValueRank);
 
 void
-Operation_Browse(UA_Server *server, UA_Session *session, UA_UInt32 *maxrefs,
+Operation_Browse(UA_Server *server, UA_Session *session, const UA_UInt32 *maxrefs,
                  const UA_BrowseDescription *descr, UA_BrowseResult *result);
 
 UA_DataValue

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -437,8 +437,8 @@ readMonitoredItems(UA_Server *server, const UA_NodeId *sessionId, void *sessionC
 
           return UA_STATUSCODE_BADNOMATCH;
         }
-        else
-          return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
+        
+        return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
     }
 
     UA_UInt32 sizeOfOutput = 0;

--- a/src/server/ua_services_discovery_multicast.c
+++ b/src/server/ua_services_discovery_multicast.c
@@ -62,10 +62,11 @@ static UA_StatusCode
 multicastListenStop(UA_Server* server) {
     mdnsd_shutdown(server->discoveryManager.mdnsDaemon);
     // wake up select
-    if(write(server->discoveryManager.mdnsSocket, "\0", 1)){}; //TODO: move to arch?
-    if(pthread_join(server->discoveryManager.mdnsThread, NULL)) {
-        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                     "Multicast error: Can not stop thread.");
+    if (write(server->discoveryManager.mdnsSocket, "\0", 1)) {
+        // TODO: if makes no sense here?
+    }  // TODO: move to arch?
+    if (pthread_join(server->discoveryManager.mdnsThread, NULL)) {
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER, "Multicast error: Can not stop thread.");
         return UA_STATUSCODE_BADUNEXPECTEDERROR;
     }
     return UA_STATUSCODE_BADNOTIMPLEMENTED;

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -139,7 +139,7 @@ Service_ModifySubscription(UA_Server *server, UA_Session *session,
 
 static void
 Operation_SetPublishingMode(UA_Server *Server, UA_Session *session,
-                            UA_Boolean *publishingEnabled, UA_UInt32 *subscriptionId,
+                            const UA_Boolean *publishingEnabled, const UA_UInt32 *subscriptionId,
                             UA_StatusCode *result) {
     UA_Subscription *sub = UA_Session_getSubscriptionById(session, *subscriptionId);
     if(!sub) {
@@ -529,7 +529,7 @@ struct setMonitoringContext {
 static void
 Operation_SetMonitoringMode(UA_Server *server, UA_Session *session,
                             struct setMonitoringContext *smc,
-                            UA_UInt32 *monitoredItemId, UA_StatusCode *result) {
+                            const UA_UInt32 *monitoredItemId, UA_StatusCode *result) {
     UA_MonitoredItem *mon = UA_Subscription_getMonitoredItem(smc->sub, *monitoredItemId);
     if(!mon) {
         *result = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
@@ -740,7 +740,7 @@ Service_Publish(UA_Server *server, UA_Session *session,
 
 static void
 Operation_DeleteSubscription(UA_Server *server, UA_Session *session, void *_,
-                             UA_UInt32 *subscriptionId, UA_StatusCode *result) {
+                             const UA_UInt32 *subscriptionId, UA_StatusCode *result) {
     *result = UA_Session_deleteSubscription(server, session, *subscriptionId);
     if(*result == UA_STATUSCODE_GOOD) {
         UA_LOG_DEBUG_SESSION(&server->config.logger, session,
@@ -776,7 +776,7 @@ Service_DeleteSubscriptions(UA_Server *server, UA_Session *session,
 
 static void
 Operation_DeleteMonitoredItem(UA_Server *server, UA_Session *session, UA_Subscription *sub,
-                              UA_UInt32 *monitoredItemId, UA_StatusCode *result) {
+                              const UA_UInt32 *monitoredItemId, UA_StatusCode *result) {
     *result = UA_Subscription_deleteMonitoredItem(server, sub, *monitoredItemId);
 }
 

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -259,7 +259,7 @@ browseWithContinuation(UA_Server *server, UA_Session *session,
 
 /* Start to browse with no previous cp */
 void
-Operation_Browse(UA_Server *server, UA_Session *session, UA_UInt32 *maxrefs,
+Operation_Browse(UA_Server *server, UA_Session *session, const UA_UInt32 *maxrefs,
                  const UA_BrowseDescription *descr, UA_BrowseResult *result) {
     /* Stack-allocate a temporary cp */
     UA_STACKARRAY(ContinuationPointEntry, cp, 1);
@@ -352,7 +352,7 @@ UA_Server_browse(UA_Server *server, UA_UInt32 maxrefs, const UA_BrowseDescriptio
 }
 
 static void
-Operation_BrowseNext(UA_Server *server, UA_Session *session, UA_Boolean *releaseContinuationPoints,
+Operation_BrowseNext(UA_Server *server, UA_Session *session, const UA_Boolean *releaseContinuationPoints,
                      const UA_ByteString *continuationPoint, UA_BrowseResult *result) {
     /* Find the continuation point */
     ContinuationPointEntry *cp;
@@ -633,7 +633,7 @@ walkBrowsePath(UA_Server *server, UA_Session *session, const UA_BrowsePath *path
 
 static void
 Operation_TranslateBrowsePathToNodeIds(UA_Server *server, UA_Session *session,
-                                       UA_UInt32 *nodeClassMask, const UA_BrowsePath *path,
+                                       const UA_UInt32 *nodeClassMask, const UA_BrowsePath *path,
                                        UA_BrowsePathResult *result) {
     if(path->relativePath.elementsSize <= 0) {
         result->statusCode = UA_STATUSCODE_BADNOTHINGTODO;

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -18,6 +18,8 @@
 #include "ua_types.h"
 #include "ua_types_generated.h"
 #include "ua_session.h"
+#include "ua_workqueue.h"
+#include "ua_plugin_nodestore.h"
 
 _UA_BEGIN_DECLS
 
@@ -134,8 +136,8 @@ struct UA_MonitoredItem {
 };
 
 void UA_MonitoredItem_init(UA_MonitoredItem *mon, UA_Subscription *sub);
-void UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *mon);
-void UA_MonitoredItem_sampleCallback(UA_Server *server, UA_MonitoredItem *mon);
+void UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *monitoredItem);
+void UA_MonitoredItem_sampleCallback(UA_Server *server, UA_MonitoredItem *monitoredItem);
 UA_StatusCode UA_MonitoredItem_registerSampleCallback(UA_Server *server, UA_MonitoredItem *mon);
 void UA_MonitoredItem_unregisterSampleCallback(UA_Server *server, UA_MonitoredItem *mon);
 

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -144,11 +144,10 @@ updateNeededForFilteredValue(const UA_Variant *value, const UA_Variant *oldValue
 
     if (UA_Variant_isScalar(value)) {
         return outOfDeadBand(value->data, oldValue->data, 0, value->type, deadbandValue);
-    } else {
-        for (size_t i = 0; i < value->arrayLength; ++i) {
-            if (outOfDeadBand(value->data, oldValue->data, i, value->type, deadbandValue))
-                return true;
-        }
+    }
+    for (size_t i = 0; i < value->arrayLength; ++i) {
+        if (outOfDeadBand(value->data, oldValue->data, i, value->type, deadbandValue))
+            return true;
     }
     return false;
 }
@@ -165,11 +164,10 @@ updateNeededForFilteredPercentValue(const UA_Variant *value, const UA_Variant *o
 
     if (UA_Variant_isScalar(value)) {
         return outOfPercentDeadBand(value->data, oldValue->data, 0, value->type, deadbandValue, euRange);
-    } else {
-        for (size_t i = 0; i < value->arrayLength; ++i) {
-            if (outOfPercentDeadBand(value->data, oldValue->data, i, value->type, deadbandValue, euRange))
-                return true;
-        }
+    }
+    for (size_t i = 0; i < value->arrayLength; ++i) {
+        if (outOfPercentDeadBand(value->data, oldValue->data, i, value->type, deadbandValue, euRange))
+            return true;
     }
     return false;
 }

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -270,6 +270,7 @@ UA_MonitoredItem_ensureQueueSpace(UA_Server *server, UA_MonitoredItem *mon) {
 #endif
         }
 
+        // NOLINTNEXTLINE
         UA_assert(del && del->mon == mon);
 
         /* Move after_del right after del in the global queue. (It is already
@@ -343,13 +344,12 @@ UA_MonitoredItem_ensureQueueSpace(UA_Server *server, UA_MonitoredItem *mon) {
         /* Set the infobits */
         if(mon->maxQueueSize > 1) {
             /* Add the infobits either to the newest or the new last entry */
-            indicator->data.value.hasStatus = true;
-            indicator->data.value.status |= (UA_STATUSCODE_INFOTYPE_DATAVALUE |
-                                             UA_STATUSCODE_INFOBITS_OVERFLOW);
+            indicator->data.value.hasStatus = true;  // NOLINT
+            indicator->data.value.status |= (UA_STATUSCODE_INFOTYPE_DATAVALUE | UA_STATUSCODE_INFOBITS_OVERFLOW);
         } else {
             /* If the queue size is reduced to one, remove the infobits */
-            indicator->data.value.status &= ~(UA_StatusCode)(UA_STATUSCODE_INFOTYPE_DATAVALUE |
-                                                             UA_STATUSCODE_INFOBITS_OVERFLOW);
+            indicator->data.value.status &=  // NOLINT
+                ~(UA_StatusCode)(UA_STATUSCODE_INFOTYPE_DATAVALUE | UA_STATUSCODE_INFOBITS_OVERFLOW);  // NOLINT
         }
     }
 

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -1300,8 +1300,8 @@ checkSymHeader(UA_SecureChannel *const channel,
         if(tokenId != channel->nextSecurityToken.tokenId) {
             if(allowPreviousToken)
                 return checkPreviousToken(channel, tokenId);
-            else
-                return UA_STATUSCODE_BADSECURECHANNELTOKENUNKNOWN;
+
+            return UA_STATUSCODE_BADSECURECHANNELTOKENUNKNOWN;
         }
         /* If the token is indeed the next token, revolve the tokens */
         UA_StatusCode retval = UA_SecureChannel_revolveTokens(channel);

--- a/src/ua_util.c
+++ b/src/ua_util.c
@@ -13,7 +13,7 @@
 #include "base64.h"
 
 size_t
-UA_readNumberWithBase(UA_Byte *buf, size_t buflen, UA_UInt32 *number, UA_Byte base) {
+UA_readNumberWithBase(const UA_Byte *buf, size_t buflen, UA_UInt32 *number, UA_Byte base) {
     UA_assert(buf);
     UA_assert(number);
     u32 n = 0;
@@ -47,7 +47,8 @@ UA_parseEndpointUrl(const UA_String *endpointUrl, UA_String *outHostname,
     /* Url must begin with "opc.tcp://" or opc.udp:// (if pubsub enabled) */
     if(endpointUrl->length < 11) {
         return UA_STATUSCODE_BADTCPENDPOINTURLINVALID;
-    } else if (strncmp((char*)endpointUrl->data, "opc.tcp://", 10) != 0) {
+    }
+    if (strncmp((char*)endpointUrl->data, "opc.tcp://", 10) != 0) {
 #ifdef UA_ENABLE_PUBSUB
         if (strncmp((char*)endpointUrl->data, "opc.udp://", 10) != 0 &&
                 strncmp((char*)endpointUrl->data, "opc.mqtt://", 11) != 0) {
@@ -117,11 +118,12 @@ UA_parseEndpointUrl(const UA_String *endpointUrl, UA_String *outHostname,
 
 UA_StatusCode
 UA_parseEndpointUrlEthernet(const UA_String *endpointUrl, UA_String *target,
-                            UA_UInt16 *vid, UA_Byte *prio) {
+                            UA_UInt16 *vid, UA_Byte *pcp) {
     /* Url must begin with "opc.eth://" */
     if(endpointUrl->length < 11) {
         return UA_STATUSCODE_BADINTERNALERROR;
-    } else if(strncmp((char*) endpointUrl->data, "opc.eth://", 10) != 0) {
+    }
+    if(strncmp((char*) endpointUrl->data, "opc.eth://", 10) != 0) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
@@ -170,7 +172,7 @@ UA_parseEndpointUrlEthernet(const UA_String *endpointUrl, UA_String *target,
     if(curr != endpointUrl->length) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
-    *prio = (UA_Byte) value;
+    *pcp = (UA_Byte) value;
 
     return UA_STATUSCODE_GOOD;
 }


### PR DESCRIPTION
Running clang-format changes the files so that build is not possible anymore without those fixes.

This PR only includes some small reformatting. No change in functionality.

@bbara this is part of your #2558 