### PR TITLE
fix(PubSub): Publishing order of multiple DataSetFields

### DIFF
--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -36,7 +36,7 @@ typedef struct UA_ReaderGroup UA_ReaderGroup;
 typedef struct{
     UA_PublishedDataSetConfig config;
     UA_DataSetMetaDataType dataSetMetaData;
-    LIST_HEAD(UA_ListOfDataSetField, UA_DataSetField) fields;
+    TAILQ_HEAD(UA_ListOfDataSetField, UA_DataSetField) fields;
     UA_NodeId identifier;
     UA_UInt16 fieldSize;
     UA_UInt16 promotedFieldsCount;
@@ -176,7 +176,7 @@ UA_WriterGroup_setPubSubState(UA_Server *server, UA_PubSubState state, UA_Writer
 typedef struct UA_DataSetField{
     UA_DataSetFieldConfig config;
     //internal fields
-    LIST_ENTRY(UA_DataSetField) listEntry;
+    TAILQ_ENTRY(UA_DataSetField) listEntry;
     UA_NodeId identifier;
     UA_NodeId publishedDataSet;             //ref to parent pds
     UA_FieldMetaData fieldMetaData;

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -185,11 +185,11 @@ UA_Server_addPublishedDataSet(UA_Server *server, const UA_PublishedDataSetConfig
     server->pubSubManager.publishedDataSets = newPubSubDataSetField;
     UA_PublishedDataSet *newPubSubDataSet = &server->pubSubManager.publishedDataSets[(server->pubSubManager.publishedDataSetsSize)];
     memset(newPubSubDataSet, 0, sizeof(UA_PublishedDataSet));
-    LIST_INIT(&newPubSubDataSet->fields);
+    TAILQ_INIT(&newPubSubDataSet->fields);
     //workaround - fixing issue with queue.h and realloc.
     for(size_t n = 0; n < server->pubSubManager.publishedDataSetsSize; n++){
-        if(server->pubSubManager.publishedDataSets[n].fields.lh_first){
-            server->pubSubManager.publishedDataSets[n].fields.lh_first->listEntry.le_prev = &server->pubSubManager.publishedDataSets[n].fields.lh_first;
+        if(server->pubSubManager.publishedDataSets[n].fields.tqh_first){
+            server->pubSubManager.publishedDataSets[n].fields.tqh_first->listEntry.tqe_prev = &server->pubSubManager.publishedDataSets[n].fields.tqh_first;
         }
     }
     newPubSubDataSet->config = tmpPublishedDataSetConfig;
@@ -267,8 +267,8 @@ UA_Server_removePublishedDataSet(UA_Server *server, const UA_NodeId pds) {
         }
         //workaround - fixing issue with queue.h and realloc.
         for(size_t n = 0; n < server->pubSubManager.publishedDataSetsSize; n++){
-            if(server->pubSubManager.publishedDataSets[n].fields.lh_first){
-                server->pubSubManager.publishedDataSets[n].fields.lh_first->listEntry.le_prev = &server->pubSubManager.publishedDataSets[n].fields.lh_first;
+            if(server->pubSubManager.publishedDataSets[n].fields.tqh_first){
+                server->pubSubManager.publishedDataSets[n].fields.tqh_first->listEntry.tqe_prev = &server->pubSubManager.publishedDataSets[n].fields.tqh_first;
             }
         }
     }

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -143,7 +143,7 @@ onRead(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                 UA_calloc(publishedDataSet->fieldSize, sizeof(UA_PublishedVariableDataType));
             size_t counter = 0;
             UA_DataSetField *field;
-            LIST_FOREACH(field, &publishedDataSet->fields, listEntry) {
+            TAILQ_FOREACH(field, &publishedDataSet->fields, listEntry) {
                 pvd[counter].attributeId = UA_ATTRIBUTEID_VALUE;
                 pvd[counter].publishedVariable = field->config.field.variable.publishParameters.publishedVariable;
                 //UA_NodeId_copy(&field->config.field.variable.publishParameters.publishedVariable, &pvd[counter].publishedVariable);

--- a/tests/pubsub/check_pubsub_config_freeze.c
+++ b/tests/pubsub/check_pubsub_config_freeze.c
@@ -93,7 +93,7 @@ START_TEST(CreateAndLockConfiguration) {
     UA_PublishedDataSet *publishedDataSet = UA_PublishedDataSet_findPDSbyId(server, dataSetWriter->connectedDataSet);
     ck_assert(publishedDataSet->config.configurationFrozen == UA_TRUE);
     UA_DataSetField *dsf;
-    LIST_FOREACH(dsf ,&publishedDataSet->fields , listEntry){
+    TAILQ_FOREACH(dsf ,&publishedDataSet->fields , listEntry){
         ck_assert(dsf->config.configurationFrozen == UA_TRUE);
     }
     //set state to disabled and implicit unlock the configuration
@@ -157,7 +157,7 @@ START_TEST(CreateAndLockConfigurationWithExternalAPI) {
         UA_PublishedDataSet *publishedDataSet = UA_PublishedDataSet_findPDSbyId(server, dataSetWriter->connectedDataSet);
         ck_assert(publishedDataSet->config.configurationFrozen == UA_TRUE);
         UA_DataSetField *dsf;
-        LIST_FOREACH(dsf ,&publishedDataSet->fields , listEntry){
+        TAILQ_FOREACH(dsf ,&publishedDataSet->fields , listEntry){
             ck_assert(dsf->config.configurationFrozen == UA_TRUE);
         }
         //set state to disabled and implicit unlock the configuration


### PR DESCRIPTION
 - The order of DSF should be the same while creating and publishing and
   the existing implementation publishes reversely
 - Used TAILQ structure for DSF instead of LIST structure