### PR TITLE
Pub sub export api ua pub sub connection regist

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -621,6 +621,10 @@ UA_Server_setReaderGroupOperational(UA_Server *server, const UA_NodeId readerGro
 UA_StatusCode UA_EXPORT
 UA_Server_setReaderGroupDisabled(UA_Server *server, const UA_NodeId readerGroupId);
 
+/* Register channel for given connectionIdentifier */
+UA_StatusCode UA_EXPORT
+UA_PubSubConnection_regist(UA_Server *server, UA_NodeId *connectionIdentifier);
+
 #endif /* UA_ENABLE_PUBSUB */
 
 _UA_END_DECLS

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -79,9 +79,6 @@ void
 UA_PubSubConnectionConfig_clear(UA_PubSubConnectionConfig *connectionConfig);
 void
 UA_PubSubConnection_clear(UA_Server *server, UA_PubSubConnection *connection);
-/* Register channel for given connectionIdentifier */
-UA_StatusCode
-UA_PubSubConnection_regist(UA_Server *server, UA_NodeId *connectionIdentifier);
 
 /**********************************************/
 /*              DataSetWriter                 */


### PR DESCRIPTION
Export API UA_PubSubConnection_regist(). This is necessary for application code to automatically publish node's value once PubSubConnection is added and server is up.