### PR TITLE
fix: Start ctt server as default application in docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+/build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,7 +452,7 @@ if(NOT UA_COMPILE_AS_CXX AND (CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID
         endif()
     endif()
 
-    if(UA_ENABLE_HARDENING AND (CMAKE_BUILD_TYPE STREQUAL "Release") OR (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
+    if(UA_ENABLE_HARDENING AND ((CMAKE_BUILD_TYPE STREQUAL "Release") OR (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")))
         check_cc_flag("-D_FORTIFY_SOURCE=2") # run-time buffer overflow detection (needs at least -O1)
     endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,29 @@
-FROM alpine:3.5
-RUN apk add --no-cache cmake gcc g++ musl-dev python py-pip make && rm -rf /var/cache/apk/*
-ADD . /tmp/open62541
-WORKDIR /tmp/open62541/build
-RUN cmake -DUA_ENABLE_AMALGAMATION=true  \
-          -DBUILD_SHARED_LIBS=true \
-          /tmp/open62541 
+FROM alpine:3.10
+RUN apk add --no-cache cmake gcc git g++ musl-dev mbedtls-dev python py-pip make && rm -rf /var/cache/apk/*
+ADD . /opt/open62541
+WORKDIR /opt/open62541
+RUN git submodule update --init --recursive
+WORKDIR /opt/open62541/build
+RUN cmake -DBUILD_SHARED_LIBS=ON \
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DUA_BUILD_EXAMPLES=ON \
+		# Hardening needs to be disabled, otherwise the docker build takes too long and travis fails
+		-DUA_ENABLE_HARDENING=OFF \
+        -DUA_ENABLE_ENCRYPTION=ON \
+        -DUA_ENABLE_SUBSCRIPTIONS=ON \
+        -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+		-DUA_NAMESPACE_ZERO=FULL \
+         /opt/open62541
 RUN make -j
-RUN cp *.h /usr/include/ && \
-    cp bin/*.so /usr/lib
+RUN make install
+
+# Generate certificates
+RUN apk add --no-cache python-dev linux-headers openssl && rm -rf /var/cache/apk/*
+RUN pip install netifaces==0.10.9
+RUN mkdir -p /opt/open62541/pki/created
+RUN python /opt/open62541/tools/certs/create_self-signed.py /opt/open62541/pki/created
+
+
+WORKDIR /opt/open62541
+EXPOSE 4840
+CMD ["/opt/open62541/build/bin/examples/server_ctt" , "/opt/open62541/pki/created/server_cert.der", "/opt/open62541/pki/created/server_key.der", "--enableUnencrypted", "--enableAnonymous"]

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -546,7 +546,9 @@ class DataTypeNode(Node):
                             fdtype = nodeset.aliases[fdtype]
                     elif at == "Name":
                         fname = str(av)
-                    #elif at == "SymbolicName":
+                    elif at == "SymbolicName":
+                        # ignore
+                        continue
                     #    symbolicName = str(av)
                     elif at == "Value":
                         enumVal = int(av)

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -29,7 +29,7 @@ fi
 # Docker build test
 if ! [ -z ${DOCKER+x} ]; then
     docker build -t open62541 .
-    docker run -d -p 127.0.0.1:80:80 --name open62541 open62541 /bin/sh
+    docker run -d -p 127.0.0.1:4840:4840 --name open62541 open62541 /bin/sh
     docker ps | grep -q open62541
     # disabled since it randomly fails
     # docker ps | grep -q open62541


### PR DESCRIPTION
The container can be built with:
`docker build -t open62541 . && docker run -p 4840:4840 open62541`