### PR TITLE
return correct error code when information model setup failed

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -41,16 +41,14 @@ def generateNodeValueInstanceName(node, parent, arrayIndex):
     return generateNodeIdPrintable(parent) + "_" + str(node.alias) + "_" + str(arrayIndex)
 
 def generateReferenceCode(reference):
-    if reference.isForward:
-        return "retVal |= UA_Server_addReference(server, %s, %s, %s, true);" % \
-               (generateNodeIdCode(reference.source),
-                generateNodeIdCode(reference.referenceType),
-                generateExpandedNodeIdCode(reference.target))
-    else:
-        return "retVal |= UA_Server_addReference(server, %s, %s, %s, false);" % \
-               (generateNodeIdCode(reference.source),
-                generateNodeIdCode(reference.referenceType),
-                generateExpandedNodeIdCode(reference.target))
+    code = []
+    forwardFlag = "true" if reference.isForward else "false"
+    code.append("retVal |= UA_Server_addReference(server, %s, %s, %s, %s);" %
+                (generateNodeIdCode(reference.source),
+                 generateNodeIdCode(reference.referenceType),
+                 generateExpandedNodeIdCode(reference.target),
+                 forwardFlag))
+    return "\n".join(code)
 
 def generateReferenceTypeNodeCode(node):
     code = []

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -48,6 +48,7 @@ def generateReferenceCode(reference):
                  generateNodeIdCode(reference.referenceType),
                  generateExpandedNodeIdCode(reference.target),
                  forwardFlag))
+    code.append("if (retVal != UA_STATUSCODE_GOOD) return retVal;")
     return "\n".join(code)
 
 def generateReferenceTypeNodeCode(node):
@@ -525,6 +526,7 @@ def generateNodeCode_begin(node, nodeset, code_global):
         code.append(" UA_NODEID_NULL,")
     code.append("(const UA_NodeAttributes*)&attr, &UA_TYPES[UA_TYPES_{}ATTRIBUTES],NULL, NULL);".
             format(makeCIdentifier(node.__class__.__name__.upper().replace("NODE" ,""))))
+    code.append("if (retVal != UA_STATUSCODE_GOOD) return retVal;")
     code.extend(codeCleanup)
 
     return "\n".join(code)


### PR DESCRIPTION
This fixes a problem I had. The root of the problem is, that in case of an error while initializing the information model the return values are combined with bit-wise OR.
I tried to use an AnalogItemType in a reduced Namespace 0 where this type is not available. The error code BadTooManySubscriptions (0x80770000) was returned, leading investigation into the wrong direction. The correct error code is BadTypeDefinitionInvalid (0x80630000).
This patch aborts initialization after the first error.