### PR TITLE
Merge from 1.0: Fix memory leak if enableRetransmissionQueue is disabled

### DIFF
--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -513,8 +513,13 @@ UA_Subscription_publish(UA_Server *server, UA_Subscription *sub) {
     sub->currentKeepAliveCount = 0;
 
     /* Free the response */
-    UA_Array_delete(response->results, response->resultsSize, &UA_TYPES[UA_TYPES_UINT32]);
-    UA_free(pre); /* No need for UA_PublishResponse_clear */
+    if(retransmission)
+        /* NotificationMessage was moved into retransmission queue */
+        UA_NotificationMessage_init(&response->notificationMessage);
+    response->availableSequenceNumbers = NULL;
+    response->availableSequenceNumbersSize = 0;
+    UA_PublishResponse_clear(&pre->response);
+    UA_free(pre);
 
     /* Repeat sending responses if there are more notifications to send */
     if(moreNotifications)


### PR DESCRIPTION
Free resources in relation to retransmission queue is available or not.