### PR TITLE
fix(debian): add python dependency to dev package

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -16,7 +16,7 @@ Package: libopen62541-<soname>-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: libopen62541-<soname> (= ${binary:Version}), ${misc:Depends}
+Depends: libopen62541-<soname> (= ${binary:Version}), ${misc:Depends}, python
 Description: Development header files for open62541
  open62541 is an open source C (C99) implementation of the OPC UA standard
 


### PR DESCRIPTION
Lintian complains that the dev package installs python scripts without stated dependency to python. Consequently there should be a dependency to python included for the dev package.