### PR TITLE
Correct boolean check on input parameters

### DIFF
--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -38,7 +38,7 @@ static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData);
 static void
 addPubSubConnection(UA_Server *server, UA_String *transportProfile,
                     UA_NetworkAddressUrlDataType *networkAddressUrl) {
-    if((server == NULL) && (transportProfile == NULL) &&
+    if((server == NULL) || (transportProfile == NULL) ||
         (networkAddressUrl == NULL)) {
         return;
     }


### PR DESCRIPTION
Currently the input parameter checks in addPubSubConnection are concatenated with boolean AND.  From the code that follows after the checks I take it that the checks should rather be concatenated with boolean OR so that any failed check will force a return.