### PR TITLE
[Discussion] feat(core): add cmake variant support for Visual Studio Code Users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,5 @@ Makefile
 /tools/certs/certs/*
 Pipfile
 Pipfile.lock
-.vscode
+.vscode/*
+!.vscode/cmake-variants.yaml

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -149,7 +149,7 @@ pub_sub:
   description: Controls Publish/Subscribe service set
   choices:
     None:
-      short: Simple-Pub/Sub
+      short: No-Pub/Sub
       long: Disables Publish/Subscribe service set
       setting:
         UA_ENABLE_PUBSUB: False

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -37,17 +37,17 @@ historization:
   description: Controls the building of historization plugin
   choices:
     Disable:
-      short: None
+      short: noHistorization
       long: Deactivates the historization plugin for building
       setting:
         UA_ENABLE_HISTORIZING: False
     Standard:
-      short: Standard
+      short: Simple-Historization
       long: Activates the historization plugin for building
       setting:
         UA_ENABLE_HISTORIZING: True
     Expermental:
-      short: Expermental
+      short: Expermental-Historization
       long: Activates the expermental historization plugin for building
       setting:
         UA_ENABLE_EXPERIMENTAL_HISTORIZING: True
@@ -94,12 +94,6 @@ multithreading:
       setting:
         UA_ENABLE_MULTITHREADING: True
         UA_ENABLE_IMMUTABLE_NODES: True
-    Multithreaded-Parsing:
-      short: Multithreaded-Parsing
-      long: Activates Utility functions that require parsing
-      setting:
-        UA_ENABLE_MULTITHREADING: True
-        UA_ENABLE_PARSING: True
 
 discovery:
   default: Enable
@@ -155,58 +149,34 @@ pub_sub:
   description: Controls Publish/Subscribe service set
   choices:
     None:
-      short: None
+      short: Simple-Pub/Sub
       long: Disables Publish/Subscribe service set
       setting:
         UA_ENABLE_PUBSUB: False
     overEthernet:
-      short: Ethernet
+      short: Ethernet-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet
       setting:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP: True
     overEthernetXDP:
-      short: EthernetXDP
+      short: EthernetXDP-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet using XDP
       setting:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP_XDP: True
     overEthernetETF:
-      short: EthernetETF
+      short: EthernetETF-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet using ETF
       setting:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP_ETF: True
     mqtt:
-      short: MQTT
+      short: MQTT-Pub/Sub
       long: Enable publish/subscribe with mqtt
       setting:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_MQTT: True
-    model_twin:
-      short: Model-Twin
-      long: able PubSub information model twin
-      setting:
-        UA_ENABLE_PUBSUB: True
-        UA_ENABLE_PUBSUB_INFORMATIONMODEL: True
-    methods:
-      short: Pub/Sub-Methods
-      long: Enable PubSub informationmodel methods
-      setting:
-        UA_ENABLE_PUBSUB: True
-        UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS: True
-    pub_sub_custom_handler:
-      short: Pub/Sub-Handler
-      long: Enable custom implementation for the publish callback handling
-      setting:
-        UA_ENABLE_PUBSUB: True
-        UA_ENABLE_PUBSUB_CUSTOM_PUBLISH_HANDLING: True
-    pub_sub_delta_frames:
-      short: Pub/Sub-Deltas
-      long: Enable sending of delta frames with only the changes
-      setting:
-        UA_ENABLE_PUBSUB: True
-        UA_ENABLE_PUBSUB_DELTAFRAMES: True
 
 namespace_zero:
   default: Reduced

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -9,7 +9,7 @@ buildType:
   default: debug
   choices:
     debug:
-      short: Debug
+      short: Dbg
       long: Builds the binaries with debugging hookups, tests and code instrumentation without any optimizations (-O0)
       buildType: Debug
       setting:
@@ -24,7 +24,7 @@ buildType:
       long: Builds the binaries with debugging information, but without any assertions, applies normal optimizations (-02)
       buildType: RelWithDebInfo
     release:
-      short: Release
+      short: Rel
       long: Builds the binaries without any debugging informtaion and no code assetions, applies high optimizations (-03)
       buildType: Release
     minSizeRel:
@@ -37,17 +37,17 @@ historization:
   description: Controls the building of historization plugin
   choices:
     Disable:
-      short: noHistorization
+      short: noHistory
       long: Deactivates the historization plugin for building
       setting:
         UA_ENABLE_HISTORIZING: False
     Standard:
-      short: Simple-Historization
+      short: Simple-History
       long: Activates the historization plugin for building
       setting:
         UA_ENABLE_HISTORIZING: True
     Expermental:
-      short: Expermental-Historization
+      short: Expmntl-History
       long: Activates the expermental historization plugin for building
       setting:
         UA_ENABLE_EXPERIMENTAL_HISTORIZING: True
@@ -57,18 +57,18 @@ subscription:
   description: Controls the subscription service
   choices:
     Standard:
-      short: Subscription
+      short: Subs
       long: Activates the subscription service
       setting:
         UA_ENABLE_SUBSCRIPTIONS: True
     Events:
-      short: Subscription-With-Events
+      short: Subs-And-Events
       long: Activates the Subscription Events
       setting:
         UA_ENABLE_SUBSCRIPTIONS: True
         UA_ENABLE_SUBSCRIPTIONS_EVENTS: True
     Disable:
-      short: noSubscription
+      short: noSubs
       long: Deactivates the subscription service
       setting:
         UA_ENABLE_SUBSCRIPTIONS: False
@@ -78,18 +78,18 @@ multithreading:
   description: Controls if the binaries are built for multithreaded execution
   choices:
     Singlethreaded:
-      short: Singlethreaded
+      short: Singlethread
       long: Builds the binaries without multithreading support
       setting:
         UA_ENABLE_MULTITHREADING: False
     Multithreaded-Mutable:
-      short: Multithreaded
+      short: Multithread
       long: Builds the binaries with multithreading support
       setting:
         UA_ENABLE_MULTITHREADING: True
         UA_ENABLE_IMMUTABLE_NODES: False
     Multithreaded-Immutable:
-      short: Multithreaded-Immutable
+      short: Multithread-Immutable
       long: Builds the binaries with multithreading support and immutable nodes
       setting:
         UA_ENABLE_MULTITHREADING: True
@@ -100,22 +100,16 @@ discovery:
   description: Controls the Discovery Server
   choices:
     Enable:
-      short: Discovery
+      short: LDS
       long: Builds the Discovery Server
       setting:
         UA_ENABLE_DISCOVERY: True
     multicast_discovery:
-      short: Multicast-Discovery
+      short: LDS-ME
       long: Enables LDS-ME Multicast Support and Discovery service
       setting:
         UA_ENABLE_DISCOVERY: True
         UA_ENABLE_DISCOVERY_MULTICAST: True
-    discovery_semaphore:
-      short: Discovery-With-Semaphore
-      long: Activates Semaphroe support
-      setting:
-        UA_ENABLE_DISCOVERY: True
-        UA_ENABLE_DISCOVERY_SEMAPHORE: True
     Disable:
       short: noDiscovery
       long: Doesnt builds the Discovery Server
@@ -127,7 +121,7 @@ encription:
   description: Controls encription support
   choices:
     noEncription:
-      short: noEncription
+      short: noEncript
       long: Deactivates all encription support
       setting:
         UA_ENABLE_ENCRYPTION: False
@@ -154,19 +148,19 @@ pub_sub:
       setting:
         UA_ENABLE_PUBSUB: False
     overEthernet:
-      short: Ethernet-Pub/Sub
+      short: Eth-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet
       setting:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP: True
     overEthernetXDP:
-      short: EthernetXDP-Pub/Sub
+      short: EthXDP-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet using XDP
       setting:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP_XDP: True
     overEthernetETF:
-      short: EthernetETF-Pub/Sub
+      short: EthETF-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet using ETF
       setting:
         UA_ENABLE_PUBSUB: True

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -1,0 +1,235 @@
+# Required extentions:
+# Cmake Tools: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools
+# Recommended extentions (for editing):
+# YAML: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+# Authors:
+# Dovydas Girdvainis 2020.04.20
+
+buildType:
+  default: debug
+  choices:
+    debug:
+      short: Debug
+      long: Builds the binaries with debugging hookups, tests and code instrumentation without any optimizations (-O0)
+      buildType: Debug
+      setting:
+        UA_DEBUG: True
+        UA_LOGLEVEL: "100"
+        UA_BUILD_UNIT_TESTS: True
+        UA_ENABLE_COVERAGE: True
+        UA_ENABLE_DETERMINISTIC_RNG: True
+        UA_ENABLE_UNIT_TESTS_MEMCHECK: True
+    relWithDebInfo:
+      short: RelWithDebInfo
+      long: Builds the binaries with debugging information, but without any assertions, applies normal optimizations (-02)
+      buildType: RelWithDebInfo
+    release:
+      short: Release
+      long: Builds the binaries without any debugging informtaion and no code assetions, applies high optimizations (-03)
+      buildType: Release
+    minSizeRel:
+      short: MinSizeRel
+      long: Builds the binaries without any debugging informtaion and no code assetions, applies high binary size optimizations (-0s)
+      buildType: MinSizeRel
+
+historization:
+  default: Disable
+  description: Controls the building of historization plugin
+  choices:
+    Disable:
+      short: None
+      long: Deactivates the historization plugin for building
+      setting:
+        UA_ENABLE_HISTORIZING: False
+    Standard:
+      short: Standard
+      long: Activates the historization plugin for building
+      setting:
+        UA_ENABLE_HISTORIZING: True
+    Expermental:
+      short: Expermental
+      long: Activates the expermental historization plugin for building
+      setting:
+        UA_ENABLE_EXPERIMENTAL_HISTORIZING: True
+
+subscription:
+  default: Standard
+  description: Controls the subscription service
+  choices:
+    Standard:
+      short: Subscription
+      long: Activates the subscription service
+      setting:
+        UA_ENABLE_SUBSCRIPTIONS: True
+    Events:
+      short: Subscription-With-Events
+      long: Activates the Subscription Events
+      setting:
+        UA_ENABLE_SUBSCRIPTIONS: True
+        UA_ENABLE_SUBSCRIPTIONS_EVENTS: True
+    Disable:
+      short: noSubscription
+      long: Deactivates the subscription service
+      setting:
+        UA_ENABLE_SUBSCRIPTIONS: False
+
+multithreading:
+  default: Singlethreaded
+  description: Controls if the binaries are built for multithreaded execution
+  choices:
+    Singlethreaded:
+      short: Singlethreaded
+      long: Builds the binaries without multithreading support
+      setting:
+        UA_ENABLE_MULTITHREADING: False
+    Multithreaded-Mutable:
+      short: Multithreaded
+      long: Builds the binaries with multithreading support
+      setting:
+        UA_ENABLE_MULTITHREADING: True
+        UA_ENABLE_IMMUTABLE_NODES: False
+    Multithreaded-Immutable:
+      short: Multithreaded-Immutable
+      long: Builds the binaries with multithreading support and immutable nodes
+      setting:
+        UA_ENABLE_MULTITHREADING: True
+        UA_ENABLE_IMMUTABLE_NODES: True
+    Multithreaded-Parsing:
+      short: Multithreaded-Parsing
+      long: Activates Utility functions that require parsing
+      setting:
+        UA_ENABLE_MULTITHREADING: True
+        UA_ENABLE_PARSING: True
+
+discovery:
+  default: Enable
+  description: Controls the Discovery Server
+  choices:
+    Enable:
+      short: Discovery
+      long: Builds the Discovery Server
+      setting:
+        UA_ENABLE_DISCOVERY: True
+    multicast_discovery:
+      short: Multicast-Discovery
+      long: Enables LDS-ME Multicast Support and Discovery service
+      setting:
+        UA_ENABLE_DISCOVERY: True
+        UA_ENABLE_DISCOVERY_MULTICAST: True
+    discovery_semaphore:
+      short: Discovery-With-Semaphore
+      long: Activates Semaphroe support
+      setting:
+        UA_ENABLE_DISCOVERY: True
+        UA_ENABLE_DISCOVERY_SEMAPHORE: True
+    Disable:
+      short: noDiscovery
+      long: Doesnt builds the Discovery Server
+      setting:
+        UA_ENABLE_DISCOVERY: False
+
+encription:
+  default: noEncription
+  description: Controls encription support
+  choices:
+    noEncription:
+      short: noEncription
+      long: Deactivates all encription support
+      setting:
+        UA_ENABLE_ENCRYPTION: False
+    mbedTLS:
+      short: mbedTLS
+      description: Activates Encription support using mbedTLS
+      setting:
+        UA_ENABLE_ENCRYPTION: True
+        UA_ENABLE_ENCRYPTION_MBEDTLS: True
+    openssl:
+      short: openssl
+      description: Activates Encription support using openssl
+      setting:
+        UA_ENABLE_ENCRYPTION: True
+        UA_ENABLE_ENCRYPTION_OPENSSL: True
+
+pub_sub:
+  default: None
+  description: Controls Publish/Subscribe service set
+  choices:
+    None:
+      short: None
+      long: Disables Publish/Subscribe service set
+      setting:
+        UA_ENABLE_PUBSUB: False
+    overEthernet:
+      short: Ethernet
+      long: Enables Publish/Subscribe UADP over Ethernet
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_ETH_UADP: True
+    overEthernetXDP:
+      short: EthernetXDP
+      long: Enables Publish/Subscribe UADP over Ethernet using XDP
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_ETH_UADP_XDP: True
+    overEthernetETF:
+      short: EthernetETF
+      long: Enables Publish/Subscribe UADP over Ethernet using ETF
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_ETH_UADP_ETF: True
+    mqtt:
+      short: MQTT
+      long: Enable publish/subscribe with mqtt
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_MQTT: True
+    model_twin:
+      short: Model-Twin
+      long: able PubSub information model twin
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_INFORMATIONMODEL: True
+    methods:
+      short: Pub/Sub-Methods
+      long: Enable PubSub informationmodel methods
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS: True
+    pub_sub_custom_handler:
+      short: Pub/Sub-Handler
+      long: Enable custom implementation for the publish callback handling
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_CUSTOM_PUBLISH_HANDLING: True
+    pub_sub_delta_frames:
+      short: Pub/Sub-Deltas
+      long: Enable sending of delta frames with only the changes
+      setting:
+        UA_ENABLE_PUBSUB: True
+        UA_ENABLE_PUBSUB_DELTAFRAMES: True
+
+namespace_zero:
+  default: Reduced
+  description: Controlls Completeness of the generated namespace zero (minimal/reduced/full)
+  choices:
+    Minimal:
+      short: Minimal
+      long: Barebones namespace zero that is compatible with most clients. But this namespace 0 is so small that it does not pass the CTT (Conformance Testing Tools of the OPC Foundation)
+      setting:
+        UA_NAMESPACE_ZERO: "MINIMAL"
+    Reduced:
+      short: Reduced
+      long: Small namespace zero that passes the CTT.
+      setting:
+        UA_NAMESPACE_ZERO: "REDUCED"
+    Full:
+      short: Full
+      long: Full namespace zero generated from the official XML definitions.
+      setting:
+        UA_NAMESPACE_ZERO: "FULL"
+    micro_emb_profile:
+      short: micro_emb_profile
+      long: Builds CTT Compliant Micro Embedded Device Server Profile
+      setting:
+        UA_NAMESPACE_ZERO: "FULL"
+        UA_ENABLE_MICRO_EMB_DEV_PROFILE: True

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -9,12 +9,12 @@ buildType:
   default: debug
   choices:
     debug:
-      short: Dbg
+      short: debug
       long: Builds the binaries with debugging hookups, tests and code instrumentation without any optimizations (-O0)
       buildType: Debug
-      setting:
+      settings:
         UA_DEBUG: True
-        UA_LOGLEVEL: "100"
+        UA_LOGLEVEL: 100
         UA_BUILD_UNIT_TESTS: True
         UA_ENABLE_COVERAGE: True
         UA_ENABLE_DETERMINISTIC_RNG: True
@@ -39,17 +39,17 @@ historization:
     Disable:
       short: noHistory
       long: Deactivates the historization plugin for building
-      setting:
+      settings:
         UA_ENABLE_HISTORIZING: False
     Standard:
       short: Simple-History
       long: Activates the historization plugin for building
-      setting:
+      settings:
         UA_ENABLE_HISTORIZING: True
     Expermental:
       short: Expmntl-History
       long: Activates the expermental historization plugin for building
-      setting:
+      settings:
         UA_ENABLE_EXPERIMENTAL_HISTORIZING: True
 
 subscription:
@@ -59,18 +59,18 @@ subscription:
     Standard:
       short: Subs
       long: Activates the subscription service
-      setting:
+      settings:
         UA_ENABLE_SUBSCRIPTIONS: True
     Events:
       short: Subs-And-Events
       long: Activates the Subscription Events
-      setting:
+      settings:
         UA_ENABLE_SUBSCRIPTIONS: True
         UA_ENABLE_SUBSCRIPTIONS_EVENTS: True
     Disable:
       short: noSubs
       long: Deactivates the subscription service
-      setting:
+      settings:
         UA_ENABLE_SUBSCRIPTIONS: False
 
 multithreading:
@@ -80,18 +80,18 @@ multithreading:
     Singlethreaded:
       short: Singlethread
       long: Builds the binaries without multithreading support
-      setting:
+      settings:
         UA_ENABLE_MULTITHREADING: False
     Multithreaded-Mutable:
       short: Multithread
       long: Builds the binaries with multithreading support
-      setting:
+      settings:
         UA_ENABLE_MULTITHREADING: True
         UA_ENABLE_IMMUTABLE_NODES: False
     Multithreaded-Immutable:
       short: Multithread-Immutable
       long: Builds the binaries with multithreading support and immutable nodes
-      setting:
+      settings:
         UA_ENABLE_MULTITHREADING: True
         UA_ENABLE_IMMUTABLE_NODES: True
 
@@ -102,18 +102,18 @@ discovery:
     Enable:
       short: LDS
       long: Builds the Discovery Server
-      setting:
+      settings:
         UA_ENABLE_DISCOVERY: True
     multicast_discovery:
       short: LDS-ME
       long: Enables LDS-ME Multicast Support and Discovery service
-      setting:
+      settings:
         UA_ENABLE_DISCOVERY: True
         UA_ENABLE_DISCOVERY_MULTICAST: True
     Disable:
       short: noDiscovery
       long: Doesnt builds the Discovery Server
-      setting:
+      settings:
         UA_ENABLE_DISCOVERY: False
 
 encription:
@@ -123,18 +123,18 @@ encription:
     noEncription:
       short: noEncript
       long: Deactivates all encription support
-      setting:
+      settings:
         UA_ENABLE_ENCRYPTION: False
     mbedTLS:
       short: mbedTLS
       description: Activates Encription support using mbedTLS
-      setting:
+      settings:
         UA_ENABLE_ENCRYPTION: True
         UA_ENABLE_ENCRYPTION_MBEDTLS: True
     openssl:
       short: openssl
       description: Activates Encription support using openssl
-      setting:
+      settings:
         UA_ENABLE_ENCRYPTION: True
         UA_ENABLE_ENCRYPTION_OPENSSL: True
 
@@ -145,30 +145,30 @@ pub_sub:
     None:
       short: No-Pub/Sub
       long: Disables Publish/Subscribe service set
-      setting:
+      settings:
         UA_ENABLE_PUBSUB: False
     overEthernet:
       short: Eth-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet
-      setting:
+      settings:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP: True
     overEthernetXDP:
       short: EthXDP-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet using XDP
-      setting:
+      settings:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP_XDP: True
     overEthernetETF:
       short: EthETF-Pub/Sub
       long: Enables Publish/Subscribe UADP over Ethernet using ETF
-      setting:
+      settings:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_ETH_UADP_ETF: True
     mqtt:
       short: MQTT-Pub/Sub
       long: Enable publish/subscribe with mqtt
-      setting:
+      settings:
         UA_ENABLE_PUBSUB: True
         UA_ENABLE_PUBSUB_MQTT: True
 
@@ -179,21 +179,21 @@ namespace_zero:
     Minimal:
       short: Minimal
       long: Barebones namespace zero that is compatible with most clients. But this namespace 0 is so small that it does not pass the CTT (Conformance Testing Tools of the OPC Foundation)
-      setting:
+      settings:
         UA_NAMESPACE_ZERO: "MINIMAL"
     Reduced:
       short: Reduced
       long: Small namespace zero that passes the CTT.
-      setting:
+      settings:
         UA_NAMESPACE_ZERO: "REDUCED"
     Full:
       short: Full
       long: Full namespace zero generated from the official XML definitions.
-      setting:
+      settings:
         UA_NAMESPACE_ZERO: "FULL"
     micro_emb_profile:
       short: micro_emb_profile
       long: Builds CTT Compliant Micro Embedded Device Server Profile
-      setting:
+      settings:
         UA_NAMESPACE_ZERO: "FULL"
         UA_ENABLE_MICRO_EMB_DEV_PROFILE: True


### PR DESCRIPTION
## Description 

This is a simple change for developers who use Visual Studio Code. It allows the developer to use predefined Cmake Options without having to create a specific Task or modify `.vscode/settings.json` file to provide various CMake options defined by open62541, as shown bellow:

![vsc_cmake_tools_support](https://user-images.githubusercontent.com/15049512/79779614-f0d42c00-833a-11ea-9b10-233aa7d21904.gif)

## Supported options
Due to limitations with CMake Tools Variant I reduced the available options to the following: 

* buildType
  * Debug - sets `UA_DEBUG`, `UA_BUILD_UNIT_TESTS`, `UA_ENABLE_COVERAGE`, `UA_ENABLE_DETERMINISTIC_RNG`, `UA_ENABLE_UNIT_TESTS_MEMCHECK`
  * RelWithDebInfo 
  * Release
  * MinSizeRel
* historization 
  * noHistory
  * Simple-History - `UA_ENABLE_HISTORIZING`
  * Expmntl-History - `UA_ENABLE_EXPERIMENTAL_HISTORIZING`
* subscription
  * Subs - `UA_ENABLE_SUBSCRIPTIONS`
  * Subs-And-Events - `UA_ENABLE_SUBSCRIPTIONS`, `UA_ENABLE_SUBSCRIPTIONS_EVENTS`
  * noSubs
* multithreading
  * Singlethread
  * Multithread - `UA_ENABLE_MULTITHREADING`
  * Multithread-Immutable - `UA_ENABLE_MULTITHREADING`, `UA_ENABLE_IMMUTABLE_NODES`
*discovery 
  * LDS - `UA_ENABLE_DISCOVERY`
  * LDS-ME - `UA_ENABLE_DISCOVERY`, `UA_ENABLE_DISCOVERY_MULTICAST`
  * noDiscovery
* encription
  * noEncript
  * mbedTLS - `UA_ENABLE_ENCRYPTION`, `UA_ENABLE_ENCRYPTION_MBEDTLS`
  * openssl - `UA_ENABLE_ENCRYPTION`,  `UA_ENABLE_ENCRYPTION_OPENSSL`
* pub_sub
  * No-Pub/Sub
  * Eth-Pub/Sub - `UA_ENABLE_PUBSUB`, `UA_ENABLE_PUBSUB_ETH_UADP`
  * EthXDP-Pub/Sub - `UA_ENABLE_PUBSUB`, `UA_ENABLE_PUBSUB_ETH_UADP_XDP`
  * EthETF-Pub/Sub - `UA_ENABLE_PUBSUB`, `UA_ENABLE_PUBSUB_ETH_UADP_ETF`
  * MQTT-Pub/Sub  - `UA_ENABLE_PUBSUB`, `UA_ENABLE_PUBSUB_MQTT`
* namespace_zero 
  * Minimal
  * Reduced
  * Full
  * micro_emb_profile - `UA_NAMESPACE_ZERO="FULL", ` `UA_ENABLE_MICRO_EMB_DEV_PROFILE`

### Development/Maintenance

It is always possible to expand the given `.vscode/cmake-variants.yaml` file and add options as needed, however as of current CMake Tools Variant Implementation, I would not recommend it, since already there are 19440 different variations.  Furthermore this file is prone to breaking, when the options defined inside `CMakeLists.txt` are changed, specifically their naming. 



