### PR TITLE
Various fixes for WebSocket layer

### DIFF
--- a/arch/network_ws.c
+++ b/arch/network_ws.c
@@ -171,8 +171,8 @@ callback_opcua(struct lws *wsi, enum lws_callback_reasons reason, void *user, vo
                     return -1;
                 }
                 UA_ByteString_deleteMembers(&entry->msg);
-                UA_free(entry);
                 SIMPLEQ_REMOVE_HEAD(&b->messages, next);
+                UA_free(entry);
             } while(!lws_send_pipe_choked(wsi));
 
             // process remaining messages

--- a/arch/network_ws.c
+++ b/arch/network_ws.c
@@ -92,6 +92,13 @@ ServerNetworkLayerWS_close(UA_Connection *connection) {
 static void
 freeConnection(UA_Connection *connection) {
     if(connection->handle) {
+        ConnectionUserData *userData = (ConnectionUserData *)connection->handle;
+        while(!SIMPLEQ_EMPTY(&userData->messages)) {
+            BufferEntry *entry = SIMPLEQ_FIRST(&userData->messages);
+            UA_ByteString_deleteMembers(&entry->msg);
+            SIMPLEQ_REMOVE_HEAD(&userData->messages, next);
+            UA_free(entry);
+        }
         UA_free(connection->handle);
     }
     UA_Connection_clear(connection);

--- a/arch/network_ws.c
+++ b/arch/network_ws.c
@@ -196,8 +196,25 @@ callback_opcua(struct lws *wsi, enum lws_callback_reasons reason, void *user, vo
             if(!layer->server)
                 break;
 
-            UA_ByteString message = {len, (UA_Byte *)in};
-            UA_Server_processBinaryMessage(layer->server, pss->connection, &message);
+            if(pss->connection->incompleteChunk.length == 0) {
+                UA_ByteString message = {len, (UA_Byte *)in};
+                UA_Server_processBinaryMessage(layer->server, pss->connection, &message);
+            } else {
+                UA_ByteString message = pss->connection->incompleteChunk;
+                pss->connection->incompleteChunk = UA_BYTESTRING_NULL;
+                UA_Byte *t = (UA_Byte*)UA_realloc(message.data, message.length + len);
+                if(!t) {
+                    UA_ByteString_deleteMembers(&message);
+                    return -1;
+                }
+                memcpy(&t[message.length], in, len);
+                message.data = t;
+                message.length += len;
+
+                UA_Server_processBinaryMessage(layer->server, pss->connection, &message);
+
+                connection_releaserecvbuffer(pss->connection, &message);
+            }
             break;
 
         default:


### PR DESCRIPTION
1. Fix memory access after free
2. Clean up message queue on connection free
3. Prepend the incomplete chunk in WebSocket layer

The last fix is necessary because the following code is actually broken (an issue will be created) https://github.com/open62541/open62541/blob/d02fc4f5a4b60bb30a3c9394643abdd93b1fd59c/src/ua_connection.c#L171-L174