### PR TITLE
ci: Migrate from Appveyor to Azure Pipelines

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,6 @@ environment:
         APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -m0=lzma -mx=9
 
     matrix:
-        - CC_NAME: MinGW Makefiles
-          CC_SHORTNAME: mingw
-          GENERATOR: MinGW Makefiles
-          FORCE_CXX: OFF
         - CC_NAME: Visual Studio 9 2008
           CC_SHORTNAME: vs2008
           GENERATOR: Visual Studio 9 2008
@@ -28,15 +24,6 @@ environment:
         - CC_NAME: Visual Studio 12 2013
           CC_SHORTNAME: vs2013
           GENERATOR: Visual Studio 12 2013
-          FORCE_CXX: OFF
-        - CC_NAME: Visual Studio 15 2017
-          CC_SHORTNAME: vs2017
-          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          GENERATOR: Visual Studio 15 2017
-          FORCE_CXX: OFF
-        - CC_NAME: Clang
-          CC_SHORTNAME: clang-mingw
-          GENERATOR: MinGW Makefiles
           FORCE_CXX: OFF
 
 cache:
@@ -51,12 +38,6 @@ init:
 install:
 - set PATH=C:\Users\appveyor\AppData\Roaming\Python\Scripts;%PATH%
 - ps: '& "./tools/appveyor/install.ps1"'
-
-before_build:
-  # Add installed tools to PATH
-  - set PATH=C:\msys64\mingw64\bin;%PATH%
-  # Workaround for CMake not wanting sh.exe on PATH for MinGW (necessary for CMake 3.12.2)
-  - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
 
 build_script:
 - ps: '& "./tools/appveyor/build.ps1"'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,117 @@
+# Docs see here:
+# https://aka.ms/yaml
+
+
+pr:
+  autoCancel: true # indicates whether additional pushes to a PR should cancel in-progress runs for the same PR. Defaults to true
+
+variables:
+  choco_cache: C:/ProgramData/chocolatey
+  vcpkg_cache: C:/vcpkg/installed
+
+jobs:
+- job: 'win_vs2017'
+  displayName: 'Windows (VS2017)'
+  pool:
+    vmImage: 'vs2017-win2016'
+  variables:
+    CC_NAME: Visual Studio 15 2017
+    CC_SHORTNAME: VS2017
+    GENERATOR: Visual Studio 15 2017
+    FORCE_CXX: OFF
+  steps:
+  - checkout: self
+    submodules: recursive
+
+  - task: CacheBeta@0
+    inputs:
+      key: $(Build.SourcesDirectory)/tools/azure-devops/install.ps1
+      path: $(choco_cache)
+    displayName: Cache Choco
+  - task: CacheBeta@0
+    inputs:
+      key: $(Build.SourcesDirectory)/tools/azure-devops/install.ps1
+      path: $(vcpkg_cache)
+    displayName: Cache vcpkg
+
+  - powershell: ./tools/azure-devops/install.ps1
+    displayName: Install Requirements
+  - powershell: ./tools/azure-devops/build.ps1
+    displayName: "Build: $(CC_NAME)"
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: open62541-$(CC_SHORTNAME)
+        # publishing artifacts from PRs from a fork is currently blocked
+    condition: succeeded()
+    displayName: "Publish Artifact: open62541-$(CC_SHORTNAME)"
+
+
+- job: 'win_msys64'
+  displayName: 'Windows (msys64)'
+  pool:
+    vmImage: 'windows-latest'
+  variables:
+    CC_NAME: MinGW Makefiles
+    CC_SHORTNAME: mingw
+    GENERATOR: MinGW Makefiles
+    FORCE_CXX: OFF
+    MSYS2_ROOT: C:/msys64
+  steps:
+  - checkout: self
+    submodules: recursive
+  - task: CacheBeta@0
+    inputs:
+      key: $(Build.SourcesDirectory)/tools/azure-devops/install.ps1
+      path: $(choco_cache)
+    displayName: Cache Choco
+
+  - powershell: ./tools/azure-devops/install.ps1
+    displayName: Install Requirements
+  - powershell: ./tools/azure-devops/build.ps1
+    displayName: "Build: $(CC_NAME)"
+    errorActionPreference: continue # Nodeset Compiler prints to stderror
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: open62541-$(CC_SHORTNAME)
+        # publishing artifacts from PRs from a fork is currently blocked
+    condition: succeeded()
+    displayName: "Publish Artifact: open62541-$(CC_SHORTNAME)"
+
+
+
+- job: 'win_clang'
+  displayName: 'Windows (clang)'
+  pool:
+    vmImage: 'windows-latest'
+  variables:
+    CC_NAME: Clang
+    CC_SHORTNAME: clang-mingw
+    GENERATOR: MinGW Makefiles
+    FORCE_CXX: OFF
+    MSYS2_ROOT: C:/msys64
+  steps:
+  - checkout: self
+    submodules: recursive
+  - task: CacheBeta@0
+    inputs:
+      key: $(Build.SourcesDirectory)/tools/azure-devops/install.ps1
+      path: $(choco_cache)
+    displayName: Cache Choco
+
+  - powershell: ./tools/azure-devops/install.ps1
+    displayName: Install Requirements
+  - powershell: ./tools/azure-devops/build.ps1
+    displayName: "Build: $(CC_NAME)"
+    errorActionPreference: continue # Nodeset Compiler prints to stderror
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: open62541-$(CC_SHORTNAME)
+        # publishing artifacts from PRs from a fork is currently blocked
+    condition: succeeded()
+    displayName: "Publish Artifact: open62541-$(CC_SHORTNAME)"

