### PR TITLE
fix(debian): hardening all but no PIE flag

### DIFF
--- a/debian/rules-template
+++ b/debian/rules-template
@@ -2,6 +2,7 @@
 
 export DH_VERBOSE = 1
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-pie
 export DEB_BUILD_OPTIONS=parallel=4
 
 override_dh_auto_configure:


### PR DESCRIPTION
This enables hardening during debian package build and fixes the error due to #3077 described in #3080 and #3085 .
This fix disables the PIE flag explicitly.
