### PR TITLE
refactor securechannel: move asym decrypt to channel

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -304,7 +304,7 @@ processServiceResponse(void *application, UA_SecureChannel *channel,
             rd->client->connectStatus = UA_STATUSCODE_BADTCPINTERNALERROR;
             return;
         }
-        decodeProcessOPNResponseAsync(rd->client, channel, messageType, requestId, message);
+        processOPNResponseAsync(rd->client, channel, messageType, requestId, message);
         return;
     }
 

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -211,9 +211,9 @@ processACKResponseAsync(void *application, UA_SecureChannel *channel,
                         UA_ByteString *chunk);
 
 void
-decodeProcessOPNResponseAsync(void *application, UA_SecureChannel *channel,
-                              UA_MessageType messageType, UA_UInt32 requestId,
-                              UA_ByteString *chunk);
+processOPNResponseAsync(void *application, UA_SecureChannel *channel,
+                        UA_MessageType messageType, UA_UInt32 requestId,
+                        UA_ByteString *message);
 
 UA_StatusCode
 openSecureChannel(UA_Client *client, UA_Boolean renew);

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -390,77 +390,6 @@ processOPN(UA_Server *server, UA_SecureChannel *channel,
     return retval;
 }
 
-static UA_StatusCode
-decryptProcessOPN(UA_Server *server, UA_SecureChannel *channel,
-                  UA_ByteString *msg) {
-    UA_LOG_DEBUG_CHANNEL(&server->config.logger, channel, "Decrypt an OPN message");
-
-    /* Skip the first header. We know length and message type. */
-    size_t offset = UA_SECURE_CONVERSATION_MESSAGE_HEADER_LENGTH;
-
-    /* Decode the asymmetric algorithm security header and call the callback
-     * to perform checks. */
-    UA_AsymmetricAlgorithmSecurityHeader asymHeader;
-    UA_AsymmetricAlgorithmSecurityHeader_init(&asymHeader);
-    UA_StatusCode retval =
-        UA_AsymmetricAlgorithmSecurityHeader_decodeBinary(msg, &offset, &asymHeader);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
-                               "Could not decode the OPN header");
-        return retval;
-    }
-
-    /* Verify the certificate before creating the SecureChannel with it */
-    if(asymHeader.senderCertificate.length > 0) {
-        retval = server->config.certificateVerification.
-            verifyCertificate(server->config.certificateVerification.context,
-                              &asymHeader.senderCertificate);
-        if(retval != UA_STATUSCODE_GOOD) {
-            UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
-                                   "Could not verify the client's certificate");
-            return retval;
-        }
-    }
-
-    if(channel->state < UA_SECURECHANNELSTATE_OPEN) {
-        retval = UA_Server_configSecureChannel(server, channel, &asymHeader);
-        if(retval != UA_STATUSCODE_GOOD) {
-            UA_AsymmetricAlgorithmSecurityHeader_clear(&asymHeader);
-            return retval;
-        }
-    }
-
-    retval = checkAsymHeader(channel, &asymHeader);
-    UA_AsymmetricAlgorithmSecurityHeader_clear(&asymHeader);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
-                               "Could not verify OPN header");
-        return retval;
-    }
-
-    /* After decryption, msg contains only the payload after the SequenceHeader */
-    UA_UInt32 requestId = 0;
-    UA_UInt32 sequenceNumber = 0;
-    retval = decryptAndVerifyChunk(channel, &channel->securityPolicy->asymmetricModule.cryptoModule,
-                                   UA_MESSAGETYPE_OPN, msg, offset, &requestId, &sequenceNumber);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
-                               "Could not decrypt and verify the OPN payload");
-        return retval;
-    }
-
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    retval = processSequenceNumberAsym(channel, sequenceNumber);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
-                               "Could not process the OPN message's sequence number");
-        return retval;
-    }
-#endif
-
-    return processOPN(server, channel, requestId, msg);
-}
-
 UA_StatusCode
 sendResponse(UA_SecureChannel *channel, UA_UInt32 requestId, UA_UInt32 requestHandle,
              UA_ResponseHeader *responseHeader, const UA_DataType *responseType) {
@@ -725,7 +654,7 @@ processSecureChannelMessage(void *application, UA_SecureChannel *channel,
         break;
     case UA_MESSAGETYPE_OPN:
         UA_LOG_TRACE_CHANNEL(&server->config.logger, channel, "Process an OPN message");
-        retval = decryptProcessOPN(server, channel, message);
+        retval = processOPN(server, channel, requestId, message);
         break;
     case UA_MESSAGETYPE_MSG:
         UA_LOG_TRACE_CHANNEL(&server->config.logger, channel, "Process a MSG");
@@ -797,11 +726,8 @@ UA_Server_processBinaryMessage(UA_Server *server, UA_Connection *connection,
     UA_debug_dumpCompleteChunk(server, channel->connection, message);
 #endif
 
-    retval = UA_SecureChannel_processPacket(channel, server, processSecureChannelMessage, message);
-    while(retval == UA_STATUSCODE_GOOD && channel->retryReceived) {
-        retval = UA_SecureChannel_processPacket(channel, server,
-                                                processSecureChannelMessage, &UA_BYTESTRING_NULL);
-    }
+    retval = UA_SecureChannel_assembleChunks(channel, server, processSecureChannelMessage,
+                                             message);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_NETWORK,
                     "Connection %i | Processing the message failed with error %s",

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -174,7 +174,7 @@ UA_StatusCode
 UA_Server_createSecureChannel(UA_Server *server, UA_Connection *connection);
 
 UA_StatusCode
-UA_Server_configSecureChannel(UA_Server *server, UA_SecureChannel *channel,
+UA_Server_configSecureChannel(void *application, UA_SecureChannel *channel,
                               const UA_AsymmetricAlgorithmSecurityHeader *asymHeader);
 
 void

--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -138,6 +138,8 @@ UA_Server_createSecureChannel(UA_Server *server, UA_Connection *connection) {
     entry->channel.securityToken.channelId = 0;
     entry->channel.securityToken.createdAt = UA_DateTime_nowMonotonic();
     entry->channel.securityToken.revisedLifetime = server->config.maxSecurityTokenLifetime;
+    entry->channel.certificateVerification = &server->config.certificateVerification;
+    entry->channel.configure = UA_Server_configSecureChannel;
 
     TAILQ_INSERT_TAIL(&server->channels, entry, pointers);
     UA_Connection_attachSecureChannel(connection, &entry->channel);
@@ -147,10 +149,11 @@ UA_Server_createSecureChannel(UA_Server *server, UA_Connection *connection) {
 }
 
 UA_StatusCode
-UA_Server_configSecureChannel(UA_Server *server, UA_SecureChannel *channel,
+UA_Server_configSecureChannel(void *application, UA_SecureChannel *channel,
                               const UA_AsymmetricAlgorithmSecurityHeader *asymHeader) {
     /* Iterate over available endpoints and choose the correct one */
     UA_SecurityPolicy *securityPolicy = NULL;
+    UA_Server *const server = (UA_Server *const)application;
     for(size_t i = 0; i < server->config.securityPoliciesSize; ++i) {
         UA_SecurityPolicy *policy = &server->config.securityPolicies[i];
         if(!UA_ByteString_equal(&asymHeader->securityPolicyUri, &policy->policyUri))

--- a/src/ua_securechannel_crypto.c
+++ b/src/ua_securechannel_crypto.c
@@ -609,11 +609,10 @@ checkAsymHeader(UA_SecureChannel *channel,
 }
 
 UA_StatusCode
-checkSymHeader(UA_SecureChannel *channel, UA_UInt32 tokenId,
-               UA_Boolean allowPreviousToken) {
+checkSymHeader(UA_SecureChannel *channel, UA_SymmetricAlgorithmSecurityHeader *securityHeader) {
     /* If the message uses a different token, check if it is the next token. */
-    if(tokenId != channel->securityToken.tokenId) {
-        if(tokenId != channel->nextSecurityToken.tokenId) {
+    if(securityHeader->tokenId != channel->securityToken.tokenId) {
+        if(securityHeader->tokenId != channel->nextSecurityToken.tokenId) {
             UA_LOG_WARNING_CHANNEL(channel->securityPolicy->logger, channel,
                                  "Received an unknown SecurityToken");
             return UA_STATUSCODE_BADSECURECHANNELTOKENUNKNOWN;

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -518,6 +518,71 @@ START_TEST(SecureChannel_sendSymmetricMessage_invalidParameters) {
     ck_assert_msg(retval != UA_STATUSCODE_GOOD, "Expected failure");
 } END_TEST
 
+
+static void
+process_callback(void *application, UA_SecureChannel *channel,
+                 UA_MessageType messageType, UA_UInt32 requestId,
+                 UA_ByteString *message) {
+    ck_assert_ptr_ne(message, NULL);
+    ck_assert_ptr_ne(application, NULL);
+    if(message != NULL && application != NULL) {
+        ck_assert_uint_ne(message->length, 0);
+        ck_assert_ptr_ne(message->data, NULL);
+        int *chunks_processed = (int *)application;
+        ++*chunks_processed;
+    }
+}
+
+START_TEST(SecureChannel_assemblePartialChunks) {
+    int chunks_processed = 0;
+    UA_ByteString buffer = UA_BYTESTRING_NULL;
+
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 32;
+
+    UA_StatusCode retval = UA_SecureChannel_assembleChunks(&testChannel, &chunks_processed, process_callback, &buffer);
+    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected success");
+    ck_assert_int_eq(chunks_processed, 1);
+
+    buffer.length = 16;
+
+    UA_SecureChannel_assembleChunks(&testChannel, &chunks_processed, process_callback, &buffer);
+    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected success");
+    ck_assert_int_eq(chunks_processed, 1);
+
+    buffer.data = &buffer.data[16];
+    UA_SecureChannel_assembleChunks(&testChannel, &chunks_processed, process_callback, &buffer);
+    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected success");
+    ck_assert_int_eq(chunks_processed, 2);
+
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff"
+                             "HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff"
+                             "HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 48;
+
+    UA_SecureChannel_assembleChunks(&testChannel, &chunks_processed, process_callback, &buffer);
+    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected success");
+    ck_assert_int_eq(chunks_processed, 3);
+
+    buffer.data = &buffer.data[48];
+    buffer.length = 32;
+
+    UA_SecureChannel_assembleChunks(&testChannel, &chunks_processed, process_callback, &buffer);
+    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected success");
+    ck_assert_int_eq(chunks_processed, 4);
+
+    buffer.data = &buffer.data[32];
+    buffer.length = 16;
+    UA_SecureChannel_assembleChunks(&testChannel, &chunks_processed, process_callback, &buffer);
+    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected success");
+    ck_assert_int_eq(chunks_processed, 5);
+} END_TEST
+
+
 static Suite *
 testSuite_SecureChannel(void) {
     Suite *s = suite_create("SecureChannel");
@@ -571,6 +636,13 @@ testSuite_SecureChannel(void) {
     tcase_add_test(tc_sendSymmetricMessage, SecureChannel_sendSymmetricMessage_modeSignAndEncrypt);
 #endif
     suite_add_tcase(s, tc_sendSymmetricMessage);
+
+    TCase *tc_assembleChunks = tcase_create("Test chunk assembly");
+    tcase_add_checked_fixture(tc_assembleChunks, setup_funcs_called, teardown_funcs_called);
+    tcase_add_checked_fixture(tc_assembleChunks, setup_key_sizes, teardown_key_sizes);
+    tcase_add_checked_fixture(tc_assembleChunks, setup_secureChannel, teardown_secureChannel);
+    tcase_add_test(tc_assembleChunks, SecureChannel_assemblePartialChunks);
+    suite_add_tcase(s, tc_assembleChunks);
 
     return s;
 }

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -214,7 +214,7 @@ START_TEST(Client_renewSecureChannelWithActiveSubscription) {
     THREAD_JOIN(server_thread);
 
     for(int i = 0; i < 15; ++i) {
-        UA_fakeSleep(1000);
+        UA_fakeSleep(100);
         UA_Server_run_iterate(server, true);
         retval = UA_Client_run_iterate(client, 0);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);

--- a/tests/fuzz/ua_debug_dump_pkgs_file.c
+++ b/tests/fuzz/ua_debug_dump_pkgs_file.c
@@ -153,7 +153,8 @@ UA_debug_dumpCompleteChunk(UA_Server *const server, UA_Connection *const connect
 
     UA_ByteString messageBufferCopy;
     UA_ByteString_copy(messageBuffer, &messageBufferCopy);
-    UA_SecureChannel_processPacket(&dummy, &dump_filename, UA_debug_dump_setName, &messageBufferCopy);
+    UA_SecureChannel_assembleChunks(&dummy, &dump_filename, UA_debug_dump_setName,
+                                    &messageBufferCopy);
     UA_ByteString_deleteMembers(&messageBufferCopy);
 
     dummy.securityPolicy = NULL;

--- a/tools/schema/Custom.Opc.Ua.Transport.bsd
+++ b/tools/schema/Custom.Opc.Ua.Transport.bsd
@@ -60,10 +60,15 @@
   </opc:StructuredType>
   
   <opc:StructuredType Name="AsymmetricAlgorithmSecurityHeader">
-    <opc:Documentation>Security Header</opc:Documentation>
+    <opc:Documentation>Asymmetric Security Header</opc:Documentation>
     <opc:Field Name="SecurityPolicyUri" TypeName="opc:ByteString" />
     <opc:Field Name="SenderCertificate" TypeName="opc:ByteString" />
     <opc:Field Name="ReceiverCertificateThumbprint" TypeName="opc:ByteString" />
+  </opc:StructuredType>
+
+  <opc:StructuredType Name="SymmetricAlgorithmSecurityHeader">
+    <opc:Documentation>Symmetric Security Header</opc:Documentation>
+    <opc:Field Name="TokenId" TypeName="opc:UInt32" />
   </opc:StructuredType>
   
   <opc:StructuredType Name="SequenceHeader">

--- a/tools/schema/datatypes_transport.txt
+++ b/tools/schema/datatypes_transport.txt
@@ -5,4 +5,5 @@ TcpHelloMessage
 TcpAcknowledgeMessage
 TcpErrorMessage
 AsymmetricAlgorithmSecurityHeader
+SymmetricAlgorithmSecurityHeader
 SequenceHeader


### PR DESCRIPTION
This moves the decryption of asymmetrically secured messages back into
the securechannel. This way control flow is unified and we dont need to
"reprocess" chunks if the sequence number check fails.
The control flow is now more obvious.
The only "downside" of this approach imho is, that we need to call the
configure callback into the application.
I find the control flow of this easier to follow than some jumping
around depending on failed checks.

This is currently contained in #3409 and i extracted it to reduce the size of the PR.
@jpfr Can you take a look?