### PR TITLE
Remove garbage value asssignment for target variables in Subscriber

### DIFF
--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -117,6 +117,7 @@ static void addSubscribedVariables (UA_Server *server, UA_NodeId dataSetReaderId
     UA_Server_DataSetReader_addTargetVariables (server, &folderId,
                                                dataSetReaderId,
                                                UA_PUBSUB_SDS_TARGET);
+    UA_free(readerConfig.dataSetMetaData.fields);
 }
 
 /* Define MetaData for TargetVariables */
@@ -126,8 +127,7 @@ static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData) {
     }
 
     UA_DataSetMetaDataType_init (pMetaData);
-    UA_String strTmp = UA_STRING ("DataSet 1");
-    UA_String_copy (&strTmp, &pMetaData->name);
+    pMetaData->name = UA_STRING ("DataSet 1");
 
     /* Static definition of number of fields size to 4 to create four different
      * targetVariables of distinct datatype
@@ -141,8 +141,7 @@ static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData) {
     UA_NodeId_copy (&UA_TYPES[UA_TYPES_DATETIME].typeId,
                     &pMetaData->fields[0].dataType);
     pMetaData->fields[0].builtInType = UA_NS0ID_DATETIME;
-    strTmp = UA_STRING ("DateTime");
-    UA_String_copy (&strTmp, &pMetaData->fields[0].name);
+    pMetaData->fields[0].name =  UA_STRING ("DateTime");
     pMetaData->fields[0].valueRank = -1; /* scalar */
 
     /* Int32 DataType */
@@ -150,8 +149,7 @@ static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData) {
     UA_NodeId_copy(&UA_TYPES[UA_TYPES_INT32].typeId,
                    &pMetaData->fields[1].dataType);
     pMetaData->fields[1].builtInType = UA_NS0ID_INT32;
-    strTmp = UA_STRING ("Int32");
-    UA_String_copy (&strTmp, &pMetaData->fields[1].name);
+    pMetaData->fields[1].name =  UA_STRING ("Int32");
     pMetaData->fields[1].valueRank = -1; /* scalar */
 
     /* Int64 DataType */
@@ -159,8 +157,7 @@ static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData) {
     UA_NodeId_copy(&UA_TYPES[UA_TYPES_INT64].typeId,
                    &pMetaData->fields[2].dataType);
     pMetaData->fields[2].builtInType = UA_NS0ID_INT64;
-    strTmp = UA_STRING ("Int64");
-    UA_String_copy (&strTmp, &pMetaData->fields[2].name);
+    pMetaData->fields[2].name =  UA_STRING ("Int64");
     pMetaData->fields[2].valueRank = -1; /* scalar */
 
     /* Boolean DataType */
@@ -168,8 +165,7 @@ static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData) {
     UA_NodeId_copy (&UA_TYPES[UA_TYPES_BOOLEAN].typeId,
                     &pMetaData->fields[3].dataType);
     pMetaData->fields[3].builtInType = UA_NS0ID_BOOLEAN;
-    strTmp = UA_STRING ("BoolToggle");
-    UA_String_copy (&strTmp, &pMetaData->fields[3].name);
+    pMetaData->fields[3].name =  UA_STRING ("BoolToggle");
     pMetaData->fields[3].valueRank = -1; /* scalar */
 }
 

--- a/src/pubsub/ua_pubsub.c
+++ b/src/pubsub/ua_pubsub.c
@@ -25,8 +25,6 @@
 #define UA_MAX_SIZENAME 64  /* Max size of Qualified Name of Subscribed Variable */
 
 /* Forward declaration */
-static size_t
-iterateVariableAttrDimension(UA_VariableAttributes varAttr);
 static void
 UA_WriterGroup_deleteMembers(UA_Server *server, UA_WriterGroup *writerGroup);
 static void
