### PR TITLE
feat(client): Call callback for failed attribute read

### DIFF
--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -796,11 +796,13 @@ void ValueAttributeRead(UA_Client *client, void *userdata,
         }
     }
 
-    /* Could not process, delete the callback anyway */
-    if(!done)
+    /* Could not process, run the callback anyway, but without value */
+    if(!done) {
         UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
                     "Cannot process the response to the async read "
                     "request %" PRIu32, requestId);
+        cc->userCallback(client, cc->userData, requestId, NULL);
+    }
 
     UA_free(cc->clientData);
     LIST_REMOVE(cc, pointers);


### PR DESCRIPTION
Currently if reading an attribute asynchronously from the client
fails, the error is not reported.  Although it is logged, the calling
program is not informed as the callback is not called.  The program
may hang forever as the callbacks are used to make progress.  After
a call to __UA_Client_readAttribute_async() the callback should be
called in all cases.  So use NULL as value pointer in ValueAttributeRead()
to report failure.  That new behavior may break existing applications,
but those programs would not work properly anyway as they wait for
the callback forever.

An open issue with this approach is, that user land can still not see the cause of the failure.  Perhaps it would be better to pass the status code or the whole read response as an additional parameter.  But that would require a much bigger API change.