### PR TITLE
[REVIEW] Attach session to channel when activating if no channel exists

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -10,7 +10,7 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017-2018 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
- *    Copyright 2018-2019 (c) HMS Industrial Networks AB (Author: Jonas Green)
+ *    Copyright 2018-2020 (c) HMS Industrial Networks AB (Author: Jonas Green)
  */
 
 #include "ua_services.h"
@@ -674,10 +674,12 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         goto rejected;
     }
 
-    if(session->header.channel && session->header.channel != channel) {
-        UA_LOG_INFO_SESSION(&server->config.logger, session, "ActivateSession: Detach old channel");
-        /* Detach the old SecureChannel and attach the new */
-        UA_Session_detachFromSecureChannel(session);
+    /* Attach the session to the currently used channel if the session isn't
+     * attached to a channel or if the session is activated on a different
+     * channel than it is attached to. */
+    if(!session->header.channel || session->header.channel != channel) {
+        UA_LOG_INFO_SESSION(&server->config.logger, session, "ActivateSession: Attach to new channel");
+        /* Attach the new SecureChannel, the old channel will be detached if present */
         UA_Session_attachToSecureChannel(session, channel);
     }
 


### PR DESCRIPTION
While testing access rights we got UaExpert to perform a sequence
that we belive the open62541 server did not handle correctly:
1. OpenSecureChannel
2. CreateSession
3. ActivateSession
4. Some initial browsing/reading that eventually failed due to
   limited access rights
5. CloseSecureCannel (session is now detached from the channel)
6. OpenSecureChannel
7. ActivateSession (same session id as activated in no. 3)

During the second ActivateSession the server failed the request
in UA_Session_generateNonce() as there was no channel attached to the
session. The session was detached from the secure channel when
UaExpert closed the channel in no. 5. This PR makes the session
attached to the new channel before generating the nonce.