### PR TITLE
Example client_encryption ignored invalid certificates

### DIFF
--- a/examples/encryption/client_encryption.c
+++ b/examples/encryption/client_encryption.c
@@ -44,10 +44,16 @@ int main(int argc, char* argv[]) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig *cc = UA_Client_getConfig(client);
     cc->securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
-    UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
+    UA_StatusCode retval = UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
                                          trustList, trustListSize,
                                          revocationList, revocationListSize);
-
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                    "Failed to set encryption." );
+        UA_Client_delete(client);
+        return EXIT_FAILURE;
+    }
+    
     UA_ByteString_clear(&certificate);
     UA_ByteString_clear(&privateKey);
     for(size_t deleteCount = 0; deleteCount < trustListSize; deleteCount++) {
@@ -56,7 +62,7 @@ int main(int argc, char* argv[]) {
 
     /* Secure client connect */
     cc->securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT; /* require encryption */
-    UA_StatusCode retval = UA_Client_connect(client, endpointUrl);
+    retval = UA_Client_connect(client, endpointUrl);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_Client_delete(client);
         return EXIT_FAILURE;


### PR DESCRIPTION
Example client_encryption: If one of the specified certificate files is in wrong format, the example ignored this and continued with policy #None

Unfortunately this does only write a short error message.  
The real error comes from `UA_CertificateVerification_Trustlist`, but even with full trace, it does not reveal which certifiate fails.  
Neither does it say anything about other parts of `UA_ClientConfig_setDefaultEncryption` failing which may lead to the same situation.

Signed-off-by: Kjeld Flarup <kfa@deif.com>