### PR TITLE
Fix the build error  when enable pub/sub support over Ethernet in VxWorks7

### DIFF
--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -3,14 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *   Copyright 2018 (c) Kontron Europe GmbH (Author: Rudolf Hoyler)
+ *   Copyright 2019 (c) Wind River Systems, Inc.
  */
 
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pubsub_ethernet.h>
 #include <open62541/util.h>
 
+#if defined(__vxworks) || defined(__VXWORKS__)
+#include <netpacket/packet.h>
+#include <netinet/if_ether.h>
+#define ETH_ALEN ETHER_ADDR_LEN
+#else
 #include <linux/if_packet.h>
 #include <netinet/ether.h>
+#endif
 
 #ifndef ETHERTYPE_UADP
 #define ETHERTYPE_UADP 0xb62c
@@ -175,7 +182,11 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
         UA_free(newChannel);
         return NULL;
     }
+#if defined(__vxworks) || defined(__VXWORKS__)
+    memcpy(channelDataEthernet->ifAddress, &ifreq.ifr_ifru.ifru_addr.sa_data, ETH_ALEN);
+#else
     memcpy(channelDataEthernet->ifAddress, &ifreq.ifr_hwaddr.sa_data, ETH_ALEN);
+#endif
 
     /* bind the socket to interface and ethertype */
     struct sockaddr_ll sll = { 0 };


### PR DESCRIPTION
UA PubSub Ethernet.c includes some Linux header files and macros. In VxWorks, these macros and header files are different from Linux. In this PR, I used VxWorks macros to implement different codes in different systems.