### PR TITLE
Fix: Add UA_EXPORT to UA_SECURITY_POLICY_NONE_URI for shared builds

### DIFF
--- a/include/open62541/plugin/securitypolicy.h
+++ b/include/open62541/plugin/securitypolicy.h
@@ -16,7 +16,7 @@
 
 _UA_BEGIN_DECLS
 
-extern const UA_ByteString UA_SECURITY_POLICY_NONE_URI;
+extern UA_EXPORT const UA_ByteString UA_SECURITY_POLICY_NONE_URI;
 
 struct UA_SecurityPolicy;
 typedef struct UA_SecurityPolicy UA_SecurityPolicy;


### PR DESCRIPTION
Missing UA_EXPORT that causes problems when building a shared library in windows.