### PR TITLE
Revert "fix(debian): hardening no bindnow"

### DIFF
--- a/debian/rules-template
+++ b/debian/rules-template
@@ -2,8 +2,7 @@
 
 export DH_VERBOSE = 1
 
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export DEB_BUILD_OPTIONS = parallel=4
+export DEB_BUILD_OPTIONS=parallel=4
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL -DUA_ENABLE_AMALGAMATION=OFF -DUA_PACK_DEBIAN=ON


### PR DESCRIPTION
Reverts open62541/open62541#3077

This leads to build errors. See e.g. #3080