### PR TITLE
PubSub: Fix inconsistent type usage for publishId

### DIFF
--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -92,8 +92,8 @@ addDataSetReader(UA_Server *server) {
     /* The following parameters are used to show that the data published by
      * tutorial_pubsub_publish.c is being subscribed and is being updated in
      * the information model */
-    UA_UInt16 publisherIdentifier = 2234;
-    readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+    UA_UInt32 publisherIdentifier = 2234;
+    readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT32];
     readerConfig.publisherId.data = &publisherIdentifier;
     readerConfig.writerGroupId    = 100;
     readerConfig.dataSetWriterId  = 62541;

--- a/src/pubsub/ua_pubsub.c
+++ b/src/pubsub/ua_pubsub.c
@@ -1955,7 +1955,7 @@ sendNetworkMessage(UA_PubSubConnection *connection, UA_WriterGroup *wg,
     nm.version = 1;
     nm.networkMessageType = UA_NETWORKMESSAGE_DATASET;
     if(connection->config->publisherIdType == UA_PUBSUB_PUBLISHERID_NUMERIC) {
-        nm.publisherIdType = UA_PUBLISHERDATATYPE_UINT16;
+        nm.publisherIdType = UA_PUBLISHERDATATYPE_UINT32;
         nm.publisherId.publisherIdUInt32 = connection->config->publisherId.numeric;
     } else if(connection->config->publisherIdType == UA_PUBSUB_PUBLISHERID_STRING){
         nm.publisherIdType = UA_PUBLISHERDATATYPE_STRING;

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -683,8 +683,8 @@ START_TEST(SinglePublishSubscribeInt32) {
         /* Parameters to filter received NetworkMessage */
         memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
         readerConfig.name             = UA_STRING ("DataSetReader Test");
-        UA_UInt16 publisherIdentifier = PUBLISHER_ID;
-        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+        UA_UInt32 publisherIdentifier = PUBLISHER_ID;
+        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT32];
         readerConfig.publisherId.data = &publisherIdentifier;
         readerConfig.writerGroupId    = WRITER_GROUP_ID;
         readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
@@ -857,8 +857,8 @@ START_TEST(SinglePublishSubscribeInt64) {
         /* Parameters to filter received NetworkMessage */
         memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
         readerConfig.name             = UA_STRING ("DataSetReader Test");
-        UA_UInt16 publisherIdentifier = PUBLISHER_ID;
-        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+        UA_UInt32 publisherIdentifier = PUBLISHER_ID;
+        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT32];
         readerConfig.publisherId.data = &publisherIdentifier;
         readerConfig.writerGroupId    = WRITER_GROUP_ID;
         readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
@@ -1031,8 +1031,8 @@ START_TEST(SinglePublishSubscribeBool) {
         /* Parameters to filter received NetworkMessage */
         memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
         readerConfig.name             = UA_STRING ("DataSetReader Test");
-        UA_UInt16 publisherIdentifier = PUBLISHER_ID;
-        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+        UA_UInt32 publisherIdentifier = PUBLISHER_ID;
+        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT32];
         readerConfig.publisherId.data = &publisherIdentifier;
         readerConfig.writerGroupId    = WRITER_GROUP_ID;
         readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
@@ -1206,8 +1206,8 @@ START_TEST(SinglePublishSubscribewithValidIdentifiers) {
         /* Parameters to filter received NetworkMessage */
         memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
         readerConfig.name             = UA_STRING ("DataSetReader Test");
-        UA_UInt16 publisherIdentifier = PUBLISHER_ID;
-        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+        UA_UInt32 publisherIdentifier = PUBLISHER_ID;
+        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT32];
         readerConfig.publisherId.data = &publisherIdentifier;
         readerConfig.writerGroupId    = WRITER_GROUP_ID;
         readerConfig.dataSetWriterId  = DATASET_WRITER_ID;


### PR DESCRIPTION
This pull request fixes an issue with inconsistent type usage (UInt32 vs. UInt16) for `publishId` which resulted in mismatching subscriptions on big-endian systems (PPC) so that no subscriptions could be received.

The commit introduces a small change in the API (I had to change the subscriber tutorial and test) by using `UA_TYPES_UINT32` instead of `UA_TYPES_UINT16` for the publisherId type.

If this is not desired, another possibility would be to use an ugly cast instead:
`nm.publisherId.publisherIdUInt16 = (UA_UInt16) connection->config->publisherId.numeric`

But I really think it's better to use UInt32 consistently here.
