### PR TITLE
Session: A NULL or empty UserIdentityToken should be treated as Anonymous

### DIFF
--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -505,9 +505,13 @@ processMSG(UA_Server *server, UA_SecureChannel *channel,
     UA_Session anonymousSession;
     if(!session) {
         if(sessionRequired) {
+#ifdef UA_ENABLE_TYPENAMES
             UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
-                                   "Service request %i without a valid session",
-                                   requestType->binaryEncodingId);
+                                   "%s refused without a valid session", requestType->typeName);
+#else
+            UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
+                                   "Service %i refused without a valid session", requestType->binaryEncodingId);
+#endif
             UA_deleteMembers(request, requestType);
             return sendServiceFault(channel, msg, requestPos, responseType,
                                     requestId, UA_STATUSCODE_BADSESSIONIDINVALID);
@@ -522,9 +526,13 @@ processMSG(UA_Server *server, UA_SecureChannel *channel,
     /* Trying to use a non-activated session?
      * Do not allow if request is of type CloseSessionRequest */
     if(sessionRequired && !session->activated && requestType != &UA_TYPES[UA_TYPES_CLOSESESSIONREQUEST]) {
+#ifdef UA_ENABLE_TYPENAMES
         UA_LOG_WARNING_SESSION(&server->config.logger, session,
-                               "Calling service %i on a non-activated session",
-                               requestType->binaryEncodingId);
+                               "%s refused on a non-activated session", requestType->typeName);
+#else
+        UA_LOG_WARNING_SESSION(&server->config.logger, session,
+                               "Service %i refused on a non-activated session", requestType->binaryEncodingId);
+#endif
         UA_SessionManager_removeSession(&server->sessionManager,
                                         &session->header.authenticationToken);
         UA_deleteMembers(request, requestType);

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -295,15 +295,17 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
             continue;
 
         /* Match the SecurityPolicy */
-        if(!UA_String_equal(&e->securityPolicyUri,
-                            &channel->securityPolicy->policyUri))
+        if(!UA_String_equal(&e->securityPolicyUri, &channel->securityPolicy->policyUri))
             continue;
 
         /* Match the UserTokenType */
         for(size_t j = 0; j < e->userIdentityTokensSize; j++) {
             const UA_UserTokenPolicy *u = &e->userIdentityTokens[j];
             if(u->tokenType == UA_USERTOKENTYPE_ANONYMOUS) {
-                if(request->userIdentityToken.content.decoded.type != &UA_TYPES[UA_TYPES_ANONYMOUSIDENTITYTOKEN])
+                /* Part 4, Section 5.6.3.2, Table 17: A NULL or empty
+                 * UserIdentityToken should be treated as Anonymous */
+                if(request->userIdentityToken.content.decoded.type != &UA_TYPES[UA_TYPES_ANONYMOUSIDENTITYTOKEN] &&
+                   request->userIdentityToken.encoding != UA_EXTENSIONOBJECT_ENCODED_NOBODY)
                     continue;
             } else if(u->tokenType == UA_USERTOKENTYPE_USERNAME) {
                 if(request->userIdentityToken.content.decoded.type != &UA_TYPES[UA_TYPES_USERNAMEIDENTITYTOKEN])


### PR DESCRIPTION
@cpipero uncovered the issue and proposed the fix in #2805.