### PR TITLE
Nodeset: Support empty display name and use BrowseName as default value

### DIFF
--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -282,9 +282,20 @@ static UA_StatusCode
 copyStandardAttributes(UA_Node *node, const UA_NodeAttributes *attr) {
     /* retval  = UA_NodeId_copy(&item->requestedNewNodeId.nodeId, &node->nodeId); */
     /* retval |= UA_QualifiedName_copy(&item->browseName, &node->browseName); */
-    UA_StatusCode retval = UA_LocalizedText_copy(&attr->displayName,
-                                                 &node->displayName);
-    retval |= UA_LocalizedText_copy(&attr->description, &node->description);
+
+	UA_StatusCode retval;
+    /* The new nodeset format has optional display name.
+     * See https://github.com/open62541/open62541/issues/2627
+     * If display name is NULL, then we take the name part of the browse name */
+    if (attr->displayName.text.length == 0) {
+		retval = UA_String_copy(&node->browseName.name,
+									   &node->displayName.text);
+    } else {
+		retval = UA_LocalizedText_copy(&attr->displayName,
+													 &node->displayName);
+		retval |= UA_LocalizedText_copy(&attr->description, &node->description);
+    }
+
     node->writeMask = attr->writeMask;
     return retval;
 }

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -430,12 +430,16 @@ def generateNodeCode_begin(node, nodeset, generate_ns0, parentref, encode_binary
         code.extend(generateDataTypeNodeCode(node))
     elif isinstance(node, ViewNode):
         code.extend(generateViewNodeCode(node))
-    code.append("attr.displayName = " + generateLocalizedTextCode(node.displayName, alloc=False) + ";")
-    code.append("#ifdef UA_ENABLE_NODESET_COMPILER_DESCRIPTIONS")
-    code.append("attr.description = " + generateLocalizedTextCode(node.description, alloc=False) + ";")
-    code.append("#endif")
-    code.append("attr.writeMask = %d;" % node.writeMask)
-    code.append("attr.userWriteMask = %d;" % node.userWriteMask)
+    if node.displayName is not None:
+        code.append("attr.displayName = " + generateLocalizedTextCode(node.displayName, alloc=False) + ";")
+    if node.description is not None:
+        code.append("#ifdef UA_ENABLE_NODESET_COMPILER_DESCRIPTIONS")
+        code.append("attr.description = " + generateLocalizedTextCode(node.description, alloc=False) + ";")
+        code.append("#endif")
+    if node.writeMask is not None:
+        code.append("attr.writeMask = %d;" % node.writeMask)
+    if node.userWriteMask is not None:
+        code.append("attr.userWriteMask = %d;" % node.userWriteMask)
 
     # AddNodes call
     code.append("retVal |= UA_Server_addNode_begin(server, UA_NODECLASS_{},".

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -68,13 +68,13 @@ def RefOrAlias(s):
 
 class Node(object):
     def __init__(self):
-        self.id = NodeId()
-        self.browseName = QualifiedName()
-        self.displayName = LocalizedText()
-        self.description = LocalizedText()
-        self.symbolicName = String()
-        self.writeMask = 0
-        self.userWriteMask = 0
+        self.id = None
+        self.browseName = None
+        self.displayName = None
+        self.description = None
+        self.symbolicName = None
+        self.writeMask = None
+        self.userWriteMask = None
         self.references = set()
         self.hidden = False
         self.modelUri = None


### PR DESCRIPTION
See https://github.com/open62541/open62541/issues/2627
With this commit we support optional display name in the NodeSet2.xml.
If it is not given, we take the name part of the BrowseName.

This is part of #2630