### PR TITLE
feat(client): state callback context

### DIFF
--- a/examples/client_async.c
+++ b/examples/client_async.c
@@ -13,7 +13,7 @@
 /* async connection callback, it only gets called after the completion of the whole
  * connection process*/
 static void
-onConnect(UA_Client *client, UA_SecureChannelState channelState,
+onConnect(UA_Client *client, void *context, UA_SecureChannelState channelState,
           UA_SessionState sessionState, UA_StatusCode connectStatus) {
     printf("Async connect returned with status code %s\n",
            UA_StatusCode_name(connectStatus));

--- a/examples/client_subscription_loop.c
+++ b/examples/client_subscription_loop.c
@@ -49,7 +49,8 @@ subscriptionInactivityCallback (UA_Client *client, UA_UInt32 subId, void *subCon
 }
 
 static void
-stateCallback(UA_Client *client, UA_SecureChannelState channelState,
+stateCallback(UA_Client *client, void *context,
+              UA_SecureChannelState channelState,
               UA_SessionState sessionState, UA_StatusCode recoveryStatus) {
     switch(channelState) {
     case UA_SECURECHANNELSTATE_CLOSED:

--- a/include/open62541/client.h
+++ b/include/open62541/client.h
@@ -136,7 +136,7 @@ typedef struct {
      * the client connection (including reconnects) has failed and the client
      * has to "give up". If the connectStatus is not set, the client still has
      * hope to connect or recover. */
-    void (*stateCallback)(UA_Client *client,
+    void (*stateCallback)(UA_Client *client, void *context,
                           UA_SecureChannelState channelState,
                           UA_SessionState sessionState,
                           UA_StatusCode connectStatus);

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -167,7 +167,8 @@ notifyClientState(UA_Client *client) {
     client->oldSessionState = client->sessionState;
 
     if(client->config.stateCallback)
-        client->config.stateCallback(client, client->channel.state,
+        client->config.stateCallback(client, client->config.clientContext,
+                                     client->channel.state,
                                      client->sessionState, client->connectStatus);
 }
 

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -881,7 +881,8 @@ static UA_SecureChannelState chanState;
 static UA_SessionState sessState;
 
 static void
-stateCallback(UA_Client *client, UA_SecureChannelState channelState,
+stateCallback(UA_Client *client, void *context,
+              UA_SecureChannelState channelState,
               UA_SessionState sessionState, UA_StatusCode recoveryStatus) {
     chanState = channelState;
     sessState = sessionState;


### PR DESCRIPTION
Callbacks that provide a context are much more useful for the callee.
Then it can derive its working data without a global variable.  Add
a stateContext to client config and pass it to the stateCallback
as parameter.