### PR TITLE
Fix buffer size negotiation

### DIFF
--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -311,7 +311,7 @@ processHEL(UA_Server *server, UA_Connection *connection,
 
     /* Build acknowledge response */
     UA_TcpAcknowledgeMessage ackMessage;
-    memcpy(&ackMessage, localConfig, sizeof(UA_TcpAcknowledgeMessage)); /* Same struct layout.. */
+    memcpy(&ackMessage, &connection->config, sizeof(UA_TcpAcknowledgeMessage)); /* Same struct layout.. */
     UA_TcpMessageHeader ackHeader;
     ackHeader.messageTypeAndChunkType = UA_MESSAGETYPE_ACK + UA_CHUNKTYPE_FINAL;
     ackHeader.messageSize = 8 + 20; /* ackHeader + ackMessage */


### PR DESCRIPTION
The server modifies the send and recv buffer sizes for the connection but doesn't
include the changed values into the Acknowledge message.

According to OPC UA Part 6, 7.1.2.4, the buffer sizes shall not be larger than what
the client requested in in the HEL message.

Sending the server's default value causes clients with smaller buffer size limits
(for example Siemens S7-1500) to abort the connection attempt.