### PR TITLE
fix(pubsub): Performance enhancement of subscriber server

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -287,7 +287,7 @@ void UA_ReaderGroup_subscribeCallback(UA_Server *server, UA_ReaderGroup *readerG
         return;
     }
 
-    connection->channel->receive(connection->channel, &buffer, NULL, 300000);
+    connection->channel->receive(connection->channel, &buffer, NULL, 1000);
     if(buffer.length > 0) {
         UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Message received:");
         UA_NetworkMessage currentNetworkMessage;


### PR DESCRIPTION
 - Socket timeout should not be 300ms as it waits for a packet
   for about 300ms and hogs the other resources
 - Reduced the timeout to 1ms as subscribe callback timer
   running at 5ms