### PR TITLE
fix(ci): Fix ppa build error. Regression from #3622

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -12,7 +12,6 @@ Build-Depends: debhelper (>= 9),
  texlive-plain-generic | texlive-generic-extra,
  latexmk,
  libmbedtls-dev
-
 Standards-Version: 4.4.1
 Section: libs
 Homepage: https://open62541.org/


### PR DESCRIPTION
There mustn't be a newline in the first block.

Otherwise the PPA build fails with:

```
dpkg-source: error: syntax error in recipe/debian/control at line 21: block lacks the 'Package' field
dpkg-buildpackage: error: dpkg-source -i -I --before-build recipe gave error exit status 25
```

/cc @andreasebner 