### PR TITLE
Extended the access control plugin with check for browsing nodes

### DIFF
--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -88,6 +88,11 @@ struct UA_AccessControl {
     UA_Boolean (*allowDeleteReference)(UA_Server *server, UA_AccessControl *ac,
                                        const UA_NodeId *sessionId, void *sessionContext,
                                        const UA_DeleteReferencesItem *item);
+
+    /* Allow browsing a node */
+    UA_Boolean (*allowBrowseNode)(UA_Server *server, UA_AccessControl *ac,
+                                  const UA_NodeId *sessionId, void *sessionContext,
+                                  const UA_NodeId *nodeId, void *nodeContext);
 #ifdef UA_ENABLE_HISTORIZING
     /* Allow insert,replace,update of historical data */
     UA_Boolean (*allowHistoryUpdateUpdateData)(UA_Server *server, UA_AccessControl *ac,

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -168,6 +168,13 @@ allowDeleteReference_default(UA_Server *server, UA_AccessControl *ac,
     return true;
 }
 
+static UA_Boolean
+allowBrowseNode_default(UA_Server *server, UA_AccessControl *ac,
+                        const UA_NodeId *sessionId, void *sessionContext,
+                        const UA_NodeId *nodeId, void *nodeContext) {
+    return true;
+}
+
 #ifdef UA_ENABLE_HISTORIZING
 static UA_Boolean
 allowHistoryUpdateUpdateData_default(UA_Server *server, UA_AccessControl *ac,
@@ -229,6 +236,7 @@ UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
     ac->getUserExecutableOnObject = getUserExecutableOnObject_default;
     ac->allowAddNode = allowAddNode_default;
     ac->allowAddReference = allowAddReference_default;
+    ac->allowBrowseNode = allowBrowseNode_default;
 
 #ifdef UA_ENABLE_HISTORIZING
     ac->allowHistoryUpdateUpdateData = allowHistoryUpdateUpdateData_default;

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -562,6 +562,14 @@ browseWithContinuation(UA_Server *server, UA_Session *session,
         return true;
     }
 
+    if(!server->config.accessControl.allowBrowseNode(server, &server->config.accessControl,
+                                                     &session->sessionId, session->sessionHandle,
+                                                     &descr->nodeId, node->context)) {
+        result->statusCode = UA_STATUSCODE_BADUSERACCESSDENIED;
+        UA_NODESTORE_RELEASE(server, node);
+        return true;
+    }
+
     RefResult rr;
     result->statusCode = RefResult_init(&rr);
     if(result->statusCode != UA_STATUSCODE_GOOD) {

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -562,7 +562,7 @@ browseWithContinuation(UA_Server *server, UA_Session *session,
         return true;
     }
 
-    if(session != server->adminSession &&
+    if(session != &server->adminSession &&
        !server->config.accessControl.allowBrowseNode(server, &server->config.accessControl,
                                                      &session->sessionId, session->sessionHandle,
                                                      &descr->nodeId, node->context)) {

--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -562,7 +562,8 @@ browseWithContinuation(UA_Server *server, UA_Session *session,
         return true;
     }
 
-    if(!server->config.accessControl.allowBrowseNode(server, &server->config.accessControl,
+    if(session != server->adminSession &&
+       !server->config.accessControl.allowBrowseNode(server, &server->config.accessControl,
                                                      &session->sessionId, session->sessionHandle,
                                                      &descr->nodeId, node->context)) {
         result->statusCode = UA_STATUSCODE_BADUSERACCESSDENIED;


### PR DESCRIPTION
The PermissionType (Part 3) defines 17 permissions. Currently the
access control plugin can control all but 2 of them. Those are Browse
and ReceiveEvents. This change adds check for browse permission of
nodes.