### PR TITLE
CMake: Cleanup of cmake code for doc generation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -2,19 +2,37 @@ find_package(Sphinx)
 find_package(LATEX)
 
 set(DOC_LATEX_DIR ${PROJECT_BINARY_DIR}/doc_latex)
-set(DOC_HTML_DIR  ${PROJECT_BINARY_DIR}/doc)
-set(DOC_SRC_DIR   ${PROJECT_BINARY_DIR}/doc_src)
+set(DOC_HTML_DIR ${PROJECT_BINARY_DIR}/doc)
+set(DOC_SRC_DIR ${PROJECT_BINARY_DIR}/doc_src)
 
 make_directory(${DOC_SRC_DIR})
+
+# Copy all files from /doc dir to the /doc_src dir. doc_src is used to compile the documentation.
+# Use custom copy command to make sure files are correctly updated when they are changed.
 file(GLOB DOC_SRC "${PROJECT_SOURCE_DIR}/doc/*")
 list(REMOVE_ITEM DOC_SRC "${PROJECT_SOURCE_DIR}/doc/conf.py")
-file(COPY ${DOC_SRC} DESTINATION ${DOC_SRC_DIR})
+list(REMOVE_ITEM DOC_SRC "${PROJECT_SOURCE_DIR}/doc/CMakeLists.txt")
+string(REPLACE "${PROJECT_SOURCE_DIR}/doc" "${DOC_SRC_DIR}" DOC_TARGET "${DOC_SRC}")
+add_custom_command(OUTPUT ${DOC_TARGET}
+                   PRE_BUILD
+                   DEPENDS ${DOC_SRC}
+                   COMMAND ${CMAKE_COMMAND}
+                   ARGS -E copy ${DOC_SRC} ${DOC_SRC_DIR}
+)
+
 configure_file("${PROJECT_SOURCE_DIR}/doc/conf.py" "${DOC_SRC_DIR}/conf.py")
 
-function(generate_rst in out)
-  add_custom_command(OUTPUT ${out} DEPENDS ${PROJECT_SOURCE_DIR}/tools/c2rst.py ${in}
-                     PRE_BUILD COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/c2rst.py ${in} ${out})
-endfunction()
+
+list(APPEND GENERATED_RST "")
+
+macro(generate_rst in out)
+    add_custom_command(OUTPUT ${out}
+                       DEPENDS ${PROJECT_SOURCE_DIR}/tools/c2rst.py ${in}
+                       PRE_BUILD
+                       COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/c2rst.py ${in} ${out})
+    list(APPEND GENERATED_RST "${out}")
+endmacro()
+
 
 # Doc from headers
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/types.h ${DOC_SRC_DIR}/types.rst)
@@ -48,66 +66,27 @@ generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_method.c ${DOC_SRC_D
 generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_client_firststeps.c ${DOC_SRC_DIR}/tutorial_client_firststeps.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/examples/pubsub/tutorial_pubsub_publish.c ${DOC_SRC_DIR}/tutorial_pubsub_publish.rst)
 
