### PR TITLE
test: fix signedness compile errors

### DIFF
--- a/tests/check_chunking.c
+++ b/tests/check_chunking.c
@@ -51,10 +51,10 @@ START_TEST(encodeArrayIntoFiveChunksShallWork) {
                                            &pos, &end, sendChunkMockUp, NULL);
 
     ck_assert_uint_eq(retval,UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(counter,4); //5 chunks allocated - callback called 4 times
+    ck_assert_uint_eq(counter,4); //5 chunks allocated - callback called 4 times
 
     dataCount += (uintptr_t)(pos - buffers[bufIndex].data);
-    ck_assert_int_eq(UA_calcSizeBinary(&v,&UA_TYPES[UA_TYPES_VARIANT]), dataCount);
+    ck_assert_uint_eq(UA_calcSizeBinary(&v,&UA_TYPES[UA_TYPES_VARIANT]), dataCount);
 
     UA_Variant_deleteMembers(&v);
     UA_Array_delete(buffers, chunkCount, &UA_TYPES[UA_TYPES_BYTESTRING]);
@@ -73,8 +73,8 @@ START_TEST(encodeStringIntoFiveChunksShallWork) {
     UA_String_init(&string);
     string.data = (UA_Byte*)UA_malloc(stringLength);
     string.length = stringLength;
-    char tmpString[9] = {'o','p','e','n','6','2','5','4','1'};
-    //char tmpString[9] = {'1','4','5','2','6','n','e','p','o'};
+    unsigned char tmpString[9] = {'o','p','e','n','6','2','5','4','1'};
+    //unsigned char tmpString[9] = {'1','4','5','2','6','n','e','p','o'};
     buffers = (UA_ByteString*)UA_Array_new(chunkCount, &UA_TYPES[UA_TYPES_BYTESTRING]);
     for(size_t i=0;i<chunkCount;i++){
         UA_ByteString_allocBuffer(&buffers[i],chunkSize);
@@ -95,10 +95,10 @@ START_TEST(encodeStringIntoFiveChunksShallWork) {
                                            &pos, &end, sendChunkMockUp, NULL);
 
     ck_assert_uint_eq(retval,UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(counter,4); //5 chunks allocated - callback called 4 times
+    ck_assert_uint_eq(counter,4); //5 chunks allocated - callback called 4 times
 
     dataCount += (uintptr_t)(pos - buffers[bufIndex].data);
-    ck_assert_int_eq(UA_calcSizeBinary(&v,&UA_TYPES[UA_TYPES_VARIANT]), dataCount);
+    ck_assert_uint_eq(UA_calcSizeBinary(&v,&UA_TYPES[UA_TYPES_VARIANT]), dataCount);
 
     UA_Variant_deleteMembers(&v);
     UA_Array_delete(buffers, chunkCount, &UA_TYPES[UA_TYPES_BYTESTRING]);
@@ -117,7 +117,7 @@ START_TEST(encodeTwoStringsIntoTenChunksShallWork) {
     UA_String_init(&string);
     string.data = (UA_Byte*)UA_malloc(stringLength);
     string.length = stringLength;
-    char tmpString[9] = {'o','p','e','n','6','2','5','4','1'};
+    unsigned char tmpString[9] = {'o','p','e','n','6','2','5','4','1'};
     buffers = (UA_ByteString*)UA_Array_new(chunkCount, &UA_TYPES[UA_TYPES_BYTESTRING]);
     for(size_t i=0;i<chunkCount;i++){
         UA_ByteString_allocBuffer(&buffers[i],chunkSize);
@@ -135,16 +135,16 @@ START_TEST(encodeTwoStringsIntoTenChunksShallWork) {
     UA_StatusCode retval = UA_encodeBinary(&string, &UA_TYPES[UA_TYPES_STRING],
                                            &pos, &end, sendChunkMockUp, NULL);
     ck_assert_uint_eq(retval,UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(counter,4); //5 chunks allocated - callback called 4 times
+    ck_assert_uint_eq(counter,4); //5 chunks allocated - callback called 4 times
     size_t offset = (uintptr_t)(pos - buffers[bufIndex].data);
-    ck_assert_int_eq(UA_calcSizeBinary(&string,&UA_TYPES[UA_TYPES_STRING]), dataCount + offset);
+    ck_assert_uint_eq(UA_calcSizeBinary(&string,&UA_TYPES[UA_TYPES_STRING]), dataCount + offset);
 
     retval = UA_encodeBinary(&string,&UA_TYPES[UA_TYPES_STRING],
                              &pos, &end, sendChunkMockUp, NULL);
     dataCount += (uintptr_t)(pos - buffers[bufIndex].data);
     ck_assert_uint_eq(retval,UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(counter,9); //10 chunks allocated - callback called 4 times
-    ck_assert_int_eq(2 * UA_calcSizeBinary(&string,&UA_TYPES[UA_TYPES_STRING]), dataCount);
+    ck_assert_uint_eq(counter,9); //10 chunks allocated - callback called 4 times
+    ck_assert_uint_eq(2 * UA_calcSizeBinary(&string,&UA_TYPES[UA_TYPES_STRING]), dataCount);
 
     UA_Array_delete(buffers, chunkCount, &UA_TYPES[UA_TYPES_BYTESTRING]);
     UA_String_deleteMembers(&string);

--- a/tests/check_types_builtin.c
+++ b/tests/check_types_builtin.c
@@ -48,7 +48,7 @@ START_TEST(UA_Byte_decodeShallModifyOnlyCurrentPosition) {
     UA_StatusCode retval = UA_Byte_decodeBinary(&src, &pos, &dst[1]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 1);
+    ck_assert_uint_eq(pos, 1);
     ck_assert_uint_eq(dst[0], 0xFF);
     ck_assert_uint_eq(dst[1], 0x08);
     ck_assert_uint_eq(dst[2], 0xFF);
@@ -71,7 +71,7 @@ START_TEST(UA_Int16_decodeShallAssumeLittleEndian) {
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(val_01_00, 1);
     ck_assert_int_eq(val_00_01, 256);
-    ck_assert_int_eq(pos, 4);
+    ck_assert_uint_eq(pos, 4);
 }
 END_TEST
 
@@ -108,7 +108,7 @@ START_TEST(UA_UInt16_decodeShallNotRespectSign) {
     retval |= UA_UInt16_decodeBinary(&src, &pos, &val_00_80);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 4);
+    ck_assert_uint_eq(pos, 4);
     ck_assert_uint_eq(val_ff_ff, (0x01 << 16)-1);
     ck_assert_uint_eq(val_00_80, (0x01 << 15));
 }
@@ -131,7 +131,7 @@ START_TEST(UA_Int32_decodeShallAssumeLittleEndian) {
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(val_01_00, 1);
     ck_assert_int_eq(val_00_01, 256);
-    ck_assert_int_eq(pos, 8);
+    ck_assert_uint_eq(pos, 8);
 }
 END_TEST
 
@@ -170,7 +170,7 @@ START_TEST(UA_UInt32_decodeShallNotRespectSign) {
     retval |= UA_UInt32_decodeBinary(&src, &pos, &val_00_80);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 8);
+    ck_assert_uint_eq(pos, 8);
     ck_assert_uint_eq(val_ff_ff, (UA_UInt32)( (0x01LL << 32 ) - 1 ));
     ck_assert_uint_eq(val_00_80, (UA_UInt32)(0x01) << 31);
 }
@@ -196,7 +196,7 @@ END_TEST
 START_TEST(UA_Int64_decodeShallRespectSign) {
     // given
     UA_ByteString rawMessage;
-    UA_UInt64 expectedVal = (UA_UInt64)0xFF << 56;
+    UA_Int64 expectedVal = (UA_Int64)0xFF << 56;
     UA_Byte  mem[8]      = { 00, 00, 00, 00, 0x00, 0x00, 0x00, 0xFF };
     rawMessage.data   = mem;
     rawMessage.length = 8;
@@ -206,7 +206,7 @@ START_TEST(UA_Int64_decodeShallRespectSign) {
     // when
     UA_Int64_decodeBinary(&rawMessage, &pos, &val);
     //then
-    ck_assert_uint_eq(val, expectedVal);
+    ck_assert_int_eq(val, expectedVal);
 }
 END_TEST
 
@@ -220,7 +220,7 @@ START_TEST(UA_Float_decodeShallWorkOnExample) {
     UA_StatusCode retval = UA_Float_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 4);
+    ck_assert_uint_eq(pos, 4);
     ck_assert(-6.5000001 < dst);
     ck_assert(dst < -6.49999999999);
 }
@@ -236,7 +236,7 @@ START_TEST(UA_Double_decodeShallGiveOne) {
     UA_StatusCode retval = UA_Double_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 8);
+    ck_assert_uint_eq(pos, 8);
     ck_assert(0.9999999 < dst);
     ck_assert(dst < 1.00000000001);
 }
@@ -252,7 +252,7 @@ START_TEST(UA_Double_decodeShallGiveZero) {
     UA_StatusCode retval = UA_Double_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 8);
+    ck_assert_uint_eq(pos, 8);
     ck_assert(-0.00000001 < dst);
     ck_assert(dst < 0.000000001);
 }
@@ -268,7 +268,7 @@ START_TEST(UA_Double_decodeShallGiveMinusTwo) {
     UA_StatusCode retval = UA_Double_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 8);
+    ck_assert_uint_eq(pos, 8);
     ck_assert(-1.9999999 > dst);
     ck_assert(dst > -2.00000000001);
 }
@@ -284,7 +284,7 @@ START_TEST(UA_Double_decodeShallGive2147483648) {
     UA_StatusCode retval = UA_Double_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 8);
+    ck_assert_uint_eq(pos, 8);
     ck_assert(2147483647.9999999 <= dst);
     ck_assert(dst <= 2147483648.00000001);
 }
@@ -301,7 +301,7 @@ START_TEST(UA_String_decodeShallAllocateMemoryAndCopyString) {
     UA_StatusCode retval = UA_String_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(dst.length, 8);
+    ck_assert_uint_eq(dst.length, 8);
     ck_assert_int_eq(dst.data[3], 'L');
     ck_assert_uint_eq(pos, UA_calcSizeBinary(&dst, &UA_TYPES[UA_TYPES_STRING]));
     // finally
@@ -320,7 +320,7 @@ START_TEST(UA_String_decodeWithNegativeSizeShallNotAllocateMemoryAndNullPtr) {
     UA_StatusCode retval = UA_String_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(dst.length, 0);
+    ck_assert_uint_eq(dst.length, 0);
     ck_assert_ptr_eq(dst.data, NULL);
 }
 END_TEST
@@ -336,7 +336,7 @@ START_TEST(UA_String_decodeWithZeroSizeShallNotAllocateMemoryAndNullPtr) {
     UA_StatusCode retval = UA_String_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(dst.length, 0);
+    ck_assert_uint_eq(dst.length, 0);
     ck_assert_ptr_eq(dst.data, UA_EMPTY_ARRAY_SENTINEL);
 }
 END_TEST
@@ -351,7 +351,7 @@ START_TEST(UA_NodeId_decodeTwoByteShallReadTwoBytesAndSetNamespaceToZero) {
     UA_StatusCode retval = UA_NodeId_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 2);
+    ck_assert_uint_eq(pos, 2);
     ck_assert_uint_eq(pos, UA_calcSizeBinary(&dst, &UA_TYPES[UA_TYPES_NODEID]));
     ck_assert_int_eq(dst.identifierType, UA_NODEIDTYPE_NUMERIC);
     ck_assert_int_eq(dst.identifier.numeric, 16);
@@ -369,7 +369,7 @@ START_TEST(UA_NodeId_decodeFourByteShallReadFourBytesAndRespectNamespace) {
     UA_StatusCode retval = UA_NodeId_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 4);
+    ck_assert_uint_eq(pos, 4);
     ck_assert_uint_eq(pos, UA_calcSizeBinary(&dst, &UA_TYPES[UA_TYPES_NODEID]));
     ck_assert_int_eq(dst.identifierType, UA_NODEIDTYPE_NUMERIC);
     ck_assert_int_eq(dst.identifier.numeric, 256);
@@ -387,11 +387,11 @@ START_TEST(UA_NodeId_decodeStringShallAllocateMemory) {
     UA_StatusCode retval = UA_NodeId_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 10);
+    ck_assert_uint_eq(pos, 10);
     ck_assert_uint_eq(pos, UA_calcSizeBinary(&dst, &UA_TYPES[UA_TYPES_NODEID]));
     ck_assert_int_eq(dst.identifierType, UA_NODEIDTYPE_STRING);
     ck_assert_int_eq(dst.namespaceIndex, 1);
-    ck_assert_int_eq(dst.identifier.string.length, 3);
+    ck_assert_uint_eq(dst.identifier.string.length, 3);
     ck_assert_int_eq(dst.identifier.string.data[1], 'L');
     // finally
     UA_NodeId_deleteMembers(&dst);
@@ -411,9 +411,9 @@ START_TEST(UA_Variant_decodeWithOutArrayFlagSetShallSetVTAndAllocateMemoryForArr
     ck_assert_uint_eq(pos, 5);
     ck_assert_uint_eq(pos, UA_calcSizeBinary(&dst, &UA_TYPES[UA_TYPES_VARIANT]));
     //ck_assert_ptr_eq((const void *)dst.type, (const void *)&UA_TYPES[UA_TYPES_INT32]); //does not compile in gcc 4.6
-    ck_assert_int_eq((uintptr_t)dst.type, (uintptr_t)&UA_TYPES[UA_TYPES_INT32]);
-    ck_assert_int_eq(dst.arrayLength, 0);
-    ck_assert_int_ne((uintptr_t)dst.data, 0);
+    ck_assert_uint_eq((uintptr_t)dst.type, (uintptr_t)&UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_uint_eq(dst.arrayLength, 0);
+    ck_assert_uint_ne((uintptr_t)dst.data, 0);
     UA_assert(dst.data != NULL); /* repeat the previous argument so that clang-analyzer is happy */
     ck_assert_int_eq(*(UA_Int32 *)dst.data, 255);
     // finally
@@ -434,11 +434,11 @@ START_TEST(UA_Variant_decodeWithArrayFlagSetShallSetVTAndAllocateMemoryForArray)
     UA_StatusCode retval = UA_Variant_decodeBinary(&src, &pos, &dst);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(pos, 1+4+2*4);
+    ck_assert_uint_eq(pos, 1+4+2*4);
     ck_assert_uint_eq(pos, UA_calcSizeBinary(&dst, &UA_TYPES[UA_TYPES_VARIANT]));
     //ck_assert_ptr_eq((const (void*))dst.type, (const void*)&UA_TYPES[UA_TYPES_INT32]); //does not compile in gcc 4.6
-    ck_assert_int_eq((uintptr_t)dst.type,(uintptr_t)&UA_TYPES[UA_TYPES_INT32]);
-    ck_assert_int_eq(dst.arrayLength, 2);
+    ck_assert_uint_eq((uintptr_t)dst.type,(uintptr_t)&UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_uint_eq(dst.arrayLength, 2);
     ck_assert_int_eq(((UA_Int32 *)dst.data)[0], 255);
     ck_assert_int_eq(((UA_Int32 *)dst.data)[1], -1);
     // finally
@@ -486,12 +486,12 @@ START_TEST(UA_Variant_decodeSingleExtensionObjectShallSetVTAndAllocateMemory){
     /* ck_assert_int_eq(retval, UA_STATUSCODE_GOOD); */
     /* // TODO!! */
     /* /\* ck_assert_int_eq(dst.encoding, UA_EXTENSIONOBJECT_DECODED); *\/ */
-    /* /\* ck_assert_int_eq((uintptr_t)dst.content.decoded.type, (uintptr_t)&UA_TYPES[UA_TYPES_EXTENSIONOBJECT]); *\/ */
-    /* /\* ck_assert_int_eq(dst.arrayLength, -1); *\/ */
+    /* /\* ck_assert_uint_eq((uintptr_t)dst.content.decoded.type, (uintptr_t)&UA_TYPES[UA_TYPES_EXTENSIONOBJECT]); *\/ */
+    /* /\* ck_assert_uint_eq(dst.arrayLength, -1); *\/ */
     /* /\* ck_assert_int_eq(((UA_ExtensionObject *)dst.data)->body.data[0], 10); *\/ */
     /* /\* ck_assert_int_eq(((UA_ExtensionObject *)dst.data)->body.data[1], 20); *\/ */
     /* /\* ck_assert_int_eq(((UA_ExtensionObject *)dst.data)->body.data[2], 30); *\/ */
-    /* /\* ck_assert_int_eq(((UA_ExtensionObject *)dst.data)->body.length, 3); *\/ */
+    /* /\* ck_assert_uint_eq(((UA_ExtensionObject *)dst.data)->body.length, 3); *\/ */
 
 
     /* // finally */
@@ -550,7 +550,7 @@ START_TEST(UA_Byte_encode_test) {
 
     ck_assert_uint_eq(dst.data[0], 0x08);
     ck_assert_uint_eq(dst.data[1], 0xFF);
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 1);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 1);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     // Test2
@@ -562,7 +562,7 @@ START_TEST(UA_Byte_encode_test) {
 
     ck_assert_int_eq(dst.data[0], 0xFF);
     ck_assert_int_eq(dst.data[1], 0x00);
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 1);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 1);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
 }
@@ -570,7 +570,7 @@ END_TEST
 
 START_TEST(UA_UInt16_encodeNegativeShallEncodeLittleEndian) {
     // given
-    UA_UInt16     src    = -1;
+    UA_UInt16     src    = (UA_UInt16)-1;
     UA_Byte       data[] = { 0x55, 0x55, 0x55, 0x55 };
     UA_ByteString dst    = { 4, data };
     UA_Byte *pos = dst.data;
@@ -579,16 +579,16 @@ START_TEST(UA_UInt16_encodeNegativeShallEncodeLittleEndian) {
     // when test 1
     UA_StatusCode retval = UA_UInt16_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 2);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 2);
     ck_assert_int_eq(dst.data[0], 0xFF);
     ck_assert_int_eq(dst.data[1], 0xFF);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     // when test 2
-    src    = -32768;
+    src    = (UA_UInt16)-32768;
     retval = UA_UInt16_encodeBinary(&src, &pos, end);
     // then test 2
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 4);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 4);
     ck_assert_int_eq(dst.data[2], 0x00);
     ck_assert_int_eq(dst.data[3], 0x80);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -606,7 +606,7 @@ START_TEST(UA_UInt16_encodeShallEncodeLittleEndian) {
     // when test 1
     UA_StatusCode retval = UA_UInt16_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 2);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 2);
     ck_assert_int_eq(dst.data[0], 0x00);
     ck_assert_int_eq(dst.data[1], 0x00);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -615,7 +615,7 @@ START_TEST(UA_UInt16_encodeShallEncodeLittleEndian) {
     src    = 32767;
     retval = UA_UInt16_encodeBinary(&src, &pos, end);
     // then test 2
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 4);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 4);
     ck_assert_int_eq(dst.data[2], 0xFF);
     ck_assert_int_eq(dst.data[3], 0x7F);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -624,7 +624,7 @@ END_TEST
 
 START_TEST(UA_UInt32_encodeShallEncodeLittleEndian) {
     // given
-    UA_UInt32     src    = -1;
+    UA_UInt32     src    = (UA_UInt32)(-1);
     UA_Byte       data[] = { 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55 };
     UA_ByteString dst    = { 8, data };
     UA_Byte *pos = dst.data;
@@ -633,7 +633,7 @@ START_TEST(UA_UInt32_encodeShallEncodeLittleEndian) {
     // when test 1
     UA_StatusCode retval = UA_UInt32_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 4);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 4);
     ck_assert_int_eq(dst.data[0], 0xFF);
     ck_assert_int_eq(dst.data[1], 0xFF);
     ck_assert_int_eq(dst.data[2], 0xFF);
@@ -644,7 +644,7 @@ START_TEST(UA_UInt32_encodeShallEncodeLittleEndian) {
     src    = 0x0101FF00;
     retval = UA_UInt32_encodeBinary(&src, &pos, end);
     // then test 2
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 8);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 8);
     ck_assert_int_eq(dst.data[4], 0x00);
     ck_assert_int_eq(dst.data[5], 0xFF);
     ck_assert_int_eq(dst.data[6], 0x01);
@@ -664,7 +664,7 @@ START_TEST(UA_Int32_encodeShallEncodeLittleEndian) {
     // when test 1
     UA_StatusCode retval = UA_Int32_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 4);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 4);
     ck_assert_int_eq(dst.data[0], 0x01);
     ck_assert_int_eq(dst.data[1], 0x00);
     ck_assert_int_eq(dst.data[2], 0x00);
