### PR TITLE
Unify memory allocation calls

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -796,13 +796,13 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
-    config->securityPolicies = (UA_SecurityPolicy*)malloc(sizeof(UA_SecurityPolicy));
+    config->securityPolicies = (UA_SecurityPolicy*)UA_malloc(sizeof(UA_SecurityPolicy));
     if(!config->securityPolicies)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     UA_StatusCode retval = UA_SecurityPolicy_None(config->securityPolicies, NULL,
                                                   UA_BYTESTRING_NULL, &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
-        free(config->securityPolicies);
+        UA_free(config->securityPolicies);
         config->securityPolicies = NULL;
         return retval;
     }
@@ -847,7 +847,7 @@ UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
 
     /* Populate SecurityPolicies */
     UA_SecurityPolicy *sp = (UA_SecurityPolicy*)
-        realloc(config->securityPolicies, sizeof(UA_SecurityPolicy) * 4);
+        UA_realloc(config->securityPolicies, sizeof(UA_SecurityPolicy) * 4);
     if(!sp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = sp;

--- a/src/pubsub/ua_pubsub_networkmessage_json.c
+++ b/src/pubsub/ua_pubsub_networkmessage_json.c
@@ -524,13 +524,13 @@ status UA_NetworkMessage_decodeJson(UA_NetworkMessage *dst, const UA_ByteString 
     memset(&ctx, 0, sizeof(CtxJson));
     ParseCtx parseCtx;
     memset(&parseCtx, 0, sizeof(ParseCtx));
-    parseCtx.tokenArray = (jsmntok_t*)malloc(sizeof(jsmntok_t) * TOKENCOUNT);
+    parseCtx.tokenArray = (jsmntok_t*)UA_malloc(sizeof(jsmntok_t) * TOKENCOUNT);
     memset(parseCtx.tokenArray, 0, sizeof(jsmntok_t) * TOKENCOUNT);
     status ret = tokenize(&parseCtx, &ctx, src);
     if(ret != UA_STATUSCODE_GOOD){
         return ret;
     }
     ret = NetworkMessage_decodeJsonInternal(dst, &ctx, &parseCtx);
-    free(parseCtx.tokenArray);
+    UA_free(parseCtx.tokenArray);
     return ret;
 }

--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -668,12 +668,12 @@ ENCODE_JSON(ByteString) {
 
     /* Check if negative... (TODO: Why is base64 3rd argument type int?) */
     if(flen < 0) {
-        free(ba64);
+        UA_free(ba64);
         return UA_STATUSCODE_BADENCODINGERROR;
     }
 
     if(ctx->pos + flen > ctx->end) {
-        free(ba64);
+        UA_free(ba64);
         return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
     }
     
@@ -683,7 +683,7 @@ ENCODE_JSON(ByteString) {
     ctx->pos += flen;
 
     /* Base64 result no longer needed */
-    free(ba64);
+    UA_free(ba64);
     
     ret |= writeJsonQuote(ctx);
     return ret;
@@ -3291,7 +3291,7 @@ UA_decodeJson(const UA_ByteString *src, void *dst, const UA_DataType *type) {
     ret = decodeJsonJumpTable[type->typeKind](dst, type, &ctx, &parseCtx, true);
 
     cleanup:
-    free(parseCtx.tokenArray);
+    UA_free(parseCtx.tokenArray);
     
     /* sanity check if all Tokens were processed */
     if(!(parseCtx.index == parseCtx.tokenCount ||


### PR DESCRIPTION
I found some malloc and free functions that should be UA_malloc and UA_free to keep the memory allocation functions unified throught the code

An issue though, is the pressence of malloc in deps/base64.c This I cannot change because, from what I understood, it works kind of as an independent file. I'm not sure the dependencies of other files and projects on this file.

This mismatch in base64.c might cause some problems when freeing the memory allocated there

