### PR TITLE
[WIP] Async operations overhaul

### DIFF
--- a/examples/tutorial_server_method_async.c
+++ b/examples/tutorial_server_method_async.c
@@ -178,16 +178,20 @@ THREAD_CALLBACK(ThreadWorker) {
     while(running) {
         UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                     "Try to dequeue an async operation");
-        const UA_AsyncOperationRequest* request = NULL;
+        const UA_CallMethodRequest *request = NULL;
         void *context = NULL;
-        UA_AsyncOperationType type;
-        if(UA_Server_getAsyncOperationNonBlocking(globalServer, &type, &request, &context, NULL) == true) {
-            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "AsyncMethod_Testing: Got entry: OKAY");
-            UA_CallMethodResult response = UA_Server_call(globalServer, &request->callMethodRequest);
-            UA_Server_setAsyncOperationResult(globalServer, (UA_AsyncOperationResponse*)&response,
-                                              context);
-            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "AsyncMethod_Testing: Call done: OKAY");
-            UA_CallMethodResult_clear(&response);
+        const UA_DataType *type;
+        if(UA_Server_getAsyncOperationNonBlocking(globalServer, &type, (const void**)&request, &context, NULL) == true) {
+            if (type == &UA_TYPES[UA_TYPES_CALLMETHODREQUEST]) {
+                UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "AsyncMethod_Testing: Got entry: OKAY");
+                UA_CallMethodResult response = UA_Server_call(globalServer, request);
+                UA_Server_setAsyncOperationResult(globalServer, &response,
+                                                  context);
+                UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "AsyncMethod_Testing: Call done: OKAY");
+                UA_CallMethodResult_clear(&response);
+            } else {
+                UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "AsyncMethod_Testing: Not supported");
+            }
         } else {
             /* not a good style, but done for simplicity :-) */
             Sleep(5000);

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1508,25 +1508,6 @@ UA_StatusCode UA_EXPORT
 UA_Server_setMethodNodeAsync(UA_Server *server, const UA_NodeId id,
                              UA_Boolean isAsync);
 
-typedef enum {
-    UA_ASYNCOPERATIONTYPE_INVALID, /* 0, the default */
-    UA_ASYNCOPERATIONTYPE_CALL
-    /* UA_ASYNCOPERATIONTYPE_READ, */
-    /* UA_ASYNCOPERATIONTYPE_WRITE, */
-} UA_AsyncOperationType;
-
-typedef union {
-    UA_CallMethodRequest callMethodRequest;
-    /* UA_ReadValueId readValueId; */
-    /* UA_WriteValue writeValue; */
-} UA_AsyncOperationRequest;
-
-typedef union {
-    UA_CallMethodResult callMethodResult;
-    /* UA_DataValue readResult; */
-    /* UA_StatusCode writeResult; */
-} UA_AsyncOperationResponse;
-
 /* Get the next async operation without blocking
  *
  * @param server The server object
@@ -1538,8 +1519,8 @@ typedef union {
  *        be set in UA_Server_setAsyncOperationResult in any case.
  * @return false if queue is empty, true else */
 UA_Boolean UA_EXPORT
-UA_Server_getAsyncOperationNonBlocking(UA_Server *server, UA_AsyncOperationType *type,
-                                       const UA_AsyncOperationRequest **request,
+UA_Server_getAsyncOperationNonBlocking(UA_Server *server, const UA_DataType **requestType,
+                                       const void **request,
                                        void **context, UA_DateTime *timeout);
 
 /* UA_Boolean UA_EXPORT */
@@ -1552,16 +1533,16 @@ UA_Server_getAsyncOperationNonBlocking(UA_Server *server, UA_AsyncOperationType 
  * @param server The server object
  * @param response Pointer to the operation result
  * @param context Pointer to the operation context */
-void UA_EXPORT
+UA_StatusCode UA_EXPORT
 UA_Server_setAsyncOperationResult(UA_Server *server,
-                                  const UA_AsyncOperationResponse *response,
+                                  const void *response,
                                   void *context);
 
 /* Get the next async operation. Attention! This method is deprecated and has
  * been replaced by UA_Server_getAsyncOperationNonBlocking! */
 UA_DEPRECATED UA_Boolean UA_EXPORT
-UA_Server_getAsyncOperation(UA_Server *server, UA_AsyncOperationType *type,
-                            const UA_AsyncOperationRequest **request,
+UA_Server_getAsyncOperation(UA_Server *server, const UA_DataType **requestType,
+                            const void **request,
                             void **context);
 
 #endif /* !UA_MULTITHREADING >= 100 */

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -170,11 +170,11 @@ UA_AsyncManager_clear(UA_AsyncManager *am, UA_Server *server) {
     /* Clean up queues */
     UA_LOCK(am->queueLock);
     while((ar = TAILQ_FIRST(&am->newQueue))) {
-        TAILQ_REMOVE(&am->resultQueue, ar, pointers);
+        TAILQ_REMOVE(&am->newQueue, ar, pointers);
         UA_AsyncOperation_delete(ar);
     }
     while((ar = TAILQ_FIRST(&am->dispatchedQueue))) {
-        TAILQ_REMOVE(&am->resultQueue, ar, pointers);
+        TAILQ_REMOVE(&am->dispatchedQueue, ar, pointers);
         UA_AsyncOperation_delete(ar);
     }
     while((ar = TAILQ_FIRST(&am->resultQueue))) {

--- a/src/server/ua_server_async.h
+++ b/src/server/ua_server_async.h
@@ -29,8 +29,10 @@ typedef struct UA_AsyncResponse UA_AsyncResponse;
 /* A single operation (of a larger request) */
 typedef struct UA_AsyncOperation {
     TAILQ_ENTRY(UA_AsyncOperation) pointers;
-    UA_CallMethodRequest request;
-    UA_CallMethodResult	response;
+    const UA_DataType *requestType;
+    void *request;
+    const UA_DataType *responseType;
+    void *response;
     size_t index;             /* Index of the operation in the array of ops in
                                * request/response */
     UA_AsyncResponse *parent; /* Always non-NULL. The parent is only removed
@@ -43,12 +45,8 @@ struct UA_AsyncResponse {
     UA_NodeId sessionId;
     UA_UInt32 requestHandle;
     UA_DateTime	timeout;
-    UA_AsyncOperationType operationType;
-    union {
-        UA_CallResponse callResponse;
-        UA_ReadResponse readResponse;
-        UA_WriteResponse writeResponse;
-    } response;
+    const UA_DataType *responseType;
+    void *response;
     UA_UInt32 opCountdown; /* Counter for outstanding operations. The AR can
                             * only be deleted when all have returned. */
 };
@@ -81,7 +79,7 @@ UA_AsyncManager_createAsyncResponse(UA_AsyncManager *am, UA_Server *server,
                                     const UA_NodeId *sessionId,
                                     const UA_UInt32 requestId,
                                     const UA_UInt32 requestHandle,
-                                    const UA_AsyncOperationType operationType,
+                                    const UA_DataType *responseType,
                                     UA_AsyncResponse **outAr);
 
 /* Only remove the AsyncResponse when the operation count is zero */
@@ -91,7 +89,9 @@ UA_AsyncManager_removeAsyncResponse(UA_AsyncManager *am, UA_AsyncResponse *ar);
 UA_StatusCode
 UA_AsyncManager_createAsyncOp(UA_AsyncManager *am, UA_Server *server,
                               UA_AsyncResponse *ar, size_t opIndex,
-                              const UA_CallMethodRequest *opRequest);
+                              const UA_DataType *opRequestType,
+                              const void *opRequest,
+                              const UA_DataType *opResponseType);
 
 typedef void (*UA_AsyncServiceOperation)(UA_Server *server, UA_Session *session,
                                          UA_UInt32 requestId, UA_UInt32 requestHandle,

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -266,7 +266,7 @@ Operation_CallMethodAsync(UA_Server *server, UA_Session *session, UA_UInt32 requ
         opResult->statusCode =
             UA_AsyncManager_createAsyncResponse(&server->asyncManager, server,
                                                 &session->sessionId, requestId,
-                                                requestHandle, UA_ASYNCOPERATIONTYPE_CALL,
+                                                requestHandle, &UA_TYPES[UA_TYPES_CALLRESPONSE],
                                                 ar);
         if(opResult->statusCode != UA_STATUSCODE_GOOD)
             goto cleanup;
@@ -275,7 +275,9 @@ Operation_CallMethodAsync(UA_Server *server, UA_Session *session, UA_UInt32 requ
     /* Create the Async Request to be taken by workers */
     opResult->statusCode =
         UA_AsyncManager_createAsyncOp(&server->asyncManager,
-                                      server, *ar, opIndex, opRequest);
+                                      server, *ar, opIndex,
+                                      &UA_TYPES[UA_TYPES_CALLMETHODREQUEST], opRequest,
+                                      &UA_TYPES[UA_TYPES_CALLMETHODRESULT]);
 
  cleanup:
     /* Release the method and object node */
@@ -308,7 +310,8 @@ Service_CallAsync(UA_Server *server, UA_Session *session, UA_UInt32 requestId,
         if(ar->opCountdown > 0) {
             /* Move all results to the AsyncResponse. The async operation results
              * will be overwritten when the workers return results. */
-            ar->response.callResponse = *response;
+            UA_CallResponse *r = (UA_CallResponse *)ar->response;
+            *r = *response;
             UA_CallResponse_init(response);
             *finished = false;
         } else {


### PR DESCRIPTION
Goals:
1. Generalize anync request handling to support different types of requests (remove hardcoded UA_CallRequest)
2. Move low level handling (UA_Server_getAsyncOperationNonBlocking, UA_Server_setAsyncOperationResult, etc) inside the library and provide UA_Server_processAsync that could be called inside a user created thread
3. Add async read/write requests
4. Add async history requests
5. ? Get rid of async request timeouts. Reasons:
    1. not all operation results have status codes (compare UA_CallResponse/UA_CallMethodResult and UA_ReadResponse/UA_DataValue), so it is not always possible to signal that a timeout event has occurred
    2. clients can better handle timeouts (inside their callbacks) since they have more info about what is going on
    3. current implementation is faulty because the working thread continues executing the current request after it has timed out