### PR TITLE
fix(client): Check client config is set before connecting

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1053,6 +1053,12 @@ initConnect(UA_Client *client, const char *endpointUrl) {
         return UA_STATUSCODE_GOOD;
     }
 
+    if(client->config.initConnectionFunc == NULL) {
+        UA_LOG_ERROR(&client->config.logger, UA_LOGCATEGORY_CLIENT,
+                     "Client connection not configured");
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
     /* Consistency check the client's own ApplicationURI */
     verifyClientApplicationURI(client);
 


### PR DESCRIPTION
If the program did not set the client default config before calling
UA_Client_connect(), the program crashed due to a initConnectionFunc
NULL pointer.  This is a regression to the 1.0 behavior.  Better
log the problem in initConnect() and return internal error to give
the user a hint what went wrong.