### PR TITLE
Search for MbedTLS when using CMake module #3364

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1341,6 +1341,12 @@ endif()
 if(UA_ENABLE_ENCRYPTION)
     list(APPEND open62541_enabled_components "Encryption")
 endif()
+if(UA_ENABLE_ENCRYPTION_MBEDTLS)
+    list(APPEND open62541_enabled_components "EncryptionMbedTLS")
+endif()
+if(UA_ENABLE_ENCRYPTION_OPENSSL)
+    list(APPEND open62541_enabled_components "EncryptionOpenSSL")
+endif()
 if(UA_ENABLE_AMALGAMATION)
     list(APPEND open62541_enabled_components "Amalgamation")
 endif()
@@ -1415,6 +1421,11 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/open62541Config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/open62541ConfigVersion.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/open62541Macros.cmake"
         DESTINATION "${cmake_configfile_install}")
+
+if(UA_ENABLE_ENCRYPTION_MBEDTLS)
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/FindMbedTLS.cmake"
+            DESTINATION "${cmake_configfile_install}")
+endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     install(FILES "${PROJECT_BINARY_DIR}/src_generated/open62541.pc"

--- a/tools/cmake/FindMbedTLS.cmake
+++ b/tools/cmake/FindMbedTLS.cmake
@@ -19,17 +19,17 @@ else()
     find_library(MBEDCRYPTO_LIBRARY mbedcrypto HINTS ${MBEDTLS_FOLDER_LIBRARY})
 endif()
 
-add_library(mbedtls UNKNOWN IMPORTED)
-set_property(TARGET mbedtls PROPERTY IMPORTED_LOCATION "${MBEDTLS_LIBRARY}")
-add_library(mbedx509 UNKNOWN IMPORTED)
-set_property(TARGET mbedx509 PROPERTY IMPORTED_LOCATION "${MBEDX509_LIBRARY}")
-add_library(mbedcrypto UNKNOWN IMPORTED)
-set_property(TARGET mbedcrypto PROPERTY IMPORTED_LOCATION "${MBEDCRYPTO_LIBRARY}")
+add_library(mbedtls::mbedtls UNKNOWN IMPORTED)
+set_property(TARGET mbedtls::mbedtls PROPERTY IMPORTED_LOCATION "${MBEDTLS_LIBRARY}")
+add_library(mbedtls::mbedx509 UNKNOWN IMPORTED)
+set_property(TARGET mbedtls::mbedx509 PROPERTY IMPORTED_LOCATION "${MBEDX509_LIBRARY}")
+add_library(mbedtls::mbedcrypto UNKNOWN IMPORTED)
+set_property(TARGET mbedtls::mbedcrypto PROPERTY IMPORTED_LOCATION "${MBEDCRYPTO_LIBRARY}")
 
-set(MBEDTLS_LIBRARIES mbedtls mbedx509 mbedcrypto)
+set(MBEDTLS_LIBRARIES mbedtls::mbedtls mbedtls::mbedx509 mbedtls::mbedcrypto)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(MBEDTLS DEFAULT_MSG
+find_package_handle_standard_args(MbedTLS DEFAULT_MSG
         MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARY MBEDX509_LIBRARY MBEDCRYPTO_LIBRARY)
 
 mark_as_advanced(MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARY MBEDX509_LIBRARY MBEDCRYPTO_LIBRARY)

--- a/tools/cmake/open62541Config.cmake.in
+++ b/tools/cmake/open62541Config.cmake.in
@@ -12,6 +12,15 @@ include("${CMAKE_CURRENT_LIST_DIR}/open62541Macros.cmake")
 
 set(open62541_COMPONENTS_ALL @open62541_enabled_components@)
 
+# find_dependency has no option to provide hints for modules, so temporary add the path to CMAKE_MODULE_PATH
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+list (FIND open62541_COMPONENTS_ALL "EncryptionMbedTLS" _index)
+if(${_index} GREATER_EQUAL 0)
+    find_dependency(MbedTLS REQUIRED)
+endif()
+
+list(REMOVE_AT CMAKE_MODULE_PATH -1)
+
 foreach(_comp ${open62541_FIND_COMPONENTS})
   list (FIND open62541_COMPONENTS_ALL "${_comp}" _index)
   if (${_index} LESS 0)


### PR DESCRIPTION
If build with encrpytion and MbedTLS backend, search for MbedTLS when including the CMake package in a project.

"mbedtls::" forces cmake to look for the target and do not fall back to library. At the moment when building the library "mbedtls" is a target that resolves to the path of library. But when including open62541 in another project, cmake falls back to library seach, as no target "mbedtls" is defined. This causes problems (especially on windows) when mbedtls is not on the well known library path. (See #3364) 
