### PR TITLE
Add FREERTOSLWIP build to travis ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -254,11 +254,31 @@ matrix:
       cache:
         directories:
           - '$HOME/.sonar/cache'
+  #
+  # FREERTOS - gcc build
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc
+            - wget 
+            - gperf
+            - python
+            - python-pip 
+            - python-setuptools 
+            - python-serial 
+            - python-pyparsing
+      env:
+        - ARCH=freertoslwip
+          
   allow_failures:
     #
     # clang-format code analysis
+    # architecture : freertos
     - env:
         - CLANG_FORMAT=true
+        - ARCH=freertoslwip
 
 cache:
   pip: true

--- a/tools/travis/travis_linux_before_install.sh
+++ b/tools/travis/travis_linux_before_install.sh
@@ -1,6 +1,35 @@
 #!/bin/bash
 set -e
 
+if [ "$ARCH" = "freertoslwip" ]; then
+    echo -e "\r\n==Compile multithreaded version==" && echo -en 'travis_fold:start:before_install.build.multithread\\r'
+    mkdir -p build && cd build
+    cmake \
+    -DUA_ARCHITECTURE:STRING=freertosLWIP \
+    -DUA_ENABLE_PUBSUB:BOOL=OFF \
+    -DUA_ENABLE_METHODCALLS:BOOL=ON \
+    -DUA_ENABLE_NODEMANAGEMENT:BOOL=ON \
+    -DUA_ENABLE_AMALGAMATION:STRING=ON \
+    -DUA_ENABLE_PUBSUB:BOOL=ON \
+    -DUA_LOGLEVEL:STRING=600 ..
+	# Compile error ignored and does not cause any problems. Related Issues: #2887 and #2893
+    make -j || true
+	cd ../..
+	git clone --recursive https://github.com/espressif/esp-idf.git esp-idf
+	cd esp-idf && git checkout tags/v3.2
+	git submodule update --init && cd ..
+	export IDF_PATH=/home/travis/build/open62541/esp-idf
+	python -m pip install --user -r $IDF_PATH/requirements.txt
+	mkdir esp && cd esp
+	wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+	tar -xzf xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+	cd .. 
+	git clone https://github.com/open62541/opcua-esp32.git opcua-esp32
+	mv opcua-esp32 $IDF_PATH/examples
+    echo -en 'travis_fold:end:before_install.build.multithread\\r'
+	exit 0
+fi
+
 if [ -z ${LOCAL_PKG+x} ] || [ -z "$LOCAL_PKG" ]; then
     echo "LOCAL_PKG is not set. Aborting..."
     exit 1
@@ -11,7 +40,7 @@ if ! [ -z ${CLANG_FORMAT+x} ]; then
     exit 0
 fi
 
-if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ]; then
+if [ -z ${DOCKER+x} ] && [ -z ${SONAR+x} ] &&  [ -z ${ARCH} ]; then
 	# Only on non-docker builds required
 
  	echo "=== Installing from external package sources in $LOCAL_PKG ===" && echo -en 'travis_fold:start:before_install.external\\r'

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -e
 
+if [ "$ARCH" = "freertoslwip" ]; then
+    echo -e "\r\n==Compile multithreaded version==" && echo -en 'travis_fold:start:script.build.freertoslwip\\r'
+    export PATH="/home/travis/build/open62541/esp/xtensa-esp32-elf/bin:$PATH"
+    export IDF_PATH=/home/travis/build/open62541/esp-idf
+    cd $IDF_PATH/examples/opcua-esp32
+    cp /home/travis/build/open62541/open62541/build/open62541.c components/open62541lib
+    sed -i '/#define UA_IPV6 LWIP_IPV6/d' /home/travis/build/open62541/open62541/build/open62541.h
+    cp /home/travis/build/open62541/open62541/build/open62541.h components/open62541lib/include
+    rm -r components/tcpip_adapter components/lwip components/freertos
+    cp -r $IDF_PATH/components/tcpip_adapter components/ && cp -r $IDF_PATH/components/lwip components/ && cp -r $IDF_PATH/components/freertos components/ 
+    cp components/freertos/include/freertos/* components/freertos/include
+    make
+    echo -en 'travis_fold:end:script.build.freertoslwip\\r'
+    exit 0
+fi
 
 # Sonar code quality
 if ! [ -z ${SONAR+x} ]; then


### PR DESCRIPTION
Created this PR with below concerns;

- Still need to externally modify the LWIP_IPV6 macro with sed. See [#2511 Comment](https://github.com/open62541/open62541/pull/2511#issuecomment-500227225) and #1910 

- tcpip.h compile error is ignored which does not have any effect on freertos build. It is raised by the used xtensa-gcc toolchain.

- python version 2.7.5 raises warnings on line;
python -m pip install --user -r $IDF_PATH/requirements.txt

where there is no warning for 2.7.12 in my local here.
https://github.com/cmbahadir/opcua-esp32/blob/open62541_ci/.travis.yml