### PR TITLE
feat(server): Lock-based enhancement using mutexes (Part 2)

### DIFF
--- a/arch/eCos/ua_architecture.h
+++ b/arch/eCos/ua_architecture.h
@@ -90,10 +90,10 @@ int gethostname_ecos(char* name, size_t len);
 #define UA_LOCK_TYPE(mutexName)
 #define UA_LOCK_TYPE_POINTER(mutexName)
 #define UA_LOCK_INIT(mutexName)
-#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK_DESTROY(mutexName)
 #define UA_LOCK(mutexName)
 #define UA_UNLOCK(mutexName)
-#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#define UA_LOCK_ASSERT(mutexName, num)
 #endif
 
 #include <open62541/architecture_functions.h>

--- a/arch/freertosLWIP/ua_architecture.h
+++ b/arch/freertosLWIP/ua_architecture.h
@@ -21,10 +21,10 @@
 #define UA_LOCK_TYPE(mutexName)
 #define UA_LOCK_TYPE_POINTER(mutexName)
 #define UA_LOCK_INIT(mutexName)
-#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK_DESTROY(mutexName)
 #define UA_LOCK(mutexName)
 #define UA_UNLOCK(mutexName)
-#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#define UA_LOCK_ASSERT(mutexName, num)
 #endif
 
 #include <open62541/architecture_functions.h>

