### PR TITLE
[Review] feat(plugin): implement configurable logger for pki_default unit

### DIFF
--- a/examples/server_ctt.c
+++ b/examples/server_ctt.c
@@ -9,10 +9,10 @@
 #define _CRT_SECURE_NO_WARNINGS /* disable fopen deprication warning in msvs */
 #endif
 
-#include <open62541/server.h>
 #include <open62541/plugin/log_stdout.h>
-#include <open62541/server_config_default.h>
 #include <open62541/plugin/pki_default.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
 
 #include <signal.h>
 #include <stdlib.h>
@@ -25,7 +25,8 @@
  * corresponding CTT configuration is available at
  * https://github.com/open62541/open62541-ctt */
 
-static const UA_NodeId baseDataVariableType = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_BASEDATAVARIABLETYPE}};
+static const UA_NodeId baseDataVariableType = {
+    0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_BASEDATAVARIABLETYPE}};
 static const UA_NodeId accessDenied = {1, UA_NODEIDTYPE_NUMERIC, {1337}};
 
 /* Custom AccessControl policy that disallows access to one specific node */
@@ -40,10 +41,8 @@ getUserAccessLevel_disallowSpecific(UA_Server *server, UA_AccessControl *ac,
 
 /* Datasource Example */
 static UA_StatusCode
-readTimeData(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
+readTimeData(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+             const UA_NodeId *nodeId, void *nodeContext, UA_Boolean sourceTimeStamp,
              const UA_NumericRange *range, UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
@@ -61,17 +60,15 @@ readTimeData(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomBoolData(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomBoolData(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                   const UA_NodeId *nodeId, void *nodeContext, UA_Boolean sourceTimeStamp,
+                   const UA_NumericRange *range, UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
         return UA_STATUSCODE_GOOD;
     }
-    UA_Boolean toggle = !((UA_UInt32_random() % 10 ) % 2);
+    UA_Boolean toggle = !((UA_UInt32_random() % 10) % 2);
     UA_Variant_setScalarCopy(&value->value, &toggle, &UA_TYPES[UA_TYPES_BOOLEAN]);
     value->hasValue = true;
     if(sourceTimeStamp) {
@@ -82,11 +79,10 @@ readRandomBoolData(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomInt16Data(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomInt16Data(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                    const UA_NodeId *nodeId, void *nodeContext,
+                    UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                    UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -103,11 +99,10 @@ readRandomInt16Data(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomInt32Data(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomInt32Data(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                    const UA_NodeId *nodeId, void *nodeContext,
+                    UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                    UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -124,19 +119,18 @@ readRandomInt32Data(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomInt64Data(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomInt64Data(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                    const UA_NodeId *nodeId, void *nodeContext,
+                    UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                    UA_DataValue *value) {
     if(range) {
-    value->hasStatus = true;
-    value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
-    return UA_STATUSCODE_GOOD;
+        value->hasStatus = true;
+        value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
+        return UA_STATUSCODE_GOOD;
     }
-        UA_Int64 toggle = (UA_Int64)UA_UInt32_random();
-        UA_Variant_setScalarCopy(&value->value, &toggle, &UA_TYPES[UA_TYPES_INT64]);
-        value->hasValue = true;
+    UA_Int64 toggle = (UA_Int64)UA_UInt32_random();
+    UA_Variant_setScalarCopy(&value->value, &toggle, &UA_TYPES[UA_TYPES_INT64]);
+    value->hasValue = true;
     if(sourceTimeStamp) {
         value->hasSourceTimestamp = true;
         value->sourceTimestamp = UA_DateTime_now();
@@ -145,11 +139,10 @@ readRandomInt64Data(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomUInt16Data(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomUInt16Data(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                     const UA_NodeId *nodeId, void *nodeContext,
+                     UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                     UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -166,11 +159,10 @@ readRandomUInt16Data(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomUInt32Data(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomUInt32Data(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                     const UA_NodeId *nodeId, void *nodeContext,
+                     UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                     UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -187,11 +179,10 @@ readRandomUInt32Data(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomUInt64Data(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomUInt64Data(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                     const UA_NodeId *nodeId, void *nodeContext,
+                     UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                     UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -208,11 +199,10 @@ readRandomUInt64Data(UA_Server *server,
 }
 
 static UA_StatusCode
-readRandomStringData (UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomStringData(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                     const UA_NodeId *nodeId, void *nodeContext,
+                     UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                     UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -227,15 +217,14 @@ readRandomStringData (UA_Server *server,
         value->hasSourceTimestamp = true;
         value->sourceTimestamp = UA_DateTime_now();
     }
-   return UA_STATUSCODE_GOOD;
+    return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-readRandomFloatData (UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomFloatData(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                    const UA_NodeId *nodeId, void *nodeContext,
+                    UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                    UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -248,15 +237,14 @@ readRandomFloatData (UA_Server *server,
         value->hasSourceTimestamp = true;
         value->sourceTimestamp = UA_DateTime_now();
     }
-   return UA_STATUSCODE_GOOD;
+    return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-readRandomDoubleData (UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readRandomDoubleData(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                     const UA_NodeId *nodeId, void *nodeContext,
+                     UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
+                     UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -269,14 +257,12 @@ readRandomDoubleData (UA_Server *server,
         value->hasSourceTimestamp = true;
         value->sourceTimestamp = UA_DateTime_now();
     }
-   return UA_STATUSCODE_GOOD;
+    return UA_STATUSCODE_GOOD;
 }
 static UA_StatusCode
-readByteString (UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext,
-             UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+readByteString(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+               const UA_NodeId *nodeId, void *nodeContext, UA_Boolean sourceTimeStamp,
+               const UA_NumericRange *range, UA_DataValue *value) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -291,18 +277,16 @@ readByteString (UA_Server *server,
         value->hasSourceTimestamp = true;
         value->sourceTimestamp = UA_DateTime_now();
     }
-   return UA_STATUSCODE_GOOD;
+    return UA_STATUSCODE_GOOD;
 }
 
 /* Method Node Example */
 #ifdef UA_ENABLE_METHODCALLS
 
 static UA_StatusCode
-helloWorld(UA_Server *server,
-           const UA_NodeId *sessionId, void *sessionContext,
-           const UA_NodeId *methodId, void *methodContext,
-           const UA_NodeId *objectId, void *objectContext,
-           size_t inputSize, const UA_Variant *input,
+helloWorld(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+           const UA_NodeId *methodId, void *methodContext, const UA_NodeId *objectId,
+           void *objectContext, size_t inputSize, const UA_Variant *input,
            size_t outputSize, UA_Variant *output) {
     /* input is a scalar string (checked by the server) */
     UA_String *name = (UA_String *)input[0].data;
@@ -318,21 +302,17 @@ helloWorld(UA_Server *server,
 }
 
 static UA_StatusCode
-noargMethod(UA_Server *server,
-            const UA_NodeId *sessionId, void *sessionContext,
-            const UA_NodeId *methodId, void *methodContext,
-            const UA_NodeId *objectId, void *objectContext,
-            size_t inputSize, const UA_Variant *input,
+noargMethod(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+            const UA_NodeId *methodId, void *methodContext, const UA_NodeId *objectId,
+            void *objectContext, size_t inputSize, const UA_Variant *input,
             size_t outputSize, UA_Variant *output) {
     return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-outargMethod(UA_Server *server,
-             const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *methodId, void *methodContext,
-             const UA_NodeId *objectId, void *objectContext,
-             size_t inputSize, const UA_Variant *input,
+outargMethod(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+             const UA_NodeId *methodId, void *methodContext, const UA_NodeId *objectId,
+             void *objectContext, size_t inputSize, const UA_Variant *input,
              size_t outputSize, UA_Variant *output) {
     UA_Int32 out = 42;
     UA_Variant_setScalarCopy(output, &out, &UA_TYPES[UA_TYPES_INT32]);
@@ -356,8 +336,9 @@ setInformationModel(UA_Server *server) {
     const UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
     UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
     UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
-    UA_Server_addVariableNode(server, myIntegerNodeId, parentNodeId, parentReferenceNodeId,
-                              myIntegerName, baseDataVariableType, myVar, NULL, NULL);
+    UA_Server_addVariableNode(server, myIntegerNodeId, parentNodeId,
+                              parentReferenceNodeId, myIntegerName, baseDataVariableType,
+                              myVar, NULL, NULL);
 
     /* add a static variable that is readable but not writable*/
     myVar = UA_VariableAttributes_default;
@@ -367,10 +348,12 @@ setInformationModel(UA_Server *server) {
     myVar.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
     myVar.valueRank = UA_VALUERANK_SCALAR;
     UA_Variant_setScalar(&myVar.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    const UA_QualifiedName myInteger2Name = UA_QUALIFIEDNAME(1, "the answer - not readable");
+    const UA_QualifiedName myInteger2Name =
+        UA_QUALIFIEDNAME(1, "the answer - not readable");
     const UA_NodeId myInteger2NodeId = UA_NODEID_STRING(1, "the.answer.no.read");
-    UA_Server_addVariableNode(server, myInteger2NodeId, parentNodeId, parentReferenceNodeId,
-                              myInteger2Name, baseDataVariableType, myVar, NULL, NULL);
+    UA_Server_addVariableNode(server, myInteger2NodeId, parentNodeId,
+                              parentReferenceNodeId, myInteger2Name, baseDataVariableType,
+                              myVar, NULL, NULL);
 
     /* add a variable that is not readable or writable for the current user */
     myVar = UA_VariableAttributes_default;
@@ -381,7 +364,8 @@ setInformationModel(UA_Server *server) {
     myVar.valueRank = UA_VALUERANK_SCALAR;
     myVar.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
     UA_Variant_setScalar(&myVar.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
-    const UA_QualifiedName accessDeniedName = UA_QUALIFIEDNAME(1, "the answer - not current user");
+    const UA_QualifiedName accessDeniedName =
+        UA_QUALIFIEDNAME(1, "the answer - not current user");
     UA_Server_addVariableNode(server, accessDenied, parentNodeId, parentReferenceNodeId,
                               accessDeniedName, baseDataVariableType, myVar, NULL, NULL);
 
@@ -396,10 +380,10 @@ setInformationModel(UA_Server *server) {
     v_attr.dataType = UA_TYPES[UA_TYPES_DATETIME].typeId;
     v_attr.valueRank = UA_VALUERANK_SCALAR;
     const UA_QualifiedName dateName = UA_QUALIFIEDNAME(1, "current time");
-    UA_Server_addDataSourceVariableNode(server, UA_NODEID_NUMERIC(1, 2345),
-                                        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
-                                        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), dateName,
-                                        baseDataVariableType, v_attr, dateDataSource, NULL, NULL);
+    UA_Server_addDataSourceVariableNode(
+        server, UA_NODEID_NUMERIC(1, 2345), UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), dateName, baseDataVariableType, v_attr,
+        dateDataSource, NULL, NULL);
 
     /* add a bytestring variable with some content */
     myVar = UA_VariableAttributes_default;
@@ -439,12 +423,11 @@ setInformationModel(UA_Server *server) {
     addmethodattributes.displayName = UA_LOCALIZEDTEXT("en-US", "Hello World");
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
-    UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1, 62541),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
-                            UA_QUALIFIEDNAME(1, "hello_world"), addmethodattributes,
-                            &helloWorld, /* callback of the method node */
-                            1, &inputArguments, 1, &outputArguments, NULL, NULL);
+    UA_Server_addMethodNode(
+        server, UA_NODEID_NUMERIC(1, 62541), UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), UA_QUALIFIEDNAME(1, "hello_world"),
+        addmethodattributes, &helloWorld, /* callback of the method node */
+        1, &inputArguments, 1, &outputArguments, NULL, NULL);
 #endif
 
     /* Add folders for demo information model */
@@ -458,40 +441,43 @@ setInformationModel(UA_Server *server) {
     UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
     object_attr.description = UA_LOCALIZEDTEXT("en-US", "Demo");
     object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Demo");
-    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Demo"),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
+    UA_Server_addObjectNode(
+        server, UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Demo"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
     object_attr.description = UA_LOCALIZEDTEXT("en-US", "Scalar");
     object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Scalar");
-    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, SCALARID),
-                            UA_NODEID_NUMERIC(1, DEMOID), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
-                            UA_QUALIFIEDNAME(1, "Scalar"),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
+    UA_Server_addObjectNode(
+        server, UA_NODEID_NUMERIC(1, SCALARID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Scalar"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
     object_attr.description = UA_LOCALIZEDTEXT("en-US", "Array");
     object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Array");
-    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, ARRAYID),
-                            UA_NODEID_NUMERIC(1, DEMOID), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
-                            UA_QUALIFIEDNAME(1, "Array"),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
+    UA_Server_addObjectNode(
+        server, UA_NODEID_NUMERIC(1, ARRAYID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Array"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
     object_attr.description = UA_LOCALIZEDTEXT("en-US", "Matrix");
     object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "Matrix");
-    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, MATRIXID), UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Matrix"),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
+    UA_Server_addObjectNode(
+        server, UA_NODEID_NUMERIC(1, MATRIXID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Matrix"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
     object_attr.description = UA_LOCALIZEDTEXT("en-US", "ScaleTest");
     object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "ScaleTest");
-    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, SCALETESTID), UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "ScaleTest"),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
+    UA_Server_addObjectNode(
+        server, UA_NODEID_NUMERIC(1, SCALETESTID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "ScaleTest"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
     /* Fill demo nodes for each type*/
     UA_UInt32 matrixDims[2] = {3, 3};
-    UA_UInt32 id = 51000; // running id in namespace 0
+    UA_UInt32 id = 51000;  // running id in namespace 0
     for(UA_UInt32 type = 0; type < UA_TYPES_DIAGNOSTICINFO; type++) {
         if(type == UA_TYPES_VARIANT || type == UA_TYPES_DIAGNOSTICINFO)
             continue;
@@ -505,7 +491,8 @@ setInformationModel(UA_Server *server) {
         UA_QualifiedName qualifiedName = UA_QUALIFIEDNAME(1, name);
 #else
         attr.displayName = UA_LOCALIZEDTEXT_ALLOC("en-US", UA_TYPES[type].typeName);
-        UA_QualifiedName qualifiedName = UA_QUALIFIEDNAME_ALLOC(1, UA_TYPES[type].typeName);
+        UA_QualifiedName qualifiedName =
+            UA_QUALIFIEDNAME_ALLOC(1, UA_TYPES[type].typeName);
 #endif
         attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
         attr.writeMask = UA_WRITEMASK_DISPLAYNAME | UA_WRITEMASK_DESCRIPTION;
@@ -516,8 +503,9 @@ setInformationModel(UA_Server *server) {
         void *value = UA_new(&UA_TYPES[type]);
         UA_Variant_setScalar(&attr.value, value, &UA_TYPES[type]);
         UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, ++id),
-                                  UA_NODEID_NUMERIC(1, SCALARID), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
-                                  qualifiedName, baseDataVariableType, attr, NULL, NULL);
+                                  UA_NODEID_NUMERIC(1, SCALARID),
+                                  UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), qualifiedName,
+                                  baseDataVariableType, attr, NULL, NULL);
         UA_Variant_clear(&attr.value);
 
         /* add an array node for every built-in type */
@@ -525,8 +513,10 @@ setInformationModel(UA_Server *server) {
         attr.valueRank = UA_VALUERANK_ONE_DIMENSION;
         attr.arrayDimensions = &arrayDims;
         attr.arrayDimensionsSize = 1;
-        UA_Variant_setArray(&attr.value, UA_Array_new(10, &UA_TYPES[type]), 10, &UA_TYPES[type]);
-        UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, ++id), UA_NODEID_NUMERIC(1, ARRAYID),
+        UA_Variant_setArray(&attr.value, UA_Array_new(10, &UA_TYPES[type]), 10,
+                            &UA_TYPES[type]);
+        UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, ++id),
+                                  UA_NODEID_NUMERIC(1, ARRAYID),
                                   UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), qualifiedName,
                                   baseDataVariableType, attr, NULL, NULL);
         UA_Variant_clear(&attr.value);
@@ -536,14 +526,16 @@ setInformationModel(UA_Server *server) {
         attr.arrayDimensions = matrixDims;
         attr.arrayDimensionsSize = 2;
         void *myMultiArray = UA_Array_new(9, &UA_TYPES[type]);
-        attr.value.arrayDimensions = (UA_UInt32 *)UA_Array_new(2, &UA_TYPES[UA_TYPES_INT32]);
+        attr.value.arrayDimensions =
+            (UA_UInt32 *)UA_Array_new(2, &UA_TYPES[UA_TYPES_INT32]);
         attr.value.arrayDimensions[0] = 3;
         attr.value.arrayDimensions[1] = 3;
         attr.value.arrayDimensionsSize = 2;
         attr.value.arrayLength = 9;
         attr.value.data = myMultiArray;
         attr.value.type = &UA_TYPES[type];
-        UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, ++id), UA_NODEID_NUMERIC(1, MATRIXID),
+        UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, ++id),
+                                  UA_NODEID_NUMERIC(1, MATRIXID),
                                   UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), qualifiedName,
                                   baseDataVariableType, attr, NULL, NULL);
         UA_Variant_clear(&attr.value);
@@ -563,15 +555,17 @@ setInformationModel(UA_Server *server) {
     iattr.valueRank = UA_VALUERANK_SCALAR;
     UA_QualifiedName iQualifiedName = UA_QUALIFIEDNAME(1, "integer");
     UA_Server_addVariableNode(server, UA_NODEID_STRING(1, "integer"),
-                              UA_NODEID_NUMERIC(1, SCALARID), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
-                              iQualifiedName, baseDataVariableType, iattr, NULL, NULL);
+                              UA_NODEID_NUMERIC(1, SCALARID),
+                              UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), iQualifiedName,
+                              baseDataVariableType, iattr, NULL, NULL);
 
     iattr.dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_UINTEGER);
     iattr.displayName = UA_LOCALIZEDTEXT("en-US", "UInteger");
     UA_QualifiedName uQualifiedName = UA_QUALIFIEDNAME(1, "uinteger");
     UA_Server_addVariableNode(server, UA_NODEID_STRING(1, "uinteger"),
-                              UA_NODEID_NUMERIC(1, SCALARID), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
-                              uQualifiedName, baseDataVariableType, iattr, NULL, NULL);
+                              UA_NODEID_NUMERIC(1, SCALARID),
+                              UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), uQualifiedName,
+                              baseDataVariableType, iattr, NULL, NULL);
     UA_Variant_clear(&iattr.value);
 
     /* Hierarchy of depth 10 for CTT testing with forward and inverse references */
@@ -579,29 +573,29 @@ setInformationModel(UA_Server *server) {
        Test->NodeIds->Paths->Starting Node 1 */
     object_attr.description = UA_LOCALIZEDTEXT("en-US", "DepthDemo");
     object_attr.displayName = UA_LOCALIZEDTEXT("en-US", "DepthDemo");
-    UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, DEPTHID), UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "DepthDemo"),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
+    UA_Server_addObjectNode(
+        server, UA_NODEID_NUMERIC(1, DEPTHID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "DepthDemo"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
 
-    id = DEPTHID; // running id in namespace 0 - Start with Matrix NODE
+    id = DEPTHID;  // running id in namespace 0 - Start with Matrix NODE
     for(UA_UInt32 i = 1; i <= 20; i++) {
         char name[15];
         UA_snprintf(name, 15, "depth%i", i);
         object_attr.description = UA_LOCALIZEDTEXT("en-US", name);
         object_attr.displayName = UA_LOCALIZEDTEXT("en-US", name);
-        UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, id + i),
-                                UA_NODEID_NUMERIC(1, i == 1 ? DEPTHID : id + i - 1),
-                                UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
-                                UA_QUALIFIEDNAME(1, name),
-                                UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
+        UA_Server_addObjectNode(
+            server, UA_NODEID_NUMERIC(1, id + i),
+            UA_NODEID_NUMERIC(1, i == 1 ? DEPTHID : id + i - 1),
+            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, name),
+            UA_NODEID_NUMERIC(0, UA_NS0ID_FOLDERTYPE), object_attr, NULL, NULL);
     }
 
     /* Scale Test: 100 nodes of each type */
     int scale_i = 0;
     UA_UInt32 scale_nodeid = 43000;
     for(UA_UInt32 type = 0; type < 15; type++) {
-        if(type == UA_TYPES_SBYTE || type == UA_TYPES_BYTE
-                || type == UA_TYPES_GUID)
+        if(type == UA_TYPES_SBYTE || type == UA_TYPES_BYTE || type == UA_TYPES_GUID)
             continue;
 
         UA_DataSource scaleTestDataSource;
@@ -673,16 +667,18 @@ setInformationModel(UA_Server *server) {
 #endif
             attr.displayName = UA_LOCALIZEDTEXT("en-US", name);
             UA_QualifiedName qualifiedName = UA_QUALIFIEDNAME(1, name);
-            UA_Server_addDataSourceVariableNode(server, UA_NODEID_NUMERIC(1, ++scale_nodeid),
-                                      UA_NODEID_NUMERIC(1, SCALETESTID),
-                                      UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),qualifiedName,
-                                      baseDataVariableType, attr, scaleTestDataSource, NULL, NULL);
+            UA_Server_addDataSourceVariableNode(
+                server, UA_NODEID_NUMERIC(1, ++scale_nodeid),
+                UA_NODEID_NUMERIC(1, SCALETESTID),
+                UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), qualifiedName,
+                baseDataVariableType, attr, scaleTestDataSource, NULL, NULL);
             scale_i++;
         }
         UA_Variant_clear(&attr.value);
     }
 
-    /* Add the variable to some more places to get a node with three inverse references for the CTT */
+    /* Add the variable to some more places to get a node with three inverse references
+     * for the CTT */
     UA_ExpandedNodeId answer_nodeid = UA_EXPANDEDNODEID_STRING(1, "the.answer");
     UA_Server_addReference(server, UA_NODEID_NUMERIC(1, DEMOID),
                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), answer_nodeid, true);
@@ -691,12 +687,13 @@ setInformationModel(UA_Server *server) {
 
     /* Example for manually setting an attribute within the server */
     UA_LocalizedText objectsName = UA_LOCALIZEDTEXT("en-US", "Objects");
-    UA_Server_writeDisplayName(server, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), objectsName);
+    UA_Server_writeDisplayName(server, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                               objectsName);
 
-#define NOARGID     60000
-#define INARGID     60001
-#define OUTARGID    60002
-#define INOUTARGID  60003
+#define NOARGID 60000
+#define INARGID 60001
+#define OUTARGID 60002
+#define INOUTARGID 60003
 #ifdef UA_ENABLE_METHODCALLS
     /* adding some more method nodes to pass CTT */
     /* Method without arguments */
@@ -704,12 +701,11 @@ setInformationModel(UA_Server *server) {
     addmethodattributes.displayName = UA_LOCALIZEDTEXT("en-US", "noarg");
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
-    UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1, NOARGID),
-                            UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
-                            UA_QUALIFIEDNAME(1, "noarg"), addmethodattributes,
-                            &noargMethod, /* callback of the method node */
-                            0, NULL, 0, NULL, NULL, NULL);
+    UA_Server_addMethodNode(
+        server, UA_NODEID_NUMERIC(1, NOARGID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), UA_QUALIFIEDNAME(1, "noarg"),
+        addmethodattributes, &noargMethod, /* callback of the method node */
+        0, NULL, 0, NULL, NULL, NULL);
 
     /* Method with in arguments */
     addmethodattributes = UA_MethodAttributes_default;
@@ -721,14 +717,13 @@ setInformationModel(UA_Server *server) {
     inputArguments.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
     inputArguments.description = UA_LOCALIZEDTEXT("en-US", "Input");
     inputArguments.name = UA_STRING("Input");
-    inputArguments.valueRank = UA_VALUERANK_SCALAR; //uaexpert will crash if set to 0 ;)
+    inputArguments.valueRank = UA_VALUERANK_SCALAR;  // uaexpert will crash if set to 0 ;)
 
-    UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1, INARGID),
-                            UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
-                            UA_QUALIFIEDNAME(1, "noarg"), addmethodattributes,
-                            &noargMethod, /* callback of the method node */
-                            1, &inputArguments, 0, NULL, NULL, NULL);
+    UA_Server_addMethodNode(
+        server, UA_NODEID_NUMERIC(1, INARGID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), UA_QUALIFIEDNAME(1, "noarg"),
+        addmethodattributes, &noargMethod, /* callback of the method node */
+        1, &inputArguments, 0, NULL, NULL, NULL);
 
     /* Method with out arguments */
     addmethodattributes = UA_MethodAttributes_default;
@@ -742,12 +737,11 @@ setInformationModel(UA_Server *server) {
     outputArguments.name = UA_STRING("Output");
     outputArguments.valueRank = UA_VALUERANK_SCALAR;
 
-    UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1, OUTARGID),
-                            UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
-                            UA_QUALIFIEDNAME(1, "outarg"), addmethodattributes,
-                            &outargMethod, /* callback of the method node */
-                            0, NULL, 1, &outputArguments, NULL, NULL);
+    UA_Server_addMethodNode(
+        server, UA_NODEID_NUMERIC(1, OUTARGID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), UA_QUALIFIEDNAME(1, "outarg"),
+        addmethodattributes, &outargMethod, /* callback of the method node */
+        0, NULL, 1, &outputArguments, NULL, NULL);
 
     /* Method with inout arguments */
     addmethodattributes = UA_MethodAttributes_default;
@@ -755,12 +749,11 @@ setInformationModel(UA_Server *server) {
     addmethodattributes.executable = true;
     addmethodattributes.userExecutable = true;
 
-    UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1, INOUTARGID),
-                            UA_NODEID_NUMERIC(1, DEMOID),
-                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
-                            UA_QUALIFIEDNAME(1, "inoutarg"), addmethodattributes,
-                            &outargMethod, /* callback of the method node */
-                            1, &inputArguments, 1, &outputArguments, NULL, NULL);
+    UA_Server_addMethodNode(
+        server, UA_NODEID_NUMERIC(1, INOUTARGID), UA_NODEID_NUMERIC(1, DEMOID),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), UA_QUALIFIEDNAME(1, "inoutarg"),
+        addmethodattributes, &outargMethod, /* callback of the method node */
+        1, &inputArguments, 1, &outputArguments, NULL, NULL);
 #endif
 }
 
@@ -777,7 +770,8 @@ disableAnonymous(UA_ServerConfig *config) {
             UA_UserTokenPolicy_clear(utp);
             /* Move the last to this position */
             if(j + 1 < ep->userIdentityTokensSize) {
-                ep->userIdentityTokens[j] = ep->userIdentityTokens[ep->userIdentityTokensSize-1];
+                ep->userIdentityTokens[j] =
+                    ep->userIdentityTokens[ep->userIdentityTokensSize - 1];
                 j--;
             }
             ep->userIdentityTokensSize--;
@@ -802,13 +796,13 @@ disableUnencrypted(UA_ServerConfig *config) {
         UA_EndpointDescription_clear(ep);
         /* Move the last to this position */
         if(i + 1 < config->endpointsSize) {
-            config->endpoints[i] = config->endpoints[config->endpointsSize-1];
+            config->endpoints[i] = config->endpoints[config->endpointsSize - 1];
             i--;
         }
         config->endpointsSize--;
     }
     /* Delete the entire array if the last Endpoint was removed */
-    if(config->endpointsSize== 0) {
+    if(config->endpointsSize == 0) {
         UA_free(config->endpoints);
         config->endpoints = NULL;
     }
@@ -818,8 +812,10 @@ static void
 disableOutdatedSecurityPolicy(UA_ServerConfig *config) {
     for(size_t i = 0; i < config->endpointsSize; i++) {
         UA_EndpointDescription *ep = &config->endpoints[i];
-        UA_ByteString basic128uri = UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
-        UA_ByteString basic256uri = UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
+        UA_ByteString basic128uri =
+            UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+        UA_ByteString basic256uri =
+            UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
         if(!UA_String_equal(&ep->securityPolicyUri, &basic128uri) &&
            !UA_String_equal(&ep->securityPolicyUri, &basic256uri))
             continue;
@@ -827,13 +823,13 @@ disableOutdatedSecurityPolicy(UA_ServerConfig *config) {
         UA_EndpointDescription_clear(ep);
         /* Move the last to this position */
         if(i + 1 < config->endpointsSize) {
-            config->endpoints[i] = config->endpoints[config->endpointsSize-1];
+            config->endpoints[i] = config->endpoints[config->endpointsSize - 1];
             i--;
         }
         config->endpointsSize--;
     }
     /* Delete the entire array if the last Endpoint was removed */
-    if(config->endpointsSize== 0) {
+    if(config->endpointsSize == 0) {
         UA_free(config->endpoints);
         config->endpoints = NULL;
     }
@@ -843,20 +839,21 @@ static void
 disableBasic128SecurityPolicy(UA_ServerConfig *config) {
     for(size_t i = 0; i < config->endpointsSize; i++) {
         UA_EndpointDescription *ep = &config->endpoints[i];
-        UA_ByteString basic128uri = UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+        UA_ByteString basic128uri =
+            UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
         if(!UA_String_equal(&ep->securityPolicyUri, &basic128uri))
             continue;
 
         UA_EndpointDescription_clear(ep);
         /* Move the last to this position */
         if(i + 1 < config->endpointsSize) {
-            config->endpoints[i] = config->endpoints[config->endpointsSize-1];
+            config->endpoints[i] = config->endpoints[config->endpointsSize - 1];
             i--;
         }
         config->endpointsSize--;
     }
     /* Delete the entire array if the last Endpoint was removed */
-    if(config->endpointsSize== 0) {
+    if(config->endpointsSize == 0) {
         UA_free(config->endpoints);
         config->endpoints = NULL;
     }
@@ -866,44 +863,45 @@ static void
 disableBasic256SecurityPolicy(UA_ServerConfig *config) {
     for(size_t i = 0; i < config->endpointsSize; i++) {
         UA_EndpointDescription *ep = &config->endpoints[i];
-        UA_ByteString basic256uri = UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
+        UA_ByteString basic256uri =
+            UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
         if(!UA_String_equal(&ep->securityPolicyUri, &basic256uri))
             continue;
 
         UA_EndpointDescription_clear(ep);
         /* Move the last to this position */
         if(i + 1 < config->endpointsSize) {
-            config->endpoints[i] = config->endpoints[config->endpointsSize-1];
+            config->endpoints[i] = config->endpoints[config->endpointsSize - 1];
             i--;
         }
         config->endpointsSize--;
     }
     /* Delete the entire array if the last Endpoint was removed */
-    if(config->endpointsSize== 0) {
+    if(config->endpointsSize == 0) {
         UA_free(config->endpoints);
         config->endpoints = NULL;
     }
 }
 
-
 static void
 disableBasic256Sha256SecurityPolicy(UA_ServerConfig *config) {
     for(size_t i = 0; i < config->endpointsSize; i++) {
         UA_EndpointDescription *ep = &config->endpoints[i];
-        UA_ByteString basic256sha256uri = UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
+        UA_ByteString basic256sha256uri =
+            UA_BYTESTRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
         if(!UA_String_equal(&ep->securityPolicyUri, &basic256sha256uri))
             continue;
 
         UA_EndpointDescription_clear(ep);
         /* Move the last to this position */
         if(i + 1 < config->endpointsSize) {
-            config->endpoints[i] = config->endpoints[config->endpointsSize-1];
+            config->endpoints[i] = config->endpoints[config->endpointsSize - 1];
             i--;
         }
         config->endpointsSize--;
     }
     /* Delete the entire array if the last Endpoint was removed */
-    if(config->endpointsSize== 0) {
+    if(config->endpointsSize == 0) {
         UA_free(config->endpoints);
         config->endpoints = NULL;
     }
@@ -946,13 +944,13 @@ usage(void) {
                    "\t[--enableAnonymous]\n");
 }
 
-int main(int argc, char **argv) {
+int
+main(int argc, char **argv) {
     signal(SIGINT, stopHandler); /* catches ctrl-c */
     signal(SIGTERM, stopHandler);
 
     for(int i = 1; i < argc; i++) {
-        if(strcmp(argv[i], "--help") == 0 ||
-           strcmp(argv[i], "-h") == 0) {
+        if(strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             usage();
             return EXIT_SUCCESS;
         }
@@ -968,7 +966,7 @@ int main(int argc, char **argv) {
         certificate = loadFile(argv[1]);
         if(certificate.length == 0) {
             UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
-                           "Unable to load file %s.", argv[pos]);
+                         "Unable to load file %s.", argv[pos]);
             return EXIT_FAILURE;
         }
         pos++;
@@ -981,7 +979,7 @@ int main(int argc, char **argv) {
         privateKey = loadFile(argv[2]);
         if(privateKey.length == 0) {
             UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
-                           "Unable to load file %s.", argv[pos]);
+                         "Unable to load file %s.", argv[pos]);
             return EXIT_FAILURE;
         }
         pos++;
@@ -1129,7 +1127,7 @@ int main(int argc, char **argv) {
             revocationListSize++;
             continue;
         }
-#else /* __linux__ */
+#else  /* __linux__ */
         if(strcmp(argv[pos], "--trustlistFolder") == 0) {
             filetype = 't';
             continue;
@@ -1171,25 +1169,20 @@ int main(int argc, char **argv) {
 
 #ifdef UA_ENABLE_ENCRYPTION
 #ifndef __linux__
-    UA_StatusCode res =
-        UA_ServerConfig_setDefaultWithSecurityPolicies(&config, 4840,
-                                                       &certificate, &privateKey,
-                                                       trustList, trustListSize,
-                                                       issuerList, issuerListSize,
-                                                       revocationList, revocationListSize);
+    UA_StatusCode res = UA_ServerConfig_setDefaultWithSecurityPolicies(
+        &config, 4840, &certificate, &privateKey, trustList, trustListSize, issuerList,
+        issuerListSize, revocationList, revocationListSize);
     if(res != UA_STATUSCODE_GOOD)
         goto cleanup;
-#else /* On Linux we can monitor the certs folder and reload when changes are made */
-    UA_StatusCode res =
-        UA_ServerConfig_setDefaultWithSecurityPolicies(&config, 4840,
-                                                       &certificate, &privateKey,
-                                                       NULL, 0, NULL, 0, NULL, 0);
+#else  /* On Linux we can monitor the certs folder and reload when changes are made */
+    UA_StatusCode res = UA_ServerConfig_setDefaultWithSecurityPolicies(
+        &config, 4840, &certificate, &privateKey, NULL, 0, NULL, 0, NULL, 0);
     if(res != UA_STATUSCODE_GOOD)
         goto cleanup;
     config.certificateVerification.clear(&config.certificateVerification);
-    res = UA_CertificateVerification_CertFolders(&config.certificateVerification,
-                                                 trustlistFolder, issuerlistFolder,
-                                                 revocationlistFolder);
+    res = UA_CertificateVerification_CertFolders(
+        &config.logger, &config.certificateVerification, trustlistFolder,
+        issuerlistFolder, revocationlistFolder);
     if(res != UA_STATUSCODE_GOOD)
         goto cleanup;
 #endif /* __linux__ */
@@ -1206,9 +1199,8 @@ int main(int argc, char **argv) {
     if(disableBasic256Sha256)
         disableBasic256Sha256SecurityPolicy(&config);
 
-#else /* UA_ENABLE_ENCRYPTION */
-    UA_StatusCode res =
-        UA_ServerConfig_setMinimal(&config, 4840, &certificate);
+#else  /* UA_ENABLE_ENCRYPTION */
+    UA_StatusCode res = UA_ServerConfig_setMinimal(&config, 4840, &certificate);
     if(res != UA_STATUSCODE_GOOD)
         goto cleanup;
 #endif /* UA_ENABLE_ENCRYPTION */
@@ -1250,7 +1242,7 @@ int main(int argc, char **argv) {
     /* run server */
     res = UA_Server_run(server, &running);
 
- cleanup:
+cleanup:
     if(server)
         UA_Server_delete(server);
     else

--- a/plugins/include/open62541/plugin/pki_default.h
+++ b/plugins/include/open62541/plugin/pki_default.h
@@ -14,7 +14,8 @@ _UA_BEGIN_DECLS
 
 /* Default implementation that accepts all certificates */
 UA_EXPORT void
-UA_CertificateVerification_AcceptAll(UA_CertificateVerification *cv);
+UA_CertificateVerification_AcceptAll(const UA_Logger *logger,
+                                     UA_CertificateVerification *cv);
 
 #ifdef UA_ENABLE_ENCRYPTION
 
@@ -24,17 +25,16 @@ UA_Bstrstr(const unsigned char *s1, size_t l1, const unsigned char *s2, size_t l
 /* Accept certificates based on a trust-list and a revocation-list. Based on
  * mbedTLS. */
 UA_EXPORT UA_StatusCode
-UA_CertificateVerification_Trustlist(UA_CertificateVerification *cv,
-                                     const UA_ByteString *certificateTrustList,
-                                     size_t certificateTrustListSize,
-                                     const UA_ByteString *certificateIssuerList,
-                                     size_t certificateIssuerListSize,
-                                     const UA_ByteString *certificateRevocationList,
-                                     size_t certificateRevocationListSize);
+UA_CertificateVerification_Trustlist(
+    const UA_Logger *logger, UA_CertificateVerification *cv,
+    const UA_ByteString *certificateTrustList, size_t certificateTrustListSize,
+    const UA_ByteString *certificateIssuerList, size_t certificateIssuerListSize,
+    const UA_ByteString *certificateRevocationList, size_t certificateRevocationListSize);
 
 #ifdef __linux__ /* Linux only so far */
 UA_EXPORT UA_StatusCode
-UA_CertificateVerification_CertFolders(UA_CertificateVerification *cv,
+UA_CertificateVerification_CertFolders(const UA_Logger *logger,
+                                       UA_CertificateVerification *cv,
                                        const char *trustListFolder,
                                        const char *issuerListFolder,
                                        const char *revocationListFolder);

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -19,8 +19,8 @@
 #include <open62541/network_ws.h>
 #endif
 #include <open62541/plugin/accesscontrol_default.h>
-#include <open62541/plugin/nodestore_default.h>
 #include <open62541/plugin/log_stdout.h>
+#include <open62541/plugin/nodestore_default.h>
 #include <open62541/plugin/pki_default.h>
 #include <open62541/plugin/securitypolicy_default.h>
 #include <open62541/server_config_default.h>
@@ -76,7 +76,7 @@ const UA_ConnectionConfig UA_ConnectionConfig_default = {
 #define APPLICATION_URI_SERVER "urn:open62541.server.application"
 
 #define STRINGIFY(arg) #arg
-#define VERSION(MAJOR, MINOR, PATCH, LABEL) \
+#define VERSION(MAJOR, MINOR, PATCH, LABEL)                                              \
     STRINGIFY(MAJOR) "." STRINGIFY(MINOR) "." STRINGIFY(PATCH) LABEL
 
 static UA_StatusCode
@@ -87,17 +87,16 @@ createEndpoint(UA_ServerConfig *conf, UA_EndpointDescription *endpoint,
 
     endpoint->securityMode = securityMode;
     UA_String_copy(&securityPolicy->policyUri, &endpoint->securityPolicyUri);
-    endpoint->transportProfileUri =
-        UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
+    endpoint->transportProfileUri = UA_STRING_ALLOC(
+        "http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
 
     /* Add security level value for the corresponding message security mode */
-    endpoint->securityLevel = (UA_Byte) securityMode;
+    endpoint->securityLevel = (UA_Byte)securityMode;
 
     /* Enable all login mechanisms from the access control plugin  */
-    UA_StatusCode retval = UA_Array_copy(conf->accessControl.userTokenPolicies,
-                                         conf->accessControl.userTokenPoliciesSize,
-                                         (void **)&endpoint->userIdentityTokens,
-                                         &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
+    UA_StatusCode retval = UA_Array_copy(
+        conf->accessControl.userTokenPolicies, conf->accessControl.userTokenPoliciesSize,
+        (void **)&endpoint->userIdentityTokens, &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
     endpoint->userIdentityTokensSize = conf->accessControl.userTokenPoliciesSize;
@@ -115,7 +114,7 @@ static UA_UsernamePasswordLogin usernamePasswords[2] = {
 
 static UA_StatusCode
 setDefaultConfig(UA_ServerConfig *conf) {
-    if (!conf)
+    if(!conf)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
     if(conf->nodestore.context == NULL)
@@ -125,7 +124,7 @@ setDefaultConfig(UA_ServerConfig *conf) {
     conf->nThreads = 1;
 
     /* Allow user to set his own logger */
-    if (!conf->logger.log)
+    if(!conf->logger.log)
         conf->logger = UA_Log_Stdout_;
 
     conf->shutdownDelay = 0.0;
@@ -138,11 +137,11 @@ setDefaultConfig(UA_ServerConfig *conf) {
     conf->buildInfo.softwareVersion =
         UA_STRING_ALLOC(VERSION(UA_OPEN62541_VER_MAJOR, UA_OPEN62541_VER_MINOR,
                                 UA_OPEN62541_VER_PATCH, UA_OPEN62541_VER_LABEL));
-    #ifdef UA_PACK_DEBIAN
+#ifdef UA_PACK_DEBIAN
     conf->buildInfo.buildNumber = UA_STRING_ALLOC("deb");
-    #else
+#else
     conf->buildInfo.buildNumber = UA_STRING_ALLOC(__DATE__ " " __TIME__);
-    #endif
+#endif
     conf->buildInfo.buildDate = UA_DateTime_now();
 
     UA_ApplicationDescription_clear(&conf->applicationDescription);
@@ -159,10 +158,10 @@ setDefaultConfig(UA_ServerConfig *conf) {
 #ifdef UA_ENABLE_DISCOVERY_MULTICAST
     UA_MdnsDiscoveryConfiguration_clear(&conf->discovery.mdns);
     conf->discovery.mdnsInterfaceIP = UA_STRING_NULL;
-# if !defined(UA_HAS_GETIFADDR)
+#if !defined(UA_HAS_GETIFADDR)
     conf->discovery.ipAddressList = NULL;
     conf->discovery.ipAddressListSize = 0;
-# endif
+#endif
 #endif
 
     /* Custom DataTypes */
@@ -179,7 +178,7 @@ setDefaultConfig(UA_ServerConfig *conf) {
 
     /* Certificate Verification that accepts every certificate. Can be
      * overwritten when the policy is specialized. */
-    UA_CertificateVerification_AcceptAll(&conf->certificateVerification);
+    UA_CertificateVerification_AcceptAll(&conf->logger, &conf->certificateVerification);
 
     /* * Global Node Lifecycle * */
     /* conf->nodeLifecycle.constructor = NULL; */
@@ -250,7 +249,7 @@ setDefaultConfig(UA_ServerConfig *conf) {
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_setBasics(UA_ServerConfig* conf) {
+UA_ServerConfig_setBasics(UA_ServerConfig *conf) {
     UA_StatusCode res = setDefaultConfig(conf);
     UA_LOG_WARNING(&conf->logger, UA_LOGCATEGORY_USERLAND,
                    "AcceptAll Certificate Verification. "
@@ -261,30 +260,31 @@ UA_ServerConfig_setBasics(UA_ServerConfig* conf) {
 static UA_StatusCode
 addDefaultNetworkLayers(UA_ServerConfig *conf, UA_UInt16 portNumber,
                         UA_UInt32 sendBufferSize, UA_UInt32 recvBufferSize) {
-    return UA_ServerConfig_addNetworkLayerTCP(conf, portNumber, sendBufferSize, recvBufferSize);
+    return UA_ServerConfig_addNetworkLayerTCP(conf, portNumber, sendBufferSize,
+                                              recvBufferSize);
 }
 
 #ifdef UA_ENABLE_WEBSOCKET_SERVER
 UA_EXPORT UA_StatusCode
 UA_ServerConfig_addNetworkLayerWS(UA_ServerConfig *conf, UA_UInt16 portNumber,
-                                   UA_UInt32 sendBufferSize, UA_UInt32 recvBufferSize) {
+                                  UA_UInt32 sendBufferSize, UA_UInt32 recvBufferSize) {
     /* Add a network layer */
-    UA_ServerNetworkLayer *tmp = (UA_ServerNetworkLayer *)
-        UA_realloc(conf->networkLayers,
-                   sizeof(UA_ServerNetworkLayer) * (1 + conf->networkLayersSize));
+    UA_ServerNetworkLayer *tmp = (UA_ServerNetworkLayer *)UA_realloc(
+        conf->networkLayers,
+        sizeof(UA_ServerNetworkLayer) * (1 + conf->networkLayersSize));
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     conf->networkLayers = tmp;
 
     UA_ConnectionConfig config = UA_ConnectionConfig_default;
-    if (sendBufferSize > 0)
+    if(sendBufferSize > 0)
         config.sendBufferSize = sendBufferSize;
-    if (recvBufferSize > 0)
+    if(recvBufferSize > 0)
         config.recvBufferSize = recvBufferSize;
 
     conf->networkLayers[conf->networkLayersSize] =
         UA_ServerNetworkLayerWS(config, portNumber, &conf->logger);
-    if (!conf->networkLayers[conf->networkLayersSize].handle)
+    if(!conf->networkLayers[conf->networkLayersSize].handle)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     conf->networkLayersSize++;
 
@@ -296,22 +296,22 @@ UA_EXPORT UA_StatusCode
 UA_ServerConfig_addNetworkLayerTCP(UA_ServerConfig *conf, UA_UInt16 portNumber,
                                    UA_UInt32 sendBufferSize, UA_UInt32 recvBufferSize) {
     /* Add a network layer */
-    UA_ServerNetworkLayer *tmp = (UA_ServerNetworkLayer *)
-        UA_realloc(conf->networkLayers,
-                   sizeof(UA_ServerNetworkLayer) * (1 + conf->networkLayersSize));
+    UA_ServerNetworkLayer *tmp = (UA_ServerNetworkLayer *)UA_realloc(
+        conf->networkLayers,
+        sizeof(UA_ServerNetworkLayer) * (1 + conf->networkLayersSize));
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     conf->networkLayers = tmp;
 
     UA_ConnectionConfig config = UA_ConnectionConfig_default;
-    if (sendBufferSize > 0)
+    if(sendBufferSize > 0)
         config.sendBufferSize = sendBufferSize;
-    if (recvBufferSize > 0)
+    if(recvBufferSize > 0)
         config.recvBufferSize = recvBufferSize;
 
     conf->networkLayers[conf->networkLayersSize] =
         UA_ServerNetworkLayerTCP(config, portNumber, 0, &conf->logger);
-    if (!conf->networkLayers[conf->networkLayersSize].handle)
+    if(!conf->networkLayers[conf->networkLayersSize].handle)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     conf->networkLayersSize++;
 
@@ -319,16 +319,16 @@ UA_ServerConfig_addNetworkLayerTCP(UA_ServerConfig *conf, UA_UInt16 portNumber,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config, 
+UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config,
                                       const UA_ByteString *certificate) {
     /* Allocate the SecurityPolicies */
-    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
-        UA_realloc(config->securityPolicies,
-                   sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
+    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)UA_realloc(
+        config->securityPolicies,
+        sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
     UA_ByteString localCertificate = UA_BYTESTRING_NULL;
     if(certificate)
@@ -349,12 +349,11 @@ UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addEndpoint(UA_ServerConfig *config, const UA_String securityPolicyUri, 
+UA_ServerConfig_addEndpoint(UA_ServerConfig *config, const UA_String securityPolicyUri,
                             UA_MessageSecurityMode securityMode) {
     /* Allocate the endpoint */
-    UA_EndpointDescription *tmp = (UA_EndpointDescription *)
-        UA_realloc(config->endpoints,
-                   sizeof(UA_EndpointDescription) * (1 + config->endpointsSize));
+    UA_EndpointDescription *tmp = (UA_EndpointDescription *)UA_realloc(
+        config->endpoints, sizeof(UA_EndpointDescription) * (1 + config->endpointsSize));
     if(!tmp) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
@@ -362,19 +361,18 @@ UA_ServerConfig_addEndpoint(UA_ServerConfig *config, const UA_String securityPol
 
     /* Lookup the security policy */
     const UA_SecurityPolicy *policy = NULL;
-    for (size_t i = 0; i < config->securityPoliciesSize; ++i) {
-        if (UA_String_equal(&securityPolicyUri, &config->securityPolicies[i].policyUri)) {
+    for(size_t i = 0; i < config->securityPoliciesSize; ++i) {
+        if(UA_String_equal(&securityPolicyUri, &config->securityPolicies[i].policyUri)) {
             policy = &config->securityPolicies[i];
             break;
         }
     }
-    if (!policy)
+    if(!policy)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
     /* Populate the endpoint */
-    UA_StatusCode retval =
-        createEndpoint(config, &config->endpoints[config->endpointsSize],
-                       policy, securityMode);
+    UA_StatusCode retval = createEndpoint(
+        config, &config->endpoints[config->endpointsSize], policy, securityMode);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
     config->endpointsSize++;
@@ -385,10 +383,10 @@ UA_ServerConfig_addEndpoint(UA_ServerConfig *config, const UA_String securityPol
 UA_EXPORT UA_StatusCode
 UA_ServerConfig_addAllEndpoints(UA_ServerConfig *config) {
     /* Allocate the endpoints */
-    UA_EndpointDescription * tmp = (UA_EndpointDescription *)
-        UA_realloc(config->endpoints,
-                   sizeof(UA_EndpointDescription) *
-                   (2 * config->securityPoliciesSize + config->endpointsSize));
+    UA_EndpointDescription *tmp = (UA_EndpointDescription *)UA_realloc(
+        config->endpoints,
+        sizeof(UA_EndpointDescription) *
+            (2 * config->securityPoliciesSize + config->endpointsSize));
     if(!tmp) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
@@ -396,7 +394,8 @@ UA_ServerConfig_addAllEndpoints(UA_ServerConfig *config) {
 
     /* Populate the endpoints */
     for(size_t i = 0; i < config->securityPoliciesSize; ++i) {
-        if(UA_String_equal(&UA_SECURITY_POLICY_NONE_URI, &config->securityPolicies[i].policyUri)) {
+        if(UA_String_equal(&UA_SECURITY_POLICY_NONE_URI,
+                           &config->securityPolicies[i].policyUri)) {
             UA_StatusCode retval =
                 createEndpoint(config, &config->endpoints[config->endpointsSize],
                                &config->securityPolicies[i], UA_MESSAGESECURITYMODE_NONE);
@@ -451,9 +450,10 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     }
 
     /* Initialize the Access Control plugin */
-    retval = UA_AccessControl_default(config, true,
-                &config->securityPolicies[config->securityPoliciesSize-1].policyUri,
-                usernamePasswordsSize, usernamePasswords);
+    retval = UA_AccessControl_default(
+        config, true,
+        &config->securityPolicies[config->securityPoliciesSize - 1].policyUri,
+        usernamePasswordsSize, usernamePasswords);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(config);
         return retval;
@@ -477,27 +477,27 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
 #ifdef UA_ENABLE_ENCRYPTION
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config, 
+UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config,
                                                const UA_ByteString *certificate,
                                                const UA_ByteString *privateKey) {
     /* Allocate the SecurityPolicies */
-    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
-        UA_realloc(config->securityPolicies,
-                   sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
+    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)UA_realloc(
+        config->securityPolicies,
+        sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
     UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
+    UA_ByteString localPrivateKey = UA_BYTESTRING_NULL;
     if(certificate)
         localCertificate = *certificate;
     if(privateKey)
-       localPrivateKey = *privateKey;
-    UA_StatusCode retval =
-        UA_SecurityPolicy_Basic128Rsa15(&config->securityPolicies[config->securityPoliciesSize],
-                                        localCertificate, localPrivateKey, &config->logger);
+        localPrivateKey = *privateKey;
+    UA_StatusCode retval = UA_SecurityPolicy_Basic128Rsa15(
+        &config->securityPolicies[config->securityPoliciesSize], localCertificate,
+        localPrivateKey, &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -511,27 +511,27 @@ UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config, 
+UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config,
                                           const UA_ByteString *certificate,
                                           const UA_ByteString *privateKey) {
     /* Allocate the SecurityPolicies */
-    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
-        UA_realloc(config->securityPolicies,
-                   sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
+    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)UA_realloc(
+        config->securityPolicies,
+        sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
     UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
+    UA_ByteString localPrivateKey = UA_BYTESTRING_NULL;
     if(certificate)
         localCertificate = *certificate;
     if(privateKey)
-       localPrivateKey = *privateKey;
-    UA_StatusCode retval =
-        UA_SecurityPolicy_Basic256(&config->securityPolicies[config->securityPoliciesSize],
-                                   localCertificate, localPrivateKey, &config->logger);
+        localPrivateKey = *privateKey;
+    UA_StatusCode retval = UA_SecurityPolicy_Basic256(
+        &config->securityPolicies[config->securityPoliciesSize], localCertificate,
+        localPrivateKey, &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -545,27 +545,27 @@ UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config, 
+UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config,
                                                 const UA_ByteString *certificate,
                                                 const UA_ByteString *privateKey) {
     /* Allocate the SecurityPolicies */
-    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
-        UA_realloc(config->securityPolicies,
-                   sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
+    UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)UA_realloc(
+        config->securityPolicies,
+        sizeof(UA_SecurityPolicy) * (1 + config->securityPoliciesSize));
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
     UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
+    UA_ByteString localPrivateKey = UA_BYTESTRING_NULL;
     if(certificate)
         localCertificate = *certificate;
     if(privateKey)
-       localPrivateKey = *privateKey;
-    UA_StatusCode retval =
-        UA_SecurityPolicy_Basic256Sha256(&config->securityPolicies[config->securityPoliciesSize],
-                                         localCertificate, localPrivateKey, &config->logger);
+        localPrivateKey = *privateKey;
+    UA_StatusCode retval = UA_SecurityPolicy_Basic256Sha256(
+        &config->securityPolicies[config->securityPoliciesSize], localCertificate,
+        localPrivateKey, &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -585,34 +585,38 @@ UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config,
                                        const UA_ByteString *privateKey) {
     /* Populate the SecurityPolicies */
     UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
+    UA_ByteString localPrivateKey = UA_BYTESTRING_NULL;
     if(certificate)
         localCertificate = *certificate;
     if(privateKey)
-       localPrivateKey = *privateKey;
+        localPrivateKey = *privateKey;
 
-    UA_StatusCode retval = UA_ServerConfig_addSecurityPolicyNone(config, &localCertificate);
+    UA_StatusCode retval =
+        UA_ServerConfig_addSecurityPolicyNone(config, &localCertificate);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#None with error code %s",
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_ServerConfig_addSecurityPolicyBasic128Rsa15(config, &localCertificate, &localPrivateKey);
+    retval = UA_ServerConfig_addSecurityPolicyBasic128Rsa15(config, &localCertificate,
+                                                            &localPrivateKey);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#Basic128Rsa15 with error code %s",
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_ServerConfig_addSecurityPolicyBasic256(config, &localCertificate, &localPrivateKey);
+    retval = UA_ServerConfig_addSecurityPolicyBasic256(config, &localCertificate,
+                                                       &localPrivateKey);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#Basic256 with error code %s",
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_ServerConfig_addSecurityPolicyBasic256Sha256(config, &localCertificate, &localPrivateKey);
+    retval = UA_ServerConfig_addSecurityPolicyBasic256Sha256(config, &localCertificate,
+                                                             &localPrivateKey);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#Basic256Sha256 with error code %s",
@@ -623,27 +627,21 @@ UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
-                                               UA_UInt16 portNumber,
-                                               const UA_ByteString *certificate,
-                                               const UA_ByteString *privateKey,
-                                               const UA_ByteString *trustList,
-                                               size_t trustListSize,
-                                               const UA_ByteString *issuerList,
-                                               size_t issuerListSize,
-                                               const UA_ByteString *revocationList,
-                                               size_t revocationListSize) {
+UA_ServerConfig_setDefaultWithSecurityPolicies(
+    UA_ServerConfig *conf, UA_UInt16 portNumber, const UA_ByteString *certificate,
+    const UA_ByteString *privateKey, const UA_ByteString *trustList, size_t trustListSize,
+    const UA_ByteString *issuerList, size_t issuerListSize,
+    const UA_ByteString *revocationList, size_t revocationListSize) {
     UA_StatusCode retval = setDefaultConfig(conf);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;
     }
 
-    retval = UA_CertificateVerification_Trustlist(&conf->certificateVerification,
-                                                  trustList, trustListSize,
-                                                  issuerList, issuerListSize,
-                                                  revocationList, revocationListSize);
-    if (retval != UA_STATUSCODE_GOOD)
+    retval = UA_CertificateVerification_Trustlist(
+        &conf->logger, &conf->certificateVerification, trustList, trustListSize,
+        issuerList, issuerListSize, revocationList, revocationListSize);
+    if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
     retval = addDefaultNetworkLayers(conf, portNumber, 0, 0);
@@ -658,9 +656,9 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
         return retval;
     }
 
-    retval = UA_AccessControl_default(conf, true,
-                &conf->securityPolicies[conf->securityPoliciesSize-1].policyUri,
-                usernamePasswordsSize, usernamePasswords);
+    retval = UA_AccessControl_default(
+        conf, true, &conf->securityPolicies[conf->securityPoliciesSize - 1].policyUri,
+        usernamePasswordsSize, usernamePasswords);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;
@@ -681,7 +679,8 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
 /* Default Client Settings */
 /***************************/
 
-UA_Client * UA_Client_new() {
+UA_Client *
+UA_Client_new() {
     UA_ClientConfig config;
     memset(&config, 0, sizeof(UA_ClientConfig));
     config.logger.log = UA_Log_Stdout_log;
@@ -696,16 +695,17 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     config->secureChannelLifeTime = 10 * 60 * 1000; /* 10 minutes */
 
     if(!config->logger.log) {
-       config->logger.log = UA_Log_Stdout_log;
-       config->logger.context = NULL;
-       config->logger.clear = UA_Log_Stdout_clear;
+        config->logger.log = UA_Log_Stdout_log;
+        config->logger.context = NULL;
+        config->logger.clear = UA_Log_Stdout_clear;
     }
 
     config->localConnectionConfig = UA_ConnectionConfig_default;
 
     /* Certificate Verification that accepts every certificate. Can be
      * overwritten when the policy is specialized. */
-    UA_CertificateVerification_AcceptAll(&config->certificateVerification);
+    UA_CertificateVerification_AcceptAll(&config->logger,
+                                         &config->certificateVerification);
     UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                    "AcceptAll Certificate Verification. "
                    "Any remote certificate will be accepted.");
@@ -721,7 +721,7 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
-    config->securityPolicies = (UA_SecurityPolicy*)UA_malloc(sizeof(UA_SecurityPolicy));
+    config->securityPolicies = (UA_SecurityPolicy *)UA_malloc(sizeof(UA_SecurityPolicy));
     if(!config->securityPolicies)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     UA_StatusCode retval = UA_SecurityPolicy_None(config->securityPolicies,
@@ -757,29 +757,31 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
 #ifdef UA_ENABLE_ENCRYPTION
 UA_StatusCode
 UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
-                                     UA_ByteString localCertificate, UA_ByteString privateKey,
+                                     UA_ByteString localCertificate,
+                                     UA_ByteString privateKey,
                                      const UA_ByteString *trustList, size_t trustListSize,
-                                     const UA_ByteString *revocationList, size_t revocationListSize) {
+                                     const UA_ByteString *revocationList,
+                                     size_t revocationListSize) {
     UA_StatusCode retval = UA_ClientConfig_setDefault(config);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
-    retval = UA_CertificateVerification_Trustlist(&config->certificateVerification,
-                                                  trustList, trustListSize,
-                                                  NULL, 0,
-                                                  revocationList, revocationListSize);
+    retval = UA_CertificateVerification_Trustlist(
+        &config->logger, &config->certificateVerification, trustList, trustListSize, NULL,
+        0, revocationList, revocationListSize);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
     /* Populate SecurityPolicies */
-    UA_SecurityPolicy *sp = (UA_SecurityPolicy*)
-        UA_realloc(config->securityPolicies, sizeof(UA_SecurityPolicy) * 4);
+    UA_SecurityPolicy *sp = (UA_SecurityPolicy *)UA_realloc(
+        config->securityPolicies, sizeof(UA_SecurityPolicy) * 4);
     if(!sp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = sp;
-                  
-    retval = UA_SecurityPolicy_Basic128Rsa15(&config->securityPolicies[config->securityPoliciesSize],
-                                             localCertificate, privateKey, &config->logger);
+
+    retval = UA_SecurityPolicy_Basic128Rsa15(
+        &config->securityPolicies[config->securityPoliciesSize], localCertificate,
+        privateKey, &config->logger);
     if(retval == UA_STATUSCODE_GOOD) {
         ++config->securityPoliciesSize;
     } else {
@@ -788,8 +790,9 @@ UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_SecurityPolicy_Basic256(&config->securityPolicies[config->securityPoliciesSize],
-                                        localCertificate, privateKey, &config->logger);
+    retval = UA_SecurityPolicy_Basic256(
+        &config->securityPolicies[config->securityPoliciesSize], localCertificate,
+        privateKey, &config->logger);
     if(retval == UA_STATUSCODE_GOOD) {
         ++config->securityPoliciesSize;
     } else {
@@ -798,8 +801,9 @@ UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_SecurityPolicy_Basic256Sha256(&config->securityPolicies[config->securityPoliciesSize],
-                                              localCertificate, privateKey, &config->logger);
+    retval = UA_SecurityPolicy_Basic256Sha256(
+        &config->securityPolicies[config->securityPoliciesSize], localCertificate,
+        privateKey, &config->logger);
     if(retval == UA_STATUSCODE_GOOD) {
         ++config->securityPoliciesSize;
     } else {

--- a/plugins/ua_pki_default.c
+++ b/plugins/ua_pki_default.c
@@ -6,44 +6,45 @@
  *    Copyright 2019 (c) Julius Pfrommer, Fraunhofer IOSB
  */
 
-#include <open62541/server_config.h>
+#include <open62541/plugin/log.h>
 #include <open62541/plugin/pki_default.h>
-#include <open62541/plugin/log_stdout.h>
+#include <open62541/server_config.h>
 
 #ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
+#include <mbedtls/error.h>
 #include <mbedtls/x509.h>
 #include <mbedtls/x509_crt.h>
-#include <mbedtls/error.h>
 #endif
 
 #define REMOTECERTIFICATETRUSTED 1
-#define ISSUERKNOWN              2
-#define DUALPARENT               3
-#define PARENTFOUND              4
+#define ISSUERKNOWN 2
+#define DUALPARENT 3
+#define PARENTFOUND 4
+
+static const UA_Logger *pki_plugin_logger = NULL;
 
 /************/
 /* AllowAll */
 /************/
 
 static UA_StatusCode
-verifyCertificateAllowAll(void *verificationContext,
-               const UA_ByteString *certificate) {
+verifyCertificateAllowAll(void *verificationContext, const UA_ByteString *certificate) {
     return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-verifyApplicationURIAllowAll(void *verificationContext,
-                             const UA_ByteString *certificate,
+verifyApplicationURIAllowAll(void *verificationContext, const UA_ByteString *certificate,
                              const UA_String *applicationURI) {
     return UA_STATUSCODE_GOOD;
 }
 
 static void
-clearVerifyAllowAll(UA_CertificateVerification *cv) {
+clearVerifyAllowAll(UA_CertificateVerification *cv) {}
 
-}
-
-void UA_CertificateVerification_AcceptAll(UA_CertificateVerification *cv) {
+void
+UA_CertificateVerification_AcceptAll(const UA_Logger *logger,
+                                     UA_CertificateVerification *cv) {
+    pki_plugin_logger = logger;
     cv->verifyCertificate = verifyCertificateAllowAll;
     cv->verifyApplicationURI = verifyApplicationURIAllowAll;
     cv->clear = clearVerifyAllowAll;
@@ -78,15 +79,17 @@ UA_Bstrstr(const unsigned char *s1, size_t l1, const unsigned char *s2, size_t l
         return s1;
 
     /* match prefix */
-    for (; (s1 = bstrchr(s1, *s2, (uintptr_t)ss1-(uintptr_t)s1+(uintptr_t)l1)) != NULL &&
-             (uintptr_t)ss1-(uintptr_t)s1+(uintptr_t)l1 != 0; ++s1) {
+    for(;
+        (s1 = bstrchr(s1, *s2, (uintptr_t)ss1 - (uintptr_t)s1 + (uintptr_t)l1)) != NULL &&
+        (uintptr_t)ss1 - (uintptr_t)s1 + (uintptr_t)l1 != 0;
+        ++s1) {
 
         /* match rest of prefix */
         const unsigned char *sc1, *sc2;
-        for (sc1 = s1, sc2 = s2; ;)
-            if (++sc2 >= ss2+l2)
+        for(sc1 = s1, sc2 = s2;;)
+            if(++sc2 >= ss2 + l2)
                 return s1;
-            else if (*++sc1 != *sc2)
+            else if(*++sc1 != *sc2)
                 break;
     }
     return NULL;
@@ -120,12 +123,12 @@ fileNamesFromFolder(const UA_String *folder, size_t *pathsSize, UA_String **path
 
     memcpy(buf, folder->data, folder->length);
     buf[folder->length] = 0;
-    
+
     DIR *dir = opendir(buf);
     if(!dir)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    *paths = (UA_String*)UA_Array_new(256, &UA_TYPES[UA_TYPES_STRING]);
+    *paths = (UA_String *)UA_Array_new(256, &UA_TYPES[UA_TYPES_STRING]);
     if(*paths == NULL) {
         closedir(dir);
         return UA_STATUSCODE_BADOUTOFMEMORY;
@@ -140,11 +143,11 @@ fileNamesFromFolder(const UA_String *folder, size_t *pathsSize, UA_String **path
     }
     size_t pathlen = strlen(buf2);
     *pathsSize = 0;
-    while((ent = readdir (dir)) != NULL && *pathsSize < 256) {
+    while((ent = readdir(dir)) != NULL && *pathsSize < 256) {
         if(ent->d_type != DT_REG)
             continue;
         buf2[pathlen] = '/';
-        buf2[pathlen+1] = 0;
+        buf2[pathlen + 1] = 0;
         strcat(buf2, ent->d_name);
         (*paths)[*pathsSize] = UA_STRING_ALLOC(buf2);
         *pathsSize += 1;
@@ -165,7 +168,7 @@ reloadCertificates(CertInfo *ci) {
 
     /* Load the trustlists */
     if(ci->trustListFolder.length > 0) {
-        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Reloading the trust-list");
+        UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER, "Reloading the trust-list");
         mbedtls_x509_crt_free(&ci->certificateTrustList);
         mbedtls_x509_crt_init(&ci->certificateTrustList);
 
@@ -174,19 +177,20 @@ reloadCertificates(CertInfo *ci) {
         f[ci->trustListFolder.length] = 0;
         err = mbedtls_x509_crt_parse_path(&ci->certificateTrustList, f);
         if(err == 0) {
-            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+            UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
                         "Loaded certificate from %s", f);
         } else {
             char errBuff[300];
             mbedtls_strerror(err, errBuff, 300);
-            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+            UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
                         "Failed to load certificate from %s", f);
         }
     }
 
     /* Load the revocationlists */
     if(ci->revocationListFolder.length > 0) {
-        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Reloading the revocation-list");
+        UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
+                    "Reloading the revocation-list");
         size_t pathsSize = 0;
         UA_String *paths = NULL;
         retval = fileNamesFromFolder(&ci->revocationListFolder, &pathsSize, &paths);
@@ -200,13 +204,13 @@ reloadCertificates(CertInfo *ci) {
             f[paths[i].length] = 0;
             err = mbedtls_x509_crl_parse_file(&ci->certificateRevocationList, f);
             if(err == 0) {
-                UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-                            "Loaded certificate from %.*s",
-                            (int)paths[i].length, paths[i].data);
+                UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
+                            "Loaded certificate from %.*s", (int)paths[i].length,
+                            paths[i].data);
             } else {
-                UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-                            "Failed to load certificate from %.*s",
-                            (int)paths[i].length, paths[i].data);
+                UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
+                            "Failed to load certificate from %.*s", (int)paths[i].length,
+                            paths[i].data);
             }
         }
         UA_Array_delete(paths, pathsSize, &UA_TYPES[UA_TYPES_STRING]);
@@ -216,7 +220,8 @@ reloadCertificates(CertInfo *ci) {
 
     /* Load the issuerlists */
     if(ci->issuerListFolder.length > 0) {
-        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Reloading the issuer-list");
+        UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
+                    "Reloading the issuer-list");
         mbedtls_x509_crt_free(&ci->certificateIssuerList);
         mbedtls_x509_crt_init(&ci->certificateIssuerList);
         char f[PATH_MAX];
@@ -224,10 +229,10 @@ reloadCertificates(CertInfo *ci) {
         f[ci->issuerListFolder.length] = 0;
         err = mbedtls_x509_crt_parse_path(&ci->certificateIssuerList, f);
         if(err == 0) {
-            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+            UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
                         "Loaded certificate from %s", f);
         } else {
-            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+            UA_LOG_INFO(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
                         "Failed to load certificate from %s", f);
         }
     }
@@ -240,7 +245,7 @@ reloadCertificates(CertInfo *ci) {
 static UA_StatusCode
 certificateVerification_verify(void *verificationContext,
                                const UA_ByteString *certificate) {
-    CertInfo *ci = (CertInfo*)verificationContext;
+    CertInfo *ci = (CertInfo *)verificationContext;
     if(!ci)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -248,13 +253,11 @@ certificateVerification_verify(void *verificationContext,
     reloadCertificates(ci);
 #endif
 
-    if(ci->trustListFolder.length == 0 &&
-       ci->issuerListFolder.length == 0 &&
-       ci->revocationListFolder.length == 0 &&
-       ci->certificateTrustList.raw.len == 0 &&
+    if(ci->trustListFolder.length == 0 && ci->issuerListFolder.length == 0 &&
+       ci->revocationListFolder.length == 0 && ci->certificateTrustList.raw.len == 0 &&
        ci->certificateIssuerList.raw.len == 0 &&
        ci->certificateRevocationList.raw.len == 0) {
-        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+        UA_LOG_WARNING(pki_plugin_logger, UA_LOGCATEGORY_SERVER,
                        "PKI plugin unconfigured. Accepting the certificate.");
         return UA_STATUSCODE_GOOD;
     }
@@ -286,44 +289,48 @@ certificateVerification_verify(void *verificationContext,
     if(mbedErr) {
         /* char errBuff[300]; */
         /* mbedtls_strerror(mbedErr, errBuff, 300); */
-        /* UA_LOG_WARNING(data->policyContext->securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY, */
-        /*                "Could not parse the remote certificate with error: %s", errBuff); */
+        /* UA_LOG_WARNING(data->policyContext->securityPolicy->logger,
+         * UA_LOGCATEGORY_SECURITYPOLICY, */
+        /*                "Could not parse the remote certificate with error: %s",
+         * errBuff); */
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     }
 
     /* Verify */
     mbedtls_x509_crt_profile crtProfile = {
         MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA1) | MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA256),
-        0xFFFFFF, 0x000000, 128 * 8 // in bits
-    }; // TODO: remove magic numbers
+        0xFFFFFF, 0x000000, 128 * 8  // in bits
+    };                               // TODO: remove magic numbers
 
     uint32_t flags = 0;
-    mbedErr = mbedtls_x509_crt_verify_with_profile(&remoteCertificate,
-                                                   &ci->certificateTrustList,
-                                                   &ci->certificateRevocationList,
-                                                   &crtProfile, NULL, &flags, NULL, NULL);
+    mbedErr = mbedtls_x509_crt_verify_with_profile(
+        &remoteCertificate, &ci->certificateTrustList, &ci->certificateRevocationList,
+        &crtProfile, NULL, &flags, NULL, NULL);
 
     /* Flag to check if the remote certificate is trusted or not */
     int TRUSTED = 0;
 
-    /* Check if the remoteCertificate is present in the trustList while mbedErr value is not zero */
-    if(mbedErr && !(flags & MBEDTLS_X509_BADCERT_EXPIRED) && !(flags & MBEDTLS_X509_BADCERT_FUTURE)) {
-        for(tempCert = &ci->certificateTrustList; tempCert != NULL; tempCert = tempCert->next) {
+    /* Check if the remoteCertificate is present in the trustList while mbedErr value is
+     * not zero */
+    if(mbedErr && !(flags & MBEDTLS_X509_BADCERT_EXPIRED) &&
+       !(flags & MBEDTLS_X509_BADCERT_FUTURE)) {
+        for(tempCert = &ci->certificateTrustList; tempCert != NULL;
+            tempCert = tempCert->next) {
             if(remoteCertificate.raw.len == tempCert->raw.len &&
-               memcmp(remoteCertificate.raw.p, tempCert->raw.p, remoteCertificate.raw.len) == 0) {
+               memcmp(remoteCertificate.raw.p, tempCert->raw.p,
+                      remoteCertificate.raw.len) == 0) {
                 TRUSTED = REMOTECERTIFICATETRUSTED;
                 break;
             }
         }
     }
 
-    /* If the remote certificate is present in the trustList then check if the issuer certificate
-     * of remoteCertificate is present in issuerList */
+    /* If the remote certificate is present in the trustList then check if the issuer
+     * certificate of remoteCertificate is present in issuerList */
     if(TRUSTED && mbedErr) {
-        mbedErr = mbedtls_x509_crt_verify_with_profile(&remoteCertificate,
-                                                       &ci->certificateIssuerList,
-                                                       &ci->certificateRevocationList,
-                                                       &crtProfile, NULL, &flags, NULL, NULL);
+        mbedErr = mbedtls_x509_crt_verify_with_profile(
+            &remoteCertificate, &ci->certificateIssuerList,
+            &ci->certificateRevocationList, &crtProfile, NULL, &flags, NULL, NULL);
 
         /* Check if the parent certificate has a CRL file available */
         if(!mbedErr) {
@@ -331,15 +338,18 @@ certificateVerification_verify(void *verificationContext,
             int dualParent = 0;
 
             /* Identify the topmost parent certificate for the remoteCertificate */
-            for( parentCert = &ci->certificateIssuerList; parentCert != NULL; parentCert = parentCert->next ) {
-                if(memcmp(remoteCertificate.issuer_raw.p, parentCert->subject_raw.p, parentCert->subject_raw.len) == 0) {
-                    for(parentCert_2 = &ci->certificateTrustList; parentCert_2 != NULL; parentCert_2 = parentCert_2->next) {
-                        if(memcmp(parentCert->issuer_raw.p, parentCert_2->subject_raw.p, parentCert_2->subject_raw.len) == 0) {
+            for(parentCert = &ci->certificateIssuerList; parentCert != NULL;
+                parentCert = parentCert->next) {
+                if(memcmp(remoteCertificate.issuer_raw.p, parentCert->subject_raw.p,
+                          parentCert->subject_raw.len) == 0) {
+                    for(parentCert_2 = &ci->certificateTrustList; parentCert_2 != NULL;
+                        parentCert_2 = parentCert_2->next) {
+                        if(memcmp(parentCert->issuer_raw.p, parentCert_2->subject_raw.p,
+                                  parentCert_2->subject_raw.len) == 0) {
                             dualParent = DUALPARENT;
                             parentFound = PARENTFOUND;
                             break;
                         }
-
                     }
 
                     parentFound = PARENTFOUND;
@@ -348,7 +358,6 @@ certificateVerification_verify(void *verificationContext,
                 if(parentFound == PARENTFOUND) {
                     break;
                 }
-
             }
 
             /* Check if there is an intermediate certificate between the topmost parent
@@ -366,8 +375,7 @@ certificateVerification_verify(void *verificationContext,
                 while(tempCrl != NULL) {
                     if(tempCrl->version != 0 &&
                        tempCrl->issuer_raw.len == parentCert->subject_raw.len &&
-                       memcmp(tempCrl->issuer_raw.p,
-                              parentCert->subject_raw.p,
+                       memcmp(tempCrl->issuer_raw.p, parentCert->subject_raw.p,
                               tempCrl->issuer_raw.len) == 0) {
                         issuerKnown = ISSUERKNOWN;
                         break;
@@ -381,35 +389,33 @@ certificateVerification_verify(void *verificationContext,
                 if(!issuerKnown) {
                     return UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN;
                 }
-
             }
-
         }
 
-    }
-    else if(!mbedErr && !TRUSTED) {
-        /* This else if section is to identify if the parent certificate which is present in trustList
-         * has CRL file corresponding to it */
+    } else if(!mbedErr && !TRUSTED) {
+        /* This else if section is to identify if the parent certificate which is present
+         * in trustList has CRL file corresponding to it */
 
         /* Identify the parent certificate of the remoteCertificate */
-        for(parentCert = &ci->certificateTrustList; parentCert != NULL; parentCert = parentCert->next) {
-            if(memcmp(remoteCertificate.issuer_raw.p, parentCert->subject_raw.p, parentCert->subject_raw.len) == 0) {
+        for(parentCert = &ci->certificateTrustList; parentCert != NULL;
+            parentCert = parentCert->next) {
+            if(memcmp(remoteCertificate.issuer_raw.p, parentCert->subject_raw.p,
+                      parentCert->subject_raw.len) == 0) {
                 parentFound = PARENTFOUND;
                 break;
             }
-
         }
 
         /* If the parent certificate is found traverse the revocationList and identify
          * if there is any CRL file that corresponds to the parentCertificate */
         if(parentFound == PARENTFOUND &&
-            memcmp(remoteCertificate.issuer_raw.p, remoteCertificate.subject_raw.p, remoteCertificate.subject_raw.len) != 0) {
+           memcmp(remoteCertificate.issuer_raw.p, remoteCertificate.subject_raw.p,
+                  remoteCertificate.subject_raw.len) != 0) {
             tempCrl = &ci->certificateRevocationList;
             while(tempCrl != NULL) {
                 if(tempCrl->version != 0 &&
                    tempCrl->issuer_raw.len == parentCert->subject_raw.len &&
-                   memcmp(tempCrl->issuer_raw.p,
-                          parentCert->subject_raw.p,
+                   memcmp(tempCrl->issuer_raw.p, parentCert->subject_raw.p,
                           tempCrl->issuer_raw.len) == 0) {
                     issuerKnown = ISSUERKNOWN;
                     break;
@@ -423,9 +429,7 @@ certificateVerification_verify(void *verificationContext,
             if(!issuerKnown) {
                 return UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN;
             }
-
         }
-
     }
 
     // TODO: Extend verification
@@ -446,8 +450,9 @@ certificateVerification_verify(void *verificationContext,
 #if UA_LOGLEVEL <= 400
         char buff[100];
         int len = mbedtls_x509_crt_verify_info(buff, 100, "", flags);
-        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_SECURITYPOLICY,
-                       "Verifying the certificate failed with error: %.*s", len-1, buff);
+        UA_LOG_WARNING(pki_plugin_logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                       "Verifying the certificate failed with error: %.*s", len - 1,
+                       buff);
 #endif
         if(flags & (uint32_t)MBEDTLS_X509_BADCERT_NOT_TRUSTED) {
             retval = UA_STATUSCODE_BADCERTIFICATEUNTRUSTED;
@@ -470,7 +475,7 @@ static UA_StatusCode
 certificateVerification_verifyApplicationURI(void *verificationContext,
                                              const UA_ByteString *certificate,
                                              const UA_String *applicationURI) {
-    CertInfo *ci = (CertInfo*)verificationContext;
+    CertInfo *ci = (CertInfo *)verificationContext;
     if(!ci)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -489,7 +494,7 @@ certificateVerification_verifyApplicationURI(void *verificationContext,
      * TODO: Improve parsing of the Alternative Subject Name */
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(UA_Bstrstr(remoteCertificate.v3_ext.p, remoteCertificate.v3_ext.len,
-               applicationURI->data, applicationURI->length) == NULL)
+                  applicationURI->data, applicationURI->length) == NULL)
         retval = UA_STATUSCODE_BADCERTIFICATEURIINVALID;
 
     mbedtls_x509_crt_free(&remoteCertificate);
@@ -498,7 +503,7 @@ certificateVerification_verifyApplicationURI(void *verificationContext,
 
 static void
 certificateVerification_clear(UA_CertificateVerification *cv) {
-    CertInfo *ci = (CertInfo*)cv->context;
+    CertInfo *ci = (CertInfo *)cv->context;
     if(!ci)
         return;
     mbedtls_x509_crt_free(&ci->certificateTrustList);
@@ -512,22 +517,25 @@ certificateVerification_clear(UA_CertificateVerification *cv) {
 }
 
 UA_StatusCode
-UA_CertificateVerification_Trustlist(UA_CertificateVerification *cv,
+UA_CertificateVerification_Trustlist(const UA_Logger *logger,
+                                     UA_CertificateVerification *cv,
                                      const UA_ByteString *certificateTrustList,
                                      size_t certificateTrustListSize,
                                      const UA_ByteString *certificateIssuerList,
                                      size_t certificateIssuerListSize,
                                      const UA_ByteString *certificateRevocationList,
                                      size_t certificateRevocationListSize) {
-    CertInfo *ci = (CertInfo*)UA_malloc(sizeof(CertInfo));
+    CertInfo *ci = (CertInfo *)UA_malloc(sizeof(CertInfo));
     if(!ci)
         return UA_STATUSCODE_BADOUTOFMEMORY;
+
+    pki_plugin_logger = logger;
     memset(ci, 0, sizeof(CertInfo));
     mbedtls_x509_crt_init(&ci->certificateTrustList);
     mbedtls_x509_crl_init(&ci->certificateRevocationList);
     mbedtls_x509_crt_init(&ci->certificateIssuerList);
 
-    cv->context = (void*)ci;
+    cv->context = (void *)ci;
     if(certificateTrustListSize > 0)
         cv->verifyCertificate = certificateVerification_verify;
     else
@@ -567,13 +575,15 @@ error:
 #ifdef __linux__ /* Linux only so far */
 
 UA_StatusCode
-UA_CertificateVerification_CertFolders(UA_CertificateVerification *cv,
+UA_CertificateVerification_CertFolders(const UA_Logger *logger,
+                                       UA_CertificateVerification *cv,
                                        const char *trustListFolder,
                                        const char *issuerListFolder,
                                        const char *revocationListFolder) {
-    CertInfo *ci = (CertInfo*)UA_malloc(sizeof(CertInfo));
+    CertInfo *ci = (CertInfo *)UA_malloc(sizeof(CertInfo));
     if(!ci)
         return UA_STATUSCODE_BADOUTOFMEMORY;
+    pki_plugin_logger = logger;
     memset(ci, 0, sizeof(CertInfo));
     mbedtls_x509_crt_init(&ci->certificateTrustList);
     mbedtls_x509_crl_init(&ci->certificateRevocationList);
@@ -587,7 +597,7 @@ UA_CertificateVerification_CertFolders(UA_CertificateVerification *cv,
 
     reloadCertificates(ci);
 
-    cv->context = (void*)ci;
+    cv->context = (void *)ci;
     cv->verifyCertificate = certificateVerification_verify;
     cv->clear = certificateVerification_clear;
     cv->verifyApplicationURI = certificateVerification_verifyApplicationURI;


### PR DESCRIPTION
## Description
This PR removes the use of the standard [log_stdout.h](https://github.com/open62541/open62541/blob/master/plugins/include/open62541/plugin/log_stdout.h) from [ua_pki_default.c](https://github.com/open62541/open62541/blob/f71912485ec60a42eebbfd96877bef5268c699e6/plugins/ua_pki_default.c) and implements the use of a more generalized [log.h](https://github.com/open62541/open62541/blob/master/include/open62541/plugin/log.h) in its place. 

This is achieved by using a `static UA_Logger` variable, which is initially set to `NULL` and set during configuration by one of the following functions: 

* `UA_CertificateVerification_AcceptAll()`
* `UA_CertificateVerification_Trustlist()`
* `UA_CertificateVerification_CertFolders()`

A `NULL` logger is acceptable since  [log.h](https://github.com/open62541/open62541/blob/master/include/open62541/plugin/log.h)  checks against it, and if it is found, no logging is done, which in principal, allows for full deactivation of the logging plugin during the configuration process.
