### PR TITLE
Fix: BadTypeDefinitionInvalid for methods in instance declarations

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -1097,7 +1097,7 @@ recursiveCallConstructors(UA_Server *server, UA_Session *session,
     if(br.statusCode != UA_STATUSCODE_GOOD)
         return br.statusCode;
 
-    /* Call the constructor for every unconstructed node */
+    /* Call the constructor for every unconstructed child node */
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     for(size_t i = 0; i < br.referencesSize; ++i) {
         UA_ReferenceDescription *rd = &br.references[i];
@@ -1110,8 +1110,8 @@ recursiveCallConstructors(UA_Server *server, UA_Session *session,
         }
 
         const UA_Node *targetType = NULL;
-        if(head->nodeClass == UA_NODECLASS_VARIABLE ||
-           head->nodeClass == UA_NODECLASS_OBJECT) {
+        if(target->head.nodeClass == UA_NODECLASS_VARIABLE ||
+           target->head.nodeClass == UA_NODECLASS_OBJECT) {
             targetType = getNodeType(server, &target->head);
             if(!targetType) {
                 UA_NODESTORE_RELEASE(server, target);


### PR DESCRIPTION
recursiveCallConstructors calls constructors for all unconstructed **child** nodes of a (parent) node recursively. Hence it determins the type of the child node in [line 1115](https://github.com/open62541/open62541/blob/master/src/server/ua_services_nodemanagement.c#L1115). So only typed children (variable and object node classes) have to be checked.
Before the fix the decission was based on the parent node class, which leads to errors, if a child is a method node for example.

This error occured while trying to load the PackML Companion Specification for the ExecuteState in PackMLMachineStateMachineType and should even be fixed in upcomming v1.1.2 updates.