### PR TITLE
[FIX] Check timestamp values in request header

### DIFF
--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -12,6 +12,7 @@
  *    Copyright 2016 (c) TorbenD
  *    Copyright 2017 (c) frax2222
  *    Copyright 2017 (c) Mark Giraud, Fraunhofer IOSB
+ *    Copyright 2019 (c) Kalycito Infotech Private Limited
  */
 
 #include "ua_server_internal.h"
@@ -557,6 +558,12 @@ processMSG(UA_Server *server, UA_SecureChannel *channel,
     /* Prepare the ResponseHeader */
     ((UA_ResponseHeader*)response)->requestHandle = requestHeader->requestHandle;
     ((UA_ResponseHeader*)response)->timestamp = UA_DateTime_now();
+
+    /* Check timestamp in the request header */
+    if(!(requestHeader->timestamp)) {
+        return sendServiceFault(channel, msg, requestPos, responseType,
+                                requestId, UA_STATUSCODE_BADINVALIDTIMESTAMP);
+    }
 
     /* Process normal services before initializing the message context.
      * Some services may initialize new message contexts and to support network

--- a/tests/testing-plugins/testing_clock.c
+++ b/tests/testing-plugins/testing_clock.c
@@ -5,7 +5,9 @@
 #include "testing_clock.h"
 #include <time.h>
 
-UA_DateTime testingClock = 0;
+/* To avoid zero timestamp value in header, the testingClock
+ * is assigned with non-zero timestamp to pass unit tests */
+UA_DateTime testingClock = 0x5C8F735D;
 
 UA_DateTime UA_DateTime_now(void) {
     return testingClock;


### PR DESCRIPTION
 - The server application should check the timestamp value in the
   header according to CTT test cases in the version 1.03.341.385
 - Timestamp is checked in the request headers of following APIs
   Service_BrowseNext(), Service_TranslateBrowsePathsToNodeIds(),
   Service_RegisterNodes(), Service_UnregisterNodes()
 - This fix will resolve the following test cases
 - ViewTranslateBrowsePath -> Err-024.js
 - ViewRegisterNodes -> Err-009.js, Err-014.js
 - View Minimum Continuation Point 01 -> Err-010.js

Signed-off-by: Jayanth Velusamy <jayanth.v@kalycito.com>