### PR TITLE
Always include security policies in the amalgamated source file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,15 +661,13 @@ if(UA_GENERATED_NAMESPACE_ZERO)
     list(APPEND lib_sources ${PROJECT_BINARY_DIR}/src_generated/ua_namespace0.c)
 endif()
 
-if(UA_ENABLE_ENCRYPTION)
-    list(APPEND default_plugin_headers
-         ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.h)
-    list(APPEND default_plugin_sources
-         ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.c
-         ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
-         ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256.c
-         ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c)
-endif()
+list(APPEND default_plugin_headers
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.h)
+list(APPEND default_plugin_sources
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.c
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256.c
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c)
 
 if(UA_ENABLE_DISCOVERY)
     list(INSERT internal_headers 13 ${PROJECT_SOURCE_DIR}/src/server/ua_discovery_manager.h)

--- a/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
@@ -5,6 +5,15 @@
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
  */
 
+#include "ua_types.h"
+#include "ua_plugin_pki.h"
+#include "ua_securitypolicies.h"
+#include "ua_securitypolicy_mbedtls_common.h"
+#include "ua_types_generated_handling.h"
+#include "ua_util.h"
+
+#ifdef UA_ENABLE_ENCRYPTION
+
 #include <mbedtls/aes.h>
 #include <mbedtls/md.h>
 #include <mbedtls/x509_crt.h>
@@ -14,13 +23,6 @@
 #include <mbedtls/error.h>
 #include <mbedtls/version.h>
 #include <mbedtls/sha1.h>
-
-#include "ua_types.h"
-#include "ua_plugin_pki.h"
-#include "ua_securitypolicies.h"
-#include "ua_securitypolicy_mbedtls_common.h"
-#include "ua_types_generated_handling.h"
-#include "ua_util.h"
 
 /* Notes:
  * mbedTLS' AES allows in-place encryption and decryption. Sow we don't have to
@@ -864,3 +866,5 @@ UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy,
 
     return policyContext_newContext_sp_basic128rsa15(policy, localPrivateKey);
 }
+
+#endif

--- a/plugins/securityPolicies/ua_securitypolicy_basic256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256.c
@@ -6,19 +6,21 @@
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  */
 
-#include <mbedtls/aes.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
-#include <mbedtls/error.h>
-#include <mbedtls/version.h>
-#include <mbedtls/sha1.h>
-
 #include "ua_types.h"
 #include "ua_plugin_pki.h"
 #include "ua_securitypolicies.h"
 #include "ua_securitypolicy_mbedtls_common.h"
 #include "ua_types_generated_handling.h"
 #include "ua_util.h"
+
+#ifdef UA_ENABLE_ENCRYPTION
+
+#include <mbedtls/aes.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/entropy_poll.h>
+#include <mbedtls/error.h>
+#include <mbedtls/version.h>
+#include <mbedtls/sha1.h>
 
 /* Notes:
  * mbedTLS' AES allows in-place encryption and decryption. Sow we don't have to
@@ -811,3 +813,5 @@ UA_SecurityPolicy_Basic256(UA_SecurityPolicy *policy,
 
     return policyContext_newContext_sp_basic256(policy, localPrivateKey);
 }
+
+#endif

--- a/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
@@ -6,6 +6,15 @@
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  */
 
+#include "ua_types.h"
+#include "ua_plugin_pki.h"
+#include "ua_securitypolicies.h"
+#include "ua_securitypolicy_mbedtls_common.h"
+#include "ua_types_generated_handling.h"
+#include "ua_util.h"
+
+#ifdef UA_ENABLE_ENCRYPTION
+
 #include <mbedtls/aes.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha256.h>
@@ -16,13 +25,6 @@
 #include <mbedtls/error.h>
 #include <mbedtls/version.h>
 #include <mbedtls/sha1.h>
-
-#include "ua_types.h"
-#include "ua_plugin_pki.h"
-#include "ua_securitypolicies.h"
-#include "ua_securitypolicy_mbedtls_common.h"
-#include "ua_types_generated_handling.h"
-#include "ua_util.h"
 
 /* Notes:
  * mbedTLS' AES allows in-place encryption and decryption. Sow we don't have to
@@ -857,3 +859,5 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy,
 
     return policyContext_newContext_sp_basic256sha256(policy, localPrivateKey);
 }
+
+#endif

--- a/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.c
+++ b/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.c
@@ -1,3 +1,10 @@
+#include "ua_types.h"
+#include "ua_plugin_pki.h"
+#include "ua_securitypolicies.h"
+#include "ua_securitypolicy_mbedtls_common.h"
+
+#ifdef UA_ENABLE_ENCRYPTION
+
 #include <mbedtls/aes.h>
 #include <mbedtls/md.h>
 #include <mbedtls/x509_crt.h>
@@ -7,11 +14,6 @@
 #include <mbedtls/error.h>
 #include <mbedtls/version.h>
 #include <mbedtls/sha1.h>
-
-#include "ua_types.h"
-#include "ua_plugin_pki.h"
-#include "ua_securitypolicies.h"
-#include "ua_securitypolicy_mbedtls_common.h"
 
 void
 swapBuffers(UA_ByteString *const bufA, UA_ByteString *const bufB) {
@@ -237,3 +239,5 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
     data->length = outOffset;
     return UA_STATUSCODE_GOOD;
 }
+
+#endif

--- a/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.h
+++ b/plugins/securityPolicies/ua_securitypolicy_mbedtls_common.h
@@ -8,6 +8,9 @@
 #define UA_SECURITYPOLICY_MBEDTLS_COMMON_H_
 
 #include "ua_plugin_securitypolicy.h"
+
+#ifdef UA_ENABLE_ENCRYPTION
+
 #include <mbedtls/md.h>
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ctr_drbg.h>
@@ -15,8 +18,6 @@
 #define UA_SHA1_LENGTH 20
 
 _UA_BEGIN_DECLS
-
-#ifdef UA_ENABLE_ENCRYPTION
 
 void
 swapBuffers(UA_ByteString *const bufA, UA_ByteString *const bufB);
@@ -56,8 +57,8 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
                         mbedtls_ctr_drbg_context *drbgContext,
                         UA_ByteString *data);
 
-#endif
-
 _UA_END_DECLS
+
+#endif
 
 #endif /* UA_SECURITYPOLICY_MBEDTLS_COMMON_H_ */


### PR DESCRIPTION
For users of the amalgamated distribution, it would be a nice feature to be able to enable and disable security support at build time.