### PR TITLE
Server should only set source timestamp for valuesource data variables

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1172,20 +1172,20 @@ writeValueAttribute(UA_Server *server, UA_Session *session,
         }
     }
 
-    /* Set the source timestamp if there is none */
-    UA_DateTime now = UA_DateTime_now();
-    if(!adjustedValue.hasSourceTimestamp) {
-        adjustedValue.sourceTimestamp = now;
-        adjustedValue.hasSourceTimestamp = true;
-    }
-
-    if(!adjustedValue.hasServerTimestamp) {
-        adjustedValue.serverTimestamp = now;
-        adjustedValue.hasServerTimestamp = true;
-    }
-
     /* Ok, do it */
     if(node->valueSource == UA_VALUESOURCE_DATA) {
+        /* Set the source timestamp if there is none */
+        UA_DateTime now = UA_DateTime_now();
+        if(!adjustedValue.hasSourceTimestamp) {
+            adjustedValue.sourceTimestamp = now;
+            adjustedValue.hasSourceTimestamp = true;
+        }
+
+        if(!adjustedValue.hasServerTimestamp) {
+            adjustedValue.serverTimestamp = now;
+            adjustedValue.hasServerTimestamp = true;
+        }
+
         if(!rangeptr)
             retval = writeValueAttributeWithoutRange(node, &adjustedValue);
         else


### PR DESCRIPTION
According to the specification, a server that can't handle source
timestamps must reject a write request that include timestamps
according to the specification.
Part 4, chapter 5.10.4.2, value description:
"If the SourceTimestamp or the ServerTimestamp is specified, the
Server shall use these values. The Server returns a
Bad_WriteNotSupported error if it does not support writing of
timestamps."

An application that cannot handle source timestamps and maps its
parameters to OPC variable nodes using the data source callbacks
should reject requests that contain source timestamps. Right now such
implementations reject all write requests as the server
implementation adds the source timestamp if omitted by the client.