### PR TITLE
fix bugs related to "remove multicast record" and "async read value"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ Makefile
 Pipfile
 Pipfile.lock
 .vscode
+/.vs

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -780,8 +780,8 @@ void ValueAttributeRead(UA_Client *client, void *userdata,
                   res->value.type == cc->outDataType) {
             /* Unpack the value */
             UA_STACKARRAY(UA_Byte, value, cc->outDataType->memSize);
-            memcpy(&value, res->value.data, cc->outDataType->memSize);
-            cc->callback(client, userdata, requestId, &value);
+            memcpy(value, res->value.data, cc->outDataType->memSize);
+            cc->callback(client, userdata, requestId, value);
             done = true;
         }
     }


### PR DESCRIPTION
[fix] bug in stopMulticastDiscoveryServer(): error caused by removing record when using custom hostname;

[fix] async read value attribute bug: crash caused by error pointer