### PR TITLE
Update pubsub_interrupt_publish.c

### DIFF
--- a/examples/pubsub_realtime/pubsub_interrupt_publish.c
+++ b/examples/pubsub_realtime/pubsub_interrupt_publish.c
@@ -219,7 +219,7 @@ UA_PubSubManager_changeRepeatedCallbackInterval(UA_Server *server,
     struct itimerspec timerspec;
     int resultTimerCreate = 0;
     pubIntervalNs = (UA_Int64) (interval_ms * MILLI_AS_NANO_SECONDS);
-    timerspec.it_interval.tv_sec = (long int) (pubIntervalNs % SECONDS_AS_NANO_SECONDS);
+    timerspec.it_interval.tv_sec = (long int) (pubIntervalNs / SECONDS_AS_NANO_SECONDS);
     timerspec.it_interval.tv_nsec = (long int) (pubIntervalNs % SECONDS_AS_NANO_SECONDS);
     timerspec.it_value.tv_sec = (long int) (pubIntervalNs / (SECONDS_AS_NANO_SECONDS));
     timerspec.it_value.tv_nsec = (long int) (pubIntervalNs % SECONDS_AS_NANO_SECONDS);


### PR DESCRIPTION
line 222: Comparing to line 186, the tv_sec should be second. so "%" is typo, should be replaced by "/". FYI.