@@ -675,7 +675,7 @@ START_TEST(UA_Int32_encodeShallEncodeLittleEndian) {
     src    = 0x7FFFFFFF;
     retval = UA_Int32_encodeBinary(&src, &pos, end);
     // then test 2
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 8);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 8);
     ck_assert_int_eq(dst.data[4], 0xFF);
     ck_assert_int_eq(dst.data[5], 0xFF);
     ck_assert_int_eq(dst.data[6], 0xFF);
@@ -695,7 +695,7 @@ START_TEST(UA_Int32_encodeNegativeShallEncodeLittleEndian) {
     // when test 1
     UA_StatusCode retval = UA_Int32_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 4);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 4);
     ck_assert_int_eq(dst.data[0], 0xFF);
     ck_assert_int_eq(dst.data[1], 0xFF);
     ck_assert_int_eq(dst.data[2], 0xFF);
@@ -706,7 +706,7 @@ END_TEST
 
 START_TEST(UA_UInt64_encodeShallWorkOnExample) {
     // given
-    UA_UInt64     src    = -1;
+    UA_UInt64     src    = (UA_UInt64)(-1LL);
     UA_Byte       data[] = { 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
                              0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55 };
     UA_ByteString dst    = { 16, data };
@@ -716,7 +716,7 @@ START_TEST(UA_UInt64_encodeShallWorkOnExample) {
     // when test 1
     UA_StatusCode retval = UA_UInt64_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 8);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 8);
     ck_assert_int_eq(dst.data[0], 0xFF);
     ck_assert_int_eq(dst.data[1], 0xFF);
     ck_assert_int_eq(dst.data[2], 0xFF);
