### PR TITLE
build(openbsd): compile options

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -10,7 +10,7 @@ if (${_index} GREATER -1 OR "${UA_ARCHITECTURE}" STREQUAL "posix")
 
 
     if("${UA_ARCHITECTURE}" STREQUAL "posix")
-        if(NOT CYGWIN AND NOT QNXNTO AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD"))
+        if(NOT CYGWIN AND NOT QNXNTO)
             ua_architecture_add_definitions(-Wshadow -Wconversion -fvisibility=hidden -fPIC)
         endif()
 


### PR DESCRIPTION
Special compiler flags for OpenBSD are no longer necessary.  The
system compiler is now clang, and the default options used for other
operating systems work fine.  On OpenBSD everything is compiled
with PIC anyway to allow random address layout.  The current logic
was implemented in 4fbef714474d80ea9f9c443ec03890c408c11c32 with
the commit message "try building as rpm" which makes no sense.