@@ -472,21 +470,6 @@ UA_Server_processNetworkMessage(UA_Server *server, UA_NetworkMessage *pMsg,
 }
 
 /**
- * Find size iterator - array dimension for VariableAttributes
- *
- * @param VariableAttributes
- * @return global variable size iterator
- */
-static size_t
-iterateVariableAttrDimension (UA_VariableAttributes varAttr) {
-    size_t sizeIterator = 0;
-    for(size_t indexIterator = 0; indexIterator < varAttr.arrayDimensionsSize; indexIterator++) {
-        sizeIterator += varAttr.arrayDimensions[indexIterator];
-    }
-    return sizeIterator;
-}
-
-/**
  * Find ReaderGroup with its identifier.
  *
  * @param server
@@ -713,285 +696,21 @@ UA_StatusCode UA_Server_DataSetReader_addTargetVariables(UA_Server *server, UA_N
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    /* To Do Declare for all other type */
-    UA_DateTime dateTimeTypeVal = 0;
     UA_TargetVariablesDataType targetVars;
     targetVars.targetVariablesSize = pDataSetReader->config.dataSetMetaData.fieldsSize;
     targetVars.targetVariables = (UA_FieldTargetDataType *)UA_calloc(targetVars.targetVariablesSize, sizeof(UA_FieldTargetDataType));
