### PR TITLE
fix(debian):use texlive-plain-generic since debian/bullseye or ubuntu/eoan

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9),
  graphviz,
  texlive-fonts-recommended,
  texlive-latex-extra,
- texlive-generic-extra,
+ texlive-plain-generic | texlive-generic-extra,
  latexmk
 Standards-Version: 4.4.1
 Section: libs


### PR DESCRIPTION
This PR addresses the problem reported by @Pro (launchpad builds failing [#3215](https://launchpadlibrarian.net/448601588/buildlog.txt.gz))

Since  Debian/bullseye or Ubuntu/Eoan the generation of the `open62541-doc` package fails because the Debian package `texlive-generic-extra` is not available anymore and should be replaced by `texlive-plain-generic`

@Pro could you please test it on launchpad?