### PR TITLE
fix(client) the string is null when UA_LOG_ERROR_CHANNEL is called

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -240,9 +240,12 @@ processERRResponse(UA_Client *client, const UA_ByteString *chunk) {
         return;
     }
 
-    UA_LOG_ERROR_CHANNEL(&client->config.logger, &client->channel,
-                         "Received an ERR response with StatusCode %s and the following reason: %.*s",
-                         UA_StatusCode_name(errMessage.error), (int)errMessage.reason.length, errMessage.reason.data);
+    if ((errMessage.reason.length > 0) && (errMessage.reason.data != NULL)) {
+        UA_LOG_ERROR_CHANNEL(&client->config.logger, &client->channel,
+                "Received an ERR response with StatusCode %s and the following reason: %.*s",
+                UA_StatusCode_name(errMessage.error), (int)errMessage.reason.length, 
+                errMessage.reason.data);
+    }
     client->connectStatus = errMessage.error;
     UA_TcpErrorMessage_clear(&errMessage);
 }


### PR DESCRIPTION
1. How to reproduce
use the open62541 stack to write an encryption client with a pair of public and key certificates. 
use the open62541 stack to write an encryption server with another pair of public and key certificates, and the client public certificate isn't  in the server's trust list.
The client try to connect to the server, the client is crashed.
2. Root cause and Solution:
The error reason (errMessage.reason) is empty but the return value of UA_TcpErrorMessage_decodeBinary is good when the following code is executed:
```
void
processERRResponse(UA_Client *client, const UA_ByteString *chunk) {
  ......
    UA_TcpErrorMessage errMessage;
    UA_StatusCode res = UA_TcpErrorMessage_decodeBinary(chunk, &offset, &errMessage);
......
        UA_LOG_ERROR_CHANNEL(&client->config.logger, &client->channel,
                "Received an ERR response with StatusCode %s and the following reason: %.*s",
                UA_StatusCode_name(errMessage.error), (int)errMessage.reason.length, 
                errMessage.reason.data);
```
UA_LOG_ERROR_CHANNEL try to format a null string.