### PR TITLE
fix: Resolve valgrind error in example Subscriber application

### DIFF
--- a/src/pubsub/ua_pubsub.c
+++ b/src/pubsub/ua_pubsub.c
@@ -723,7 +723,7 @@ UA_StatusCode UA_Server_DataSetReader_addTargetVariables(UA_Server *server, UA_N
             vAttr.displayName.text = pDataSetReader->config.dataSetMetaData.fields[iteratorField].name;
             if(pDataSetReader->config.dataSetMetaData.fields[iteratorField].name.length < slen) {
                 slen = (UA_UInt16)pDataSetReader->config.dataSetMetaData.fields[iteratorField].name.length;
-                UA_snprintf(szTmpName, sizeof(szTmpName), "%s", (const char*)pDataSetReader->config.dataSetMetaData.fields[iteratorField].name.data);
+                UA_snprintf(szTmpName, sizeof(szTmpName), "%.*s", (int)slen, (const char*)pDataSetReader->config.dataSetMetaData.fields[iteratorField].name.data);
             }
 
             szTmpName[slen] = '\0';
@@ -744,7 +744,7 @@ UA_StatusCode UA_Server_DataSetReader_addTargetVariables(UA_Server *server, UA_N
             UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_USERLAND, "addVariableNode %s succeeded", szTmpName);
         }
         else {
-            UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_USERLAND, "addVariableNode: error 0x%x", retval);
+            UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND, "addVariableNode: error 0x%x", retval);
         }
 
         UA_FieldTargetDataType_init(&targetVars.targetVariables[iteratorField]);

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -395,9 +395,9 @@ START_TEST(AddTargetVariableWithValidConfiguration) {
         UA_DataSetMetaDataType *pMetaData = &dataSetReaderConfig.dataSetMetaData;
         UA_DataSetMetaDataType_init (pMetaData);
         pMetaData->name = UA_STRING ("DataSet Test");
-        /* Static definition of number of fields size to 4 to create four different
-         * targetVariables of distinct datatype */
-        pMetaData->fieldsSize = 1;
+        /* Static definition of number of fields size to 2 to create targetVariables
+         * with DateTime and ByteString datatype */
+        pMetaData->fieldsSize = 2;
         pMetaData->fields = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
                              &UA_TYPES[UA_TYPES_FIELDMETADATA]);
 
@@ -407,6 +407,13 @@ START_TEST(AddTargetVariableWithValidConfiguration) {
                         &pMetaData->fields[0].dataType);
         pMetaData->fields[0].builtInType = UA_NS0ID_DATETIME;
         pMetaData->fields[0].valueRank = -1; /* scalar */
+
+        /* ByteString DataType */
+        UA_FieldMetaData_init (&pMetaData->fields[1]);
+        UA_NodeId_copy (&UA_TYPES[UA_TYPES_BYTESTRING].typeId,
+                        &pMetaData->fields[1].dataType);
+        pMetaData->fields[1].builtInType = UA_NS0ID_BYTESTRING;
+        pMetaData->fields[1].valueRank = -1; /* scalar */
 
         retVal |= UA_Server_addDataSetReader(server, localreaderGroupIdentifier, &dataSetReaderConfig, &localDataSetreaderIdentifier);
 
@@ -418,8 +425,8 @@ START_TEST(AddTargetVariableWithValidConfiguration) {
                                  folderBrowseName, UA_NODEID_NUMERIC (0,
                                  UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
         retVal |=  UA_Server_DataSetReader_addTargetVariables(server, &folderId, localDataSetreaderIdentifier, UA_PUBSUB_SDS_TARGET);
-        UA_free(pMetaData->fields);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        UA_free(pMetaData->fields);
     } END_TEST
 
 START_TEST(SinglePublishSubscribeDateTime) {


### PR DESCRIPTION
- Fix valgrind errors while running tutorial_pubsub_subscribe application by modifying UA_snprintf in UA_Server_DataSetReader_addTargetVariables 
- Unit test to verify that no segmentation fault occurs when adding ByteString variable in Subscriber metadata