### PR TITLE
fix order of files to amalgamate, before amalgamation would conflict …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,10 +680,10 @@ set(internal_headers ${PROJECT_SOURCE_DIR}/deps/open62541_queue.h
                      ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub.h
                      ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_manager.h
                      ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_ns0.h
+		     ${PROJECT_SOURCE_DIR}/src/server/ua_server_async.h
                      ${PROJECT_SOURCE_DIR}/src/server/ua_server_internal.h
                      ${PROJECT_SOURCE_DIR}/src/server/ua_services.h
-                     ${PROJECT_SOURCE_DIR}/src/client/ua_client_internal.h
-					 ${PROJECT_SOURCE_DIR}/src/server/ua_server_async.h)
+                     ${PROJECT_SOURCE_DIR}/src/client/ua_client_internal.h)
 
 # TODO: make client optional
 set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c


### PR DESCRIPTION
…with multithreading now it works

Hi,
I'm proposing this tiny fix.
It solves the problem that when you do (in the base branch):

cmake -DUA_ENABLE_AMALGAMATION=ON  -DUA_MULTITHREADING=101 ../

it fails to build because amalgamation picks wrong order of headers.

With this simple fix both unamalgamated and amalgamated version build fine with multithreading enabled.