### PR TITLE
Fixed path problem for automatic code generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1120,8 +1120,8 @@ include(linting_target)
 # Enable shared library with `-DBUILD_SHARED_LIBS=ON`
 
 set(cmake_configfile_install ${CMAKE_INSTALL_LIBDIR}/cmake/open62541)
-set(open62541_install_tools_dir share/open62541/tools)
-set(open62541_install_nodeset_dir share/open62541/tools/ua-nodeset)
+set(open62541_install_tools_dir open62541/tools)
+set(open62541_install_nodeset_dir open62541/tools/ua-nodeset)
 
 # This list of components allows to define a find_package requirement.
 # E.g.:

--- a/open62541.spec
+++ b/open62541.spec
@@ -50,8 +50,8 @@ rm examples/CMakeLists.txt
 %dir %{_includedir}/open62541
 %{_includedir}/open62541/*
 %{_libdir}/cmake/open62541*
-%dir %{_exec_prefix}/share/open62541
-%{_exec_prefix}/share/open62541/*
+%dir %{_exec_prefix}/sopen62541
+%{_exec_prefix}/open62541/*
 
 %doc FEATURES.md
 %doc examples/

--- a/open62541.spec
+++ b/open62541.spec
@@ -50,7 +50,7 @@ rm examples/CMakeLists.txt
 %dir %{_includedir}/open62541
 %{_includedir}/open62541/*
 %{_libdir}/cmake/open62541*
-%dir %{_exec_prefix}/sopen62541
+%dir %{_exec_prefix}/open62541
 %{_exec_prefix}/open62541/*
 
 %doc FEATURES.md


### PR DESCRIPTION
Fixed problem reported in issue #3004 by removing the not existing "share" folder from "open62541_install_tools_dir" and "open62541_install_nodeset_dir " in the main CMakeFile of the project.