### PR TITLE
Debian: Do not copy lib into open62541-dev to avoid overriding open62541 package

### DIFF
--- a/debian/open62541-dev.install
+++ b/debian/open62541-dev.install
@@ -1,5 +1,5 @@
-usr/include/*
-usr/lib/*/lib{*.a,*.so,*.so.*}
+usr/include
+usr/lib/*/{*.a,*.so}
 usr/lib/*/cmake/open62541/*
 usr/lib/*/pkgconfig/open62541.pc
 usr/share/open62541/*

--- a/debian/open62541.install
+++ b/debian/open62541.install
@@ -1,1 +1,1 @@
-usr/lib/*/lib{*.a,*.so,*.so.*}
+usr/lib/*/*.so.*


### PR DESCRIPTION
Fixes #2906