### PR TITLE
Small fix for evaluateWhereClauseContentFilter

### DIFF
--- a/src/server/ua_subscription_events.c
+++ b/src/server/ua_subscription_events.c
@@ -323,7 +323,7 @@ UA_Server_evaluateWhereClauseContentFilter(
                 UA_Variant typeNodeIdVariant;
                 UA_Variant_init(&typeNodeIdVariant);
                 UA_StatusCode readStatusCode =
-                    UA_Server_readObjectProperty(
+                    readObjectProperty(
                         server, *eventNode,
                         eventTypeQualifiedName, &typeNodeIdVariant);
                 if(readStatusCode != UA_STATUSCODE_GOOD)


### PR DESCRIPTION
Fixes recursive lock inside UA_Server_evaluateWhereClauseContentFilter