### PR TITLE
Fix type of resuse and loopback options to UA_TYPES_BOOLEAN in tutorial_pubsub_connection.c example

### DIFF
--- a/examples/pubsub/tutorial_pubsub_connection.c
+++ b/examples/pubsub/tutorial_pubsub_connection.c
@@ -64,10 +64,10 @@ int main(void) {
     UA_Variant_setScalar(&connectionOptions[0].value, &ttl, &UA_TYPES[UA_TYPES_UINT32]);
     connectionOptions[1].key = UA_QUALIFIEDNAME(0, "loopback");
     UA_Boolean loopback = UA_FALSE;
-    UA_Variant_setScalar(&connectionOptions[1].value, &loopback, &UA_TYPES[UA_TYPES_UINT32]);
+    UA_Variant_setScalar(&connectionOptions[1].value, &loopback, &UA_TYPES[UA_TYPES_BOOLEAN]);
     connectionOptions[2].key = UA_QUALIFIEDNAME(0, "reuse");
     UA_Boolean reuse = UA_TRUE;
-    UA_Variant_setScalar(&connectionOptions[2].value, &reuse, &UA_TYPES[UA_TYPES_UINT32]);
+    UA_Variant_setScalar(&connectionOptions[2].value, &reuse, &UA_TYPES[UA_TYPES_BOOLEAN]);
     connectionConfig.connectionProperties = connectionOptions;
     connectionConfig.connectionPropertiesSize = 3;
     /* Create a new concrete connection and add the connection


### PR DESCRIPTION
The `resuse` and `loopback` options are defined as type UA_TYPES_UINT32 in the example, but in UA_PubSubChannelUDPMC_open [plugins/ua_pubsub_udp.c] are expected to be of type
BOOLEAN. Using UINT32 for either of them will cause the options not to
be evaluated and hence not used.