--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -157,7 +157,7 @@ extern void * (*UA_globalRealloc)(void *ptr, size_t size);
                                         pthread_mutexattr_settype(&mutexName##_attr, PTHREAD_MUTEX_RECURSIVE); \
                                         pthread_mutex_init(&mutexName, &mutexName##_attr); \
                                         mutexName##Counter = 0;
-#define UA_LOCK_RELEASE(mutexName) pthread_mutex_destroy(&mutexName); \
+#define UA_LOCK_DESTROY(mutexName) pthread_mutex_destroy(&mutexName); \
                                    pthread_mutexattr_destroy(&mutexName##_attr);
 
 #define UA_LOCK(mutexName) pthread_mutex_lock(&mutexName); \
@@ -165,16 +165,15 @@ extern void * (*UA_globalRealloc)(void *ptr, size_t size);
 
 #define UA_UNLOCK(mutexName) UA_assert(--(mutexName##Counter) == 0); \
                              pthread_mutex_unlock(&mutexName);
-#define UA_LOCK_SWITCH(currentMutex, newMutex)  UA_UNLOCK(currentMutex) \
-                                                UA_LOCK(newMutex)
+#define UA_LOCK_ASSERT(mutexName, num) UA_assert(mutexName##Counter == num);
 #else
 #define UA_LOCK_TYPE_NAME
 #define UA_LOCK_TYPE(mutexName)
 #define UA_LOCK_INIT(mutexName)
-#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK_DESTROY(mutexName)
 #define UA_LOCK(mutexName)
 #define UA_UNLOCK(mutexName)
-#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#define UA_LOCK_ASSERT(mutexName, num)
 #endif
 
 #include <open62541/architecture_functions.h>

--- a/arch/vxworks/ua_architecture.h
+++ b/arch/vxworks/ua_architecture.h
@@ -116,10 +116,10 @@
 #define UA_LOCK_TYPE(mutexName)
 #define UA_LOCK_TYPE_POINTER(mutexName)
 #define UA_LOCK_INIT(mutexName)
-#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK_DESTROY(mutexName)
 #define UA_LOCK(mutexName)
 #define UA_UNLOCK(mutexName)
-#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#define UA_LOCK_ASSERT(mutexName, num)
 #endif
 
 #include <open62541/architecture_functions.h>

--- a/arch/wec7/ua_architecture.h
+++ b/arch/wec7/ua_architecture.h
@@ -144,10 +144,9 @@ char *strerror(int errnum);
 #define UA_LOCK_TYPE(mutexName)
 #define UA_LOCK_TYPE_POINTER(mutexName)
 #define UA_LOCK_INIT(mutexName)
-#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK_DESTROY(mutexName)
 #define UA_LOCK(mutexName)
 #define UA_UNLOCK(mutexName)
-#define UA_LOCK_SWITCH(currentMutex, newMutex)
 #endif
 
 #include <open62541/architecture_functions.h>

--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -149,22 +149,21 @@
                                 int mutexName##Counter;
 #define UA_LOCK_INIT(mutexName) InitializeCriticalSection(&mutexName); \
                                 mutexName##Counter = 0;;
-#define UA_LOCK_RELEASE(mutexName) DeleteCriticalSection(&mutexName);
+#define UA_LOCK_DESTROY(mutexName) DeleteCriticalSection(&mutexName);
 #define UA_LOCK(mutexName) EnterCriticalSection(&mutexName); \
                            UA_assert(++(mutexName##Counter) == 1);
 #define UA_UNLOCK(mutexName) UA_assert(--(mutexName##Counter) == 0); \
                              LeaveCriticalSection(&mutexName);
-#define UA_LOCK_SWITCH(currentMutex, newMutex)  UA_UNLOCK(currentMutex) \
-                                                        UA_LOCK(newMutex)
+#define UA_LOCK_ASSERT(mutexName, num) UA_assert(mutexName##Counter == num);
 #else
 #define UA_LOCK_TYPE_NAME
 #define UA_LOCK_TYPE(mutexName)
 #define UA_LOCK_TYPE_POINTER(mutexName)
 #define UA_LOCK_INIT(mutexName)
-#define UA_LOCK_RELEASE(mutexName)
+#define UA_LOCK_DESTROY(mutexName)
 #define UA_LOCK(mutexName)
 #define UA_UNLOCK(mutexName)
-#define UA_LOCK_SWITCH(currentMutex, newMutex)
+#define UA_LOCK_ASSERT(mutexName, num)
 #endif
 
 #include <open62541/architecture_functions.h>

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -910,7 +910,7 @@ typedef void (*UA_Server_EventNotificationCallback)
  * @return Returns a description of the created MonitoredItem. The structure
  * also contains a StatusCode (in case of an error) and the identifier of the
  * new MonitoredItem. */
-UA_MonitoredItemCreateResult UA_EXPORT
+UA_MonitoredItemCreateResult UA_EXPORT UA_THREADSAFE
 UA_Server_createDataChangeMonitoredItem(UA_Server *server,
           UA_TimestampsToReturn timestampsToReturn,
           const UA_MonitoredItemCreateRequest item,
@@ -923,7 +923,7 @@ UA_Server_createDataChangeMonitoredItem(UA_Server *server,
 /*           const UA_MonitoredItemCreateRequest item, void *context, */
 /*           UA_Server_EventNotificationCallback callback); */
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_deleteMonitoredItem(UA_Server *server, UA_UInt32 monitoredItemId);
 
 #endif
@@ -1315,7 +1315,7 @@ UA_Server_deleteReference(UA_Server *server, const UA_NodeId sourceNodeId,
  * @param eventType The type of the event for which a node should be created
  * @param outNodeId The NodeId of the newly created node for the event
  * @return The StatusCode of the UA_Server_createEvent method */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_createEvent(UA_Server *server, const UA_NodeId eventType,
                       UA_NodeId *outNodeId);
 
@@ -1326,7 +1326,7 @@ UA_Server_createEvent(UA_Server *server, const UA_NodeId eventType,
  * @param outEvent the EventId of the new event
  * @param deleteEventNode Specifies whether the node representation of the event should be deleted
  * @return The StatusCode of the UA_Server_triggerEvent method */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_triggerEvent(UA_Server *server, const UA_NodeId eventNodeId, const UA_NodeId originId,
                        UA_ByteString *outEventId, const UA_Boolean deleteEventNode);
 

--- a/plugins/ua_nodestore_default.c
+++ b/plugins/ua_nodestore_default.c
@@ -348,7 +348,7 @@ UA_Nodestore_delete(void *nsCtx) {
 
     NodeMap *ns = (NodeMap*)nsCtx;
 #if UA_MULTITHREADING >= 100
-    UA_LOCK_RELEASE(ns->lock);
+    UA_LOCK_DESTROY(ns->lock);
 #endif
     ZIP_ITER(NodeTree, &ns->root, deleteNodeVisitor, NULL);
     UA_free(ns);

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -176,8 +176,8 @@ void UA_Server_delete(UA_Server *server) {
 #endif
 
 #if UA_MULTITHREADING >= 100
-    UA_LOCK_RELEASE(server->networkMutex)
-    UA_LOCK_RELEASE(server->serviceMutex)
+    UA_LOCK_DESTROY(server->networkMutex)
+    UA_LOCK_DESTROY(server->serviceMutex)
 #endif
 
     /* Clean up the Admin Session */

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -539,7 +539,9 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
 #endif
 
     /* Dispatch the synchronous service call and send the response */
+    UA_LOCK(server->serviceMutex);
     service(server, session, requestHeader, responseHeader);
+    UA_UNLOCK(server->serviceMutex);
     return sendResponse(channel, requestId, requestHeader->requestHandle,
                         responseHeader, responseType);
 }

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -247,6 +247,13 @@ readWithReadValue(UA_Server *server, const UA_NodeId *nodeId,
 UA_BrowsePathResult
 translateBrowsePathToNodeIds(UA_Server *server, const UA_BrowsePath *browsePath);
 
+void
+monitoredItem_sampleCallback(UA_Server *server, UA_MonitoredItem *monitoredItem);
+
+UA_BrowsePathResult
+browseSimplifiedBrowsePath(UA_Server *server, const UA_NodeId origin,
+                           size_t browsePathSize, const UA_QualifiedName *browsePath);
+
 /***************************************/
 /* Check Information Model Consistency */
 /***************************************/

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -28,6 +28,11 @@
 
 _UA_BEGIN_DECLS
 
+#if UA_MULTITHREADING >= 100
+#undef UA_THREADSAFE
+#define UA_THREADSAFE UA_DEPRECATED
+#endif
+
 #ifdef UA_ENABLE_PUBSUB
 #include "ua_pubsub_manager.h"
 #endif

--- a/src/server/ua_services.h
+++ b/src/server/ua_services.h
@@ -183,7 +183,7 @@ void Service_CloseSession(UA_Server *server, UA_Session *session,
  * AddNodes Service
  * ^^^^^^^^^^^^^^^^
  * Used to add one or more Nodes into the AddressSpace hierarchy. */
-UA_THREADSAFE void Service_AddNodes(UA_Server *server, UA_Session *session,
+void Service_AddNodes(UA_Server *server, UA_Session *session,
                       const UA_AddNodesRequest *request,
                       UA_AddNodesResponse *response);
 
@@ -191,7 +191,7 @@ UA_THREADSAFE void Service_AddNodes(UA_Server *server, UA_Session *session,
  * AddReferences Service
  * ^^^^^^^^^^^^^^^^^^^^^
  * Used to add one or more References to one or more Nodes. */
-UA_THREADSAFE void Service_AddReferences(UA_Server *server, UA_Session *session,
+void Service_AddReferences(UA_Server *server, UA_Session *session,
                            const UA_AddReferencesRequest *request,
                            UA_AddReferencesResponse *response);
 
@@ -199,7 +199,7 @@ UA_THREADSAFE void Service_AddReferences(UA_Server *server, UA_Session *session,
  * DeleteNodes Service
  * ^^^^^^^^^^^^^^^^^^^
  * Used to delete one or more Nodes from the AddressSpace. */
-UA_THREADSAFE void Service_DeleteNodes(UA_Server *server, UA_Session *session,
+void Service_DeleteNodes(UA_Server *server, UA_Session *session,
                          const UA_DeleteNodesRequest *request,
                          UA_DeleteNodesResponse *response);
 
@@ -207,7 +207,7 @@ UA_THREADSAFE void Service_DeleteNodes(UA_Server *server, UA_Session *session,
  * DeleteReferences
  * ^^^^^^^^^^^^^^^^
  * Used to delete one or more References of a Node. */
-UA_THREADSAFE void Service_DeleteReferences(UA_Server *server, UA_Session *session,
+void Service_DeleteReferences(UA_Server *server, UA_Session *session,
                               const UA_DeleteReferencesRequest *request,
                               UA_DeleteReferencesResponse *response);
 
@@ -302,8 +302,8 @@ void Service_UnregisterNodes(UA_Server *server, UA_Session *session,
  * elements are indexed, such as an array, this Service allows Clients to read
  * the entire set of indexed values as a composite, to read individual elements
  * or to read ranges of elements of the composite. */
-UA_THREADSAFE void Service_Read(UA_Server *server, UA_Session *session,
-                                const UA_ReadRequest *request, UA_ReadResponse *response);
+void Service_Read(UA_Server *server, UA_Session *session,
+                  const UA_ReadRequest *request, UA_ReadResponse *response);
 
 /**
  * Write Service
@@ -312,8 +312,8 @@ UA_THREADSAFE void Service_Read(UA_Server *server, UA_Session *session,
  * elements are indexed, such as an array, this Service allows Clients to write
  * the entire set of indexed values as a composite, to write individual elements
  * or to write ranges of elements of the composite. */
-UA_THREADSAFE void Service_Write(UA_Server *server, UA_Session *session,
-                                 const UA_WriteRequest *request, UA_WriteResponse *response);
+void Service_Write(UA_Server *server, UA_Session *session,
+                   const UA_WriteRequest *request, UA_WriteResponse *response);
 
 /**
  * HistoryRead Service
@@ -353,9 +353,9 @@ Service_HistoryUpdate(UA_Server *server, UA_Session *session,
  * context of an existing Session. If the Session is terminated, the results of
  * the method's execution cannot be returned to the Client and are discarded. */
 #ifdef UA_ENABLE_METHODCALLS
-UA_THREADSAFE void Service_Call(UA_Server *server, UA_Session *session,
-                                const UA_CallRequest *request,
-                                UA_CallResponse *response);
+void Service_Call(UA_Server *server, UA_Session *session,
+                  const UA_CallRequest *request,
+                  UA_CallResponse *response);
 #endif
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -613,7 +613,7 @@ UA_Server_readObjectProperty(UA_Server *server, const UA_NodeId objectId,
     bp.relativePath.elements = &rpe;
 
     UA_StatusCode retval;
-    UA_BrowsePathResult bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
+    UA_BrowsePathResult bpr = translateBrowsePathToNodeIds(server, &bp);
     if(bpr.statusCode != UA_STATUSCODE_GOOD || bpr.targetsSize < 1) {
         retval = bpr.statusCode;
         UA_BrowsePathResult_deleteMembers(&bpr);
@@ -1669,7 +1669,7 @@ UA_Server_writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
     bp.relativePath.elements = &rpe;
 
     UA_StatusCode retval;
-    UA_BrowsePathResult bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
+    UA_BrowsePathResult bpr = translateBrowsePathToNodeIds(server, &bp);
     if(bpr.statusCode != UA_STATUSCODE_GOOD || bpr.targetsSize < 1) {
         retval = bpr.statusCode;
         UA_BrowsePathResult_deleteMembers(&bpr);

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -504,13 +504,12 @@ Service_Read(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
-    UA_LOCK(server->serviceMutex);
+
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_Read,
                                            request,
                                            &request->nodesToReadSize, &UA_TYPES[UA_TYPES_READVALUEID],
                                            &response->resultsSize, &UA_TYPES[UA_TYPES_DATAVALUE]);
-    UA_UNLOCK(server->serviceMutex);
 }
 
 UA_DataValue
@@ -1454,12 +1453,11 @@ Service_Write(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
-    UA_LOCK(server->serviceMutex)
+
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_Write, NULL,
                                            &request->nodesToWriteSize, &UA_TYPES[UA_TYPES_WRITEVALUE],
                                            &response->resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
-    UA_UNLOCK(server->serviceMutex);
 }
 
 UA_StatusCode

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -484,6 +484,7 @@ void
 Service_Read(UA_Server *server, UA_Session *session,
              const UA_ReadRequest *request, UA_ReadResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing ReadRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Check if the timestampstoreturn is valid */
     if(request->timestampsToReturn < 0 ||
@@ -504,6 +505,8 @@ Service_Read(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
+
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_Read,
@@ -1447,12 +1450,15 @@ Service_Write(UA_Server *server, UA_Session *session,
               UA_WriteResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing WriteRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxNodesPerWrite != 0 &&
        request->nodesToWriteSize > server->config.maxNodesPerWrite) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
+
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_Write, NULL,

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -116,6 +116,7 @@ void Service_FindServers(UA_Server *server, UA_Session *session,
                          const UA_FindServersRequest *request,
                          UA_FindServersResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing FindServersRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Return the server itself? */
     UA_Boolean foundSelf = false;
@@ -209,6 +210,8 @@ void
 Service_GetEndpoints(UA_Server *server, UA_Session *session,
                      const UA_GetEndpointsRequest *request,
                      UA_GetEndpointsResponse *response) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* If the client expects to see a specific endpointurl, mirror it back. If
        not, clone the endpoints with the discovery url of all networklayers. */
     const UA_String *endpointUrl = &request->endpointUrl;
@@ -468,6 +471,7 @@ void Service_RegisterServer(UA_Server *server, UA_Session *session,
                             UA_RegisterServerResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing RegisterServerRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     process_RegisterServer(server, session, &request->requestHeader, &request->server, 0,
                            NULL, &response->responseHeader, 0, NULL, 0, NULL);
 }
@@ -477,6 +481,7 @@ void Service_RegisterServer2(UA_Server *server, UA_Session *session,
                              UA_RegisterServer2Response *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing RegisterServer2Request");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     process_RegisterServer(server, session, &request->requestHeader, &request->server,
                            request->discoveryConfigurationSize, request->discoveryConfiguration,
                            &response->responseHeader, &response->configurationResultsSize,

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -263,6 +263,7 @@ void Service_Call(UA_Server *server, UA_Session *session,
                   UA_CallResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing CallRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxNodesPerMethodCall != 0 &&
        request->methodsToCallSize > server->config.maxNodesPerMethodCall) {

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -269,12 +269,11 @@ void Service_Call(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
-    UA_LOCK(server->serviceMutex);
+
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_CallMethod, NULL,
                                            &request->methodsToCallSize, &UA_TYPES[UA_TYPES_CALLMETHODREQUEST],
                                            &response->resultsSize, &UA_TYPES[UA_TYPES_CALLMETHODRESULT]);
-    UA_UNLOCK(server->serviceMutex);
 }
 
 UA_CallMethodResult UA_EXPORT

--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -148,6 +148,8 @@ static void
 Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session, struct createMonContext *cmc,
                               const UA_MonitoredItemCreateRequest *request,
                               UA_MonitoredItemCreateResult *result) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* Check available capacity */
     if(cmc->sub &&
        (((server->config.maxMonitoredItems != 0) &&
@@ -278,6 +280,7 @@ Service_CreateMonitoredItems(UA_Server *server, UA_Session *session,
                              const UA_CreateMonitoredItemsRequest *request,
                              UA_CreateMonitoredItemsResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing CreateMonitoredItemsRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxMonitoredItemsPerCall != 0 &&
        request->itemsToCreateSize > server->config.maxMonitoredItemsPerCall) {
@@ -302,6 +305,8 @@ Service_CreateMonitoredItems(UA_Server *server, UA_Session *session,
 
     /* Reset the subscription lifetime */
     cmc.sub->currentLifetimeCount = 0;
+
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_CreateMonitoredItem, &cmc,
@@ -369,6 +374,7 @@ Service_ModifyMonitoredItems(UA_Server *server, UA_Session *session,
                              const UA_ModifyMonitoredItemsRequest *request,
                              UA_ModifyMonitoredItemsResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing ModifyMonitoredItemsRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxMonitoredItemsPerCall != 0 &&
        request->itemsToModifySize > server->config.maxMonitoredItemsPerCall) {
@@ -390,6 +396,8 @@ Service_ModifyMonitoredItems(UA_Server *server, UA_Session *session,
     }
 
     sub->currentLifetimeCount = 0; /* Reset the subscription lifetime */
+
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session,
@@ -485,6 +493,7 @@ Service_SetMonitoringMode(UA_Server *server, UA_Session *session,
                           const UA_SetMonitoringModeRequest *request,
                           UA_SetMonitoringModeResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing SetMonitoringMode");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxMonitoredItemsPerCall != 0 &&
        request->monitoredItemIdsSize > server->config.maxMonitoredItemsPerCall) {
@@ -499,6 +508,8 @@ Service_SetMonitoringMode(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         return;
     }
+
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     smc.sub->currentLifetimeCount = 0; /* Reset the subscription lifetime */
 
@@ -522,6 +533,7 @@ Service_DeleteMonitoredItems(UA_Server *server, UA_Session *session,
                              UA_DeleteMonitoredItemsResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing DeleteMonitoredItemsRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxMonitoredItemsPerCall != 0 &&
        request->monitoredItemIdsSize > server->config.maxMonitoredItemsPerCall) {
@@ -535,6 +547,8 @@ Service_DeleteMonitoredItems(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         return;
     }
+
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Reset the subscription lifetime */
     sub->currentLifetimeCount = 0;

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -1279,6 +1279,7 @@ Service_AddNodes(UA_Server *server, UA_Session *session,
                  const UA_AddNodesRequest *request,
                  UA_AddNodesResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing AddNodesRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxNodesPerNodeManagement != 0 &&
        request->nodesToAddSize > server->config.maxNodesPerNodeManagement) {
@@ -1616,6 +1617,7 @@ void Service_DeleteNodes(UA_Server *server, UA_Session *session,
                          UA_DeleteNodesResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing DeleteNodesRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxNodesPerNodeManagement != 0 &&
        request->nodesToDeleteSize > server->config.maxNodesPerNodeManagement) {
@@ -1740,6 +1742,7 @@ void Service_AddReferences(UA_Server *server, UA_Session *session,
                            UA_AddReferencesResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing AddReferencesRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxNodesPerNodeManagement != 0 &&
        request->referencesToAddSize > server->config.maxNodesPerNodeManagement) {
@@ -1822,6 +1825,7 @@ Service_DeleteReferences(UA_Server *server, UA_Session *session,
                          UA_DeleteReferencesResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing DeleteReferencesRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(server->config.maxNodesPerNodeManagement != 0 &&
        request->referencesToDeleteSize > server->config.maxNodesPerNodeManagement) {

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -1285,13 +1285,12 @@ Service_AddNodes(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
-    UA_LOCK(server->serviceMutex);
+
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session,
                                            (UA_ServiceOperation)Operation_addNode, NULL,
                                            &request->nodesToAddSize, &UA_TYPES[UA_TYPES_ADDNODESITEM],
                                            &response->resultsSize, &UA_TYPES[UA_TYPES_ADDNODESRESULT]);
-    UA_UNLOCK(server->serviceMutex)
 }
 
 UA_StatusCode
@@ -1623,14 +1622,13 @@ void Service_DeleteNodes(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
-    UA_LOCK(server->serviceMutex);
+
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session,
                                            (UA_ServiceOperation)deleteNodeOperation,
                                            NULL, &request->nodesToDeleteSize,
                                            &UA_TYPES[UA_TYPES_DELETENODESITEM],
                                            &response->resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
-    UA_UNLOCK(server->serviceMutex);
 }
 
 UA_StatusCode
@@ -1748,14 +1746,13 @@ void Service_AddReferences(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
-    UA_LOCK(server->serviceMutex);
+
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session,
                                            (UA_ServiceOperation)Operation_addReference,
                                            NULL, &request->referencesToAddSize,
                                            &UA_TYPES[UA_TYPES_ADDREFERENCESITEM],
                                            &response->resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
-    UA_UNLOCK(server->serviceMutex);
 }
 
 UA_StatusCode
@@ -1831,14 +1828,13 @@ Service_DeleteReferences(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADTOOMANYOPERATIONS;
         return;
     }
-    UA_LOCK(server->serviceMutex);
+
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session,
                                            (UA_ServiceOperation)Operation_deleteReference,
                                            NULL, &request->referencesToDeleteSize,
                                            &UA_TYPES[UA_TYPES_DELETEREFERENCESITEM],
                                            &response->resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
-    UA_UNLOCK(server->serviceMutex);
 }
 
 UA_StatusCode

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -522,6 +522,7 @@ Service_CloseSession(UA_Server *server, UA_Session *session,
                      const UA_CloseSessionRequest *request,
                      UA_CloseSessionResponse *response) {
     UA_LOG_INFO_SESSION(&server->config.logger, session, "CloseSession");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     response->responseHeader.serviceResult =
         UA_SessionManager_removeSession(&server->sessionManager,

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -61,6 +61,8 @@ void
 Service_CreateSubscription(UA_Server *server, UA_Session *session,
                            const UA_CreateSubscriptionRequest *request,
                            UA_CreateSubscriptionResponse *response) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* Check limits for the number of subscriptions */
     if(((server->config.maxSubscriptions != 0) &&
         (server->numSubscriptions >= server->config.maxSubscriptions)) ||
@@ -110,6 +112,7 @@ Service_ModifySubscription(UA_Server *server, UA_Session *session,
                            const UA_ModifySubscriptionRequest *request,
                            UA_ModifySubscriptionResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing ModifySubscriptionRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     UA_Subscription *sub = UA_Session_getSubscriptionById(session, request->subscriptionId);
     if(!sub) {
@@ -151,6 +154,8 @@ Service_SetPublishingMode(UA_Server *server, UA_Session *session,
                           const UA_SetPublishingModeRequest *request,
                           UA_SetPublishingModeResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing SetPublishingModeRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     UA_Boolean publishingEnabled = request->publishingEnabled; /* request is const */
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_SetPublishingMode,
@@ -317,6 +322,7 @@ Service_DeleteSubscriptions(UA_Server *server, UA_Session *session,
                             UA_DeleteSubscriptionsResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing DeleteSubscriptionsRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session,
@@ -338,6 +344,7 @@ Service_Republish(UA_Server *server, UA_Session *session,
                   UA_RepublishResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing RepublishRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Get the subscription */
     UA_Subscription *sub = UA_Session_getSubscriptionById(session, request->subscriptionId);

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -703,6 +703,7 @@ Operation_Browse(UA_Server *server, UA_Session *session, const UA_UInt32 *maxref
 void Service_Browse(UA_Server *server, UA_Session *session,
                     const UA_BrowseRequest *request, UA_BrowseResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing BrowseRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Test the number of operations in the request */
     if(server->config.maxNodesPerBrowse != 0 &&
@@ -783,6 +784,8 @@ Service_BrowseNext(UA_Server *server, UA_Session *session,
                    UA_BrowseNextResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing BrowseNextRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     UA_Boolean releaseContinuationPoints = request->releaseContinuationPoints; /* request is const */
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_BrowseNext,
@@ -1134,6 +1137,7 @@ Service_TranslateBrowsePathsToNodeIds(UA_Server *server, UA_Session *session,
                                       UA_TranslateBrowsePathsToNodeIdsResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing TranslateBrowsePathsToNodeIdsRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Test the number of operations in the request */
     if(server->config.maxNodesPerTranslateBrowsePathsToNodeIds != 0 &&
@@ -1194,6 +1198,7 @@ void Service_RegisterNodes(UA_Server *server, UA_Session *session,
                            UA_RegisterNodesResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing RegisterNodesRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     //TODO: hang the nodeids to the session if really needed
     if(request->nodesToRegisterSize == 0) {
@@ -1220,6 +1225,7 @@ void Service_UnregisterNodes(UA_Server *server, UA_Session *session,
                              UA_UnregisterNodesResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session,
                          "Processing UnRegisterNodesRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     //TODO: remove the nodeids from the session if really needed
     if(request->nodesToUnregisterSize == 0)

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -201,6 +201,8 @@ detectValueChangeWithFilter(UA_Server *server, UA_Session *session, UA_Monitored
 static UA_StatusCode
     detectValueChange(UA_Server *server, UA_Session *session, UA_MonitoredItem *mon,
                   UA_DataValue value, UA_ByteString *encoding, UA_Boolean *changed) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* Apply Filter */
     if(mon->filter.dataChangeFilter.trigger == UA_DATACHANGETRIGGER_STATUS)
         value.hasValue = false;

--- a/tests/server/check_server_historical_data.c
+++ b/tests/server/check_server_historical_data.c
@@ -305,7 +305,9 @@ requestHistory(UA_DateTime start,
     request.nodesToReadSize = 1;
     request.nodesToRead = valueId;
 
+    UA_LOCK(server->serviceMutex);
     Service_HistoryRead(server, &server->adminSession, &request, response);
+    UA_UNLOCK(server->serviceMutex);
     UA_HistoryReadRequest_deleteMembers(&request);
 }
 
@@ -497,7 +499,9 @@ deleteHistory(UA_DateTime start,
 
     UA_HistoryUpdateResponse response;
     UA_HistoryUpdateResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_HistoryUpdate(server, &server->adminSession, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     UA_HistoryUpdateRequest_deleteMembers(&request);
     UA_StatusCode ret = UA_STATUSCODE_GOOD;
     if (response.responseHeader.serviceResult != UA_STATUSCODE_GOOD)
@@ -549,7 +553,9 @@ updateHistory(UA_PerformUpdateType updateType, UA_DateTime *updateData, UA_Statu
 
     UA_HistoryUpdateResponse response;
     UA_HistoryUpdateResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_HistoryUpdate(server, &server->adminSession, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     UA_HistoryUpdateRequest_deleteMembers(&request);
     UA_StatusCode ret = UA_STATUSCODE_GOOD;
     if (response.responseHeader.serviceResult != UA_STATUSCODE_GOOD)

--- a/tests/server/check_server_readspeed.c
+++ b/tests/server/check_server_readspeed.c
@@ -94,7 +94,9 @@ START_TEST(readSpeed) {
         size_t offset = 0;
         retval |= UA_decodeBinary(&request_msg, &offset, &req, &UA_TYPES[UA_TYPES_READREQUEST], NULL);
 
+        UA_LOCK(server->serviceMutex);
         Service_Read(server, &server->adminSession, &req, &res);
+        UA_UNLOCK(server->serviceMutex);
 
         UA_Byte *rpos = response_msg.data;
         const UA_Byte *rend = &response_msg.data[response_msg.length];

--- a/tests/server/check_services_subscriptions.c
+++ b/tests/server/check_services_subscriptions.c
@@ -67,7 +67,9 @@ createSubscription(void) {
     UA_CreateSubscriptionResponse response;
     UA_CreateSubscriptionResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     subscriptionId = response.subscriptionId;
 
@@ -98,7 +100,9 @@ createMonitoredItem(void) {
     UA_CreateMonitoredItemsResponse response;
     UA_CreateMonitoredItemsResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_CreateMonitoredItems(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.resultsSize, 1);
     ck_assert_uint_eq(response.results[0].statusCode, UA_STATUSCODE_GOOD);
@@ -118,8 +122,9 @@ START_TEST(Server_createSubscription) {
 
     UA_CreateSubscriptionResponse response;
     UA_CreateSubscriptionResponse_init(&response);
-
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     subscriptionId = response.subscriptionId;
 
@@ -145,7 +150,9 @@ START_TEST(Server_modifySubscription) {
     UA_ModifySubscriptionResponse response;
     UA_ModifySubscriptionResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_ModifySubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
 
     UA_ModifySubscriptionResponse_deleteMembers(&response);
@@ -164,7 +171,10 @@ START_TEST(Server_setPublishingMode) {
     UA_SetPublishingModeResponse response;
     UA_SetPublishingModeResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_SetPublishingMode(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
+
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.resultsSize, 1);
     ck_assert_uint_eq(response.results[0], UA_STATUSCODE_GOOD);
@@ -184,7 +194,9 @@ START_TEST(Server_republish) {
     UA_RepublishResponse response;
     UA_RepublishResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_Republish(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_BADMESSAGENOTAVAILABLE);
 
     UA_RepublishResponse_deleteMembers(&response);
@@ -201,7 +213,9 @@ START_TEST(Server_republish_invalid) {
     UA_RepublishResponse response;
     UA_RepublishResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_Republish(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID);
 
     UA_RepublishResponse_deleteMembers(&response);
@@ -220,7 +234,9 @@ START_TEST(Server_deleteSubscription) {
     UA_DeleteSubscriptionsResponse del_response;
     UA_DeleteSubscriptionsResponse_init(&del_response);
 
+    UA_LOCK(server->serviceMutex);
     Service_DeleteSubscriptions(server, session, &del_request, &del_response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(del_response.resultsSize, 1);
     ck_assert_uint_eq(del_response.results[0], UA_STATUSCODE_GOOD);
 
@@ -236,7 +252,9 @@ START_TEST(Server_publishCallback) {
     UA_CreateSubscriptionRequest_init(&request);
     request.publishingEnabled = true;
     UA_CreateSubscriptionResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     UA_UInt32 subscriptionId1 = response.subscriptionId;
     UA_CreateSubscriptionResponse_deleteMembers(&response);
@@ -245,7 +263,9 @@ START_TEST(Server_publishCallback) {
     UA_CreateSubscriptionRequest_init(&request);
     request.publishingEnabled = true;
     UA_CreateSubscriptionResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     UA_UInt32 subscriptionId2 = response.subscriptionId;
     UA_Double publishingInterval = response.revisedPublishingInterval;
@@ -277,7 +297,9 @@ START_TEST(Server_publishCallback) {
     UA_DeleteSubscriptionsResponse del_response;
     UA_DeleteSubscriptionsResponse_init(&del_response);
 
+    UA_LOCK(server->serviceMutex);
     Service_DeleteSubscriptions(server, session, &del_request, &del_response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(del_response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(del_response.resultsSize, 2);
     ck_assert_uint_eq(del_response.results[0], UA_STATUSCODE_GOOD);
@@ -318,7 +340,9 @@ START_TEST(Server_modifyMonitoredItems) {
     UA_ModifyMonitoredItemsResponse response;
     UA_ModifyMonitoredItemsResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_ModifyMonitoredItems(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.resultsSize, 1);
     ck_assert_uint_eq(response.results[0].statusCode, UA_STATUSCODE_GOOD);
@@ -336,7 +360,9 @@ START_TEST(Server_overflow) {
     UA_CreateSubscriptionRequest_init(&createSubscriptionRequest);
     createSubscriptionRequest.publishingEnabled = true;
     UA_CreateSubscriptionResponse_init(&createSubscriptionResponse);
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &createSubscriptionRequest, &createSubscriptionResponse);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(createSubscriptionResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     UA_UInt32 localSubscriptionId = createSubscriptionResponse.subscriptionId;
     UA_Double publishingInterval = createSubscriptionResponse.revisedPublishingInterval;
@@ -368,7 +394,9 @@ START_TEST(Server_overflow) {
     UA_CreateMonitoredItemsResponse createMonitoredItemsResponse;
     UA_CreateMonitoredItemsResponse_init(&createMonitoredItemsResponse);
 
+    UA_LOCK(server->serviceMutex);
     Service_CreateMonitoredItems(server, session, &createMonitoredItemsRequest, &createMonitoredItemsResponse);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(createMonitoredItemsResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(createMonitoredItemsResponse.resultsSize, 1);
     ck_assert_uint_eq(createMonitoredItemsResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
@@ -438,8 +466,10 @@ START_TEST(Server_overflow) {
     UA_ModifyMonitoredItemsResponse modifyMonitoredItemsResponse;
     UA_ModifyMonitoredItemsResponse_init(&modifyMonitoredItemsResponse);
 
+    UA_LOCK(server->serviceMutex);
     Service_ModifyMonitoredItems(server, session, &modifyMonitoredItemsRequest,
                                  &modifyMonitoredItemsResponse);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.resultsSize, 1);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
@@ -468,8 +498,10 @@ START_TEST(Server_overflow) {
 
     UA_ModifyMonitoredItemsResponse_init(&modifyMonitoredItemsResponse);
 
+    UA_LOCK(server->serviceMutex);
     Service_ModifyMonitoredItems(server, session, &modifyMonitoredItemsRequest,
                                  &modifyMonitoredItemsResponse);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.resultsSize, 1);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
@@ -497,8 +529,10 @@ START_TEST(Server_overflow) {
 
     UA_ModifyMonitoredItemsResponse_init(&modifyMonitoredItemsResponse);
 
+    UA_LOCK(server->serviceMutex);
     Service_ModifyMonitoredItems(server, session, &modifyMonitoredItemsRequest,
                                  &modifyMonitoredItemsResponse);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.resultsSize, 1);
     ck_assert_uint_eq(modifyMonitoredItemsResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
@@ -522,8 +556,10 @@ START_TEST(Server_overflow) {
     UA_DeleteSubscriptionsResponse deleteSubscriptionsResponse;
     UA_DeleteSubscriptionsResponse_init(&deleteSubscriptionsResponse);
 
+    UA_LOCK(server->serviceMutex);
     Service_DeleteSubscriptions(server, session, &deleteSubscriptionsRequest,
                                 &deleteSubscriptionsResponse);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(deleteSubscriptionsResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(deleteSubscriptionsResponse.resultsSize, 1);
     ck_assert_uint_eq(deleteSubscriptionsResponse.results[0], UA_STATUSCODE_GOOD);
@@ -547,7 +583,9 @@ START_TEST(Server_setMonitoringMode) {
     UA_SetMonitoringModeResponse response;
     UA_SetMonitoringModeResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_SetMonitoringMode(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.resultsSize, 1);
     ck_assert_uint_eq(response.results[0], UA_STATUSCODE_GOOD);
@@ -569,7 +607,9 @@ START_TEST(Server_deleteMonitoredItems) {
     UA_DeleteMonitoredItemsResponse response;
     UA_DeleteMonitoredItemsResponse_init(&response);
 
+    UA_LOCK(server->serviceMutex);
     Service_DeleteMonitoredItems(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.resultsSize, 1);
     ck_assert_uint_eq(response.results[0], UA_STATUSCODE_GOOD);
@@ -588,7 +628,9 @@ START_TEST(Server_lifeTimeCount) {
     request.requestedLifetimeCount = 3;
     request.requestedMaxKeepAliveCount = 1;
     UA_CreateSubscriptionResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.revisedMaxKeepAliveCount, 1);
     ck_assert_uint_eq(response.revisedLifetimeCount, 3);
@@ -600,7 +642,9 @@ START_TEST(Server_lifeTimeCount) {
     request.requestedLifetimeCount = 4;
     request.requestedMaxKeepAliveCount = 2;
     UA_CreateSubscriptionResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.revisedMaxKeepAliveCount, 2);
     /* revisedLifetimeCount is revised to 3*MaxKeepAliveCount == 3 */
@@ -633,7 +677,9 @@ START_TEST(Server_lifeTimeCount) {
 
     UA_CreateMonitoredItemsResponse mresponse;
     UA_CreateMonitoredItemsResponse_init(&mresponse);
+    UA_LOCK(server->serviceMutex);
     Service_CreateMonitoredItems(server, session, &mrequest, &mresponse);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(mresponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(mresponse.resultsSize, 1);
     ck_assert_uint_eq(mresponse.results[0].statusCode, UA_STATUSCODE_GOOD);
@@ -740,7 +786,9 @@ START_TEST(Server_invalidPublishingInterval) {
     request.publishingEnabled = true;
     request.requestedPublishingInterval = -5.0; // Must be positive
     UA_CreateSubscriptionResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_CreateSubscription(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert(response.revisedPublishingInterval ==
               server->config.publishingIntervalLimits.min);
@@ -778,7 +826,9 @@ START_TEST(Server_invalidSamplingInterval) {
 
     UA_CreateMonitoredItemsResponse response;
     UA_CreateMonitoredItemsResponse_init(&response);
+    UA_LOCK(server->serviceMutex);
     Service_CreateMonitoredItems(server, session, &request, &response);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.resultsSize, 1);
     ck_assert_uint_eq(response.results[0].statusCode, UA_STATUSCODE_GOOD);

--- a/tests/server/check_subscription_events.c
+++ b/tests/server/check_subscription_events.c
@@ -144,9 +144,10 @@ removeSubscription(void) {
 
     UA_DeleteSubscriptionsResponse deleteSubscriptionsResponse;
     UA_DeleteSubscriptionsResponse_init(&deleteSubscriptionsResponse);
-
+    UA_LOCK(server->serviceMutex);
     Service_DeleteSubscriptions(server, &server->adminSession, &deleteSubscriptionsRequest,
                                 &deleteSubscriptionsResponse);
+    UA_UNLOCK(server->serviceMutex);
     UA_DeleteSubscriptionsResponse_deleteMembers(&deleteSubscriptionsResponse);
 }
 


### PR DESCRIPTION
Continuation of PR #2993:
- Locks for the subscription and monitoredItem service sets
- Locks for the view service set 
- Fixes for unit tests
- Refactoring of the used multithreading macros
