### PR TITLE
 [PubSub] First Batch of DataSetMetaData implementation

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -215,6 +215,11 @@ UA_StatusCode UA_EXPORT
 UA_Server_getPublishedDataSetConfig(UA_Server *server, const UA_NodeId pds,
                                     UA_PublishedDataSetConfig *config);
 
+/* Returns a deep copy of the DataSetMetaData for an specific PDS */
+UA_StatusCode UA_EXPORT
+UA_Server_getPublishedDataSetMetaData(UA_Server *server, const UA_NodeId pds,
+                                      UA_DataSetMetaDataType *metaData);
+
 /* Remove PublishedDataSet, identified by the NodeId. Deletion of PDS removes
  * all contained and linked PDS Fields. Connected WriterGroups will be also
  * removed. */

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -201,10 +201,50 @@ UA_Server_addPublishedDataSet(UA_Server *server, const UA_PublishedDataSetConfig
     if(pdsIdentifier != NULL){
         UA_NodeId_copy(&newPubSubDataSet->identifier, pdsIdentifier);
     }
-    server->pubSubManager.publishedDataSetsSize++;
+
     result.addResult = UA_STATUSCODE_GOOD;
     result.fieldAddResults = NULL;
     result.fieldAddResultsSize = 0;
+
+    //fill the DataSetMetaData
+    switch(tmpPublishedDataSetConfig.publishedDataSetType){
+        case UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE:
+            if(UA_DataSetMetaDataType_copy(&tmpPublishedDataSetConfig.config.itemsTemplate.metaData,
+                    &newPubSubDataSet->dataSetMetaData) != UA_STATUSCODE_GOOD){
+                UA_Server_removeDataSetField(server, newPubSubDataSet->identifier);
+                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
+            }
+            break;
+        case UA_PUBSUB_DATASET_PUBLISHEDEVENTS_TEMPLATE:
+            if(UA_DataSetMetaDataType_copy(&tmpPublishedDataSetConfig.config.eventTemplate.metaData,
+                    &newPubSubDataSet->dataSetMetaData) != UA_STATUSCODE_GOOD){
+                UA_Server_removeDataSetField(server, newPubSubDataSet->identifier);
+                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
+            }
+            break;
+        case UA_PUBSUB_DATASET_PUBLISHEDEVENTS:
+            newPubSubDataSet->dataSetMetaData.configurationVersion.majorVersion = UA_PubSubConfigurationVersionTimeDifference();
+            newPubSubDataSet->dataSetMetaData.configurationVersion.minorVersion = UA_PubSubConfigurationVersionTimeDifference();
+            newPubSubDataSet->dataSetMetaData.dataSetClassId = UA_GUID_NULL;
+            if(UA_String_copy(&tmpPublishedDataSetConfig.name, &newPubSubDataSet->dataSetMetaData.name) != UA_STATUSCODE_GOOD){
+                UA_Server_removeDataSetField(server, newPubSubDataSet->identifier);
+                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
+            }
+            newPubSubDataSet->dataSetMetaData.description = UA_LOCALIZEDTEXT_ALLOC("", "");
+            break;
+        case UA_PUBSUB_DATASET_PUBLISHEDITEMS:
+            newPubSubDataSet->dataSetMetaData.configurationVersion.majorVersion = UA_PubSubConfigurationVersionTimeDifference();
+            newPubSubDataSet->dataSetMetaData.configurationVersion.minorVersion = UA_PubSubConfigurationVersionTimeDifference();
+            if(UA_String_copy(&tmpPublishedDataSetConfig.name, &newPubSubDataSet->dataSetMetaData.name) != UA_STATUSCODE_GOOD){
+                UA_Server_removeDataSetField(server, newPubSubDataSet->identifier);
+                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
+            }
+            newPubSubDataSet->dataSetMetaData.description = UA_LOCALIZEDTEXT_ALLOC("", "");
+            newPubSubDataSet->dataSetMetaData.dataSetClassId = UA_GUID_NULL;
+            break;
+    }
+
+    server->pubSubManager.publishedDataSetsSize++;
     result.configurationVersion.majorVersion = UA_PubSubConfigurationVersionTimeDifference();
     result.configurationVersion.minorVersion = UA_PubSubConfigurationVersionTimeDifference();
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL

--- a/tests/pubsub/check_pubsub_config_freeze.c
+++ b/tests/pubsub/check_pubsub_config_freeze.c
@@ -75,6 +75,21 @@ START_TEST(CreateAndLockConfiguration) {
     UA_WriterGroup *writerGroup = UA_WriterGroup_findWGbyId(server, writerGroup1);
     ck_assert(writerGroup->state == UA_PUBSUBSTATE_DISABLED);
 
+    UA_DataSetMetaDataType dataSetMetaDataType; 
+    UA_DataSetMetaDataType_init(&dataSetMetaDataType);
+    ck_assert(UA_Server_getPublishedDataSetMetaData(server, publishedDataSet1, &dataSetMetaDataType) == UA_STATUSCODE_GOOD);
+    UA_DataSetMetaDataType_deleteMembers(&dataSetMetaDataType);
+
+    UA_PublishedDataSetConfig publishedDataSetConfig;
+    memset(&publishedDataSetConfig, 0, sizeof(UA_PublishedDataSetConfig));
+    publishedDataSetConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE;
+    UA_DataSetMetaDataType metaDataType; 
+    UA_DataSetMetaDataType_init(&metaDataType);
+    publishedDataSetConfig.config.itemsTemplate.metaData = metaDataType;
+    publishedDataSetConfig.config.itemsTemplate.variablesToAddSize = 1;
+    publishedDataSetConfig.config.itemsTemplate.variablesToAdd = UA_PublishedVariableDataType_new();
+    UA_PublishedDataSetConfig_clear(&publishedDataSetConfig);
+
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");


### PR DESCRIPTION
This PR adds the automatic generation of DataSetMeta after  adding a PublishedDataSet and DataSetFields. The DataSetMetaData is  necessary for subscribers to decode the received packages.

The following new API method can be used to get a copy of the DataSetMetaData: 
UA_StatusCode UA_EXPORT UA_Server_getPublishedDataSetMetaData(UA_Server *server, const UA_NodeId pds, UA_DataSetMetaDataType *metaData);


