### PR TITLE
Fix discovery url registration

### DIFF
--- a/include/open62541/plugin/network.h
+++ b/include/open62541/plugin/network.h
@@ -152,6 +152,9 @@ struct UA_ServerNetworkLayer {
     /* Points to external memory, i.e. handled by server or client */
     UA_NetworkStatistics *statistics;
 
+    /* Describes the url of the network layer which is used by the remote to connect to this network layer.
+     * The url will be used for the discovery and endpoint services.
+     */
     UA_String discoveryUrl;
 
     UA_ConnectionConfig localConnectionConfig;

--- a/include/open62541/server_config.h
+++ b/include/open62541/server_config.h
@@ -100,6 +100,13 @@ struct UA_ServerConfig {
      * - The ApplicationUri set in the ApplicationDescription must match the
      *   URI set in the server certificate */
     UA_BuildInfo buildInfo;
+    /*
+     * For local servers,
+     *  the discovery urls will be copied from the network layers at server initialization.
+     *  This means, that there is no use in setting the discovery urls manually, as they will be overriden.
+     * For registered remote servers,
+     *  the discovery url are set in the registration and contains the url of their endpoints.
+     */
     UA_ApplicationDescription applicationDescription;
     UA_ByteString serverCertificate;
 


### PR DESCRIPTION
Earlier the discovery urls are generated by the server configuration
and the network layers. Now only the server configuration is used.
The network layers are only used as a fall back if the server
configuration does not provide discovery urls.