### PR TITLE
Fix ConditionId Search (Alarms and Conditions)

### DIFF
--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -75,15 +75,6 @@ typedef enum {
   UA_ACTIVE_LOWLOW
 } UA_ActiveState;
 
-/* In the first implementation there will be only one entry in this list
- * conditionBranchId is always NULL. */
-typedef struct UA_ConditionBranch {
-    LIST_ENTRY(UA_ConditionBranch) listEntry;
-    UA_NodeId conditionBranchId;
-    UA_ByteString lastEventId;
-    UA_Boolean isCallerAC;
-} UA_ConditionBranch;
-
 typedef struct {
     UA_TwoStateVariableChangeCallback enableStateCallback;
     UA_TwoStateVariableChangeCallback ackStateCallback;
@@ -93,6 +84,23 @@ typedef struct {
     UA_TwoStateVariableChangeCallback activeStateCallback;
 } UA_ConditionCallbacks;
 
+/*
+ * In Alarms and Conditions first implementation, conditionBranchId
+ * is always equal to NULL NodeId (UA_NODEID_NULL). That ConditionBranch
+ * represents the current state Condition. The current state is determined
+ * by the last Event triggered (lastEventId). See Part 9, 5.5.2, BranchId.
+ */
+typedef struct UA_ConditionBranch {
+    LIST_ENTRY(UA_ConditionBranch) listEntry;
+    UA_NodeId conditionBranchId;
+    UA_ByteString lastEventId;
+    UA_Boolean isCallerAC;
+} UA_ConditionBranch;
+
+/*
+ * In Alarms and Conditions first implementation, A Condition
+ * have only one ConditionBranch entry.
+ */
 typedef struct UA_Condition {
     LIST_ENTRY(UA_Condition) listEntry;
     LIST_HEAD(, UA_ConditionBranch) conditionBranchHead;
@@ -105,6 +113,9 @@ typedef struct UA_Condition {
     UA_Boolean isLimitAlarm;
 } UA_Condition;
 
+/*
+ * A ConditionSource can have multiple Conditions.
+ */
 typedef struct UA_ConditionSource {
     LIST_ENTRY(UA_ConditionSource) listEntry;
     LIST_HEAD(, UA_Condition) conditionHead;

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -1829,7 +1829,7 @@ UA_getConditionId(UA_Server *server, const UA_NodeId *conditionNodeId,
             /* Get Branch Entry*/
             UA_ConditionBranch *branch;
             LIST_FOREACH(branch, &cond->conditionBranchHead, listEntry) {
-                if(!UA_NodeId_equal(&branch->conditionBranchId, conditionNodeId)) {
+                if(UA_NodeId_equal(&branch->conditionBranchId, conditionNodeId)) {
                     *outConditionId = cond->conditionId;
                     return UA_STATUSCODE_GOOD;
                 }

--- a/src/server/ua_subscription_events.c
+++ b/src/server/ua_subscription_events.c
@@ -195,10 +195,11 @@ resolveSimpleAttributeOperand(UA_Server *server, UA_Session *session, const UA_N
     /* If this list (browsePath) is empty the Node is the instance of the
      * TypeDefinition. */
     if(sao->browsePathSize == 0) {
+      UA_NodeId conditionTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_CONDITIONTYPE);
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
       //TODO check for Branches! One Condition could have multiple Branches
       // Set ConditionId
-      UA_NodeId conditionTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_CONDITIONTYPE);
       if(UA_NodeId_equal(&sao->typeDefinitionId, &conditionTypeId)){
         UA_NodeId conditionId;
         UA_StatusCode retval = UA_getConditionId(server, origin, &conditionId);
@@ -210,7 +211,10 @@ resolveSimpleAttributeOperand(UA_Server *server, UA_Session *session, const UA_N
       else
         rvi.nodeId = sao->typeDefinitionId;
 #else
-      rvi.nodeId = sao->typeDefinitionId;
+      if(UA_NodeId_equal(&sao->typeDefinitionId, &conditionTypeId))
+        return UA_STATUSCODE_BADNOTSUPPORTED;
+      else
+        rvi.nodeId = sao->typeDefinitionId;
 #endif /*UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS*/
         UA_DataValue v = UA_Server_readWithSession(server, session, &rvi,
 		                                           UA_TIMESTAMPSTORETURN_NEITHER);


### PR DESCRIPTION
both BranchId and the passed ConditionId should be equal if we want to set the Event Field "ConditionId" with the main ConditionId.
Using "!UA_NodeId_equal" at this place allows the program to go each time inside the if-clause because BranchId is always equal Null NodeId. As a result, each Event ends up having a ConditionId Field within it.
This should fix the problem in https://github.com/open62541/open62541/pull/3415#issuecomment-582816205 and is related to https://github.com/open62541/open62541/issues/3451#issuecomment-591349071