### PR TITLE
[CTT Fix] Connect using trusted client certificate

### DIFF
--- a/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
+ *    Copyright 2019 (c) Kalycito Infotech Private Limited
+ *
  */
 
 #include <open62541/plugin/securitypolicy_default.h>
@@ -35,7 +37,7 @@
 #define UA_SECURITYPOLICY_BASIC128RSA15_SYM_ENCRYPTION_BLOCK_SIZE 16
 #define UA_SECURITYPOLICY_BASIC128RSA15_SYM_PLAIN_TEXT_BLOCK_SIZE 16
 #define UA_SECURITYPOLICY_BASIC128RSA15_MINASYMKEYLENGTH 128
-#define UA_SECURITYPOLICY_BASIC128RSA15_MAXASYMKEYLENGTH 256
+#define UA_SECURITYPOLICY_BASIC128RSA15_MAXASYMKEYLENGTH 512
 
 typedef struct {
     const UA_SecurityPolicy *securityPolicy;

--- a/plugins/securityPolicies/ua_securitypolicy_basic256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256.c
@@ -4,6 +4,8 @@
  *
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
+ *    Copyright 2019 (c) Kalycito Infotech Private Limited
+ *
  */
 
 #include <open62541/plugin/securitypolicy.h>
@@ -37,7 +39,7 @@
 #define UA_SECURITYPOLICY_BASIC256_SYM_ENCRYPTION_BLOCK_SIZE 16
 #define UA_SECURITYPOLICY_BASIC256_SYM_PLAIN_TEXT_BLOCK_SIZE 16
 #define UA_SECURITYPOLICY_BASIC256_MINASYMKEYLENGTH 128
-#define UA_SECURITYPOLICY_BASIC256_MAXASYMKEYLENGTH 256
+#define UA_SECURITYPOLICY_BASIC256_MAXASYMKEYLENGTH 512
 
 typedef struct {
     const UA_SecurityPolicy *securityPolicy;


### PR DESCRIPTION
 - At present if trusted client certificate having key
   encrypted with sha2-4096 is passed the response
   received is BadCertificateUseNotAllowed
 - According to CTT (Test case 052.js in Security
   Certificate Validation) the expected result is Good
 - Fixed the same by changing the max key length value

Signed-off-by: Asish Ganesh <asish.g@kalycito.com>