### PR TITLE
[Review] Historical events

### DIFF
--- a/include/open62541/plugin/historydatabase.h
+++ b/include/open62541/plugin/historydatabase.h
@@ -39,6 +39,37 @@ struct UA_HistoryDatabase {
                 UA_Boolean historizing,
                 const UA_DataValue *value);
 
+    /* This function will be called when an event is triggered.
+     * Use it to insert data into your event database.
+     * No default implementation is provided by UA_HistoryDatabase_default.
+     *
+     * server is the server this node lives in.
+     * hdbContext is the context of the UA_HistoryDatabase.
+     * sessionId and sessionContext identify the session which set this value.
+     * originId is the node id of the event's origin.
+     * emitterId is the node id of the event emitter.
+     * eventId is the node id of the event that is being emitted.
+     * willEventNodeBeDeleted specifies whether the event node will be deleted after
+     *                        it has been triggered (this might be relevant for
+     *                        in-memory storage).
+     * historicalEventFilter is the value of the HistoricalEventFilter property of
+     *                       the emitter (OPC UA Part 11, 5.3.2), it is NULL if
+     *                       the property does not exist or is not set.
+     * fieldList is the event field list returned after application of
+     *           historicalEventFilter to the event node
+     *           (NULL if historicalEventFilter is NULL or filtering was
+     *           unsuccessful); the fieldList is not deleted so
+     *           make sure to delete it when it is no longer needed. */
+    void
+    (*setEvent)(UA_Server *server,
+                void *hdbContext,
+                const UA_NodeId *originId,
+                const UA_NodeId *emitterId,
+                const UA_NodeId *eventId,
+                UA_Boolean willEventNodeBeDeleted,
+                const UA_EventFilter *historicalEventFilter,
+                UA_EventFieldList *fieldList);
+
     /* This function is called if a history read is requested with
      * isRawReadModified set to false. Setting it to NULL will result in a
      * response with statuscode UA_STATUSCODE_BADHISTORYOPERATIONUNSUPPORTED.
@@ -90,6 +121,22 @@ struct UA_HistoryDatabase {
                const UA_HistoryReadValueId *nodesToRead,
                UA_HistoryReadResponse *response,
                UA_HistoryModifiedData * const * const historyData);
+
+    /* No default implementation is provided by UA_HistoryDatabase_default
+     * for the following function */
+    void
+    (*readEvent)(UA_Server *server,
+               void *hdbContext,
+               const UA_NodeId *sessionId,
+               void *sessionContext,
+               const UA_RequestHeader *requestHeader,
+               const UA_ReadEventDetails *historyReadDetails,
+               UA_TimestampsToReturn timestampsToReturn,
+               UA_Boolean releaseContinuationPoints,
+               size_t nodesToReadSize,
+               const UA_HistoryReadValueId *nodesToRead,
+               UA_HistoryReadResponse *response,
+               UA_HistoryEvent * const * const historyData);
 
     /* No default implementation is provided by UA_HistoryDatabase_default
      * for the following function */

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -274,6 +274,11 @@ UA_StatusCode
 readWithReadValue(UA_Server *server, const UA_NodeId *nodeId,
                   const UA_AttributeId attributeId, void *v);
 
+UA_StatusCode
+readObjectProperty(UA_Server *server, const UA_NodeId objectId,
+                   const UA_QualifiedName propertyName,
+                   UA_Variant *value);
+
 UA_BrowsePathResult
 translateBrowsePathToNodeIds(UA_Server *server, const UA_BrowsePath *browsePath);
 

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1582,6 +1582,10 @@ Service_HistoryRead(UA_Server *server, UA_Session *session,
             }
             break;
         }
+        case UA_TYPES_READEVENTDETAILS:
+            historyDataType = &UA_TYPES[UA_TYPES_HISTORYEVENT];
+            readHistory = (UA_HistoryDatabase_readFunc)server->config.historyDatabase.readEvent;
+            break;
         case UA_TYPES_READPROCESSEDDETAILS:
             readHistory = (UA_HistoryDatabase_readFunc)server->config.historyDatabase.readProcessed;
             break;

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -601,9 +601,10 @@ __UA_Server_read(UA_Server *server, const UA_NodeId *nodeId,
 }
 
 UA_StatusCode
-UA_Server_readObjectProperty(UA_Server *server, const UA_NodeId objectId,
-                             const UA_QualifiedName propertyName,
-                             UA_Variant *value) {
+readObjectProperty(UA_Server *server, const UA_NodeId objectId,
+                   const UA_QualifiedName propertyName,
+                   UA_Variant *value) {
+    UA_LOCK_ASSERT(server->serviceMutex, 1);
     UA_RelativePathElement rpe;
     UA_RelativePathElement_init(&rpe);
     rpe.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY);
@@ -618,19 +619,27 @@ UA_Server_readObjectProperty(UA_Server *server, const UA_NodeId objectId,
     bp.relativePath.elements = &rpe;
 
     UA_StatusCode retval;
-    UA_LOCK(server->serviceMutex);
     UA_BrowsePathResult bpr = translateBrowsePathToNodeIds(server, &bp);
     if(bpr.statusCode != UA_STATUSCODE_GOOD || bpr.targetsSize < 1) {
         retval = bpr.statusCode;
         UA_BrowsePathResult_clear(&bpr);
-        UA_UNLOCK(server->serviceMutex);
         return retval;
     }
 
     retval = readWithReadValue(server, &bpr.targets[0].targetId.nodeId, UA_ATTRIBUTEID_VALUE, value);
-    UA_UNLOCK(server->serviceMutex);
 
     UA_BrowsePathResult_clear(&bpr);
+    return retval;
+}
+
+
+UA_StatusCode
+UA_Server_readObjectProperty(UA_Server *server, const UA_NodeId objectId,
+                             const UA_QualifiedName propertyName,
+                             UA_Variant *value) {
+    UA_LOCK(server->serviceMutex);
+    UA_StatusCode retval = readObjectProperty(server, objectId, propertyName, value);
+    UA_UNLOCK(server->serviceMutex);
     return retval;
 }
 


### PR DESCRIPTION
This PR adds two new methods to UA_HistoryDatabase: setEvent and readEvent.

It also adds readObjectProperty function which is then used in historical events' implementation. (UA_Server_readObjectProperty/readObjectProperty are now analogous to UA_Server_writeObjectProperty/writeObjectProperty).

Some notes:

1. OPC UA Part 11, clause 5.3.2 says: "A HistoricalEventNode that has Event history available will provide the Property [HistoricalEventFilter]". When an event is triggered the server tries to read the HistoricalEventFilter property of an emitting node (not the origin node) and if the property is present it filters the event object and passes results to setEvent (happens for each emitter). On readEvent the client's filter should be mapped to a filter contained in the HistoricalEventFilter to costruct results properly (ideally some utility function should be added for that).

2. It is possible to historize events without setting HistoricalEventFilter because setEvent is always called and it has eventId as a parameter.

3. willEventNodeBeDeleted is added for the following scenario:
users can implement a very simple in-memory event history database by leaving event nodes in the nodestore; on readEvent they can get the relevant nodes and filter them against a client's filter.

4. It may be justified to make UA_Server_filterEvent public to facilitate the use cases 2 and 3.
