### PR TITLE
Compiler warnings while using Open62541 as library

### DIFF
--- a/include/open62541/plugin/log.h
+++ b/include/open62541/plugin/log.h
@@ -68,6 +68,10 @@ UA_LOG_TRACE(const UA_Logger *logger, UA_LogCategory category, const char *msg, 
     va_list args; va_start(args, msg);
     logger->log(logger->context, UA_LOGLEVEL_TRACE, category, msg, args);
     va_end(args);
+#else
+    (void) logger;
+    (void) category;
+    (void) msg;
 #endif
 }
 
@@ -79,6 +83,10 @@ UA_LOG_DEBUG(const UA_Logger *logger, UA_LogCategory category, const char *msg, 
     va_list args; va_start(args, msg);
     logger->log(logger->context, UA_LOGLEVEL_DEBUG, category, msg, args);
     va_end(args);
+#else
+    (void) logger;
+    (void) category;
+    (void) msg;
 #endif
 }
 
@@ -90,6 +98,10 @@ UA_LOG_INFO(const UA_Logger *logger, UA_LogCategory category, const char *msg, .
     va_list args; va_start(args, msg);
     logger->log(logger->context, UA_LOGLEVEL_INFO, category, msg, args);
     va_end(args);
+#else
+    (void) logger;
+    (void) category;
+    (void) msg;
 #endif
 }
 
@@ -101,6 +113,10 @@ UA_LOG_WARNING(const UA_Logger *logger, UA_LogCategory category, const char *msg
     va_list args; va_start(args, msg);
     logger->log(logger->context, UA_LOGLEVEL_WARNING, category, msg, args);
     va_end(args);
+#else
+    (void) logger;
+    (void) category;
+    (void) msg;
 #endif
 }
 
@@ -112,6 +128,10 @@ UA_LOG_ERROR(const UA_Logger *logger, UA_LogCategory category, const char *msg, 
     va_list args; va_start(args, msg);
     logger->log(logger->context, UA_LOGLEVEL_ERROR, category, msg, args);
     va_end(args);
+#else
+    (void) logger;
+    (void) category;
+    (void) msg;
 #endif
 }
 
@@ -123,6 +143,10 @@ UA_LOG_FATAL(const UA_Logger *logger, UA_LogCategory category, const char *msg, 
     va_list args; va_start(args, msg);
     logger->log(logger->context, UA_LOGLEVEL_FATAL, category, msg, args);
     va_end(args);
+#else
+    (void) logger;
+    (void) category;
+    (void) msg;
 #endif
 }
 


### PR DESCRIPTION
Hello,
while playing around with your cool project, we encountered a problem regarding the zero compiler warnings promise. When building the project as a library with a log-level other than 100 (set as part of the CMakeLists.txt line 129), the compiler creates warnings in the project using the open62541 library as the log-levels are realized by removing code via the use of macros. This possibly leaves empty functions that have a couple of unused arguments (source of this is the header file include.open62541.plugin/log.h). We solved this (quick&dirty) by adding an else case to the removal-macros that just 'touches' the variables. However, I did not check if the C++ optimizer is still able to remove the dead code section in production releases.
In addition, I would suggest to change the macro removal behavior to a better solution (e.g., using constexpr), but do not have the time to look into this in the near future. 
Thanks again for the cool project.