### PR TITLE
[Review] feat(server): exception-based model

### DIFF
--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -18,6 +18,7 @@
  * / OPC UA services to interact with the information model. */
 
 #include <open62541/server.h>
+#include <open62541_queue.h>
 #include "ziptree.h"
 
 _UA_BEGIN_DECLS
@@ -207,6 +208,9 @@ typedef struct {
     UA_Byte accessLevel;
     UA_Double minimumSamplingInterval;
     UA_Boolean historizing;
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    LIST_HEAD(MonitoredItems, UA_MonitoredItem) monitoredItems;
+#endif
 } UA_VariableNode;
 
 /**

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -94,19 +94,30 @@ typedef struct {
     UA_ReferenceTargetNameTree refTargetsNameTree;
 } UA_NodeReferenceKind;
 
-#define UA_NODE_BASEATTRIBUTES                  \
-    UA_NodeId nodeId;                           \
-    UA_NodeClass nodeClass;                     \
-    UA_QualifiedName browseName;                \
-    UA_LocalizedText displayName;               \
-    UA_LocalizedText description;               \
-    UA_UInt32 writeMask;                        \
-    size_t referencesSize;                      \
-    UA_NodeReferenceKind *references;           \
-                                                \
-    /* Members specific to open62541 */         \
-    void *context;                              \
-    UA_Boolean constructed; /* Constructors were called */
+struct MonitoredItemsList {
+    struct UA_MonitoredItem *slh_first;
+};
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+#define UA_MONITORED_ITEMS_EXTENSION struct MonitoredItemsList monitoredItemQueue;
+#else
+#define UA_MONITORED_ITEMS_EXTENSION
+#endif
+
+#define UA_NODE_BASEATTRIBUTES                             \
+    UA_NodeId nodeId;                                      \
+    UA_NodeClass nodeClass;                                \
+    UA_QualifiedName browseName;                           \
+    UA_LocalizedText displayName;                          \
+    UA_LocalizedText description;                          \
+    UA_UInt32 writeMask;                                   \
+    size_t referencesSize;                                 \
+    UA_NodeReferenceKind *references;                      \
+                                                           \
+    /* Members specific to open62541 */                    \
+    void *context;                                         \
+    UA_Boolean constructed; /* Constructors were called */ \
+    UA_MONITORED_ITEMS_EXTENSION                           \
 
 typedef struct {
     UA_NODE_BASEATTRIBUTES
@@ -208,9 +219,6 @@ typedef struct {
     UA_Byte accessLevel;
     UA_Double minimumSamplingInterval;
     UA_Boolean historizing;
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-    LIST_HEAD(MonitoredItems, UA_MonitoredItem) monitoredItems;
-#endif
 } UA_VariableNode;
 
 /**
@@ -275,9 +283,6 @@ typedef struct {
 
 typedef struct {
     UA_NODE_BASEATTRIBUTES
-#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
-    struct UA_MonitoredItem *monitoredItemQueue;
-#endif
     UA_Byte eventNotifier;
 } UA_ObjectNode;
 

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -18,7 +18,7 @@
  * / OPC UA services to interact with the information model. */
 
 #include <open62541/server.h>
-#include <open62541_queue.h>
+#include "open62541_queue.h"
 #include "ziptree.h"
 
 _UA_BEGIN_DECLS

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -18,7 +18,6 @@
  * / OPC UA services to interact with the information model. */
 
 #include <open62541/server.h>
-#include "open62541_queue.h"
 #include "ziptree.h"
 
 _UA_BEGIN_DECLS

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -949,6 +949,19 @@ UA_Server_createDataChangeMonitoredItem(UA_Server *server,
 UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_deleteMonitoredItem(UA_Server *server, UA_UInt32 monitoredItemId);
 
+/* This method notifies the Server about a value change in a data source
+ * that is attached to a variable node.
+ *
+ * If a MonitoredItem uses the exception-based model (i.e. sampling interval = 0),
+ * the value is not sampled. With this method, userspace can inform
+ * proactively about a change in the data source and thus trigger a notification.
+ *
+ * @param server The server containing the variable node.
+ * @param node The NodeId of the variable node whose data source has changed.
+ * @return The StatusCode of the operation. */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_notifyValueChange(UA_Server *server, const UA_NodeId node);
+
 #endif
 
 /**

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -210,7 +210,7 @@ setDefaultConfig(UA_ServerConfig *conf) {
 #endif
 
     /* Limits for MonitoredItems */
-    conf->samplingIntervalLimits = UA_DURATIONRANGE(50.0, 24.0 * 3600.0 * 1000.0);
+    conf->samplingIntervalLimits = UA_DURATIONRANGE(0.0, 24.0 * 3600.0 * 1000.0);
     conf->queueSizeLimits = UA_UINT32RANGE(1, 100);
 
 #ifdef UA_ENABLE_DISCOVERY

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -360,6 +360,11 @@ translateBrowsePathToNodeIds(UA_Server *server, const UA_BrowsePath *browsePath)
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 void
 monitoredItem_sampleCallback(UA_Server *server, UA_MonitoredItem *monitoredItem);
+
+UA_StatusCode
+sampleCallbackWithValue(UA_Server *server, UA_Session *session,
+    UA_Subscription *sub, UA_MonitoredItem *mon,
+    UA_DataValue *value, UA_Boolean *movedValue);
 #endif
 
 UA_BrowsePathResult

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1227,31 +1227,19 @@ writeValueAttribute(UA_Server *server, UA_Session *session,
     }
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
-    /* If this node references a monitored item (exception-based model), queue a notification. */
-    UA_MonitoredItem *mon, *mon_tmp;
-    /* Iterate through monitored items */
-    LIST_FOREACH_SAFE(mon, &node->monitoredItems, listEntryVariableNode, mon_tmp) {
-        /* The MonitoredItem is attached to a subscription (not server-local).
-         * Prepare a notification and enqueue it. */
-        if (mon->subscription) {
-            /* Allocate a new notification */
-            UA_Notification *newNotification = (UA_Notification *)UA_calloc(1, sizeof(UA_Notification));
-            if (!newNotification) {
-                return UA_STATUSCODE_BADOUTOFMEMORY;
+    if (retval == UA_STATUSCODE_GOOD) {
+        /* If this node references a monitored item (exception-based model), queue a notification. */
+        UA_MonitoredItem *mon, *mon_tmp;
+        /* Iterate through monitored items */
+        SLIST_FOREACH_SAFE(mon, &node->monitoredItemQueue, listEntryNode, mon_tmp) {
+            /* The MonitoredItem is attached to a subscription (not server-local).
+             * Prepare a notification and enqueue it. */
+            if (mon->subscription) {
+                UA_DataValue value_copy;
+                UA_DataValue_copy(&adjustedValue, &value_copy);
+                UA_Boolean movedValue = UA_FALSE;
+                retval = sampleCallbackWithValue(server, session, mon->subscription, mon, &value_copy, &movedValue);
             }
-
-            retval = UA_DataValue_copy(&adjustedValue, &newNotification->data.value);
-            if (retval != UA_STATUSCODE_GOOD) {
-                UA_free(newNotification);
-                return retval;
-            }
-
-            UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Subscription %" PRIu32 " | "
-                "MonitoredItem %" PRIi32 " | Enqueue a new notification",
-                sub ? sub->subscriptionId : 0, mon->monitoredItemId);
-
-            newNotification->mon = mon;
-            UA_Notification_enqueue(server, mon->subscription, mon, newNotification);
         }
     }
 #endif

--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -158,9 +158,9 @@ setMonitoredItemSettings(UA_Server *server, UA_Session *session, UA_MonitoredIte
 
                 /* Remove monitored item from the variable node's list */
                 UA_MonitoredItem *tempMon;
-                LIST_FOREACH(tempMon, &vn->monitoredItems, listEntryVariableNode) {
+                SLIST_FOREACH(tempMon, &vn->monitoredItemQueue, listEntryNode) {
                     if (mon->monitoredItemId == tempMon->monitoredItemId) {
-                        LIST_REMOVE(tempMon, listEntryVariableNode);
+                        SLIST_REMOVE(&vn->monitoredItemQueue, tempMon, UA_MonitoredItem, listEntryNode);
                         break;
                     }
                 }
@@ -170,7 +170,7 @@ setMonitoredItemSettings(UA_Server *server, UA_Session *session, UA_MonitoredIte
 
                 /* If the exception-based model is used, add mon to the variable node's list */
                 if (samplingInterval == 0.0) {
-                    LIST_INSERT_HEAD(&vn->monitoredItems, mon, listEntryVariableNode);
+                    SLIST_INSERT_HEAD(&vn->monitoredItemQueue, mon, listEntryNode);
                 }
             }
             UA_NODESTORE_RELEASE(server, (const UA_Node *)vn);
@@ -209,9 +209,7 @@ static UA_StatusCode
 UA_Server_addMonitoredItemToNodeEditNodeCallback(UA_Server *server, UA_Session *session,
                                                  UA_Node *node, void *data) {
     /* data is the MonitoredItem */
-    /* SLIST_INSERT_HEAD */
-    ((UA_MonitoredItem *)data)->next = ((UA_ObjectNode *)node)->monitoredItemQueue;
-    ((UA_ObjectNode *)node)->monitoredItemQueue = (UA_MonitoredItem *)data;
+    SLIST_INSERT_HEAD(&node->monitoredItemQueue, (UA_MonitoredItem *)data, listEntryNode);
     return UA_STATUSCODE_GOOD;
 }
 #endif

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -147,6 +147,7 @@ typedef TAILQ_HEAD(NotificationQueue, UA_Notification) NotificationQueue;
 struct UA_MonitoredItem {
     UA_DelayedCallback delayedFreePointers;
     LIST_ENTRY(UA_MonitoredItem) listEntry;
+    LIST_ENTRY(UA_MonitoredItem) listEntryVariableNode;
     UA_Subscription *subscription; /* Local MonitoredItem if the subscription is NULL */
     UA_UInt32 monitoredItemId;
     UA_UInt32 clientHandle;

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -146,8 +146,8 @@ typedef TAILQ_HEAD(NotificationQueue, UA_Notification) NotificationQueue;
 
 struct UA_MonitoredItem {
     UA_DelayedCallback delayedFreePointers;
-    LIST_ENTRY(UA_MonitoredItem) listEntry;
-    LIST_ENTRY(UA_MonitoredItem) listEntryVariableNode;
+    LIST_ENTRY(UA_MonitoredItem) listEntry; /* used in subscription or local monitored items */
+    SLIST_ENTRY(UA_MonitoredItem) listEntryNode; /* used in Node */
     UA_Subscription *subscription; /* Local MonitoredItem if the subscription is NULL */
     UA_UInt32 monitoredItemId;
     UA_UInt32 clientHandle;
@@ -195,10 +195,6 @@ struct UA_MonitoredItem {
     UA_UInt32 queueSize;
     UA_UInt32 eventOverflows; /* Separate counter for the queue. Can at most
                                * double the queue size */
-
-#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
-    UA_MonitoredItem *next;
-#endif
 
 #ifdef UA_ENABLE_DA
     UA_StatusCode lastStatus;

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -170,7 +170,7 @@ static UA_StatusCode
 
 /* movedValue returns whether the sample was moved to the notification. The
  * default is false. */
-static UA_StatusCode
+UA_StatusCode
 sampleCallbackWithValue(UA_Server *server, UA_Session *session,
                         UA_Subscription *sub, UA_MonitoredItem *mon,
                         UA_DataValue *value, UA_Boolean *movedValue) {

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -210,7 +210,7 @@ UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *monitoredItem) {
     UA_MonitoredItem_unregisterSampleCallback(server, monitoredItem);
 
     /* Remove monitored item from the list inside the variable node */
-    UA_Node *node = (UA_Node*)UA_NODESTORE_GET(server, &monitoredItem->monitoredNodeId);
+    UA_Node *node = (UA_Node*)(uintptr_t)UA_NODESTORE_GET(server, &monitoredItem->monitoredNodeId);
     if (node) {
         UA_MonitoredItem *tempMon;
         SLIST_FOREACH(tempMon, &node->monitoredItemQueue, listEntryNode) {

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -212,7 +212,6 @@ UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *monitoredItem) {
     /* Remove monitored item from the list inside the variable node */
     UA_Node *node = (UA_Node*)UA_NODESTORE_GET(server, &monitoredItem->monitoredNodeId);
     if (node) {
-        struct MonitoredItemsList *itemsList = &node->monitoredItemQueue;
         UA_MonitoredItem *tempMon;
         SLIST_FOREACH(tempMon, &node->monitoredItemQueue, listEntryNode) {
             if (monitoredItem->monitoredItemId == tempMon->monitoredItemId) {
@@ -220,6 +219,7 @@ UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *monitoredItem) {
                 break;
             }
         }
+        UA_NODESTORE_RELEASE(server, node);
     }
 
     /* Remove the queued notifications if attached to a subscription (not a

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -210,16 +210,14 @@ UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *monitoredItem) {
     UA_MonitoredItem_unregisterSampleCallback(server, monitoredItem);
 
     /* Remove monitored item from the list inside the variable node */
-    const UA_Node *node = UA_NODESTORE_GET(server, &monitoredItem->monitoredNodeId);
+    UA_Node *node = (UA_Node*)UA_NODESTORE_GET(server, &monitoredItem->monitoredNodeId);
     if (node) {
-        if (node->nodeClass == UA_NODECLASS_VARIABLE) {
-            UA_VariableNode *vn = (UA_VariableNode *)node;
-            UA_MonitoredItem *tempMon;
-            LIST_FOREACH(tempMon, &vn->monitoredItems, listEntryVariableNode) {
-                if (monitoredItem->monitoredItemId == tempMon->monitoredItemId) {
-                    LIST_REMOVE(tempMon, listEntryVariableNode);
-                    break;
-                }
+        struct MonitoredItemsList *itemsList = &node->monitoredItemQueue;
+        UA_MonitoredItem *tempMon;
+        SLIST_FOREACH(tempMon, &node->monitoredItemQueue, listEntryNode) {
+            if (monitoredItem->monitoredItemId == tempMon->monitoredItemId) {
+                SLIST_REMOVE(&node->monitoredItemQueue, tempMon, UA_MonitoredItem, listEntryNode);
+                break;
             }
         }
     }


### PR DESCRIPTION
Hi!

This PR implements the exception-based model according to OPC UA Part 4 [p. 60] 5.12.1.2.
In short: When setting the sampling interval of a monitored item to 0, the server reports data changes proactively. The value will not be sampled periodically.

For now, only Server calls (e.g. UA_Server_writeValue) trigger a notification. Userland can not trigger notifications for a DataSource yet.

Looking forward to your comments!

Regards,
Max