--- a/tools/appveyor/install.ps1
+++ b/tools/appveyor/install.ps1
@@ -4,36 +4,12 @@ try {
     & git submodule sync
     & git submodule --quiet update --init --recursive
 
-    Write-Host -ForegroundColor Green "`n### CMake and Python pre-installed AppVeyor Windows build VMs ###`n"
-
     Write-Host -ForegroundColor Green "`n### Installing sphinx ###`n"
     & cinst sphinx --source python
 
-    Write-Host -ForegroundColor Green "`n### Installing mbedtls ###`n"
-
-    if ($env:CC_SHORTNAME -eq "mingw" -or $env:CC_SHORTNAME -eq "clang-mingw") {
-        # pacman may complain that the directory does not exist, thus create it.
-        # See https://github.com/open62541/open62541/issues/2068
-        & C:\msys64\usr\bin\mkdir -p /var/cache/pacman/pkg
-        & C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-mbedtls
-    } elseif ($env:CC_SHORTNAME -eq "vs2015" -or $env:CC_SHORTNAME -eq "vs2017") {
-        # we need the static version, since open62541 is built with /MT
-        # vcpkg currently only supports VS2015 and newer builds
-        & vcpkg install mbedtls:x86-windows-static
-    }
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-        Write-Host -ForegroundColor Red "`n`n*** Installing mbedtls failed. Exiting ... ***"
+        Write-Host -ForegroundColor Red "`n`n*** Installing dependencies failed. Exiting ... ***"
         exit $LASTEXITCODE
-    }
-
-    if ($env:CC_SHORTNAME -eq "vs2015" -or $env:CC_SHORTNAME -eq "vs2017") {
-        Write-Host -ForegroundColor Green "`n### Installing libcheck ###`n"
-        & appveyor DownloadFile https://github.com/Pro/check/releases/download/0.12.0_dbg/check.zip
-        & 7z x check.zip -oc:\ -bso0 -bsp0
-
-        Write-Host -ForegroundColor Green "`n### Installing DrMemory ###`n"
-        & cinst --no-progress drmemory.portable
-        $env:Path = 'C:\Program Files (x86)\Dr. Memory\bin;' + $env:Path        
     }
 
 } catch {

--- a/tools/azure-devops/build.ps1
+++ b/tools/azure-devops/build.ps1
@@ -1,6 +1,8 @@
 
 try {
-    cd $env:APPVEYOR_BUILD_FOLDER
+
+
+    Write-Host -ForegroundColor Green "`n## Build Path $env:Build_Repository_LocalPath #####`n"
 
     $vcpkg_toolchain = ""
     $vcpkg_triplet = ""
@@ -13,11 +15,29 @@ try {
         $build_encryption = "ON"
     }
 
-    $vcpkg_toolchain = '-DCMAKE_TOOLCHAIN_FILE="C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake"'
-    $vcpkg_triplet = '-DVCPKG_TARGET_TRIPLET="x86-windows-static"'
-    # since https://github.com/Microsoft/vcpkg/commit/0334365f516c5f229ff4fcf038c7d0190979a38a#diff-464a170117fa96bf98b2f8d224bf503c
-    # vcpkg need to have  "C:\Tools\vcpkg\installed\x86-windows-static"
-    New-Item -Force -ItemType directory -Path "C:\Tools\vcpkg\installed\x86-windows-static"
+    if ($env:CC_SHORTNAME -eq "mingw" -or $env:CC_SHORTNAME -eq "clang-mingw") {
+        # Workaround for CMake not wanting sh.exe on PATH for MinGW (necessary for CMake 3.12.2)
+        $env:PATH = ($env:PATH.Split(';') | Where-Object { $_ -ne 'C:\Program Files\Git\bin' }) -join ';'
+        $env:PATH = ($env:PATH.Split(';') | Where-Object { $_ -ne 'C:\Program Files\Git\usr\bin' }) -join ';'
+        # Add mingw to path so that CMake finds e.g. clang
+        $env:PATH = "$env:MSYS2_ROOT\mingw64\bin;$env:PATH"
+        [System.Environment]::SetEnvironmentVariable('Path', $path, 'Machine')
+    }
+
+    if ($env:CC_SHORTNAME -eq "mingw") {
+
+    } elseif ($env:CC_SHORTNAME -eq "clang-mingw") {
+        # Setup clang
+        $env:CC = "clang --target=x86_64-w64-mingw32"
+        $env:CXX = "clang++ --target=x86_64-w64-mingw32"
+        clang --version
+    } else {
+        $vcpkg_toolchain = '-DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"'
+        $vcpkg_triplet = '-DVCPKG_TARGET_TRIPLET="x86-windows-static"'
+        # since https://github.com/Microsoft/vcpkg/commit/0334365f516c5f229ff4fcf038c7d0190979a38a#diff-464a170117fa96bf98b2f8d224bf503c
+        # vcpkg need to have  "C:\Tools\vcpkg\installed\x86-windows-static"
+        New-Item -Force -ItemType directory -Path "C:/vcpkg/installed/x86-windows-static"
+    }
 
     $cmake_cnf="$vcpkg_toolchain", "$vcpkg_triplet", "-G`"$env:GENERATOR`"", "-DUA_COMPILE_AS_CXX:BOOL=$env:FORCE_CXX"
 
@@ -73,7 +93,7 @@ try {
     & cmake $cmake_cnf `
             -DBUILD_SHARED_LIBS:BOOL=OFF `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
-            -DCMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER-$env:CC_SHORTNAME-static" `
+            -DCMAKE_INSTALL_PREFIX="$env:Build_Repository_LocalPath-$env:CC_SHORTNAME-static" `
             -DUA_BUILD_EXAMPLES:BOOL=ON `
             -DUA_ENABLE_AMALGAMATION:BOOL=OFF ..
     & cmake --build . --target install --config RelWithDebInfo
@@ -83,7 +103,7 @@ try {
         exit $LASTEXITCODE
     }
     cd ..
-    & 7z a -tzip open62541-$env:CC_SHORTNAME-static.zip "$env:APPVEYOR_BUILD_FOLDER\pack\*" "$env:APPVEYOR_BUILD_FOLDER-$env:CC_SHORTNAME-static\*"
+    & 7z a -tzip "$env:Build_ArtifactStagingDirectory/open62541-$env:CC_SHORTNAME-static.zip" "$env:Build_Repository_LocalPath\pack\*" "$env:Build_Repository_LocalPath-$env:CC_SHORTNAME-static\*"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0)
     {
         Write-Host -ForegroundColor Red "`n`n*** Zipping failed. Exiting ... ***"
@@ -98,7 +118,7 @@ try {
     & cmake $cmake_cnf `
             -DBUILD_SHARED_LIBS:BOOL=ON `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
-            -DCMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER-$env:CC_SHORTNAME-dynamic" `
+            -DCMAKE_INSTALL_PREFIX="$env:Build_Repository_LocalPath-$env:CC_SHORTNAME-dynamic" `
             -DUA_BUILD_EXAMPLES:BOOL=ON `
             -DUA_ENABLE_AMALGAMATION:BOOL=OFF ..
     & cmake --build . --target install --config RelWithDebInfo
@@ -108,13 +128,45 @@ try {
         exit $LASTEXITCODE
     }
     cd ..
-    & 7z a -tzip open62541-$env:CC_SHORTNAME-dynamic.zip "$env:APPVEYOR_BUILD_FOLDER\pack\*" "$env:APPVEYOR_BUILD_FOLDER-$env:CC_SHORTNAME-static\*"
+    & 7z a -tzip "$env:Build_ArtifactStagingDirectory/open62541-$env:CC_SHORTNAME-dynamic.zip" "$env:Build_Repository_LocalPath\pack\*" "$env:Build_Repository_LocalPath-$env:CC_SHORTNAME-static\*"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0)
     {
         Write-Host -ForegroundColor Red "`n`n*** Zipping failed. Exiting ... ***"
         exit $LASTEXITCODE
     }
     Remove-Item -Path build -Recurse -Force
+
+    # Only execute unit tests on vs2017 to save compilation time
+    if ($env:CC_SHORTNAME -eq "vs2017") {
+        Write-Host -ForegroundColor Green "`n###################################################################"
+        Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with unit tests #####`n"
+        New-Item -ItemType directory -Path "build"
+        cd build
+        & cmake $cmake_cnf `
+                -DBUILD_SHARED_LIBS:BOOL=OFF `
+                -DCMAKE_BUILD_TYPE=Debug `
+                -DUA_BUILD_EXAMPLES=OFF `
+                -DUA_BUILD_UNIT_TESTS=ON `
+                -DUA_ENABLE_DA=ON `
+                -DUA_ENABLE_DISCOVERY=ON `
+                -DUA_ENABLE_DISCOVERY_MULTICAST=ON `
+                -DUA_ENABLE_ENCRYPTION:BOOL=$build_encryption `
+                -DUA_ENABLE_JSON_ENCODING:BOOL=ON `
+                -DUA_ENABLE_PUBSUB:BOOL=ON `
+                -DUA_ENABLE_PUBSUB_DELTAFRAMES:BOOL=ON `
+                -DUA_ENABLE_PUBSUB_INFORMATIONMODEL:BOOL=ON `
+                -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
+        & cmake --build . --config Debug
+        if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+            Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
+            exit $LASTEXITCODE
+        }
+        & cmake --build . --target test-verbose --config Debug
+        if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+            Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
+            exit $LASTEXITCODE
+        }
+    }
 
     # # do not cache log
     # Remove-Item -Path c:\miktex\texmfs\data\miktex\log -Recurse -Force

--- a/tools/azure-devops/install.ps1
+++ b/tools/azure-devops/install.ps1
@@ -1,0 +1,45 @@
+$ErrorActionPreference = "Stop"
+
+try {
+
+    Write-Host -ForegroundColor Green "`n### Installing sphinx ###`n"
+    & choco install -y sphinx --no-progress --source python
+
+    if ($env:CC_SHORTNAME -eq "mingw" -or $env:CC_SHORTNAME -eq "clang-mingw") {
+        Write-Host -ForegroundColor Green "`n### Installing msys64 ###`n"
+        & choco install -y msys2 --no-progress --params="/InstallDir:$env:MSYS2_ROOT /NoUpdate /NoPath"
+
+        Write-Host -ForegroundColor Green "`n### Installing mbedtls via PacMan ###`n"
+        # pacman may complain that the directory does not exist, thus create it.
+        # See https://github.com/open62541/open62541/issues/2068
+        & C:\msys64\usr\bin\mkdir -p /var/cache/pacman/pkg
+        & C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-mbedtls
+
+        Write-Host -ForegroundColor Green "`n### Installing clang via PacMan ###`n"
+        & C:\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-clang mingw-w64-i686-clang
+    } elseif ($env:CC_SHORTNAME -eq "vs2015" -or $env:CC_SHORTNAME -eq "vs2017") {
+        Write-Host -ForegroundColor Green "`n### Installing mbedtls via vcpkg ###`n"
+        & vcpkg install mbedtls:x86-windows-static
+
+        Write-Host -ForegroundColor Green "`n### Installing libcheck via vcpkg ###`n"
+        & vcpkg install check:x86-windows-static
+
+        Write-Host -ForegroundColor Green "`n### Installing DrMemory ###`n"
+        & choco install -y --no-progress drmemory.portable
+        $env:Path = 'C:\Program Files (x86)\Dr. Memory\bin;' + $env:Path        
+    }
+
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        Write-Host -ForegroundColor Red "`n`n*** Installing dependencies failed. Exiting ... ***"
+        exit $LASTEXITCODE
+    }
+
+} catch {
+    # Print a detailed error message
+    $FullException = ($_.Exception|format-list -force) | Out-String
+    Write-Host -ForegroundColor Red "`n------------------ Exception ------------------`n$FullException`n"
+    [Console]::Out.Flush()
+    # Wait a bit to make sure appveyor shows the error message
+    Start-Sleep 10
+    throw
+}


### PR DESCRIPTION
This moves most of the builds from Appveyor to the more efficient
and significantly faster Azure Pipelines system.

**We will get much faster Windows builds**

For now Azure Pipelines by default only supports VS2015 and VS2017,
therefore the builds for VS2013 and VS2008 still remain on Appveyor.

These can be transferred at a later stage.
