### PR TITLE
[REVIEW] build(server): add support for mdnsd dependency as a conan package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,16 @@ set(XDP_LIBRARY "/usr/local/src/bpf-next/tools/lib/bpf/libbpf.a")
 include(macros_internal)
 include(macros_public)
 
+################################
+# Conan Package Manager Helper #
+################################
+
+option(CONAN_PKG_MANAGER "Manage various external dependencies via conan package manager." OFF)
+if(CONAN_PKG_MANAGER)
+    include(conan_install)
+    execute_conan_install()
+endif()
+
 #############################
 # Compiled binaries folders #
 #############################
@@ -417,7 +427,7 @@ endif()
 option(UA_BUILD_OSS_FUZZ "Special build switch used in oss-fuzz" OFF)
 mark_as_advanced(UA_BUILD_OSS_FUZZ)
 
-# Advanced Build Targets
+# Advanced Build Targetsl
 option(UA_PACK_DEBIAN "Special build switch used in .deb packaging" OFF)
 mark_as_advanced(UA_PACK_DEBIAN)
 
@@ -659,7 +669,12 @@ configure_file(open62541.pc.in ${PROJECT_BINARY_DIR}/src_generated/open62541.pc 
 
 if(UA_ENABLE_DISCOVERY_MULTICAST)
     set(MDNSD_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported" FORCE)
-    configure_file("deps/mdnsd/libmdnsd/mdnsd_config.h.in" "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h")
+    if(NOT CONAN_PKG_MANAGER)
+        configure_file("deps/mdnsd/libmdnsd/mdnsd_config.h.in" "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h")
+    else()
+        find_package(mdnsd REQUIRED)
+        add_compile_definitions(USE_CONAN_PKG_MANAGER)
+    endif()
 endif()
 
 set(exported_headers ${exported_headers}
@@ -934,19 +949,27 @@ if(UA_DEBUG_DUMP_PKGS)
 endif()
 
 if(UA_ENABLE_DISCOVERY_MULTICAST)
-    # prepend in list, otherwise it complains that winsock2.h has to be included before windows.h
-    set(internal_headers ${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h
-                         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.h
-                         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.h
-                         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.h
-                         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h
-                         ${internal_headers} )
-    set(lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_server_discovery_mdns.c
-        ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.c
-        ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.c
-        ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.c
-        ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.c
-        ${lib_sources})
+    if(NOT CONAN_PKG_MANAGER)
+        # prepend in list, otherwise it complains that winsock2.h has to be included before windows.h
+        set(internal_headers ${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h
+                            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.h
+                            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.h
+                            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.h
+                            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h
+                            ${internal_headers} 
+        )
+        set(lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_server_discovery_mdns.c
+            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.c
+            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.c
+            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.c
+            ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.c
+            ${lib_sources}
+        )
+    else()
+        set(lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_server_discovery_mdns.c
+            ${lib_sources}
+        )
+    endif()
 endif()
 
 if(UA_BUILD_FUZZING OR UA_BUILD_OSS_FUZZ)
@@ -1166,6 +1189,10 @@ if(UA_ENABLE_AMALGAMATION)
 else()
     add_library(open62541-object OBJECT ${lib_sources} ${internal_headers} ${exported_headers})
 
+    if(CONAN_PKG_MANAGER)
+        target_link_libraries(open62541-object PUBLIC mdnsd::mdnsd)
+    endif()
+
     add_custom_target(open62541-code-generation DEPENDS
                       open62541-generator-types
                       open62541-generator-transport
@@ -1266,6 +1293,10 @@ endif(NOT "${ua_architecture_remove_definitions}" STREQUAL "")
 
 GET_PROPERTY(ua_architecture_append_to_library GLOBAL PROPERTY UA_ARCHITECTURE_APPEND_TO_LIBRARY)
 list(APPEND open62541_LIBRARIES ${ua_architecture_append_to_library})
+
+if(UA_ENABLE_DISCOVERY_MULTICAST AND CONAN_PKG_MANAGER)
+    list(APPEND open62541_LIBRARIES mdnsd::mdnsd)
+endif()
 
 target_compile_definitions(open62541 PUBLIC UA_ARCHITECTURE_${UA_ARCHITECTURE_UPPER})
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,6 @@
+[requires]
+pro-mdnsd/0.8.4
+
+[generators]
+cmake_paths
+cmake_find_package

--- a/src/server/ua_discovery_manager.h
+++ b/src/server/ua_discovery_manager.h
@@ -50,8 +50,11 @@ typedef struct periodicServerRegisterCallback_entry {
 
 #ifdef UA_ENABLE_DISCOVERY_MULTICAST
 
+#ifndef USE_CONAN_PKG_MANAGER
 #include "mdnsd/libmdnsd/mdnsd.h"
-
+#else 
+#include "libmdnsd/mdnsd.h"
+#endif
 /**
  * TXT record:
  * [servername]-[hostname]._opcua-tcp._tcp.local. TXT path=/ caps=NA,DA,...

--- a/src/server/ua_server_discovery_mdns.c
+++ b/src/server/ua_server_discovery_mdns.c
@@ -11,8 +11,13 @@
 #ifdef UA_ENABLE_DISCOVERY_MULTICAST
 
 #ifndef UA_ENABLE_AMALGAMATION
+#ifndef USE_CONAN_PKG_MANAGER
 #include "mdnsd/libmdnsd/xht.h"
 #include "mdnsd/libmdnsd/sdtxt.h"
+#else 
+#include "libmdnsd/xht.h"
+#include "libmdnsd/sdtxt.h"
+#endif
 #endif
 
 #ifdef _WIN32

--- a/tools/cmake/conan_install.cmake
+++ b/tools/cmake/conan_install.cmake
@@ -1,0 +1,73 @@
+include(CMakeParseArguments)
+
+# Calls conan install to get the required dependnecies, specified in a conanfile.txt 
+# If no conanfile.txt was provided tries to search for one in the local project directory
+# Given conanfile name does not matter if it confirms with typical file naming
+# @Author: Dovydas Girdvainis
+# @Date: 2020-02-12
+macro(execute_conan_install)
+    set(options SILENT)
+    set(oneValueArgs CONANFILE)
+    set(multiValueArgs DUMMY)
+    cmake_parse_arguments(EXECUTE_CONAN_INSTALL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    find_program(conan_command conan)  
+    if(NOT conan_command)
+      message(FATAL_ERROR "Conan executable not found! If conan is not installed follow the instructions at: https://docs.conan.io/en/latest/installation.html")
+    else()
+      message(STATUS "Found program: ${conan_command}")
+      execute_process(COMMAND ${conan_command} --version
+                      OUTPUT_VARIABLE CONAN_VERSION_OUTPUT
+      )
+      message(STATUS "Using Conan Version ${CONAN_VERSION_OUTPUT}")  
+    endif()
+
+    if("${CONANFILE}" STREQUAL "")
+      find_file(LOCAL_CONANFILE conanfile.txt PATHS ${PROJECT_SOURCE_DIR} NO_DEFAULT_PATH)
+      if(NOT EXISTS "${LOCAL_CONANFILE}") 
+        message(FATAL_ERROR "No conanafile found in local project directory: ${PROJECT_SOURCE_DIR}")
+      else()
+        message(STATUS "Using local conanfile: ${LOCAL_CONANFILE}")
+        set(CONANFILE ${LOCAL_CONANFILE})
+      endif()
+    else()
+      if(NOT EXISTS "${CONANFILE}") 
+        message(FATAL_ERROR "Provided conanafile: ${CONANFILE} does not exist!")
+      endif()
+    endif()
+
+    execute_process(COMMAND ${conan_command} install ${CONANFILE}
+                    RESULT_VARIABLE return_code
+                    OUTPUT_VARIABLE conan_output
+                    ERROR_VARIABLE conan_error
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    if(NOT SILENT)
+      message("${conan_output}")
+    endif()
+    
+    if(NOT "${return_code}" STREQUAL "0")
+      message(WARNING "Conan failt to install failed!")
+      message("${conan_error}")
+      message(WARNING "Trying to build sources locally!")
+      execute_process(COMMAND ${conan_command} install ${CONANFILE} --build
+                      RESULT_VARIABLE return_code
+                      OUTPUT_VARIABLE conan_output
+                      ERROR_VARIABLE conan_error
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      )
+
+      if(NOT SILENT)
+        message("${conan_output}")
+      endif()
+
+      if(NOT "${return_code}" STREQUAL "0")
+        message(FATAL_ERROR "${conan_error}")
+      endif()
+    endif()
+    message(STATUS "Using generated conan paths from: ${CMAKE_BINARY_DIR}/conan_paths.cmake")
+    include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
+
+    
+endmacro(execute_conan_install)


### PR DESCRIPTION
## Description

This PR adds a new option called `CONAN_PKG_MANAGER` to allow the developers to use [pro-mdnsd](https://github.com/conan-io/conan-center-index/tree/master/recipes/pro-mdnsd) conan package instead of directly linking to a [submodule](https://github.com/Pro/mdnsd/tree/860b40669fb6932b2f0993e1437d46218ce53df4). 

To achieve automatic conan package installation through cmake, [conan_install.cmake](https://github.com/Hahn-Schickard/open62541/blob/conan_pkg_mnger/tools/cmake/conan_install.cmake) cmake modules is introduced. This module handles conan execution within cmake environment.

Source files [ua_discovery_manager.c](https://github.com/Hahn-Schickard/open62541/blob/conan_pkg_mnger/src/server/ua_discovery_manager.c) and [ua_discovery_manager.h](https://github.com/Hahn-Schickard/open62541/blob/conan_pkg_mnger/src/server/ua_discovery_manager.h) had to be expanded with new preprocesor definitions to support the new paths for the **mdnsd** library.

This PR helps to solve issue #3706 for future conan pkg releases.

Signed-off-by: Dovydas Girdvainis <dovydas.girdvainis@hahn-schickard.de>