### PR TITLE
Fix: compatibility with CMake version 3.0.2

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -13,12 +13,7 @@ file(GLOB DOC_SRC "${PROJECT_SOURCE_DIR}/doc/*")
 list(REMOVE_ITEM DOC_SRC "${PROJECT_SOURCE_DIR}/doc/conf.py")
 list(REMOVE_ITEM DOC_SRC "${PROJECT_SOURCE_DIR}/doc/CMakeLists.txt")
 string(REPLACE "${PROJECT_SOURCE_DIR}/doc" "${DOC_SRC_DIR}" DOC_TARGET "${DOC_SRC}")
-add_custom_command(OUTPUT ${DOC_TARGET}
-                   PRE_BUILD
-                   DEPENDS ${DOC_SRC}
-                   COMMAND ${CMAKE_COMMAND}
-                   ARGS -E copy ${DOC_SRC} ${DOC_SRC_DIR}
-)
+file(COPY ${DOC_SRC} DESTINATION ${DOC_SRC_DIR})
 
 configure_file("${PROJECT_SOURCE_DIR}/doc/conf.py" "${DOC_SRC_DIR}/conf.py")
 


### PR DESCRIPTION
With **cmake 3.0.2** the command **cmake -E copy ...** doesn't copy a list of files but only single files therefore the **add_custom_command** fails on i.e. debian8.
If the **DEPENDS in add_custom_command** is not important here and we want to be compatible with **cmake 3.0.2** the easiest cure would be to go back to the **file(COPY...** command.
