### PR TITLE
support multiple conditions

### DIFF
--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -2251,22 +2251,23 @@ UA_Server_createCondition(UA_Server *server,
     /* create HasCondition Reference (HasCondition should be forward from the ConditionSourceNode to the Condition.
      * else, HasCondition should be forward from the ConditionSourceNode to the ConditionType Node) */
     UA_NodeId nodIdNull = UA_NODEID_NULL;
-    UA_ExpandedNodeId hasConditionTarget;
     if(!UA_NodeId_equal(&hierarchialReferenceType, &nodIdNull)) {
-        hasConditionTarget = UA_EXPANDEDNODEID_NUMERIC(newNodeId.namespaceIndex, newNodeId.identifier.numeric);
+        UA_ExpandedNodeId expandedNewNodeId = UA_EXPANDEDNODEID_NUMERIC(newNodeId.namespaceIndex, newNodeId.identifier.numeric);
 
         /* create hierarchical Reference to ConditionSource to expose the ConditionNode in Address Space */
         retval = UA_Server_addReference(server, conditionSource, hierarchialReferenceType,
-                                        UA_EXPANDEDNODEID_NUMERIC(newNodeId.namespaceIndex, newNodeId.identifier.numeric), true);// only Check hierarchialReferenceType
+                                        expandedNewNodeId, true);// only Check hierarchialReferenceType
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Creating hierarchical Reference to ConditionSource failed",);
-    }
-    else
-        hasConditionTarget = UA_EXPANDEDNODEID_NUMERIC(conditionType.namespaceIndex, conditionType.identifier.numeric);
 
-    UA_NodeId hasConditionId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCONDITION);
-    retval = UA_Server_addReference(server, conditionSource, hasConditionId,
-                                    hasConditionTarget, true);
-    CONDITION_ASSERT_RETURN_RETVAL(retval, "Creating HasCondition Reference failed",);
+        retval = UA_Server_addReference(server, conditionSource, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCONDITION),
+                                        expandedNewNodeId, true);
+        CONDITION_ASSERT_RETURN_RETVAL(retval, "Creating HasCondition Reference failed",);
+    }
+    else {
+        retval = UA_Server_addReference(server, conditionSource, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCONDITION),
+                                        UA_EXPANDEDNODEID_NUMERIC(conditionType.namespaceIndex, conditionType.identifier.numeric), true);
+        CONDITION_ASSERT_RETURN_RETVAL(retval, "Creating HasCondition Reference failed",);
+    }
 
     /* Set standard fields */
     retval = setStandardConditionFields(server, &newNodeId, &conditionType,

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -509,11 +509,11 @@ updateConditionLastEventId(UA_Server *server,
                         UA_ByteString_deleteMembers(&conditionBranchEntryTmp->lastEventId);
                         return UA_ByteString_copy(lastEventId, &conditionBranchEntryTmp->lastEventId);
                     }
+                    else { // TODO update condition branch
+                        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Condition Branch not implemented");
+                        return UA_STATUSCODE_BADNOTFOUND;
+                    }
                 }
-            }
-            else { // TODO update condition branch
-                UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND,"Condition Branch not implemented");
-                return UA_STATUSCODE_BADNOTFOUND;
             }
         }
     }
@@ -542,11 +542,11 @@ setIsCallerAC(UA_Server *server,
                         conditionBranchEntryTmp->isCallerAC = isCallerAC;
                         return;
                     }
+                    else {// TODO condition branch
+                        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Condition Branch not implemented");
+                        return;
+                    }
                 }
-            }
-            else {// TODO condition branch
-                UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Condition Branch not implemented");
-                return;
             }
         }
     }
@@ -574,11 +574,11 @@ isConditionOrBranch(UA_Server *server,
                           *isCallerAC = conditionBranchEntryTmp->isCallerAC;
                           return true;
                         }
+                        else {
+                            UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Condition Branch not implemented");
+                            return false;
+                        }
                     }
-            }
-            else {
-                UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Condition Branch not implemented");
-                return false;
             }
         }
     }

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -2266,7 +2266,8 @@ UA_Server_createCondition(UA_Server *server,
     else {
         retval = UA_Server_addReference(server, conditionSource, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCONDITION),
                                         UA_EXPANDEDNODEID_NUMERIC(conditionType.namespaceIndex, conditionType.identifier.numeric), true);
-        CONDITION_ASSERT_RETURN_RETVAL(retval, "Creating HasCondition Reference failed",);
+        if(retval != UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED)
+            CONDITION_ASSERT_RETURN_RETVAL(retval, "Creating HasCondition Reference failed",);
     }
 
     /* Set standard fields */


### PR DESCRIPTION
I was not able to add multiple (unexposed) conditions. One problem was an error in the handling/detection of condition branches.
The more difficult problem occurs when adding unexposed conditions with the same condition source. In this case, we have to make sure that a HASCONDITION reference is only added once from the condition source to the condition type. I did not found a way to check if this reference already exists. Therefore I just ignore this error.