### PR TITLE
Levelled log

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -157,6 +157,8 @@ add_example(server_repeated_job server_repeated_job.c)
 
 add_example(server_inheritance server_inheritance.c)
 
+add_example(server_loglevel server_loglevel.c)
+
 if(UA_ENABLE_HISTORIZING)
     add_example(tutorial_server_historicaldata tutorial_server_historicaldata.c)
 endif()

--- a/examples/server_loglevel.c
+++ b/examples/server_loglevel.c
@@ -1,0 +1,77 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+
+#include <signal.h>
+#include <stdlib.h>
+#ifdef __linux__
+#include <getopt.h>
+#endif
+
+UA_Boolean running = true;
+static void stopHandler(int sig) {
+    running = false;
+}
+
+int main(int argc, char **argv) {
+    signal(SIGINT, stopHandler); /* catches ctrl-c */
+    signal(SIGTERM, stopHandler);
+
+    UA_LogLevel log_level = UA_LOGLEVEL_ERROR;
+
+#ifdef __linux__
+    static struct option long_options[] = {
+            {"help",     no_argument,       0,  'h' },
+            {"loglevel", required_argument, 0,  'l' },
+            {0,          0,                 0,  0 }
+    };
+    int long_index = 0;
+    int opt;
+    while ((opt = getopt_long(argc, argv,"hl",
+                   long_options, &long_index )) != -1) {
+        switch (opt) {
+            // This assumes that the mapping between UA_LogLevel and int is known
+             case 'l' : log_level = (UA_LogLevel)atoi(optarg);
+                 break;
+             case 'h' : printf( "Usage server_loglevel --loglevel=level\n" );
+                        exit(1);
+                 break;
+             default: fprintf(stderr,"Illegal argument '%c'\n", opt);
+                 exit(EXIT_FAILURE);
+        }
+    }
+#endif
+
+    UA_Server *server = UA_Server_new();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_ServerConfig_setDefault(config);
+    UA_ServerConfig_setDefault(config);
+    config->logger = UA_Log_Stdout_withLevel( log_level );
+
+    /* Some data */
+    UA_StatusCode retval;
+    UA_ObjectTypeAttributes otAttr = UA_ObjectTypeAttributes_default;
+    otAttr.description = UA_LOCALIZEDTEXT("en-US", "Some Data");
+    otAttr.displayName = UA_LOCALIZEDTEXT("en-US", "data");
+    UA_Server_addObjectTypeNode(server, UA_NODEID_NUMERIC(1, 10000),
+                                UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
+                                UA_QUALIFIEDNAME(1, "data"), otAttr, NULL, NULL);
+
+    UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+    vAttr.description =  UA_LOCALIZEDTEXT("en-US", "Some Data");
+    vAttr.displayName =  UA_LOCALIZEDTEXT("en-US", "data");
+    UA_UInt32 ageVar = 0;
+    UA_Variant_setScalar(&vAttr.value, &ageVar, &UA_TYPES[UA_TYPES_UINT32]);
+    UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 10001),
+                              UA_NODEID_NUMERIC(1, 10000), UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY),
+                              UA_QUALIFIEDNAME(1, "data"), UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, NULL);
+
+    retval = UA_Server_run(server, &running);
+
+    UA_Server_delete(server);
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/plugins/include/open62541/plugin/log_stdout.h
+++ b/plugins/include/open62541/plugin/log_stdout.h
@@ -22,6 +22,11 @@ UA_Log_Stdout_log(void *_, UA_LogLevel level, UA_LogCategory category,
 UA_EXPORT void
 UA_Log_Stdout_clear(void *logContext);
 
+/* By default the client and server is configured with UA_Log_Stdout
+   This constructs a logger with a configurable max log level */
+
+UA_EXPORT UA_Logger UA_Log_Stdout_withLevel(UA_LogLevel minlevel);
+
 _UA_END_DECLS
 
 #endif /* UA_LOG_STDOUT_H_ */


### PR DESCRIPTION
Add UA_Log_Stdout_ErrorLevel which only prints Error level and above regardless of UA_LOGLEVEL being set lower.  

The logger can be enabled like this:
```
UA_ServerConfig *open62541_server_config = UA_Server_getConfig(open62541_server);
UA_ServerConfig_setDefault(open62541_server_config);
open62541_server_config->logger = UA_Log_Stdout_ErrorLevel_; 
```

This also allows log level being a command line parameter.
```
UA_Logger mylogger = {UA_Log_Stdout_loglevelcheck, (void*)mylevel, UA_Log_Stdout_clear};
```

The PR also makes it easier to clone UA_Log_Stdout, as some definitions is moved to `open62541/plugin/log_stdout.h`

The PR is based on 1.0.1, but should also be possible to cherry pick to master.
