### PR TITLE
[REVIEW] Fix(nc): Enable child nodes of method nodes with UA_ENABLE_METHODCALLS

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -238,7 +238,7 @@ _UA_END_DECLS
                     writec("\n".join(code_global))
                     writec("\n")
                 writec("\nstatic UA_StatusCode function_" + outfilebase + "_" + str(functionNumber) + "_begin(UA_Server *server, UA_UInt16* ns) {")
-                if isinstance(node, MethodNode):
+                if isinstance(node, MethodNode) or isinstance(node.parent, MethodNode):
                     writec("#ifdef UA_ENABLE_METHODCALLS")
                 writec(code)
 
@@ -259,7 +259,7 @@ _UA_END_DECLS
 
         writec("return retVal;")
 
-        if isinstance(node, MethodNode):
+        if isinstance(node, MethodNode) or isinstance(node.parent, MethodNode):
             writec("#else")
             writec("return UA_STATUSCODE_GOOD;")
             writec("#endif /* UA_ENABLE_METHODCALLS */")
@@ -267,10 +267,10 @@ _UA_END_DECLS
 
         writec("\nstatic UA_StatusCode function_" + outfilebase + "_" + str(functionNumber) + "_finish(UA_Server *server, UA_UInt16* ns) {")
 
-        if isinstance(node, MethodNode):
+        if isinstance(node, MethodNode) or isinstance(node.parent, MethodNode):
             writec("#ifdef UA_ENABLE_METHODCALLS")
         writec("return " + generateNodeCode_finish(node))
-        if isinstance(node, MethodNode):
+        if isinstance(node, MethodNode) or isinstance(node.parent, MethodNode):
             writec("#else")
             writec("return UA_STATUSCODE_GOOD;")
             writec("#endif /* UA_ENABLE_METHODCALLS */")


### PR DESCRIPTION
Child nodes of methods nodes are not affected by the
UA_ENABLE_METHODCALLS in nodesets compiled by the
nodeset_compiler.py.
If UA_ENABLE_METHODCALLS is not set, the method nodes won't be
created but child nodes of the method nodes will. These child nodes
will fail during initialization as their parent node doesn't exist.

An example of this in Opc.Ua.NodeSet2.Reduced.xml is the
GetMonitoredItems node that has two child nodes; OutputArguments and
InputArguments.

This change makes child nodes of method nodes to only be initialized
if UA_ENABLE_METHODCALLS is defined.