### PR TITLE
fix(server): ContainsNoLoop typo

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -240,8 +240,8 @@ UA_Server_readInverseName(UA_Server *server, const UA_NodeId nodeId,
 }
 
 static UA_INLINE UA_THREADSAFE UA_StatusCode
-UA_Server_readContainsNoLoop(UA_Server *server, const UA_NodeId nodeId,
-                             UA_Boolean *outContainsNoLoops) {
+UA_Server_readContainsNoLoops(UA_Server *server, const UA_NodeId nodeId,
+                              UA_Boolean *outContainsNoLoops) {
     return __UA_Server_read(server, &nodeId, UA_ATTRIBUTEID_CONTAINSNOLOOPS,
                             outContainsNoLoops);
 }
@@ -316,7 +316,7 @@ UA_Server_readExecutable(UA_Server *server, const UA_NodeId nodeId,
  * - NodeClass
  * - NodeId
  * - Symmetric
- * - ContainsNoLoop
+ * - ContainsNoLoops
  *
  * The following attributes cannot be written from the server, as they are
  * specific to the different users and set by the access control callback:


### PR DESCRIPTION
The attribute ContainsNoLoops is called with an s at the end.  The
function name UA_Server_readContainsNoLoop() contains a typo and
the s is missing.  Although this is an API break it shoud be corrected
to be consistent with the rest of the code and compliant to the
standard.