### PR TITLE
Fix deleting a configured uninitialized  mdns server

### DIFF
--- a/src/server/ua_discovery_manager.c
+++ b/src/server/ua_discovery_manager.c
@@ -72,8 +72,11 @@ initMulticastDiscoveryServer(UA_DiscoveryManager *dm, UA_Server* server) {
 
 static void
 destroyMulticastDiscoveryServer(UA_DiscoveryManager *dm) {
-    mdnsd_shutdown(dm->mdnsDaemon);
-    mdnsd_free(dm->mdnsDaemon);
+    if(dm->mdnsDaemon)
+    {
+        mdnsd_shutdown(dm->mdnsDaemon);
+        mdnsd_free(dm->mdnsDaemon);
+    }
     if(dm->mdnsSocket != UA_INVALID_SOCKET) {
         UA_close(dm->mdnsSocket);
         dm->mdnsSocket = UA_INVALID_SOCKET;

--- a/tests/server/check_discovery.c
+++ b/tests/server/check_discovery.c
@@ -127,6 +127,13 @@ static void teardown_register(void) {
     UA_Server_delete(server_register);
 }
 
+START_TEST(Server_new_delete) {
+    UA_Server *pServer = UA_Server_new();
+    configure_lds_server(pServer);
+    UA_Server_delete(pServer);
+}
+END_TEST
+
 START_TEST(Server_register) {
     UA_Client *clientRegister = UA_Client_new();
     UA_ClientConfig_setDefault(UA_Client_getConfig(clientRegister));
@@ -554,6 +561,11 @@ END_TEST
 
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Register Server and Client");
+
+    TCase *tc_new_del = tcase_create("New Delete");
+    tcase_add_test(tc_new_del, Server_new_delete);
+    suite_add_tcase(s,tc_new_del);
+
     TCase *tc_register = tcase_create("RegisterServer");
     tcase_add_unchecked_fixture(tc_register, setup_lds, teardown_lds);
     tcase_add_unchecked_fixture(tc_register, setup_register, teardown_register);

--- a/tests/server/check_discovery.c
+++ b/tests/server/check_discovery.c
@@ -37,13 +37,9 @@ THREAD_CALLBACK(serverloop_lds) {
     return 0;
 }
 
-static void setup_lds(void) {
-    // start LDS server
-    running_lds = UA_Boolean_new();
-    *running_lds = true;
-
-    server_lds = UA_Server_new();
-    UA_ServerConfig *config_lds = UA_Server_getConfig(server_lds);
+static void configure_lds_server(UA_Server *pServer)
+{
+    UA_ServerConfig *config_lds = UA_Server_getConfig(pServer);
     UA_ServerConfig_setDefault(config_lds);
 
     config_lds->applicationDescription.applicationType = UA_APPLICATIONTYPE_DISCOVERYSERVER;
@@ -62,6 +58,15 @@ static void setup_lds(void) {
     config_lds->discovery.mdns.serverCapabilities = caps;
 #endif
     config_lds->discovery.cleanupTimeout = registerTimeout;
+}
+
+static void setup_lds(void) {
+    // start LDS server
+    running_lds = UA_Boolean_new();
+    *running_lds = true;
+
+    server_lds = UA_Server_new();
+    configure_lds_server(server_lds);
 
     UA_Server_run_startup(server_lds);
     THREAD_CREATE(server_thread_lds, serverloop_lds);


### PR DESCRIPTION
This (new) test case failed due to a null pointer access.
```
START_TEST(Server_new_delete) {
	UA_Server *pServer = UA_Server_new();
	configure_lds_server(pServer);
	UA_Server_delete(pServer);
}
END_TEST
```

~~Fix will (hopefully) added later this day by me, when I found the exact reason.~~
Fix is added
