### PR TITLE
fix(server): misplaced UA_DEPRECATED macro

### DIFF
--- a/include/open62541/server_config.h
+++ b/include/open62541/server_config.h
@@ -156,7 +156,7 @@ struct UA_ServerConfig {
 #if UA_MULTITHREADING >= 100
     UA_Double asyncOperationTimeout; /* in ms, 0 => unlimited */
     size_t maxAsyncOperationQueueSize; /* 0 => unlimited */
-    UA_Double asyncCallRequestTimeout UA_DEPRECATED; /* in ms, 0 => unlimited */
+    UA_DEPRECATED UA_Double asyncCallRequestTimeout; /* in ms, 0 => unlimited */
     /* Notify workers when an async operation was enqueued */
     UA_Server_AsyncOperationNotifyCallback asyncOperationNotifyCallback;
 #endif


### PR DESCRIPTION
Fix error C2143: syntax error : missing ';' before 'type' in MSVC
For MSVC, "UA_DEPRECATED" evaluates to "__declspec(deprecated)" which cannot be placed at the end of a deprecated statement, only in the front.