-    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     for (size_t iteratorField = 0; iteratorField < pDataSetReader->config.dataSetMetaData.fieldsSize; iteratorField++) {
         UA_VariableAttributes vAttr = UA_VariableAttributes_default;
         vAttr.valueRank = pDataSetReader->config.dataSetMetaData.fields[iteratorField].valueRank;
         if(pDataSetReader->config.dataSetMetaData.fields[iteratorField].arrayDimensionsSize > 0) {
-            retVal = UA_Array_copy(pDataSetReader->config.dataSetMetaData.fields[iteratorField].arrayDimensions, pDataSetReader->config.dataSetMetaData.fields[iteratorField].arrayDimensionsSize, (void**)&vAttr.arrayDimensions, &UA_TYPES[UA_TYPES_UINT32]);
-            if(retVal == UA_STATUSCODE_GOOD) {
+            retval = UA_Array_copy(pDataSetReader->config.dataSetMetaData.fields[iteratorField].arrayDimensions, pDataSetReader->config.dataSetMetaData.fields[iteratorField].arrayDimensionsSize, (void**)&vAttr.arrayDimensions, &UA_TYPES[UA_TYPES_UINT32]);
+            if(retval == UA_STATUSCODE_GOOD) {
                 vAttr.arrayDimensionsSize = pDataSetReader->config.dataSetMetaData.fields[iteratorField].arrayDimensionsSize;
             }
 
         }
 
-        switch (pDataSetReader->config.dataSetMetaData.fields[iteratorField].builtInType) {
-            case UA_NS0ID_BOOLEAN:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Boolean *boolArray = (UA_Boolean*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_BOOLEAN]);
-                    UA_Variant_setArrayCopy(&vAttr.value, boolArray, sizeIterator, &UA_TYPES[UA_TYPES_BOOLEAN]);
-                    UA_Array_delete(boolArray, sizeIterator, &UA_TYPES[UA_TYPES_BOOLEAN]);
-                }
-                else {
-                    UA_Boolean boolTypeVal = false;
-                    UA_Variant_setScalar(&vAttr.value, &boolTypeVal, &UA_TYPES[UA_TYPES_BOOLEAN]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-            break;
-
-            case UA_NS0ID_SBYTE:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-
-                    UA_SByte *sbyteArray = (UA_SByte*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_SBYTE]);
-                    UA_Variant_setArrayCopy(&vAttr.value, sbyteArray, sizeIterator, &UA_TYPES[UA_TYPES_SBYTE]);
-                    UA_Array_delete(sbyteArray, sizeIterator, &UA_TYPES[UA_TYPES_SBYTE]);
-                }
-                else {
-                    UA_SByte sbyteTypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &sbyteTypeVal, &UA_TYPES[UA_TYPES_SBYTE]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_BYTE:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Byte *byteArray = (UA_Byte*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_BYTE]);
-                    UA_Variant_setArrayCopy(&vAttr.value, byteArray, sizeIterator, &UA_TYPES[UA_TYPES_BYTE]);
-                    UA_Array_delete(byteArray, sizeIterator, &UA_TYPES[UA_TYPES_BYTE]);
-                }
-                else {
-                    UA_Byte byteTypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &byteTypeVal, &UA_TYPES[UA_TYPES_BYTE]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_INT16:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Int16 *int16Array = (UA_Int16*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_INT16]);
-                    UA_Variant_setArrayCopy(&vAttr.value, int16Array, sizeIterator, &UA_TYPES[UA_TYPES_INT16]);
-                    UA_Array_delete(int16Array, sizeIterator, &UA_TYPES[UA_TYPES_INT16]);
-                }
-                else {
-                    UA_Int16 int16TypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &int16TypeVal, &UA_TYPES[UA_TYPES_INT16]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_UINT16:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_UInt16 *uint16Array = (UA_UInt16*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_UINT16]);
-                    UA_Variant_setArrayCopy(&vAttr.value, uint16Array, sizeIterator, &UA_TYPES[UA_TYPES_UINT16]);
-                    UA_Array_delete(uint16Array, sizeIterator, &UA_TYPES[UA_TYPES_UINT16]);
-                }
-                else {
-                    UA_UInt16 uint16TypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &uint16TypeVal, &UA_TYPES[UA_TYPES_UINT16]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_INT32:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Int32 *int32Array = (UA_Int32*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_INT32]);
-                    UA_Variant_setArrayCopy(&vAttr.value, int32Array, sizeIterator, &UA_TYPES[UA_TYPES_INT32]);
-                    UA_Array_delete(int32Array, sizeIterator, &UA_TYPES[UA_TYPES_INT32]);
-                }
-                else {
-                    UA_Int32 int32TypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &int32TypeVal, &UA_TYPES[UA_TYPES_INT32]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_UINT32:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_UInt32 *uint32Array = (UA_UInt32*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_UINT32]);
-                    UA_Variant_setArrayCopy(&vAttr.value, uint32Array, sizeIterator, &UA_TYPES[UA_TYPES_UINT32]);
-                    UA_Array_delete(uint32Array, sizeIterator, &UA_TYPES[UA_TYPES_UINT32]);
-                }
-                else {
-                    UA_UInt32 uint32TypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &uint32TypeVal, &UA_TYPES[UA_TYPES_UINT32]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_INT64:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Int64 *int64Array = (UA_Int64*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_INT64]);
-                    UA_Variant_setArrayCopy(&vAttr.value, int64Array, sizeIterator, &UA_TYPES[UA_TYPES_INT64]);
-                    UA_Array_delete(int64Array, sizeIterator, &UA_TYPES[UA_TYPES_INT64]);
-                }
-                else {
-                    UA_Int64 int64TypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &int64TypeVal, &UA_TYPES[UA_TYPES_INT64]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_UINT64:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_UInt64 *uint64Array = (UA_UInt64*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_UINT64]);
-                    UA_Variant_setArrayCopy(&vAttr.value, uint64Array, sizeIterator, &UA_TYPES[UA_TYPES_UINT64]);
-                    UA_Array_delete(uint64Array, sizeIterator, &UA_TYPES[UA_TYPES_UINT64]);
-                }
-                else {
-                    UA_UInt64 uint64TypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &uint64TypeVal, &UA_TYPES[UA_TYPES_UINT64]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_FLOAT:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Float *floatArray = (UA_Float*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_FLOAT]);
-                    UA_Variant_setArrayCopy(&vAttr.value, floatArray, sizeIterator, &UA_TYPES[UA_TYPES_FLOAT]);
-                    UA_Array_delete(floatArray, sizeIterator, &UA_TYPES[UA_TYPES_FLOAT]);
-                }
-                else {
-                    UA_Float floatTypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &floatTypeVal, &UA_TYPES[UA_TYPES_FLOAT]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_DOUBLE:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Double *doubleArray = (UA_Double*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_DOUBLE]);
-                    UA_Variant_setArrayCopy(&vAttr.value, doubleArray, sizeIterator, &UA_TYPES[UA_TYPES_DOUBLE]);
-                    UA_Array_delete(doubleArray, sizeIterator, &UA_TYPES[UA_TYPES_DOUBLE]);
-                }
-                else {
-                    UA_Double doubleTypeVal = 0.0;
-                    UA_Variant_setScalar(&vAttr.value, &doubleTypeVal, &UA_TYPES[UA_TYPES_DOUBLE]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_STRING:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_String *stringArray = (UA_String*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_STRING]);
-                    UA_Variant_setArrayCopy(&vAttr.value, stringArray, sizeIterator, &UA_TYPES[UA_TYPES_STRING]);
-                    UA_Array_delete(stringArray, sizeIterator, &UA_TYPES[UA_TYPES_STRING]);
-                }
-                else {
-                    UA_String stringTypeVal = UA_STRING_NULL;
-                    UA_Variant_setScalar(&vAttr.value, &stringTypeVal, &UA_TYPES[UA_TYPES_STRING]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_DATETIME:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_DateTime *dateTimeArray = (UA_DateTime*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_DATETIME]);
-                    UA_Variant_setArrayCopy(&vAttr.value, dateTimeArray, sizeIterator, &UA_TYPES[UA_TYPES_DATETIME]);
-                    UA_Array_delete(dateTimeArray, sizeIterator, &UA_TYPES[UA_TYPES_DATETIME]);
-                }
-                else {
-                    dateTimeTypeVal = 0;
-                    UA_Variant_setScalar(&vAttr.value, &dateTimeTypeVal, &UA_TYPES[UA_TYPES_DATETIME]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_GUID:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_Guid *guidArray = (UA_Guid*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_GUID]);
-                    UA_Variant_setArrayCopy(&vAttr.value, guidArray, sizeIterator, &UA_TYPES[UA_TYPES_GUID]);
-                    UA_Array_delete(guidArray, sizeIterator, &UA_TYPES[UA_TYPES_GUID]);
-                }
-                else {
-                    UA_Guid guidTypeVal = UA_GUID_NULL;
-                    UA_Variant_setScalar(&vAttr.value, &guidTypeVal, &UA_TYPES[UA_TYPES_GUID]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_NODEID:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_NodeId *nodeidArray = (UA_NodeId*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_NODEID]);
-                    UA_Variant_setArrayCopy(&vAttr.value, nodeidArray, sizeIterator, &UA_TYPES[UA_TYPES_NODEID]);
-                    UA_Array_delete(nodeidArray, sizeIterator, &UA_TYPES[UA_TYPES_NODEID]);
-                }
-                else {
-                    UA_NodeId nodeidTypeVal = UA_NODEID_NULL;
-                    UA_Variant_setScalar(&vAttr.value, &nodeidTypeVal, &UA_TYPES[UA_TYPES_NODEID]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            case UA_NS0ID_BYTESTRING:
-                if(vAttr.arrayDimensionsSize > 0) {
-                    size_t sizeIterator = iterateVariableAttrDimension(vAttr);
-                    UA_ByteString *byteStringArray = (UA_ByteString*)UA_Array_new(sizeIterator, &UA_TYPES[UA_TYPES_BYTESTRING]);
-                    UA_Variant_setArrayCopy(&vAttr.value, byteStringArray, sizeIterator, &UA_TYPES[UA_TYPES_BYTESTRING]);
-                    UA_Array_delete(byteStringArray, sizeIterator, &UA_TYPES[UA_TYPES_BYTESTRING]);
-                }
-                else {
-                    UA_ByteString byteStringTypeVal = UA_BYTESTRING_NULL;
-                    UA_Variant_setScalar(&vAttr.value, &byteStringTypeVal, &UA_TYPES[UA_TYPES_BYTESTRING]);
-                }
-
-                UA_NodeId_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType, &vAttr.dataType);
-
-            break;
-
-            default:
-                /* Type not supported */
-                UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Type %u not supported, create empty variable.", pDataSetReader->config.dataSetMetaData.fields[iteratorField].builtInType);
-            break;
-        }
+        vAttr.dataType = pDataSetReader->config.dataSetMetaData.fields[iteratorField].dataType;
 
         vAttr.accessLevel = UA_ACCESSLEVELMASK_READ;
         UA_LocalizedText_copy(&pDataSetReader->config.dataSetMetaData.fields[iteratorField].description, &vAttr.description);
