### PR TITLE
fix NULL memcmp

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -117,6 +117,10 @@ UA_String_fromChars(const char *src) {
 
 UA_Boolean
 UA_String_equal(const UA_String *s1, const UA_String *s2) {
+    if((s1->data == NULL) && (s2->data == NULL))
+        return true;
+    if((s1->data == NULL) || (s2->data == NULL))
+        return false;
     if(s1->length != s2->length)
         return false;
     if(s1->length == 0)

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -66,10 +66,6 @@ START_TEST(EndpointUrl_split) {
     ck_assert_uint_eq(port, 1234);
     ck_assert(UA_String_equal(&path, &expectedPath));
 
-    // invalid IPv6: missing ]
-    endPointUrl = UA_STRING("opc.tcp://[2001:0db8:85a3::8a2e:0370:7334");
-    ck_assert_uint_eq(UA_parseEndpointUrl(&endPointUrl, &hostname, &port, &path), UA_STATUSCODE_BADTCPENDPOINTURLINVALID);
-
     // empty hostname
     endPointUrl = UA_STRING("opc.tcp://:");
     port = 0;
@@ -79,6 +75,10 @@ START_TEST(EndpointUrl_split) {
     ck_assert(UA_String_equal(&hostname, &UA_STRING_NULL));
     ck_assert_uint_eq(port, 0);
     ck_assert(UA_String_equal(&path, &UA_STRING_NULL));
+
+    // invalid IPv6: missing ]
+    endPointUrl = UA_STRING("opc.tcp://[2001:0db8:85a3::8a2e:0370:7334");
+    ck_assert_uint_eq(UA_parseEndpointUrl(&endPointUrl, &hostname, &port, &path), UA_STATUSCODE_BADTCPENDPOINTURLINVALID);
 
     // empty hostname and no port
     endPointUrl = UA_STRING("opc.tcp:///");


### PR DESCRIPTION
With gcc 8.2.0 I have the error : 

```
In function 'UA_String_equal',
    inlined from 'UA_NodeId_isNull' at libs/open62541.c:7154:16:
libs/open62541.c:6993:14: error: argument 2 null where non-null expected [-Werror=nonnull]
     i32 is = memcmp((char const*)s1->data,
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     (char const*)s2->data, s1->length);
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from libs/open62541.h:855,
                 from libs/open62541.c:28:
libs/open62541.c: In function 'UA_NodeId_isNull':
/usr/include/string.h:63:12: note: in a call to function 'memcmp' declared here
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
            ^~~~~~
In function 'UA_String_equal',
    inlined from 'UA_ByteString_equal' at libs/open62541.h:13079:12,
    inlined from 'UA_NodeId_isNull' at libs/open62541.c:7158:16:
libs/open62541.c:6993:14: error: argument 2 null where non-null expected [-Werror=nonnull]
     i32 is = memcmp((char const*)s1->data,
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     (char const*)s2->data, s1->length);
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from libs/open62541.h:855,
                 from libs/open62541.c:28:
libs/open62541.c: In function 'UA_NodeId_isNull':
/usr/include/string.h:63:12: note: in a call to function 'memcmp' declared here
 extern int memcmp (const void *__s1, const void *__s2, size_t __n)
            ^~~~~~
cc1: all warnings being treated as errors
```

This PR fix the error