### PR TITLE
test: build with sign conversion warning

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,13 +11,6 @@ if(NOT MSVC AND UA_ENABLE_UNIT_TESTS_MEMCHECK)
     find_package(Valgrind REQUIRED)
 endif()
 
-if(APPLE)
-    # CLang on Apple complains about many cases like this:
-    # /Users/travis/build/open62541/open62541/tests/check_chunking.c:148:22: warning: implicit conversion changes signedness: 'size_t' (aka 'unsigned long') to 'intmax_t' (aka 'long') [-Wsign-conversion]
-    #    ck_assert_int_eq(counter,9); //10 chunks allocated - callback called 4 times
-    add_definitions(-Wno-sign-conversion)
-endif()
-
 get_property(open62541_BUILD_INCLUDE_DIRS TARGET open62541 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 include_directories(${open62541_BUILD_INCLUDE_DIRS})
 # ua_server_internal.h
@@ -46,6 +39,8 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "OpenBSD")
 endif()
 
 add_definitions(-DUA_sleep_ms=UA_comboSleep)
+
+check_add_cc_flag("-Wno-sign-conversion") # Allow warnings for sign conversion in the tests
 
 #############################
 # Compiled binaries folders #
@@ -103,10 +98,6 @@ target_compile_definitions(open62541-testplugins PRIVATE -DUA_DYNAMIC_LINKING_EX
 
 if(NOT MSVC)
     add_definitions(-Wno-deprecated-declarations)
-endif()
-# Workaround some clang warnings in the uni tests
-if((NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD") AND (CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID}" STREQUAL "xClang"))
-    add_definitions(-Wno-sign-conversion)
 endif()
 
 # Unit Test Definition Macro


### PR DESCRIPTION
CLang warns about implicit sign conversion by default.  When building
the tests, it may fail with a hard error.  Remove workaround for
Apple and non-working workaround for OpenBSD.  After the conversions
in the test files have been fixed, enable the warning for all
platforms.  Then the CI should catch regressions.