### PR TITLE
fix(security policy) the  securityPolicy pointer in *_PolicyContext is invalidate

### DIFF
--- a/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
@@ -5,7 +5,8 @@
  *    Copyright 2018-2019 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
  *    Copyright 2018 (c) HMS Industrial Networks AB (Author: Jonas Green)
- *
+ *    Copyright 2020 (c) Wind River Systems, Inc.
+ * 
  */
 
 #include <open62541/plugin/securitypolicy_default.h>
@@ -41,7 +42,6 @@
 #define UA_SECURITYPOLICY_BASIC128RSA15_MAXASYMKEYLENGTH 512
 
 typedef struct {
-    const UA_SecurityPolicy *securityPolicy;
     UA_ByteString localCertThumbprint;
 
     mbedtls_ctr_drbg_context drbgContext;
@@ -643,7 +643,7 @@ updateCertificateAndPrivateKey_sp_basic128rsa15(UA_SecurityPolicy *securityPolic
         goto error;
     }
 
-    retval = asym_makeThumbprint_sp_basic128rsa15(pc->securityPolicy,
+    retval = asym_makeThumbprint_sp_basic128rsa15(securityPolicy,
                                                   &securityPolicy->localCertificate,
                                                   &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
@@ -686,7 +686,6 @@ policyContext_newContext_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
     mbedtls_entropy_init(&pc->entropyContext);
     mbedtls_pk_init(&pc->localPrivateKey);
     mbedtls_md_init(&pc->sha1MdContext);
-    pc->securityPolicy = securityPolicy;
 
     /* Initialized the message digest */
     const mbedtls_md_info_t *const mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
@@ -728,7 +727,7 @@ policyContext_newContext_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
     retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
-    retval = asym_makeThumbprint_sp_basic128rsa15(pc->securityPolicy,
+    retval = asym_makeThumbprint_sp_basic128rsa15(securityPolicy,
                                                   &securityPolicy->localCertificate,
                                                   &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)

--- a/plugins/securityPolicies/ua_securitypolicy_basic256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256.c
@@ -5,6 +5,7 @@
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
+ *    Copyright 2020 (c) Wind River Systems, Inc.
  *
  */
 
@@ -41,7 +42,6 @@
 #define UA_SECURITYPOLICY_BASIC256_MAXASYMKEYLENGTH 512
 
 typedef struct {
-    const UA_SecurityPolicy *securityPolicy;
     UA_ByteString localCertThumbprint;
 
     mbedtls_ctr_drbg_context drbgContext;
@@ -592,7 +592,7 @@ updateCertificateAndPrivateKey_sp_basic256(UA_SecurityPolicy *securityPolicy,
         goto error;
     }
 
-    retval = asym_makeThumbprint_sp_basic256(pc->securityPolicy,
+    retval = asym_makeThumbprint_sp_basic256(securityPolicy,
                                              &securityPolicy->localCertificate,
                                              &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
@@ -635,7 +635,6 @@ policyContext_newContext_sp_basic256(UA_SecurityPolicy *securityPolicy,
     mbedtls_entropy_init(&pc->entropyContext);
     mbedtls_pk_init(&pc->localPrivateKey);
     mbedtls_md_init(&pc->sha1MdContext);
-    pc->securityPolicy = securityPolicy;
 
     /* Initialized the message digest */
     const mbedtls_md_info_t *mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
@@ -676,9 +675,9 @@ policyContext_newContext_sp_basic256(UA_SecurityPolicy *securityPolicy,
     retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
-    retval = asym_makeThumbprint_sp_basic256(pc->securityPolicy,
-                                                  &securityPolicy->localCertificate,
-                                                  &pc->localCertThumbprint);
+    retval = asym_makeThumbprint_sp_basic256(securityPolicy,
+                                             &securityPolicy->localCertificate,
+                                             &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
 

--- a/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
@@ -5,6 +5,7 @@
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  *    Copyright 2018 (c) HMS Industrial Networks AB (Author: Jonas Green)
+ *    Copyright 2020 (c) Wind River Systems, Inc.
  */
 
 #include <open62541/plugin/securitypolicy_default.h>
@@ -41,7 +42,6 @@
 #define UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH 512
 
 typedef struct {
-    const UA_SecurityPolicy *securityPolicy;
     UA_ByteString localCertThumbprint;
 
     mbedtls_ctr_drbg_context drbgContext;
@@ -633,7 +633,7 @@ updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPoli
         goto error;
     }
 
-    retval = asym_makeThumbprint_sp_basic256sha256(pc->securityPolicy,
+    retval = asym_makeThumbprint_sp_basic256sha256(securityPolicy,
                                                    &securityPolicy->localCertificate,
                                                    &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
@@ -676,7 +676,6 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
     mbedtls_entropy_init(&pc->entropyContext);
     mbedtls_pk_init(&pc->localPrivateKey);
     mbedtls_md_init(&pc->sha256MdContext);
-    pc->securityPolicy = securityPolicy;
 
     /* Initialized the message digest */
     const mbedtls_md_info_t *const mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
@@ -717,7 +716,7 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
     retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
-    retval = asym_makeThumbprint_sp_basic256sha256(pc->securityPolicy,
+    retval = asym_makeThumbprint_sp_basic256sha256(securityPolicy,
                                                   &securityPolicy->localCertificate,
                                                   &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)


### PR DESCRIPTION
Root cause:

1. The function UA_ServerConfig_addAllSecurityPolicies() in
https://github.com/open62541/open62541/blob/master/plugins/ua_config_default.c will do like this:
`
    UA_ServerConfig_addAllSecurityPolicies (...) {
	...
    UA_ServerConfig_addSecurityPolicyNone(config, &localCertificate);
    UA_ServerConfig_addSecurityPolicyBasic128Rsa15(config, &localCertificate, &localPrivateKey);
    UA_ServerConfig_addSecurityPolicyBasic256(config, &localCertificate, &localPrivateKey);
    UA_ServerConfig_addSecurityPolicyBasic256Sha256(config, &localCertificate, &localPrivateKey);
	...
	}
`	
	
2. The function UA_ServerConfig_addSecurityPolicyBasic128Rsa15() will do like this:
`
    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
             UA_realloc(config->securityPolicies,
                     sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
    config->securityPolicies = tmp;	
     UA_SecurityPolicy_Basic128Rsa15(&config->securityPolicies[config->securityPoliciesSize],
                                        localCertificate, localPrivateKey, &config->logger);
`										

3. In this function UA_SecurityPolicy_Basic128Rsa15(), we will save the pointer &config->securityPolicies[config->securityPoliciesSize] into Basic128Rsa15_PolicyContext.securityPolicy.
										
4. The function UA_ServerConfig_addSecurityPolicyBasic128Rsa15() will do like this:	
`
    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
             UA_realloc(config->securityPolicies,
                     sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
    config->securityPolicies = tmp;	
   UA_SecurityPolicy_Basic256(&config->securityPolicies[config->securityPoliciesSize],
                                   localCertificate, localPrivateKey, &config->logger);
`								   
								   
tmp = UA_realloc() may return a new pointer and the block is moved to a new location. So the value Basic128Rsa15_PolicyContext.securityPolicy is dirty which is saved in the last call to UA_SecurityPolicy_Basic128Rsa15().

5. These functions have the issue: UA_SecurityPolicy_Basic256() UA_SecurityPolicy_Basic256Sha256() UA_SecurityPolicy_Basic128Rsa15()

Solution:
the variable securityPolicy in:
`
typedef struct {
    const UA_SecurityPolicy *securityPolicy;
    UA_ByteString localCertThumbprint;
    mbedtls_ctr_drbg_context drbgContext;
    mbedtls_entropy_context entropyContext;
    mbedtls_md_context_t sha1MdContext;
    mbedtls_pk_context localPrivateKey;
} Basic256_PolicyContext;
`
isn't used almostly. Remove it.