@@ -1018,15 +737,14 @@ UA_StatusCode UA_Server_DataSetReader_addTargetVariables(UA_Server *server, UA_N
 
         /* Add variable to the given parent node */
         UA_NodeId newNode;
-        retVal = UA_Server_addVariableNode(server, UA_NODEID_NULL, *parentNode,
+        retval = UA_Server_addVariableNode(server, UA_NODEID_NULL, *parentNode,
                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), qn,
                                        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newNode);
-        if(retVal == UA_STATUSCODE_GOOD) {
+        if(retval == UA_STATUSCODE_GOOD) {
             UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_USERLAND, "addVariableNode %s succeeded", szTmpName);
         }
         else {
-            retval = retVal;
-            UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_USERLAND, "addVariableNode: error 0x%x", retVal);
+            UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_USERLAND, "addVariableNode: error 0x%x", retval);
         }
 
         UA_FieldTargetDataType_init(&targetVars.targetVariables[iteratorField]);
@@ -1034,7 +752,6 @@ UA_StatusCode UA_Server_DataSetReader_addTargetVariables(UA_Server *server, UA_N
         UA_NodeId_copy(&newNode, &targetVars.targetVariables[iteratorField].targetNodeId);
         UA_NodeId_deleteMembers(&newNode);
         if(vAttr.arrayDimensionsSize > 0) {
-            UA_Variant_deleteMembers(&vAttr.value);
             UA_Array_delete(vAttr.arrayDimensions, vAttr.arrayDimensionsSize, &UA_TYPES[UA_TYPES_UINT32]);
         }
     }

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -684,6 +684,166 @@ START_TEST(SinglePublishSubscribeInt32) {
         UA_Variant_delete(publishedNodeData);
     } END_TEST
 
