### PR TITLE
fix(client): don't check security policy for anonym token type

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -600,7 +600,8 @@ selectEndpoint(UA_Client *client, const UA_String endpointUrl) {
             UA_UserTokenPolicy* userToken = &endpoint->userIdentityTokens[j];
 
             /* Usertokens also have a security policy... */
-            if (userToken->securityPolicyUri.length > 0 &&
+            if (tokenPolicy->tokenType != UA_USERTOKENTYPE_ANONYMOUS && 
+                userToken->securityPolicyUri.length > 0 &&
                 !getSecurityPolicy(client, userToken->securityPolicyUri)) {
                 UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT, "Rejecting UserTokenPolicy %lu in endpoint %lu: security policy '%.*s' not available",
                 (long unsigned)j, (long unsigned)i,

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -600,7 +600,7 @@ selectEndpoint(UA_Client *client, const UA_String endpointUrl) {
             UA_UserTokenPolicy* userToken = &endpoint->userIdentityTokens[j];
 
             /* Usertokens also have a security policy... */
-            if (tokenPolicy->tokenType != UA_USERTOKENTYPE_ANONYMOUS && 
+            if (userToken->tokenType != UA_USERTOKENTYPE_ANONYMOUS && 
                 userToken->securityPolicyUri.length > 0 &&
                 !getSecurityPolicy(client, userToken->securityPolicyUri)) {
                 UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT, "Rejecting UserTokenPolicy %lu in endpoint %lu: security policy '%.*s' not available",


### PR DESCRIPTION
Some servers send a securityPolicyUri even with tokenType UA_USERTOKENTYPE_ANONYMOUS which doesn't make sense at all.

An open62541 based client should be able the connect to such servers anyway

Duplicate of #3788 for the 1.0 branch.
