### PR TITLE
debian: use GNUInstallDirs vars to set multiarch-tuple in pkg-config file

### DIFF
--- a/open62541.pc.in
+++ b/open62541.pc.in
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/lib
-sharedlibdir=@CMAKE_INSTALL_PREFIX@/share
-includedir=@CMAKE_INSTALL_PREFIX@/include
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+sharedlibdir=${libdir}
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: open62541
 Description: open62541 is an open source C (C99) implementation of OPC UA


### PR DESCRIPTION
With this fix GNUInstallDirs takes care of the multiarch-tuple (i.e. `x86_64-linux-gnu`) of the library path on debian.
