### PR TITLE
Fix issues with MSVC 2012

### DIFF
--- a/include/ua_config.h.in
+++ b/include/ua_config.h.in
@@ -54,7 +54,9 @@ extern "C" {
 /* Include stdint.h and stdbool.h or workaround for older Visual Studios */
 #if !defined(_MSC_VER) || _MSC_VER >= 1600
 # include <stdint.h>
-# include <stdbool.h> /* C99 Boolean */
+# if !defined(__cplusplus) && (!defined(_MSC_VER) || _MSC_VER > 1700)
+#  include <stdbool.h> /* C99 Boolean */
+# endif
 # if defined(_WRS_KERNEL)
 # define UINT32_C(x) ((x) + (UINT32_MAX - UINT32_MAX)) 
 # endif

--- a/plugins/ua_log_socket_error.h
+++ b/plugins/ua_log_socket_error.h
@@ -19,7 +19,7 @@ extern "C" {
     FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, \
     NULL, WSAGetLastError(), \
     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), \
-    (LPSTR)&errno_str, 0, NULL); \
+    (LPTSTR)&errno_str, 0, NULL); \
     LOG; \
     LocalFree(errno_str); \
 }


### PR DESCRIPTION
stdbool.h is only available in MSVC 2013 and later. A C++ build using MSVC 2012 is possible if the include is removed.