### PR TITLE
For 1 dimension arrays, initializing arrayDimensionsSize may confuse some OPC clients.

### DIFF
--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -63,6 +63,7 @@ START_TEST(check1dimValues) {
     UA_Point *p = (UA_Point *)out.data;
     ck_assert(!UA_Variant_isScalar(&out));
     ck_assert(out.arrayLength == 4);
+    ck_assert(out.arrayDimensionsSize == 0);    // For 1 dimension arrays, initializing arrayDimensionsSize may confuse some OPC clients.
     ck_assert(p[0].x == (UA_Double)1.0);
     ck_assert(p[3].y == (UA_Double)8.0);
     UA_Variant_clear(&out);

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -195,7 +195,11 @@ def generateCommonVariableCode(node, nodeset):
             code += code1
             codeCleanup += codeCleanup1
             codeGlobal += codeGlobal1
-            if node.valueRank is not None and node.valueRank > 0 and len(node.arrayDimensions) == node.valueRank and len(node.value.value) > 0:
+            # #1978 Variant arrayDimensions are only required to properly decode multidimensional arrays
+            # (valueRank > 1) from data stored as one-dimensional array of arrayLength elements.
+            # One-dimensional arrays are already completely defined by arraylength attribute so setting
+            # also arrayDimensions, even if not explicitly forbidden, can confuse clients
+            if node.valueRank is not None and node.valueRank > 1 and len(node.arrayDimensions) == node.valueRank and len(node.value.value) > 0:
                 numElements = 1
                 hasZero = False
                 for v in node.arrayDimensions:


### PR DESCRIPTION
PR #1810 caused to loose the fix done in PR #1978...
I've re-introduced that fix and added a unit test to avoid this in the future.
In our case the problem showed in two OPC-UA Client (“Unified Automation UaExpert” and “Integration Objects OPC UA Explorer”):
when trying to do a Method Call, no Input / Output Arguments were shown (UA Explorer told they’re Opc.Ua.Matrix instead of array).