### PR TITLE
[Review] (Bug) Fix crashes that occur when immutable nodes are enabled

### DIFF
--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -210,15 +210,16 @@ UA_Node_copy(const UA_Node *src, UA_Node *dst) {
                 drefs->refTargets[j].targetHash = srefs->refTargets[j].targetHash;
                 drefs->refTargets[j].zipfields.zip_right = NULL;
                 if(srefs->refTargets[j].zipfields.zip_right)
-                    *(uintptr_t*)&drefs->refTargets[j].zipfields.zip_left =
+                    *(uintptr_t*)&drefs->refTargets[j].zipfields.zip_right =
                         (uintptr_t)srefs->refTargets[j].zipfields.zip_right + arraydiff;
                 drefs->refTargets[j].zipfields.zip_left = NULL;
                 if(srefs->refTargets[j].zipfields.zip_left)
                     *(uintptr_t*)&drefs->refTargets[j].zipfields.zip_left =
                         (uintptr_t)srefs->refTargets[j].zipfields.zip_left + arraydiff;
+                drefs->refTargets[j].zipfields.rank = srefs->refTargets[j].zipfields.rank;
             }
-            srefs->refTargetsTree.zip_root = NULL;
-            if(drefs->refTargetsTree.zip_root)
+            drefs->refTargetsTree.zip_root = NULL;
+            if(srefs->refTargetsTree.zip_root)
                 *(uintptr_t*)&drefs->refTargetsTree.zip_root =
                     (uintptr_t)srefs->refTargetsTree.zip_root + arraydiff;
             drefs->refTargetsSize= srefs->refTargetsSize;


### PR DESCRIPTION
This PR proposes some fixes to the UA_Node_copy function.

To reproduce crashes compile the library (master [[last commit](https://github.com/open62541/open62541/commit/a2d07b3e54fdd6038a7f36eaa53e8ad2a537288e)]) with -DUA_ENABLE_IMMUTABLE_NODES=1 and run the unit tests.