### PR TITLE
ci: Disable shallow submodules since they lead to errors on travis.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "deps/mdnsd"]
 	path = deps/mdnsd
 	url = https://github.com/Pro/mdnsd.git
-	shallow = true
 [submodule "deps/ua-nodeset"]
 	path = deps/ua-nodeset
 	url = https://github.com/OPCFoundation/UA-Nodeset
 	branch = v1.04
-	shallow = true

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -98,6 +98,7 @@ add_fuzzer(fuzz_src_ua_util fuzz_src_ua_util.cc)
 # Add fuzzer for mdns dependency. It's currently not fuzzed separately.
 # See also: https://github.com/google/oss-fuzz/pull/2928
 add_fuzzer(fuzz_mdns_message ${PROJECT_SOURCE_DIR}/deps/mdnsd/tests/fuzz/fuzz_mdns_message.cc)
+add_fuzzer(fuzz_mdns_xht ${PROJECT_SOURCE_DIR}/deps/mdnsd/tests/fuzz/fuzz_mdns_xht.cc)
 
 
 if(UA_ENABLE_JSON_ENCODING)


### PR DESCRIPTION
It seems that for shallow submodules travis sometimes does not find
the referenced remote commit