### PR TITLE
Included plugin/log.h cleanup in UA_Client_delete(..).

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -74,6 +74,13 @@ UA_ClientConfig_deleteMembers(UA_ClientConfig *config) {
         config->securityPolicies[i].clear(&config->securityPolicies[i]);
     UA_free(config->securityPolicies);
     config->securityPolicies = 0;
+
+    if (config->logger.context && config->logger.clear) {
+        config->logger.clear(config->logger.context);
+        config->logger.context = NULL;
+        config->logger.log = NULL;
+        config->logger.clear = NULL;
+    }
 }
 
 static void


### PR DESCRIPTION
The log plugin provides a cleanup routine which is not called in UA_Client_delete(..). Since automatic cleanup can be enabled/disabled by setting UA_Logger.clear function pointer, UA_Client_delete(..) should automatically cleanup the log plugin.