### PR TITLE
Automatically set CMake version based on git tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
 
 dist: trusty
 
+# Make sure we have the git tags. Travis uses shallow checkout where git describe does not work
+git:
+  depth: false
+
 matrix:
   fast_finish: true
   include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,22 +32,12 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # Version #
 ###########
 
-set(OPEN62541_VER_MAJOR 1)
-set(OPEN62541_VER_MINOR 0)
-set(OPEN62541_VER_PATCH 0)
-set(OPEN62541_VER_LABEL "-rc2") # Appended to the X.Y.Z version format. For example "-rc1" or an empty string
+include(SetGitBasedVersion)
 
-# Set OPEN62541_VER_COMMIT
-if(GIT_FOUND)
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --tags
-                    RESULT_VARIABLE res_var OUTPUT_VARIABLE GIT_COM_ID WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-    if(${res_var} EQUAL 0 AND NOT OPEN62541_VER_COMMIT STREQUAL "")
-        string(REPLACE "\n" "" OPEN62541_VER_COMMIT ${GIT_COM_ID} )
-    endif()
-endif()
-if(NOT OPEN62541_VER_COMMIT OR OPEN62541_VER_COMMIT STREQUAL "")
-    set(OPEN62541_VER_COMMIT "undefined")
-endif()
+# The version string will be automatically set based on the git describe output.
+# This will automate the version strings. Just create a new tag, and the version will be set correctly.
+set_open62541_version()
+MESSAGE(STATUS "open62541 Version: ${OPEN62541_VER_MAJOR}.${OPEN62541_VER_MINOR}.${OPEN62541_VER_PATCH}${OPEN62541_VER_LABEL}")
 
 #################
 # Build Options #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 version: '{build}'
 
 clone_folder: c:\projects\open62541
-clone_depth: 20
+
+# Do not set clone depth, we need all the tags to automatically detect the version based on git describe
+# clone_depth: 20
 
 # Avoid building branch if it is part of a PR and built anyways
 skip_branch_with_pr: true

--- a/debian/update_changelog.py
+++ b/debian/update_changelog.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import subprocess
+import os
+import re
+from email.utils import formatdate
+
+git_describe_version = subprocess.check_output(["git", "describe", "--tags", "--dirty", "--match", "v*"]).decode('utf-8').strip()
+
+# v1.2
+# v1.2.3
+# v1.2.3-rc1
+# v1.2.3-rc1-dirty
+# v1.2.3-5-g4538abcd
+# v1.2.3-5-g4538abcd-dirty
+# git_describe_version = "v1.2.3"
+
+m = re.match(r"^v([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-(.*)+)?$", git_describe_version)
+version_major = m.group(1) if m.group(1) is not None else "0"
+version_minor = m.group(2).replace(".", "") if m.group(2) is not None else "0"
+version_patch = m.group(3).replace(".", "") if m.group(3) is not None else "0"
+version_label = m.group(4) if m.group(4) is not None else ""
+#print("major {} minor {} patch {} label {}".format(version_major, version_minor, version_patch, version_label))
+
+debian_distribution = "unstable"
+if version_label is not "":
+    debian_distribution = "UNRELEASED"
+
+dirpath = os.path.dirname(os.path.realpath(__file__))
+changelog_file = os.path.join(dirpath, "changelog")
+
+# remove leading 'v'
+changelog_version = git_describe_version[1:] if git_describe_version[0] == 'v' else git_describe_version
+
+with open(changelog_file, 'r') as original: data = original.read()
+with open(changelog_file, 'w') as modified:
+    new_entry = """open62541 ({version}) {distribution}; urgency=medium
+
+  * Full changelog is available here: https://github.com/open62541/open62541/blob/master/CHANGELOG
+
+ -- open62541 Team <open62541-core@googlegroups.com>  {time}
+""".format(version=changelog_version, time=formatdate(), distribution = debian_distribution)
+
+    modified.write(new_entry + "\n" + data)

