### PR TITLE
Add 'Aes128Sha256RsaOaep' security policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,7 +817,8 @@ list(APPEND default_plugin_sources
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/securitypolicy_mbedtls_common.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256.c
-     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c)
+     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_aes128sha256rsaoaep.c)
 endif()
 
 if (UA_ENABLE_ENCRYPTION_OPENSSL)
@@ -828,6 +829,7 @@ list(APPEND default_plugin_sources
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic128rsa15.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic256.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic256sha256.c
+     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_aes128sha256rsaoaep.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_pki_openssl.c)
 endif()
 

--- a/plugins/include/open62541/plugin/securitypolicy_default.h
+++ b/plugins/include/open62541/plugin/securitypolicy_default.h
@@ -38,6 +38,12 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy,
                                  const UA_ByteString localPrivateKey,
                                  const UA_Logger *logger);
 
+UA_EXPORT UA_StatusCode
+UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy,
+                                 const UA_ByteString localCertificate,
+                                 const UA_ByteString localPrivateKey,
+                                 const UA_Logger *logger);
+
 #endif
 
 _UA_END_DECLS

--- a/plugins/include/open62541/server_config_default.h
+++ b/plugins/include/open62541/server_config_default.h
@@ -182,6 +182,21 @@ UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config,
                                                 const UA_ByteString *certificate,
                                                 const UA_ByteString *privateKey);
 
