### PR TITLE
Pull OPN decoding/encoding in the client/server layer

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -384,7 +384,7 @@ receiveServiceResponse(UA_Client *client, void *response, const UA_DataType *res
             UA_Client_disconnect(client);
             break;
         }
-    } while(!rd.received);
+    } while(!rd.received && responseType); /* Return if we don't wait for an async response */
     return retval;
 }
 

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -262,9 +262,15 @@ processServiceResponse(void *application, UA_SecureChannel *channel,
                        const UA_ByteString *message) {
     SyncResponseDescription *rd = (SyncResponseDescription*)application;
 
+    /* Process undecoded OPN forwarded from the SecureChannel */
+    if(messageType == UA_MESSAGETYPE_OPN) {
+        decodeProcessOPNResponseAsync(rd->client, &rd->client->channel,
+                                      messageType, requestId, message);
+        return;
+    }
+
     /* Must be OPN or MSG */
-    if(messageType != UA_MESSAGETYPE_OPN &&
-       messageType != UA_MESSAGETYPE_MSG) {
+    if(messageType != UA_MESSAGETYPE_MSG) {
         UA_LOG_TRACE_CHANNEL(&rd->client->config.logger, channel,
                              "Invalid message type");
         return;

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -184,12 +184,12 @@ openSecureChannel(UA_Client *client, UA_Boolean renew) {
     opnSecRq.requestHeader.authenticationToken = client->authenticationToken;
     if(renew) {
         opnSecRq.requestType = UA_SECURITYTOKENREQUESTTYPE_RENEW;
-        UA_LOG_DEBUG(&client->config.logger, UA_LOGCATEGORY_SECURECHANNEL,
-                     "Requesting to renew the SecureChannel");
+        UA_LOG_DEBUG_CHANNEL(&client->config.logger, &client->channel,
+                             "Requesting to renew the SecureChannel");
     } else {
         opnSecRq.requestType = UA_SECURITYTOKENREQUESTTYPE_ISSUE;
-        UA_LOG_DEBUG(&client->config.logger, UA_LOGCATEGORY_SECURECHANNEL,
-                     "Requesting to open a SecureChannel");
+        UA_LOG_DEBUG_CHANNEL(&client->config.logger, &client->channel,
+                             "Requesting to open a SecureChannel");
     }
 
     /* Set the securityMode to input securityMode from client data */

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -212,6 +212,11 @@ UA_StatusCode
 processOPNResponseAsync(void *application, UA_Connection *connection,
                         UA_ByteString *chunk);
 
+void
+decodeProcessOPNResponseAsync(void *application, UA_SecureChannel *channel,
+                              UA_MessageType messageType, UA_UInt32 requestId,
+                              const UA_ByteString *msg);
+
 UA_StatusCode
 openSecureChannel(UA_Client *client, UA_Boolean renew);
 

--- a/src/ua_connection.c
+++ b/src/ua_connection.c
@@ -147,16 +147,22 @@ processChunk(UA_Connection *connection, void *application,
     if(chunk_length < 16 || chunk_length > connection->config.recvBufferSize)
         return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;
 
-    /* Have an the complete chunk */
+    /* Incomplete chunk */
     if(chunk_length > remaining) {
         *done = true;
         return UA_STATUSCODE_GOOD;
     }
 
+    *done = false;
+
+    /* Buffer everything after the OPN message: Process in the next
+     * iteration. */
+    if(msgtype == UA_MESSAGETYPE_OPN)
+        *done = true;
+
     /* Process the chunk; forward the position pointer */
     temp.length = chunk_length;
     *posp += chunk_length;
-    *done = false;
     return processCallback(application, connection, &temp);
 }
 

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -300,6 +300,12 @@ encodeHeadersSym(UA_MessageContext *const messageContext, size_t totalLength) {
 
     UA_SymmetricAlgorithmSecurityHeader symSecHeader;
     symSecHeader.tokenId = channel->securityToken.tokenId;
+    /* This is a server SecureChannel and we have sent out the OPN response but
+     * not gotten a request with the new token. So we want to send with
+     * nextSecurityToken and still allow to receive with the old one. */
+    if(channel->nextSecurityToken.tokenId != 0)
+        symSecHeader.tokenId = channel->nextSecurityToken.tokenId;
+
     res |= UA_encodeBinary(&symSecHeader.tokenId,
                            &UA_TRANSPORT[UA_TRANSPORT_SYMMETRICALGORITHMSECURITYHEADER],
                            &header_pos, &messageContext->buf_end, NULL, NULL);
@@ -711,8 +717,6 @@ decryptAddChunk(UA_SecureChannel *channel, const UA_ByteString *chunk,
         (messageHeader.messageHeader.messageTypeAndChunkType & UA_BITMASK_MESSAGETYPE);
     UA_ChunkType chunkType = (UA_ChunkType)
         (messageHeader.messageHeader.messageTypeAndChunkType & UA_BITMASK_CHUNKTYPE);
-    UA_UInt32 requestId = 0;
-    UA_UInt32 sequenceNumber = 0;
     UA_ByteString chunkPayload;
 
     switch(messageType) {
@@ -722,7 +726,7 @@ decryptAddChunk(UA_SecureChannel *channel, const UA_ByteString *chunk,
             return UA_STATUSCODE_BADTCPMESSAGETYPEINVALID;
         chunkPayload.length = chunk->length - offset;
         chunkPayload.data = chunk->data + offset;
-        return putPayload(channel, requestId, messageType, chunkType, &chunkPayload);
+        return putPayload(channel, 0, messageType, chunkType, &chunkPayload);
 
         /* MSG and CLO: Symmetric encryption */
     case UA_MESSAGETYPE_MSG:
@@ -744,6 +748,8 @@ decryptAddChunk(UA_SecureChannel *channel, const UA_ByteString *chunk,
         if(retval != UA_STATUSCODE_GOOD)
             return retval;
 
+        UA_UInt32 requestId = 0;
+        UA_UInt32 sequenceNumber = 0;
         retval = decryptAndVerifyChunk(channel, &channel->securityPolicy->symmetricModule.cryptoModule,
                                        messageType, chunk, offset, &requestId, &sequenceNumber, &chunkPayload);
         if(retval != UA_STATUSCODE_GOOD)
@@ -766,32 +772,7 @@ decryptAddChunk(UA_SecureChannel *channel, const UA_ByteString *chunk,
         if(chunkType != UA_CHUNKTYPE_FINAL)
             return UA_STATUSCODE_BADTCPMESSAGETYPEINVALID;
 
-        /* Decode the asymmetric algorithm security header and call the callback
-         * to perform checks. */
-        UA_AsymmetricAlgorithmSecurityHeader asymHeader;
-        UA_AsymmetricAlgorithmSecurityHeader_init(&asymHeader);
-        offset = UA_SECURE_CONVERSATION_MESSAGE_HEADER_LENGTH;
-        retval = UA_AsymmetricAlgorithmSecurityHeader_decodeBinary(chunk, &offset, &asymHeader);
-        if(retval != UA_STATUSCODE_GOOD)
-            return retval;
-
-        retval = checkAsymHeader(channel, &asymHeader);
-        UA_AsymmetricAlgorithmSecurityHeader_deleteMembers(&asymHeader);
-        if(retval != UA_STATUSCODE_GOOD)
-            return retval;
-
-        retval = decryptAndVerifyChunk(channel, &channel->securityPolicy->asymmetricModule.cryptoModule,
-                                       messageType, chunk, offset, &requestId, &sequenceNumber, &chunkPayload);
-        if(retval != UA_STATUSCODE_GOOD)
-            return retval;
-
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-        retval = processSequenceNumberAsym(channel, sequenceNumber);
-        if(retval != UA_STATUSCODE_GOOD)
-            return retval;
-#endif
-
-        return putPayload(channel, requestId, messageType, chunkType, &chunkPayload);
+        return putPayload(channel, 0, messageType, chunkType, (UA_ByteString*)(uintptr_t)chunk);
     }
 
         /* Invalid message type */

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -615,7 +615,7 @@ UA_SecureChannel_processCompleteMessages(UA_SecureChannel *channel, void *applic
 
 /* Sets the payload to a pointer inside the chunk buffer. Returns the requestId
  * and the sequenceNumber */
-static UA_StatusCode
+UA_StatusCode
 decryptAndVerifyChunk(const UA_SecureChannel *channel,
                       const UA_SecurityPolicyCryptoModule *cryptoModule,
                       UA_MessageType messageType, const UA_ByteString *chunk,

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -232,6 +232,15 @@ void
 hideBytesAsym(const UA_SecureChannel *channel, UA_Byte **buf_start,
               const UA_Byte **buf_end);
 
+/* Sets the payload to a pointer inside the chunk buffer. Returns the requestId
+ * and the sequenceNumber */
+UA_StatusCode
+decryptAndVerifyChunk(const UA_SecureChannel *channel,
+                      const UA_SecurityPolicyCryptoModule *cryptoModule,
+                      UA_MessageType messageType, const UA_ByteString *chunk,
+                      size_t offset, UA_UInt32 *requestId,
+                      UA_UInt32 *sequenceNumber, UA_ByteString *payload);
+
 size_t
 calculateAsymAlgSecurityHeaderLength(const UA_SecureChannel *channel);
 


### PR DESCRIPTION
This clears up the control flow for OPN messages.
They are simply forwarded to the client/server layer.

This is preparatory work for more cleanup in the client.