### PR TITLE
docs: Update contributing guidelines for conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,97 @@ The following are the minimal requirements that every PR needs to meet.
   link automatically appears on the page of the first PR. In addition, the CLA
   text can be accessed [here](https://cla-assistant.io/open62541/open62541).
 
-### Commit and PR Hygiene
+## Commit and PR Hygiene
+
+We have very precise rules over how our git commit messages can be formatted.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**.  But also,
+we use the git commit messages to **generate the change log**.
+
+This convention is identical to the [Conventional Commits](https://www.conventionalcommits.org) specification or the one used by Angular.
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```text
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+The footer should contain a [closing reference to an issue](https://help.github.com/articles/closing-issues-via-commit-messages/) if any.
+
+Samples: (even more [samples](https://github.com/angular/angular/commits/master))
+
+```text
+docs(server): add function documentation
+```
+```text
+fix(core): fix parsing of endpoint url
+
+Parsing of endpoint urls now also supports https
+```
+
+### Revert
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+### Type
+Must be one of the following:
+
+- **build**: Changes that affect the build system or external dependencies
+- **ci**: Changes to our CI configuration files and scripts (example scopes: travis, appveyor, fuzz)
+- **docs**: Documentation only changes
+- **feat**: A new feature
+- **fix**: A bug fix
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **test**: Adding missing tests or correcting existing tests
+
+### Scope
+The scope is optional, but recommended to be used. It should be the name of the component which is affected (as perceived by the person reading the changelog generated from commit messages).
+
+The following is the list of supported scopes:
+
+- **arch**: Changes to specific architecture code in `root/arch`
+- **client**: Changes only affecting client code
+- **core**: Core functionality used by the client and server
+- **encrypt**: Encryption changes
+- **example**: Example code changes
+- **multithread**: Changes specifically for multithreading
+- **nc**: Nodeset compiler
+- **pack**: Packaging setting changes
+- **plugis**: Change to any (optional) plugin
+- **pubsub**: Changes to the pubsub code
+- **server**: Changes only affecting server code
+
+### Subject
+The subject contains a succinct description of the change:
+
+- use the imperative, present tense: "change" not "changed" nor "changes"
+- don't capitalize the first letter
+- no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+
+## General commit hygiene
+
+We are using the [Conventional Commits](https://www.conventionalcommits.org) specification (see previous section).
 
 These sites explain a core set of good practice rules for preparing a PR:
 
@@ -64,8 +154,7 @@ The following points will be especially looked at during the review.
   commit changes that belong together.
 
 - **Commit Messages**: Good commit messages help in understanding changes.
-  Consider the following article with best practices for commit messages:
-  https://chris.beams.io/posts/git-commit
+  See previous section.
 
 - **Linear Commit History**: Our goal is to maintain a linear commit history
   where possible. Use the `git rebase` functionality before pushing a PR. Use


### PR DESCRIPTION
This PR updates the contributing guidelines to clarify the commit message structure.

It recommends to stick with https://www.conventionalcommits.org

This allows us to automatically generate the changelog and in the future use semantic releases more easily.

To check if at least the PR title or any commit inside the PR conforms with the guideline, I just enabled https://github.com/probot/semantic-pull-requests

This will add another CI status. Currently it is not required, but I suggest to set it as required after some time testing it.