### PR TITLE
Kludge to hook calls to default logger (UA_Logger_Stdout_). Users can…

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -43,7 +43,7 @@ UA_Server_new() {
     UA_ServerConfig config;
     memset(&config, 0, sizeof(UA_ServerConfig));
     /* Set a default logger and NodeStore for the initialization */
-    config.logger = UA_Log_Stdout_;
+    config.logger = *UA_Log_Stdout;
     UA_Nodestore_HashMap(&config.nodestore);
     return UA_Server_newWithConfig(&config);
 }
@@ -124,7 +124,7 @@ setDefaultConfig(UA_ServerConfig *conf) {
 
     /* Allow user to set his own logger */
     if (!conf->logger.log)
-        conf->logger = UA_Log_Stdout_;
+        conf->logger = *UA_Log_Stdout;
 
     conf->shutdownDelay = 0.0;
 
@@ -666,9 +666,7 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
 UA_Client * UA_Client_new() {
     UA_ClientConfig config;
     memset(&config, 0, sizeof(UA_ClientConfig));
-    config.logger.log = UA_Log_Stdout_log;
-    config.logger.context = NULL;
-    config.logger.clear = UA_Log_Stdout_clear;
+    config.logger = *UA_Log_Stdout;
     return UA_Client_newWithConfig(&config);
 }
 
@@ -683,9 +681,7 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     config->secureChannelLifeTime = 10 * 60 * 1000; /* 10 minutes */
 
     if(!config->logger.log) {
-       config->logger.log = UA_Log_Stdout_log;
-       config->logger.context = NULL;
-       config->logger.clear = UA_Log_Stdout_clear;
+       config->logger = *UA_Log_Stdout;
     }
 
     config->localConnectionConfig = UA_ConnectionConfig_default;


### PR DESCRIPTION
Hi,
it seems that log redirection is still incomplete. E.g. in my environment (linux) I can successfully intercept most server messages, but some are still generated internally by using the default logger directly (or, worst, by calling **UA_Log_Stdout_log** function directly). This is bad for my application, since I need to collect all messages consistently. So I modified the way the library initializes client and server configurations in such a way that I can redirect the logger by assigning address of my custom **UA_Logger** structure to global pointer **UA_Logger_Stdout**. I am aware that this is a temporary solution (e.g. in general it isn't clean for a library to expose global variables, a registration functon would be better), but solved my problem.
I hope it could help.
Regards