### PR TITLE
fix(server): Add missing macro definitions for multithreading

### DIFF
--- a/arch/eCos/ua_architecture.h
+++ b/arch/eCos/ua_architecture.h
@@ -83,6 +83,19 @@ int gethostname_ecos(char* name, size_t len);
     LOG; \
 }
 
+#if UA_MULTITHREADING >= 100
+#error Multithreading unsupported
+#else
+#define UA_LOCK_TYPE_NAME
+#define UA_LOCK_TYPE(mutexName)
+#define UA_LOCK_TYPE_POINTER(mutexName)
+#define UA_LOCK_INIT(mutexName)
+#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK(mutexName)
+#define UA_UNLOCK(mutexName)
+#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#endif
+
 #include <open62541/architecture_functions.h>
 
 #endif /* PLUGINS_ARCH_ECOS_UA_ARCHITECTURE_H_ */

--- a/arch/freertosLWIP/ua_architecture.h
+++ b/arch/freertosLWIP/ua_architecture.h
@@ -14,6 +14,19 @@
 #include "ua_lwip.h"
 #include "ua_freeRTOS.h"
 
+#if UA_MULTITHREADING >= 100
+#error Multithreading unsupported
+#else
+#define UA_LOCK_TYPE_NAME
+#define UA_LOCK_TYPE(mutexName)
+#define UA_LOCK_TYPE_POINTER(mutexName)
+#define UA_LOCK_INIT(mutexName)
+#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK(mutexName)
+#define UA_UNLOCK(mutexName)
+#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#endif
+
 #include <open62541/architecture_functions.h>
 
 #endif /* PLUGINS_ARCH_FREERTOSLWIP_UA_ARCHITECTURE_H_ */

--- a/arch/vxworks/ua_architecture.h
+++ b/arch/vxworks/ua_architecture.h
@@ -109,6 +109,19 @@
     LOG; \
 }
 
+#if UA_MULTITHREADING >= 100
+#error Multithreading unsupported
+#else
+#define UA_LOCK_TYPE_NAME
+#define UA_LOCK_TYPE(mutexName)
+#define UA_LOCK_TYPE_POINTER(mutexName)
+#define UA_LOCK_INIT(mutexName)
+#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK(mutexName)
+#define UA_UNLOCK(mutexName)
+#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#endif
+
 #include <open62541/architecture_functions.h>
 
 #endif /* PLUGINS_ARCH_VXWORKS_UA_ARCHITECTURE_H_ */

--- a/arch/wec7/ua_architecture.h
+++ b/arch/wec7/ua_architecture.h
@@ -137,6 +137,19 @@ char *strerror(int errnum);
 }
 #define UA_LOG_SOCKET_ERRNO_GAI_WRAP UA_LOG_SOCKET_ERRNO_WRAP
 
+#if UA_MULTITHREADING >= 100
+#error Multithreading unsupported
+#else
+#define UA_LOCK_TYPE_NAME
+#define UA_LOCK_TYPE(mutexName)
+#define UA_LOCK_TYPE_POINTER(mutexName)
+#define UA_LOCK_INIT(mutexName)
+#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK(mutexName)
+#define UA_UNLOCK(mutexName)
+#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#endif
+
 #include <open62541/architecture_functions.h>
 
 /* Fix redefinition of SLIST_ENTRY on mingw winnt.h */


### PR DESCRIPTION
Fix for issue in PR #2993 

Multithreading is supported only for posix and win32.
Nevertheless, the defined macros for multithreading must be provided for other architectures as well. 

  