### PR TITLE
feat(debian): more compatible version numbers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-open62541 (1.0-rc1) UNRELEASED; urgency=low
+open62541 (1.0~rc1) UNRELEASED; urgency=low
 
   * Release Candidate 1 for 1.0 Version.
 

--- a/tools/prepare_packaging.py
+++ b/tools/prepare_packaging.py
@@ -38,12 +38,15 @@ changelog_file = os.path.join(debian_path, "changelog")
 
 # remove leading 'v'
 changelog_version = git_describe_version[1:] if git_describe_version[0] == 'v' else git_describe_version
-
+# replace all '-' with '~' in version
+changelog_version = changelog_version.replace('-', '~')
+ 
 with open(changelog_file, 'r') as original: data = original.read()
 with open(changelog_file, 'w') as modified:
     new_entry = """open62541 ({version}) {distribution}; urgency=medium
 
-  * Full changelog is available here: https://github.com/open62541/open62541/blob/master/CHANGELOG
+  * Full changelog is available here: 
+    https://github.com/open62541/open62541/blob/master/CHANGELOG
 
  -- open62541 Team <open62541-core@googlegroups.com>  {time}
 """.format(version=changelog_version, time=formatdate(), distribution = debian_distribution)

--- a/tools/prepare_packaging.py
+++ b/tools/prepare_packaging.py
@@ -40,7 +40,7 @@ changelog_file = os.path.join(debian_path, "changelog")
 changelog_version = git_describe_version[1:] if git_describe_version[0] == 'v' else git_describe_version
 # replace all '-' with '~' in version
 changelog_version = changelog_version.replace('-', '~')
- 
+
 with open(changelog_file, 'r') as original: data = original.read()
 with open(changelog_file, 'w') as modified:
     new_entry = """open62541 ({version}) {distribution}; urgency=medium


### PR DESCRIPTION
**[PLEASE REVIEW]**

The main intention of this PR is to make the Debian version numbers more compatible to the Debian policy.

**Problem:**
When building pack/1.0 or pack/master `dpkg-source` complains
`dpkg-source: error: can't build with source format '3.0 (native)': native package version may not have a revision`
This is due to the fact that Debian uses dashes to mark revisions and revisions are not allowed with format `3.0(native)`.
The generated version numbers in  `debian/changelog` look like `1.0-rc1-53-g123456`, this has a second disadvantage. For example the version `1.0` will be identified by `dpkg` as smaller than the release candidate version `1.0-rc1` (could be checked with `dpkg --compare-versions`). As result one can only install `1.0` if version `1.0-rc1` has been purged before.

1. This PR should substitute `-` with `~` in the version numbers, that should solve all these problems.
With version numbers like `1.0~rc1~53~g123456` we achieve the following:
**`dpkg` compares version:**
`1.0` greater than `1.0~rc1` 
`1.0~rc1` greater than `1.0~rc1~53` 
`1.0~rc1~53` greater than `1.0~rc1~53~g12345`
and `dpkg` is able to installl the greater version on top of the  smaller one.

2. This PR also includes a line break into the generated `debian/changelog` to prevent a `lintian` message about overlong lines in `debian/changelog` and the PR also replaces the dash in the version of the original `debian/changelog` with tilde so that the generated `debian/changelog` will have growing version numbers (i.e. template has now `1.0~rc1` and the generated has something like `1.0~rc1~53~g123456` )

3. With this changes one could directly check out `pack/master` or `pack/1.0` and do a local build with i.e. `git-buildpackage`, nice side effect :-)

Any comments, hints are welcome...
