### PR TITLE
Add UA_Server_writeDataValue

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -395,11 +395,28 @@ UA_Server_writeEventNotifier(UA_Server *server, const UA_NodeId nodeId,
                              &UA_TYPES[UA_TYPES_BYTE], &eventNotifier);
 }
 
+/**
+ * Writes an UA_Variant to a variable/variableType node.
+ * StatusCode is set to UA_STATUSCODE_GOOD, sourceTimestamp and
+ * serverTimestamp are set to UA_DateTime_now()
+ */
 static UA_INLINE UA_THREADSAFE UA_StatusCode
 UA_Server_writeValue(UA_Server *server, const UA_NodeId nodeId,
                      const UA_Variant value) {
     return __UA_Server_write(server, &nodeId, UA_ATTRIBUTEID_VALUE,
                              &UA_TYPES[UA_TYPES_VARIANT], &value);
+}
+
+/**
+ * Writes an UA_DataValue to a variable/variableType node.
+ * In contrast to UA_Server_writeValue, this functions can also write
+ * sourceTimestamp, serverTimestamp and statusCode.
+ */
+static UA_INLINE UA_THREADSAFE UA_StatusCode
+UA_Server_writeDataValue(UA_Server *server, const UA_NodeId nodeId,
+                     const UA_DataValue value) {
+    return __UA_Server_write(server, &nodeId, UA_ATTRIBUTEID_VALUE,
+                             &UA_TYPES[UA_TYPES_DATAVALUE], &value);
 }
 
 static UA_INLINE UA_THREADSAFE UA_StatusCode

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1526,12 +1526,14 @@ writeWithWriteValue(UA_Server *server, const UA_NodeId *nodeId,
     wvalue.nodeId = *nodeId;
     wvalue.attributeId = attributeId;
     wvalue.value.hasValue = true;
-    if(attr_type != &UA_TYPES[UA_TYPES_VARIANT]) {
+    if(attr_type == &UA_TYPES[UA_TYPES_VARIANT]) {
+        wvalue.value.value = *(const UA_Variant*)attr;
+    } else if(attr_type == &UA_TYPES[UA_TYPES_DATAVALUE]) {
+        wvalue.value = *(const UA_DataValue*)attr;
+    } else {
         /* hacked cast. the target WriteValue is used as const anyway */
         UA_Variant_setScalar(&wvalue.value.value,
                              (void*)(uintptr_t)attr, attr_type);
-    } else {
-        wvalue.value.value = *(const UA_Variant*)attr;
     }
     return writeAttribute(server, &wvalue);
 }


### PR DESCRIPTION
This pull request adds UA_Server_writeDataValue, analog to UA_Server_writeValue, but accepting a UA_DataValue, so you can control the StatusCodes and TimeStamps.