### PR TITLE
[WIP] feat(pubsub): change std_log.h into log.h, implement configurable loger for pubsub_ethernet module

### DIFF
--- a/plugins/include/open62541/plugin/pubsub_ethernet.h
+++ b/plugins/include/open62541/plugin/pubsub_ethernet.h
@@ -7,12 +7,13 @@
 #ifndef UA_NETWORK_PUBSUB_ETHERNET_H_
 #define UA_NETWORK_PUBSUB_ETHERNET_H_
 
+#include <open62541/plugin/log.h>
 #include <open62541/plugin/pubsub.h>
 
 _UA_BEGIN_DECLS
 
 UA_PubSubTransportLayer UA_EXPORT
-UA_PubSubTransportLayerEthernet(void);
+UA_PubSubTransportLayerEthernet(const UA_Logger *logger);
 
 _UA_END_DECLS
 

--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -6,13 +6,12 @@
  *   Copyright 2019 (c) Wind River Systems, Inc.
  */
 
-#include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pubsub_ethernet.h>
 #include <open62541/util.h>
 
 #if defined(__vxworks) || defined(__VXWORKS__)
-#include <netpacket/packet.h>
 #include <netinet/if_ether.h>
+#include <netpacket/packet.h>
 #define ETH_ALEN ETHER_ADDR_LEN
 #else
 #include <linux/if_packet.h>
@@ -22,6 +21,8 @@
 #ifndef ETHERTYPE_UADP
 #define ETHERTYPE_UADP 0xb62c
 #endif
