### PR TITLE
[REVIEW] Added possibility to configure max TCP connections limit

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -236,7 +236,6 @@ ServerNetworkLayerTCP_add(UA_ServerNetworkLayer *nl, ServerNetworkLayerTCP *laye
     /* Allocate and initialize the connection */
     ConnectionEntry *e = (ConnectionEntry*)UA_malloc(sizeof(ConnectionEntry));
     if(!e){
-        UA_close(newsockfd);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 

--- a/include/open62541/network_tcp.h
+++ b/include/open62541/network_tcp.h
@@ -13,6 +13,15 @@
 
 _UA_BEGIN_DECLS
 
+/* Initializes a TCP network layer.
+ *
+ * @param config The connection config.
+ * @param port The TCP port to listen to.
+ * @param maxConnections Maximum number of TCP connections this network layer
+ *                       instance is allowed to allocate. Set to 0 for unlimited
+ *                       number of connections.
+ * @param logger Pointer to a logger
+ * @return Returns the network layer instance */
 UA_ServerNetworkLayer UA_EXPORT
 UA_ServerNetworkLayerTCP(UA_ConnectionConfig config, UA_UInt16 port,
                          UA_UInt16 maxConnections, UA_Logger *logger);

--- a/include/open62541/network_tcp.h
+++ b/include/open62541/network_tcp.h
@@ -14,7 +14,8 @@
 _UA_BEGIN_DECLS
 
 UA_ServerNetworkLayer UA_EXPORT
-UA_ServerNetworkLayerTCP(UA_ConnectionConfig config, UA_UInt16 port, UA_Logger *logger);
+UA_ServerNetworkLayerTCP(UA_ConnectionConfig config, UA_UInt16 port,
+                         UA_UInt16 maxConnections, UA_Logger *logger);
 
 UA_Connection UA_EXPORT
 UA_ClientConnectionTCP(UA_ConnectionConfig config, const UA_String endpointUrl,

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -308,7 +308,7 @@ UA_ServerConfig_addNetworkLayerTCP(UA_ServerConfig *conf, UA_UInt16 portNumber,
         config.recvBufferSize = recvBufferSize;
 
     conf->networkLayers[conf->networkLayersSize] =
-        UA_ServerNetworkLayerTCP(config, portNumber, &conf->logger);
+        UA_ServerNetworkLayerTCP(config, portNumber, 0, &conf->logger);
     if (!conf->networkLayers[conf->networkLayersSize].handle)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     conf->networkLayersSize++;


### PR DESCRIPTION
In for example LWIP the number of TCP connection resources must be
configured at compile time. On a device with several protocols that
relies on TCP they must share this common pool of TCP resources. To
avoid one protocol allocating all TCP resources they must limit
themselfs in the number of TCP connections they allocate.