### PR TITLE
Relaxate the clang-format requirements for now and allow failure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,9 +2,16 @@
 Language:        Cpp
 BasedOnStyle:    llvm
 IndentWidth:     4
-ColumnLimit:     120
+ColumnLimit:     90
 SpacesBeforeTrailingComments: 2
-#SpaceBeforeRangeBasedForLoopColon: false
-#ForEachMacros:   [ foreach, LIST_FOREACH, LIST_FOREACH_SAFE ]
+ForEachMacros:   [ foreach, LIST_FOREACH, LIST_FOREACH_SAFE ]
 DisableFormat:   false
 
+# No space between if and parentheses
+SpaceBeforeParens: Never
+
+# Format function declarations
+BinPackParameters: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlignAfterOpenBracket: Align
+AlwaysBreakAfterReturnType: All

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,7 @@ matrix:
         - PYTHON=python3
 #
 # clang-format code analysis
+# is allowed to fail (see allow_failures)
     - os: linux
       compiler: clang-6.0
       addons:
@@ -196,12 +197,6 @@ matrix:
             - clang-format-6.0
       env:
         - CLANG_FORMAT=true
-        - PYTHON=python3
-#
-# cpplint checking
-    #- os: linux
-    #  compiler: gcc
-    #  env: LINT=true
 #
 # DOCKER build
     - os: linux
@@ -248,6 +243,11 @@ matrix:
       cache:
         directories:
           - '$HOME/.sonar/cache'
+  allow_failures:
+    #
+    # clang-format code analysis
+    - env:
+        - CLANG_FORMAT=true
 
 cache:
   pip: true

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -121,8 +121,10 @@ if ! [ -z ${CLANG_FORMAT+x} ]; then
     fi
 
     echo "====== clang-format Format Errors ======"
-    echo -e "Please fix the following issues:\n\n"
+    echo -e "Please fix the following issues. \n\nYou can also copy the output between the lines here and save it as file 'fixup.patch'.\nThen apply it with 'git apply fixup.patch'\n\n"
+    echo -e "=============== COPY HERE - START =================\n"
     echo "${difference}"
+    echo -e "\n============= COPY HERE - END ===================="
 
     echo -en 'travis_fold:start:script.clang-format\\r'
     exit 1

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -109,6 +109,9 @@ if ! [ -z ${CLANG_FORMAT+x} ]; then
     # We want to get colored diff output into the variable
     git config color.diff always
 
+    # Ignore files in the deps directory diff by resetting them to master
+    git diff --name-only $TRAVIS_BRANCH | grep 'deps/*' | xargs git checkout $TRAVIS_BRANCH --
+
     # clang-format the diff to the target branch of the PR
     difference="$($LOCAL_PKG/bin/git-clang-format --style=file --diff $TRAVIS_BRANCH)"
 


### PR DESCRIPTION
This PR relaxates the requirement that all the PRs need to be formatted according to our clang-format style.

Travis is set to allow failure for this build, but still tests it to give feedback.