### PR TITLE
refactor(client): initialize sockfd with invalid socket

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -827,6 +827,7 @@ UA_ClientConnectionTCP_init(UA_ConnectionConfig config, const UA_String endpoint
     memset(&connection, 0, sizeof(UA_Connection));
 
     connection.state = UA_CONNECTIONSTATE_OPENING;
+    connection.sockfd = UA_INVALID_SOCKET;
     connection.send = connection_write;
     connection.recv = connection_recv;
     connection.close = ClientNetworkLayerTCP_close;


### PR DESCRIPTION
In UA_ClientConnectionTCP_init() the memset of the connection
initialized the sockfd field with 0.  As this is a valid file
decriptor, some other bug caused to close stdin.  If sockfd is
initilized with -1, it will fail earlier which helps debugging.