### PR TITLE
fix(server): Do not overwrite logger in default server config

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -119,7 +119,10 @@ setDefaultConfig(UA_ServerConfig *conf) {
 
     /* --> Start setting the default static config <-- */
     conf->nThreads = 1;
-    conf->logger = UA_Log_Stdout_;
+
+    /* Allow user to set his own logger */
+    if (!conf->logger.log)
+        conf->logger = UA_Log_Stdout_;
 
     conf->shutdownDelay = 0.0;
 


### PR DESCRIPTION
The user may want to set his own logger even before any output is generated.