### PR TITLE
Subscriber fix

### DIFF
--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -156,10 +156,10 @@ static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData) {
 
     /* Int64 DataType */
     UA_FieldMetaData_init (&pMetaData->fields[2]);
-    UA_NodeId_copy(&UA_TYPES[UA_TYPES_INT32].typeId,
+    UA_NodeId_copy(&UA_TYPES[UA_TYPES_INT64].typeId,
                    &pMetaData->fields[2].dataType);
-    pMetaData->fields[2].builtInType = UA_NS0ID_INT32;
-    strTmp = UA_STRING ("Int32Fast");
+    pMetaData->fields[2].builtInType = UA_NS0ID_INT64;
+    strTmp = UA_STRING ("Int64");
     UA_String_copy (&strTmp, &pMetaData->fields[2].name);
     pMetaData->fields[2].valueRank = -1; /* scalar */
 

--- a/src/pubsub/ua_pubsub.c
+++ b/src/pubsub/ua_pubsub.c
@@ -271,6 +271,8 @@ UA_Server_removeReaderGroup(UA_Server *server, UA_NodeId groupIdentifier) {
         return UA_STATUSCODE_BADNOTFOUND;
     }
 
+    /* Unregister subscribe callback */
+    UA_PubSubManager_removeRepeatedPubSubCallback(server, readerGroup->subscribeCallbackId);
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
     /* To Do:RemoveGroupRepresentation(server, &readerGroup->identifier) */
 #endif


### PR DESCRIPTION
 - Corrected datatype Int32 to Int64 inside fillTestDataSetMetaData function
 - Resolve segmentation fault when removing ReaderGroup as suggested in #2849 