### PR TITLE
feat(server:) Use config customHostname to bind server address

### DIFF
--- a/tests/server/check_server_userspace.c
+++ b/tests/server/check_server_userspace.c
@@ -133,7 +133,7 @@ START_TEST(Server_forEachChildNodeCall) {
 
 
 START_TEST(Server_set_customHostname) {
-    UA_String customHost = UA_STRING("fancy-host");
+    UA_String customHost = UA_STRING("localhost");
     UA_UInt16 port = 10042;
 
     UA_Server *server = UA_Server_new();


### PR DESCRIPTION
It should be possible to bind to a specific address instead of
always using a * socket for TCP listen.  Reuse the customHostname
of the server config.  That means that the hostname in the server
URL must be an IP address or resolveable by DNS.  The client also
puts the hostname of the URL into getaddrinfo(3) so this should not
be a problem.  Behavior changes if the customHostname was used to
create a discoveryUrl before.  Then it will be used to additionally
bind the address now.

I need this feature to build a proxy firewall that has several interface addresses. The OPC UA server should only listen on one of these.  Combining the bind address with the FQDN or IP addess in the URL seems reasonable to me.  If you disagree I could also try to extend the config and pass a second hostname down to the gethostbyname(3) in ServerNetworkLayerTCP_start().