### PR TITLE
fix(debian): hardening no bindnow

### DIFF
--- a/debian/rules-template
+++ b/debian/rules-template
@@ -2,7 +2,8 @@
 
 export DH_VERBOSE = 1
 
-export DEB_BUILD_OPTIONS=parallel=4
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_BUILD_OPTIONS = parallel=4
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL -DUA_ENABLE_AMALGAMATION=OFF -DUA_PACK_DEBIAN=ON


### PR DESCRIPTION
This patch fixes following _lintian_ output:
 
```
I: libopen62541-1: hardening-no-bindnow usr/lib/x86_64-linux-gnu/libopen62541.so.1.0.0
N: 
N:    This package provides an ELF binary that lacks the "bindnow" linker
N:    flag.
N:    
N:    This is needed (together with "relro") to make the "Global Offset Table"
N:    (GOT) fully read-only. The bindnow feature trades startup time for
N:    improved security. Please consider enabling this feature or consider
N:    overriding the tag (possibly with a comment about why).
N:    
N:    If you use dpkg-buildflags, you may have to add hardening=+bindnow or
N:    hardening=+all to DEB_BUILD_MAINT_OPTIONS.
N:    
N:    The relevant compiler flags are set in LDFLAGS.
N:    
N:    Refer to https://wiki.debian.org/Hardening for details.
N:
```