### PR TITLE
Fix: Error message in triggerConditionEvent

### DIFF
--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -2568,7 +2568,7 @@ UA_Server_triggerConditionEvent(UA_Server *server, const UA_NodeId condition,
     }
     else {
         UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_USERLAND,
-                       "Cannot trigger condition event when Retain is false. StatusCode %s", UA_StatusCode_name(retval));
+                       "Cannot trigger condition event when "CONDITION_FIELD_ENABLEDSTATE"."CONDITION_FIELD_TWOSTATEVARIABLE_ID" is false. StatusCode %s", UA_StatusCode_name(retval));
     }
 
     return retval;


### PR DESCRIPTION
As EnableState.Id is checked instead of the Retain when triggering a condition, I changed the error message.
https://github.com/open62541/open62541/blob/a2209072c72ed25918fbd00f19b14e491745a90b/src/server/ua_subscription_alarms_conditions.c#L2549-L2552

https://github.com/open62541/open62541/blob/a2209072c72ed25918fbd00f19b14e491745a90b/src/server/ua_subscription_alarms_conditions.c#L628