### PR TITLE
fix(debian): separate tools from dev

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9),
  git,
  graphviz,
  python (>= 2.7),
-Standards-Version: 4.1.2
+Standards-Version: 4.4.1
 Section: libs
 Homepage: https://open62541.org/
 Vcs-Git: https://github.com/open62541/open62541.git
@@ -16,13 +16,42 @@ Package: libopen62541-<soname>-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: libopen62541-<soname> (= ${binary:Version}), ${misc:Depends}, python
-Description: Development header files for open62541
- open62541 is an open source C (C99) implementation of the OPC UA standard
+Depends: libopen62541-<soname> (= ${binary:Version}), ${misc:Depends}
+Description: Open source implementation of OPC UA - development files
+ open62541 (http://open62541.org) is an open source and free implementation
+ of OPC UA (OPC Unified Architecture) written in the common subset of the
+ C99 and C++98 languages.
+ The library is usable with all major compilers and provides the necessary
+ tools to implement dedicated OPC UA clients and servers, or to integrate
+ OPC UA-based communication into existing applications.
+ .
+ This package provides the open62541 header and development files
+
+Package: libopen62541-<soname>-tools
+Section: libdevel
+Architecture: all
+Depends: ${misc:Depends}, python
+Recommends: libopen62541-<soname>-dev
+Description: Open source implementation of OPC UA - tools
+ open62541 (http://open62541.org) is an open source and free implementation
+ of OPC UA (OPC Unified Architecture) written in the common subset of the
+ C99 and C++98 languages.
+ The library is usable with all major compilers and provides the necessary
+ tools to implement dedicated OPC UA clients and servers, or to integrate
+ OPC UA-based communication into existing applications.
+ .
+ This package provides some open62541 tools, e.g. the nodeset compiler
 
 Package: libopen62541-<soname>
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Open source implementation of OPC UA (OPC Unified Architecture) aka IEC 62541
- open62541 is an open source C (C99) implementation of the OPC UA standard
+Description: Open source implementation of OPC UA - shared library
+ open62541 (http://open62541.org) is an open source and free implementation
+ of OPC UA (OPC Unified Architecture) written in the common subset of the
+ C99 and C++98 languages.
+ The library is usable with all major compilers and provides the necessary
+ tools to implement dedicated OPC UA clients and servers, or to integrate
+ OPC UA-based communication into existing applications.
+ .
+ This package provides the open62541 shared library

--- a/debian/control-template
+++ b/debian/control-template
@@ -3,7 +3,6 @@ Priority: optional
 Maintainer: open62541 Team <open62541-core@googlegroups.com>
 Build-Depends: debhelper (>= 9),
  cmake (>= 2.8),
- git,
  graphviz,
  python (>= 2.7),
 Standards-Version: 4.4.1

--- a/debian/libopen62541-dev.install-template
+++ b/debian/libopen62541-dev.install-template
@@ -2,4 +2,3 @@ usr/include
 usr/lib/*/*.so
 usr/lib/*/cmake/open62541/*
 usr/lib/*/pkgconfig/open62541.pc
-usr/share/open62541/*

--- a/debian/libopen62541-tools.install-template
+++ b/debian/libopen62541-tools.install-template
@@ -1,1 +1,6 @@
-usr/share/open62541/tools
+usr/share/open62541/tools/*.py
+usr/share/open62541/tools/certs
+usr/share/open62541/tools/nodeset_compiler
+usr/share/open62541/tools/schema
+usr/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml
+usr/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.Types.bsd

--- a/debian/libopen62541-tools.install-template
+++ b/debian/libopen62541-tools.install-template
@@ -4,3 +4,6 @@ usr/share/open62541/tools/nodeset_compiler
 usr/share/open62541/tools/schema
 usr/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml
 usr/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.Types.bsd
+usr/share/open62541/tools/ua-nodeset/Schema/AttributeIds.csv
+usr/share/open62541/tools/ua-nodeset/Schema/NodeIds.csv
+usr/share/open62541/tools/ua-nodeset/Schema/StatusCode.csv

--- a/debian/libopen62541-tools.install-template
+++ b/debian/libopen62541-tools.install-template
@@ -1,0 +1,1 @@
+usr/share/open62541/tools

--- a/tools/prepare_packaging.py
+++ b/tools/prepare_packaging.py
@@ -81,6 +81,9 @@ install_file_template = os.path.join(debian_path, "libopen62541-dev.install-temp
 install_file = os.path.join(debian_path, "libopen62541-{}-dev.install".format(version_major))
 os.rename(install_file_template, install_file)
 
+install_file_template = os.path.join(debian_path, "libopen62541-tools.install-template")
+install_file = os.path.join(debian_path, "libopen62541-{}-tools.install".format(version_major))
+os.rename(install_file_template, install_file)
 
 # Create rule file and replace template variables
 rule_file_template = os.path.join(debian_path, "rules-template")


### PR DESCRIPTION
Building pack/1.0 produces the lintian message

```
I: libopen62541-1-dev: arch-dep-package-has-big-usr-share 104164kB 98%
N: 
N:    The package has a significant amount of architecture-independent data
N:    (over 4MB, or over 2MB and more than 50% of the package) in /usr/share
N:    but is an architecture-dependent package. This is wasteful of mirror
N:    space and bandwidth since it means distributing multiple copies of this
N:    data, one for each architecture.
N:
```
which is correct because the `libopen62541-<soname>-dev` package is architecture dependent and the tools are not. 

This PR splits the previous `libopen62541-<soname>-dev` into the architecture dependent `libopen62541-<soname>-dev` package and the architecture independent `libopen62541-<soname>-tools` package. The `libopen62541-<soname>-tools` package gets a `Recommends: libopen62541-<soname>-dev`.

BTW  I've added some minor changes such as this PR bumps the Debian `Standards-Version:` to the current version `4.4.1` and in addition extends the description of the packages a bit to avoid the following lintian complaints 

```
I: open62541 source: duplicate-long-description libopen62541-1-dev libopen62541-1
N: 
N:    The listed binary packages all share the same extended description. Some
N:    additional information in the extended description explaining what is in
N:    each package and how it differs from the other packages is useful,
N:    particularly for users who aren't familiar with Debian's package naming
N:    conventions.
N:    
```
and
```
I: libopen62541-1: extended-description-is-probably-too-short
N: 
N:    The extended description (the lines after the first line of the
N:    "Description:" field) is only one or two lines long. The extended
N:    description should provide a user with enough information to decide
N:    whether they want to install this package, what it contains, and how it
N:    compares to similar packages. One or two lines is normally not enough to
N:    do this.
N:
```
