### PR TITLE
[CTT Fix] Remove localhost from hostname in server certificate

### DIFF
--- a/tools/certs/create_self-signed.py
+++ b/tools/certs/create_self-signed.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this 
+# License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 2019 (c) Kalycito Infotech Private Limited
+#
 
+import netifaces
 import sys
 import os
 import socket
@@ -20,6 +24,43 @@ if len(sys.argv) == 3:
 
 certsdir = os.path.dirname(os.path.abspath(__file__))
 print(certsdir)
+
+# Function return TRUE (1) when an IP address is associated with the
+# given interface
+def is_interface_up(interface):
+    addr = netifaces.ifaddresses(interface)
+    return netifaces.AF_INET in addr
+
+# Initialize looping variables
+interfaceNum = 0
+iteratorValue = 0
+
+# Read the number of interfaces available
+numberOfInterfaces = int(format(len(netifaces.interfaces())))
+
+# Traverse through the available network interfaces and store the
+# corresponding IP addresses of the network interface in a variable
+for interfaceNum in range(0, numberOfInterfaces):
+    # Function call which returns whether the given
+    # interface is up or not
+    check = is_interface_up(netifaces.interfaces()[interfaceNum])
+
+    # Check if the interface is up and not the loopback one
+    # If yes set the IP Address for the environmental variables
+    if check != 0 and netifaces.interfaces()[interfaceNum] != 'lo':
+        if iteratorValue == 0:
+            os.environ['IPADDRESS1'] = netifaces.ifaddresses(netifaces.interfaces()[interfaceNum])[netifaces.AF_INET][0]['addr']
+        if iteratorValue == 1:
+            os.environ['IPADDRESS2'] = netifaces.ifaddresses(netifaces.interfaces()[interfaceNum])[netifaces.AF_INET][0]['addr']
+        iteratorValue = iteratorValue + 1
+        if iteratorValue == 2:
+            break
+
+# If there is only one interface available then set the second
+# IP address as loopback IP
+if iteratorValue < 2:
+    os.environ['IPADDRESS2'] = "127.0.0.1"
+
 os.environ['HOSTNAME'] = socket.gethostname()
 openssl_conf = os.path.join(certsdir, "localhost.cnf")
 

--- a/tools/certs/localhost.cnf
+++ b/tools/certs/localhost.cnf
@@ -13,6 +13,8 @@ RANDFILE		= $ENV::HOME/.rnd
 oid_section		= new_oids
 
 hostname = ${ENV::HOSTNAME}
+ipaddress1 = ${ENV::IPADDRESS1}
+ipaddress2 = ${ENV::IPADDRESS2}
 
 # To use this configuration file with the "-extfile" option of the
 # "openssl x509" utility, name here the section containing the
@@ -225,10 +227,10 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
 
 [ alt_names ]
-DNS.1 = localhost
+DNS.1 = ${hostname}
 DNS.2 = ${hostname}
-IP.1 = 127.0.0.1
-IP.2 = 0.0.0.0
+IP.1 = ${ipaddress1}
+IP.2 = ${ipaddress2}
 URI.1 = urn:unconfigured:application
 
 [ v3_ca ]


### PR DESCRIPTION
 - Currently generated server certificate (server_cert.der) has
   hostname set to localhost and IP Address set to 127.0.0.1
 - In new CTT, using "localhost" as hostname in a certificate or
   EndpointUrl is not allowed
 - So modified Python script and the corresponding configuration
   file (localhost.cnf) to dynamically identify the network
   interfaces and the corresponding IP addresses

Signed-off-by: Asish Ganesh <asish.g@kalycito.com>