+
+# Doc targets
+
 add_custom_target(doc_latex ${SPHINX_EXECUTABLE}
-  -b latex "${DOC_SRC_DIR}" "${DOC_LATEX_DIR}"
-  DEPENDS ${DOC_SRC_DIR}/types.rst ${DOC_SRC_DIR}/constants.rst ${DOC_SRC_DIR}/types_generated.rst
-          ${DOC_SRC_DIR}/statuscodes.rst
-          ${DOC_SRC_DIR}/server.rst ${DOC_SRC_DIR}/server_config.rst
-          ${DOC_SRC_DIR}/client.rst ${DOC_SRC_DIR}/client_subscriptions.rst
-          ${DOC_SRC_DIR}/client_highlevel.rst ${DOC_SRC_DIR}/client_config.rst
-          ${DOC_SRC_DIR}/plugin_log.rst ${DOC_SRC_DIR}/plugin_network.rst
-          ${DOC_SRC_DIR}/services.rst ${DOC_SRC_DIR}/plugin_accesscontrol.rst
-          ${DOC_SRC_DIR}/nodestore.rst
-          ${DOC_SRC_DIR}/tutorials.rst
-          ${DOC_SRC_DIR}/tutorial_datatypes.rst
-          ${DOC_SRC_DIR}/tutorial_client_firststeps.rst
-          ${DOC_SRC_DIR}/tutorial_server_firststeps.rst
-          ${DOC_SRC_DIR}/tutorial_server_variable.rst
-          ${DOC_SRC_DIR}/tutorial_server_variabletype.rst
-          ${DOC_SRC_DIR}/tutorial_server_datasource.rst
-          ${DOC_SRC_DIR}/tutorial_server_monitoreditems.rst
-          ${DOC_SRC_DIR}/tutorial_server_object.rst
-          ${DOC_SRC_DIR}/tutorial_server_method.rst
-          ${DOC_SRC_DIR}/tutorial_pubsub_publish.rst
-          ${DOC_SRC_DIR}/plugin_pubsub_connection.rst
-          ${DOC_SRC_DIR}/pubsub.rst
-          ${DOC_SRC_DIR}/tutorial_server_events.rst
-  COMMENT "Building LaTeX sources for documentation with Sphinx")
+                  -b latex "${DOC_SRC_DIR}" "${DOC_LATEX_DIR}"
+                  DEPENDS ${GENERATED_RST} ${DOC_TARGET}
+                  COMMENT "Building LaTeX sources for documentation with Sphinx")
 add_dependencies(doc_latex open62541)
 
 add_custom_target(doc_pdf ${PDFLATEX_COMPILER} -interaction=batchmode "open62541.tex"
-  WORKING_DIRECTORY ${DOC_LATEX_DIR}
-  # compile it twice so that the contents pages are correct
-  COMMAND ${PDFLATEX_COMPILER} -interaction=batchmode "open62541.tex"
-  DEPENDS ${PDFLATEX_COMPILER}
-  COMMENT "Generating PDF documentation from LaTeX sources")
+                  WORKING_DIRECTORY ${DOC_LATEX_DIR}
+                  # compile it twice so that the contents pages are correct
+                  COMMAND ${PDFLATEX_COMPILER} -interaction=batchmode "open62541.tex"
+                  DEPENDS ${PDFLATEX_COMPILER}
+                  COMMENT "Generating PDF documentation from LaTeX sources")
 add_dependencies(doc_pdf doc_latex)
 
 add_custom_target(doc ${SPHINX_EXECUTABLE}
-  -b html "${DOC_SRC_DIR}" "${DOC_HTML_DIR}"
-  DEPENDS ${DOC_SRC_DIR}/types.rst ${DOC_SRC_DIR}/constants.rst ${DOC_SRC_DIR}/types_generated.rst
-          ${DOC_SRC_DIR}/statuscodes.rst
-          ${DOC_SRC_DIR}/server.rst ${DOC_SRC_DIR}/server_config.rst
-          ${DOC_SRC_DIR}/client.rst ${DOC_SRC_DIR}/client_subscriptions.rst
-          ${DOC_SRC_DIR}/client_highlevel.rst ${DOC_SRC_DIR}/client_config.rst
-          ${DOC_SRC_DIR}/plugin_log.rst ${DOC_SRC_DIR}/plugin_network.rst
-          ${DOC_SRC_DIR}/services.rst ${DOC_SRC_DIR}/plugin_accesscontrol.rst
-          ${DOC_SRC_DIR}/nodestore.rst
-          ${DOC_SRC_DIR}/tutorials.rst
-          ${DOC_SRC_DIR}/tutorial_datatypes.rst
-          ${DOC_SRC_DIR}/tutorial_client_firststeps.rst
-          ${DOC_SRC_DIR}/tutorial_server_firststeps.rst
-          ${DOC_SRC_DIR}/tutorial_server_variable.rst
-          ${DOC_SRC_DIR}/tutorial_server_variabletype.rst
-          ${DOC_SRC_DIR}/tutorial_server_datasource.rst
-          ${DOC_SRC_DIR}/tutorial_server_monitoreditems.rst
-          ${DOC_SRC_DIR}/tutorial_server_object.rst
-          ${DOC_SRC_DIR}/tutorial_server_method.rst
-          ${DOC_SRC_DIR}/tutorial_pubsub_publish.rst
-          ${DOC_SRC_DIR}/plugin_pubsub_connection.rst
-          ${DOC_SRC_DIR}/pubsub.rst
-          ${DOC_SRC_DIR}/tutorial_server_events.rst
-  COMMENT "Building HTML documentation with Sphinx")
+                  -b html "${DOC_SRC_DIR}" "${DOC_HTML_DIR}"
+                  DEPENDS ${GENERATED_RST} ${DOC_TARGET}
+                  COMMENT "Building HTML documentation with Sphinx")
 add_dependencies(doc open62541)
 
 set_target_properties(doc doc_latex doc_pdf PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE)


### PR DESCRIPTION
Replaces #2552 

With this code, the copy command is replaced with a custom command which makes sure that the dependencies are correctly set.