+/* Adds the security policy ``SecurityPolicy#Aes128Sha256RsaOaep`` to the server. A
+ * server certificate may be supplied but is optional.
+ *
+ * Certificate verification should be configured before calling this
+ * function. See PKI plugin.
+ *
+ * @param config The configuration to manipulate
+ * @param certificate The server certificate.
+ * @param privateKey The private key that corresponds to the certificate.
+ */
+UA_EXPORT UA_StatusCode
+UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config,
+                                                     const UA_ByteString *certificate,
+                                                     const UA_ByteString *privateKey);
+
 /* Adds all supported security policies and sets up certificate
  * validation procedures.
  *

--- a/plugins/securityPolicies/openssl/ua_openssl_aes128sha256rsaoaep.c
+++ b/plugins/securityPolicies/openssl/ua_openssl_aes128sha256rsaoaep.c
@@ -1,0 +1,684 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2020 (c) Wind River Systems, Inc.
+ */
+
+#include <open62541/plugin/securitypolicy_default.h>
+#include <open62541/util.h>
+
+#ifdef UA_ENABLE_ENCRYPTION_OPENSSL
+
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+
+#include <open62541/plugin/securitypolicy_openssl_common.h>
+
+#define UA_SHA256_LENGTH 32 /* 256 bit */
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN 42
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_SIGNING_KEY_LENGTH 32
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_KEY_LENGTH 16
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_PLAIN_TEXT_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH 256
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH 512
+
+typedef struct {
+    UA_ByteString localPrivateKey;
+    UA_ByteString localCertThumbprint;
+    const UA_Logger *logger;
+} Policy_Context_Aes128Sha256RsaOaep;
+
+typedef struct {
+    UA_ByteString localSymSigningKey;
+    UA_ByteString localSymEncryptingKey;
+    UA_ByteString localSymIv;
+    UA_ByteString remoteSymSigningKey;
+    UA_ByteString remoteSymEncryptingKey;
+    UA_ByteString remoteSymIv;
+
+    Policy_Context_Aes128Sha256RsaOaep *policyContext;
+    UA_ByteString remoteCertificate;
+    X509 *remoteCertificateX509; /* X509 */
+} Channel_Context_Aes128Sha256RsaOaep;
+
+/* create the policy context */
+
+static UA_StatusCode
+UA_Policy_New_Context(UA_SecurityPolicy *securityPolicy,
+                      const UA_ByteString localPrivateKey, const UA_Logger *logger) {
+    Policy_Context_Aes128Sha256RsaOaep *context =
+        (Policy_Context_Aes128Sha256RsaOaep *)UA_malloc(
+            sizeof(Policy_Context_Aes128Sha256RsaOaep));
+    if(context == NULL) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    /* copy the local private key and add a NULL to the end */
+
+    UA_StatusCode retval =
+        UA_copyCertificate(&context->localPrivateKey, &localPrivateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_free(context);
+        return retval;
+    }
+
+    retval = UA_Openssl_X509_GetCertificateThumbprint(
+        &securityPolicy->localCertificate, &context->localCertThumbprint, true);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ByteString_deleteMembers(&context->localPrivateKey);
+        UA_free(context);
+        return retval;
+    }
+
+    context->logger = logger;
+    securityPolicy->policyContext = context;
+
+    return UA_STATUSCODE_GOOD;
+}
+
+/* clear the policy context */
+
+static void
+UA_Policy_Clear_Context(UA_SecurityPolicy *policy) {
+    if(policy == NULL)
+        return;
+
+    UA_ByteString_deleteMembers(&policy->localCertificate);
+
+    /* delete all allocated members in the context */
+
+    Policy_Context_Aes128Sha256RsaOaep *pc =
+        (Policy_Context_Aes128Sha256RsaOaep *)policy->policyContext;
+    UA_ByteString_deleteMembers(&pc->localPrivateKey);
+    UA_ByteString_deleteMembers(&pc->localCertThumbprint);
+    UA_free(pc);
+    return;
+}
+
+/* create the channel context */
+
+static UA_StatusCode
+UA_ChannelModule_New_Context(const UA_SecurityPolicy *securityPolicy,
+                             const UA_ByteString *remoteCertificate,
+                             void **channelContext) {
+    if(securityPolicy == NULL || remoteCertificate == NULL || channelContext == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    Channel_Context_Aes128Sha256RsaOaep *context =
+        (Channel_Context_Aes128Sha256RsaOaep *)UA_malloc(
+            sizeof(Channel_Context_Aes128Sha256RsaOaep));
+    if(context == NULL) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    UA_ByteString_init(&context->localSymSigningKey);
+    UA_ByteString_init(&context->localSymEncryptingKey);
+    UA_ByteString_init(&context->localSymIv);
+    UA_ByteString_init(&context->remoteSymSigningKey);
+    UA_ByteString_init(&context->remoteSymEncryptingKey);
+    UA_ByteString_init(&context->remoteSymIv);
+
+    UA_StatusCode retval =
+        UA_copyCertificate(&context->remoteCertificate, remoteCertificate);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_free(context);
+        return retval;
+    }
+
+    /* decode to X509 */
+    const unsigned char *pData = context->remoteCertificate.data;
+    context->remoteCertificateX509 =
+        d2i_X509(NULL, &pData, (long)context->remoteCertificate.length);
+    if(context->remoteCertificateX509 == NULL) {
+        UA_ByteString_clear(&context->remoteCertificate);
+        UA_free(context);
+    }
+
+    context->policyContext =
+        (Policy_Context_Aes128Sha256RsaOaep *)(securityPolicy->policyContext);
+
+    *channelContext = context;
+
+    UA_LOG_INFO(
+        securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+        "The Aes128Sha256RsaOaep security policy channel with openssl is created.");
+
+    return UA_STATUSCODE_GOOD;
+}
+
+/* delete the channel context */
+
+static void
+UA_ChannelModule_Delete_Context(void *channelContext) {
+    if(channelContext != NULL) {
+        Channel_Context_Aes128Sha256RsaOaep *cc =
+            (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+        X509_free(cc->remoteCertificateX509);
+        UA_ByteString_deleteMembers(&cc->remoteCertificate);
+        UA_ByteString_deleteMembers(&cc->localSymSigningKey);
+        UA_ByteString_deleteMembers(&cc->localSymEncryptingKey);
+        UA_ByteString_deleteMembers(&cc->localSymIv);
+        UA_ByteString_deleteMembers(&cc->remoteSymSigningKey);
+        UA_ByteString_deleteMembers(&cc->remoteSymEncryptingKey);
+        UA_ByteString_deleteMembers(&cc->remoteSymIv);
+
+        UA_LOG_INFO(
+            cc->policyContext->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+            "The Aes128Sha256RsaOaep security policy channel with openssl is deleted.");
+        UA_free(cc);
+    }
+}
+
+/* Verifies the signature of the message using the provided keys in the context.
+ * AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256
+ */
+
+static UA_StatusCode
+UA_AsySig_Aes128Sha256RsaOaep_Verify(const UA_SecurityPolicy *securityPolicy,
+                                     void *channelContext, const UA_ByteString *message,
+                                     const UA_ByteString *signature) {
+    if(securityPolicy == NULL || message == NULL || signature == NULL ||
+       channelContext == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_StatusCode retval = UA_OpenSSL_RSA_PKCS1_V15_SHA256_Verify(
+        message, cc->remoteCertificateX509, signature);
+
+    return retval;
+}
+
+/* Compares the supplied certificate with the certificate
+ * in the endpoit context
+ */
+
+static UA_StatusCode
+UA_compareCertificateThumbprint(const UA_SecurityPolicy *securityPolicy,
+                                const UA_ByteString *certificateThumbprint) {
+    if(securityPolicy == NULL || certificateThumbprint == NULL) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
+    Policy_Context_Aes128Sha256RsaOaep *pc =
+        (Policy_Context_Aes128Sha256RsaOaep *)securityPolicy->policyContext;
+    if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
+        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+    return UA_STATUSCODE_GOOD;
+}
+
+/* Generates a thumbprint for the specified certificate */
+
+static UA_StatusCode
+UA_makeCertificateThumbprint(const UA_SecurityPolicy *securityPolicy,
+                             const UA_ByteString *certificate,
+                             UA_ByteString *thumbprint) {
+    return UA_Openssl_X509_GetCertificateThumbprint(certificate, thumbprint, false);
+}
+
+static UA_StatusCode
+UA_Asym_Aes128Sha256RsaOaep_Decrypt(const UA_SecurityPolicy *securityPolicy,
+                                    void *channelContext, UA_ByteString *data) {
+    if(securityPolicy == NULL || channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_StatusCode ret =
+        UA_Openssl_RSA_Oaep_Decrypt(data, &cc->policyContext->localPrivateKey);
+    return ret;
+}
+
+static size_t
+UA_Asym_Aes128Sha256RsaOaep_getRemoteSignatureSize(
+    const UA_SecurityPolicy *securityPolicy, const void *channelContext) {
+    if(securityPolicy == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes128Sha256RsaOaep *cc =
+        (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_Int32 keyLen;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    UA_assert(keyLen == 256); /* 256 bytes 2048 bit */
+    return (size_t)keyLen;
+}
+
+static size_t
+UA_AsySig_Aes128Sha256RsaOaep_getLocalSignatureSize(
+    const UA_SecurityPolicy *securityPolicy, const void *channelContext) {
+    if(securityPolicy == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Policy_Context_Aes128Sha256RsaOaep *pc =
+        (Policy_Context_Aes128Sha256RsaOaep *)securityPolicy->policyContext;
+    UA_Int32 keyLen;
+    UA_Openssl_RSA_Private_GetKeyLength(&pc->localPrivateKey, &keyLen);
+    UA_assert(keyLen == 256); /* 256 bytes 2048 bits */
+
+    return (size_t)keyLen;
+}
+
+static size_t
+UA_AsymEn_Aes128Sha256RsaOaep_getRemotePlainTextBlockSize(
+    const UA_SecurityPolicy *securityPolicy, const void *channelContext) {
+    if(securityPolicy == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes128Sha256RsaOaep *cc =
+        (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_Int32 keyLen;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen - UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN;
+}
+
+static size_t
+UA_AsymEn_Aes128Sha256RsaOaep_getRemoteBlockSize(const UA_SecurityPolicy *securityPolicy,
+                                                 const void *channelContext) {
+    if(securityPolicy == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes128Sha256RsaOaep *cc =
+        (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_Int32 keyLen;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen;
+}
+
+static size_t
+UA_AsymEn_Aes128Sha256RsaOaep_getRemoteKeyLength(const UA_SecurityPolicy *securityPolicy,
+                                                 const void *channelContext) {
+    if(securityPolicy == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes128Sha256RsaOaep *cc =
+        (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_Int32 keyLen;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen * 8;
+}
+
+static UA_StatusCode
+UA_Sym_Aes128Sha256RsaOaep_generateNonce(const UA_SecurityPolicy *sp,
+                                         UA_ByteString *out) {
+    UA_Int32 rc = RAND_bytes(out->data, (int)out->length);
+    if(rc != 1) {
+        return UA_STATUSCODE_BADUNEXPECTEDERROR;
+    }
+    return UA_STATUSCODE_GOOD;
+}
+
+static size_t
+UA_SymEn_Aes128Sha256RsaOaep_getLocalKeyLength(const UA_SecurityPolicy *securityPolicy,
+                                               const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_KEY_LENGTH;
+}
+
+static size_t
+UA_SymEn_Aes128Sha256RsaOaep_getLocalBlockSize(const UA_SecurityPolicy *securityPolicy,
+                                               const void *channelContext) {
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE;
+}
+
+static size_t
+UA_SymSig_Aes128Sha256RsaOaep_getLocalKeyLength(const UA_SecurityPolicy *securityPolicy,
+                                                const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_SIGNING_KEY_LENGTH;
+}
+
+static UA_StatusCode
+UA_Sym_Aes128Sha256RsaOaep_generateKey(const UA_SecurityPolicy *securityPolicy,
+                                       const UA_ByteString *secret,
+                                       const UA_ByteString *seed, UA_ByteString *out) {
+    return UA_Openssl_Random_Key_PSHA256_Derive(secret, seed, out);
+}
+
+static UA_StatusCode
+UA_ChannelModule_Aes128Sha256RsaOaep_setLocalSymSigningKey(void *channelContext,
+                                                           const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_ByteString_deleteMembers(&cc->localSymSigningKey);
+    return UA_ByteString_copy(key, &cc->localSymSigningKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes128Sha256RsaOaep_setLocalSymEncryptingKey(void *channelContext,
+                                                         const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_ByteString_deleteMembers(&cc->localSymEncryptingKey);
+    return UA_ByteString_copy(key, &cc->localSymEncryptingKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes128Sha256RsaOaep_setLocalSymIv(void *channelContext,
+                                              const UA_ByteString *iv) {
+    if(iv == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_ByteString_deleteMembers(&cc->localSymIv);
+    return UA_ByteString_copy(iv, &cc->localSymIv);
+}
+
+static size_t
+UA_SymEn_Aes128Sha256RsaOaep_getRemoteKeyLength(const UA_SecurityPolicy *securityPolicy,
+                                                const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_KEY_LENGTH;
+}
+
+static size_t
+UA_SymEn_Aes128Sha256RsaOaep_getRemoteBlockSize(const UA_SecurityPolicy *securityPolicy,
+                                                const void *channelContext) {
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE;
+}
+
+static size_t
+UA_SymSig_Aes128Sha256RsaOaep_getRemoteKeyLength(const UA_SecurityPolicy *securityPolicy,
+                                                 const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_SIGNING_KEY_LENGTH;
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes128Sha256RsaOaep_setRemoteSymSigningKey(void *channelContext,
+                                                       const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_ByteString_deleteMembers(&cc->remoteSymSigningKey);
+    return UA_ByteString_copy(key, &cc->remoteSymSigningKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes128Sha256RsaOaep_setRemoteSymEncryptingKey(void *channelContext,
+                                                          const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_ByteString_deleteMembers(&cc->remoteSymEncryptingKey);
+    return UA_ByteString_copy(key, &cc->remoteSymEncryptingKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes128Sha256RsaOaep_setRemoteSymIv(void *channelContext,
+                                               const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    UA_ByteString_deleteMembers(&cc->remoteSymIv);
+    return UA_ByteString_copy(key, &cc->remoteSymIv);
+}
+
+static UA_StatusCode
+UA_AsySig_Aes128Sha256RsaOaep_sign(const UA_SecurityPolicy *securityPolicy,
+                                   void *channelContext, const UA_ByteString *message,
+                                   UA_ByteString *signature) {
+    if(securityPolicy == NULL || channelContext == NULL || message == NULL ||
+       signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Policy_Context_Aes128Sha256RsaOaep *pc =
+        (Policy_Context_Aes128Sha256RsaOaep *)securityPolicy->policyContext;
+    return UA_Openssl_RSA_PKCS1_V15_SHA256_Sign(message, &pc->localPrivateKey, signature);
+}
+
+static UA_StatusCode
+UA_AsymEn_Aes128Sha256RsaOaep_encrypt(const UA_SecurityPolicy *securityPolicy,
+                                      void *channelContext, UA_ByteString *data) {
+    if(securityPolicy == NULL || channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    return UA_Openssl_RSA_OAEP_Encrypt(
+        data, UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN,
+        cc->remoteCertificateX509);
+}
+
+static size_t
+UA_SymSig_Aes128Sha256RsaOaep_getRemoteSignatureSize(
+    const UA_SecurityPolicy *securityPolicy, const void *channelContext) {
+    return UA_SHA256_LENGTH;
+}
+
+static UA_StatusCode
+UA_SymSig_Aes128Sha256RsaOaep_verify(const UA_SecurityPolicy *securityPolicy,
+                                     void *channelContext, const UA_ByteString *message,
+                                     const UA_ByteString *signature) {
+    if(securityPolicy == NULL || channelContext == NULL || message == NULL ||
+       signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    return UA_OpenSSL_HMAC_SHA256_Verify(message, &cc->remoteSymSigningKey, signature);
+}
+
+static UA_StatusCode
+UA_SymSig_Aes128Sha256RsaOaep_sign(const UA_SecurityPolicy *securityPolicy,
+                                   void *channelContext, const UA_ByteString *message,
+                                   UA_ByteString *signature) {
+    if(securityPolicy == NULL || channelContext == NULL || message == NULL ||
+       signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    return UA_OpenSSL_HMAC_SHA256_Sign(message, &cc->localSymSigningKey, signature);
+}
+
+static size_t
+UA_SymSig_Aes128Sha256RsaOaep_getLocalSignatureSize(
+    const UA_SecurityPolicy *securityPolicy, const void *channelContext) {
+    return UA_SHA256_LENGTH;
+}
+
+static UA_StatusCode
+UA_SymEn_Aes128Sha256RsaOaep_decrypt(const UA_SecurityPolicy *securityPolicy,
+                                     void *channelContext, UA_ByteString *data) {
+    if(securityPolicy == NULL || channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    return UA_OpenSSL_AES_128_CBC_Decrypt(&cc->remoteSymIv, &cc->remoteSymEncryptingKey,
+                                          data);
+}
+
+static UA_StatusCode
+UA_SymEn_Aes128Sha256RsaOaep_encrypt(const UA_SecurityPolicy *securityPolicy,
+                                     void *channelContext, UA_ByteString *data) {
+    if(securityPolicy == NULL || channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Channel_Context_Aes128Sha256RsaOaep *cc =
+        (Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    return UA_OpenSSL_AES_128_CBC_Encrypt(&cc->localSymIv, &cc->localSymEncryptingKey,
+                                          data);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes128Sha256RsaOaep_compareCertificate(const void *channelContext,
+                                                   const UA_ByteString *certificate) {
+    if(channelContext == NULL || certificate == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes128Sha256RsaOaep *cc =
+        (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
+    return UA_OpenSSL_X509_compare(certificate, cc->remoteCertificateX509);
+}
+
+static size_t
+UA_SymEn_Aes128Sha256RsaOaep_getLocalPlainTextBlockSize(
+    const UA_SecurityPolicy *securityPolicy, const void *channelContext) {
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_PLAIN_TEXT_BLOCK_SIZE;
+}
+
+static size_t
+UA_AsymEn_Aes128Sha256RsaOaep_getLocalKeyLength(const UA_SecurityPolicy *securityPolicy,
+                                                const void *channelContext) {
+    if(securityPolicy == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Policy_Context_Aes128Sha256RsaOaep *pc =
+        (Policy_Context_Aes128Sha256RsaOaep *)securityPolicy->policyContext;
+    UA_Int32 keyLen;
+    UA_Openssl_RSA_Private_GetKeyLength(&pc->localPrivateKey, &keyLen);
+    UA_assert(keyLen == 256); /* 256 bytes 2048 bits */
+
+    return (size_t)keyLen * 8;
+}
+
+/* the main entry of Aes128Sha256RsaOaep */
+
+UA_StatusCode
+UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy,
+                                      const UA_ByteString localCertificate,
+                                      const UA_ByteString localPrivateKey,
+                                      const UA_Logger *logger) {
+
+    UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
+    UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
+    UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
+    UA_StatusCode retval;
+
+    UA_LOG_INFO(logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                "The Aes128Sha256RsaOaep security policy with openssl is added.");
+
+    UA_Openssl_Init();
+    memset(policy, 0, sizeof(UA_SecurityPolicy));
+    policy->logger = logger;
+    policy->policyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep\0");
+
+    /* set ChannelModule context  */
+
+    channelModule->newContext = UA_ChannelModule_New_Context;
+    channelModule->deleteContext = UA_ChannelModule_Delete_Context;
+    channelModule->setLocalSymSigningKey =
+        UA_ChannelModule_Aes128Sha256RsaOaep_setLocalSymSigningKey;
+    channelModule->setLocalSymEncryptingKey =
+        UA_ChannelM_Aes128Sha256RsaOaep_setLocalSymEncryptingKey;
+    channelModule->setLocalSymIv = UA_ChannelM_Aes128Sha256RsaOaep_setLocalSymIv;
+    channelModule->setRemoteSymSigningKey =
+        UA_ChannelM_Aes128Sha256RsaOaep_setRemoteSymSigningKey;
+    channelModule->setRemoteSymEncryptingKey =
+        UA_ChannelM_Aes128Sha256RsaOaep_setRemoteSymEncryptingKey;
+    channelModule->setRemoteSymIv = UA_ChannelM_Aes128Sha256RsaOaep_setRemoteSymIv;
+    channelModule->compareCertificate =
+        UA_ChannelM_Aes128Sha256RsaOaep_compareCertificate;
+
+    /* Copy the certificate and add a NULL to the end */
+
+    retval = UA_copyCertificate(&policy->localCertificate, &localCertificate);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* AsymmetricModule - signature algorithm */
+
+    UA_SecurityPolicySignatureAlgorithm *asySigAlgorithm =
+        &asymmetricModule->cryptoModule.signatureAlgorithm;
+    asySigAlgorithm->uri =
+        UA_STRING("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\0");
+    asySigAlgorithm->verify = UA_AsySig_Aes128Sha256RsaOaep_Verify;
+    asySigAlgorithm->getRemoteSignatureSize =
+        UA_Asym_Aes128Sha256RsaOaep_getRemoteSignatureSize;
+    asySigAlgorithm->getLocalSignatureSize =
+        UA_AsySig_Aes128Sha256RsaOaep_getLocalSignatureSize;
+    asySigAlgorithm->sign = UA_AsySig_Aes128Sha256RsaOaep_sign;
+    asySigAlgorithm->getLocalKeyLength = NULL;
+    asySigAlgorithm->getRemoteKeyLength = NULL;
+
+    /*  AsymmetricModule encryption algorithm */
+
+    UA_SecurityPolicyEncryptionAlgorithm *asymEncryAlg =
+        &asymmetricModule->cryptoModule.encryptionAlgorithm;
+    asymEncryAlg->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#rsa-oaep\0");
+    asymEncryAlg->decrypt = UA_Asym_Aes128Sha256RsaOaep_Decrypt;
+    asymEncryAlg->getRemotePlainTextBlockSize =
+        UA_AsymEn_Aes128Sha256RsaOaep_getRemotePlainTextBlockSize;
+    asymEncryAlg->getRemoteBlockSize = UA_AsymEn_Aes128Sha256RsaOaep_getRemoteBlockSize;
+    asymEncryAlg->getRemoteKeyLength = UA_AsymEn_Aes128Sha256RsaOaep_getRemoteKeyLength;
+    asymEncryAlg->encrypt = UA_AsymEn_Aes128Sha256RsaOaep_encrypt;
+    asymEncryAlg->getLocalKeyLength = UA_AsymEn_Aes128Sha256RsaOaep_getLocalKeyLength;
+    asymEncryAlg->getLocalPlainTextBlockSize = NULL;
+    asymEncryAlg->getLocalBlockSize = NULL;
+
+    /* asymmetricModule */
+
+    asymmetricModule->compareCertificateThumbprint = UA_compareCertificateThumbprint;
+    asymmetricModule->makeCertificateThumbprint = UA_makeCertificateThumbprint;
+
+    /* SymmetricModule */
+
+    symmetricModule->secureChannelNonceLength = 32;
+    symmetricModule->generateNonce = UA_Sym_Aes128Sha256RsaOaep_generateNonce;
+    symmetricModule->generateKey = UA_Sym_Aes128Sha256RsaOaep_generateKey;
+
+    /* Symmetric encryption Algorithm */
+
+    UA_SecurityPolicyEncryptionAlgorithm *symEncryptionAlgorithm =
+        &symmetricModule->cryptoModule.encryptionAlgorithm;
+    symEncryptionAlgorithm->uri =
+        UA_STRING("http://www.w3.org/2001/04/xmlenc#aes128-cbc\0");
+    symEncryptionAlgorithm->getLocalKeyLength =
+        UA_SymEn_Aes128Sha256RsaOaep_getLocalKeyLength;
+    symEncryptionAlgorithm->getLocalBlockSize =
+        UA_SymEn_Aes128Sha256RsaOaep_getLocalBlockSize;
+    symEncryptionAlgorithm->getRemoteKeyLength =
+        UA_SymEn_Aes128Sha256RsaOaep_getRemoteKeyLength;
+    symEncryptionAlgorithm->getRemoteBlockSize =
+        UA_SymEn_Aes128Sha256RsaOaep_getRemoteBlockSize;
+    symEncryptionAlgorithm->decrypt = UA_SymEn_Aes128Sha256RsaOaep_decrypt;
+    symEncryptionAlgorithm->encrypt = UA_SymEn_Aes128Sha256RsaOaep_encrypt;
+    symEncryptionAlgorithm->getLocalPlainTextBlockSize =
+        UA_SymEn_Aes128Sha256RsaOaep_getLocalPlainTextBlockSize;
+
+    /* Symmetric signature Algorithm */
+
+    UA_SecurityPolicySignatureAlgorithm *symSignatureAlgorithm =
+        &symmetricModule->cryptoModule.signatureAlgorithm;
+    symSignatureAlgorithm->uri =
+        UA_STRING("http://www.w3.org/2000/09/xmldsig#hmac-sha2-256\0");
+    symSignatureAlgorithm->getLocalKeyLength =
+        UA_SymSig_Aes128Sha256RsaOaep_getLocalKeyLength;
+    symSignatureAlgorithm->getRemoteKeyLength =
+        UA_SymSig_Aes128Sha256RsaOaep_getRemoteKeyLength;
+    symSignatureAlgorithm->getRemoteSignatureSize =
+        UA_SymSig_Aes128Sha256RsaOaep_getRemoteSignatureSize;
+    symSignatureAlgorithm->verify = UA_SymSig_Aes128Sha256RsaOaep_verify;
+    symSignatureAlgorithm->sign = UA_SymSig_Aes128Sha256RsaOaep_sign;
+    symSignatureAlgorithm->getLocalSignatureSize =
+        UA_SymSig_Aes128Sha256RsaOaep_getLocalSignatureSize;
+
+    retval = UA_Policy_New_Context(policy, localPrivateKey, logger);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ByteString_clear(&policy->localCertificate);
+        return retval;
+    }
+    policy->clear = UA_Policy_Clear_Context;
+
+    /* Use the same signature algorithm as the asymmetric component for
+       certificate signing (see standard) */
+
+    policy->certificateSigningAlgorithm =
+        policy->asymmetricModule.cryptoModule.signatureAlgorithm;
+
+    return UA_STATUSCODE_GOOD;
+}
+
+#endif

--- a/plugins/securityPolicies/ua_securitypolicy_aes128sha256rsaoaep.c
+++ b/plugins/securityPolicies/ua_securitypolicy_aes128sha256rsaoaep.c
@@ -26,20 +26,20 @@
 #include <mbedtls/x509_crt.h>
 
 /* Notes:
- * mbedTLS' AES allows in-place encryption and decryption. Sow we don't have to
+ * mbedTLS' AES allows in-place encryption and decryption. So we don't have to
  * allocate temp buffers.
  * https://tls.mbed.org/discussions/generic/in-place-decryption-with-aes256-same-input-output-buffer
  */
 
-#define UA_SECURITYPOLICY_BASIC256SHA256_RSAPADDING_LEN 42
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN 42
 #define UA_SHA1_LENGTH 20
 #define UA_SHA256_LENGTH 32
-#define UA_BASIC256SHA256_SYM_SIGNING_KEY_LENGTH 32
-#define UA_SECURITYPOLICY_BASIC256SHA256_SYM_KEY_LENGTH 32
-#define UA_SECURITYPOLICY_BASIC256SHA256_SYM_ENCRYPTION_BLOCK_SIZE 16
-#define UA_SECURITYPOLICY_BASIC256SHA256_SYM_PLAIN_TEXT_BLOCK_SIZE 16
-#define UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH 256
-#define UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH 512
+#define UA_AES128SHA256RSAOAEP_SYM_SIGNING_KEY_LENGTH 32
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_KEY_LENGTH 16
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_PLAIN_TEXT_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH 256
+#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH 512
 
 typedef struct {
     UA_ByteString localCertThumbprint;
@@ -48,10 +48,10 @@ typedef struct {
     mbedtls_entropy_context entropyContext;
     mbedtls_md_context_t sha256MdContext;
     mbedtls_pk_context localPrivateKey;
-} Basic256Sha256_PolicyContext;
+} Aes128Sha256PsaOaep_PolicyContext;
 
 typedef struct {
-    Basic256Sha256_PolicyContext *policyContext;
+    Aes128Sha256PsaOaep_PolicyContext *policyContext;
 
     UA_ByteString localSymSigningKey;
     UA_ByteString localSymEncryptingKey;
@@ -62,7 +62,7 @@ typedef struct {
     UA_ByteString remoteSymIv;
 
     mbedtls_x509_crt remoteCertificate;
-} Basic256Sha256_ChannelContext;
+} Aes128Sha256PsaOaep_ChannelContext;
 
 /********************/
 /* AsymmetricModule */
@@ -70,10 +70,10 @@ typedef struct {
 
 /* VERIFY AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                              Basic256Sha256_ChannelContext *cc,
-                              const UA_ByteString *message,
-                              const UA_ByteString *signature) {
+asym_verify_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                   Aes128Sha256PsaOaep_ChannelContext *cc,
+                                   const UA_ByteString *message,
+                                   const UA_ByteString *signature) {
     if(securityPolicy == NULL || message == NULL || signature == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -106,10 +106,10 @@ asym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 
 /* AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_sign_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                            Basic256Sha256_ChannelContext *cc,
-                            const UA_ByteString *message,
-                            UA_ByteString *signature) {
+asym_sign_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                 Aes128Sha256PsaOaep_ChannelContext *cc,
+                                 const UA_ByteString *message,
+                                 UA_ByteString *signature) {
     if(securityPolicy == NULL || message == NULL || signature == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -121,7 +121,7 @@ asym_sign_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
     mbedtls_sha256(message->data, message->length, hash, 0);
 #endif
 
-    Basic256Sha256_PolicyContext *pc = cc->policyContext;
+    Aes128Sha256PsaOaep_PolicyContext *pc = cc->policyContext;
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(pc->localPrivateKey);
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256);
 
@@ -140,8 +140,8 @@ asym_sign_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 }
 
 static size_t
-asym_getLocalSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                             const Basic256Sha256_ChannelContext *cc) {
+asym_getLocalSignatureSize_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                  const Aes128Sha256PsaOaep_ChannelContext *cc) {
     if(securityPolicy == NULL || cc == NULL)
         return 0;
 
@@ -149,8 +149,8 @@ asym_getLocalSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityPo
 }
 
 static size_t
-asym_getRemoteSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                              const Basic256Sha256_ChannelContext *cc) {
+asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                   const Aes128Sha256PsaOaep_ChannelContext *cc) {
     if(securityPolicy == NULL || cc == NULL)
         return 0;
 
@@ -159,9 +159,9 @@ asym_getRemoteSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityP
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                               Basic256Sha256_ChannelContext *cc,
-                               UA_ByteString *data) {
+asym_encrypt_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                    Aes128Sha256PsaOaep_ChannelContext *cc,
+                                    UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -177,9 +177,9 @@ asym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                               Basic256Sha256_ChannelContext *cc,
-                               UA_ByteString *data) {
+asym_decrypt_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                    Aes128Sha256PsaOaep_ChannelContext *cc,
+                                    UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
     return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
@@ -187,47 +187,47 @@ asym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 }
 
 static size_t
-asym_getLocalEncryptionKeyLength_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                                   const Basic256Sha256_ChannelContext *cc) {
+asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                        const Aes128Sha256PsaOaep_ChannelContext *cc) {
     return mbedtls_pk_get_len(&cc->policyContext->localPrivateKey) * 8;
 }
 
 static size_t
-asym_getRemoteEncryptionKeyLength_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                                    const Basic256Sha256_ChannelContext *cc) {
+asym_getRemoteEncryptionKeyLength_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                         const Aes128Sha256PsaOaep_ChannelContext *cc) {
     return mbedtls_pk_get_len(&cc->remoteCertificate.pk) * 8;
 }
 
 static size_t
-asym_getRemoteBlockSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                          const Basic256Sha256_ChannelContext *cc) {
+asym_getRemoteBlockSize_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                               const Aes128Sha256PsaOaep_ChannelContext *cc) {
     mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
     return rsaContext->len;
 }
 
 static size_t
-asym_getRemotePlainTextBlockSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                                   const Basic256Sha256_ChannelContext *cc) {
+asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                        const Aes128Sha256PsaOaep_ChannelContext *cc) {
     mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    return rsaContext->len - UA_SECURITYPOLICY_BASIC256SHA256_RSAPADDING_LEN;
+    return rsaContext->len - UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN;
 }
 
 static UA_StatusCode
-asym_makeThumbprint_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                      const UA_ByteString *certificate,
-                                      UA_ByteString *thumbprint) {
+asym_makeThumbprint_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                           const UA_ByteString *certificate,
+                                           UA_ByteString *thumbprint) {
     if(securityPolicy == NULL || certificate == NULL || thumbprint == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
     return mbedtls_thumbprint_sha1(certificate, thumbprint);
 }
 
 static UA_StatusCode
-asymmetricModule_compareCertificateThumbprint_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                                                const UA_ByteString *certificateThumbprint) {
+asymmetricModule_compareCertificateThumbprint_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                                     const UA_ByteString *certificateThumbprint) {
     if(securityPolicy == NULL || certificateThumbprint == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
+    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
     if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
         return UA_STATUSCODE_BADCERTIFICATEINVALID;
 
@@ -239,10 +239,10 @@ asymmetricModule_compareCertificateThumbprint_sp_basic256sha256(const UA_Securit
 /*******************/
 
 static UA_StatusCode
-sym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                             Basic256Sha256_ChannelContext *cc,
-                             const UA_ByteString *message,
-                             const UA_ByteString *signature) {
+sym_verify_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                  Aes128Sha256PsaOaep_ChannelContext *cc,
+                                  const UA_ByteString *message,
+                                  const UA_ByteString *signature) {
     if(securityPolicy == NULL || cc == NULL || message == NULL || signature == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -253,8 +253,8 @@ sym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     }
 
-    Basic256Sha256_PolicyContext *pc =
-        (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
+    Aes128Sha256PsaOaep_PolicyContext *pc =
+        (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
 
     unsigned char mac[UA_SHA256_LENGTH];
     mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
@@ -266,10 +266,10 @@ sym_verify_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 }
 
 static UA_StatusCode
-sym_sign_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                           const Basic256Sha256_ChannelContext *cc,
-                           const UA_ByteString *message,
-                           UA_ByteString *signature) {
+sym_sign_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                const Aes128Sha256PsaOaep_ChannelContext *cc,
+                                const UA_ByteString *message,
+                                UA_ByteString *signature) {
     if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -279,39 +279,39 @@ sym_sign_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 }
 
 static size_t
-sym_getSignatureSize_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                       const void *channelContext) {
+sym_getSignatureSize_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                            const void *channelContext) {
     return UA_SHA256_LENGTH;
 }
 
 static size_t
-sym_getSigningKeyLength_sp_basic256sha256(const UA_SecurityPolicy *const securityPolicy,
-                                          const void *const channelContext) {
-    return UA_BASIC256SHA256_SYM_SIGNING_KEY_LENGTH;
+sym_getSigningKeyLength_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *const securityPolicy,
+                                               const void *const channelContext) {
+    return UA_AES128SHA256RSAOAEP_SYM_SIGNING_KEY_LENGTH;
 }
 
 static size_t
-sym_getEncryptionKeyLength_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                             const void *channelContext) {
-    return UA_SECURITYPOLICY_BASIC256SHA256_SYM_KEY_LENGTH;
+sym_getEncryptionKeyLength_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                  const void *channelContext) {
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_KEY_LENGTH;
 }
 
 static size_t
-sym_getEncryptionBlockSize_sp_basic256sha256(const UA_SecurityPolicy *const securityPolicy,
-                                             const void *const channelContext) {
-    return UA_SECURITYPOLICY_BASIC256SHA256_SYM_ENCRYPTION_BLOCK_SIZE;
+sym_getEncryptionBlockSize_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *const securityPolicy,
+                                                  const void *const channelContext) {
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE;
 }
 
 static size_t
-sym_getPlainTextBlockSize_sp_basic256sha256(const UA_SecurityPolicy *const securityPolicy,
-                                            const void *const channelContext) {
-    return UA_SECURITYPOLICY_BASIC256SHA256_SYM_PLAIN_TEXT_BLOCK_SIZE;
+sym_getPlainTextBlockSize_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *const securityPolicy,
+                                                 const void *const channelContext) {
+    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_PLAIN_TEXT_BLOCK_SIZE;
 }
 
 static UA_StatusCode
-sym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                              const Basic256Sha256_ChannelContext *cc,
-                              UA_ByteString *data) {
+sym_encrypt_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                   const Aes128Sha256PsaOaep_ChannelContext *cc,
+                                   UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -350,9 +350,9 @@ sym_encrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 }
 
 static UA_StatusCode
-sym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                              const Basic256Sha256_ChannelContext *cc,
-                              UA_ByteString *data) {
+sym_decrypt_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                   const Aes128Sha256PsaOaep_ChannelContext *cc,
+                                   UA_ByteString *data) {
     if(securityPolicy == NULL || cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -388,26 +388,26 @@ sym_decrypt_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 }
 
 static UA_StatusCode
-sym_generateKey_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                  const UA_ByteString *secret, const UA_ByteString *seed,
-                                  UA_ByteString *out) {
+sym_generateKey_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                       const UA_ByteString *secret, const UA_ByteString *seed,
+                                       UA_ByteString *out) {
     if(securityPolicy == NULL || secret == NULL || seed == NULL || out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic256Sha256_PolicyContext *pc =
-        (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
+    Aes128Sha256PsaOaep_PolicyContext *pc =
+        (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
 
     return mbedtls_generateKey(&pc->sha256MdContext, secret, seed, out);
 }
 
 static UA_StatusCode
-sym_generateNonce_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                    UA_ByteString *out) {
+sym_generateNonce_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                         UA_ByteString *out) {
     if(securityPolicy == NULL || securityPolicy->policyContext == NULL || out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic256Sha256_PolicyContext *pc =
-        (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
+    Aes128Sha256PsaOaep_PolicyContext *pc =
+        (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
     int mbedErr = mbedtls_ctr_drbg_random(&pc->drbgContext, out->data, out->length);
     if(mbedErr)
         return UA_STATUSCODE_BADUNEXPECTEDERROR;
@@ -420,8 +420,8 @@ sym_generateNonce_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 
 /* Assumes that the certificate has been verified externally */
 static UA_StatusCode
-parseRemoteCertificate_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                         const UA_ByteString *remoteCertificate) {
+parseRemoteCertificate_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+                                              const UA_ByteString *remoteCertificate) {
     if(remoteCertificate == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -433,15 +433,15 @@ parseRemoteCertificate_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
 
     /* Check the key length */
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    if(rsaContext->len < UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH ||
-       rsaContext->len > UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH)
+    if(rsaContext->len < UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH ||
+       rsaContext->len > UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH)
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
 
     return UA_STATUSCODE_GOOD;
 }
 
 static void
-channelContext_deleteContext_sp_basic256sha256(Basic256Sha256_ChannelContext *cc) {
+channelContext_deleteContext_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc) {
     UA_ByteString_deleteMembers(&cc->localSymSigningKey);
     UA_ByteString_deleteMembers(&cc->localSymEncryptingKey);
     UA_ByteString_deleteMembers(&cc->localSymIv);
@@ -456,21 +456,21 @@ channelContext_deleteContext_sp_basic256sha256(Basic256Sha256_ChannelContext *cc
 }
 
 static UA_StatusCode
-channelContext_newContext_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
-                                            const UA_ByteString *remoteCertificate,
-                                            void **pp_contextData) {
+channelContext_newContext_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                 const UA_ByteString *remoteCertificate,
+                                                 void **pp_contextData) {
     if(securityPolicy == NULL || remoteCertificate == NULL || pp_contextData == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* Allocate the channel context */
-    *pp_contextData = UA_malloc(sizeof(Basic256Sha256_ChannelContext));
+    *pp_contextData = UA_malloc(sizeof(Aes128Sha256PsaOaep_ChannelContext));
     if(*pp_contextData == NULL)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    Basic256Sha256_ChannelContext *cc = (Basic256Sha256_ChannelContext *)*pp_contextData;
+    Aes128Sha256PsaOaep_ChannelContext *cc = (Aes128Sha256PsaOaep_ChannelContext *)*pp_contextData;
 
     /* Initialize the channel context */
-    cc->policyContext = (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
+    cc->policyContext = (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
 
     UA_ByteString_init(&cc->localSymSigningKey);
     UA_ByteString_init(&cc->localSymEncryptingKey);
@@ -483,17 +483,17 @@ channelContext_newContext_sp_basic256sha256(const UA_SecurityPolicy *securityPol
     mbedtls_x509_crt_init(&cc->remoteCertificate);
 
     // TODO: this can be optimized so that we dont allocate memory before parsing the certificate
-    UA_StatusCode retval = parseRemoteCertificate_sp_basic256sha256(cc, remoteCertificate);
+    UA_StatusCode retval = parseRemoteCertificate_sp_aes128sha256rsaoaep(cc, remoteCertificate);
     if(retval != UA_STATUSCODE_GOOD) {
-        channelContext_deleteContext_sp_basic256sha256(cc);
+        channelContext_deleteContext_sp_aes128sha256rsaoaep(cc);
         *pp_contextData = NULL;
     }
     return retval;
 }
 
 static UA_StatusCode
-channelContext_setLocalSymEncryptingKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                          const UA_ByteString *key) {
+channelContext_setLocalSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+                                                               const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -502,8 +502,8 @@ channelContext_setLocalSymEncryptingKey_sp_basic256sha256(Basic256Sha256_Channel
 }
 
 static UA_StatusCode
-channelContext_setLocalSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                       const UA_ByteString *key) {
+channelContext_setLocalSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+                                                            const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -513,8 +513,8 @@ channelContext_setLocalSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelCon
 
 
 static UA_StatusCode
-channelContext_setLocalSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                               const UA_ByteString *iv) {
+channelContext_setLocalSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+                                                    const UA_ByteString *iv) {
     if(iv == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -523,8 +523,8 @@ channelContext_setLocalSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *cc
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymEncryptingKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                           const UA_ByteString *key) {
+channelContext_setRemoteSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+                                                                const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -533,8 +533,8 @@ channelContext_setRemoteSymEncryptingKey_sp_basic256sha256(Basic256Sha256_Channe
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                        const UA_ByteString *key) {
+channelContext_setRemoteSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+                                                             const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -543,8 +543,8 @@ channelContext_setRemoteSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelCo
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                const UA_ByteString *iv) {
+channelContext_setRemoteSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+                                                     const UA_ByteString *iv) {
     if(iv == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -553,8 +553,8 @@ channelContext_setRemoteSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *c
 }
 
 static UA_StatusCode
-channelContext_compareCertificate_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
-                                                    const UA_ByteString *certificate) {
+channelContext_compareCertificate_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
+                                                         const UA_ByteString *certificate) {
     if(cc == NULL || certificate == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -574,7 +574,7 @@ channelContext_compareCertificate_sp_basic256sha256(const Basic256Sha256_Channel
 }
 
 static void
-clear_sp_basic256sha256(UA_SecurityPolicy *securityPolicy) {
+clear_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy) {
     if(securityPolicy == NULL)
         return;
 
@@ -584,7 +584,7 @@ clear_sp_basic256sha256(UA_SecurityPolicy *securityPolicy) {
         return;
 
     /* delete all allocated members in the context */
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)
+    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)
         securityPolicy->policyContext;
 
     mbedtls_ctr_drbg_free(&pc->drbgContext);
@@ -594,24 +594,24 @@ clear_sp_basic256sha256(UA_SecurityPolicy *securityPolicy) {
     UA_ByteString_deleteMembers(&pc->localCertThumbprint);
 
     UA_LOG_DEBUG(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                 "Deleted members of EndpointContext for sp_basic256sha256");
+                 "Deleted members of EndpointContext for sp_aes128sha256rsaoaep");
 
     UA_free(pc);
     securityPolicy->policyContext = NULL;
 }
 
 static UA_StatusCode
-updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
-                                                 const UA_ByteString newCertificate,
-                                                 const UA_ByteString newPrivateKey) {
+updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy,
+                                                      const UA_ByteString newCertificate,
+                                                      const UA_ByteString newPrivateKey) {
     if(securityPolicy == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     if(securityPolicy->policyContext == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Basic256Sha256_PolicyContext *pc =
-            (Basic256Sha256_PolicyContext *) securityPolicy->policyContext;
+    Aes128Sha256PsaOaep_PolicyContext *pc =
+            (Aes128Sha256PsaOaep_PolicyContext *) securityPolicy->policyContext;
 
     UA_ByteString_deleteMembers(&securityPolicy->localCertificate);
 
@@ -633,9 +633,9 @@ updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPoli
         goto error;
     }
 
-    retval = asym_makeThumbprint_sp_basic256sha256(securityPolicy,
-                                                   &securityPolicy->localCertificate,
-                                                   &pc->localCertThumbprint);
+    retval = asym_makeThumbprint_sp_aes128sha256rsaoaep(securityPolicy,
+                                                        &securityPolicy->localCertificate,
+                                                        &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
 
@@ -645,13 +645,13 @@ updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPoli
     UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Could not update certificate and private key");
     if(securityPolicy->policyContext != NULL)
-        clear_sp_basic256sha256(securityPolicy);
+        clear_sp_aes128sha256rsaoaep(securityPolicy);
     return retval;
 }
 
 static UA_StatusCode
-policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
-                                           const UA_ByteString localPrivateKey) {
+policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy,
+                                                const UA_ByteString localPrivateKey) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(securityPolicy == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -662,8 +662,8 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)
-        UA_malloc(sizeof(Basic256Sha256_PolicyContext));
+    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)
+        UA_malloc(sizeof(Aes128Sha256PsaOaep_PolicyContext));
     securityPolicy->policyContext = (void *)pc;
     if(!pc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -671,7 +671,7 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
     }
 
     /* Initialize the PolicyContext */
-    memset(pc, 0, sizeof(Basic256Sha256_PolicyContext));
+    memset(pc, 0, sizeof(Aes128Sha256PsaOaep_PolicyContext));
     mbedtls_ctr_drbg_init(&pc->drbgContext);
     mbedtls_entropy_init(&pc->entropyContext);
     mbedtls_pk_init(&pc->localPrivateKey);
@@ -716,9 +716,9 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
     retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
-    retval = asym_makeThumbprint_sp_basic256sha256(securityPolicy,
-                                                  &securityPolicy->localCertificate,
-                                                  &pc->localCertThumbprint);
+    retval = asym_makeThumbprint_sp_aes128sha256rsaoaep(securityPolicy,
+                                                        &securityPolicy->localCertificate,
+                                                        &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
 
@@ -728,17 +728,17 @@ error:
     UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Could not create securityContext: %s", UA_StatusCode_name(retval));
     if(securityPolicy->policyContext != NULL)
-        clear_sp_basic256sha256(securityPolicy);
+        clear_sp_aes128sha256rsaoaep(securityPolicy);
     return retval;
 }
 
 UA_StatusCode
-UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_ByteString localCertificate,
+UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy, const UA_ByteString localCertificate,
                                  const UA_ByteString localPrivateKey, const UA_Logger *logger) {
     memset(policy, 0, sizeof(UA_SecurityPolicy));
     policy->logger = logger;
 
-    policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
+    policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep");
 
     UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
@@ -760,14 +760,14 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_ByteString 
         UA_STRING("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\0");
     asym_signatureAlgorithm->verify =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *,
-                           const UA_ByteString *, const UA_ByteString *))asym_verify_sp_basic256sha256;
+                           const UA_ByteString *, const UA_ByteString *))asym_verify_sp_aes128sha256rsaoaep;
     asym_signatureAlgorithm->sign =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *,
-                           const UA_ByteString *, UA_ByteString *))asym_sign_sp_basic256sha256;
+                           const UA_ByteString *, UA_ByteString *))asym_sign_sp_aes128sha256rsaoaep;
     asym_signatureAlgorithm->getLocalSignatureSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getLocalSignatureSize_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getLocalSignatureSize_sp_aes128sha256rsaoaep;
     asym_signatureAlgorithm->getRemoteSignatureSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteSignatureSize_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep;
     asym_signatureAlgorithm->getLocalKeyLength = NULL; // TODO: Write function
     asym_signatureAlgorithm->getRemoteKeyLength = NULL; // TODO: Write function
 
@@ -775,28 +775,28 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_ByteString 
         &asymmetricModule->cryptoModule.encryptionAlgorithm;
     asym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#rsa-oaep\0");
     asym_encryptionAlgorithm->encrypt =
-        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))asym_encrypt_sp_basic256sha256;
+        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))asym_encrypt_sp_aes128sha256rsaoaep;
     asym_encryptionAlgorithm->decrypt =
         (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))
-            asym_decrypt_sp_basic256sha256;
+            asym_decrypt_sp_aes128sha256rsaoaep;
     asym_encryptionAlgorithm->getLocalKeyLength =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getLocalEncryptionKeyLength_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep;
     asym_encryptionAlgorithm->getRemoteKeyLength =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteEncryptionKeyLength_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemoteEncryptionKeyLength_sp_aes128sha256rsaoaep;
     asym_encryptionAlgorithm->getLocalBlockSize = NULL; // TODO: Write function
     asym_encryptionAlgorithm->getRemoteBlockSize = (size_t (*)(const UA_SecurityPolicy *,
-                                                               const void *))asym_getRemoteBlockSize_sp_basic256sha256;
+                                                               const void *))asym_getRemoteBlockSize_sp_aes128sha256rsaoaep;
     asym_encryptionAlgorithm->getLocalPlainTextBlockSize = NULL; // TODO: Write function
     asym_encryptionAlgorithm->getRemotePlainTextBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemotePlainTextBlockSize_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep;
 
-    asymmetricModule->makeCertificateThumbprint = asym_makeThumbprint_sp_basic256sha256;
+    asymmetricModule->makeCertificateThumbprint = asym_makeThumbprint_sp_aes128sha256rsaoaep;
     asymmetricModule->compareCertificateThumbprint =
-        asymmetricModule_compareCertificateThumbprint_sp_basic256sha256;
+        asymmetricModule_compareCertificateThumbprint_sp_aes128sha256rsaoaep;
 
     /* SymmetricModule */
-    symmetricModule->generateKey = sym_generateKey_sp_basic256sha256;
-    symmetricModule->generateNonce = sym_generateNonce_sp_basic256sha256;
+    symmetricModule->generateKey = sym_generateKey_sp_aes128sha256rsaoaep;
+    symmetricModule->generateNonce = sym_generateNonce_sp_aes128sha256rsaoaep;
 
     UA_SecurityPolicySignatureAlgorithm *sym_signatureAlgorithm =
         &symmetricModule->cryptoModule.signatureAlgorithm;
@@ -804,69 +804,69 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_ByteString 
         UA_STRING("http://www.w3.org/2000/09/xmldsig#hmac-sha1\0");
     sym_signatureAlgorithm->verify =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *, const UA_ByteString *,
-                           const UA_ByteString *))sym_verify_sp_basic256sha256;
+                           const UA_ByteString *))sym_verify_sp_aes128sha256rsaoaep;
     sym_signatureAlgorithm->sign =
         (UA_StatusCode (*)(const UA_SecurityPolicy *, void *,
-                           const UA_ByteString *, UA_ByteString *))sym_sign_sp_basic256sha256;
-    sym_signatureAlgorithm->getLocalSignatureSize = sym_getSignatureSize_sp_basic256sha256;
-    sym_signatureAlgorithm->getRemoteSignatureSize = sym_getSignatureSize_sp_basic256sha256;
+                           const UA_ByteString *, UA_ByteString *))sym_sign_sp_aes128sha256rsaoaep;
+    sym_signatureAlgorithm->getLocalSignatureSize = sym_getSignatureSize_sp_aes128sha256rsaoaep;
+    sym_signatureAlgorithm->getRemoteSignatureSize = sym_getSignatureSize_sp_aes128sha256rsaoaep;
     sym_signatureAlgorithm->getLocalKeyLength =
         (size_t (*)(const UA_SecurityPolicy *,
-                    const void *))sym_getSigningKeyLength_sp_basic256sha256;
+                    const void *))sym_getSigningKeyLength_sp_aes128sha256rsaoaep;
     sym_signatureAlgorithm->getRemoteKeyLength =
         (size_t (*)(const UA_SecurityPolicy *,
-                    const void *))sym_getSigningKeyLength_sp_basic256sha256;
+                    const void *))sym_getSigningKeyLength_sp_aes128sha256rsaoaep;
 
     UA_SecurityPolicyEncryptionAlgorithm *sym_encryptionAlgorithm =
         &symmetricModule->cryptoModule.encryptionAlgorithm;
-    sym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#aes256-cbc");
+    sym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#aes128-cbc");
     sym_encryptionAlgorithm->encrypt =
-        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_encrypt_sp_basic256sha256;
+        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_encrypt_sp_aes128sha256rsaoaep;
     sym_encryptionAlgorithm->decrypt =
-        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_decrypt_sp_basic256sha256;
-    sym_encryptionAlgorithm->getLocalKeyLength = sym_getEncryptionKeyLength_sp_basic256sha256;
-    sym_encryptionAlgorithm->getRemoteKeyLength = sym_getEncryptionKeyLength_sp_basic256sha256;
+        (UA_StatusCode(*)(const UA_SecurityPolicy *, void *, UA_ByteString *))sym_decrypt_sp_aes128sha256rsaoaep;
+    sym_encryptionAlgorithm->getLocalKeyLength = sym_getEncryptionKeyLength_sp_aes128sha256rsaoaep;
+    sym_encryptionAlgorithm->getRemoteKeyLength = sym_getEncryptionKeyLength_sp_aes128sha256rsaoaep;
     sym_encryptionAlgorithm->getLocalBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_aes128sha256rsaoaep;
     sym_encryptionAlgorithm->getRemoteBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getEncryptionBlockSize_sp_aes128sha256rsaoaep;
     sym_encryptionAlgorithm->getLocalPlainTextBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_aes128sha256rsaoaep;
     sym_encryptionAlgorithm->getRemotePlainTextBlockSize =
-        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_basic256sha256;
+        (size_t (*)(const UA_SecurityPolicy *, const void *))sym_getPlainTextBlockSize_sp_aes128sha256rsaoaep;
     symmetricModule->secureChannelNonceLength = 32;
 
     // Use the same signature algorithm as the asymmetric component for certificate signing (see standard)
     policy->certificateSigningAlgorithm = policy->asymmetricModule.cryptoModule.signatureAlgorithm;
 
     /* ChannelModule */
-    channelModule->newContext = channelContext_newContext_sp_basic256sha256;
+    channelModule->newContext = channelContext_newContext_sp_aes128sha256rsaoaep;
     channelModule->deleteContext = (void (*)(void *))
-        channelContext_deleteContext_sp_basic256sha256;
+        channelContext_deleteContext_sp_aes128sha256rsaoaep;
 
     channelModule->setLocalSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymEncryptingKey_sp_basic256sha256;
+        channelContext_setLocalSymEncryptingKey_sp_aes128sha256rsaoaep;
     channelModule->setLocalSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymSigningKey_sp_basic256sha256;
+        channelContext_setLocalSymSigningKey_sp_aes128sha256rsaoaep;
     channelModule->setLocalSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymIv_sp_basic256sha256;
+        channelContext_setLocalSymIv_sp_aes128sha256rsaoaep;
 
     channelModule->setRemoteSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymEncryptingKey_sp_basic256sha256;
+        channelContext_setRemoteSymEncryptingKey_sp_aes128sha256rsaoaep;
     channelModule->setRemoteSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymSigningKey_sp_basic256sha256;
+        channelContext_setRemoteSymSigningKey_sp_aes128sha256rsaoaep;
     channelModule->setRemoteSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymIv_sp_basic256sha256;
+        channelContext_setRemoteSymIv_sp_aes128sha256rsaoaep;
 
     channelModule->compareCertificate = (UA_StatusCode (*)(const void *, const UA_ByteString *))
-        channelContext_compareCertificate_sp_basic256sha256;
+        channelContext_compareCertificate_sp_aes128sha256rsaoaep;
 
-    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_basic256sha256;
-    policy->clear = clear_sp_basic256sha256;
+    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep;
+    policy->clear = clear_sp_aes128sha256rsaoaep;
 
-    UA_StatusCode res = policyContext_newContext_sp_basic256sha256(policy, localPrivateKey);
+    UA_StatusCode res = policyContext_newContext_sp_aes128sha256rsaoaep(policy, localPrivateKey);
     if(res != UA_STATUSCODE_GOOD)
-        clear_sp_basic256sha256(policy);
+        clear_sp_aes128sha256rsaoaep(policy);
 
     return res;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,7 +85,8 @@ if(UA_ENABLE_ENCRYPTION_MBEDTLS)
        ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/securitypolicy_mbedtls_common.c
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256.c
-              ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c)
+              ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+              ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_aes128sha256rsaoaep.c)
 endif()
 
 if(UA_ENABLE_ENCRYPTION_OPENSSL)
@@ -94,6 +95,7 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL)
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic128rsa15.c
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic256.c
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic256sha256.c
+              ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_aes128sha256rsaoaep.c
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_pki_openssl.c)
 endif()
 
@@ -479,6 +481,10 @@ if(UA_ENABLE_ENCRYPTION_MBEDTLS)
     add_executable(check_encryption_basic256sha256 encryption/check_encryption_basic256sha256.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
     target_link_libraries(check_encryption_basic256sha256 ${LIBS})
     add_test_valgrind(encryption_basic256sha256 ${TESTS_BINARY_DIR}/check_encryption_basic256sha256)
+
+    add_executable(check_encryption_aes128sha256rsaoaep encryption/check_encryption_aes128sha256rsaoaep.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+    target_link_libraries(check_encryption_aes128sha256rsaoaep ${LIBS})
+    add_test_valgrind(encryption_aes128sha256rsaoaep ${TESTS_BINARY_DIR}/check_encryption_aes128sha256rsaoaep)
 endif()
 
 if(UA_ENABLE_ENCRYPTION_OPENSSL)
@@ -489,6 +495,10 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL)
     add_executable(check_encryption_basic256sha256 encryption/check_encryption_basic256sha256.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
     target_link_libraries(check_encryption_basic256sha256 ${LIBS})
     add_test_valgrind(encryption_basic256sha256 ${TESTS_BINARY_DIR}/check_encryption_basic256sha256)
+
+    add_executable(check_encryption_aes128sha256rsaoaep encryption/check_encryption_aes128sha256rsaoaep.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+    target_link_libraries(check_encryption_aes128sha256rsaoaep ${LIBS})
+    add_test_valgrind(encryption_aes128sha256rsaoaep ${TESTS_BINARY_DIR}/check_encryption_aes128sha256rsaoaep)
 endif()
 
 # Tests for Nodeset Compiler

--- a/tests/encryption/check_encryption_aes128sha256rsaoaep.c
+++ b/tests/encryption/check_encryption_aes128sha256rsaoaep.c
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2019 (c) Kalycito Infotech Private Limited
+ *
+ */
+
+#include <open62541/client.h>
+#include <open62541/client_config_default.h>
+#include <open62541/client_highlevel.h>
+#include <open62541/plugin/securitypolicy.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+
+#include "client/ua_client_internal.h"
+#include "ua_server_internal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "certificates.h"
+#include "check.h"
+#include "testing_clock.h"
+#include "testing_networklayers.h"
+#include "thread_wrapper.h"
+
+UA_Server *server;
+UA_Boolean running;
+UA_ServerNetworkLayer nl;
+THREAD_HANDLE server_thread;
+
+THREAD_CALLBACK(serverloop) {
+    while(running)
+        UA_Server_run_iterate(server, true);
+    return 0;
+}
+
+static void setup(void) {
+    running = true;
+
+    /* Load certificate and private key */
+    UA_ByteString certificate;
+    certificate.length = CERT_DER_LENGTH;
+    certificate.data = CERT_DER_DATA;
+
+    UA_ByteString privateKey;
+    privateKey.length = KEY_DER_LENGTH;
+    privateKey.data = KEY_DER_DATA;
+
+    /* Load the trustlist */
+    size_t trustListSize = 0;
+    UA_ByteString *trustList = NULL;
+
+    /* Load the issuerList */
+    size_t issuerListSize = 0;
+    UA_ByteString *issuerList = NULL;
+
+    /* TODO test trustList
+    if(argc > 3)
+        trustListSize = (size_t)argc-3;
+    UA_STACKARRAY(UA_ByteString, trustList, trustListSize);
+    for(size_t i = 0; i < trustListSize; i++)
+        trustList[i] = loadFile(argv[i+3]);
+    */
+
+    /* Loading of a revocation list currently unsupported */
+    UA_ByteString *revocationList = NULL;
+    size_t revocationListSize = 0;
+
+    server = UA_Server_new();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
+                                                   trustList, trustListSize,
+                                                   issuerList, issuerListSize,
+                                                   revocationList, revocationListSize);
+
+    /* Set the ApplicationUri used in the certificate */
+    UA_String_clear(&config->applicationDescription.applicationUri);
+    config->applicationDescription.applicationUri =
+        UA_STRING_ALLOC("urn:unconfigured:application");
+
+    for(size_t i = 0; i < trustListSize; i++)
+        UA_ByteString_deleteMembers(&trustList[i]);
+
+    UA_Server_run_startup(server);
+    THREAD_CREATE(server_thread, serverloop);
+}
+
+static void teardown(void) {
+    running = false;
+    THREAD_JOIN(server_thread);
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(encryption_connect) {
+    UA_Client *client = NULL;
+    UA_EndpointDescription* endpointArray = NULL;
+    size_t endpointArraySize = 0;
+    UA_ByteString *trustList = NULL;
+    size_t trustListSize = 0;
+    UA_ByteString *revocationList = NULL;
+    size_t revocationListSize = 0;
+
+    /* Load certificate and private key */
+    UA_ByteString certificate;
+    certificate.length = CERT_DER_LENGTH;
+    certificate.data = CERT_DER_DATA;
+    ck_assert_int_ne(certificate.length, 0);
+
+    UA_ByteString privateKey;
+    privateKey.length = KEY_DER_LENGTH;
+    privateKey.data = KEY_DER_DATA;
+    ck_assert_int_ne(privateKey.length, 0);
+
+    /* The Get endpoint (discovery service) is done with
+     * security mode as none to see the server's capability
+     * and certificate */
+    client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+    ck_assert(client != NULL);
+    UA_StatusCode retval = UA_Client_getEndpoints(client, "opc.tcp://localhost:4840",
+                                                  &endpointArraySize, &endpointArray);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(endpointArraySize > 0);
+
+    UA_Array_delete(endpointArray, endpointArraySize,
+                    &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
+
+    /* TODO test trustList Load revocationList is not supported now
+    if(argc > MIN_ARGS) {
+        trustListSize = (size_t)argc-MIN_ARGS;
+        retval = UA_ByteString_allocBuffer(trustList, trustListSize);
+        if(retval != UA_STATUSCODE_GOOD) {
+            cleanupClient(client, remoteCertificate);
+            return (int)retval;
+        }
+
+        for(size_t trustListCount = 0; trustListCount < trustListSize; trustListCount++) {
+            trustList[trustListCount] = loadFile(argv[trustListCount+3]);
+        }
+    }
+    */
+
+    UA_Client_delete(client);
+
+    /* Secure client initialization */
+    client = UA_Client_new();
+    UA_ClientConfig *cc = UA_Client_getConfig(client);
+    UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
+                                         trustList, trustListSize,
+                                         revocationList, revocationListSize);
+    cc->securityPolicyUri =
+        UA_STRING_ALLOC("http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep");
+    ck_assert(client != NULL);
+
+    for(size_t deleteCount = 0; deleteCount < trustListSize; deleteCount++) {
+        UA_ByteString_deleteMembers(&trustList[deleteCount]);
+    }
+
+    /* Secure client connect */
+    retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Variant val;
+    UA_Variant_init(&val);
+    UA_NodeId nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
+    retval = UA_Client_readValueAttribute(client, nodeId, &val);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_Variant_deleteMembers(&val);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static Suite* testSuite_encryption(void) {
+    Suite *s = suite_create("Encryption");
+    TCase *tc_encryption = tcase_create("Encryption Aes128Sha256RsaOaep security policy");
+    tcase_add_checked_fixture(tc_encryption, setup, teardown);
+#ifdef UA_ENABLE_ENCRYPTION
+    tcase_add_test(tc_encryption, encryption_connect);
+#endif /* UA_ENABLE_ENCRYPTION */
+    suite_add_tcase(s,tc_encryption);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_encryption();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -72,7 +72,8 @@ if(UA_ENABLE_ENCRYPTION)
        ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/securitypolicy_mbedtls_common.c
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
               ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256.c
-              ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c)
+              ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+              ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_aes128sha256rsaoaep.c)
 endif()
 
 add_library(open62541-fuzzplugins OBJECT


### PR DESCRIPTION
- Aes128Sha256RsaOaep security policy tested against UaExpert, OPCF reference client and UA browser.
- Unit test added for the same
- Symmetric encryption algorithm Uri is corrected in 'Basic256Sha256' policy