### PR TITLE
fix(client): Correctly set endpointUrl in HEL Message

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -84,7 +84,7 @@ HelAckHandshake(UA_Client *client, const UA_String endpointUrl) {
     hello.sendBufferSize = client->config.localConnectionConfig.sendBufferSize;
     hello.maxMessageSize = client->config.localConnectionConfig.localMaxMessageSize;
     hello.maxChunkCount = client->config.localConnectionConfig.localMaxChunkCount;
-    hello.endpointUrl = client->endpointUrl;
+    hello.endpointUrl = endpointUrl;
 
     UA_Byte *bufPos = &message.data[8]; /* skip the header */
     const UA_Byte *bufEnd = &message.data[message.length];


### PR DESCRIPTION
There is currently an inconsistency. The client->endpointUrl variable is only used for the async connect. This is just a quick-fix.

Fixup for #3390 See:
https://github.com/open62541/open62541/commit/e93f8ebb698a1dd957952e68b15e09f0e4303ebe#diff-096258576a8c3ac7adc8daaf14b817e2L83