### PR TITLE
Fix UA_ClientConnectionTCP_init

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -774,6 +774,7 @@ UA_ClientConnectionTCP_init(UA_ConnectionConfig config, const UA_String endpoint
 
     TCPClientConnection *tcpClientConnection = (TCPClientConnection*) UA_malloc(
                     sizeof(TCPClientConnection));
+    memset(tcpClientConnection, 0, sizeof(TCPClientConnection));
     connection.handle = (void*) tcpClientConnection;
     tcpClientConnection->timeout = timeout;
     UA_String hostnameString = UA_STRING_NULL;


### PR DESCRIPTION
memset(tcpClientConnection, 0, sizeof(TCPClientConnection)) added to initialize TCPClientConnection struct members. If TCPClientConnection members not initialized and UA_parseEndpointUrl return error ClientNetworkLayerTCP_free will raise exception.