### PR TITLE
fix(ci): Use the regular valgrind from homebrew on MacOS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -255,6 +255,9 @@ matrix:
           - '$HOME/.sonar/cache'
   allow_failures:
     #
+    # MacOS X
+    - env:
+        - HOMEBREW_NO_AUTO_UPDATE=1
     # clang-format code analysis
     - env:
         - CLANG_FORMAT=true

--- a/tools/travis/travis_osx_before_install.sh
+++ b/tools/travis/travis_osx_before_install.sh
@@ -2,7 +2,7 @@
 set -e
 
 brew install check
-brew install --HEAD valgrind
+brew install valgrind
 brew install graphviz
 brew install python
 brew install mbedtls


### PR DESCRIPTION
The git repository for the HEAD version is unstable.