### PR TITLE
Travis: Different way to set custom hostname on OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,10 +223,6 @@ matrix:
 # OSX clang build
     - os: osx
       compiler: clang
-      # OSX may have different hostnames between processes, which causes multicast unit test to fail.
-      # Hardcode the hostname here
-      addons:
-        hostname: travis-osx
       # disable homebrew auto update which takes a lot of time
       env: HOMEBREW_NO_AUTO_UPDATE=1
       cache:

--- a/tools/travis/travis_osx_script.sh
+++ b/tools/travis/travis_osx_script.sh
@@ -5,6 +5,17 @@ echo "\n=== Building ==="
 export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
 export PATH="/Users/travis/Library/Python/2.7/bin:$PATH"
 
+# OSX may have different hostnames between processes, which causes multicast unit test to fail.
+# Hardcode the hostname here
+# Note: do not use the `hostname` addon from travis:
+# addons:
+#  hostname: travis-osx
+#
+# Travis support says:
+# the `hostname` command is actually a super ephemeral way to change it. There’s a different way:
+# `sudo scutil --set HostName <new host name>` which is more permanent and potentially more resilient
+sudo scutil --set HostName travis-osx
+
 echo "Full Namespace 0 Generation" && echo -en 'travis_fold:start:script.build.ns0\\r'
 mkdir -p build
 cd build


### PR DESCRIPTION
Travis support says:
the `hostname` command is actually a super ephemeral way to change it. There’s a different way:
`sudo scutil --set HostName <new host name>` which is more permanent and potentially more resilient