### PR TITLE
Do not overwrite the UA_Client logger when using UA_ClientConfig_setD…

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -679,9 +679,11 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     config->timeout = 5000;
     config->secureChannelLifeTime = 10 * 60 * 1000; /* 10 minutes */
 
-    config->logger.log = UA_Log_Stdout_log;
-    config->logger.context = NULL;
-    config->logger.clear = UA_Log_Stdout_clear;
+    if(!config->logger.log) {
+       config->logger.log = UA_Log_Stdout_log;
+       config->logger.context = NULL;
+       config->logger.clear = UA_Log_Stdout_clear;
+    }
 
     config->localConnectionConfig = UA_ConnectionConfig_default;
 


### PR DESCRIPTION
…efault

Default logger is set in UA_Client_new(). If the logger is replaced after UA_Client creation to a custom logger, and UA_ClientConfig_setDefault(Encryption) is called, the custom logger is overwritten.