### PR TITLE
fix(plugin): Do not call openlog from syslog plugin

### DIFF
--- a/plugins/include/open62541/plugin/log_syslog.h
+++ b/plugins/include/open62541/plugin/log_syslog.h
@@ -25,14 +25,15 @@ _UA_BEGIN_DECLS
 
 #if defined(__linux__) || defined(__unix__)
 
-/* Returns a syslog-logger for messages up to the specified level. The ident and
- * option parameters are forwarded to the initial openlog. */
+/* Returns a syslog-logger for messages up to the specified level.
+ * The programm must call openlog(3) before using this logger. */
 UA_EXPORT UA_Logger
-UA_Log_Syslog_withLevel(const char *ident, int option, UA_LogLevel minlevel);
+UA_Log_Syslog_withLevel(UA_LogLevel minlevel);
 
-/* Log all warning levels supported by syslog (no trace-warnings) */
+/* Log all warning levels supported by syslog (no trace-warnings).
+ * The programm must call openlog(3) before using this logger. */
 UA_EXPORT UA_Logger
-UA_Log_Syslog(const char *ident, int option);
+UA_Log_Syslog(void);
 
 #endif
 

--- a/plugins/ua_log_syslog.c
+++ b/plugins/ua_log_syslog.c
@@ -73,13 +73,12 @@ UA_Log_Syslog_clear(void *logContext) {
 }
 
 UA_Logger
-UA_Log_Syslog(const char *ident, int option) {
-    return UA_Log_Syslog_withLevel(ident, option, UA_LOGLEVEL_TRACE);
+UA_Log_Syslog(void) {
+    return UA_Log_Syslog_withLevel(UA_LOGLEVEL_TRACE);
 }
 
 UA_Logger
-UA_Log_Syslog_withLevel(const char *ident, int option, UA_LogLevel minlevel) {
-    openlog(ident, option, LOG_USER);
+UA_Log_Syslog_withLevel(UA_LogLevel minlevel) {
     UA_Logger logger = {UA_Log_Syslog_log, (void*)minlevel, UA_Log_Syslog_clear};
     return logger;
 }


### PR DESCRIPTION
A library should not call openlog(3).  It is the program's job to
do this once at startup.  There it can select its ident, logopts
and facility.  Remove the call and its parameter from UA_Log_Syslog()
and UA_Log_Syslog_withLevel().  Write in the documentation that
openlog(3) must be called before.