### PR TITLE
fix(debian): remove braces in debhelper config file

### DIFF
--- a/debian/libopen62541-dev.install-template
+++ b/debian/libopen62541-dev.install-template
@@ -1,5 +1,5 @@
 usr/include
-usr/lib/*/{*.a,*.so}
+usr/lib/*/*.so
 usr/lib/*/cmake/open62541/*
 usr/lib/*/pkgconfig/open62541.pc
 usr/share/open62541/*


### PR DESCRIPTION
Braces should be removed here because _lintian_ states 
```
 N:    This debhelper config file appears to use shell brace expansion (such as
 N:    {foo,bar}) to specify files. This happens to work due to an accident of
 N:    implementation but is not a supported feature. Only ?, *, and [...] are
 N:    supported.
 N:    
```
As long as this package produces only the shared lib the affected line should be reduced
 to ```usr/lib/*/*.so```
