### PR TITLE
docs: Add package to Arch User Repository

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -107,5 +107,6 @@ Install them with:
 
 Arch packages are available in the AUR
 
- * Stable Builds: <insert_link_here>
+ * Stable Builds: https://aur.archlinux.org/packages/open62541/
+ * Unstable Builds (current master): https://aur.archlinux.org/packages/open62541-git/
  * In order to add custom build options (:ref:`build_options`), you can set the environment variable ``OPEN62541_CMAKE_FLAGS``

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -104,3 +104,8 @@ Install them with:
     sudo add-apt-repository ppa:open62541-team/ppa
     sudo apt-get update
     sudo apt-get install libopen62541-dev
+
+Arch packages are available in the AUR
+
+ * Stable Builds: <insert_link_here>
+ * In order to add custom build options (:ref:`build_options`), you can set the environment variable ``OPEN62541_CMAKE_FLAGS``


### PR DESCRIPTION
The Arch User Repository (AUR) is where the Arch community can submit packages and is supported across all Arch-based distributions.

In order to submit a package to the AUR, a [PKGBUILD](https://wiki.archlinux.org/index.php/PKGBUILD) is added to the AUR and the files are compiled from source during installation. Analogue to the existing packages available for Debian, I have created a PKGBUILD for the current 1.0 branch (which would have to be updated to the 2.0 branch when this is released, this information will be added to the ["Creating a New Release" page in the Wiki](https://github.com/open62541/open62541/wiki/Creating-a-new-release)) as a stable "open62541" package and a PKGBUILD for the current master which is called "open62541-git" following conventions for AUR packages.

The default CMake variables are the same as for the Debian builds (full namespace 0, no amalgamation, build shared libs and build type is "RelWithDebInfo"). Since the packages are compiled from source it is possible to add further CMake build options or even override the default ones by specifying the `OPEN62541_CMAKE_FLAGS` environment variable. An example for installation when using the "yay" AUR helper where events should be enabled and the build type should be "Debug" looks like this:
`OPEN62541_CMAKE_FLAGS="-DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON -DCMAKE_BUILD_TYPE=Debug" yay -S open62541`

The versions of the packages are based on the commits since the last tag.

The missing hyperlink in the documentation will be added as soon as this has been approved and an AUR page exists for the package.

Here are the PKGBUILDs for the two packages:

open62541-git:
```
# Maintainer: open62541 Team <open62541-core@googlegroups.com>
branch=master
pkgname=open62541-git
src_name=open62541
pkgver=v1.0_rc3_r18_g07d98934
pkgrel=1
pkgdesc="An open source and free implementation of OPC Unified Architecture written in the common subset of the C99 and C++98 languages."
provides=('open62541')
conflicts=('open62541')
arch=('any')
url="http://open62541.org/"
license=('MPL2')
makedepends=('cmake')
source=("git+https://github.com/open62541/open62541.git#branch=$branch")
md5sums=('SKIP')
sha256sums=('SKIP')

prepare() {
    # Install the libraries to lib instead of lib64
    # Install to /usr/ instead of /usr/local/
    OPEN62541_CMAKE_FLAGS_DEFAULT=\
"-DBUILD_SHARED_LIBS=ON"\
" -DUA_NAMESPACE_ZERO=FULL"\
" -DUA_ENABLE_AMALGAMATION=OFF"\
" -DCMAKE_BUILD_TYPE=RelWithDebInfo"\
" -DCMAKE_INSTALL_PREFIX=$pkgdir/usr/"\
" -DCMAKE_INSTALL_LIBDIR=$pkgdir/usr/lib/"

    # OPEN62541_CMAKE_FLAGS is an environment variable which can be
    # set in order to specify custom compilation flags for open62541.
    # This allows integrating further features. Please review the wiki
    # for more information.

    OPEN62541_CMAKE_FLAGS="$OPEN62541_CMAKE_FLAGS_DEFAULT $OPEN62541_CMAKE_FLAGS"

    cd "$srcdir/$src_name"
    git submodule init
    git config submodule.UA-Nodeset.url "$srcdir/UA-Nodeset"
    git config submodule.mdnsd "$srcdir/mdnsd"
    git submodule update
}

pkgver() {
     cd "$srcdir/$src_name"
     git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/_/g'
}

build() {
    cd "$srcdir/$src_name"

    mkdir -p build
    cd build

    cmake $OPEN62541_CMAKE_FLAGS ..
    make
}

package() {
    cd "$srcdir/$src_name/build"

    make install
    install -Dm644 ../LICENSE "$pkgdir/usr/share/licenses/$src_name/LICENSE"
}
```

open62541:
```
# Maintainer: open62541 Team <open62541-core@googlegroups.com>
branch=1.0
pkgname=open62541
pkgver=v1.0_rc4_r8_g6b93d4e0
pkgrel=1
pkgdesc="An open source and free implementation of OPC Unified Architecture written in the common subset of the C99 and C++98 languages."
arch=('any')
url="http://open62541.org/"
license=('MPL2')
makedepends=('cmake')
source=("git+https://github.com/open62541/open62541.git#branch=$branch")
md5sums=('SKIP')
sha256sums=('SKIP')

prepare() {
    # Install the libraries to lib instead of lib64
    # Install to /usr/ instead of /usr/local/
    OPEN62541_CMAKE_FLAGS_DEFAULT=\
"-DBUILD_SHARED_LIBS=ON"\
" -DUA_NAMESPACE_ZERO=FULL"\
" -DUA_ENABLE_AMALGAMATION=OFF"\
" -DCMAKE_BUILD_TYPE=RelWithDebInfo"\
" -DCMAKE_INSTALL_PREFIX=$pkgdir/usr/"\
" -DCMAKE_INSTALL_LIBDIR=$pkgdir/usr/lib/"

    # OPEN62541_CMAKE_FLAGS is an environment variable which can be
    # set in order to specify custom compilation flags for open62541.
    # This allows integrating further features. Please review the wiki
    # for more information.

    OPEN62541_CMAKE_FLAGS="$OPEN62541_CMAKE_FLAGS_DEFAULT $OPEN62541_CMAKE_FLAGS"

    cd "$srcdir/$pkgname"
    git submodule init
    git config submodule.UA-Nodeset.url "$srcdir/UA-Nodeset"
    git config submodule.mdnsd "$srcdir/mdnsd"
    git submodule update
}

pkgver() {
     cd "$srcdir/$pkgname"
     git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/_/g'
}

build() {
    cd "$srcdir/$pkgname"

    mkdir -p build
    cd build

    cmake $OPEN62541_CMAKE_FLAGS ..
    make
}

package() {
    cd "$srcdir/$pkgname/build"

    make install
    install -Dm644 ../LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
}
```


