### PR TITLE
Core: More intuitive node id ordering

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -332,19 +332,19 @@ UA_NodeId_order(const UA_NodeId *n1, const UA_NodeId *n2) {
         break;
     case UA_NODEIDTYPE_STRING:
     case UA_NODEIDTYPE_BYTESTRING: {
+        size_t minLength = UA_MIN(n1->identifier.string.length, n2->identifier.string.length);
+        int cmp = strncmp((const char*)n1->identifier.string.data,
+                          (const char*)n2->identifier.string.data,
+                          minLength);
+        if(cmp < 0)
+            return UA_ORDER_LESS;
+        if(cmp > 0)
+            return UA_ORDER_MORE;
+
         if(n1->identifier.string.length < n2->identifier.string.length)
             return UA_ORDER_LESS;
         if(n1->identifier.string.length > n2->identifier.string.length)
             return UA_ORDER_MORE;
-        if(n1->identifier.string.length > 0) {
-            int cmp = strncmp((const char*)n1->identifier.string.data,
-                              (const char*)n2->identifier.string.data,
-                              n1->identifier.string.length);
-            if(cmp < 0)
-                return UA_ORDER_LESS;
-            if(cmp > 0)
-                return UA_ORDER_MORE;
-        }
         break;
     }
     default:

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -309,18 +309,26 @@ UA_NodeId_order(const UA_NodeId *n1, const UA_NodeId *n2) {
             return UA_ORDER_MORE;
         break;
     case UA_NODEIDTYPE_GUID:
-        if(n1->identifier.guid.data1 < n2->identifier.guid.data1 ||
-           n1->identifier.guid.data2 < n2->identifier.guid.data2 ||
-           n1->identifier.guid.data3 < n2->identifier.guid.data3 ||
-           strncmp((const char*)n1->identifier.guid.data4,
-                   (const char*)n2->identifier.guid.data4, 8) < 0)
+        if(n1->identifier.guid.data1 < n2->identifier.guid.data1) {
             return UA_ORDER_LESS;
-        if(n1->identifier.guid.data1 > n2->identifier.guid.data1 ||
-           n1->identifier.guid.data2 > n2->identifier.guid.data2 ||
-           n1->identifier.guid.data3 > n2->identifier.guid.data3 ||
-           strncmp((const char*)n1->identifier.guid.data4,
-                   (const char*)n2->identifier.guid.data4, 8) > 0)
+        } else if(n1->identifier.guid.data1 > n2->identifier.guid.data1) {
             return UA_ORDER_MORE;
+        } else if(n1->identifier.guid.data2 < n2->identifier.guid.data2) {
+            return UA_ORDER_LESS;
+        } else if(n1->identifier.guid.data2 > n2->identifier.guid.data2) {
+            return UA_ORDER_MORE;
+        } else if(n1->identifier.guid.data3 < n2->identifier.guid.data3) {
+            return UA_ORDER_LESS;
+        } else if(n1->identifier.guid.data3 > n2->identifier.guid.data3) {
+            return UA_ORDER_MORE;
+        } else {
+            int cmp = memcmp(n1->identifier.guid.data4, n2->identifier.guid.data4, 8);
+
+            if(cmp < 0) return UA_ORDER_LESS;
+            if(cmp > 0) return UA_ORDER_MORE;
+
+        }
+
         break;
     case UA_NODEIDTYPE_STRING:
     case UA_NODEIDTYPE_BYTESTRING: {

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -393,6 +393,137 @@ START_TEST(idToStringByte) {
 } END_TEST
 
 
+START_TEST(idOrderNs) {
+    UA_NodeId id_ns1 = UA_NODEID_NUMERIC(1, 12345);
+    UA_NodeId id_ns3 = UA_NODEID_NUMERIC(3, 12345);
+
+    ck_assert(UA_NodeId_order(&id_ns1, &id_ns1) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_ns1, &id_ns3) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_ns3, &id_ns1) == UA_ORDER_MORE);
+} END_TEST
+
+START_TEST(idOrderIdentifier) {
+    UA_NodeId id_num = UA_NODEID_NUMERIC(1, 12345);
+    UA_NodeId id_str = UA_NODEID_STRING(1, "asdf");
+
+    ck_assert(UA_NodeId_order(&id_num, &id_num) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_num, &id_str) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_str, &id_num) == UA_ORDER_MORE);
+} END_TEST
+
+START_TEST(idOrderNumeric) {
+    UA_NodeId id_num_12345 = UA_NODEID_NUMERIC(1, 12345);
+    UA_NodeId id_num_23456 = UA_NODEID_NUMERIC(1, 23456);
+
+    ck_assert(UA_NodeId_order(&id_num_12345, &id_num_12345) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_num_12345, &id_num_23456) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_num_23456, &id_num_12345) == UA_ORDER_MORE);
+} END_TEST
+
+START_TEST(idOrderGuid) {
+
+    // See also https://github.com/open62541/open62541/pull/2904#issuecomment-514111395
+
+    // 00000000-FFFF-FFFF-FFFFFFFFFFFF,
+    UA_Guid guid1 = {
+            0,
+            0xffff,
+            0xffff,
+            { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }
+    };
+    // 00000001-0000-0000-000000000000
+    UA_Guid guid2 = {
+            0x1,
+            0,
+            0,
+            { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+    // 00000000-0000-FFFF-FFFFFFFFFFFF
+    UA_Guid guid3 = {
+            0,
+            0,
+            0xffff,
+            { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }
+    };
+    // 00000000-0001-0000-000000000000
+    UA_Guid guid4 = {
+            0,
+            0x1,
+            0,
+            { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+    // 00000000-0000-0000-FFFFFFFFFFFF
+    UA_Guid guid5 = {
+            0,
+            0,
+            0,
+            { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }
+    };
+    // 00000000-0000-0001-000000000000
+    UA_Guid guid6 = {
+            0,
+            0,
+            0x1,
+            { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+    // 00000000-0000-0000-000000000000
+    UA_Guid guid7 = {
+            0,
+            0,
+            0,
+            { 0, 0, 0, 0, 0, 0, 0, 0 }
+    };
+    // 00000000-0000-0000-000000000001
+    UA_Guid guid8 = {
+            0,
+            0,
+            0,
+            { 0, 0, 0, 0, 0, 0, 0, 0x1 }
+    };
+
+
+    UA_NodeId id_guid_1 = UA_NODEID_GUID(1, guid1);
+    UA_NodeId id_guid_2 = UA_NODEID_GUID(1, guid2);
+    ck_assert(UA_NodeId_order(&id_guid_1, &id_guid_1) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_guid_1, &id_guid_2) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_guid_2, &id_guid_1) == UA_ORDER_MORE);
+
+    UA_NodeId id_guid_3 = UA_NODEID_GUID(1, guid3);
+    UA_NodeId id_guid_4 = UA_NODEID_GUID(1, guid4);
+    ck_assert(UA_NodeId_order(&id_guid_3, &id_guid_3) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_guid_3, &id_guid_4) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_guid_4, &id_guid_3) == UA_ORDER_MORE);
+
+    UA_NodeId id_guid_5 = UA_NODEID_GUID(1, guid5);
+    UA_NodeId id_guid_6 = UA_NODEID_GUID(1, guid6);
+    ck_assert(UA_NodeId_order(&id_guid_5, &id_guid_5) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_guid_5, &id_guid_2) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_guid_6, &id_guid_5) == UA_ORDER_MORE);
+
+    UA_NodeId id_guid_7 = UA_NODEID_GUID(1, guid7);
+    UA_NodeId id_guid_8 = UA_NODEID_GUID(1, guid8);
+    ck_assert(UA_NodeId_order(&id_guid_7, &id_guid_7) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_guid_7, &id_guid_8) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_guid_8, &id_guid_7) == UA_ORDER_MORE);
+
+} END_TEST
+
+START_TEST(idOrderString) {
+    UA_NodeId id_str_a = UA_NODEID_STRING(1, "aaaaa");
+    UA_NodeId id_str_b = UA_NODEID_STRING(1, "baa");
+
+    ck_assert(UA_NodeId_order(&id_str_a, &id_str_a) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_str_a, &id_str_b) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_str_b, &id_str_a) == UA_ORDER_MORE);
+
+    UA_NodeId id_str_c = UA_NODEID_STRING(1, "cddd");
+    UA_NodeId id_str_d = UA_NODEID_STRING(1, "dddd");
+
+    ck_assert(UA_NodeId_order(&id_str_c, &id_str_c) == UA_ORDER_EQ);
+    ck_assert(UA_NodeId_order(&id_str_c, &id_str_d) == UA_ORDER_LESS);
+    ck_assert(UA_NodeId_order(&id_str_d, &id_str_c) == UA_ORDER_MORE);
+} END_TEST
+
 
 static Suite* testSuite_Utils(void) {
     Suite *s = suite_create("Utils");
@@ -416,6 +547,14 @@ static Suite* testSuite_Utils(void) {
     tcase_add_test(tc1, idToStringGuid);
     tcase_add_test(tc1, idToStringByte);
     suite_add_tcase(s, tc1);
+
+    TCase *tc2 = tcase_create("test nodeid order");
+    tcase_add_test(tc1, idOrderNs);
+    tcase_add_test(tc1, idOrderIdentifier);
+    tcase_add_test(tc1, idOrderNumeric);
+    tcase_add_test(tc1, idOrderGuid);
+    tcase_add_test(tc1, idOrderString);
+    suite_add_tcase(s, tc2);
 
     return s;
 }


### PR DESCRIPTION
Fix function UA_NodeId_order when compare UA_NodeId with identifierType equal UA_NODEIDTYPE_GUID

Fixes #2898