### PR TITLE
feat(debian): add static library to dev package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,6 +977,10 @@ else()
     target_compile_definitions(open62541-plugins PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
     set_target_properties(open62541-plugins PROPERTIES FOLDER "open62541/lib")
 
+    if(UA_PACK_DEBIAN)
+        add_library(open62541-static STATIC $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-plugins>)
+        set_target_properties(open62541-static PROPERTIES OUTPUT_NAME open62541)
+    endif()
     add_library(open62541 $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-plugins>)
 
     if(UA_COMPILE_AS_CXX)
@@ -1147,7 +1151,12 @@ if(UA_ENABLE_DISCOVERY_MULTICAST)
 endif()
 
 # export library (either static or shared depending on BUILD_SHARED_LIBS)
-install(TARGETS open62541
+if(UA_PACK_DEBIAN)
+    set(EXTRATARGETS "open62541-static")
+else()
+    set(EXTRATARGETS "")
+endif()
+install(TARGETS open62541 ${EXTRATARGETS}
         EXPORT open62541Targets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/debian/control-template
+++ b/debian/control-template
@@ -3,7 +3,6 @@ Priority: optional
 Maintainer: open62541 Team <open62541-core@googlegroups.com>
 Build-Depends: debhelper (>= 9),
  cmake (>= 2.8),
- graphviz,
  python (>= 2.7),
  python-sphinx,
  python-sphinx-rtd-theme | base-files (<= 7.2ubuntu5.6~),

--- a/debian/libopen62541-dev.install-template
+++ b/debian/libopen62541-dev.install-template
@@ -1,4 +1,5 @@
 usr/include
 usr/lib/*/*.so
+usr/lib/*/*.a
 usr/lib/*/cmake/open62541/*
 usr/lib/*/pkgconfig/open62541.pc


### PR DESCRIPTION
This PR adds the static library to the Debian dev package to enable the build of static linked apps. 
The dev package now provides the header files, the soft link to the shared lib AND the static lib. 
This PR is based on a cherry pick of the prototype work of @ralphlange (see https://github.com/ralphlange/open62541/tree/feature/debianization/debian)