### PR TITLE
Compability with generated types of UnifiedAutomation SDK

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -869,7 +869,7 @@ struct UA_DataType {
     UA_UInt32 overlayable      : 1;  /* The type has the identical memory layout
                                       * in memory and on the binary stream. */
     UA_UInt32 membersSize      : 8;  /* How many members does the type have? */
-    UA_UInt32 binaryEncodingId : 16; /* NodeId of datatype when encoded as binary */
+    UA_UInt32 binaryEncodingId;      /* NodeId of datatype when encoded as binary */
     //UA_UInt16  xmlEncodingId;      /* NodeId of datatype when encoded as XML */
     UA_DataTypeMember *members;
 };

--- a/tools/schema/datatypes_typedescription.txt
+++ b/tools/schema/datatypes_typedescription.txt
@@ -1,3 +1,5 @@
 StructureDefinition
 StructureField
 StructureType
+EnumDefinition
+EnumField


### PR DESCRIPTION
We observed generated binary encoding IDs that do not fit into an UA_UInt16, e.g. ns=2;i=543211 => Increasing UA_DataType.binaryEncodingId to UInt32.

In addition, added EnumDefinition and EnumField to decode datatype binary information (UA_ATTRIBUTEID_DATATYPEDEFINITION) from OPC UA servers.