### PR TITLE
fix(server): Add warning if fuzzing build is enabled

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -523,6 +523,15 @@ UA_ServerStatistics UA_Server_getStatistics(UA_Server *server)
 
 UA_StatusCode
 UA_Server_run_startup(UA_Server *server) {
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    /* Prominently warn user that fuzzing build is enabled. This will tamper with authentication tokens and other important variables
+     * E.g. if fuzzing is enabled, and two clients are connected, subscriptions do not work properly,
+     * since the tokens will be overridden to allow easier fuzzing. */
+    UA_LOG_FATAL(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                       "Server was built with unsafe fuzzing mode. This should only be used for specific fuzzing builds.");
+#endif
+
     /* ensure that the uri for ns1 is set up from the app description */
     setupNs1Uri(server);
 


### PR DESCRIPTION
If `UA_BUILD_FUZZING` authentication tokens and other variables are overridden internally. This causes subscriptions and other parts of the code to not work as expected.

Since `UA_BUILD_FUZZING` should not be used for debug or release builds in general, show a warning to avoid accidental usage of this build option.