### PR TITLE
fix(debian): avoid overwriting env var DEB_BUILD_OPTIONS

### DIFF
--- a/debian/rules-template
+++ b/debian/rules-template
@@ -3,13 +3,15 @@
 export DH_VERBOSE = 1
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-pie
-export DEB_BUILD_OPTIONS=parallel=4
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL -DUA_ENABLE_AMALGAMATION=OFF -DUA_PACK_DEBIAN=ON
 
 override_dh_auto_test:
 	dh_auto_test -- ARGS+=--output-on-failure
+
+override_dh_auto_build:
+	dh_auto_build -- -j`nproc --ignore=2`
 
 %:
 	dh $@ --buildsystem=cmake --parallel


### PR DESCRIPTION
This PR fixes the lintian reported issue 
```
W: open62541 source: debian-rules-sets-DEB_BUILD_OPTIONS line 6
N: 
N:    The debian/rules file sets the DEB_BUILD_OPTIONS variable, which will
N:    override any user-specified build profile.
```
With the environment variable `DEB_BUILD_OPTIONS` the packager could influence the build process of a package as required (e.g. disable tests during build to get a faster build like `DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -rfakeroot ...`) but this will be overwritten by setting  `DEB_BUILD_OPTIONS` in `debian/rules` which is not the best idea.

This PR enables parallel build (using all available processor cores except 2) by injecting the appropriate option to `dh_auto_build`.
