### PR TITLE
fix(debian package) Enable encryption for the official debian packages

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -10,7 +10,9 @@ Build-Depends: debhelper (>= 9),
  texlive-fonts-recommended,
  texlive-latex-extra,
  texlive-plain-generic | texlive-generic-extra,
- latexmk
+ latexmk,
+ libmbedtls-dev
+
 Standards-Version: 4.4.1
 Section: libs
 Homepage: https://open62541.org/
@@ -50,7 +52,7 @@ Description: Open source implementation of OPC UA - tools
 Package: libopen62541-<soname>
 Architecture: any
 Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, libmbedtls10 | libmbedtls12
 Description: Open source implementation of OPC UA - shared library
  open62541 (http://open62541.org) is an open source and free implementation
  of OPC UA (OPC Unified Architecture) written in the common subset of the

--- a/debian/rules-template
+++ b/debian/rules-template
@@ -5,7 +5,7 @@ export DH_VERBOSE = 1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-pie
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL -DUA_ENABLE_AMALGAMATION=OFF -DUA_PACK_DEBIAN=ON
+	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL -DUA_ENABLE_ENCRYPTION=ON -DUA_ENABLE_AMALGAMATION=OFF -DUA_PACK_DEBIAN=ON
 
 override_dh_auto_test:
 	dh_auto_test -- ARGS+=--output-on-failure


### PR DESCRIPTION
Currently the official debian packages (https://launchpad.net/~open62541-team/+archive/ubuntu/daily) do not include encryption. This PR adjust the dependecies to build these packages with encryption support. The missing encryption leads to errors like this:

`/usr/bin/c++  -O3 -DNDEBUG   CMakeFiles/testOPCUA.dir/simpleClient.C.o  -o testOPCUA -lopen62541 
CMakeFiles/testOPCUA.dir/simpleClient.C.o: In function `setupClient(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
simpleClient.C:(.text+0x4d8): undefined reference to `UA_ClientConfig_setDefaultEncryption'`