--- a/tools/cmake/SetGitBasedVersion.cmake
+++ b/tools/cmake/SetGitBasedVersion.cmake
@@ -1,0 +1,86 @@
+get_filename_component(VERSION_SRC_DIR ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
+set(VERSION_SRC_DIR "${VERSION_SRC_DIR}/..")
+
+find_package(Git)
+
+function(set_open62541_version)
+
+    # Generate a git-describe version string from Git repository tags
+    if(GIT_EXECUTABLE AND NOT DEFINED OPEN62541_VERSION)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "v*"
+            WORKING_DIRECTORY "${VERSION_SRC_DIR}"
+            OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
+            RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(NOT GIT_DESCRIBE_ERROR_CODE)
+            set(OPEN62541_VERSION ${GIT_DESCRIBE_VERSION})
+
+            # Example values can be:
+            # v1.2
+            # v1.2.3
+            # v1.2.3-rc1
+            # v1.2.3-rc1-dirty
+            # v1.2.3-5-g4538abcd
+            # v1.2.3-5-g4538abcd-dirty
+
+            STRING(REGEX REPLACE "^(v[0-9\\.]+)(.*)$"
+                   "\\1"
+                   GIT_VERSION_NUMBERS
+                   "${GIT_DESCRIBE_VERSION}" )
+            STRING(REGEX REPLACE "^v([0-9\\.]+)(.*)$"
+                   "\\2"
+                   GIT_VERSION_LABEL
+                   "${GIT_DESCRIBE_VERSION}" )
+
+            if("${GIT_VERSION_NUMBERS}" MATCHES "^v([0-9]+)(.*)$")
+                STRING(REGEX REPLACE "^v([0-9]+)\\.?(.*)$"
+                       "\\1"
+                       GIT_VER_MAJOR
+                       "${GIT_VERSION_NUMBERS}" )
+                if("${GIT_VERSION_NUMBERS}" MATCHES "^v([0-9]+)\\.([0-9]+)(.*)$")
+                    STRING(REGEX REPLACE "^v([0-9]+)\\.([0-9]+)(.*)$"
+                           "\\2"
+                           GIT_VER_MINOR
+                           "${GIT_VERSION_NUMBERS}" )
+                    if("${GIT_VERSION_NUMBERS}" MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$")
+                        STRING(REGEX REPLACE "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$"
+                               "\\3"
+                               GIT_VER_PATCH
+                               "${GIT_VERSION_NUMBERS}" )
+                    else()
+                        set(GIT_VER_PATCH 0)
+                    endif()
+                else()
+                    set(GIT_VER_MINOR 0)
+                    set(GIT_VER_PATCH 0)
+                endif()
+
+            else()
+                set(GIT_VER_MAJOR 0)
+                set(GIT_VER_MINOR 0)
+                set(GIT_VER_PATCH 0)
+            endif()
+            set(OPEN62541_VER_MAJOR ${GIT_VER_MAJOR} PARENT_SCOPE)
+            set(OPEN62541_VER_MINOR ${GIT_VER_MINOR} PARENT_SCOPE)
+            set(OPEN62541_VER_PATCH ${GIT_VER_PATCH} PARENT_SCOPE)
+            set(OPEN62541_VER_LABEL "${GIT_VERSION_LABEL}" PARENT_SCOPE)
+        endif()
+        set(OPEN62541_VER_COMMIT ${GIT_DESCRIBE_VERSION} PARENT_SCOPE)
+
+
+    endif()
+
+    # Final fallback: Just use a bogus version string that is semantically older
+    # than anything else and spit out a warning to the developer.
+    if(NOT DEFINED OPEN62541_VERSION)
+        set(OPEN62541_VERSION "v0.0.0-unknown")
+        set(OPEN62541_VER_MAJOR 0 PARENT_SCOPE)
+        set(OPEN62541_VER_MINOR 0 PARENT_SCOPE)
+        set(OPEN62541_VER_PATCH 0 PARENT_SCOPE)
+        set(OPEN62541_VER_LABEL "-unknown" PARENT_SCOPE)
+        set(OPEN62541_VER_COMMIT "undefined" PARENT_SCOPE)
+        message(WARNING "Failed to determine OPEN62541_VERSION from repository tags. Using default version \"${OPEN62541_VERSION}\".")
+    endif()
+endfunction()

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -438,6 +438,11 @@ echo -en 'travis_fold:end:script.build.unit_test_ns0_full\\r'
 
 if ! [ -z ${DEBIAN+x} ]; then
     echo -e "\r\n== Building the Debian package =="  && echo -en 'travis_fold:start:script.build.debian\\r'
+    /usr/bin/$PYTHON ./debian/update_changelog.py
+    echo -e "\r\n --- New debian changelog content ---"
+    echo -e "--------------------------------------"
+    cat ./debian/changelog
+    echo -e "--------------------------------------"
     dpkg-buildpackage -b
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cp ../open62541*.deb .


### PR DESCRIPTION
This makes the creation of new releases more straight forward by automatically setting the `OPEN62541_VER_...` variables based on the output of `git describe`.

Creating a new tag will automatically take the version numbers from that tag.

This PR also adds support for automatically updating and setting the version of the debian changelog.

After merge, we do not have to manually set version numbers in the code anymore.

The current release for example has a wrong rc suffix: 
https://github.com/open62541/open62541/releases/tag/v1.0-rc4