### PR TITLE
Certificate fixes

### DIFF
--- a/examples/server_ctt.c
+++ b/examples/server_ctt.c
@@ -1,5 +1,9 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
- * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
+ *
+ * Copyright 2019 (c) Kalycito Infotech Private Limited
+ *
+ */
 
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS /* disable fopen deprication warning in msvs */
@@ -13,6 +17,11 @@
 #include <stdlib.h>
 
 #include "common.h"
+
+#define TRUSTLISTCOUNT       3
+#define REVOCATIONLISTCOUNT  4
+#define STARTOFLIST          5
+#define BASEVALUE            10
 
 /* This server is configured to the Compliance Testing Tools (CTT) against. The
  * corresponding CTT configuration is available at
@@ -470,25 +479,30 @@ int main(int argc, char **argv) {
         }
 
         /* Load the trustlist */
-        size_t trustListSize = 0;
-        if(argc > 3)
-            trustListSize = (size_t)argc-3;
+        char* pBuffer;
+        size_t trustListSize = (size_t)strtol(argv[TRUSTLISTCOUNT], &pBuffer, BASEVALUE);
         UA_STACKARRAY(UA_ByteString, trustList, trustListSize);
-        for(size_t i = 0; i < trustListSize; i++)
-            trustList[i] = loadFile(argv[i+3]);
+        for(size_t iteratorValue = 0; iteratorValue <= trustListSize; iteratorValue++) {
+            trustList[iteratorValue] = loadFile(argv[iteratorValue + STARTOFLIST]);
+        }
 
         /* Loading of a revocation list currently unsupported */
-        UA_ByteString *revocationList = NULL;
-        size_t revocationListSize = 0;
+        size_t revocationListSize = (size_t)strtol(argv[REVOCATIONLISTCOUNT], &pBuffer, BASEVALUE);
+        UA_STACKARRAY(UA_ByteString, revocationList, revocationListSize);
+        for(size_t iteratorValue = 0; iteratorValue < revocationListSize; iteratorValue++) {
+            revocationList[iteratorValue] = loadFile(argv[trustListSize + STARTOFLIST]);
+        }
 
         UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840,
                                                        &certificate, &privateKey,
                                                        trustList, trustListSize,
                                                        revocationList, revocationListSize);
+
         UA_ByteString_clear(&certificate);
         UA_ByteString_clear(&privateKey);
-        for(size_t i = 0; i < trustListSize; i++)
-            UA_ByteString_clear(&trustList[i]);
+        for(size_t iteratorValue = 0; iteratorValue < trustListSize; iteratorValue++) {
+            UA_ByteString_clear(&trustList[iteratorValue]);
+        }
     }
 #else
     UA_ByteString certificate = UA_BYTESTRING_NULL;

--- a/plugins/ua_pki_default.c
+++ b/plugins/ua_pki_default.c
@@ -2,6 +2,7 @@
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
  *
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
+ *    Copyright 2019 (c) Kalycito Infotech Private Limited
  */
 
 #include <open62541/plugin/pki_default.h>
@@ -79,6 +80,18 @@ certificateVerification_verify(void *verificationContext,
                                                    &crtProfile, NULL, &flags, NULL, NULL);
 
     // TODO: Extend verification
+
+    /* This condition will check whether the certificate is a User certificate
+     * or a CA certificate. If the MBEDTLS_X509_KU_KEY_CERT_SIGN and
+     * MBEDTLS_X509_KU_CRL_SIGN of key_usage are set, then the certificate
+     * shall be condidered as CA Certificate and cannot be used to establish a
+     * connection. Refer the test case CTT/Security/Security Certificate Validation/029.js
+     * for more details */
+    if((remoteCertificate.key_usage & MBEDTLS_X509_KU_KEY_CERT_SIGN) &&
+       (remoteCertificate.key_usage & MBEDTLS_X509_KU_CRL_SIGN)) {
+        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
+    }
+
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(mbedErr) {
         /* char buff[100]; */

--- a/src/ua_connection.c
+++ b/src/ua_connection.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2014-2017 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2014, 2016-2017 (c) Florian Palm
@@ -8,6 +8,7 @@
  *    Copyright 2015 (c) Oleksiy Vasylyev
  *    Copyright 2016-2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Mark Giraud, Fraunhofer IOSB
+ *    Copyright 2019 (c) Kalycito Infotech Private Limited
  */
 
 #include <open62541/transport_generated_encoding_binary.h>
@@ -54,12 +55,13 @@ UA_Connection_processHELACK(UA_Connection *connection,
     return UA_STATUSCODE_GOOD;
 }
 
-/* Hides somme errors before sending them to a client according to the
+/* Hides some errors before sending them to a client according to the
  * standard. */
 static void
 hideErrors(UA_TcpErrorMessage *const error) {
     switch(error->error) {
     case UA_STATUSCODE_BADCERTIFICATEUNTRUSTED:
+    case UA_STATUSCODE_BADCERTIFICATEREVOKED:
         error->error = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         error->reason = UA_STRING_NULL;
         break;


### PR DESCRIPTION
This PR contains a implementation for passing trusted certificates and CRL files from command line argument.

**Usage:**

1. Create a directories `trustList` and `crl`
2. Copy the trusted certificates to `trustList` folder and revocation list to `crl` folder
3. Run server_ctt using the following command
`./server_ctt server_cert.der server_key.der -t trustList/ -c crl/`
4. Tested with certificates in CTT project (ver 1.03.341.389) `ctt_project_folder\PKI\copyToServer\ApplicationInstance_PKI`

**TODO:**

1. Make it robust
2. Cleanup hard-coded items
3. Windows build

@jpfr Shall we have a separate branch for this PR?


Regards
opcua-tsn-team-kalycito
