### PR TITLE
fix(nc): correct nested datatype definition parsing

### DIFF
--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -617,8 +617,8 @@ class DataTypeNode(Node):
             else:
                 logger.debug( "Encodable as: " + str(self.__baseTypeEncoding__))
                 self.__isEnum__ = False
-                self.__definition__ = typeDict
             logger.debug( "")
+        self.__definition__ = typeDict
         return self.__baseTypeEncoding__
 
 class ViewNode(Node):


### PR DESCRIPTION
The nodeset_compiler parsing code now correctly constructs the `__definition__`
Python attribute of a `DataTypeNode` if the input UANodeSetXML satisfies the following conditions:
1. The nodeset contains a datatype node in which another datatype node is nested.
2. The enclosing datatype node is located before the nested datatype in the UANodeSetXML.

Fixes #3716