### PR TITLE
feat(server): Add support for HasInterface on Object

### DIFF
--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -270,6 +270,11 @@ UA_StatusCode
 getParentTypeAndInterfaceHierarchy(UA_Server *server, const UA_NodeId *typeNode,
                                    UA_NodeId **typeHierarchy, size_t *typeHierarchySize);
 
+/* Returns the recursive interface hierarchy of the node */
+UA_StatusCode
+getInterfaceHierarchy(UA_Server *server, const UA_NodeId *objectNode,
+                                   UA_NodeId **typeHierarchy, size_t *typeHierarchySize);
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
 
 UA_StatusCode UA_EXPORT


### PR DESCRIPTION
A HasInterface reference can be on an ObjectType (already supported) and on an Object (not yet supported).

This PR adds support for HasInterface on an Object.

See https://reference.opcfoundation.org/v104/Core/docs/Amendment7/4.9.2/