### PR TITLE
NodesetCompiler: Add function stubs for methodnodes

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -543,16 +543,8 @@ def getNodeMethodCallbackName(node, outfilebase):
         return outfilebase + "_" + methodname
     return methodname
 
-
 def generateNodeCode_finish(node, outfilebase):
     code = []
-
-    # prepare methodcall parameters
-    methodname = getNodeMethodCallbackName(node, outfilebase)
-    inputargs_size = "0"
-    inputargs = "NULL"
-    outputargs_size = "0"
-    outputargs = "NULL"
 
     if isinstance(node, MethodNode):
         code.append("UA_StatusCode retVal = UA_STATUSCODE_GOOD;")
@@ -563,10 +555,9 @@ def generateNodeCode_finish(node, outfilebase):
 
     if isinstance(node, MethodNode):
         code.append(", NULL, 0, NULL, 0, NULL);")
-        #code.append(", " + methodname + ", " + inputargs_size + ", " + inputargs + ", " + outputargs_size + ", " + outputargs + ");")
         code.append("retVal |= UA_Server_setMethodNode_callback(server, ")
         code.append(generateNodeIdCode(node.id))
-        code.append(", " + methodname + ");")
+        code.append(", " + getNodeMethodCallbackName(node, outfilebase) + ");")
         code.append("return retVal;")
     else:
         code.append(");")


### PR DESCRIPTION
* Function stubs are generated in the header file
* Calling functions does work (tested with 2x Uint32 Input, 1x Uint32 output)
* ~~Something is still wrong when using UAExpert:~~ ![grafik](https://user-images.githubusercontent.com/20518746/67694033-a03ad200-f99a-11e9-9691-342c042ea209.png) When using the default nodeset instead of minimal this error goes away.

Related: https://github.com/open62541/open62541/issues/3199