@@ -731,7 +731,7 @@ START_TEST(UA_UInt64_encodeShallWorkOnExample) {
     src    = 0x7F0033AA44EE6611;
     retval = UA_UInt64_encodeBinary(&src, &pos, end);
     // then test 2
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 16);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 16);
     ck_assert_int_eq(dst.data[8], 0x11);
     ck_assert_int_eq(dst.data[9], 0x66);
     ck_assert_int_eq(dst.data[10], 0xEE);
@@ -756,7 +756,7 @@ START_TEST(UA_Int64_encodeShallEncodeLittleEndian) {
     // when test 1
     UA_StatusCode retval = UA_Int64_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 8);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 8);
     ck_assert_int_eq(dst.data[0], 0x11);
     ck_assert_int_eq(dst.data[1], 0x66);
     ck_assert_int_eq(dst.data[2], 0xEE);
@@ -781,7 +781,7 @@ START_TEST(UA_Int64_encodeNegativeShallEncodeLittleEndian) {
     // when test 1
     UA_StatusCode retval = UA_Int64_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 8);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 8);
     ck_assert_int_eq(dst.data[0], 0xFF);
     ck_assert_int_eq(dst.data[1], 0xFF);
     ck_assert_int_eq(dst.data[2], 0xFF);
@@ -821,13 +821,13 @@ START_TEST(UA_Float_encodeShallWorkOnExample) {
 
     for(size_t i = 0; i < 7; i++) {
         UA_Byte *pos = dst.data;
-        UA_Int32 retval = UA_Float_encodeBinary(&src[i], &pos, end);
-        ck_assert_int_eq((uintptr_t)(pos - dst.data), 4);
-        ck_assert_int_eq(dst.data[0], result[i][0]);
-        ck_assert_int_eq(dst.data[1], result[i][1]);
-        ck_assert_int_eq(dst.data[2], result[i][2]);
-        ck_assert_int_eq(dst.data[3], result[i][3]);
-        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+        UA_UInt32 retval = UA_Float_encodeBinary(&src[i], &pos, end);
+        ck_assert_uint_eq((uintptr_t)(pos - dst.data), 4);
+        ck_assert_uint_eq(dst.data[0], result[i][0]);
+        ck_assert_uint_eq(dst.data[1], result[i][1]);
+        ck_assert_uint_eq(dst.data[2], result[i][2]);
+        ck_assert_uint_eq(dst.data[3], result[i][3]);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     }
 }
 END_TEST
@@ -844,7 +844,7 @@ START_TEST(UA_Double_encodeShallWorkOnExample) {
     // when test 1
     UA_StatusCode retval = UA_Double_encodeBinary(&src, &pos, end);
     // then test 1
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 8);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 8);
     ck_assert_int_eq(dst.data[6], 0x1A);
     ck_assert_int_eq(dst.data[7], 0xC0);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -868,7 +868,7 @@ START_TEST(UA_String_encodeShallWorkOnExample) {
     // when
     UA_StatusCode retval = UA_String_encodeBinary(&src, &pos, end);
     // then
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), sizeof(UA_Int32)+11);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), sizeof(UA_Int32)+11);
     ck_assert_uint_eq(sizeof(UA_Int32)+11, UA_calcSizeBinary(&src, &UA_TYPES[UA_TYPES_STRING]));
     ck_assert_int_eq(dst.data[0], 11);
     ck_assert_int_eq(dst.data[sizeof(UA_Int32)+0], 'A');
@@ -898,7 +898,7 @@ START_TEST(UA_ExpandedNodeId_encodeShallWorkOnExample) {
     UA_StatusCode retval = UA_ExpandedNodeId_encodeBinary(&src, &pos, end);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 13);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 13);
     ck_assert_uint_eq(13, UA_calcSizeBinary(&src, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]));
     ck_assert_int_eq(dst.data[0], 0x80); // namespaceuri flag
 }
@@ -921,7 +921,7 @@ START_TEST(UA_DataValue_encodeShallWorkOnExampleWithoutVariant) {
     // when
     UA_StatusCode retval = UA_DataValue_encodeBinary(&src, &pos, end);
     // then
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 9);
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 9);
     ck_assert_uint_eq(9, UA_calcSizeBinary(&src, &UA_TYPES[UA_TYPES_DATAVALUE]));
     ck_assert_int_eq(dst.data[0], 0x08); // encodingMask
     ck_assert_int_eq(dst.data[1], 80);   // 8 Byte serverTimestamp
