### PR TITLE
feat(nc): add support for reading Historizing attribute in UAVariable elements

### DIFF
--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -253,6 +253,8 @@ class VariableNode(Node):
                 self.dataType = RefOrAlias(av)
             elif  at == "ArrayDimensions":
                 self.arrayDimensions = av.split(",")
+            elif at == "Historizing":
+                self.historizing = "false" not in av.lower()
 
         for x in xmlelement.childNodes:
             if x.nodeType != x.ELEMENT_NODE:


### PR DESCRIPTION
Parsing of UAVariable xml element now also supports the Historizing attribute.

The Historizing attribute is documented in Annex F.8 of the document OPC Unified Architecture - Part 6 Mappings - Release 1.04 - OPC 10000-6 (https://opcfoundation.org/developer-tools/specifications-unified-architecture/part-6-mappings), and is also documented in the `UANodeSet.xsd` XML Schema file v1.04, at https://github.com/OPCFoundation/UA-Nodeset/blob/v1.04/Schema/UANodeSet.xsd#L358 .

Closes https://github.com/open62541/open62541/issues/2516