+START_TEST(SinglePublishSubscribeInt64) {
+        /* To check status after running both publisher and subscriber */
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+        UA_PublishedDataSetConfig pdsConfig;
+        UA_NodeId dataSetWriter;
+        UA_NodeId readerIdentifier;
+        UA_NodeId writerGroup;
+        UA_DataSetReaderConfig readerConfig;
+
+        /* Published DataSet */
+        memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
+        pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
+        pdsConfig.name = UA_STRING("PublishedDataSet Test");
+        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetTest);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Create variable to publish integer data */
+        UA_NodeId publisherNode;
+        UA_VariableAttributes attr = UA_VariableAttributes_default;
+        attr.description           = UA_LOCALIZEDTEXT("en-US","Published Int64");
+        attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Int64");
+        attr.dataType              = UA_TYPES[UA_TYPES_INT64].typeId;
+        UA_Int64 publisherData     = 64;
+        UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_INT64]);
+        retVal                     = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                                               UA_QUALIFIEDNAME(1, "Published Int64"),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                                               attr, NULL, &publisherNode);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Data Set Field */
+        UA_NodeId dataSetFieldIdent;
+        UA_DataSetFieldConfig dataSetFieldConfig;
+        memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
+        dataSetFieldConfig.dataSetFieldType              = UA_PUBSUB_DATASETFIELD_VARIABLE;
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Published Int64");
+        dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
+        dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
+        UA_Server_addDataSetField (server, publishedDataSetTest, &dataSetFieldConfig, &dataSetFieldIdent);
+
+        /* Writer group */
+        UA_WriterGroupConfig writerGroupConfig;
+        memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
+        writerGroupConfig.name               = UA_STRING("WriterGroup Test");
+        writerGroupConfig.publishingInterval = PUBLISH_INTERVAL;
+        writerGroupConfig.enabled            = UA_FALSE;
+        writerGroupConfig.writerGroupId      = WRITER_GROUP_ID;
+        writerGroupConfig.encodingMimeType   = UA_PUBSUB_ENCODING_UADP;
+        retVal |= UA_Server_addWriterGroup(server, connection_test, &writerGroupConfig, &writerGroup);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* DataSetWriter */
+        UA_DataSetWriterConfig dataSetWriterConfig;
+        memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
+        dataSetWriterConfig.name            = UA_STRING("DataSetWriter Test");
+        dataSetWriterConfig.dataSetWriterId = DATASET_WRITER_ID;
+        dataSetWriterConfig.keyFrameCount   = 10;
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup, publishedDataSetTest, &dataSetWriterConfig, &dataSetWriter);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Reader Group */
+        UA_ReaderGroupConfig readerGroupConfig;
+        memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
+        readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
+        retVal |=  UA_Server_addReaderGroup(server, connection_test, &readerGroupConfig, &readerGroupTest);
+
+        /* Data Set Reader */
+        /* Parameters to filter received NetworkMessage */
+        memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
+        readerConfig.name             = UA_STRING ("DataSetReader Test");
+        readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
+        /* Setting up Meta data configuration in DataSetReader */
+        UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
+        /* FilltestMetadata function in subscriber implementation */
+        UA_DataSetMetaDataType_init (pMetaData);
+        pMetaData->name       = UA_STRING ("DataSet Test");
+        /* Static definition of number of fields size to 1 to create one
+           targetVariable */
+        pMetaData->fieldsSize = 1;
+        pMetaData->fields     = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
+                                                                 &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+                /* Unsigned Integer DataType */
+        UA_FieldMetaData_init (&pMetaData->fields[0]);
+        UA_NodeId_copy (&UA_TYPES[UA_TYPES_INT64].typeId,
+                        &pMetaData->fields[0].dataType);
+        pMetaData->fields[0].builtInType = UA_NS0ID_INT64;
+        pMetaData->fields[0].valueRank   = -1; /* scalar */
+        retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
+                                             &readerIdentifier);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        /* Add Subscribed Variables */
+        UA_NodeId folderId;
+        UA_NodeId newnodeId;
+        UA_String folderName      = readerConfig.dataSetMetaData.name;
+        UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+        UA_QualifiedName folderBrowseName;
+        if (folderName.length > 0) {
+            oAttr.displayName.locale        = UA_STRING ("en-US");
+            oAttr.displayName.text          = folderName;
+            folderBrowseName.namespaceIndex = 1;
+            folderBrowseName.name           = folderName;
+        }
+        else {
+            oAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Variables");
+            folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
+        }
+
+        retVal = UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                         folderBrowseName, UA_NODEID_NUMERIC(0,
+                                         UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Variable to subscribe data */
+        UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+        vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int64");
+        vAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int64");
+        vAttr.dataType    = UA_TYPES[UA_TYPES_INT64].typeId;
+        retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID),
+                                           UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Int64"),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        UA_TargetVariablesDataType targetVars;
+        targetVars.targetVariablesSize = 1;
+        targetVars.targetVariables     = (UA_FieldTargetDataType *)
+                                          UA_calloc(targetVars.targetVariablesSize,
+                                          sizeof(UA_FieldTargetDataType));
+        /* For creating Targetvariable */
+        UA_FieldTargetDataType_init(&targetVars.targetVariables[0]);
+        targetVars.targetVariables[0].attributeId  = UA_ATTRIBUTEID_VALUE;
+        targetVars.targetVariables[0].targetNodeId = newnodeId;
+        retVal |= UA_Server_DataSetReader_createTargetVariables(server, readerIdentifier,
+                                                                &targetVars);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        UA_TargetVariablesDataType_deleteMembers(&targetVars);
+        UA_free(pMetaData->fields);
+        /* run server - publisher and subscriber */
+        UA_Server_run_iterate(server,true);
+
+        /* Read data sent by the Publisher */
+        UA_Variant *publishedNodeData = UA_Variant_new();
+        retVal                        = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID), publishedNodeData);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Read data received by the Subscriber */
+        UA_Variant *subscribedNodeData = UA_Variant_new();
+        retVal                         = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID), subscribedNodeData);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Check if data sent from Publisher is being received by Subscriber */
+        ck_assert_int_eq(*(UA_Int64 *)publishedNodeData->data, *(UA_Int64 *)subscribedNodeData->data);
+        UA_Variant_delete(subscribedNodeData);
+        UA_Variant_delete(publishedNodeData);
+    } END_TEST
+
 int main(void) {
     TCase *tc_add_pubsub_readergroup = tcase_create("PubSub readerGroup items handling");
     tcase_add_checked_fixture(tc_add_pubsub_readergroup, setup, teardown);
@@ -716,6 +876,7 @@ int main(void) {
     tcase_add_checked_fixture(tc_pubsub_publish_subscribe, setup, teardown);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeDateTime);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeInt32);