+
+static const UA_Logger *pubsub_ethernet_plugin_logger = NULL;
 
 /* Ethernet network layer specific internal data */
 typedef struct {
@@ -44,17 +45,16 @@ typedef struct {
  * We do not support currently IP addresses or hostnames.
  */
 static UA_StatusCode
-UA_parseHardwareAddress(UA_String* target, UA_Byte* destinationMac) {
+UA_parseHardwareAddress(UA_String *target, UA_Byte *destinationMac) {
     size_t curr = 0, idx = 0;
     for(; idx < ETH_ALEN; idx++) {
         UA_UInt32 value;
         size_t progress =
-            UA_readNumberWithBase(&target->data[curr],
-                                  target->length - curr, &value, 16);
+            UA_readNumberWithBase(&target->data[curr], target->length - curr, &value, 16);
         if(progress == 0 || value > (long)0xff)
             return UA_STATUSCODE_BADINTERNALERROR;
 
-        destinationMac[idx] = (UA_Byte) value;
+        destinationMac[idx] = (UA_Byte)value;
 
         curr += progress;
         if(curr == target->length)
@@ -66,7 +66,7 @@ UA_parseHardwareAddress(UA_String* target, UA_Byte* destinationMac) {
         curr++; /* skip '-' */
     }
 
-    if(idx != (ETH_ALEN-1))
+    if(idx != (ETH_ALEN - 1))
         return UA_STATUSCODE_BADINTERNALERROR;
 
     return UA_STATUSCODE_GOOD;
@@ -80,56 +80,61 @@ UA_parseHardwareAddress(UA_String* target, UA_Byte* destinationMac) {
 static UA_PubSubChannel *
 UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig) {
 
-    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+    UA_LOG_INFO(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
                 "Open PubSub ethernet connection.");
 
     /* allocate and init memory for the ethernet specific internal data */
-    UA_PubSubChannelDataEthernet* channelDataEthernet =
-            (UA_PubSubChannelDataEthernet*) UA_calloc(1, sizeof(*channelDataEthernet));
+    UA_PubSubChannelDataEthernet *channelDataEthernet =
+        (UA_PubSubChannelDataEthernet *)UA_calloc(1, sizeof(*channelDataEthernet));
     if(!channelDataEthernet) {
-        UA_LOG_ERROR (UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-            "PubSub Connection creation failed. Out of memory.");
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub Connection creation failed. Out of memory.");
         return NULL;
     }
 
     /* handle specified network address */
     UA_NetworkAddressUrlDataType *address;
     if(UA_Variant_hasScalarType(&connectionConfig->address,
-                                 &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE])) {
-        address = (UA_NetworkAddressUrlDataType *) connectionConfig->address.data;
+                                &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE])) {
+        address = (UA_NetworkAddressUrlDataType *)connectionConfig->address.data;
     } else {
-        UA_LOG_ERROR (UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-            "PubSub Connection creation failed. Invalid Address.");
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub Connection creation failed. Invalid Address.");
         UA_free(channelDataEthernet);
         return NULL;
     }
-    UA_LOG_DEBUG(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Specified Interface Name = %.*s",
-         (int) address->networkInterface.length, address->networkInterface.data);
-    UA_LOG_DEBUG(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Specified Network Url = %.*s",
-         (int)address->url.length, address->url.data);
+    UA_LOG_DEBUG(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                 "Specified Interface Name = %.*s", (int)address->networkInterface.length,
+                 address->networkInterface.data);
+    UA_LOG_DEBUG(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                 "Specified Network Url = %.*s", (int)address->url.length,
+                 address->url.data);
 
     UA_String target;
     /* encode the URL and store information in internal structure */
     if(UA_parseEndpointUrlEthernet(&address->url, &target, &channelDataEthernet->vid,
                                    &channelDataEthernet->prio)) {
-        UA_LOG_ERROR (UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-            "PubSub Connection creation failed. Invalid Address URL.");
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub Connection creation failed. Invalid Address URL.");
         UA_free(channelDataEthernet);
         return NULL;
     }
 
     /* Get a valid MAC address from target definition */
-    if(UA_parseHardwareAddress(&target, channelDataEthernet->targetAddress) != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-                     "PubSub Connection creation failed. Invalid destination MAC address.");
+    if(UA_parseHardwareAddress(&target, channelDataEthernet->targetAddress) !=
+       UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(
+            pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+            "PubSub Connection creation failed. Invalid destination MAC address.");
         UA_free(channelDataEthernet);
         return NULL;
     }
 
     /* generate a new Pub/Sub channel and open a related socket */
-    UA_PubSubChannel *newChannel = (UA_PubSubChannel*)UA_calloc(1, sizeof(UA_PubSubChannel));
+    UA_PubSubChannel *newChannel =
+        (UA_PubSubChannel *)UA_calloc(1, sizeof(UA_PubSubChannel));
     if(!newChannel) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
                      "PubSub Connection creation failed. Out of memory.");
         UA_free(channelDataEthernet);
         return NULL;
@@ -138,8 +143,8 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
     /* Open a packet socket */
     int sockFd = UA_socket(PF_PACKET, SOCK_RAW, 0);
     if(sockFd < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-            "PubSub connection creation failed. Cannot create socket.");
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub connection creation failed. Cannot create socket.");
         UA_free(channelDataEthernet);
         UA_free(newChannel);
         return NULL;
@@ -149,8 +154,8 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
     /* allow the socket to be reused */
     int opt = 1;
     if(UA_setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-            "PubSub connection creation failed. Cannot set socket reuse.");
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub connection creation failed. Cannot set socket reuse.");
         UA_close(sockFd);
         UA_free(channelDataEthernet);
         UA_free(newChannel);
@@ -160,12 +165,12 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
     /* get interface index */
     struct ifreq ifreq;
     memset(&ifreq, 0, sizeof(struct ifreq));
-    strncpy(ifreq.ifr_name, (char*)address->networkInterface.data,
-            UA_MIN(address->networkInterface.length, sizeof(ifreq.ifr_name)-1));
+    strncpy(ifreq.ifr_name, (char *)address->networkInterface.data,
+            UA_MIN(address->networkInterface.length, sizeof(ifreq.ifr_name) - 1));
 
     if(ioctl(sockFd, SIOCGIFINDEX, &ifreq) < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-           "PubSub connection creation failed. Cannot get interface index.");
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub connection creation failed. Cannot get interface index.");
         UA_close(sockFd);
         UA_free(channelDataEthernet);
         UA_free(newChannel);
@@ -175,7 +180,8 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
 
     /* determine own MAC address (source address for send) */
     if(ioctl(sockFd, SIOCGIFHWADDR, &ifreq) < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+        UA_LOG_ERROR(
+            pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
             "PubSub connection creation failed. Cannot determine own MAC address.");
         UA_close(sockFd);
         UA_free(channelDataEthernet);
@@ -189,14 +195,14 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
 #endif
 
     /* bind the socket to interface and ethertype */
-    struct sockaddr_ll sll = { 0 };
+    struct sockaddr_ll sll = {0};
     sll.sll_family = AF_PACKET;
     sll.sll_ifindex = channelDataEthernet->ifindex;
     sll.sll_protocol = htons(ETHERTYPE_UADP);
 
-    if(UA_bind(sockFd, (struct sockaddr*)&sll, sizeof(sll)) < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-            "PubSub connection creation failed. Cannot bind socket.");
+    if(UA_bind(sockFd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub connection creation failed. Cannot bind socket.");
         UA_close(sockFd);
         UA_free(channelDataEthernet);
         UA_free(newChannel);
@@ -234,9 +240,10 @@ is_multicast_address(const UA_Byte *address) {
 static UA_StatusCode
 UA_PubSubChannelEthernet_regist(UA_PubSubChannel *channel,
                                 UA_ExtensionObject *transportSettings,
-                                void (*notUsedHere)(UA_ByteString *encodedBuffer, UA_ByteString *topic)) {
+                                void (*notUsedHere)(UA_ByteString *encodedBuffer,
+                                                    UA_ByteString *topic)) {
     UA_PubSubChannelDataEthernet *channelDataEthernet =
-        (UA_PubSubChannelDataEthernet *) channel->handle;
+        (UA_PubSubChannelDataEthernet *)channel->handle;
 
     if(!is_multicast_address(channelDataEthernet->targetAddress))
         return UA_STATUSCODE_GOOD;
@@ -247,8 +254,10 @@ UA_PubSubChannelEthernet_regist(UA_PubSubChannel *channel,
     mreq.mr_alen = ETH_ALEN;
     memcpy(mreq.mr_address, channelDataEthernet->targetAddress, ETH_ALEN);
 
-    if(UA_setsockopt(channel->sockfd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (char*) &mreq, sizeof(mreq)) < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "PubSub Connection regist failed. %s", strerror(errno));
+    if(UA_setsockopt(channel->sockfd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (char *)&mreq,
+                     sizeof(mreq)) < 0) {
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub Connection regist failed. %s", strerror(errno));
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
@@ -264,7 +273,7 @@ static UA_StatusCode
 UA_PubSubChannelEthernet_unregist(UA_PubSubChannel *channel,
                                   UA_ExtensionObject *transportSettings) {
     UA_PubSubChannelDataEthernet *channelDataEthernet =
-        (UA_PubSubChannelDataEthernet *) channel->handle;
+        (UA_PubSubChannelDataEthernet *)channel->handle;
 
     if(!is_multicast_address(channelDataEthernet->targetAddress)) {
         return UA_STATUSCODE_GOOD;
@@ -276,8 +285,10 @@ UA_PubSubChannelEthernet_unregist(UA_PubSubChannel *channel,
     mreq.mr_alen = ETH_ALEN;
     memcpy(mreq.mr_address, channelDataEthernet->targetAddress, ETH_ALEN);
 
-    if(UA_setsockopt(channel->sockfd, SOL_PACKET, PACKET_DROP_MEMBERSHIP, (char*) &mreq, sizeof(mreq)) < 0) { 
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "PubSub Connection regist failed.");
+    if(UA_setsockopt(channel->sockfd, SOL_PACKET, PACKET_DROP_MEMBERSHIP, (char *)&mreq,
+                     sizeof(mreq)) < 0) {
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub Connection regist failed.");
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
@@ -294,17 +305,17 @@ UA_PubSubChannelEthernet_send(UA_PubSubChannel *channel,
                               UA_ExtensionObject *transportSettings,
                               const UA_ByteString *buf) {
     UA_PubSubChannelDataEthernet *channelDataEthernet =
-        (UA_PubSubChannelDataEthernet *) channel->handle;
+        (UA_PubSubChannelDataEthernet *)channel->handle;
 
     /* Allocate a buffer for the ethernet data which contains the ethernet
      * header (without VLAN tag), the VLAN tag and the OPC-UA/Ethernet data. */
     char *bufSend, *ptrCur;
     size_t lenBuf;
-    struct ether_header* ethHdr;
+    struct ether_header *ethHdr;
 
     lenBuf = sizeof(*ethHdr) + 4 + buf->length;
-    bufSend = (char*) UA_malloc(lenBuf);
-    ethHdr = (struct ether_header*) bufSend;
+    bufSend = (char *)UA_malloc(lenBuf);
+    ethHdr = (struct ether_header *)bufSend;
 
     /* Set (own) source MAC address */
     memcpy(ethHdr->ether_shost, channelDataEthernet->ifAddress, ETH_ALEN);
@@ -317,16 +328,17 @@ UA_PubSubChannelEthernet_send(UA_PubSubChannel *channel,
     ptrCur = bufSend + sizeof(*ethHdr);
     if(channelDataEthernet->vid == 0) {
         ethHdr->ether_type = htons(ETHERTYPE_UADP);
-        lenBuf -= 4;  /* no VLAN tag */
+        lenBuf -= 4; /* no VLAN tag */
     } else {
         ethHdr->ether_type = htons(ETHERTYPE_VLAN);
         /* set VLAN ID */
         UA_UInt16 vlanTag;
-        vlanTag = (UA_UInt16) (channelDataEthernet->vid + (channelDataEthernet->prio << 13));
-        *((UA_UInt16 *) ptrCur) = htons(vlanTag);
+        vlanTag =
+            (UA_UInt16)(channelDataEthernet->vid + (channelDataEthernet->prio << 13));
+        *((UA_UInt16 *)ptrCur) = htons(vlanTag);
         ptrCur += sizeof(UA_UInt16);
         /* set Ethernet */
-        *((UA_UInt16 *) ptrCur) = htons(ETHERTYPE_UADP);
+        *((UA_UInt16 *)ptrCur) = htons(ETHERTYPE_UADP);
         ptrCur += sizeof(UA_UInt16);
     }
 
@@ -335,9 +347,9 @@ UA_PubSubChannelEthernet_send(UA_PubSubChannel *channel,
 
     ssize_t rc;
     rc = UA_send(channel->sockfd, bufSend, lenBuf, 0);
-    if(rc  < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-            "PubSub connection send failed. Send message failed.");
+    if(rc < 0) {
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub connection send failed. Send message failed.");
         UA_free(bufSend);
         return UA_STATUSCODE_BADINTERNALERROR;
     }
@@ -354,9 +366,10 @@ UA_PubSubChannelEthernet_send(UA_PubSubChannel *channel,
  */
 static UA_StatusCode
 UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *message,
-                                 UA_ExtensionObject *transportSettings, UA_UInt32 timeout) {
+                                 UA_ExtensionObject *transportSettings,
+                                 UA_UInt32 timeout) {
     UA_PubSubChannelDataEthernet *channelDataEthernet =
-        (UA_PubSubChannelDataEthernet *) channel->handle;
+        (UA_PubSubChannelDataEthernet *)channel->handle;
 
     struct ether_header eth_hdr;
     struct msghdr msg;
@@ -378,7 +391,7 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
         UA_fd_set(channel->sockfd, &fdset);
         struct timeval tmptv = {(long int)(timeout / 1000000),
                                 (long int)(timeout % 1000000)};
-        int resultsize = UA_select(channel->sockfd+1, &fdset, NULL, NULL, &tmptv);
+        int resultsize = UA_select(channel->sockfd + 1, &fdset, NULL, NULL, &tmptv);
         if(resultsize == 0) {
             message->length = 0;
             return UA_STATUSCODE_GOODNONCRITICALTIMEOUT;
@@ -392,12 +405,12 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
     /* Read the current packet on the socket */
     ssize_t dataLen = recvmsg(channel->sockfd, &msg, 0);
     if(dataLen < 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
                      "PubSub connection receive failed. Receive message failed.");
         return UA_STATUSCODE_BADINTERNALERROR;
     }
     if((size_t)dataLen < sizeof(eth_hdr)) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+        UA_LOG_ERROR(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_SERVER,
                      "PubSub connection receive failed. Packet too small.");
         return UA_STATUSCODE_BADINTERNALERROR;
     }
@@ -435,8 +448,9 @@ UA_PubSubChannelEthernet_close(UA_PubSubChannel *channel) {
  */
 static UA_PubSubChannel *
 TransportLayerEthernet_addChannel(UA_PubSubConnectionConfig *connectionConfig) {
-    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "PubSub channel requested");
-    UA_PubSubChannel * pubSubChannel = UA_PubSubChannelEthernet_open(connectionConfig);
+    UA_LOG_INFO(pubsub_ethernet_plugin_logger, UA_LOGCATEGORY_USERLAND,
+                "PubSub channel requested");
+    UA_PubSubChannel *pubSubChannel = UA_PubSubChannelEthernet_open(connectionConfig);
     if(pubSubChannel) {
         pubSubChannel->regist = UA_PubSubChannelEthernet_regist;
         pubSubChannel->unregist = UA_PubSubChannelEthernet_unregist;
@@ -449,7 +463,8 @@ TransportLayerEthernet_addChannel(UA_PubSubConnectionConfig *connectionConfig) {
 }
 
 UA_PubSubTransportLayer
-UA_PubSubTransportLayerEthernet() {
+UA_PubSubTransportLayerEthernet(const UA_Logger *logger) {
+    pubsub_ethernet_plugin_logger = logger;
     UA_PubSubTransportLayer pubSubTransportLayer;
     pubSubTransportLayer.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");

--- a/tests/pubsub/check_pubsub_connection_ethernet.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet.c
@@ -5,234 +5,285 @@
  * Copyright (c) 2019 Kalycito Infotech Private Limited
  */
 
+#include <open62541/plugin/log.h>
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/plugin/pubsub_ethernet.h>
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
-#include <ua_server_internal.h>
-#include <open62541/types_generated_encoding_binary.h>
-#include <open62541/plugin/log_stdout.h>
-#include <open62541/plugin/log.h>
 #include <open62541/types_generated.h>
-#include <open62541/plugin/pubsub_ethernet.h>
+#include <open62541/types_generated_encoding_binary.h>
+
 #include "ua_pubsub.h"
 #include "ua_pubsub_manager.h"
+#include <ua_server_internal.h>
+
+#include <check.h>
 
 #include <linux/if_packet.h>
 #include <netinet/ether.h>
 
-#include <check.h>
-
-#define             ETHERNET_INTERFACE                 "enp4s0"
-#define             MULTICAST_MAC_ADDRESS              "opc.eth://01-00-5E-00-00-01"
+#define ETHERNET_INTERFACE "enp4s0"
+#define MULTICAST_MAC_ADDRESS "opc.eth://01-00-5E-00-00-01"
 
 UA_Server *server = NULL;
 
-static void setup(void) {
+static void
+setup(void) {
     server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 
-    config->pubsubTransportLayers = (UA_PubSubTransportLayer *)
-        UA_malloc(sizeof(UA_PubSubTransportLayer));
-    config->pubsubTransportLayers[0] = UA_PubSubTransportLayerEthernet();
+    config->pubsubTransportLayers =
+        (UA_PubSubTransportLayer *)UA_malloc(sizeof(UA_PubSubTransportLayer));
+    config->pubsubTransportLayers[0] = UA_PubSubTransportLayerEthernet(&config->logger);
     config->pubsubTransportLayersSize++;
     UA_Server_run_startup(server);
 }
 
-static void teardown(void) {
+static void
+teardown(void) {
     UA_Server_run_shutdown(server);
     UA_Server_delete(server);
 }
 
-START_TEST(AddConnectionsWithMinimalValidConfiguration){
+START_TEST(AddConnectionsWithMinimalValidConfiguration) {
     UA_StatusCode retVal;
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("Ethernet Connection");
-    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE), UA_STRING(MULTICAST_MAC_ADDRESS)};
+    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE),
+                                                      UA_STRING(MULTICAST_MAC_ADDRESS)};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
+    connectionConfig.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
     ck_assert_int_eq(server->pubSubManager.connectionsSize, 1);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-    ck_assert(! TAILQ_EMPTY(&server->pubSubManager.connections));
+    ck_assert(!TAILQ_EMPTY(&server->pubSubManager.connections));
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     ck_assert(&server->pubSubManager.connections.tqh_first->listEntry.tqe_next != NULL);
     ck_assert_int_eq(server->pubSubManager.connectionsSize, 2);
-} END_TEST
+}
+END_TEST
 
-
-START_TEST(AddRemoveAddConnectionWithMinimalValidConfiguration){
-        UA_StatusCode retVal;
-        UA_PubSubConnectionConfig connectionConfig;
-        memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
-        connectionConfig.name = UA_STRING("Ethernet Connection");
-        UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE), UA_STRING(MULTICAST_MAC_ADDRESS)};
-        UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
-                             &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-        connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
-        UA_NodeId connectionIdent;
-        retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
-        ck_assert_int_eq(server->pubSubManager.connectionsSize, 1);
-        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-        ck_assert(! TAILQ_EMPTY(&server->pubSubManager.connections));
-        retVal |= UA_Server_removePubSubConnection(server, connectionIdent);
-        ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
-        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-        retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
-        ck_assert_int_eq(server->pubSubManager.connectionsSize, 1);
-        ck_assert(&server->pubSubManager.connections.tqh_first->listEntry.tqe_next != NULL);
-        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-} END_TEST
-
-START_TEST(AddConnectionWithInvalidAddress){
+START_TEST(AddRemoveAddConnectionWithMinimalValidConfiguration) {
     UA_StatusCode retVal;
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("Ethernet Connection");
-    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE), UA_STRING("opc.eth://a0:36:9f:04:5b:11")};
+    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE),
+                                                      UA_STRING(MULTICAST_MAC_ADDRESS)};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
-    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
-    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
-    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
-    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
-    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
-} END_TEST
-
-START_TEST(AddConnectionWithInvalidInterface){
-    UA_StatusCode retVal;
-    UA_PubSubConnectionConfig connectionConfig;
-    memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
-    connectionConfig.name = UA_STRING("Ethernet Connection");
-    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING(MULTICAST_MAC_ADDRESS)};
-    UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
-                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
-    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
-    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
-    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
-    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
-    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
-} END_TEST
-
-START_TEST(AddConnectionWithUnknownTransportURL){
-        UA_StatusCode retVal;
-        UA_PubSubConnectionConfig connectionConfig;
-        memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
-        connectionConfig.name = UA_STRING("Ethernet Connection");
-        UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE), UA_STRING(MULTICAST_MAC_ADDRESS)};
-        UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
-                             &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-        connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/unknown-eth-uadp");
-        UA_NodeId connectionIdent;
-        retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
-        ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
-        ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
-} END_TEST
-
-START_TEST(AddConnectionWithNullConfig){
-        UA_StatusCode retVal;
-        retVal = UA_Server_addPubSubConnection(server, NULL, NULL);
-        ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
-        ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
-    } END_TEST
-
-START_TEST(AddSingleConnectionWithMaximalConfiguration){
-    UA_NetworkAddressUrlDataType networkAddressUrlData = {UA_STRING(ETHERNET_INTERFACE), UA_STRING(MULTICAST_MAC_ADDRESS)};
-    UA_Variant address;
-    UA_Variant_setScalar(&address, &networkAddressUrlData, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    UA_KeyValuePair connectionOptions[3];
-    connectionOptions[0].key = UA_QUALIFIEDNAME(0, "ttl");
-    UA_UInt32 ttl = 10;
-    UA_Variant_setScalar(&connectionOptions[0].value, &ttl, &UA_TYPES[UA_TYPES_UINT32]);
-    connectionOptions[1].key = UA_QUALIFIEDNAME(0, "loopback");
-    UA_Boolean loopback = UA_FALSE;
-    UA_Variant_setScalar(&connectionOptions[1].value, &loopback, &UA_TYPES[UA_TYPES_BOOLEAN]);
-    connectionOptions[2].key = UA_QUALIFIEDNAME(0, "reuse");
-    UA_Boolean reuse = UA_TRUE;
-    UA_Variant_setScalar(&connectionOptions[2].value, &reuse, &UA_TYPES[UA_TYPES_BOOLEAN]);
-
-    UA_PubSubConnectionConfig connectionConf;
-    memset(&connectionConf, 0, sizeof(UA_PubSubConnectionConfig));
-    connectionConf.name = UA_STRING("Ethernet Connection");
-    connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
-    connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
-    connectionConf.connectionPropertiesSize = 3;
-    connectionConf.connectionProperties = connectionOptions;
-    connectionConf.address = address;
-    UA_NodeId connection;
-    UA_StatusCode retVal = UA_Server_addPubSubConnection(server, &connectionConf, &connection);
+    connectionConfig.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
+    UA_NodeId connectionIdent;
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
     ck_assert_int_eq(server->pubSubManager.connectionsSize, 1);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-    ck_assert(! TAILQ_EMPTY(&server->pubSubManager.connections));
-} END_TEST
+    ck_assert(!TAILQ_EMPTY(&server->pubSubManager.connections));
+    retVal |= UA_Server_removePubSubConnection(server, connectionIdent);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 1);
+    ck_assert(&server->pubSubManager.connections.tqh_first->listEntry.tqe_next != NULL);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+}
+END_TEST
 
-START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
-    UA_NetworkAddressUrlDataType networkAddressUrlData = {UA_STRING(ETHERNET_INTERFACE), UA_STRING(MULTICAST_MAC_ADDRESS)};
+START_TEST(AddConnectionWithInvalidAddress) {
+    UA_StatusCode retVal;
+    UA_PubSubConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
+    connectionConfig.name = UA_STRING("Ethernet Connection");
+    UA_NetworkAddressUrlDataType networkAddressUrl = {
+        UA_STRING(ETHERNET_INTERFACE), UA_STRING("opc.eth://a0:36:9f:04:5b:11")};
+    UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    connectionConfig.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
+    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
+    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
+}
+END_TEST
+
+START_TEST(AddConnectionWithInvalidInterface) {
+    UA_StatusCode retVal;
+    UA_PubSubConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
+    connectionConfig.name = UA_STRING("Ethernet Connection");
+    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL,
+                                                      UA_STRING(MULTICAST_MAC_ADDRESS)};
+    UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    connectionConfig.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
+    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
+    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
+}
+END_TEST
+
+START_TEST(AddConnectionWithUnknownTransportURL) {
+    UA_StatusCode retVal;
+    UA_PubSubConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
+    connectionConfig.name = UA_STRING("Ethernet Connection");
+    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE),
+                                                      UA_STRING(MULTICAST_MAC_ADDRESS)};
+    UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    connectionConfig.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/unknown-eth-uadp");
+    UA_NodeId connectionIdent;
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
+    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+}
+END_TEST
+
+START_TEST(AddConnectionWithNullConfig) {
+    UA_StatusCode retVal;
+    retVal = UA_Server_addPubSubConnection(server, NULL, NULL);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 0);
+    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+}
+END_TEST
+
+START_TEST(AddSingleConnectionWithMaximalConfiguration) {
+    UA_NetworkAddressUrlDataType networkAddressUrlData = {
+        UA_STRING(ETHERNET_INTERFACE), UA_STRING(MULTICAST_MAC_ADDRESS)};
     UA_Variant address;
-    UA_Variant_setScalar(&address, &networkAddressUrlData, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    UA_Variant_setScalar(&address, &networkAddressUrlData,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     UA_KeyValuePair connectionOptions[3];
     connectionOptions[0].key = UA_QUALIFIEDNAME(0, "ttl");
     UA_UInt32 ttl = 10;
     UA_Variant_setScalar(&connectionOptions[0].value, &ttl, &UA_TYPES[UA_TYPES_UINT32]);
     connectionOptions[1].key = UA_QUALIFIEDNAME(0, "loopback");
     UA_Boolean loopback = UA_FALSE;
-    UA_Variant_setScalar(&connectionOptions[1].value, &loopback, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_Variant_setScalar(&connectionOptions[1].value, &loopback,
+                         &UA_TYPES[UA_TYPES_BOOLEAN]);
     connectionOptions[2].key = UA_QUALIFIEDNAME(0, "reuse");
     UA_Boolean reuse = UA_TRUE;
-    UA_Variant_setScalar(&connectionOptions[2].value, &reuse, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_Variant_setScalar(&connectionOptions[2].value, &reuse,
+                         &UA_TYPES[UA_TYPES_BOOLEAN]);
 
     UA_PubSubConnectionConfig connectionConf;
     memset(&connectionConf, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConf.name = UA_STRING("Ethernet Connection");
-    connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
+    connectionConf.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     connectionConf.enabled = true;
     connectionConf.publisherId.numeric = 223344;
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
     UA_NodeId connection;
-    UA_StatusCode retVal = UA_Server_addPubSubConnection(server, &connectionConf, &connection);
+    UA_StatusCode retVal =
+        UA_Server_addPubSubConnection(server, &connectionConf, &connection);
+    ck_assert_int_eq(server->pubSubManager.connectionsSize, 1);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+    ck_assert(!TAILQ_EMPTY(&server->pubSubManager.connections));
+}
+END_TEST
+
+START_TEST(GetMaximalConnectionConfigurationAndCompareValues) {
+    UA_NetworkAddressUrlDataType networkAddressUrlData = {
+        UA_STRING(ETHERNET_INTERFACE), UA_STRING(MULTICAST_MAC_ADDRESS)};
+    UA_Variant address;
+    UA_Variant_setScalar(&address, &networkAddressUrlData,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    UA_KeyValuePair connectionOptions[3];
+    connectionOptions[0].key = UA_QUALIFIEDNAME(0, "ttl");
+    UA_UInt32 ttl = 10;
+    UA_Variant_setScalar(&connectionOptions[0].value, &ttl, &UA_TYPES[UA_TYPES_UINT32]);
+    connectionOptions[1].key = UA_QUALIFIEDNAME(0, "loopback");
+    UA_Boolean loopback = UA_FALSE;
+    UA_Variant_setScalar(&connectionOptions[1].value, &loopback,
+                         &UA_TYPES[UA_TYPES_BOOLEAN]);
+    connectionOptions[2].key = UA_QUALIFIEDNAME(0, "reuse");
+    UA_Boolean reuse = UA_TRUE;
+    UA_Variant_setScalar(&connectionOptions[2].value, &reuse,
+                         &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    UA_PubSubConnectionConfig connectionConf;
+    memset(&connectionConf, 0, sizeof(UA_PubSubConnectionConfig));
+    connectionConf.name = UA_STRING("Ethernet Connection");
+    connectionConf.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
+    connectionConf.enabled = true;
+    connectionConf.publisherId.numeric = 223344;
+    connectionConf.connectionPropertiesSize = 3;
+    connectionConf.connectionProperties = connectionOptions;
+    connectionConf.address = address;
+    UA_NodeId connection;
+    UA_StatusCode retVal =
+        UA_Server_addPubSubConnection(server, &connectionConf, &connection);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     retVal |= UA_Server_getPubSubConnectionConfig(server, connection, &connectionConfig);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-    ck_assert(connectionConfig.connectionPropertiesSize == connectionConf.connectionPropertiesSize);
+    ck_assert(connectionConfig.connectionPropertiesSize ==
+              connectionConf.connectionPropertiesSize);
     ck_assert(UA_String_equal(&connectionConfig.name, &connectionConf.name) == UA_TRUE);
-    ck_assert(UA_String_equal(&connectionConfig.transportProfileUri, &connectionConf.transportProfileUri) == UA_TRUE);
-    UA_NetworkAddressUrlDataType networkAddressUrlDataCopy = *((UA_NetworkAddressUrlDataType *)connectionConfig.address.data);
-    ck_assert(UA_NetworkAddressUrlDataType_calcSizeBinary(&networkAddressUrlDataCopy) == UA_NetworkAddressUrlDataType_calcSizeBinary(&networkAddressUrlData));
-    for(size_t i = 0; i < connectionConfig.connectionPropertiesSize; i++){
-        ck_assert(UA_String_equal(&connectionConfig.connectionProperties[i].key.name, &connectionConf.connectionProperties[i].key.name) == UA_TRUE);
-        ck_assert(UA_Variant_calcSizeBinary(&connectionConfig.connectionProperties[i].value) == UA_Variant_calcSizeBinary(&connectionConf.connectionProperties[i].value));
+    ck_assert(UA_String_equal(&connectionConfig.transportProfileUri,
+                              &connectionConf.transportProfileUri) == UA_TRUE);
+    UA_NetworkAddressUrlDataType networkAddressUrlDataCopy =
+        *((UA_NetworkAddressUrlDataType *)connectionConfig.address.data);
+    ck_assert(UA_NetworkAddressUrlDataType_calcSizeBinary(&networkAddressUrlDataCopy) ==
+              UA_NetworkAddressUrlDataType_calcSizeBinary(&networkAddressUrlData));
+    for(size_t i = 0; i < connectionConfig.connectionPropertiesSize; i++) {
+        ck_assert(UA_String_equal(&connectionConfig.connectionProperties[i].key.name,
+                                  &connectionConf.connectionProperties[i].key.name) ==
+                  UA_TRUE);
+        ck_assert(
+            UA_Variant_calcSizeBinary(&connectionConfig.connectionProperties[i].value) ==
+            UA_Variant_calcSizeBinary(&connectionConf.connectionProperties[i].value));
     }
     UA_PubSubConnectionConfig_clear(&connectionConfig);
-} END_TEST
+}
+END_TEST
 
-int main(void) {
-    TCase *tc_add_pubsub_connections_minimal_config = tcase_create("Create PubSub Ethernet Connections with minimal valid config");
+int
+main(void) {
+    TCase *tc_add_pubsub_connections_minimal_config =
+        tcase_create("Create PubSub Ethernet Connections with minimal valid config");
     tcase_add_checked_fixture(tc_add_pubsub_connections_minimal_config, setup, teardown);
-    tcase_add_test(tc_add_pubsub_connections_minimal_config, AddConnectionsWithMinimalValidConfiguration);
-    tcase_add_test(tc_add_pubsub_connections_minimal_config, AddRemoveAddConnectionWithMinimalValidConfiguration);
+    tcase_add_test(tc_add_pubsub_connections_minimal_config,
+                   AddConnectionsWithMinimalValidConfiguration);
+    tcase_add_test(tc_add_pubsub_connections_minimal_config,
+                   AddRemoveAddConnectionWithMinimalValidConfiguration);
 
-    TCase *tc_add_pubsub_connections_invalid_config = tcase_create("Create PubSub Ethernet Connections with invalid configurations");
+    TCase *tc_add_pubsub_connections_invalid_config =
+        tcase_create("Create PubSub Ethernet Connections with invalid configurations");
     tcase_add_checked_fixture(tc_add_pubsub_connections_invalid_config, setup, teardown);
-    tcase_add_test(tc_add_pubsub_connections_invalid_config, AddConnectionWithInvalidAddress);
-    tcase_add_test(tc_add_pubsub_connections_invalid_config, AddConnectionWithInvalidInterface);
-    tcase_add_test(tc_add_pubsub_connections_invalid_config, AddConnectionWithUnknownTransportURL);
+    tcase_add_test(tc_add_pubsub_connections_invalid_config,
+                   AddConnectionWithInvalidAddress);
+    tcase_add_test(tc_add_pubsub_connections_invalid_config,
+                   AddConnectionWithInvalidInterface);
+    tcase_add_test(tc_add_pubsub_connections_invalid_config,
+                   AddConnectionWithUnknownTransportURL);
     tcase_add_test(tc_add_pubsub_connections_invalid_config, AddConnectionWithNullConfig);
 
-    TCase *tc_add_pubsub_connections_maximal_config = tcase_create("Create PubSub Ethernet Connections with maximal valid config");
+    TCase *tc_add_pubsub_connections_maximal_config =
+        tcase_create("Create PubSub Ethernet Connections with maximal valid config");
     tcase_add_checked_fixture(tc_add_pubsub_connections_maximal_config, setup, teardown);
-    tcase_add_test(tc_add_pubsub_connections_maximal_config, AddSingleConnectionWithMaximalConfiguration);
-    tcase_add_test(tc_add_pubsub_connections_maximal_config, GetMaximalConnectionConfigurationAndCompareValues);
+    tcase_add_test(tc_add_pubsub_connections_maximal_config,
+                   AddSingleConnectionWithMaximalConfiguration);
+    tcase_add_test(tc_add_pubsub_connections_maximal_config,
+                   GetMaximalConnectionConfigurationAndCompareValues);
 
     Suite *s = suite_create("PubSub Ethernet connection creation");
     suite_add_tcase(s, tc_add_pubsub_connections_minimal_config);
@@ -241,9 +292,8 @@ int main(void) {
 
     SRunner *sr = srunner_create(s);
     srunner_set_fork_status(sr, CK_NOFORK);
-    srunner_run_all(sr,CK_NORMAL);
+    srunner_run_all(sr, CK_NORMAL);
     int number_failed = srunner_ntests_failed(sr);
     srunner_free(sr);
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-

--- a/tests/pubsub/check_pubsub_publish_ethernet.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet.c
@@ -8,21 +8,24 @@
 #include <open62541/plugin/pubsub_ethernet.h>
 #include <open62541/server_config_default.h>
 #include <open62541/server_pubsub.h>
-#include <check.h>
 
 #include "open62541/types_generated_encoding_binary.h"
-#include "ua_pubsub.h"
-#include "ua_server_internal.h"
-#include "ua_pubsub_networkmessage.h"
 
-#define PUBLISHING_MULTICAST_MAC_ADDRESS1  "opc.eth://01-00-5E-7F-00-01"
-#define PUBLISHING_MULTICAST_MAC_ADDRESS2  "opc.eth://01-00-5E-7F-00-01:8.4"
-#define TRANSPORT_PROFILE_URI              "http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp"
-#define UA_SUBSCRIBER_PORT                 4801    /* Port for Subscriber*/
-#define PUBLISHER_ID                       2234    /* Publisher Id*/
-#define ETHERNET_INTERFACE                 "enp2s0"
-#define BUFFER_STRING                      "Hello! This is Ethernet Testing"
-#define CONNECTION_NAME                    "Ethernet Test Connection"
+#include "ua_pubsub.h"
+#include "ua_pubsub_networkmessage.h"
+#include "ua_server_internal.h"
+
+#include <check.h>
+
+#define PUBLISHING_MULTICAST_MAC_ADDRESS1 "opc.eth://01-00-5E-7F-00-01"
+#define PUBLISHING_MULTICAST_MAC_ADDRESS2 "opc.eth://01-00-5E-7F-00-01:8.4"
+#define TRANSPORT_PROFILE_URI                                                            \
+    "http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp"
+#define UA_SUBSCRIBER_PORT 4801 /* Port for Subscriber*/
+#define PUBLISHER_ID 2234       /* Publisher Id*/
+#define ETHERNET_INTERFACE "enp2s0"
+#define BUFFER_STRING "Hello! This is Ethernet Testing"
+#define CONNECTION_NAME "Ethernet Test Connection"
 
 /* Global declaration for test cases  */
 UA_Server *server = NULL;
@@ -31,27 +34,29 @@ UA_PubSubConnection *connection;
 UA_NodeId connection_test;
 
 /* setup() is to create an environment for test cases */
-static void setup(void) {
+static void
+setup(void) {
     /*Add setup by creating new server with valid configuration */
     server = UA_Server_new();
     config = UA_Server_getConfig(server);
     UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
     UA_Server_run_startup(server);
-    config->pubsubTransportLayers = (UA_PubSubTransportLayer *) UA_malloc(sizeof(UA_PubSubTransportLayer));
+    config->pubsubTransportLayers =
+        (UA_PubSubTransportLayer *)UA_malloc(sizeof(UA_PubSubTransportLayer));
     if(!config->pubsubTransportLayers) {
         UA_ServerConfig_clean(config);
     }
 
-    config->pubsubTransportLayers[0] = UA_PubSubTransportLayerEthernet();
+    config->pubsubTransportLayers[0] = UA_PubSubTransportLayerEthernet(&config->logger);
     config->pubsubTransportLayersSize++;
-
 }
 
 /* teardown() is to delete the environment set for test cases */
-static void teardown(void) {
+static void
+teardown(void) {
     /*Call server delete functions */
-   UA_Server_run_shutdown(server);
-   UA_Server_delete(server);
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
 }
 
 START_TEST(EthernetSendWithoutVLANTag) {
@@ -62,7 +67,8 @@ START_TEST(EthernetSendWithoutVLANTag) {
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING(CONNECTION_NAME);
     /* Provide a multicast MAC without VLAN tag */
-    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE), UA_STRING(PUBLISHING_MULTICAST_MAC_ADDRESS1)};
+    UA_NetworkAddressUrlDataType networkAddressUrl = {
+        UA_STRING(ETHERNET_INTERFACE), UA_STRING(PUBLISHING_MULTICAST_MAC_ADDRESS1)};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
@@ -79,18 +85,19 @@ START_TEST(EthernetSendWithoutVLANTag) {
     /* Validate the Ethernet send API */
     retVal = connection->channel->send(connection->channel, NULL, &testBuffer);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-
-    } END_TEST
+}
+END_TEST
 
 START_TEST(EthernetSendWithVLANTag) {
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
-    UA_ByteString testBuffer ;
+    UA_ByteString testBuffer;
     /* Add connection to the server */
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING(CONNECTION_NAME);
     /* Provide a multicast MAC without VLAN tag */
-    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING(ETHERNET_INTERFACE), UA_STRING(PUBLISHING_MULTICAST_MAC_ADDRESS2)};
+    UA_NetworkAddressUrlDataType networkAddressUrl = {
+        UA_STRING(ETHERNET_INTERFACE), UA_STRING(PUBLISHING_MULTICAST_MAC_ADDRESS2)};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
@@ -107,13 +114,14 @@ START_TEST(EthernetSendWithVLANTag) {
     /* Validate the Ethernet send API */
     retVal = connection->channel->send(connection->channel, NULL, &testBuffer);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+}
+END_TEST
 
-    } END_TEST
-
-
-int main(void) {
+int
+main(void) {
     /*Test case to run both publisher*/
-    TCase *tc_pubsub_ethernet_send = tcase_create("Publisher publishing Ethernet packets");
+    TCase *tc_pubsub_ethernet_send =
+        tcase_create("Publisher publishing Ethernet packets");
     tcase_add_checked_fixture(tc_pubsub_ethernet_send, setup, teardown);
     tcase_add_test(tc_pubsub_ethernet_send, EthernetSendWithoutVLANTag);
     tcase_add_test(tc_pubsub_ethernet_send, EthernetSendWithVLANTag);
@@ -123,11 +131,9 @@ int main(void) {
 
     SRunner *suiteRunner = srunner_create(suite);
     srunner_set_fork_status(suiteRunner, CK_NOFORK);
-    srunner_run_all(suiteRunner,CK_NORMAL);
+    srunner_run_all(suiteRunner, CK_NORMAL);
     int number_failed = srunner_ntests_failed(suiteRunner);
     srunner_free(suiteRunner);
 
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-
-


### PR DESCRIPTION
## Description
This PR removes the use of the standard [log_stdout.h](https://github.com/open62541/open62541/blob/master/plugins/include/open62541/plugin/log_stdout.h) from [ua_pubsub_ethernet.c](https://github.com/open62541/open62541/blob/master/plugins/ua_pubsub_ethernet.c) and implements the use of a more generalized [log.h](https://github.com/open62541/open62541/blob/master/include/open62541/plugin/log.h) in its place. 

Simmilarly to [PR#3567](https://github.com/open62541/open62541/pull/3567) this is achieved by using a `static UA_Logger` variable, which is initially set to `NULL` and set during configuration when setting the transport layer by `UA_PubSubTransportLayerEthernet(&config->logger)`

A `NULL` logger is acceptable since  [log.h](https://github.com/open62541/open62541/blob/master/include/open62541/plugin/log.h)  checks against it, and if it is found, no logging is done, which in principal, allows for full deactivation of the logging plugin during the configuration process.