@@ -958,7 +958,7 @@ START_TEST(UA_DataValue_encodeShallWorkOnExampleWithVariant) {
     // when
     UA_StatusCode retval = UA_DataValue_encodeBinary(&src, &pos, end);
     // then
-    ck_assert_int_eq((uintptr_t)(pos - dst.data), 1+(1+4)+8);           // represents the length
+    ck_assert_uint_eq((uintptr_t)(pos - dst.data), 1+(1+4)+8);           // represents the length
     ck_assert_uint_eq(1+(1+4)+8, UA_calcSizeBinary(&src, &UA_TYPES[UA_TYPES_DATAVALUE]));
     ck_assert_int_eq(dst.data[0], 0x08 | 0x01); // encodingMask
     ck_assert_int_eq(dst.data[1], 0x06);        // Variant's Encoding Mask - INT32
@@ -1079,8 +1079,8 @@ START_TEST(UA_Array_copyByteArrayShallWorkOnExample) {
     //given
     UA_String testString;
     UA_Byte  *dstArray;
-    UA_Int32  size = 5;
-    UA_Int32  i    = 0;
+    UA_UInt32  size = 5;
+    UA_UInt32  i    = 0;
     testString.data = (UA_Byte*)UA_malloc(size);
     testString.data[0] = 'O';
     testString.data[1] = 'P';
@@ -1121,7 +1121,7 @@ START_TEST(UA_Array_copyUA_StringShallWorkOnExample) {
     for(i = 0;i < 3;i++) {
         for(j = 0;j < 3;j++)
             ck_assert_int_eq(srcArray[i].data[j], dstArray[i].data[j]);
-        ck_assert_int_eq(srcArray[i].length, dstArray[i].length);
+        ck_assert_uint_eq(srcArray[i].length, dstArray[i].length);
     }
     //finally
     UA_Array_delete(srcArray, 3, &UA_TYPES[UA_TYPES_STRING]);
@@ -1147,7 +1147,7 @@ START_TEST(UA_DiagnosticInfo_copyShallWorkOnExample) {
     //then
     for(size_t i = 0;i < testString.length;i++)
         ck_assert_int_eq(copiedValue.additionalInfo.data[i], value.additionalInfo.data[i]);
-    ck_assert_int_eq(copiedValue.additionalInfo.length, value.additionalInfo.length);
+    ck_assert_uint_eq(copiedValue.additionalInfo.length, value.additionalInfo.length);
 
     ck_assert_int_eq(copiedValue.hasInnerDiagnosticInfo, value.hasInnerDiagnosticInfo);
     ck_assert_int_eq(copiedValue.innerDiagnosticInfo->locale, value.innerDiagnosticInfo->locale);
@@ -1195,25 +1195,25 @@ START_TEST(UA_ApplicationDescription_copyShallWorkOnExample) {
 
     for(size_t i = 0; i < appString.length; i++)
         ck_assert_int_eq(copiedValue.applicationUri.data[i], value.applicationUri.data[i]);
-    ck_assert_int_eq(copiedValue.applicationUri.length, value.applicationUri.length);
+    ck_assert_uint_eq(copiedValue.applicationUri.length, value.applicationUri.length);
 
     for(size_t i = 0; i < discString.length; i++)
         ck_assert_int_eq(copiedValue.discoveryProfileUri.data[i], value.discoveryProfileUri.data[i]);
-    ck_assert_int_eq(copiedValue.discoveryProfileUri.length, value.discoveryProfileUri.length);
+    ck_assert_uint_eq(copiedValue.discoveryProfileUri.length, value.discoveryProfileUri.length);
 
     for(size_t i = 0; i < gateWayString.length; i++)
         ck_assert_int_eq(copiedValue.gatewayServerUri.data[i], value.gatewayServerUri.data[i]);
-    ck_assert_int_eq(copiedValue.gatewayServerUri.length, value.gatewayServerUri.length);
+    ck_assert_uint_eq(copiedValue.gatewayServerUri.length, value.gatewayServerUri.length);
 
     //String Array Test
     for(UA_Int32 i = 0;i < 3;i++) {
         for(UA_Int32 j = 0;j < 6;j++)
             ck_assert_int_eq(value.discoveryUrls[i].data[j], copiedValue.discoveryUrls[i].data[j]);
-        ck_assert_int_eq(value.discoveryUrls[i].length, copiedValue.discoveryUrls[i].length);
+        ck_assert_uint_eq(value.discoveryUrls[i].length, copiedValue.discoveryUrls[i].length);
     }
     ck_assert_int_eq(copiedValue.discoveryUrls[0].data[2], 'o');
     ck_assert_int_eq(copiedValue.discoveryUrls[0].data[3], 'p');
-    ck_assert_int_eq(copiedValue.discoveryUrlsSize, value.discoveryUrlsSize);
+    ck_assert_uint_eq(copiedValue.discoveryUrlsSize, value.discoveryUrlsSize);
 
     //finally
     // UA_ApplicationDescription_deleteMembers(&value); // do not free the members as they are statically allocated
@@ -1232,7 +1232,7 @@ START_TEST(UA_QualifiedName_copyShallWorkOnInputExample) {
     ck_assert_int_eq(ret, UA_STATUSCODE_GOOD);
     ck_assert_int_eq('E', dst.name.data[1]);
     ck_assert_int_eq('!', dst.name.data[7]);
-    ck_assert_int_eq(8, dst.name.length);
+    ck_assert_uint_eq(8, dst.name.length);
     ck_assert_int_eq(5, dst.namespaceIndex);
     // finally
     UA_QualifiedName_deleteMembers(&dst);
@@ -1263,8 +1263,8 @@ START_TEST(UA_LocalizedText_copycstringShallWorkOnInputExample) {
 
     // then
     ck_assert_int_eq('1', dst.text.data[4]);
-    ck_assert_int_eq(0, dst.locale.length);
-    ck_assert_int_eq(7, dst.text.length);
+    ck_assert_uint_eq(0, dst.locale.length);
+    ck_assert_uint_eq(7, dst.text.length);
 }
 END_TEST
 
@@ -1310,10 +1310,10 @@ START_TEST(UA_Variant_copyShallWorkOnSingleValueExample) {
     UA_String copiedString = *(UA_String*)(copiedValue.data);
     for(UA_Int32 i = 0;i < 5;i++)
         ck_assert_int_eq(copiedString.data[i], testString.data[i]);
-    ck_assert_int_eq(copiedString.length, testString.length);
+    ck_assert_uint_eq(copiedString.length, testString.length);
 
-    ck_assert_int_eq(value.arrayDimensionsSize, copiedValue.arrayDimensionsSize);
-    ck_assert_int_eq(value.arrayLength, copiedValue.arrayLength);
+    ck_assert_uint_eq(value.arrayDimensionsSize, copiedValue.arrayDimensionsSize);
+    ck_assert_uint_eq(value.arrayLength, copiedValue.arrayLength);
 
     //finally
     ((UA_String*)value.data)->data = NULL; // the string is statically allocated. do not free it.
@@ -1364,22 +1364,22 @@ START_TEST(UA_Variant_copyShallWorkOn1DArrayExample) {
     UA_Variant_copy(&value, &copiedValue);
 
     //then
-    UA_Int32 i1 = value.arrayDimensions[0];
-    UA_Int32 i2 = copiedValue.arrayDimensions[0];
-    ck_assert_int_eq(i1, i2);
+    UA_UInt32 i1 = value.arrayDimensions[0];
+    UA_UInt32 i2 = copiedValue.arrayDimensions[0];
+    ck_assert_uint_eq(i1, i2);
 
     for(UA_Int32 i = 0;i < 3;i++) {
         for(UA_Int32 j = 0;j < 6;j++) {
             ck_assert_int_eq(((UA_String *)value.data)[i].data[j],
                     ((UA_String *)copiedValue.data)[i].data[j]);
         }
-        ck_assert_int_eq(((UA_String *)value.data)[i].length,
+        ck_assert_uint_eq(((UA_String *)value.data)[i].length,
                 ((UA_String *)copiedValue.data)[i].length);
     }
     ck_assert_int_eq(((UA_String *)copiedValue.data)[0].data[2], 'o');
     ck_assert_int_eq(((UA_String *)copiedValue.data)[0].data[3], 'p');
-    ck_assert_int_eq(value.arrayDimensionsSize, copiedValue.arrayDimensionsSize);
-    ck_assert_int_eq(value.arrayLength, copiedValue.arrayLength);
+    ck_assert_uint_eq(value.arrayDimensionsSize, copiedValue.arrayDimensionsSize);
+    ck_assert_uint_eq(value.arrayLength, copiedValue.arrayLength);
 
     //finally
     UA_Variant_deleteMembers(&value);
@@ -1418,10 +1418,10 @@ START_TEST(UA_Variant_copyShallWorkOn2DArrayExample) {
 
     //then
     //1st dimension
-    UA_Int32 i1 = value.arrayDimensions[0];
-    UA_Int32 i2 = copiedValue.arrayDimensions[0];
-    ck_assert_int_eq(i1, i2);
-    ck_assert_int_eq(i1, dim1);
+    UA_UInt32 i1 = value.arrayDimensions[0];
+    UA_UInt32 i2 = copiedValue.arrayDimensions[0];
+    ck_assert_uint_eq(i1, i2);
+    ck_assert_uint_eq(i1, dim1);
 
 
     //2nd dimension
@@ -1432,14 +1432,14 @@ START_TEST(UA_Variant_copyShallWorkOn2DArrayExample) {
 
 
     for(UA_Int32 i = 0;i < 6;i++) {
-        i1 = ((UA_Int32 *)value.data)[i];
-        i2 = ((UA_Int32 *)copiedValue.data)[i];
+        i1 = ((UA_UInt32 *)value.data)[i];
+        i2 = ((UA_UInt32 *)copiedValue.data)[i];
         ck_assert_int_eq(i1, i2);
         ck_assert_int_eq(i2, i);
     }
 
-    ck_assert_int_eq(value.arrayDimensionsSize, copiedValue.arrayDimensionsSize);
-    ck_assert_int_eq(value.arrayLength, copiedValue.arrayLength);
+    ck_assert_uint_eq(value.arrayDimensionsSize, copiedValue.arrayDimensionsSize);
+    ck_assert_uint_eq(value.arrayLength, copiedValue.arrayLength);
 
     //finally
     UA_Variant_deleteMembers(&value);
@@ -1482,15 +1482,15 @@ START_TEST(UA_ExtensionObject_encodeDecodeShallWorkOnExtensionObject) {
     /* size_t posDecode = 0; */
     /* UA_ExtensionObject_decodeBinary(&dst, &posDecode, &extensionObjectDecoded); */
 
-    /* ck_assert_int_eq(posEncode, posDecode); */
-    /* ck_assert_int_eq(extensionObjectDecoded.body.length, extensionObject.body.length); */
+    /* ck_assert_uint_eq(posEncode, posDecode); */
+    /* ck_assert_uint_eq(extensionObjectDecoded.body.length, extensionObject.body.length); */
 
     /* UA_VariableAttributes varAttrDecoded; */
     /* UA_VariableAttributes_init(&varAttrDecoded); */
     /* posDecode = 0; */
     /* UA_VariableAttributes_decodeBinary(&extensionObjectDecoded.body, &posDecode, &varAttrDecoded); */
     /* ck_assert_uint_eq(41, varAttrDecoded.userWriteMask); */
-    /* ck_assert_int_eq(-1, varAttrDecoded.value.arrayLength); */
+    /* ck_assert_uint_eq(-1, varAttrDecoded.value.arrayLength); */
 
     /* // finally */
     /* UA_ExtensionObject_deleteMembers(&extensionObjectDecoded); */

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -289,8 +289,8 @@ START_TEST(parseCustomScalarExtensionObject) {
     UA_ExtensionObject eo2;
     size_t offset = 0;
     retval = UA_decodeBinary(&buf, &offset, &eo2, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT], &customDataTypes);
-    ck_assert_int_eq(offset, (uintptr_t)(bufPos - buf.data));
-    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(offset, (uintptr_t)(bufPos - buf.data));
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     ck_assert_int_eq(eo2.encoding, UA_EXTENSIONOBJECT_DECODED);
     ck_assert(eo2.content.decoded.type == &PointType);
@@ -330,7 +330,7 @@ START_TEST(parseCustomArray) {
     retval = UA_decodeBinary(&buf, &offset, &var2, &UA_TYPES[UA_TYPES_VARIANT], &customDataTypes);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert(var2.type == &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
-    ck_assert_int_eq(var2.arrayLength, 10);
+    ck_assert_uint_eq(var2.arrayLength, 10);
 
     for (size_t i = 0; i < 10; i++) {
         UA_ExtensionObject *eo = &((UA_ExtensionObject*)var2.data)[i];

--- a/tests/check_types_memory.c
+++ b/tests/check_types_memory.c
@@ -84,15 +84,15 @@ START_TEST(arrayCopyShallMakeADeepCopy) {
     a1[2] = (UA_String){3, (UA_Byte*)"ccc"};
     // when
     UA_String *a2;
-    UA_Int32 retval = UA_Array_copy((const void *)a1, 3, (void **)&a2, &UA_TYPES[UA_TYPES_STRING]);
+    UA_UInt32 retval = UA_Array_copy((const void *)a1, 3, (void **)&a2, &UA_TYPES[UA_TYPES_STRING]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(a1[0].length, 1);
-    ck_assert_int_eq(a1[1].length, 2);
-    ck_assert_int_eq(a1[2].length, 3);
-    ck_assert_int_eq(a1[0].length, a2[0].length);
-    ck_assert_int_eq(a1[1].length, a2[1].length);
-    ck_assert_int_eq(a1[2].length, a2[2].length);
+    ck_assert_uint_eq(a1[0].length, 1);
+    ck_assert_uint_eq(a1[1].length, 2);
+    ck_assert_uint_eq(a1[2].length, 3);
+    ck_assert_uint_eq(a1[0].length, a2[0].length);
+    ck_assert_uint_eq(a1[1].length, a2[1].length);
+    ck_assert_uint_eq(a1[2].length, a2[2].length);
     ck_assert_ptr_ne(a1[0].data, a2[0].data);
     ck_assert_ptr_ne(a1[1].data, a2[1].data);
     ck_assert_ptr_ne(a1[2].data, a2[2].data);
@@ -225,8 +225,8 @@ START_TEST(decodeScalarBasicTypeFromRandomBufferShallSucceed) {
     // given
     void *obj1 = NULL;
     UA_ByteString msg1;
-    UA_Int32 retval = UA_STATUSCODE_GOOD;
-    UA_Int32 buflen = 256;
+    UA_UInt32 retval = UA_STATUSCODE_GOOD;
+    UA_UInt32 buflen = 256;
     retval = UA_ByteString_allocBuffer(&msg1, buflen); // fixed size
 #ifdef _WIN32
     srand(42);
@@ -234,7 +234,7 @@ START_TEST(decodeScalarBasicTypeFromRandomBufferShallSucceed) {
     srandom(42);
 #endif
     for(int n = 0;n < RANDOM_TESTS;n++) {
-        for(UA_Int32 i = 0;i < buflen;i++) {
+        for(UA_UInt32 i = 0;i < buflen;i++) {
 #ifdef _WIN32
             UA_UInt32 rnd;
             rnd = rand();
@@ -260,8 +260,8 @@ END_TEST
 START_TEST(decodeComplexTypeFromRandomBufferShallSurvive) {
     // given
     UA_ByteString msg1;
-    UA_Int32 retval = UA_STATUSCODE_GOOD;
-    UA_Int32 buflen = 256;
+    UA_UInt32 retval = UA_STATUSCODE_GOOD;
+    UA_UInt32 buflen = 256;
     retval = UA_ByteString_allocBuffer(&msg1, buflen); // fixed size
 #ifdef _WIN32
     srand(42);
@@ -270,7 +270,7 @@ START_TEST(decodeComplexTypeFromRandomBufferShallSurvive) {
 #endif
     // when
     for(int n = 0;n < RANDOM_TESTS;n++) {
-        for(UA_Int32 i = 0;i < buflen;i++) {
+        for(UA_UInt32 i = 0;i < buflen;i++) {
 #ifdef _WIN32
             UA_UInt32 rnd;
             rnd = rand();
@@ -327,17 +327,17 @@ START_TEST(calcSizeBinaryShallBeCorrect) {
         return;
     void *obj = UA_new(&UA_TYPES[_i]);
     size_t predicted_size = UA_calcSizeBinary(obj, &UA_TYPES[_i]);
-    ck_assert_int_ne(predicted_size, 0);
+    ck_assert_uint_ne(predicted_size, 0);
     UA_ByteString msg;
     UA_StatusCode retval = UA_ByteString_allocBuffer(&msg, predicted_size);
-    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     UA_Byte *pos = msg.data;
     const UA_Byte *end = &msg.data[msg.length];
     retval = UA_encodeBinary(obj, &UA_TYPES[_i], &pos, &end, NULL, NULL);
     if(retval)
         printf("%i\n",_i);
-    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq((uintptr_t)(pos - msg.data), predicted_size);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq((uintptr_t)(pos - msg.data), predicted_size);
     UA_delete(obj, &UA_TYPES[_i]);
     UA_ByteString_deleteMembers(&msg);
 }

--- a/tests/check_types_parse.c
+++ b/tests/check_types_parse.c
@@ -18,7 +18,7 @@ START_TEST(base64) {
     res = UA_ByteString_fromBase64(&test1out, &test1base64);
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
 
-    ck_assert_int_eq(test1.length, test1out.length);
+    ck_assert_uint_eq(test1.length, test1out.length);
     for(size_t i = 0; i < test1.length; i++)
         ck_assert_int_eq(test1.data[i], test1out.data[i]);
 
@@ -35,7 +35,7 @@ START_TEST(base64) {
     res = UA_ByteString_fromBase64(&test2out, &test2base64);
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
 
-    ck_assert_int_eq(test2.length, test2out.length);
+    ck_assert_uint_eq(test2.length, test2out.length);
     for(size_t i = 0; i < test2.length; i++)
         ck_assert_int_eq(test2.data[i], test2out.data[i]);
 
@@ -145,40 +145,40 @@ START_TEST(parseRelativePath) {
     UA_RelativePath rp;
     UA_StatusCode res = UA_RelativePath_parse(&rp, UA_STRING(""));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 0);
+    ck_assert_uint_eq(rp.elementsSize, 0);
 
     res = UA_RelativePath_parse(&rp, UA_STRING("/2:Block&.Output"));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 1);
+    ck_assert_uint_eq(rp.elementsSize, 1);
     UA_RelativePath_clear(&rp);
 
     /* Paths with no BrowseName */
     res = UA_RelativePath_parse(&rp, UA_STRING("//"));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 2);
+    ck_assert_uint_eq(rp.elementsSize, 2);
     UA_RelativePath_clear(&rp);
 
     res = UA_RelativePath_parse(&rp, UA_STRING("/."));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 2);
+    ck_assert_uint_eq(rp.elementsSize, 2);
     UA_RelativePath_clear(&rp);
 
     res = UA_RelativePath_parse(&rp, UA_STRING("<0:HierachicalReferences>2:Wheel"));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 1);
+    ck_assert_uint_eq(rp.elementsSize, 1);
     ck_assert_int_eq(rp.elements[0].targetName.namespaceIndex, 2);
     UA_RelativePath_clear(&rp);
 
     res = UA_RelativePath_parse(&rp, UA_STRING("<0:HasComponent>1:Boiler/1:HeatSensor"));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 2);
+    ck_assert_uint_eq(rp.elementsSize, 2);
     ck_assert_int_eq(rp.elements[0].targetName.namespaceIndex, 1);
     ck_assert_int_eq(rp.elements[1].targetName.namespaceIndex, 1);
     UA_RelativePath_clear(&rp);
 
     res = UA_RelativePath_parse(&rp, UA_STRING(".1:Boiler/1:HeatSensor/"));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 3);
+    ck_assert_uint_eq(rp.elementsSize, 3);
     ck_assert_int_eq(rp.elements[0].targetName.namespaceIndex, 1);
     ck_assert_int_eq(rp.elements[1].targetName.namespaceIndex, 1);
     UA_String tmp = UA_STRING("HeatSensor");
@@ -188,13 +188,13 @@ START_TEST(parseRelativePath) {
 
     res = UA_RelativePath_parse(&rp, UA_STRING("<!HasChild>Truck"));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 1);
+    ck_assert_uint_eq(rp.elementsSize, 1);
     ck_assert_int_eq(rp.elements[0].isInverse, true);
     UA_RelativePath_clear(&rp);
 
     res = UA_RelativePath_parse(&rp, UA_STRING("<0:HasChild>"));
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(rp.elementsSize, 1);
+    ck_assert_uint_eq(rp.elementsSize, 1);
     UA_RelativePath_clear(&rp);
 } END_TEST
 

--- a/tests/check_types_range.c
+++ b/tests/check_types_range.c
@@ -14,13 +14,13 @@ START_TEST(parseRange) {
     UA_String str = UA_STRING("1:2,0:3,5");
     UA_StatusCode retval = UA_NumericRange_parseFromString(&range, &str);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(range.dimensionsSize,3);
-    ck_assert_int_eq(range.dimensions[0].min,1);
-    ck_assert_int_eq(range.dimensions[0].max,2);
-    ck_assert_int_eq(range.dimensions[1].min,0);
-    ck_assert_int_eq(range.dimensions[1].max,3);
-    ck_assert_int_eq(range.dimensions[2].min,5);
-    ck_assert_int_eq(range.dimensions[2].max,5);
+    ck_assert_uint_eq(range.dimensionsSize,3);
+    ck_assert_uint_eq(range.dimensions[0].min,1);
+    ck_assert_uint_eq(range.dimensions[0].max,2);
+    ck_assert_uint_eq(range.dimensions[1].min,0);
+    ck_assert_uint_eq(range.dimensions[1].max,3);
+    ck_assert_uint_eq(range.dimensions[2].min,5);
+    ck_assert_uint_eq(range.dimensions[2].max,5);
     UA_free(range.dimensions);
 } END_TEST
 
@@ -29,11 +29,11 @@ START_TEST(parseRangeMinEqualMax) {
     UA_String str = UA_STRING("1:2,1");
     UA_StatusCode retval = UA_NumericRange_parseFromString(&range, &str);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(range.dimensionsSize,2);
-    ck_assert_int_eq(range.dimensions[0].min,1);
-    ck_assert_int_eq(range.dimensions[0].max,2);
-    ck_assert_int_eq(range.dimensions[1].min,1);
-    ck_assert_int_eq(range.dimensions[1].max,1);
+    ck_assert_uint_eq(range.dimensionsSize,2);
+    ck_assert_uint_eq(range.dimensions[0].min,1);
+    ck_assert_uint_eq(range.dimensions[0].max,2);
+    ck_assert_uint_eq(range.dimensions[1].min,1);
+    ck_assert_uint_eq(range.dimensions[1].max,1);
     UA_free(range.dimensions);
 } END_TEST
 
@@ -51,8 +51,8 @@ START_TEST(copySimpleArrayRange) {
 
     retval = UA_Variant_copyRange(&v, &v2, r);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(3, v2.arrayLength);
-    ck_assert_int_eq(2, *(UA_UInt32*)v2.data);
+    ck_assert_uint_eq(3, v2.arrayLength);
+    ck_assert_uint_eq(2, *(UA_UInt32*)v2.data);
 
     UA_Variant_deleteMembers(&v2);
     UA_free(r.dimensions);
@@ -75,7 +75,7 @@ START_TEST(copyIntoStringArrayRange) {
 
     retval = UA_Variant_copyRange(&v, &v2, r);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(2, v2.arrayLength);
+    ck_assert_uint_eq(2, v2.arrayLength);
 
     UA_String s1 = UA_STRING("bc");
     UA_String s2 = UA_STRING("xy");

--- a/tests/client/check_client_highlevel.c
+++ b/tests/client/check_client_highlevel.c
@@ -878,7 +878,7 @@ START_TEST(Node_ReadWrite_ArrayDimensions) {
     UA_StatusCode retval = UA_Client_readArrayDimensionsAttribute(client, nodeReadWriteGeneric,
                                                                   &arrayDimsReadSize, &arrayDimsRead);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(arrayDimsReadSize, 0);
+    ck_assert_uint_eq(arrayDimsReadSize, 0);
 
     // Set a vector of size 1 as the value
     UA_Double vec2[2] = {0.0, 0.0};
@@ -906,7 +906,7 @@ START_TEST(Node_ReadWrite_ArrayDimensions) {
     retval = UA_Client_readArrayDimensionsAttribute(client, nodeReadWriteGeneric,
                                                     &arrayDimsReadSize, &arrayDimsRead);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(arrayDimsReadSize, 1);
+    ck_assert_uint_eq(arrayDimsReadSize, 1);
     ck_assert_int_eq(arrayDimsRead[0], 1);
     UA_Array_delete(arrayDimsRead, arrayDimsReadSize, &UA_TYPES[UA_TYPES_UINT32]);
 }

--- a/tests/server/check_nodestore.c
+++ b/tests/server/check_nodestore.c
@@ -36,7 +36,7 @@ static void checkZeroVisitor(void *context, const UA_Node* node) {
     if (node == NULL) zeroCnt++;
 }
 
-static UA_Node* createNode(UA_Int16 nsid, UA_Int32 id) {
+static UA_Node* createNode(UA_UInt16 nsid, UA_UInt32 id) {
     UA_Node *p = ns.newNode(&ns.context, UA_NODECLASS_VARIABLE);
     p->nodeId.identifierType = UA_NODEIDTYPE_NUMERIC;
     p->nodeId.namespaceIndex = nsid;
@@ -80,7 +80,7 @@ START_TEST(findNodeInUA_NodeStoreWithSingleEntry) {
     ns.insertNode(ns.context, n1, NULL);
     UA_NodeId in1 = UA_NODEID_NUMERIC(0,2253);
     const UA_Node* nr = ns.getNode(ns.context, &in1);
-    ck_assert_int_eq((uintptr_t)n1, (uintptr_t)nr);
+    ck_assert_uint_eq((uintptr_t)n1, (uintptr_t)nr);
     ns.releaseNode(ns.context, nr);
 }
 END_TEST
@@ -90,7 +90,7 @@ START_TEST(failToFindNodeInOtherUA_NodeStore) {
     ns.insertNode(ns.context, n1, NULL);
     UA_NodeId in1 = UA_NODEID_NUMERIC(1, 2255);
     const UA_Node* nr = ns.getNode(ns.context, &in1);
-    ck_assert_int_eq((uintptr_t)nr, 0);
+    ck_assert_uint_eq((uintptr_t)nr, 0);
 }
 END_TEST
 
@@ -110,7 +110,7 @@ START_TEST(findNodeInUA_NodeStoreWithSeveralEntries) {
 
     UA_NodeId in3 = UA_NODEID_NUMERIC(0, 2257);
     const UA_Node* nr = ns.getNode(ns.context, &in3);
-    ck_assert_int_eq((uintptr_t)nr, (uintptr_t)n3);
+    ck_assert_uint_eq((uintptr_t)nr, (uintptr_t)n3);
     ns.releaseNode(ns.context, nr);
 }
 END_TEST
@@ -180,7 +180,7 @@ START_TEST(failToFindNonExistentNodeInUA_NodeStoreWithSeveralEntries) {
 
     UA_NodeId id = UA_NODEID_NUMERIC(0, 12);
     const UA_Node* nr = ns.getNode(ns.context, &id);
-    ck_assert_int_eq((uintptr_t)nr, 0);
+    ck_assert_uint_eq((uintptr_t)nr, 0);
 }
 END_TEST
 

--- a/tests/server/check_server.c
+++ b/tests/server/check_server.c
@@ -37,13 +37,13 @@ START_TEST(checkGetConfig) {
 START_TEST(checkGetNamespaceByName) {
     size_t notFoundIndex = 62541;
     UA_StatusCode notFound = UA_Server_getNamespaceByName(server, UA_STRING("http://opcfoundation.org/UA/invalid"), &notFoundIndex);
-    ck_assert_int_eq(notFoundIndex, 62541); // not changed
-    ck_assert_int_eq(notFound, UA_STATUSCODE_BADNOTFOUND);
+    ck_assert_uint_eq(notFoundIndex, 62541); // not changed
+    ck_assert_uint_eq(notFound, UA_STATUSCODE_BADNOTFOUND);
 
     size_t foundIndex = 62541;
     UA_StatusCode found = UA_Server_getNamespaceByName(server, UA_STRING("http://opcfoundation.org/UA/"), &foundIndex);
-    ck_assert_int_eq(foundIndex, 0); // this namespace always has index 0 (defined by the standard)
-    ck_assert_int_eq(found, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(foundIndex, 0); // this namespace always has index 0 (defined by the standard)
+    ck_assert_uint_eq(found, UA_STATUSCODE_GOOD);
 } END_TEST
 
 static void timedCallbackHandler(UA_Server *s, void *data) {

--- a/tests/server/check_server_callbacks.c
+++ b/tests/server/check_server_callbacks.c
@@ -188,7 +188,7 @@ START_TEST(client_readMultipleAttributes) {
         retval = response.responseHeader.serviceResult;
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-        ck_assert_int_eq(response.resultsSize, 3);
+        ck_assert_uint_eq(response.resultsSize, 3);
         ck_assert_uint_eq(response.results[0].status, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(response.results[1].status, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(response.results[2].status, UA_STATUSCODE_BADNODEIDUNKNOWN);

--- a/tests/server/check_server_userspace.c
+++ b/tests/server/check_server_userspace.c
@@ -152,9 +152,9 @@ START_TEST(Server_set_customHostname) {
     for (size_t i=0; i<config->networkLayersSize; i++) {
         const UA_ServerNetworkLayer *nl = &config->networkLayers[i];
         char discoveryUrl[256];
-        int len = snprintf(discoveryUrl, 255, "opc.tcp://%.*s:%d/", (int)customHost.length, customHost.data, port);
-        ck_assert_int_eq(nl->discoveryUrl.length, len);
-        ck_assert_int_eq(config->applicationDescription.discoveryUrls[i].length, len);
+        unsigned int len = (unsigned int)snprintf(discoveryUrl, 255, "opc.tcp://%.*s:%d/", (int)customHost.length, customHost.data, port);
+        ck_assert_uint_eq(nl->discoveryUrl.length, len);
+        ck_assert_uint_eq(config->applicationDescription.discoveryUrls[i].length, len);
         ck_assert(strncmp(discoveryUrl, (char*)nl->discoveryUrl.data, len)==0);
         ck_assert(strncmp(discoveryUrl, (char*)config->applicationDescription.discoveryUrls[i].data, len)==0);
     }

--- a/tests/server/check_services_attributes.c
+++ b/tests/server/check_services_attributes.c
@@ -180,7 +180,7 @@ START_TEST(ReadSingleAttributeValueWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     ck_assert_int_eq(resp.status, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_INT32] == resp.value.type);
     ck_assert_int_eq(42, *(UA_Int32* )resp.value.data);
     UA_DataValue_deleteMembers(&resp);
@@ -218,7 +218,7 @@ START_TEST(ReadSingleAttributeValueRangeWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(4, resp.value.arrayLength);
+    ck_assert_uint_eq(4, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_INT32] == resp.value.type);
     UA_DataValue_deleteMembers(&resp);
 } END_TEST
@@ -232,7 +232,7 @@ START_TEST(ReadSingleAttributeNodeIdWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     const UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_NODEID] == resp.value.type);
     UA_NodeId* respval = (UA_NodeId*) resp.value.data;
     ck_assert_int_eq(1, respval->namespaceIndex);
@@ -248,7 +248,7 @@ START_TEST(ReadSingleAttributeNodeClassWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_NODECLASS] == resp.value.type);
     ck_assert_int_eq(*(UA_Int32*)resp.value.data,UA_NODECLASS_VARIABLE);
     UA_DataValue_deleteMembers(&resp);
@@ -264,7 +264,7 @@ START_TEST(ReadSingleAttributeBrowseNameWithoutTimestamp) {
     
     UA_QualifiedName* respval = (UA_QualifiedName*) resp.value.data;
     const UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "the answer");
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_QUALIFIEDNAME] == resp.value.type);
     ck_assert_int_eq(1, respval->namespaceIndex);
     ck_assert(UA_String_equal(&myIntegerName.name, &respval->name));
@@ -282,7 +282,7 @@ START_TEST(ReadSingleAttributeDisplayNameWithoutTimestamp) {
     UA_LocalizedText* respval = (UA_LocalizedText*) resp.value.data;
     const UA_LocalizedText comp = UA_LOCALIZEDTEXT("locale", "the answer");
     UA_VariableNode* compNode = makeCompareSequence();
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_LOCALIZEDTEXT] == resp.value.type);
     ck_assert(UA_String_equal(&comp.text, &respval->text));
     ck_assert(UA_String_equal(&compNode->displayName.locale, &respval->locale));
@@ -300,7 +300,7 @@ START_TEST(ReadSingleAttributeDescriptionWithoutTimestamp) {
     
     UA_LocalizedText* respval = (UA_LocalizedText*) resp.value.data;
     UA_VariableNode* compNode = makeCompareSequence();
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_LOCALIZEDTEXT] == resp.value.type);
     ck_assert(UA_String_equal(&compNode->description.locale, &respval->locale));
     ck_assert(UA_String_equal(&compNode->description.text, &respval->text));
@@ -317,7 +317,7 @@ START_TEST(ReadSingleAttributeWriteMaskWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
     
     UA_UInt32* respval = (UA_UInt32*) resp.value.data;
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_UINT32] == resp.value.type);
     ck_assert_int_eq(0,*respval);
     UA_DataValue_deleteMembers(&resp);
@@ -333,7 +333,7 @@ START_TEST(ReadSingleAttributeUserWriteMaskWithoutTimestamp) {
 
     /* Uncommented since the userwritemask is always 0xffffffff for the local admin user */
     /* UA_UInt32* respval = (UA_UInt32*) resp.value.data; */
-    /* ck_assert_int_eq(0, resp.value.arrayLength); */
+    /* ck_assert_uint_eq(0, resp.value.arrayLength); */
     /* ck_assert_ptr_eq(&UA_TYPES[UA_TYPES_UINT32], resp.value.type); */
     /* ck_assert_int_eq(0,*respval); */
     UA_DataValue_deleteMembers(&resp);
@@ -347,7 +347,7 @@ START_TEST(ReadSingleAttributeIsAbstractWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_BOOLEAN] == resp.value.type);
     ck_assert(*(UA_Boolean* )resp.value.data==false);
     UA_DataValue_deleteMembers(&resp);
@@ -361,7 +361,7 @@ START_TEST(ReadSingleAttributeSymmetricWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_BOOLEAN] == resp.value.type);
     ck_assert(*(UA_Boolean* )resp.value.data==false);
     UA_DataValue_deleteMembers(&resp);
@@ -377,7 +377,7 @@ START_TEST(ReadSingleAttributeInverseNameWithoutTimestamp) {
 
     UA_LocalizedText* respval = (UA_LocalizedText*) resp.value.data;
     const UA_LocalizedText comp = UA_LOCALIZEDTEXT("", "OrganizedBy");
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_LOCALIZEDTEXT] == resp.value.type);
     ck_assert(UA_String_equal(&comp.text, &respval->text));
     ck_assert(UA_String_equal(&comp.locale, &respval->locale));
@@ -392,7 +392,7 @@ START_TEST(ReadSingleAttributeContainsNoLoopsWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_BOOLEAN] == resp.value.type);
     ck_assert(*(UA_Boolean* )resp.value.data==false);
     UA_DataValue_deleteMembers(&resp);
@@ -407,7 +407,7 @@ START_TEST(ReadSingleAttributeEventNotifierWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     ck_assert_int_eq(UA_STATUSCODE_GOOD, resp.status);
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_BYTE] == resp.value.type);
     ck_assert_int_eq(*(UA_Byte*)resp.value.data, 0);
     UA_DataValue_deleteMembers(&resp);
@@ -421,7 +421,7 @@ START_TEST(ReadSingleAttributeDataTypeWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert_int_eq(UA_STATUSCODE_GOOD, resp.status);
     ck_assert_int_eq(true, resp.hasValue);
     ck_assert(&UA_TYPES[UA_TYPES_NODEID] == resp.value.type);
@@ -439,7 +439,7 @@ START_TEST(ReadSingleAttributeValueRankWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_INT32] == resp.value.type);
     ck_assert_int_eq(-2, *(UA_Int32* )resp.value.data);
     UA_DataValue_deleteMembers(&resp);
@@ -453,7 +453,7 @@ START_TEST(ReadSingleAttributeArrayDimensionsWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_UINT32] == resp.value.type);
     ck_assert_ptr_eq((UA_Int32*)resp.value.data,0);
     UA_DataValue_deleteMembers(&resp);
@@ -467,7 +467,7 @@ START_TEST(ReadSingleAttributeAccessLevelWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_BYTE] == resp.value.type);
     ck_assert_int_eq(*(UA_Byte*)resp.value.data, UA_ACCESSLEVELMASK_READ); // set by default
     UA_DataValue_deleteMembers(&resp);
@@ -484,7 +484,7 @@ START_TEST(ReadSingleAttributeUserAccessLevelWithoutTimestamp) {
     /* Uncommented since the accesslevel is always 0xff for the local admin user */
     /* const UA_VariableNode* compNode = */
     /*     (const UA_VariableNode*)UA_NodeStore_getNode(server->nsCtx, &rvi.nodeId); */
-    /* ck_assert_int_eq(0, resp.value.arrayLength); */
+    /* ck_assert_uint_eq(0, resp.value.arrayLength); */
     /* ck_assert_ptr_eq(&UA_TYPES[UA_TYPES_BYTE], resp.value.type); */
     /* ck_assert_int_eq(*(UA_Byte*)resp.value.data, compNode->accessLevel & 0xFF); // 0xFF is the default userAccessLevel */
     UA_DataValue_deleteMembers(&resp);
@@ -501,7 +501,7 @@ START_TEST(ReadSingleAttributeMinimumSamplingIntervalWithoutTimestamp) {
     UA_Double* respval = (UA_Double*) resp.value.data;
     UA_VariableNode *compNode = makeCompareSequence();
     UA_Double comp = (UA_Double) compNode->minimumSamplingInterval;
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_DOUBLE] == resp.value.type);
     ck_assert(*respval == comp);
     UA_DataValue_deleteMembers(&resp);
@@ -516,7 +516,7 @@ START_TEST(ReadSingleAttributeHistorizingWithoutTimestamp) {
 
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_BOOLEAN] == resp.value.type);
     ck_assert(*(UA_Boolean*)resp.value.data==false);
     UA_DataValue_deleteMembers(&resp);
@@ -532,7 +532,7 @@ START_TEST(ReadSingleAttributeExecutableWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     ck_assert_int_eq(true, resp.hasValue);
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert(&UA_TYPES[UA_TYPES_BOOLEAN] == resp.value.type);
     ck_assert(*(UA_Boolean*)resp.value.data==true);
     UA_DataValue_deleteMembers(&resp);
@@ -549,7 +549,7 @@ START_TEST(ReadSingleAttributeUserExecutableWithoutTimestamp) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
 
     /* Uncommented since userexecutable is always true for the local admin user */
-    /* ck_assert_int_eq(0, resp.value.arrayLength); */
+    /* ck_assert_uint_eq(0, resp.value.arrayLength); */
     /* ck_assert_ptr_eq(&UA_TYPES[UA_TYPES_BOOLEAN], resp.value.type); */
     /* ck_assert(*(UA_Boolean*)resp.value.data==false); */
     UA_DataValue_deleteMembers(&resp);

--- a/tests/server/check_services_call.c
+++ b/tests/server/check_services_call.c
@@ -197,7 +197,7 @@ START_TEST(callMethodWithWronglyTypedArguments) {
     UA_CallMethodResult_init(&result);
     result = UA_Server_call(server, &callMethodRequest);
 
-    ck_assert_int_gt(result.inputArgumentResultsSize, 0);
+    ck_assert_uint_gt(result.inputArgumentResultsSize, 0);
     ck_assert_int_eq(result.inputArgumentResults[0], UA_STATUSCODE_BADTYPEMISMATCH);
     ck_assert_int_eq(result.statusCode, UA_STATUSCODE_BADINVALIDARGUMENT);
 

--- a/tests/server/check_services_nodemanagement.c
+++ b/tests/server/check_services_nodemanagement.c
@@ -386,7 +386,7 @@ START_TEST(DeleteObjectAndReferences) {
         if(UA_NodeId_equal(&br.references[i].nodeId.nodeId, &objectid))
             refCount++;
     }
-    ck_assert_int_eq(refCount, 1);
+    ck_assert_uint_eq(refCount, 1);
     UA_BrowseResult_deleteMembers(&br);
 
     /* Delete the object */
@@ -400,7 +400,7 @@ START_TEST(DeleteObjectAndReferences) {
         if(UA_NodeId_equal(&br.references[i].nodeId.nodeId, &objectid))
             refCount++;
     }
-    ck_assert_int_eq(refCount, 0);
+    ck_assert_uint_eq(refCount, 0);
     UA_BrowseResult_deleteMembers(&br);
 
     /* Add an object the second time */
@@ -423,7 +423,7 @@ START_TEST(DeleteObjectAndReferences) {
         if(UA_NodeId_equal(&br.references[i].nodeId.nodeId, &objectid))
             refCount++;
     }
-    ck_assert_int_eq(refCount, 1);
+    ck_assert_uint_eq(refCount, 1);
     UA_BrowseResult_deleteMembers(&br);
 } END_TEST
 

--- a/tests/server/check_services_view.c
+++ b/tests/server/check_services_view.c
@@ -100,7 +100,7 @@ START_TEST(Service_Browse_WithMaxResults) {
     for(UA_UInt32 i = 1; i <= total; i++) {
         size_t sum_total =
             browseWithMaxResults(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), i);
-        ck_assert_int_eq(total, sum_total);
+        ck_assert_uint_eq(total, sum_total);
     }
     
     UA_Server_delete(server);
@@ -196,9 +196,9 @@ START_TEST(Service_TranslateBrowsePathsToNodeIds) {
     UA_TranslateBrowsePathsToNodeIdsResponse response = UA_Client_Service_translateBrowsePathsToNodeIds(client, request);
 
     ck_assert_int_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(response.resultsSize, 1);
+    ck_assert_uint_eq(response.resultsSize, 1);
 
-    ck_assert_int_eq(response.results[0].targetsSize, 1);
+    ck_assert_uint_eq(response.results[0].targetsSize, 1);
     ck_assert_int_eq(response.results[0].targets[0].targetId.nodeId.identifierType, UA_NODEIDTYPE_NUMERIC);
     ck_assert_int_eq(response.results[0].targets[0].targetId.nodeId.identifier.numeric, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
 
@@ -217,7 +217,7 @@ START_TEST(BrowseSimplifiedBrowsePath) {
                                              UA_NODEID_NUMERIC(0, UA_NS0ID_ROOTFOLDER),
                                              1, &objectsName);
 
-    ck_assert_int_eq(bpr.targetsSize, 1);
+    ck_assert_uint_eq(bpr.targetsSize, 1);
 
     UA_BrowsePathResult_deleteMembers(&bpr);
 }


### PR DESCRIPTION
My clang 8.0.1 on OpenBSD could not compile the test programs due
to implicit conversion changes signedness errors.  Use the correct
unsigned ck_assert_uint_eq() function and change some data types.