### PR TITLE
feat(debian): add PDF and HTML docs including examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1218,6 +1218,19 @@ install(DIRECTORY ${UA_install_tools_dirs}
 
 install(FILES ${UA_install_tools_files} DESTINATION ${open62541_install_tools_dir})
 
+if (UA_PACK_DEBIAN)    
+    set(UA_install_examples_dirs "examples/"
+        "examples/access_control"
+        "examples/custom_datatype"
+        "examples/discovery"
+        "examples/encryption"
+        "examples/nodeset"
+        "examples/pubsub")
+
+    set(open62541_install_examples_dir share/open62541/examples)
+    install(DIRECTORY ${UA_install_examples_dirs} COMPONENT examples DESTINATION ${open62541_install_examples_dir} USE_SOURCE_PERMISSIONS)
+endif()
+
 if(NOT UA_ENABLE_AMALGAMATION)
     # Recreate the include folder structure from the source also in /usr/lib/include/open62541
 

--- a/debian/control-template
+++ b/debian/control-template
@@ -5,6 +5,13 @@ Build-Depends: debhelper (>= 9),
  cmake (>= 2.8),
  graphviz,
  python (>= 2.7),
+ python-sphinx,
+ python-sphinx-rtd-theme | base-files (<= 7.2ubuntu5.6~),
+ graphviz,
+ texlive-fonts-recommended,
+ texlive-latex-extra,
+ texlive-generic-extra,
+ latexmk
 Standards-Version: 4.4.1
 Section: libs
 Homepage: https://open62541.org/
@@ -54,3 +61,19 @@ Description: Open source implementation of OPC UA - shared library
  OPC UA-based communication into existing applications.
  .
  This package provides the open62541 shared library
+
+Package: open62541-doc
+Section: doc
+Architecture: all
+Multi-Arch: foreign
+Depends: ${misc:Depends}, ${sphinxdoc:Depends}
+Description: Open source implementation of OPC UA - documentation
+ open62541 (http://open62541.org) is an open source and free implementation
+ of OPC UA (OPC Unified Architecture) written in the common subset of the
+ C99 and C++98 languages.
+ The library is usable with all major compilers and provides the necessary
+ tools to implement dedicated OPC UA clients and servers, or to integrate
+ OPC UA-based communication into existing applications.
+ .
+ This package provides the open62541 documentation as PDF and HTML
+ and example applications

--- a/debian/open62541-doc.doc-base-template
+++ b/debian/open62541-doc.doc-base-template
@@ -1,0 +1,16 @@
+Document: open62541
+Title: open62541 Manual
+Author: The open62541 Team <open62541-core@googlegroups.com>
+Abstract: open62541 (http://open62541.org) is an open source 
+ and free implementation of OPC UA (OPC Unified Architecture) 
+ written in the common subset of the C99 and C++98 languages.   
+ This manual contains an introduction to the open62541 library 
+ and describes how to use it for server and client applications. 
+Section: Network/Communication
+
+Format: HTML
+Index: /usr/share/doc/open62541/open62541.html/index.html
+Files: /usr/share/doc/open62541/open62541.html/*
+
+Format: PDF
+Files: /usr/share/doc/open62541/open62541.pdf.gz

--- a/debian/open62541-doc.install-template
+++ b/debian/open62541-doc.install-template
@@ -1,0 +1,2 @@
+usr/share/doc/open62541
+usr/share/open62541/examples

--- a/debian/rules-template
+++ b/debian/rules-template
@@ -12,6 +12,11 @@ override_dh_auto_test:
 
 override_dh_auto_build:
 	dh_auto_build -- -j`nproc --ignore=2`
+	make -C obj-${DEB_HOST_GNU_TYPE} doc doc_pdf
+
+override_dh_install:
+	dh_install
+	dh_sphinxdoc -X_sources
 
 %:
 	dh $@ --buildsystem=cmake --parallel

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -86,3 +86,32 @@ add_dependencies(doc open62541)
 
 set_target_properties(doc doc_latex doc_pdf PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE)
 set_target_properties(doc doc_latex doc_pdf PROPERTIES FOLDER "open62541/doc")
+
+if (UA_PACK_DEBIAN)
+    set(open62541_install_debdoc_html_dir share/doc/open62541/open62541.html)
+    set(open62541_install_debdoc_dir share/doc/open62541)
+
+    set(open62541_debdoc_pdf_files "${DOC_LATEX_DIR}/open62541.pdf")
+
+    install(DIRECTORY ${DOC_HTML_DIR}/
+        COMPONENT htmldoc 
+        DESTINATION ${open62541_install_debdoc_dir}/open62541.html 
+        USE_SOURCE_PERMISSIONS
+        FILES_MATCHING 
+        PATTERN "*.*"
+        PATTERN "_sources" EXCLUDE
+        PATTERN "_static/ua-wireshark-pubsub.png" EXCLUDE
+        PATTERN "_static/ua-wireshark.png" EXCLUDE
+        PATTERN "_static/nodeset_compiler_pump.png" EXCLUDE
+        PATTERN ".doctrees" EXCLUDE
+        PATTERN ".buildinfo" EXCLUDE
+        PATTERN "CMakeFiles" EXCLUDE
+        PATTERN "CMakeLists.txt" EXCLUDE
+        PATTERN "Makefile" EXCLUDE
+        PATTERN "*.map" EXCLUDE
+        PATTERN "*.cmake" EXCLUDE
+        PATTERN "*.inv" EXCLUDE
+        PATTERN "*.py" EXCLUDE
+        )
+    install(FILES ${open62541_debdoc_pdf_files} COMPONENT pdfdoc DESTINATION ${open62541_install_debdoc_dir})
+endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -100,18 +100,8 @@ if (UA_PACK_DEBIAN)
         FILES_MATCHING 
         PATTERN "*.*"
         PATTERN "_sources" EXCLUDE
-        PATTERN "_static/ua-wireshark-pubsub.png" EXCLUDE
-        PATTERN "_static/ua-wireshark.png" EXCLUDE
-        PATTERN "_static/nodeset_compiler_pump.png" EXCLUDE
-        PATTERN ".doctrees" EXCLUDE
-        PATTERN ".buildinfo" EXCLUDE
         PATTERN "CMakeFiles" EXCLUDE
-        PATTERN "CMakeLists.txt" EXCLUDE
-        PATTERN "Makefile" EXCLUDE
-        PATTERN "*.map" EXCLUDE
-        PATTERN "*.cmake" EXCLUDE
-        PATTERN "*.inv" EXCLUDE
-        PATTERN "*.py" EXCLUDE
+        PATTERN "cmake_install.cmake" EXCLUDE
         )
     install(FILES ${open62541_debdoc_pdf_files} COMPONENT pdfdoc DESTINATION ${open62541_install_debdoc_dir})
 endif()

--- a/tools/prepare_packaging.py
+++ b/tools/prepare_packaging.py
@@ -85,6 +85,14 @@ install_file_template = os.path.join(debian_path, "libopen62541-tools.install-te
 install_file = os.path.join(debian_path, "libopen62541-{}-tools.install".format(version_major))
 os.rename(install_file_template, install_file)
 
+install_file_template = os.path.join(debian_path, "open62541-doc.doc-base-template")
+install_file = os.path.join(debian_path, "open62541-doc.doc-base")
+os.rename(install_file_template, install_file)
+
+install_file_template = os.path.join(debian_path, "open62541-doc.install-template")
+install_file = os.path.join(debian_path, "open62541-doc.install")
+os.rename(install_file_template, install_file)
+
 # Create rule file and replace template variables
 rule_file_template = os.path.join(debian_path, "rules-template")
 rule_file = os.path.join(debian_path, "rules")


### PR DESCRIPTION
This PR adds a Debian doc package and provides the PDF and HTML documentation for open62541, the installation place, as usual at Debian systems, will be `/usr/share/doc/open62541`.
In addition the package provides the open62541 example application sources at `/usr/share/open62541/examples`.
This PR is based on prototype work of @ralphlange (see https://github.com/ralphlange/open62541/tree/feature/debianization/debian)