### PR TITLE
fix(log): Use logger clear callback consistenly

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -76,12 +76,11 @@ UA_ClientConfig_deleteMembers(UA_ClientConfig *config) {
     UA_free(config->securityPolicies);
     config->securityPolicies = 0;
 
-    if (config->logger.context && config->logger.clear) {
+    /* Logger */
+    if(config->logger.clear)
         config->logger.clear(config->logger.context);
-        config->logger.context = NULL;
-        config->logger.log = NULL;
-        config->logger.clear = NULL;
-    }
+    config->logger.log = NULL;
+    config->logger.clear = NULL;
 }
 
 static void

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -76,6 +76,8 @@ UA_ServerConfig_clean(UA_ServerConfig *config) {
     /* Logger */
     if(config->logger.clear)
         config->logger.clear(config->logger.context);
+    config->logger.log = NULL;
+    config->logger.clear = NULL;
 }
 
 void


### PR DESCRIPTION
The client did check that logger context is not NULL before calling
the clear() callback.  This does not make sense as the default
config uses UA_Log_Stdout_clear() with a NULL context.  It does
make sense to reset the logger callbacks in the client and server
config clean() functions, so that they cannot be called after that.
Do that consistently for both client and server.