### PR TITLE
fix(client): don't check security policy for anonym token type

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -695,7 +695,8 @@ responseGetEndpoints(UA_Client *client, void *userdata, UA_UInt32 requestId,
             const UA_DataType *tokenType = client->config.userIdentityToken.content.decoded.type;
 
             /* Usertokens also have a security policy... */
-            if(tokenPolicy->securityPolicyUri.length > 0 &&
+            if(tokenPolicy->tokenType != UA_USERTOKENTYPE_ANONYMOUS && 
+               tokenPolicy->securityPolicyUri.length > 0 &&
                !getSecurityPolicy(client, tokenPolicy->securityPolicyUri)) {
                 UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
                             "Rejecting UserTokenPolicy %lu in endpoint %lu: "


### PR DESCRIPTION
Some servers send a securityPolicyUri even with tokenType UA_USERTOKENTYPE_ANONYMOUS which doesn't make sense at all.

An open62541 based client should be able the connect to such servers anyway