### PR TITLE
fix(cmake): Only add mbedtls targets if they do not exist yet.

### DIFF
--- a/tools/cmake/FindMbedTLS.cmake
+++ b/tools/cmake/FindMbedTLS.cmake
@@ -19,12 +19,15 @@ else()
     find_library(MBEDCRYPTO_LIBRARY mbedcrypto HINTS ${MBEDTLS_FOLDER_LIBRARY})
 endif()
 
-add_library(mbedtls::mbedtls UNKNOWN IMPORTED)
-set_property(TARGET mbedtls::mbedtls PROPERTY IMPORTED_LOCATION "${MBEDTLS_LIBRARY}")
-add_library(mbedtls::mbedx509 UNKNOWN IMPORTED)
-set_property(TARGET mbedtls::mbedx509 PROPERTY IMPORTED_LOCATION "${MBEDX509_LIBRARY}")
-add_library(mbedtls::mbedcrypto UNKNOWN IMPORTED)
-set_property(TARGET mbedtls::mbedcrypto PROPERTY IMPORTED_LOCATION "${MBEDCRYPTO_LIBRARY}")
+if (NOT TARGET mbedtls::mbedtls)
+    # Only add library if not yet added. If project referenced multiple times, the target is also created multiple times.
+    add_library(mbedtls::mbedtls UNKNOWN IMPORTED)
+    set_property(TARGET mbedtls::mbedtls PROPERTY IMPORTED_LOCATION "${MBEDTLS_LIBRARY}")
+    add_library(mbedtls::mbedx509 UNKNOWN IMPORTED)
+    set_property(TARGET mbedtls::mbedx509 PROPERTY IMPORTED_LOCATION "${MBEDX509_LIBRARY}")
+    add_library(mbedtls::mbedcrypto UNKNOWN IMPORTED)
+    set_property(TARGET mbedtls::mbedcrypto PROPERTY IMPORTED_LOCATION "${MBEDCRYPTO_LIBRARY}")
+endif()
 
 set(MBEDTLS_LIBRARIES mbedtls::mbedtls mbedtls::mbedx509 mbedtls::mbedcrypto)
 


### PR DESCRIPTION
If open62541 is included multiple times with find_package, the target may be created multiple times and cmake complains.