### PR TITLE
DNS lookup WSAStartup bug fix on Win 10 environment 

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -778,6 +778,8 @@ UA_ClientConnectionTCP_poll(UA_Client *client, void *data, UA_UInt32 timeout) {
 UA_Connection
 UA_ClientConnectionTCP_init(UA_ConnectionConfig config, const UA_String endpointUrl,
                             UA_UInt32 timeout, UA_Logger *logger) {
+    UA_initialize_architecture_network();
+
     UA_Connection connection;
     memset(&connection, 0, sizeof(UA_Connection));
 


### PR DESCRIPTION
Quick fix for connection problems between client and server. It crashed with _DNS look up failed (WSAStartup was not called.)_
Pull request for [this Issue](https://github.com/open62541/open62541/issues/3609)