### PR TITLE
[BREAKING] feat(core): Allow all types of NodeId for the binary encoding identifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1039,7 +1039,8 @@ ua_generate_datatypes(
     TARGET_SUFFIX "transport"
     NAMESPACE_IDX 1
     FILE_CSV "${UA_FILE_NODEIDS}"
-    FILES_BSD "${UA_FILE_TYPES_BSD}" "${PROJECT_SOURCE_DIR}/tools/schema/Custom.Opc.Ua.Transport.bsd"
+    IMPORT_BSD "TYPES#${UA_FILE_TYPES_BSD}"
+    FILES_BSD "${PROJECT_SOURCE_DIR}/tools/schema/Custom.Opc.Ua.Transport.bsd"
     FILES_SELECTED "${PROJECT_SOURCE_DIR}/tools/schema/datatypes_transport.txt"
 )
 

--- a/examples/custom_datatype/custom_datatype.h
+++ b/examples/custom_datatype/custom_datatype.h
@@ -21,36 +21,35 @@ typedef struct {
 static UA_DataTypeMember Point_members[3] = {
     /* x */
     {
-        UA_TYPENAME("x") /* .memberName */
         UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
         0,               /* .padding */
         true,            /* .namespaceZero, see .memberTypeIndex */
         false,           /* .isArray */
         false            /* .isOptional */
+        UA_TYPENAME("x") /* .memberName */
     },
 
     /* y */
     {
-        UA_TYPENAME("y") /* .memberName */
         UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
         Point_padding_y, /* .padding */
         true,            /* .namespaceZero, see .memberTypeIndex */
         false,           /* .isArray */
         false            /* .isOptional */
+        UA_TYPENAME("y") /* .memberName */
     },
     /* z */
     {
-        UA_TYPENAME("z") /* .memberName */
         UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
         Point_padding_z, /* .padding */
         true,            /* .namespaceZero, see .memberTypeIndex */
         false,           /* .isArray */
         false            /* .isOptional */
+        UA_TYPENAME("z") /* .memberName */
     }
 };
 
 static const UA_DataType PointType = {
-        UA_TYPENAME("Point")                /* .tyspeName */
         {1, UA_NODEIDTYPE_NUMERIC, {4242}}, /* .typeId */
         {1, UA_NODEIDTYPE_NUMERIC, {Point_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                             identifier used on the wire (the
@@ -63,6 +62,7 @@ static const UA_DataType PointType = {
                                             the absence of padding) */
         3,                                  /* .membersSize */
         Point_members
+        UA_TYPENAME("Point")                /* .tyspeName */
 };
 
 /* The datatype description for the Measurement-Series datatype (Array Example)*/
@@ -74,27 +74,26 @@ typedef struct {
 
 static UA_DataTypeMember Measurements_members[2] = {
     {
-        UA_TYPENAME("Measurement description") /* .memberName */
         UA_TYPES_STRING,                       /* .memberTypeIndex, points into UA_TYPES
-                                               since namespaceZero is true */
+                                                   since namespaceZero is true */
         0,                                     /* .padding */
         true,                                  /* .namespaceZero, see .memberTypeIndex */
         false,                                 /* .isArray */
         false                                  /* .isOptional */
+        UA_TYPENAME("Measurement description") /* .memberName */
     },
     {
-        UA_TYPENAME("Measurements")            /* .memberName */
         UA_TYPES_FLOAT,                        /* .memberTypeIndex, points into UA_TYPES
-                                               since namespaceZero is true */
+                                                   since namespaceZero is true */
         0,                                     /* .padding */
-         true,                                 /* .namespaceZero, see .memberTypeIndex */
+        true,                                  /* .namespaceZero, see .memberTypeIndex */
         true,                                  /* .isArray */
         false                                  /* .isOptional */
+        UA_TYPENAME("Measurements")            /* .memberName */
     }
 };
 
 static const UA_DataType MeasurementType = {
-    UA_TYPENAME("Measurement")              /* .tyspeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4443}},     /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {Measurement_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                             identifier used on the wire (the
@@ -104,9 +103,10 @@ static const UA_DataType MeasurementType = {
     UA_DATATYPEKIND_STRUCTURE,              /* .typeKind */
     false,                                  /* .pointerFree */
     false,                                  /* .overlayable (depends on endianness and
-                                            the absence of padding) */
+                                                the absence of padding) */
     2,                                      /* .membersSize */
     Measurements_members
+    UA_TYPENAME("Measurement")              /* .tyspeName */
 };
 
 
@@ -120,7 +120,6 @@ typedef struct {
 static UA_DataTypeMember Opt_members[3] = {
     /* a */
     {
-        UA_TYPENAME("a")                                      /* .memberName */
         UA_TYPES_INT16,                                       /* .memberTypeIndex, points
                                                               into UA_TYPES since
                                                               namespaceZero is true */
@@ -129,10 +128,10 @@ static UA_DataTypeMember Opt_members[3] = {
                                                               .memberTypeIndex */
         false,                                                /* .isArray */
         false                                                 /* .isOptional */
+        UA_TYPENAME("a")                                      /* .memberName */
     },
     /* b */
     {
-        UA_TYPENAME("b")                                      /* .memberName */
         UA_TYPES_FLOAT,                                       /* .memberTypeIndex, points
                                                               into UA_TYPES since
                                                               namespaceZero is true */
@@ -141,23 +140,23 @@ static UA_DataTypeMember Opt_members[3] = {
                                                                .memberTypeIndex */
         false,                                                /* .isArray */
         true                                                  /* .isOptional */
+        UA_TYPENAME("b")                                      /* .memberName */
     },
     /* c */
     {
-        UA_TYPENAME("c")                                      /* .memberName */
         UA_TYPES_FLOAT,                                       /* .memberTypeIndex, points
-                                                              into UA_TYPES since
-                                                              namespaceZero is true */
+                                                                  into UA_TYPES since
+                                                                  namespaceZero is true */
         offsetof(Opt,c) - offsetof(Opt,b) - sizeof(void *),   /* .padding */
         true,                                                 /* .namespaceZero, see
-                                                              .memberTypeIndex */
+                                                                  .memberTypeIndex */
         false,                                                /* .isArray */
         true                                                  /* .isOptional */
+        UA_TYPENAME("c")                                      /* .memberName */
     }
 };
 
 static const UA_DataType OptType = {
-    UA_TYPENAME("Opt")                  /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4644}}, /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {Opt_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                         identifier used on the wire (the
@@ -167,9 +166,10 @@ static const UA_DataType OptType = {
     UA_DATATYPEKIND_OPTSTRUCT,          /* .typeKind */
     false,                              /* .pointerFree */
     false,                              /* .overlayable (depends on endianness and
-                                        the absence of padding) */
+                                            the absence of padding) */
     3,                                  /* .membersSize */
     Opt_members
+    UA_TYPENAME("Opt")                  /* .typeName */
 };
 
 /* The datatype description for the Uni datatype (Union example) */
@@ -185,27 +185,26 @@ typedef struct {
 
 static UA_DataTypeMember Uni_members[2] = {
     {
-        UA_TYPENAME("optionA")      /* .memberName */
         UA_TYPES_DOUBLE,            /* .memberTypeIndex, points into UA_TYPES since
                                     namespaceZero is true */
         sizeof(UA_UInt32),          /* .padding */
         true,                       /* .namespaceZero, see .memberTypeIndex */
         false,                      /* .isArray */
         false                       /* .isOptional */
+        UA_TYPENAME("optionA")      /* .memberName */
     },
     {
-        UA_TYPENAME("optionB")      /* .memberName */
         UA_TYPES_STRING,            /* .memberTypeIndex, points into UA_TYPES since
                                     namespaceZero is true */
         sizeof(UA_UInt32),          /* .padding */
         true,                       /* .namespaceZero, see .memberTypeIndex */
         false,                      /* .isArray */
         false                       /* .isOptional */
+        UA_TYPENAME("optionB")      /* .memberName */
     }
 };
 
 static const UA_DataType UniType = {
-    UA_TYPENAME("Uni")                      /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4845}},     /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {Uni_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                             identifier used on the wire (the
@@ -218,4 +217,5 @@ static const UA_DataType UniType = {
                                             the absence of padding) */
     2,                                      /* .membersSize */
     Uni_members
+    UA_TYPENAME("Uni")                      /* .typeName */
 };

--- a/examples/custom_datatype/custom_datatype.h
+++ b/examples/custom_datatype/custom_datatype.h
@@ -52,6 +52,9 @@ static UA_DataTypeMember Point_members[3] = {
 static const UA_DataType PointType = {
         UA_TYPENAME("Point")                /* .tyspeName */
         {1, UA_NODEIDTYPE_NUMERIC, {4242}}, /* .typeId */
+        {1, UA_NODEIDTYPE_NUMERIC, {Point_binary_encoding_id}}, /* .binaryEncodingId, the numeric
+                                            identifier used on the wire (the
+                                            namespaceindex is from .typeId) */
         sizeof(Point),                      /* .memSize */
         0,                                  /* .typeIndex, in the array of custom types */
         UA_DATATYPEKIND_STRUCTURE,          /* .typeKind */
@@ -59,9 +62,6 @@ static const UA_DataType PointType = {
         false,                              /* .overlayable (depends on endianness and
                                             the absence of padding) */
         3,                                  /* .membersSize */
-        Point_binary_encoding_id,           /* .binaryEncodingId, the numeric
-                                            identifier used on the wire (the
-                                            namespaceindex is from .typeId) */
         Point_members
 };
 
@@ -96,6 +96,9 @@ static UA_DataTypeMember Measurements_members[2] = {
 static const UA_DataType MeasurementType = {
     UA_TYPENAME("Measurement")              /* .tyspeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4443}},     /* .typeId */
+    {1, UA_NODEIDTYPE_NUMERIC, {Measurement_binary_encoding_id}}, /* .binaryEncodingId, the numeric
+                                            identifier used on the wire (the
+                                            namespaceindex is from .typeId) */
     sizeof(Measurements),                   /* .memSize */
     1,                                      /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_STRUCTURE,              /* .typeKind */
@@ -103,9 +106,6 @@ static const UA_DataType MeasurementType = {
     false,                                  /* .overlayable (depends on endianness and
                                             the absence of padding) */
     2,                                      /* .membersSize */
-    Measurement_binary_encoding_id,         /* .binaryEncodingId, the numeric
-                                            identifier used on the wire (the
-                                            namespaceindex is from .typeId) */
     Measurements_members
 };
 
@@ -159,6 +159,9 @@ static UA_DataTypeMember Opt_members[3] = {
 static const UA_DataType OptType = {
     UA_TYPENAME("Opt")                  /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4644}}, /* .typeId */
+    {1, UA_NODEIDTYPE_NUMERIC, {Opt_binary_encoding_id}}, /* .binaryEncodingId, the numeric
+                                        identifier used on the wire (the
+                                        namespaceindex is from .typeId) */
     sizeof(Opt),                        /* .memSize */
     2,                                  /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_OPTSTRUCT,          /* .typeKind */
@@ -166,9 +169,6 @@ static const UA_DataType OptType = {
     false,                              /* .overlayable (depends on endianness and
                                         the absence of padding) */
     3,                                  /* .membersSize */
-    Opt_binary_encoding_id,             /* .binaryEncodingId, the numeric
-                                        identifier used on the wire (the
-                                        namespaceindex is from .typeId) */
     Opt_members
 };
 
@@ -207,6 +207,9 @@ static UA_DataTypeMember Uni_members[2] = {
 static const UA_DataType UniType = {
     UA_TYPENAME("Uni")                      /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4845}},     /* .typeId */
+    {1, UA_NODEIDTYPE_NUMERIC, {Uni_binary_encoding_id}}, /* .binaryEncodingId, the numeric
+                                            identifier used on the wire (the
+                                            namespaceindex is from .typeId) */
     sizeof(Uni),                            /* .memSize */
     3,                                      /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_UNION,                  /* .typeKind */
@@ -214,8 +217,5 @@ static const UA_DataType UniType = {
     false,                                  /* .overlayable (depends on endianness and
                                             the absence of padding) */
     2,                                      /* .membersSize */
-    Uni_binary_encoding_id,                 /* .binaryEncodingId, the numeric
-                                            identifier used on the wire (the
-                                            namespaceindex is from .typeId) */
     Uni_members
 };

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -967,6 +967,8 @@ struct UA_DataType {
     const char *typeName;
 #endif
     UA_NodeId typeId;                /* The nodeid of the type */
+    UA_NodeId binaryEncodingId;      /* NodeId of datatype when encoded as binary */
+    //UA_NodeId xmlEncodingId;       /* NodeId of datatype when encoded as XML */
     UA_UInt16 memSize;               /* Size of the struct in memory */
     UA_UInt16 typeIndex;             /* Index of the type in the datatypetable */
     UA_UInt32 typeKind         : 6;  /* Dispatch index for the handling routines */
@@ -975,8 +977,6 @@ struct UA_DataType {
     UA_UInt32 overlayable      : 1;  /* The type has the identical memory layout
                                       * in memory and on the binary stream. */
     UA_UInt32 membersSize      : 8;  /* How many members does the type have? */
-    UA_UInt32 binaryEncodingId;      /* NodeId of datatype when encoded as binary */
-    //UA_UInt16  xmlEncodingId;      /* NodeId of datatype when encoded as XML */
     UA_DataTypeMember *members;
 };
 

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -906,9 +906,6 @@ typedef struct UA_DiagnosticInfo {
  * type operations as static inline functions. */
 
 typedef struct {
-#ifdef UA_ENABLE_TYPEDESCRIPTION
-    const char *memberName;
-#endif
     UA_UInt16 memberTypeIndex;    /* Index of the member in the array of data
                                      types */
     UA_Byte   padding;            /* How much padding is there before this
@@ -923,6 +920,9 @@ typedef struct {
                                      namespace zero only.*/
     UA_Boolean isArray       : 1; /* The member is an array */
     UA_Boolean isOptional    : 1; /* The member is an optional field */
+#ifdef UA_ENABLE_TYPEDESCRIPTION
+    const char *memberName;       /* Human-readable member name */
+#endif
 } UA_DataTypeMember;
 
 /* The DataType "kind" is an internal type classification. It is used to
@@ -963,9 +963,6 @@ typedef enum {
 } UA_DataTypeKind;
 
 struct UA_DataType {
-#ifdef UA_ENABLE_TYPEDESCRIPTION
-    const char *typeName;
-#endif
     UA_NodeId typeId;                /* The nodeid of the type */
     UA_NodeId binaryEncodingId;      /* NodeId of datatype when encoded as binary */
     //UA_NodeId xmlEncodingId;       /* NodeId of datatype when encoded as XML */
@@ -978,6 +975,12 @@ struct UA_DataType {
                                       * in memory and on the binary stream. */
     UA_UInt32 membersSize      : 8;  /* How many members does the type have? */
     UA_DataTypeMember *members;
+
+    /* The typename is only for debugging. Move last so the members pointers
+     * stays within the cacheline. */
+#ifdef UA_ENABLE_TYPEDESCRIPTION
+    const char *typeName;
+#endif
 };
 
 /* Test if the data type is a numeric builtin data type. This includes Boolean,
@@ -1104,7 +1107,7 @@ UA_Guid UA_EXPORT UA_Guid_random(void);     /* no cryptographic entropy */
 /* The following is used to exclude type names in the definition of UA_DataType
  * structures if the feature is disabled. */
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-# define UA_TYPENAME(name) name,
+# define UA_TYPENAME(name) , name
 #else
 # define UA_TYPENAME(name)
 #endif

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -200,8 +200,8 @@ UA_SecureChannel_sendAsymmetricOPNMessage(UA_SecureChannel *channel,
     hideBytesAsym(channel, &buf_pos, &buf_end);
 
     /* Encode the message type and content */
-    UA_NodeId typeId = UA_NODEID_NUMERIC(0, contentType->binaryEncodingId);
-    retval |= UA_encodeBinary(&typeId, &UA_TYPES[UA_TYPES_NODEID], &buf_pos, &buf_end, NULL, NULL);
+    retval |= UA_encodeBinary(&contentType->binaryEncodingId, &UA_TYPES[UA_TYPES_NODEID],
+                              &buf_pos, &buf_end, NULL, NULL);
     retval |= UA_encodeBinary(content, contentType, &buf_pos, &buf_end, NULL, NULL);
     if(retval != UA_STATUSCODE_GOOD) {
         connection->releaseSendBuffer(connection, &buf);
@@ -462,8 +462,8 @@ UA_SecureChannel_sendSymmetricMessage(UA_SecureChannel *channel, UA_UInt32 reque
     UA_assert(mc.buf_pos == &mc.messageBuffer.data[UA_SECURE_MESSAGE_HEADER_LENGTH]);
     UA_assert(mc.buf_end <= &mc.messageBuffer.data[mc.messageBuffer.length]);
 
-    UA_NodeId typeId = UA_NODEID_NUMERIC(0, payloadType->binaryEncodingId);
-    retval = UA_MessageContext_encode(&mc, &typeId, &UA_TYPES[UA_TYPES_NODEID]);
+    retval = UA_MessageContext_encode(&mc, &payloadType->binaryEncodingId,
+                                      &UA_TYPES[UA_TYPES_NODEID]);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -264,11 +264,9 @@ START_TEST(SecureChannel_sendAsymmetricOPNMessage_sentDataIsValid) {
                   requestId,
                   sequenceHeader.requestId);
 
-    UA_NodeId original =
-        UA_NODEID_NUMERIC(0, UA_TYPES[UA_TYPES_OPENSECURECHANNELRESPONSE].binaryEncodingId);
     UA_NodeId requestTypeId;
     UA_NodeId_decodeBinary(&sentData, &offset, &requestTypeId);
-    ck_assert_msg(UA_NodeId_equal(&original, &requestTypeId), "Expected nodeIds to be equal");
+    ck_assert_msg(UA_NodeId_equal(&UA_TYPES[UA_TYPES_OPENSECURECHANNELRESPONSE].binaryEncodingId, &requestTypeId), "Expected nodeIds to be equal");
 
     UA_OpenSecureChannelResponse sentResponse;
     UA_OpenSecureChannelResponse_decodeBinary(&sentData, &offset, &sentResponse);
@@ -340,11 +338,9 @@ START_TEST(Securechannel_sendAsymmetricOPNMessage_extraPaddingPresentWhenKeyLarg
     ck_assert_msg(sequenceHeader.requestId == requestId, "Expected requestId to be %i but was %i",
                   requestId, sequenceHeader.requestId);
 
-    UA_NodeId original =
-        UA_NODEID_NUMERIC(0, UA_TYPES[UA_TYPES_OPENSECURECHANNELRESPONSE].binaryEncodingId);
     UA_NodeId requestTypeId;
     UA_NodeId_decodeBinary(&sentData, &offset, &requestTypeId);
-    ck_assert_msg(UA_NodeId_equal(&original, &requestTypeId), "Expected nodeIds to be equal");
+    ck_assert_msg(UA_NodeId_equal(&UA_TYPES[UA_TYPES_OPENSECURECHANNELRESPONSE].binaryEncodingId, &requestTypeId), "Expected nodeIds to be equal");
 
     UA_OpenSecureChannelResponse sentResponse;
     UA_OpenSecureChannelResponse_decodeBinary(&sentData, &offset, &sentResponse);

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -38,30 +38,29 @@ typedef struct {
 static UA_DataTypeMember members[3] = {
     /* x */
     {
-        UA_TYPENAME("x") /* .memberName */
         UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since
                             .namespaceZero is true */
         0,               /* .padding */
         true,            /* .namespaceZero, see .memberTypeIndex */
-        false,            /* .isArray */
-        false           /* .isOptional*/
+        false,           /* .isArray */
+        false            /* .isOptional*/
+        UA_TYPENAME("x") /* .memberName */
     },
 
     /* y */
     {
-        UA_TYPENAME("y")
         UA_TYPES_FLOAT, padding_y, true, false, false
+        UA_TYPENAME("y")
     },
 
     /* z */
     {
-        UA_TYPENAME("z")
         UA_TYPES_FLOAT, padding_z, true, false, false
+        UA_TYPENAME("z")
     }
 };
 
 static const UA_DataType PointType = {
-    UA_TYPENAME("Point")             /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {1}}, /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {17}}, /* .binaryEncodingId, the numeric
                                          identifier used on the wire (the
@@ -74,6 +73,7 @@ static const UA_DataType PointType = {
                                          the absence of padding) */
     3,                               /* .membersSize */
     members
+    UA_TYPENAME("Point")             /* .typeName */
 };
 
 const UA_DataTypeArray customDataTypes = {NULL, 1, &PointType};
@@ -87,35 +87,34 @@ typedef struct {
 static UA_DataTypeMember Opt_members[3] = {
         /* a */
         {
-                UA_TYPENAME("a") /* .memberName */
                 UA_TYPES_INT16,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
                 0, /* .padding */
                 true,       /* .namespaceZero, see .memberTypeIndex */
                 false,      /* .isArray */
                 false       /* .isOptional */
+                UA_TYPENAME("a") /* .memberName */
         },
         /* b */
         {
-                UA_TYPENAME("b")
                 UA_TYPES_FLOAT,
                 offsetof(Opt,b) - offsetof(Opt,a) - sizeof(UA_Int16),
                 true,
                 false,
                 true        /* b is an optional field */
+                UA_TYPENAME("b")
         },
         /* c */
         {
-                UA_TYPENAME("c")
                 UA_TYPES_FLOAT,
                 offsetof(Opt,c) - offsetof(Opt,b) - sizeof(void *),
                 true,
                 false,
                 true        /* b is an optional field */
+                UA_TYPENAME("c")
         }
 };
 
 static const UA_DataType OptType = {
-        UA_TYPENAME("Opt")             /* .typeName */
         {1, UA_NODEIDTYPE_NUMERIC, {4242}}, /* .typeId */
         {1, UA_NODEIDTYPE_NUMERIC, {5}}, /* .binaryEncodingId, the numeric
                                          identifier used on the wire (the
@@ -128,6 +127,7 @@ static const UA_DataType OptType = {
                                          the absence of padding) */
         3,                               /* .membersSize */
         Opt_members
+        UA_TYPENAME("Opt")             /* .typeName */
 };
 
 const UA_DataTypeArray customDataTypesOptStruct = {&customDataTypes, 2, &OptType};
@@ -142,33 +142,32 @@ typedef struct {
 
 static UA_DataTypeMember ArrayOptStruct_members[3] = {
     {
-        UA_TYPENAME("Measurement description") /* .memberName */
         UA_TYPES_STRING,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
         0,               /* .padding */
         true,            /* .namespaceZero, see .memberTypeIndex */
         false,            /* .isArray */
         false
+        UA_TYPENAME("Measurement description") /* .memberName */
     },
     {
-        UA_TYPENAME("TestArray1") /* .memberName */
         UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
         offsetof(OptArray, bSize) - offsetof(OptArray, description) - sizeof(UA_String),               /* .padding */
         true,            /* .namespaceZero, see .memberTypeIndex */
         true,            /* .isArray */
         true
+        UA_TYPENAME("TestArray1") /* .memberName */
     },
     {
-        UA_TYPENAME("TestArray2") /* .memberName */
         UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
         offsetof(OptArray, cSize) - offsetof(OptArray, b) - sizeof(void *),               /* .padding */
         true,            /* .namespaceZero, see .memberTypeIndex */
         true,            /* .isArray */
         false
+        UA_TYPENAME("TestArray2") /* .memberName */
     }
 };
 
 static const UA_DataType ArrayOptType = {
-    UA_TYPENAME("OptArray")             /* .tyspeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4243}},     /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {1337}}, /* .binaryEncodingId, the numeric
                                          identifier used on the wire (the
@@ -181,6 +180,7 @@ static const UA_DataType ArrayOptType = {
                                          the absence of padding) */
     3,                               /* .membersSize */
     ArrayOptStruct_members
+    UA_TYPENAME("OptArray")             /* .tyspeName */
 };
 
 const UA_DataTypeArray customDataTypesOptArrayStruct = {&customDataTypesOptStruct, 3, &ArrayOptType};
@@ -197,25 +197,24 @@ typedef struct {
 
 static UA_DataTypeMember Uni_members[2] = {
         {
-                UA_TYPENAME("optionA")
                 UA_TYPES_DOUBLE,
                 sizeof(UA_UInt32),
                 true,
                 false,
                 false
+                UA_TYPENAME("optionA")
         },
         {
-                UA_TYPENAME("optionB")
                 UA_TYPES_STRING,
                 sizeof(UA_UInt32),
                 true,
                 false,
                 false
+                UA_TYPENAME("optionB")
         }
 };
 
 static const UA_DataType UniType = {
-        UA_TYPENAME("Uni")
         {1, UA_NODEIDTYPE_NUMERIC, {4245}},
         {1, UA_NODEIDTYPE_NUMERIC, {13338}},
         sizeof(Uni),
@@ -225,6 +224,7 @@ static const UA_DataType UniType = {
         false,
         2,
         Uni_members
+        UA_TYPENAME("Uni")
 };
 
 const UA_DataTypeArray customDataTypesUnion = {&customDataTypesOptArrayStruct, 2, &UniType};

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -63,6 +63,9 @@ static UA_DataTypeMember members[3] = {
 static const UA_DataType PointType = {
     UA_TYPENAME("Point")             /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {1}}, /* .typeId */
+    {1, UA_NODEIDTYPE_NUMERIC, {17}}, /* .binaryEncodingId, the numeric
+                                         identifier used on the wire (the
+                                         namespaceindex is from .typeId) */
     sizeof(Point),                   /* .memSize */
     0,                               /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_STRUCTURE,       /* .typeKind */
@@ -70,9 +73,6 @@ static const UA_DataType PointType = {
     false,                           /* .overlayable (depends on endianness and
                                          the absence of padding) */
     3,                               /* .membersSize */
-    0,                               /* .binaryEncodingId, the numeric
-                                         identifier used on the wire (the
-                                         namespaceindex is from .typeId) */
     members
 };
 
@@ -117,6 +117,9 @@ static UA_DataTypeMember Opt_members[3] = {
 static const UA_DataType OptType = {
         UA_TYPENAME("Opt")             /* .typeName */
         {1, UA_NODEIDTYPE_NUMERIC, {4242}}, /* .typeId */
+        {1, UA_NODEIDTYPE_NUMERIC, {5}}, /* .binaryEncodingId, the numeric
+                                         identifier used on the wire (the
+                                         namespaceindex is from .typeId) */
         sizeof(Opt),                   /* .memSize */
         0,                               /* .typeIndex, in the array of custom types */
         UA_DATATYPEKIND_OPTSTRUCT,       /* .typeKind */
@@ -124,9 +127,6 @@ static const UA_DataType OptType = {
         false,                           /* .overlayable (depends on endianness and
                                          the absence of padding) */
         3,                               /* .membersSize */
-        0,                               /* .binaryEncodingId, the numeric
-                                         identifier used on the wire (the
-                                         namespaceindex is from .typeId) */
         Opt_members
 };
 
@@ -170,6 +170,9 @@ static UA_DataTypeMember ArrayOptStruct_members[3] = {
 static const UA_DataType ArrayOptType = {
     UA_TYPENAME("OptArray")             /* .tyspeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4243}},     /* .typeId */
+    {1, UA_NODEIDTYPE_NUMERIC, {1337}}, /* .binaryEncodingId, the numeric
+                                         identifier used on the wire (the
+                                         namespaceindex is from .typeId) */
     sizeof(OptArray),                   /* .memSize */
     0,                               /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_OPTSTRUCT,       /* .typeKind */
@@ -177,9 +180,6 @@ static const UA_DataType ArrayOptType = {
     false,                           /* .overlayable (depends on endianness and
                                          the absence of padding) */
     3,                               /* .membersSize */
-    0,                               /* .binaryEncodingId, the numeric
-                                         identifier used on the wire (the
-                                         namespaceindex is from .typeId) */
     ArrayOptStruct_members
 };
 
@@ -217,13 +217,13 @@ static UA_DataTypeMember Uni_members[2] = {
 static const UA_DataType UniType = {
         UA_TYPENAME("Uni")
         {1, UA_NODEIDTYPE_NUMERIC, {4245}},
+        {1, UA_NODEIDTYPE_NUMERIC, {13338}},
         sizeof(Uni),
         1,
         UA_DATATYPEKIND_UNION,
         false,
         false,
         2,
-        0,
         Uni_members
 };
 

--- a/tests/fuzz/ua_debug_dump_pkgs_file.c
+++ b/tests/fuzz/ua_debug_dump_pkgs_file.c
@@ -94,13 +94,13 @@ UA_debug_dumpSetServiceName(const UA_ByteString *msg, char serviceNameTarget[100
 
     const UA_DataType *requestType = NULL;
 
-    for (size_t i=0; i<UA_TYPES_COUNT; i++) {
-        if (UA_TYPES[i].binaryEncodingId == requestTypeId.identifier.numeric) {
+    for(size_t i = 0; i < UA_TYPES_COUNT; i++) {
+        if(UA_NodeId_equal(&UA_TYPES[i].binaryEncodingId, &requestTypeId)) {
             requestType = &UA_TYPES[i];
             break;
         }
     }
-    if (requestType == NULL) {
+    if(!requestType) {
         snprintf(serviceNameTarget, 100, "invalid_request_no_type");
         return UA_STATUSCODE_BADUNEXPECTEDERROR;
     }

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -129,7 +129,7 @@ class CGenerator(object):
                                          getNodeidTypeAndId(datatype.binaryEncodingId))
         idName = makeCIdentifier(datatype.name)
         pointerfree = "true" if datatype.pointerfree else "false"
-        return "{\n    UA_TYPENAME(\"%s\") /* .typeName */\n" % idName + \
+        return "{\n" + \
                "    " + typeid + ", /* .typeId */\n" + \
                "    " + binaryEncodingId + ", /* .binaryEncodingId */\n" + \
                "    sizeof(UA_" + idName + "), /* .memSize */\n" + \
@@ -138,7 +138,9 @@ class CGenerator(object):
                "    " + pointerfree + ", /* .pointerFree */\n" + \
                "    " + self.get_type_overlayable(datatype) + ", /* .overlayable */\n" + \
                "    " + str(len(datatype.members)) + ", /* .membersSize */\n" + \
-               "    %s_members" % idName + " /* .members */\n}"
+               "    %s_members" % idName + "  /* .members */\n" + \
+               "    UA_TYPENAME(\"%s\") /* .typeName */\n" % idName + \
+               "}"
 
     @staticmethod
     def print_members(datatype):
@@ -159,8 +161,7 @@ class CGenerator(object):
             member_name_capital = member_name
             if len(member_name) > 0:
                 member_name_capital = member_name[0].upper() + member_name[1:]
-            m = "\n{\n    UA_TYPENAME(\"%s\") /* .memberName */\n" % member_name_capital
-            m += "    UA_%s_%s, /* .memberTypeIndex */\n" % (
+            m = "\n{\n    UA_%s_%s, /* .memberTypeIndex */\n" % (
                 member.member_type.outname.upper(), makeCIdentifier(member.member_type.name.upper()))
             m += "    "
             if not before:
@@ -179,8 +180,9 @@ class CGenerator(object):
                     m += " - sizeof(UA_%s)," % makeCIdentifier(before.member_type.name)
             m += " /* .padding */\n"
             m += "    %s, /* .namespaceZero */\n" % ("true" if member.member_type.ns0 else "false")
-            m += ("    true," if member.is_array else "    false,") + " /* .isArray */\n"
-            m += ("    true" if member.is_optional else "    false") + " /* .isOptional */\n}"
+            m += ("    true" if member.is_array else "    false") + ", /* .isArray */\n"
+            m += ("    true" if member.is_optional else "    false") + "  /* .isOptional */\n"
+            m += "    UA_TYPENAME(\"%s\") /* .memberName */\n}" % member_name_capital
             if i != size:
                 m += ","
             members += m

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -137,13 +137,13 @@ class CGenerator(object):
         pointerfree = "true" if datatype.pointerfree else "false"
         return "{\n    UA_TYPENAME(\"%s\") /* .typeName */\n" % idName + \
                "    " + typeid + ", /* .typeId */\n" + \
+               "    {0, UA_NODEIDTYPE_NUMERIC, {" + binaryEncodingId + "}}, /* .binaryEncodingId */\n" + \
                "    sizeof(UA_" + idName + "), /* .memSize */\n" + \
                "    " + self.get_type_index(datatype) + ", /* .typeIndex */\n" + \
                "    " + self.get_type_kind(datatype) + ", /* .typeKind */\n" + \
                "    " + pointerfree + ", /* .pointerFree */\n" + \
                "    " + self.get_type_overlayable(datatype) + ", /* .overlayable */\n" + \
                "    " + str(len(datatype.members)) + ", /* .membersSize */\n" + \
-               "    " + binaryEncodingId + ", /* .binaryEncodingId */\n" + \
                "    %s_members" % idName + " /* .members */\n}"
 
     @staticmethod


### PR DESCRIPTION
This is a breaking change for those using custom datatypes.
The change is necessary for the use case of #3787.