### PR TITLE
feat(server): set admin session context

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -736,7 +736,11 @@ typedef struct {
                                          const UA_NodeId *targetParentNodeId,
                                          const UA_NodeId *referenceTypeId,
                                          UA_NodeId *targetNodeId);
-    } UA_GlobalNodeLifecycle;
+} UA_GlobalNodeLifecycle;
+
+void UA_EXPORT
+UA_Server_setAdminSessionContext(UA_Server *server,
+                                 void *context);
 
 typedef struct {
     /* Can be NULL. May replace the nodeContext */

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -2247,6 +2247,12 @@ UA_Server_setMethodNode_callback(UA_Server *server,
 /* Lifecycle Management */
 /************************/
 
+void UA_EXPORT
+UA_Server_setAdminSessionContext(UA_Server *server,
+                                 void *context) {
+    server->adminSession.sessionHandle = context;
+}
+
 static UA_StatusCode
 setNodeTypeLifecycle(UA_Server *server, UA_Session *session,
                      UA_Node* node, UA_NodeTypeLifecycle *lifecycle) {


### PR DESCRIPTION
In callbacks the userland needs its context.  The node lifecycle
callbacks often use the server's admin session.  Unfortunatey the
API does not provide a possiblility to set the handle of the admin
session, so the context in the lifecycle callbacks is always NULL.
As the admin session is not part of the config it cannot be set
like the callbacks.  Provide an additional server method
UA_Server_setGlobalNodeLifecycle() that sets both, the callbacks
and the context.