### PR TITLE
fix(debian): remove trailing white space and lines

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -26,4 +26,3 @@ Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Open source implementation of OPC UA (OPC Unified Architecture) aka IEC 62541
  open62541 is an open source C (C99) implementation of the OPC UA standard
-

--- a/debian/rules-template
+++ b/debian/rules-template
@@ -13,5 +13,3 @@ override_dh_auto_test:
 
 %:
 	dh $@ --buildsystem=cmake --parallel
-
-

--- a/tools/prepare_packaging.py
+++ b/tools/prepare_packaging.py
@@ -45,7 +45,7 @@ with open(changelog_file, 'r') as original: data = original.read()
 with open(changelog_file, 'w') as modified:
     new_entry = """open62541 ({version}) {distribution}; urgency=medium
 
-  * Full changelog is available here: 
+  * Full changelog is available here:
     https://github.com/open62541/open62541/blob/master/CHANGELOG
 
  -- open62541 Team <open62541-core@googlegroups.com>  {time}


### PR DESCRIPTION
This PR prevents some annoying lintian messages...
