### PR TITLE
Fix: Mutex on win32

### DIFF
--- a/tests/testing-plugins/thread_wrapper.h
+++ b/tests/testing-plugins/thread_wrapper.h
@@ -45,8 +45,8 @@
 #define MUTEX_HANDLE HANDLE
 
 /* Will return UA_FALSE when zero */
-#define MUTEX_INIT(name) (CreateMutex(NULL, FALSE, NULL) != 0)
-#define MUTEX_LOCK(name) (WaitForSingleObject((name), INFINITE) != 0)
+#define MUTEX_INIT(name) (((name) = CreateMutex(NULL, FALSE, NULL)) != 0)
+#define MUTEX_LOCK(name) (WaitForSingleObject((name), INFINITE) == WAIT_OBJECT_0)
 #define MUTEX_UNLOCK(name) (ReleaseMutex((name)) != 0)
 #define MUTEX_DESTROY(name) (CloseHandle((name)) != 0)
 #endif


### PR DESCRIPTION
This fixes the mutex handling of the tests on windows.

I don't know the reason, why this is different to 
https://github.com/open62541/open62541/blob/578d521931777181d1a881c8335ca5fafcd66eb2/arch/win32/ua_architecture.h#L147-L156

It may be a good idea to unify this in the future. But some tricks are required to test without UA_MULTITHREADING set.