### PR TITLE
adding missing submodule init command to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ADD . /opt/open62541
 WORKDIR /opt/open62541
 RUN git remote add github-upstream https://github.com/open62541/open62541.git
 RUN git fetch --tags github-upstream
+RUN git submodule update --init --recursive
 
 WORKDIR /opt/open62541/build
 RUN cmake -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
fix: adding missing submodule init command to Dockerfile

Without this line, `docker build` terminates with the following error message:

> CMake Error at CMakeLists.txt:830 (message):
>   File /opt/open62541/deps/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml not found.
>   You probably need to initialize the git submodule for deps/ua-nodeset.

