### PR TITLE
Fix: NodesetGenerator QualifiedName: 'NoneType' object has no attribute 'name'

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -123,7 +123,7 @@ def generateNodeValueCode(prepend , node, instanceName, valueName, global_var_co
     elif isinstance(node, DateTime):
         return prepend + " = " + generateDateTimeCode(node.value) + ";"
     elif isinstance(node, QualifiedName):
-        return prepend + " = " + generateQualifiedNameCode(node.value, alloc=asIndirect) + ";"
+        return prepend + " = " + generateQualifiedNameCode(node, alloc=asIndirect) + ";"
     elif isinstance(node, StatusCode):
         raise Exception("generateNodeValueCode for type " + node.__class__.name + " not implemented")
     elif isinstance(node, DiagnosticInfo):


### PR DESCRIPTION
This fixes QualifiedName Values in Nodeset files like this:

    <UAVariable DataType="QualifiedName" ParentNodeId="ns=1;i=1012" NodeId="ns=1;i=6030" BrowseName="DefaultInstanceBrowseName">
        <DisplayName>DefaultInstanceBrowseName</DisplayName>
        <References>
            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1012</Reference>
            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
        </References>
        <Value>
            <uax:QualifiedName>
                <uax:NamespaceIndex>2</uax:NamespaceIndex>
                <uax:Name>Identification</uax:Name>
            </uax:QualifiedName>
        </Value>
    </UAVariable>


Previous leading to this:
```
INFO:__main__:Generating Code for Backend: open62541
Traceback (most recent call last):
  File "<DevDir>/Open62541_Tests/install-debug/share/open62541/tools/nodeset_compiler/nodeset_compiler.py", line 189, in <module>
    generateOpen62541Code(ns, args.outputFile, args.internal_headers, args.typesArray)
  File "<DevDir>\Open62541_Tests\install-debug\share\open62541\tools\nodeset_compiler\backend_open62541.py", line 229, in generateOpen62541Code
    code = generateNodeCode_begin(node, nodeset, code_global)
  File "<DevDir>\Open62541_Tests\install-debug\share\open62541\tools\nodeset_compiler\backend_open62541_nodes.py", line 497, in generateNodeCode_begin
    [code1, codeCleanup1, codeGlobal1] = generateVariableNodeCode(node, nodeset)
  File "<DevDir>\Open62541_Tests\install-debug\share\open62541\tools\nodeset_compiler\backend_open62541_nodes.py", line 235, in generateVariableNodeCode
    [code1, codeCleanup1, codeGlobal1] = generateCommonVariableCode(node, nodeset)
  File "<DevDir>\Open62541_Tests\install-debug\share\open62541\tools\nodeset_compiler\backend_open62541_nodes.py", line 195, in generateCommonVariableCode
    [code1, codeCleanup1, codeGlobal1] = generateValueCode(node.value, nodeset.nodes[node.id], nodeset)
  File "<DevDir>\Open62541_Tests\install-debug\share\open62541\tools\nodeset_compiler\backend_open62541_nodes.py", line 436, in generateValueCode
    code.append(generateNodeValueCode("*" + valueName, node.value[0], instanceName, valueName, codeGlobal, asIndirect=True))
  File "<DevDir>\Open62541_Tests\install-debug\share\open62541\tools\nodeset_compiler\backend_open62541_datatypes.py", line 126, in generateNodeValueCode
    return prepend + " = " + generateQualifiedNameCode(node.value, alloc=asIndirect) + ";"
  File "<DevDir>\Open62541_Tests\install-debug\share\open62541\tools\nodeset_compiler\backend_open62541_datatypes.py", line 77, in generateQualifiedNameCode
    vn = makeCLiteral(value.name)
AttributeError: 'NoneType' object has no attribute 'name'
```

Caused as the class does not use a value member as some others (e.g. DateTime)
https://github.com/open62541/open62541/blob/6608c28ebfecf8f64756b49e77937c7c86057085/tools/nodeset_compiler/datatypes.py#L687-L707
