### PR TITLE
Solved issues related to SecurityToken renewal

### DIFF
--- a/src/server/ua_securechannel_manager.c
+++ b/src/server/ua_securechannel_manager.c
@@ -87,11 +87,6 @@ UA_SecureChannelManager_cleanupTimedOut(UA_SecureChannelManager *cm,
             removeSecureChannel(cm, entry);
             continue;
         }
-
-        /* Revolve the channel tokens */
-        if(entry->channel.nextSecurityToken.tokenId > 0) {
-            UA_SecureChannel_revolveTokens(&entry->channel);
-        }
     }
 }
 

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -1326,6 +1326,7 @@ checkSymHeader(UA_SecureChannel *const channel,
         if(channel->securityToken.tokenId == tokenId) {
             retval = UA_SecureChannel_generateRemoteKeys(channel, channel->securityPolicy);
             UA_ChannelSecurityToken_deleteMembers(&channel->previousSecurityToken);
+            UA_ChannelSecurityToken_init(&channel->previousSecurityToken);
             return retval;
         }
     }
@@ -1338,6 +1339,7 @@ checkSymHeader(UA_SecureChannel *const channel,
         UA_StatusCode retval =
             UA_SecureChannel_generateRemoteKeys(channel, channel->securityPolicy);
         UA_ChannelSecurityToken_deleteMembers(&channel->previousSecurityToken);
+        UA_ChannelSecurityToken_init(&channel->previousSecurityToken);
         return retval;
     }
 


### PR DESCRIPTION
* previousSecurityToken structure of UA_SecureChannel was not cleared
after generating the new remote symmetric key. This caused a server
to renew the remote key every time a message chunk was received. If
the client requested a renewal of the secure channel and new nonces
were exchanged, but the client continued to use the "old"
SecurityToken for some more message chunks the server generated a
remote key based on the new nonces when it should have used the key
of the current SecurityToken.
* UA_SecureChannelManager_cleanupTimedOut() changed currently used
SecurityToken to the next one if present. According to Part 4,
chapter 5.5.2 OpenSecureChannel the server shall use the existing
SecurityToken until it expires or the server receives a message
secured with the new SecurityToken. Hence, it shouldn't trigg itself
change the SecurityToken.
* Fixed issues in renew channel test cases of the client