### PR TITLE
fix(client): optional reqId in client read async

### DIFF
--- a/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c
+++ b/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c
@@ -303,13 +303,13 @@ UA_Openssl_RSA_Public_Encrypt  (const UA_ByteString * message,
     size_t encryptedPos = ((dataPos - 1) / encryptedBlockSize + 1) * keySize;
     size_t bytesToEncrypt = (dataPos - 1) % encryptedBlockSize + 1;
     size_t encryptedTextLen = encryptedPos;
-    size_t everyEncryptedBytes;
 
     while (dataPos > 0) {
+        size_t outlen = keySize;
         encryptedPos -= keySize;
         dataPos -= bytesToEncrypt;
-        opensslRet = EVP_PKEY_encrypt (ctx, encrypted->data + encryptedPos,
-             &everyEncryptedBytes, message->data + dataPos, bytesToEncrypt);
+        opensslRet = EVP_PKEY_encrypt (ctx, encrypted->data + encryptedPos, &outlen,
+                                       message->data + dataPos, bytesToEncrypt);
        
         if (opensslRet != 1) {
             ret = UA_STATUSCODE_BADINTERNALERROR;

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -939,9 +939,11 @@ connectIterate(UA_Client *client, UA_UInt32 timeout) {
         if(client->connectStatus != UA_STATUSCODE_GOOD)
             return client->connectStatus;
 
-        client->connectStatus = UA_SecureChannel_generateNewKeys(&client->channel);
-        if(client->connectStatus != UA_STATUSCODE_GOOD)
-            return client->connectStatus;
+        if (client->channel.remoteNonce.length != 0) {
+            client->connectStatus = UA_SecureChannel_generateNewKeys(&client->channel);
+            if(client->connectStatus != UA_STATUSCODE_GOOD)
+                return client->connectStatus;
+        }
     }
 
     /* Open the SecureChannel */
@@ -1221,3 +1223,4 @@ UA_Client_disconnect(UA_Client *client) {
     notifyClientState(client);
     return UA_STATUSCODE_GOOD;
 }
+


### PR DESCRIPTION
In all other async functions the request id is optional, but
__UA_Client_readAttribute_async crashes if it is NULL.  Pass local
storage to __UA_Client_AsyncService() and set the value of reqId
parameter only if the pointer is not NULL.

For that allocate the custem callback before the call to async
service.  This has the additional advantage that in case of memory
allocation error, the read attribute async has not done half the
work.  It would fail early instead.