+    tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeInt64);
 
     Suite *suite = suite_create("PubSub readerGroups/reader/Fields handling and publishing");
     suite_add_tcase(suite, tc_add_pubsub_readergroup);

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -844,6 +844,167 @@ START_TEST(SinglePublishSubscribeInt64) {
         UA_Variant_delete(publishedNodeData);
     } END_TEST
 
+START_TEST(SinglePublishSubscribeBool) {
+        /* To check status after running both publisher and subscriber */
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+        UA_PublishedDataSetConfig pdsConfig;
+        UA_NodeId dataSetWriter;
+        UA_NodeId readerIdentifier;
+        UA_NodeId writerGroup;
+        UA_DataSetReaderConfig readerConfig;
+
+        /* Published DataSet */
+        memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
+        pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
+        pdsConfig.name = UA_STRING("PublishedDataSet Test");
+        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetTest);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Create variable to publish boolean data */
+        UA_NodeId publisherNode;
+        UA_VariableAttributes attr = UA_VariableAttributes_default;
+        attr.description           = UA_LOCALIZEDTEXT("en-US","Published Bool");
+        attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Bool");
+        attr.dataType              = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+        UA_Boolean publisherData   = UA_FALSE;
+        UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_BOOLEAN]);
+        retVal                     = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                                               UA_QUALIFIEDNAME(1, "Published Bool"),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                                               attr, NULL, &publisherNode);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Data Set Field */
+        UA_NodeId dataSetFieldIdent;
+        UA_DataSetFieldConfig dataSetFieldConfig;
+        memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
+        dataSetFieldConfig.dataSetFieldType              = UA_PUBSUB_DATASETFIELD_VARIABLE;
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Published Bool");
+        dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
+        dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
+        UA_Server_addDataSetField (server, publishedDataSetTest, &dataSetFieldConfig, &dataSetFieldIdent);
+
+        /* Writer group */
+        UA_WriterGroupConfig writerGroupConfig;
+        memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
+        writerGroupConfig.name               = UA_STRING("WriterGroup Test");
+        writerGroupConfig.publishingInterval = PUBLISH_INTERVAL;
+        writerGroupConfig.enabled            = UA_FALSE;
+        writerGroupConfig.writerGroupId      = WRITER_GROUP_ID;
+        writerGroupConfig.encodingMimeType   = UA_PUBSUB_ENCODING_UADP;
+        retVal |= UA_Server_addWriterGroup(server, connection_test, &writerGroupConfig, &writerGroup);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* DataSetWriter */
+        UA_DataSetWriterConfig dataSetWriterConfig;
+        memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
+        dataSetWriterConfig.name            = UA_STRING("DataSetWriter Test");
+        dataSetWriterConfig.dataSetWriterId = DATASET_WRITER_ID;
+        dataSetWriterConfig.keyFrameCount   = 10;
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup, publishedDataSetTest, &dataSetWriterConfig, &dataSetWriter);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Reader Group */
+        UA_ReaderGroupConfig readerGroupConfig;
+        memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
+        readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
+        retVal |=  UA_Server_addReaderGroup(server, connection_test, &readerGroupConfig, &readerGroupTest);
+
+        /* Data Set Reader */
+        /* Parameters to filter received NetworkMessage */
+        memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
+        readerConfig.name             = UA_STRING ("DataSetReader Test");
+        readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
+        /* Setting up Meta data configuration in DataSetReader */
+        UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
+        /* FilltestMetadata function in subscriber implementation */
+        UA_DataSetMetaDataType_init (pMetaData);
+        pMetaData->name       = UA_STRING ("DataSet Test");
+        /* Static definition of number of fields size to 1 to create one
+           targetVariable */
+        pMetaData->fieldsSize = 1;
+        pMetaData->fields     = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
+                                                                 &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+        /* Boolean DataType */
+        UA_FieldMetaData_init (&pMetaData->fields[0]);
+        UA_NodeId_copy (&UA_TYPES[UA_TYPES_BOOLEAN].typeId,
+                        &pMetaData->fields[0].dataType);
+        pMetaData->fields[0].builtInType = UA_NS0ID_BOOLEAN;
+        pMetaData->fields[0].valueRank   = -1; /* scalar */
+        retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
+                                             &readerIdentifier);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        /* Add Subscribed Variables */
+        UA_NodeId folderId;
+        UA_NodeId newnodeId;
+        UA_String folderName      = readerConfig.dataSetMetaData.name;
+        UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+        UA_QualifiedName folderBrowseName;
+        if (folderName.length > 0) {
+            oAttr.displayName.locale        = UA_STRING ("en-US");
+            oAttr.displayName.text          = folderName;
+            folderBrowseName.namespaceIndex = 1;
+            folderBrowseName.name           = folderName;
+        }
+        else {
+            oAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Variables");
+            folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
+        }
+
+        retVal = UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                         folderBrowseName, UA_NODEID_NUMERIC(0,
+                                         UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Variable to subscribe data */
+        UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+        vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed Bool");
+        vAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Bool");
+        vAttr.dataType    = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+        retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID),
+                                           UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Bool"),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        UA_TargetVariablesDataType targetVars;
+        targetVars.targetVariablesSize = 1;
+        targetVars.targetVariables     = (UA_FieldTargetDataType *)
+                                          UA_calloc(targetVars.targetVariablesSize,
+                                          sizeof(UA_FieldTargetDataType));
+        /* For creating Targetvariable */
+        UA_FieldTargetDataType_init(&targetVars.targetVariables[0]);
+        targetVars.targetVariables[0].attributeId  = UA_ATTRIBUTEID_VALUE;
+        targetVars.targetVariables[0].targetNodeId = newnodeId;
+        retVal |= UA_Server_DataSetReader_createTargetVariables(server, readerIdentifier,
+                                                                &targetVars);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        UA_TargetVariablesDataType_deleteMembers(&targetVars);
+        UA_free(pMetaData->fields);
+        /* run server - publisher and subscriber */
+        UA_Server_run_iterate(server,true);
+
+        /* Read data sent by the Publisher */
+        UA_Variant *publishedNodeData = UA_Variant_new();
+        retVal                        = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID), publishedNodeData);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Read data received by the Subscriber */
+        UA_Variant *subscribedNodeData = UA_Variant_new();
+        retVal                         = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID), subscribedNodeData);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Check if data sent from Publisher is being received by Subscriber */
+        ck_assert_int_eq(*(UA_Boolean *)publishedNodeData->data, *(UA_Boolean *)subscribedNodeData->data);
+        UA_Variant_delete(subscribedNodeData);
+        UA_Variant_delete(publishedNodeData);
+    } END_TEST
+
+
 int main(void) {
     TCase *tc_add_pubsub_readergroup = tcase_create("PubSub readerGroup items handling");
     tcase_add_checked_fixture(tc_add_pubsub_readergroup, setup, teardown);
@@ -877,6 +1038,7 @@ int main(void) {
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeDateTime);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeInt32);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeInt64);
+    tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeBool);
 
     Suite *suite = suite_create("PubSub readerGroups/reader/Fields handling and publishing");
     suite_add_tcase(suite, tc_add_pubsub_readergroup);


### PR DESCRIPTION
 - Remove the garbage value assignment for variables created using UA_Server_DataSetReader_addTargetVariables | Values will be assigned as NULL by default
 - Unit test cases to verify the published and subscribed data for the following datatypes
    - Int32
    - Int64
    - Boolean