### PR TITLE
fix(pubsub): Resolve PublisherId and DataSetWriterId check issue

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -182,7 +182,7 @@ checkReaderIdentifier(UA_Server *server, UA_NetworkMessage *pMsg, UA_DataSetRead
 static UA_StatusCode
 getReaderFromIdentifier(UA_Server *server, UA_NetworkMessage *pMsg,
                         UA_DataSetReader **dataSetReader, UA_PubSubConnection *pConnection) {
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    UA_StatusCode retval = UA_STATUSCODE_BADNOTFOUND;
     if(!pMsg->publisherIdEnabled) {
         UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                     "Cannot process DataSetReader without PublisherId");


### PR DESCRIPTION
 - Changed status code of retval to UA_STATUSCODE_BADNOTFOUND
   as the API functionality fails to invoke an error even a wrong
   publisherID is subscribed
 - TODO: Add Unit test case for PublisherId and DataSetWriterId checks