### PR TITLE
[Review] Move access control function call remove() from service close session to session manager

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -523,9 +523,6 @@ Service_CloseSession(UA_Server *server, UA_Session *session,
                      UA_CloseSessionResponse *response) {
     UA_LOG_INFO_SESSION(&server->config.logger, session, "CloseSession");
 
-    /* Callback into userland access control */
-    server->config.accessControl.closeSession(server, &server->config.accessControl,
-                                              &session->sessionId, session->sessionHandle);
     response->responseHeader.serviceResult =
         UA_SessionManager_removeSession(&server->sessionManager,
                                         &session->header.authenticationToken);

--- a/src/server/ua_session_manager.c
+++ b/src/server/ua_session_manager.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2014-2017 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2014, 2017 (c) Florian Palm
@@ -44,8 +44,10 @@ removeSession(UA_SessionManager *sm, session_list_entry *sentry) {
 #endif
 
     /* Callback into userland access control */
-    server->config.accessControl.closeSession(server, &server->config.accessControl,
-                                              &session->sessionId, session->sessionHandle);
+    sm->server->config.accessControl.closeSession(sm->server,
+                                                  &sm->server->config.accessControl,
+                                                  &sentry->session.sessionId,
+                                                  sentry->session.sessionHandle);
 
     /* Detach the Session from the SecureChannel */
     UA_Session_detachFromSecureChannel(&sentry->session);

--- a/src/server/ua_session_manager.c
+++ b/src/server/ua_session_manager.c
@@ -43,6 +43,10 @@ removeSession(UA_SessionManager *sm, session_list_entry *sentry) {
     }
 #endif
 
+    /* Callback into userland access control */
+    server->config.accessControl.closeSession(server, &server->config.accessControl,
+                                              &session->sessionId, session->sessionHandle);
+
     /* Detach the Session from the SecureChannel */
     UA_Session_detachFromSecureChannel(&sentry->session);
 


### PR DESCRIPTION
Fix for issue #3013 