### PR TITLE
feat(server): Lock-based enhancement using mutexes (Part 3)

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1352,14 +1352,14 @@ UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
                              size_t* foundIndex);
 
 #ifdef UA_ENABLE_HISTORIZING
-UA_Boolean UA_EXPORT
+UA_Boolean UA_EXPORT UA_THREADSAFE
 UA_Server_AccessControl_allowHistoryUpdateUpdateData(UA_Server *server,
                                                      const UA_NodeId *sessionId, void *sessionContext,
                                                      const UA_NodeId *nodeId,
                                                      UA_PerformUpdateType performInsertReplace,
                                                      const UA_DataValue *value);
 
-UA_Boolean UA_EXPORT
+UA_Boolean UA_EXPORT UA_THREADSAFE
 UA_Server_AccessControl_allowHistoryUpdateDeleteRawModified(UA_Server *server,
                                                             const UA_NodeId *sessionId, void *sessionContext,
                                                             const UA_NodeId *nodeId,

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -971,13 +971,13 @@ UA_Server_setMethodNode_callback(UA_Server *server,
  * @param propertyName The name of the property
  * @param value The value to be set for the event attribute
  * @return The StatusCode for setting the event attribute */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
                               const UA_QualifiedName propertyName,
                               const UA_Variant value);
 
 /* Directly point to the scalar value instead of a variant */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_writeObjectProperty_scalar(UA_Server *server, const UA_NodeId objectId,
                                      const UA_QualifiedName propertyName,
                                      const void *value, const UA_DataType *type);
@@ -989,7 +989,7 @@ UA_Server_writeObjectProperty_scalar(UA_Server *server, const UA_NodeId objectId
  * @param propertyName The name of the property
  * @param value Contains the property value after reading. Must not be NULL.
  * @return The StatusCode for setting the event attribute */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_readObjectProperty(UA_Server *server, const UA_NodeId objectId,
                              const UA_QualifiedName propertyName,
                              UA_Variant *value);
@@ -1344,10 +1344,10 @@ UA_Server_updateCertificate(UA_Server *server,
  * Utility Functions
  * ----------------- */
 /* Add a new namespace to the server. Returns the index of the new namespace */
-UA_UInt16 UA_EXPORT UA_Server_addNamespace(UA_Server *server, const char* name);
+UA_UInt16 UA_EXPORT UA_THREADSAFE UA_Server_addNamespace(UA_Server *server, const char* name);
 
 /* Get namespace by name from the server. */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
                              size_t* foundIndex);
 

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -454,18 +454,18 @@ UA_Server_writeExecutable(UA_Server *server, const UA_NodeId nodeId,
 
 /* Browse the references of a particular node. See the definition of
  * BrowseDescription structure for details. */
-UA_BrowseResult UA_EXPORT
+UA_BrowseResult UA_EXPORT UA_THREADSAFE
 UA_Server_browse(UA_Server *server, UA_UInt32 maxReferences,
                  const UA_BrowseDescription *bd);
 
-UA_BrowseResult UA_EXPORT
+UA_BrowseResult UA_EXPORT UA_THREADSAFE
 UA_Server_browseNext(UA_Server *server, UA_Boolean releaseContinuationPoint,
                      const UA_ByteString *continuationPoint);
 
 /* Nonstandard version of the browse service that recurses into child nodes.
  * Possible loops (that can occur for non-hierarchical references) are handled
  * by adding every target node at most once to the results array. */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_browseRecursive(UA_Server *server, const UA_BrowseDescription *bd,
                           size_t *resultsSize, UA_ExpandedNodeId **results);
 
@@ -481,7 +481,7 @@ UA_Server_translateBrowsePathToNodeIds(UA_Server *server,
  * RelativePath that specifies forward references which are subtypes of the
  * HierarchicalReferences ReferenceType. All Nodes followed by the browsePath
  * shall be of the NodeClass Object or Variable. */
-UA_BrowsePathResult UA_EXPORT
+UA_BrowsePathResult UA_EXPORT UA_THREADSAFE
 UA_Server_browseSimplifiedBrowsePath(UA_Server *server, const UA_NodeId origin,
                                      size_t browsePathSize,
                                      const UA_QualifiedName *browsePath);
@@ -868,7 +868,7 @@ typedef struct {
                     const UA_DataValue *data);
 } UA_ValueCallback;
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_setVariableNode_valueCallback(UA_Server *server,
                                         const UA_NodeId nodeId,
                                         const UA_ValueCallback callback);

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -103,7 +103,7 @@ typedef void (*UA_ServerCallback)(UA_Server *server, void *data);
  *        identifier is not set.
  * @return Upon success, UA_STATUSCODE_GOOD is returned. An error code
  *         otherwise. */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_addTimedCallback(UA_Server *server, UA_ServerCallback callback,
                            void *data, UA_DateTime date, UA_UInt64 *callbackId);
 
@@ -120,11 +120,11 @@ UA_Server_addTimedCallback(UA_Server *server, UA_ServerCallback callback,
  *        identifier is not set.
  * @return Upon success, UA_STATUSCODE_GOOD is returned. An error code
  *         otherwise. */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_addRepeatedCallback(UA_Server *server, UA_ServerCallback callback,
                               void *data, UA_Double interval_ms, UA_UInt64 *callbackId);
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_changeRepeatedCallbackInterval(UA_Server *server, UA_UInt64 callbackId,
                                          UA_Double interval_ms);
 
@@ -132,7 +132,7 @@ UA_Server_changeRepeatedCallbackInterval(UA_Server *server, UA_UInt64 callbackId
  *
  * @param server The server object.
  * @param callbackId The id of the callback */
-void UA_EXPORT
+void UA_EXPORT UA_THREADSAFE
 UA_Server_removeCallback(UA_Server *server, UA_UInt64 callbackId);
 
 #define UA_Server_removeRepeatedCallback(server, callbackId) \
@@ -496,7 +496,7 @@ typedef UA_StatusCode
                            UA_NodeId referenceTypeId, void *handle);
 #endif
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_forEachChildNodeCall(UA_Server *server, UA_NodeId parentNodeId,
                                UA_NodeIteratorCallback callback, void *handle);
 
@@ -517,7 +517,7 @@ UA_Server_forEachChildNodeCall(UA_Server *server, UA_NodeId parentNodeId,
  * @param client the client which is used to call the RegisterServer. It must
  *        already be connected to the correct endpoint
  * @param semaphoreFilePath optional parameter pointing to semaphore file. */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_register_discovery(UA_Server *server, struct UA_Client *client,
                              const char* semaphoreFilePath);
 
@@ -526,7 +526,7 @@ UA_Server_register_discovery(UA_Server *server, struct UA_Client *client,
  * @param server
  * @param client the client which is used to call the RegisterServer. It must
  *        already be connected to the correct endpoint */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_unregister_discovery(UA_Server *server, struct UA_Client *client);
 
  /* Adds a periodic callback to register the server with the LDS (local discovery server)
@@ -552,7 +552,7 @@ UA_Server_unregister_discovery(UA_Server *server, struct UA_Client *client);
   * @param intervalMs
   * @param delayFirstRegisterMs
   * @param periodicCallbackId */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_addPeriodicServerRegisterCallback(UA_Server *server, struct UA_Client *client,
                                             const char* discoveryServerUrl,
                                             UA_Double intervalMs,
@@ -572,7 +572,7 @@ typedef void (*UA_Server_registerServerCallback)(const UA_RegisteredServer *regi
  * @param cb the callback
  * @param data data passed to the callback
  * @return UA_STATUSCODE_SUCCESS on success */
-void UA_EXPORT
+void UA_EXPORT UA_THREADSAFE
 UA_Server_setRegisterServerCallback(UA_Server *server, UA_Server_registerServerCallback cb,
                                     void* data);
 
@@ -600,7 +600,7 @@ typedef void (*UA_Server_serverOnNetworkCallback)(const UA_ServerOnNetwork *serv
  * @param cb the callback
  * @param data data passed to the callback
  * @return UA_STATUSCODE_SUCCESS on success */
-void UA_EXPORT
+void UA_EXPORT UA_THREADSAFE
 UA_Server_setServerOnNetworkCallback(UA_Server *server,
                                      UA_Server_serverOnNetworkCallback cb,
                                      void* data);
@@ -729,16 +729,16 @@ typedef struct {
                        const UA_NodeId *nodeId, void **nodeContext);
 } UA_NodeTypeLifecycle;
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_setNodeTypeLifecycle(UA_Server *server, UA_NodeId nodeId,
                                UA_NodeTypeLifecycle lifecycle);
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_getNodeContext(UA_Server *server, UA_NodeId nodeId,
                          void **nodeContext);
 
 /* Careful! The user has to ensure that the destructor callbacks still work. */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_setNodeContext(UA_Server *server, UA_NodeId nodeId,
                          void *nodeContext);
 

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -441,9 +441,11 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
                   const UA_DataType *responseType, UA_Boolean sessionRequired) {
     /* CreateSession doesn't need a session */
     if(requestType == &UA_TYPES[UA_TYPES_CREATESESSIONREQUEST]) {
+        UA_LOCK(server->serviceMutex);
         Service_CreateSession(server, channel,
                               (const UA_CreateSessionRequest *)requestHeader,
                               (UA_CreateSessionResponse *)responseHeader);
+        UA_UNLOCK(server->serviceMutex);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         /* Store the authentication token and session ID so we can help fuzzing
          * by setting these values in the next request automatically */
@@ -457,9 +459,12 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
     /* Find the matching session */
     UA_Session *session = (UA_Session*)
         UA_SecureChannel_getSession(channel, &requestHeader->authenticationToken);
-    if(!session && !UA_NodeId_isNull(&requestHeader->authenticationToken))
+    if(!session && !UA_NodeId_isNull(&requestHeader->authenticationToken)) {
+        UA_LOCK(server->serviceMutex);
         session = UA_SessionManager_getSessionByToken(&server->sessionManager,
                                                       &requestHeader->authenticationToken);
+        UA_UNLOCK(server->serviceMutex)
+    }
 
     if(requestType == &UA_TYPES[UA_TYPES_ACTIVATESESSIONREQUEST]) {
         if(!session) {
@@ -469,9 +474,11 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
             return sendServiceFaultWithRequest(channel, requestHeader, responseType,
                                     requestId, UA_STATUSCODE_BADSESSIONIDINVALID);
         }
+        UA_LOCK(server->serviceMutex);
         Service_ActivateSession(server, channel, session,
                                 (const UA_ActivateSessionRequest*)requestHeader,
                                 (UA_ActivateSessionResponse*)responseHeader);
+        UA_UNLOCK(server->serviceMutex);
         return sendResponse(channel, requestId, requestHeader->requestHandle,
                             responseHeader, responseType);
     }
@@ -512,8 +519,10 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
                                "Service %i refused on a non-activated session",
                                requestType->binaryEncodingId);
 #endif
+        UA_LOCK(server->serviceMutex);
         UA_SessionManager_removeSession(&server->sessionManager,
                                         &session->header.authenticationToken);
+        UA_UNLOCK(server->serviceMutex);
         return sendServiceFaultWithRequest(channel, requestHeader, responseType,
                                            requestId, UA_STATUSCODE_BADSESSIONNOTACTIVATED);
     }
@@ -533,7 +542,9 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /* The publish request is not answered immediately */
     if(requestType == &UA_TYPES[UA_TYPES_PUBLISHREQUEST]) {
+        UA_LOCK(server->serviceMutex);
         Service_Publish(server, session, (const UA_PublishRequest*)requestHeader, requestId);
+        UA_UNLOCK(server->serviceMutex);
         return UA_STATUSCODE_GOOD;
     }
 #endif

--- a/src/server/ua_server_discovery.c
+++ b/src/server/ua_server_discovery.c
@@ -12,11 +12,13 @@
 
 #ifdef UA_ENABLE_DISCOVERY
 
-static UA_StatusCode
+UA_StatusCode
 register_server_with_discovery_server(UA_Server *server,
-                                      UA_Client *client,
+                                      void *pClient,
                                       const UA_Boolean isUnregister,
                                       const char* semaphoreFilePath) {
+    UA_Client *client = (UA_Client *) pClient;
+
     /* Prepare the request. Do not cleanup the request after the service call,
      * as the members are stack-allocated or point into the server config. */
     UA_RegisterServer2Request request;
@@ -116,14 +118,20 @@ register_server_with_discovery_server(UA_Server *server,
 UA_StatusCode
 UA_Server_register_discovery(UA_Server *server, UA_Client *client,
                              const char* semaphoreFilePath) {
-    return register_server_with_discovery_server(server, client,
-                                                 false, semaphoreFilePath);
+    UA_LOCK(server->serviceMutex);
+    UA_StatusCode retval = register_server_with_discovery_server(server, client,
+                                                                 false, semaphoreFilePath);
+    UA_UNLOCK(server->serviceMutex);
+    return retval;
 }
 
 UA_StatusCode
 UA_Server_unregister_discovery(UA_Server *server, UA_Client *client) {
-    return register_server_with_discovery_server(server, client,
-                                                 true, NULL);
+    UA_LOCK(server->serviceMutex);
+    UA_StatusCode retval = register_server_with_discovery_server(server, client,
+                                                                 true, NULL);
+    UA_UNLOCK(server->serviceMutex);
+    return retval;
 }
 
 #endif /* UA_ENABLE_DISCOVERY */

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -259,6 +259,10 @@ UA_BrowsePathResult
 browseSimplifiedBrowsePath(UA_Server *server, const UA_NodeId origin,
                            size_t browsePathSize, const UA_QualifiedName *browsePath);
 
+UA_StatusCode
+writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
+                    const UA_QualifiedName propertyName, const UA_Variant value);
+
 /***************************************/
 /* Check Information Model Consistency */
 /***************************************/

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -263,6 +263,26 @@ UA_StatusCode
 writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
                     const UA_QualifiedName propertyName, const UA_Variant value);
 
+UA_StatusCode
+getNodeContext(UA_Server *server, UA_NodeId nodeId, void **nodeContext);
+
+void
+removeCallback(UA_Server *server, UA_UInt64 callbackId);
+
+UA_StatusCode
+changeRepeatedCallbackInterval(UA_Server *server, UA_UInt64 callbackId, UA_Double interval_ms);
+
+UA_StatusCode
+addRepeatedCallback(UA_Server *server, UA_ServerCallback callback,
+                    void *data, UA_Double interval_ms, UA_UInt64 *callbackId);
+
+#ifdef UA_ENABLE_DISCOVERY
+UA_StatusCode
+register_server_with_discovery_server(UA_Server *server,
+                                      void *client,
+                                      const UA_Boolean isUnregister,
+                                      const char* semaphoreFilePath);
+#endif
 /***************************************/
 /* Check Information Model Consistency */
 /***************************************/

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -547,13 +547,17 @@ readMonitoredItems(UA_Server *server, const UA_NodeId *sessionId, void *sessionC
                    void *objectContext, size_t inputSize,
                    const UA_Variant *input, size_t outputSize,
                    UA_Variant *output) {
+    UA_LOCK(server->serviceMutex);
     UA_Session *session = UA_SessionManager_getSessionById(&server->sessionManager, sessionId);
+    UA_UNLOCK(server->serviceMutex);
     if(!session)
         return UA_STATUSCODE_BADINTERNALERROR;
     if (inputSize == 0 || !input[0].data)
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
     UA_UInt32 subscriptionId = *((UA_UInt32*)(input[0].data));
+    UA_LOCK(server->serviceMutex);
     UA_Subscription* subscription = UA_Session_getSubscriptionById(session, subscriptionId);
+    UA_UNLOCK(server->serviceMutex);
     if(!subscription)
     {
         if(LIST_EMPTY(&session->serverSubscriptions))

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -540,12 +540,15 @@ UA_Server_readWithSession(UA_Server *server, UA_Session *session,
 UA_DataValue
 readAttribute(UA_Server *server, const UA_ReadValueId *item,
                UA_TimestampsToReturn timestamps) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     return UA_Server_readWithSession(server, &server->adminSession, item, timestamps);
 }
 
 UA_StatusCode
 readWithReadValue(UA_Server *server, const UA_NodeId *nodeId,
                                 const UA_AttributeId attributeId, void *v) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* Call the read service */
     UA_ReadValueId item;
     UA_ReadValueId_init(&item);
@@ -1482,6 +1485,7 @@ writeWithSession(UA_Server *server, UA_Session *session,
 
 UA_StatusCode
 writeAttribute(UA_Server *server, const UA_WriteValue *value) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     return UA_Server_editNode(server, &server->adminSession, &value->nodeId,
                               (UA_EditNodeCallback)copyAttributeIntoNode,
                                /* casting away const qualifier because callback uses const anyway */
@@ -1501,6 +1505,7 @@ writeWithWriteValue(UA_Server *server, const UA_NodeId *nodeId,
                   const UA_AttributeId attributeId,
                   const UA_DataType *attr_type,
                   const void *attr) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     UA_WriteValue wvalue;
     UA_WriteValue_init(&wvalue);
     wvalue.nodeId = *nodeId;
@@ -1533,6 +1538,8 @@ void
 Service_HistoryRead(UA_Server *server, UA_Session *session,
                     const UA_HistoryReadRequest *request,
                     UA_HistoryReadResponse *response) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     if(request->historyReadDetails.encoding != UA_EXTENSIONOBJECT_DECODED) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADNOTSUPPORTED;
         return;
@@ -1614,6 +1621,8 @@ void
 Service_HistoryUpdate(UA_Server *server, UA_Session *session,
                     const UA_HistoryUpdateRequest *request,
                     UA_HistoryUpdateResponse *response) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     response->resultsSize = request->historyUpdateDetailsSize;
     response->results = (UA_HistoryUpdateResult*)UA_Array_new(response->resultsSize, &UA_TYPES[UA_TYPES_HISTORYUPDATERESULT]);
     if (!response->results) {
@@ -1682,6 +1691,7 @@ UA_StatusCode
 writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
                               const UA_QualifiedName propertyName,
                               const UA_Variant value) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     UA_RelativePathElement rpe;
     UA_RelativePathElement_init(&rpe);
     rpe.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY);

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -309,6 +309,7 @@ process_RegisterServer(UA_Server *server, UA_Session *session,
                        UA_StatusCode **responseConfigurationResults,
                        size_t *responseDiagnosticInfosSize,
                        UA_DiagnosticInfo *responseDiagnosticInfos) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     /* Find the server from the request in the registered list */
     registeredServer_list_entry* current;
     registeredServer_list_entry *registeredServer_entry = NULL;

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -408,10 +408,13 @@ process_RegisterServer(UA_Server *server, UA_Session *session,
             return;
         }
 
-        if(server->discoveryManager.registerServerCallback)
+        if(server->discoveryManager.registerServerCallback) {
+            UA_UNLOCK(server->serviceMutex);
             server->discoveryManager.
-                registerServerCallback(requestServer,
-                                       server->discoveryManager.registerServerCallbackData);
+                    registerServerCallback(requestServer,
+                                           server->discoveryManager.registerServerCallbackData);
+            UA_LOCK(server->serviceMutex);
+        }
 
         // server found, remove from list
         LIST_REMOVE(registeredServer_entry, pointers);
@@ -455,10 +458,13 @@ process_RegisterServer(UA_Server *server, UA_Session *session,
     // Previously we only called it if it was a new register call. It may be the case that this endpoint
     // registered before, then crashed, restarts and registeres again. In that case the entry is not deleted
     // and the callback would not be called.
-    if(server->discoveryManager.registerServerCallback)
+    if(server->discoveryManager.registerServerCallback) {
+        UA_UNLOCK(server->serviceMutex);
         server->discoveryManager.
-            registerServerCallback(requestServer,
-                                   server->discoveryManager.registerServerCallbackData);
+                registerServerCallback(requestServer,
+                                       server->discoveryManager.registerServerCallbackData);
+        UA_LOCK(server->serviceMutex)
+    }
 
     // copy the data from the request into the list
     UA_RegisteredServer_copy(requestServer, &registeredServer_entry->registeredServer);
@@ -565,6 +571,7 @@ void UA_Discovery_cleanupTimedOut(UA_Server *server, UA_DateTime nowMonotonic) {
 static void
 periodicServerRegister(UA_Server *server, void *data) {
     UA_assert(data != NULL);
+    UA_LOCK(server->serviceMutex);
 
     struct PeriodicServerRegisterCallback *cb = (struct PeriodicServerRegisterCallback *)data;
 
@@ -578,7 +585,7 @@ periodicServerRegister(UA_Server *server, void *data) {
            UA_StatusCode retval = UA_Server_register_discovery(server,
            "opc.tcp://localhost:4840", "/path/to/some/file");
         */
-        retval = UA_Server_register_discovery(server, cb->client, NULL);
+        retval = register_server_with_discovery_server(server, cb->client, false, NULL);
     }
     if (cb->client->state == UA_CLIENTSTATE_CONNECTED) {
         UA_StatusCode retval1 = UA_Client_disconnect(cb->client);
@@ -606,7 +613,8 @@ periodicServerRegister(UA_Server *server, void *data) {
             nextInterval = cb->default_interval;
 
         cb->this_interval = nextInterval;
-        UA_Server_changeRepeatedCallbackInterval(server, cb->id, nextInterval);
+        changeRepeatedCallbackInterval(server, cb->id, nextInterval);
+        UA_UNLOCK(server->serviceMutex);
         return;
     }
 
@@ -616,11 +624,12 @@ periodicServerRegister(UA_Server *server, void *data) {
                  (int)(cb->default_interval/1000));
 
     if(!cb->registered) {
-        retval = UA_Server_changeRepeatedCallbackInterval(server, cb->id, cb->default_interval);
+        retval = changeRepeatedCallbackInterval(server, cb->id, cb->default_interval);
         /* If changing the interval fails, try again after the next registering */
         if(retval == UA_STATUSCODE_GOOD)
             cb->registered = true;
     }
+    UA_UNLOCK(server->serviceMutex);
 }
 
 UA_StatusCode
@@ -630,17 +639,20 @@ UA_Server_addPeriodicServerRegisterCallback(UA_Server *server,
                                             UA_Double intervalMs,
                                             UA_Double delayFirstRegisterMs,
                                             UA_UInt64 *periodicCallbackId) {
-
+    UA_LOCK(server->serviceMutex);
     /* No valid server URL */
     if(!discoveryServerUrl) {
         UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "No discovery server URL provided");
+        UA_UNLOCK(server->serviceMutex);
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
 
-    if (client->connection.state != UA_CONNECTION_CLOSED)
+    if (client->connection.state != UA_CONNECTION_CLOSED) {
+        UA_UNLOCK(server->serviceMutex);
         return UA_STATUSCODE_BADINVALIDSTATE;
+    }
 
     /* check if we are already registering with the given discovery url and remove the old periodic call */
     {
@@ -650,7 +662,7 @@ UA_Server_addPeriodicServerRegisterCallback(UA_Server *server,
             if(strcmp(rs->callback->discovery_server_url, discoveryServerUrl) == 0) {
                 UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                             "There is already a register callback for '%s' in place. Removing the older one.", discoveryServerUrl);
-                UA_Server_removeRepeatedCallback(server, rs->callback->id);
+                removeCallback(server, rs->callback->id);
                 LIST_REMOVE(rs, pointers);
                 UA_free(rs->callback->discovery_server_url);
                 UA_free(rs->callback);
@@ -664,8 +676,10 @@ UA_Server_addPeriodicServerRegisterCallback(UA_Server *server,
     struct PeriodicServerRegisterCallback* cb =
         (struct PeriodicServerRegisterCallback*)
         UA_malloc(sizeof(struct PeriodicServerRegisterCallback));
-    if(!cb)
+    if(!cb) {
+        UA_UNLOCK(server->serviceMutex);
         return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
 
     /* Start repeating a failed register after 1s, then increase the delay. Set
      * to 500ms, as the delay is doubled before changing the callback
@@ -678,19 +692,21 @@ UA_Server_addPeriodicServerRegisterCallback(UA_Server *server,
     cb->discovery_server_url = (char*)UA_malloc(len+1);
     if (!cb->discovery_server_url) {
         UA_free(cb);
+        UA_UNLOCK(server->serviceMutex);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     memcpy(cb->discovery_server_url, discoveryServerUrl, len+1);
 
     /* Add the callback */
     UA_StatusCode retval =
-        UA_Server_addRepeatedCallback(server, periodicServerRegister,
-                                      cb, delayFirstRegisterMs, &cb->id);
+        addRepeatedCallback(server, periodicServerRegister,
+                            cb, delayFirstRegisterMs, &cb->id);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "Could not create periodic job for server register. "
                      "StatusCode %s", UA_StatusCode_name(retval));
         UA_free(cb);
+        UA_UNLOCK(server->serviceMutex);
         return retval;
     }
 
@@ -699,8 +715,9 @@ UA_Server_addPeriodicServerRegisterCallback(UA_Server *server,
     periodicServerRegisterCallback_entry *newEntry =
             (periodicServerRegisterCallback_entry *)UA_malloc(sizeof(periodicServerRegisterCallback_entry));
     if(!newEntry) {
-        UA_Server_removeRepeatedCallback(server, cb->id);
+        removeCallback(server, cb->id);
         UA_free(cb);
+        UA_UNLOCK(server->serviceMutex);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     newEntry->callback = cb;
@@ -709,6 +726,7 @@ UA_Server_addPeriodicServerRegisterCallback(UA_Server *server,
 
     if(periodicCallbackId)
         *periodicCallbackId = cb->id;
+    UA_UNLOCK(server->serviceMutex);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -716,8 +734,10 @@ void
 UA_Server_setRegisterServerCallback(UA_Server *server,
                                     UA_Server_registerServerCallback cb,
                                     void* data) {
+    UA_LOCK(server->serviceMutex);
     server->discoveryManager.registerServerCallback = cb;
     server->discoveryManager.registerServerCallbackData = data;
+    UA_UNLOCK(server->serviceMutex);
 }
 
 #endif /* UA_ENABLE_DISCOVERY */

--- a/src/server/ua_services_discovery_multicast.c
+++ b/src/server/ua_services_discovery_multicast.c
@@ -154,6 +154,8 @@ filterServerRecord(size_t serverCapabilityFilterSize, UA_String *serverCapabilit
 void Service_FindServersOnNetwork(UA_Server *server, UA_Session *session,
                                   const UA_FindServersOnNetworkRequest *request,
                                   UA_FindServersOnNetworkResponse *response) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     if (!server->config.discovery.mdnsEnable) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADNOTIMPLEMENTED;
         return;

--- a/src/server/ua_services_discovery_multicast.c
+++ b/src/server/ua_services_discovery_multicast.c
@@ -255,8 +255,10 @@ void
 UA_Server_setServerOnNetworkCallback(UA_Server *server,
                                      UA_Server_serverOnNetworkCallback cb,
                                      void* data) {
+    UA_LOCK(server->serviceMutex);
     server->discoveryManager.serverOnNetworkCallback = cb;
     server->discoveryManager.serverOnNetworkCallbackData = data;
+    UA_UNLOCK(server->serviceMutex);
 }
 
 static void

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -219,8 +219,8 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
     /* Release the output arguments node */
     UA_Nodestore_releaseNode(server->nsCtx, (const UA_Node*)outputArguments);
 
-    UA_UNLOCK(server->serviceMutex);
     /* Call the method */
+    UA_UNLOCK(server->serviceMutex);
     result->statusCode = method->method(server, &session->sessionId, session->sessionHandle,
                                         &method->nodeId, method->context,
                                         &object->nodeId, object->context,

--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -26,6 +26,8 @@ setMonitoredItemSettings(UA_Server *server, UA_MonitoredItem *mon,
                          UA_MonitoringMode monitoringMode,
                          const UA_MonitoringParameters *params,
                          const UA_DataType* dataType) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
 
     if(mon->attributeId == UA_ATTRIBUTEID_EVENTNOTIFIER) {
@@ -306,8 +308,6 @@ Service_CreateMonitoredItems(UA_Server *server, UA_Session *session,
     /* Reset the subscription lifetime */
     cmc.sub->currentLifetimeCount = 0;
 
-    UA_LOCK_ASSERT(server->serviceMutex, 1);
-
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session, (UA_ServiceOperation)Operation_CreateMonitoredItem, &cmc,
                                            &request->itemsToCreateSize, &UA_TYPES[UA_TYPES_MONITOREDITEMCREATEREQUEST],
@@ -396,8 +396,6 @@ Service_ModifyMonitoredItems(UA_Server *server, UA_Session *session,
     }
 
     sub->currentLifetimeCount = 0; /* Reset the subscription lifetime */
-
-    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     response->responseHeader.serviceResult =
         UA_Server_processServiceOperations(server, session,
@@ -509,8 +507,6 @@ Service_SetMonitoringMode(UA_Server *server, UA_Session *session,
         return;
     }
 
-    UA_LOCK_ASSERT(server->serviceMutex, 1);
-
     smc.sub->currentLifetimeCount = 0; /* Reset the subscription lifetime */
 
     smc.monitoringMode = request->monitoringMode;
@@ -547,8 +543,6 @@ Service_DeleteMonitoredItems(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         return;
     }
-
-    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Reset the subscription lifetime */
     sub->currentLifetimeCount = 0;

--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -248,7 +248,7 @@ Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session, struct cre
     /* Register MonitoredItem in userland */
     if(server->config.monitoredItemRegisterCallback) {
         void *targetContext = NULL;
-        UA_Server_getNodeContext(server, request->itemToMonitor.nodeId, &targetContext);
+        getNodeContext(server, request->itemToMonitor.nodeId, &targetContext);
         UA_UNLOCK(server->serviceMutex);
         server->config.monitoredItemRegisterCallback(server, &session->sessionId,
                                                      session->sessionHandle,

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -1321,6 +1321,8 @@ addNode(UA_Server *server, const UA_NodeClass nodeClass,
         const UA_NodeAttributes *attr,
         const UA_DataType *attributeType,
         void *nodeContext, UA_NodeId *outNewNodeId) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* Create the AddNodesItem */
     UA_AddNodesItem item;
     UA_AddNodesItem_init(&item);
@@ -1668,6 +1670,7 @@ UA_Server_deleteNode(UA_Server *server, const UA_NodeId nodeId,
 UA_StatusCode
 deleteNode(UA_Server *server, const UA_NodeId nodeId,
                      UA_Boolean deleteReferences) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     UA_DeleteNodesItem item;
     item.deleteTargetReferences = deleteReferences;
     item.nodeId = nodeId;
@@ -1983,6 +1986,7 @@ setDataSource(UA_Server *server, UA_Session *session,
 UA_StatusCode
 setVariableNode_dataSource(UA_Server *server, const UA_NodeId nodeId,
                                      const UA_DataSource dataSource) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     return UA_Server_editNode(server, &server->adminSession, &nodeId,
                               (UA_EditNodeCallback)setDataSource,
                               /* casting away const because callback casts it back anyway */
@@ -2197,6 +2201,7 @@ UA_StatusCode
 setMethodNode_callback(UA_Server *server,
                                  const UA_NodeId methodNodeId,
                                  UA_MethodCallback methodCallback) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     return UA_Server_editNode(server, &server->adminSession, &methodNodeId,
                                               (UA_EditNodeCallback)editMethodCallback,
                                               (void*)(uintptr_t)methodCallback);

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -59,6 +59,8 @@ void
 Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
                       const UA_CreateSessionRequest *request,
                       UA_CreateSessionResponse *response) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     if(!channel) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         return;
@@ -322,6 +324,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
                         UA_Session *session, const UA_ActivateSessionRequest *request,
                         UA_ActivateSessionResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Execute ActivateSession");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(session->validTill < UA_DateTime_nowMonotonic()) {
         UA_LOG_INFO_SESSION(&server->config.logger, session,

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -27,6 +27,8 @@ setSubscriptionSettings(UA_Server *server, UA_Subscription *subscription,
                         UA_UInt32 requestedLifetimeCount,
                         UA_UInt32 requestedMaxKeepAliveCount,
                         UA_UInt32 maxNotificationsPerPublish, UA_Byte priority) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* deregister the callback if required */
     Subscription_unregisterPublishCallback(server, subscription);
 
@@ -136,9 +138,10 @@ Service_ModifySubscription(UA_Server *server, UA_Session *session,
 }
 
 static void
-Operation_SetPublishingMode(UA_Server *Server, UA_Session *session,
+Operation_SetPublishingMode(UA_Server *server, UA_Session *session,
                             const UA_Boolean *publishingEnabled, const UA_UInt32 *subscriptionId,
                             UA_StatusCode *result) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     UA_Subscription *sub = UA_Session_getSubscriptionById(session, *subscriptionId);
     if(!sub) {
         *result = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -181,6 +181,7 @@ void
 Service_Publish(UA_Server *server, UA_Session *session,
                 const UA_PublishRequest *request, UA_UInt32 requestId) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing PublishRequest");
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     /* Return an error if the session has no subscription */
     if(LIST_EMPTY(&session->serverSubscriptions)) {

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -1033,6 +1033,8 @@ static void
 Operation_TranslateBrowsePathToNodeIds(UA_Server *server, UA_Session *session,
                                        const UA_UInt32 *nodeClassMask, const UA_BrowsePath *path,
                                        UA_BrowsePathResult *result) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     if(path->relativePath.elementsSize <= 0) {
         result->statusCode = UA_STATUSCODE_BADNOTHINGTODO;
         return;
@@ -1114,6 +1116,7 @@ Operation_TranslateBrowsePathToNodeIds(UA_Server *server, UA_Session *session,
 UA_BrowsePathResult
 translateBrowsePathToNodeIds(UA_Server *server,
                                        const UA_BrowsePath *browsePath) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     UA_BrowsePathResult result;
     UA_BrowsePathResult_init(&result);
     UA_UInt32 nodeClassMask = 0; /* All node classes */
@@ -1158,6 +1161,8 @@ Service_TranslateBrowsePathsToNodeIds(UA_Server *server, UA_Session *session,
 UA_BrowsePathResult
 browseSimplifiedBrowsePath(UA_Server *server, const UA_NodeId origin,
                            size_t browsePathSize, const UA_QualifiedName *browsePath) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* Construct the BrowsePath */
     UA_BrowsePath bp;
     UA_BrowsePath_init(&bp);

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -87,6 +87,8 @@ void UA_Session_addSubscription(UA_Server *server, UA_Session *session, UA_Subsc
 UA_StatusCode
 UA_Session_deleteSubscription(UA_Server *server, UA_Session *session,
                               UA_UInt32 subscriptionId) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     UA_Subscription *sub = UA_Session_getSubscriptionById(session, subscriptionId);
     if(!sub)
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -23,6 +23,7 @@ void UA_Session_init(UA_Session *session) {
 }
 
 void UA_Session_deleteMembersCleanup(UA_Session *session, UA_Server* server) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     UA_Session_detachFromSecureChannel(session);
     UA_ApplicationDescription_deleteMembers(&session->clientDescription);
     UA_NodeId_deleteMembers(&session->header.authenticationToken);

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -566,6 +566,7 @@ Subscription_registerPublishCallback(UA_Server *server, UA_Subscription *sub) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, sub->session,
                          "Subscription %u | Register subscription "
                          "publishing callback", sub->subscriptionId);
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
 
     if(sub->publishCallbackIsRegistered)
         return UA_STATUSCODE_GOOD;

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -563,8 +563,8 @@ Subscription_registerPublishCallback(UA_Server *server, UA_Subscription *sub) {
         return UA_STATUSCODE_GOOD;
 
     UA_StatusCode retval =
-        UA_Server_addRepeatedCallback(server, (UA_ServerCallback)publishCallback,
-                                      sub, (UA_UInt32)sub->publishingInterval, &sub->publishCallbackId);
+        addRepeatedCallback(server, (UA_ServerCallback)publishCallback,
+                            sub, (UA_UInt32)sub->publishingInterval, &sub->publishCallbackId);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
@@ -580,7 +580,7 @@ Subscription_unregisterPublishCallback(UA_Server *server, UA_Subscription *sub) 
     if(!sub->publishCallbackIsRegistered)
         return;
 
-    UA_Server_removeRepeatedCallback(server, sub->publishCallbackId);
+    removeCallback(server, sub->publishCallbackId);
     sub->publishCallbackIsRegistered = false;
 }
 

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -307,7 +307,7 @@ sampleCallbackWithValue(UA_Server *server, UA_Session *session,
     if(!sub) {
         UA_LocalMonitoredItem *localMon = (UA_LocalMonitoredItem*) mon;
         void *nodeContext = NULL;
-        UA_Server_getNodeContext(server, mon->monitoredNodeId, &nodeContext);
+        getNodeContext(server, mon->monitoredNodeId, &nodeContext);
         UA_UNLOCK(server->serviceMutex);
         localMon->callback.dataChangeCallback(server, mon->monitoredItemId,
                                               localMon->context,

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -330,6 +330,8 @@ UA_MonitoredItem_sampleCallback(UA_Server *server, UA_MonitoredItem *monitoredIt
 
 void
 monitoredItem_sampleCallback(UA_Server *server, UA_MonitoredItem *monitoredItem) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     UA_Subscription *sub = monitoredItem->subscription;
     UA_Session *session = &server->adminSession;
     if(sub)

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -348,6 +348,7 @@ UA_MonitoredItem_ensureQueueSpace(UA_Server *server, UA_MonitoredItem *mon) {
 
 UA_StatusCode
 UA_MonitoredItem_registerSampleCallback(UA_Server *server, UA_MonitoredItem *mon) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     if(mon->sampleCallbackIsRegistered)
         return UA_STATUSCODE_GOOD;
 

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -192,6 +192,8 @@ UA_MonitoredItem_init(UA_MonitoredItem *mon, UA_Subscription *sub) {
 
 void
 UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *monitoredItem) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
+
     /* Remove the sampling callback */
     UA_MonitoredItem_unregisterSampleCallback(server, monitoredItem);
 

--- a/tests/multithreading/check_mt_addDeleteObject.c
+++ b/tests/multithreading/check_mt_addDeleteObject.c
@@ -71,7 +71,6 @@ void server_deleteObject(void* value){
     UA_StatusCode ret = UA_STATUSCODE_GOOD;
     do {
         ret = UA_Server_deleteNode(tc.server, UA_NODEID_STRING(1, string_buf), true);
-        sleep(1); //for valgrind
     } while (ret != UA_STATUSCODE_GOOD);
 }
 

--- a/tests/multithreading/check_mt_readWriteDeleteCallback.c
+++ b/tests/multithreading/check_mt_readWriteDeleteCallback.c
@@ -76,7 +76,6 @@ static void setup(void) {
 
 static
 void server_deleteValue(void *value) {
-    //UA_fakeSleep(100);
     UA_StatusCode ret = UA_Server_deleteNode(tc.server, pumpTypeId, true);
     ck_assert_int_eq(UA_STATUSCODE_GOOD, ret);
 }

--- a/tests/multithreading/mt_testing.h
+++ b/tests/multithreading/mt_testing.h
@@ -3,9 +3,6 @@
 
 #include <open62541/server_config_default.h>
 
-#define THREAD_CALLBACK_PARAM(name, param) static void * name(void *param)
-#define THREAD_CREATE_PARAM(handle, callback, param) pthread_create(&(handle), NULL, callback, (void*) &(param))
-
 typedef struct {
     void (*func)(void *param); //function to execute
     size_t counter; //index of the iteration
@@ -56,7 +53,7 @@ THREAD_CALLBACK_PARAM(workerLoop, val) {
         tmp.counter = i;
         tmp.func(&tmp);
     }
-    return NULL;
+    return 0;
 }
 
 THREAD_CALLBACK_PARAM(clientLoop, val) {
@@ -72,7 +69,7 @@ THREAD_CALLBACK_PARAM(clientLoop, val) {
     }
     UA_Client_disconnect(tc.clients[tmp.index]);
     UA_Client_delete(tc.clients[tmp.index]);
-    return NULL;
+    return 0;
 }
 
 static UA_INLINE void

--- a/tests/server/check_services_subscriptions.c
+++ b/tests/server/check_services_subscriptions.c
@@ -33,8 +33,10 @@ createSession(void) {
     UA_CreateSessionRequest request;
     UA_CreateSessionRequest_init(&request);
     request.requestedSessionTimeout = UA_UINT32_MAX;
+    UA_LOCK(server->serviceMutex);
     UA_StatusCode retval = UA_SessionManager_createSession(&server->sessionManager, NULL,
                                                            &request, &session);
+    UA_UNLOCK(server->serviceMutex);
     ck_assert_uint_eq(retval, 0);
 }
 

--- a/tests/testing-plugins/thread_wrapper.h
+++ b/tests/testing-plugins/thread_wrapper.h
@@ -10,18 +10,19 @@
 #include <pthread.h>
 #define THREAD_HANDLE pthread_t
 #define THREAD_CREATE(handle, callback) pthread_create(&handle, NULL, callback, NULL)
+#define THREAD_CREATE_PARAM(handle, callback, param) pthread_create(&(handle), NULL, callback, (void*) &(param))
 #define THREAD_JOIN(handle) pthread_join(handle, NULL)
 #define THREAD_CALLBACK(name) static void * name(void *_)
-
+#define THREAD_CALLBACK_PARAM(name, param) static void * name(void *param)
 #else
 
 #include <windows.h>
 #define THREAD_HANDLE HANDLE
 #define THREAD_CREATE(handle, callback) { handle = CreateThread( NULL, 0, callback, NULL, 0, NULL); }
+#define THREAD_CREATE_PARAM(handle, callback, param) { handle = CreateThread( NULL, 0, callback,  (LPVOID) &param, 0, NULL); }
 #define THREAD_JOIN(handle) WaitForSingleObject(handle, INFINITE)
-
-
 #define THREAD_CALLBACK(name) static DWORD WINAPI name( LPVOID lpParam )
+#define THREAD_CALLBACK_PARAM(name, param) static DWORD WINAPI name( LPVOID param )
 
 #endif
 


### PR DESCRIPTION
Continuation of PR #2993 and #3043:

- Fixing issues with win32 plattform
- Locks for remaining server.h - functions
- Locks for Session, Subscription and MonitoredItem - handling
- Additional assertions