### PR TITLE
[WIP] Tool to test all possible failure points that use malloc, calloc and realloc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,40 @@ git:
 matrix:
   fast_finish: true
   include:
+  
+# gcc-4.8 (trusty) full host and cross build with tests:
+# doc, cert, cross-mingw32, cross-mingw64, cross-linux32, cross-raspi, linux64,
+# amalgamated, shared, multithread, encryption, discovery, json, test-ns0-full, test-ns0-minimal
+    - os: linux
+      compiler: gcc-4.8
+      addons:
+        apt:
+          sources:
+            # see https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
+            - ubuntu-toolchain-r-test
+          packages:
+            - mingw-w64
+            - gcc-mingw-w64-i686
+            - gcc-mingw-w64-x86-64
+            - binutils-mingw-w64-i686
+            - g++-multilib
+            - cmake
+            # doc
+            - python-sphinx
+            - graphviz
+            - texlive-generic-extra
+            - texlive-fonts-recommended
+            - texlive-latex-extra
+            - latexmk
+            # tests
+            - check
+            - libsubunit-dev
+            - valgrind
+      env:
+        - COVERAGE=true
+        - MINGW=true
+  
+  
 #
 # gcc-4.8 (trusty) full host and cross build with tests:
 # doc, cert, cross-mingw32, cross-mingw64, cross-linux32, cross-raspi, linux64,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -508,5 +508,19 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL)
     add_test_valgrind(encryption_aes128sha256rsaoaep ${TESTS_BINARY_DIR}/check_encryption_aes128sha256rsaoaep)
 endif()
 
+
+if(UA_ENABLE_MALLOC_SINGLETON)
+	add_executable(check_allocation allocation/check_allocation.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+	target_link_libraries(check_allocation ${LIBS})
+	add_test_valgrind(allocation ${TESTS_BINARY_DIR}/check_allocation)
+	
+	add_custom_command(	TARGET check_allocation POST_BUILD
+						COMMAND ${PYTHON_EXECUTABLE} ${open62541_TOOLS_DIR}/asmParser.py -f ${TESTS_BINARY_DIR}/check_allocation
+						DEPENDS 
+						${TESTS_BINARY_DIR}/check_allocation
+						${open62541_TOOLS_DIR}/asmParser.py)
+endif(UA_ENABLE_MALLOC_SINGLETON)
+					
+
 # Tests for Nodeset Compiler
 add_subdirectory(nodeset-compiler)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -515,7 +515,7 @@ if(UA_ENABLE_MALLOC_SINGLETON)
 	add_test_valgrind(allocation ${TESTS_BINARY_DIR}/check_allocation)
 	
 	add_custom_command(	TARGET check_allocation POST_BUILD
-						COMMAND ${PYTHON_EXECUTABLE} ${open62541_TOOLS_DIR}/asmParser.py -f ${TESTS_BINARY_DIR}/check_allocation
+						COMMAND ${PYTHON_EXECUTABLE} ${open62541_TOOLS_DIR}/asmParser.py -b ${TESTS_BINARY_DIR}/check_allocation -e "namespace0_generated" -f "UA_mallocSingleton" -f "UA_callocSingleton" -f "UA_reallocSingleton"
 						DEPENDS 
 						${TESTS_BINARY_DIR}/check_allocation
 						${open62541_TOOLS_DIR}/asmParser.py)

--- a/tests/allocation/check_allocation.c
+++ b/tests/allocation/check_allocation.c
@@ -67,18 +67,9 @@ static void functionToTest(void) {
   int nptrs = backtrace(stackBuffer, STACK_DEPTH); \
     for(int i = 0; i < nptrs; i++) { \
       if(stackBuffer[i] == (void*) currentInfo.addressToBreak) { \
-        printf("BREAKING at address %" PRIxPTR ",line:\n%s\n", currentInfo.addressToBreak, currentInfo.lineToBreak); \
+        printf("BREAKING at address %" PRIxPTR ": %s", currentInfo.addressToBreak, currentInfo.lineToBreak); \
         numberOfBreaks++; \
         currentInfo.alreadyBroken = !0; \
-        char** strs = backtrace_symbols(stackBuffer, nptrs); \
-        if(!strs) { \
-          printf("Error getting stack trace names\n"); \
-        } else { \
-          for(int j = 0; j < nptrs; j++) { \
-            printf("%s\n", strs[j]); \
-          } \
-          free(strs); \
-        } \
         return NULL; \
       } \
     }
@@ -120,14 +111,14 @@ START_TEST( checkAllocation) {
 
       currentInfo.alreadyBroken = 0;
       currentInfo.addressToBreak = atoi(lineBuffer);
-      printf("Line to break is %" PRIxPTR ", line:\n%s\n", currentInfo.addressToBreak, currentInfo.lineToBreak);
+      printf("Line to break is %" PRIxPTR ": %s", currentInfo.addressToBreak, currentInfo.lineToBreak);
       totalFailurePoints++;
 
       functionToTest();
 
     }
 
-    printf("No more file reading. %d of %d failure points were tested\n", numberOfBreaks, totalFailurePoints);
+    printf("No more lines to break. %d of %d failure points were tested\n", numberOfBreaks, totalFailurePoints);
 
   }
 }
@@ -163,7 +154,6 @@ int main(void) {
   srunner_set_fork_status(sr, CK_NOFORK);
   srunner_run_all(sr, CK_NORMAL);
   int number_failed = srunner_ntests_failed(sr);
-  printf("Number of failure is %d", number_failed);
   srunner_free(sr);
   return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/allocation/check_allocation.c
+++ b/tests/allocation/check_allocation.c
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright 2019 (c) basysKom GmbH <opensource@basyskom.com> (Author: Frank Meerkötter)
+ */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/types.h>
+
+#include "server/ua_server_internal.h"
+#include "server/ua_services.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "check.h"
+
+#include <execinfo.h>
+
+#define MEMORY_FILE "allocationFailurePoints"
+#define STACK_DEPTH 20
+
+struct BreakingInfo {
+  uintptr_t addressToBreak;
+  const char* lineToBreak;
+  bool alreadyBroken;
+
+};
+
+static struct BreakingInfo currentInfo = { 0, "", false };
+
+static void* stackBuffer[STACK_DEPTH];
+static FILE* memoryFile;
+static int numberOfBreaks = 0;
+static int totalFailurePoints = 0;
+
+
+static UA_Server* server = NULL;
+
+//static void timedCallbackHandler(UA_Server* s, void* data) {
+//  *((UA_Boolean*) data) = false; // stop the server via a timedCallback
+//}
+
+
+static void functionToTest(void) {
+  server = UA_Server_new();
+  if(!server)
+    return;
+
+  if(UA_STATUSCODE_GOOD != UA_ServerConfig_setDefault(UA_Server_getConfig(server))) {
+    UA_Server_delete(server);
+    return;
+  }
+
+  //UA_Boolean running = true;
+  // 0 is in the past so the server will terminate on the first iteration
+  //UA_Server_addTimedCallback(server, &timedCallbackHandler, &running, 0, NULL);
+
+  UA_Server_delete(server);
+}
+
+#define CHECK_STACK_AND_BREAK \
+  if (currentInfo.alreadyBroken) return NULL; \
+  int nptrs = backtrace(stackBuffer, STACK_DEPTH); \
+    for(int i = 0; i < nptrs; i++) { \
+      if(stackBuffer[i] == (void*) currentInfo.addressToBreak) { \
+        printf("BREAKING at address %" PRIxPTR ",line:\n%s\n", currentInfo.addressToBreak, currentInfo.lineToBreak); \
+        numberOfBreaks++; \
+        currentInfo.alreadyBroken = !0; \
+        char** strs = backtrace_symbols(stackBuffer, nptrs); \
+        if(!strs) { \
+          printf("Error getting stack trace names\n"); \
+        } else { \
+          for(int j = 0; j < nptrs; j++) { \
+            printf("%s\n", strs[j]); \
+          } \
+          free(strs); \
+        } \
+        return NULL; \
+      } \
+    }
+
+
+
+void* mallocWrapper(size_t size);
+void* callocWrapper(size_t nelem, size_t elsize);
+void* reallocWrapper(void* ptr, size_t size);
+
+void* mallocWrapper(size_t size) {
+  CHECK_STACK_AND_BREAK
+  return malloc(size);
+}
+
+void* callocWrapper(size_t nelem, size_t elsize) {
+  CHECK_STACK_AND_BREAK
+  return calloc(nelem, elsize);
+}
+
+void* reallocWrapper(void* ptr, size_t size) {
+  CHECK_STACK_AND_BREAK
+  return realloc(ptr, size);
+}
+
+START_TEST( checkAllocation) {
+  ck_assert(memoryFile != NULL);
+  if(memoryFile) {
+    char lineBuffer[200];
+    while(fgets(lineBuffer, 200, memoryFile)) {
+      char* startOfText = strchr(lineBuffer, ',');
+      if(startOfText == 0) {
+        printf("Line %s doesn't have source file description\n", lineBuffer);
+        currentInfo.lineToBreak = "";
+      } else {
+        currentInfo.lineToBreak = startOfText + 1;
+        *startOfText = '\0';
+      }
+
+      currentInfo.alreadyBroken = 0;
+      currentInfo.addressToBreak = atoi(lineBuffer);
+      printf("Line to break is %" PRIxPTR ", line:\n%s\n", currentInfo.addressToBreak, currentInfo.lineToBreak);
+      totalFailurePoints++;
+
+      functionToTest();
+
+    }
+
+    printf("No more file reading. %d of %d failure points were tested\n", numberOfBreaks, totalFailurePoints);
+
+  }
+}
+END_TEST
+
+static void setup(void) {
+  //open file
+  memoryFile = fopen(MEMORY_FILE, "r");
+  if(!memoryFile) {
+    printf("ERROR: Couldn't find file %s\n", MEMORY_FILE);
+  }
+  UA_mallocSingleton = mallocWrapper;
+  UA_callocSingleton = callocWrapper;
+  UA_reallocSingleton = reallocWrapper;
+
+}
+
+static void teardown(void) {
+  if(memoryFile) {
+    fclose(memoryFile);
+  }
+}
+
+int main(void) {
+  Suite* s = suite_create("Allocation Failure");
+
+  TCase* tc_call = tcase_create("Allocation failure points");
+  tcase_add_checked_fixture(tc_call, setup, teardown);
+  tcase_add_test(tc_call, checkAllocation);
+  suite_add_tcase(s, tc_call);
+
+  SRunner* sr = srunner_create(s);
+  srunner_set_fork_status(sr, CK_NOFORK);
+  srunner_run_all(sr, CK_NORMAL);
+  int number_failed = srunner_ntests_failed(sr);
+  printf("Number of failure is %d", number_failed);
+  srunner_free(sr);
+  return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tools/asmParser.py
+++ b/tools/asmParser.py
@@ -168,7 +168,7 @@ print(str(len(all_address_to_break)) + " possible failure points were found")
 memoryFile = open("allocationFailurePoints", "w")
 for address in all_address_to_break:
     lineToWrite = str(address[0]) + "," + str(address[1]) + "\n"
-    print(lineToWrite[:-1])
+    #print(lineToWrite[:-1])
     memoryFile.write(lineToWrite)
 
 memoryFile.close()

--- a/tools/asmParser.py
+++ b/tools/asmParser.py
@@ -38,7 +38,7 @@ class TheyCallMe():
 # Get a function by name, and if not present, create it
 def get_function_create(name, address):
     function = get_function_by_name(name) 
-    if function == None:
+    if function is None:
         function = Function(name, int(address, 16))
         all_functions.append(function)
 
@@ -84,7 +84,7 @@ def parse_asm(lines):
             
             # A function pointer is being called
             if len(function_called_info) != 2: 
-                if function_pointer_to_call == None:
+                if function_pointer_to_call is None:
                     continue
                 else:
                     function_called = function_pointer_to_call
@@ -120,8 +120,8 @@ def get_function_by_name(name):
 # Given a function name and a stack, go backwards to find all points where the initial
 # function name is called.
 # The stack's purpose is to avoid recursive function calls, which will get this function stuck
-def create_traceback(function, stack):
- 
+def create_traceback(function_name, stack):
+    function = get_function_by_name(function_name)
     if None == function:
         return
 
@@ -134,7 +134,7 @@ def create_traceback(function, stack):
         if they_call_me_function not in stack:
             
             stack.append(they_call_me_function)
-            create_traceback(they_call_me_function.function, stack)
+            create_traceback(they_call_me_function.function.name, stack)
             # After the recursion finishes, we pop the recently added function from stack.
             stack.pop()
 
@@ -162,7 +162,7 @@ print("File already parsed. We'll build now all function-chains that might call 
 for function_name in function_names:
     function = get_function_by_name(function_name)
     stack = [TheyCallMe(function, 0, "")]
-    create_traceback(function, stack)
+    create_traceback(function.name, stack)
 
 print(str(len(all_address_to_break)) + " possible failure points were found")
 memoryFile = open("allocationFailurePoints", "w")

--- a/tools/asmParser.py
+++ b/tools/asmParser.py
@@ -1,0 +1,177 @@
+import subprocess
+import io
+import argparse
+
+all_functions = []
+all_address_to_break = []
+
+# Represents a function in the code. 
+# It has a name, and address (taken from the assembly code) and two lists: 
+# one of the functions it calls, and another of the functions that call it
+class Function():
+
+    def __init__(self, name, address):
+        self.name = name
+        self.address = address
+        self.i_call = []
+        self.they_call_me = []
+
+    def add_i_call(self, function):
+        self.i_call.append(function)
+
+    def add_they_call_me(self, function, address, line):
+        self.they_call_me.append(TheyCallMe(function, address, line))
+
+    def  __str__(self):
+        return "Function " + self.name + " with address " + str(self.address)
+
+# Represents a point in code that is calling another function.
+# It contains the function object that is calling, and the address and the source code line (taken from the assembly code) where it is calling from 
+class TheyCallMe():
+
+    def __init__(self, function, address, line):
+        self.function = function
+        self.address = address
+        self.line = line
+
+
+# Get a function by name, and if not present, create it
+def get_function_create(name, address):
+    function = get_function_by_name(name) 
+    if function == None:
+        function = Function(name, int(address, 16))
+        all_functions.append(function)
+
+    return function
+        
+# Get the next assembly code address
+def get_next_adress(lines):
+    for i in range(len(lines)):
+        if lines[i][0] == " ": #skip source code lines, since they start right at the beginning of the line
+            return int(lines[i].split(":")[0].strip(), 16)
+
+# Get the source code line, which was seen before
+def get_call_line(lines):
+    for i in range(len(lines) - 1, 0, -1):
+        if lines[i][0] != " ":
+            return lines[i][:-1] #remove the new line
+
+# Given a list of lines representing the assembly code, it parses it and store the functions,
+# where they are calling and who's calling them
+# This code should be changed for another assembly code type
+def parse_asm(lines):
+    print("File has " + str(len(lines)) + " lines")
+    
+    for i in range(len(lines)):
+        line = lines[i]
+        
+        # Skip empty lines
+        if "" == line:
+            continue
+        
+        # The first line of a function contains ">:"
+        if ">:" in line:
+            function_pointer_to_call = None # clear the stored function pointer 
+            function_address = line.strip().split(' ')[0]
+            function_name = line.strip().split(' ')[1][1:-2]
+            current_function = Function(function_name, int(function_address, 16))
+            all_functions.append(current_function)
+            
+        # The function is calling another function
+        elif "callq" in line:
+            function_called_info = line.split("callq")[1].strip().split(" ")
+            function_called = None
+            
+            # A function pointer is being called
+            if len(function_called_info) != 2: 
+                if function_pointer_to_call == None:
+                    continue
+                else:
+                    function_called = function_pointer_to_call
+            
+            else: # A normal function is being called
+                called_function_address = function_called_info[0]
+                called_function_name = function_called_info[1][1:-1]
+                
+                function_called = get_function_create(called_function_name, called_function_address) 
+      
+            current_function.add_i_call(function_called)
+            current_address = get_next_adress(lines[i+1:]) # For some reason, the next address is the calling point in the function
+            current_line = get_call_line(lines[:i - 1])
+            function_called.add_they_call_me(current_function, current_address, current_line)
+        
+        # Where a function pointer is assigned to the function to call, this "lea" command is seen
+        elif "lea " in line:
+            function_called_info = line.split("#")
+            if len(function_called_info) != 2:
+                #print("Line" + str(i + 1) + ":\n" + line + "\nis loading a function pointer but not couldnt'find the information about it")
+                continue
+            function_called_info = function_called_info[1].strip().split(" ")
+            called_function_address = function_called_info[0]
+            called_function_name = function_called_info[1][1:-1]
+            function_pointer_to_call = get_function_create(called_function_name, called_function_address) 
+
+# Get a function object by its name
+def get_function_by_name(name):
+    for function in all_functions:
+        if function.name == name:
+            return function
+
+# Given a function name and a stack, go backwards to find all points where the initial
+# function name is called.
+# The stack's purpose is to avoid recursive function calls, which will get this function stuck
+def create_traceback(function, stack):
+ 
+    if None == function:
+        return
+
+    for they_call_me_function in function.they_call_me:
+        breaking_place_to_add = (they_call_me_function.address, they_call_me_function.line)
+        if breaking_place_to_add not in all_address_to_break:
+            all_address_to_break.append(breaking_place_to_add)
+
+        # If the calling function is already in the stack, we don't go further since it will get stuck
+        if they_call_me_function not in stack:
+            
+            stack.append(they_call_me_function)
+            create_traceback(they_call_me_function.function, stack)
+            # After the recursion finishes, we pop the recently added function from stack.
+            stack.pop()
+
+
+current_function = None
+function_pointer_to_call = None
+
+# construct the argument parser and parse the arguments
+ap = argparse.ArgumentParser()
+ap.add_argument("-f", "--file", required = True, help = "Path to binary file")
+args = vars(ap.parse_args())
+
+print("Parsing assembly file from " + args["file"])
+
+assemblyText = io.StringIO(subprocess.check_output("objdump -dl -j .text " + args["file"] +  " | tail -n +7", shell=True).decode('utf-8'))
+
+lines = assemblyText.readlines()
+
+parse_asm(lines)
+        
+function_names = ["UA_mallocSingleton", "UA_callocSingleton", "UA_reallocSingleton"]
+
+print("File already parsed. We'll build now all function-chains that might call the following functions: " + str(function_names))
+
+for function_name in function_names:
+    function = get_function_by_name(function_name)
+    stack = [TheyCallMe(function, 0, "")]
+    create_traceback(function, stack)
+
+print(str(len(all_address_to_break)) + " possible failure points were found")
+memoryFile = open("allocationFailurePoints", "w")
+for address in all_address_to_break:
+    lineToWrite = str(address[0]) + "," + str(address[1]) + "\n"
+    print(lineToWrite[:-1])
+    memoryFile.write(lineToWrite)
+
+memoryFile.close()
+
+
+    

--- a/tools/lookForAllocError.py
+++ b/tools/lookForAllocError.py
@@ -1,0 +1,90 @@
+import sys
+import subprocess
+import os.path
+import re
+import os
+
+
+project_src = sys.argv[1]
+allocation_test_file = sys.argv[2]
+
+valgrind_log = "check_allocation.log"
+valgrind_flags = "--quiet --trace-children=yes --leak-check=full --run-libc-freeres=no --sim-hints=no-nptl-pthread-stackcache --track-fds=yes"
+valgrind_command = "valgrind --error-exitcode=1 --suppressions=" + project_src + "/tools/valgrind_suppressions.supp " + valgrind_flags + " --log-file=" + valgrind_log +  " " +  allocation_test_file
+check_allocation_command = "python " + project_src + "/tools/valgrind_check_error.py " + valgrind_log + " " + valgrind_command 
+
+# Execute a command and output its stdout text
+def execute(command):
+
+    print("\n----------------Executing Tests ---------------------\n")
+
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    # Poll process for new output until finished
+    while True:
+        nextline = process.stdout.readline().decode('utf-8')
+        if nextline == '' and process.poll() is not None:
+            break
+        sys.stdout.write(nextline)
+        sys.stdout.flush()
+
+    return process.returncode
+
+
+def write_lines_in_file(file, lines):
+    for line in lines:
+        file.write(line)
+
+print("opening allocation failure files")
+
+failurePoints = open("allocationFailurePoints", "r")
+lines = failurePoints.readlines()
+failurePoints.close()
+
+print("making a copy of it")
+failurePointsOriginal = open("allocationFailurePointsORIGINAL", "w+")
+write_lines_in_file(failurePointsOriginal, lines)
+failurePointsOriginal.close()
+
+length = len(lines)
+
+while True:
+    
+    part1 = lines[int(length/2):]
+    part2 = lines[:int(length/2)]
+    
+    with open("allocationFailurePoints", "w") as failurePoints:
+        write_lines_in_file(failurePoints, part1)
+    
+    print("##################### length is " + str(len(part1)))    
+    ret_code = execute(check_allocation_command)
+    
+    if ret_code == 0: #no errors in this part
+        with open("allocationFailurePoints", "w") as failurePoints:
+            write_lines_in_file(failurePoints, part2)
+        
+        print("##################### length is " + str(len(part2)))
+        ret_code = execute(check_allocation_command)
+        if ret_code == 0: 
+            print("2- The file doesn't have any line that make the test fail")
+            exit(1)
+        else:
+            if len(part2) == 1:
+                print("2- The line that breaks the tests is " + part2[0])
+                exit(0)
+            lines = part2
+            
+    else:
+        if len(part1) == 1:
+            print("1- The line that breaks the tests is " + part1[0])
+            exit(0)
+        lines = part1  
+        
+    length = len(lines)
+        
+
+    
+
+
+
+

--- a/tools/lookForAllocError.py
+++ b/tools/lookForAllocError.py
@@ -1,8 +1,5 @@
 import sys
 import subprocess
-import os.path
-import re
-import os
 
 
 project_src = sys.argv[1]
@@ -46,45 +43,29 @@ failurePointsOriginal = open("allocationFailurePointsORIGINAL", "w+")
 write_lines_in_file(failurePointsOriginal, lines)
 failurePointsOriginal.close()
 
-length = len(lines)
+testedFailurePoints = open("testedAllocationFailurePoints", "r")
+lines = testedFailurePoints.readlines()
+testedFailurePoints.close()
 
-while True:
-    
-    part1 = lines[int(length/2):]
-    part2 = lines[:int(length/2)]
+
+failure_lines = []
+
+for line in lines:
     
     with open("allocationFailurePoints", "w") as failurePoints:
-        write_lines_in_file(failurePoints, part1)
+        write_lines_in_file(failurePoints, line)
     
-    print("##################### length is " + str(len(part1)))    
-    ret_code = execute(check_allocation_command)
     
-    if ret_code == 0: #no errors in this part
+    if execute(check_allocation_command) != 0:
+        failure_lines.append(line)
+        
+
+if len(failure_lines) !=0:
+    print("---------------------------------------------  THE FOLLOWING LINES FAIL ----------------------------------")
+    
+    for line in failure_lines:
+        print("LINE:\n" + line + "\n")
         with open("allocationFailurePoints", "w") as failurePoints:
-            write_lines_in_file(failurePoints, part2)
+            write_lines_in_file(failurePoints, line)
         
-        print("##################### length is " + str(len(part2)))
-        ret_code = execute(check_allocation_command)
-        if ret_code == 0: 
-            print("2- The file doesn't have any line that make the test fail")
-            exit(1)
-        else:
-            if len(part2) == 1:
-                print("2- The line that breaks the tests is " + part2[0])
-                exit(0)
-            lines = part2
-            
-    else:
-        if len(part1) == 1:
-            print("1- The line that breaks the tests is " + part1[0])
-            exit(0)
-        lines = part1  
-        
-    length = len(lines)
-        
-
-    
-
-
-
-
+        execute(check_allocation_command)

--- a/tools/lookForAllocError.py
+++ b/tools/lookForAllocError.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import subprocess
 

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -489,9 +489,9 @@ if [ "$CC" != "tcc" ]; then
         -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
         -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
         -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
-        -DUA_NAMESPACE_ZERO=REDUCED \
-    	-DUA_ENABLE_MALLOC_SINGLETON=ON ..
-    make -j && make test ARGS="-V"
+        -DUA_NAMESPACE_ZERO=REDUCED ..
+    	
+    make -j && make test
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf    
     echo -en 'travis_fold:end:script.build.unit_test_ns0_reduced_openssl\\r'

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -28,7 +28,7 @@ if ! [ -z ${COVERAGE+x} ]; then
     make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then 
     	cd tests
-    	python ../tools/lookForAllocError.py $(pwd)/../  $(pwd)/../bin/tests/check_allocation
+    	/usr/bin/$PYTHON ../../tools/lookForAllocError.py $(pwd)/../../  $(pwd)/../bin/tests/check_allocation
     	exit 1
     fi
     set -e

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -464,7 +464,8 @@ if [ "$CC" != "tcc" ]; then
         -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
         -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
         -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
-        -DUA_NAMESPACE_ZERO=MINIMAL ..
+        -DUA_NAMESPACE_ZERO=MINIMAL \
+    	-DUA_ENABLE_MALLOC_SINGLETON=ON ..
 
     make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then exit 1 ; fi
@@ -488,7 +489,8 @@ if [ "$CC" != "tcc" ]; then
         -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
         -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
         -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
-        -DUA_NAMESPACE_ZERO=REDUCED ..
+        -DUA_NAMESPACE_ZERO=REDUCED \
+    	-DUA_ENABLE_MALLOC_SINGLETON=ON ..
     make -j && make test
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf    

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -464,9 +464,8 @@ if [ "$CC" != "tcc" ]; then
         -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
         -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
         -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
-        -DUA_NAMESPACE_ZERO=MINIMAL \
-    	-DUA_ENABLE_MALLOC_SINGLETON=ON ..
-
+        -DUA_NAMESPACE_ZERO=MINIMAL ..
+    	
     make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf
@@ -513,7 +512,9 @@ if [ "$CC" != "tcc" ]; then
         -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
         -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
         -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
-        -DUA_NAMESPACE_ZERO=REDUCED ..
+        -DUA_NAMESPACE_ZERO=REDUCED \
+        -DUA_ENABLE_MALLOC_SINGLETON=ON ..
+        
     make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then exit 1 ; fi
     echo -en 'travis_fold:end:script.build.unit_test_ns0_reduced\\r'

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -491,7 +491,7 @@ if [ "$CC" != "tcc" ]; then
         -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
         -DUA_NAMESPACE_ZERO=REDUCED \
     	-DUA_ENABLE_MALLOC_SINGLETON=ON ..
-    make -j && make test
+    make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then exit 1 ; fi
     cd .. && rm build -rf    
     echo -en 'travis_fold:end:script.build.unit_test_ns0_reduced_openssl\\r'

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -25,7 +25,11 @@ if ! [ -z ${COVERAGE+x} ]; then
         -DUA_ENABLE_MALLOC_SINGLETON=ON ..
         
     make -j && make test ARGS="-V"
-    if [ $? -ne 0 ] ; then exit 1 ; fi
+    if [ $? -ne 0 ] ; then 
+    	cd tests
+    	python ../tools/lookForAllocError.py $(pwd)/../  $(pwd)/../bin/tests/check_allocation
+    	exit 1
+    fi
     echo -en 'travis_fold:end:script.build.unit_test_ns0_reduced\\r'
 
     # only run coveralls on main repo and when MINGW=true

--- a/tools/travis/travis_linux_script.sh
+++ b/tools/travis/travis_linux_script.sh
@@ -24,12 +24,14 @@ if ! [ -z ${COVERAGE+x} ]; then
         -DUA_NAMESPACE_ZERO=REDUCED \
         -DUA_ENABLE_MALLOC_SINGLETON=ON ..
         
+    set +e
     make -j && make test ARGS="-V"
     if [ $? -ne 0 ] ; then 
     	cd tests
     	python ../tools/lookForAllocError.py $(pwd)/../  $(pwd)/../bin/tests/check_allocation
     	exit 1
     fi
+    set -e
     echo -en 'travis_fold:end:script.build.unit_test_ns0_reduced\\r'
 
     # only run coveralls on main repo and when MINGW=true


### PR DESCRIPTION
This is a tool I've been playing around with. It works as follow:


Once the test I created (check_allocation) is compiled, I added a post command in CMake that executes a python script. This python script (asmParser.py) does the following:
 - objdump the check_allocation executable to read the whole assembly code
 - Parse the assembly code, and create a complete tree of functions calls 
 - It looks at malloc, realloc and calloc, and for each, it starts going backwards recursively to see where these functions are being called from. For each possible place in code, the script stores the assemly address and the source code line and writes this information in a file (one address per line)

The test itself (check_allocation) then:
- reads this file, and for each line, it gets the adddess and soruce code line. It sets the address as the next address where malloc, calloc and realloc should fail in a global variable, and run some tests (for now, it's just setting the config default in a server, and deleteing it later). 
- Each of these functions (malloc, realloc and calloc) are implemented with a wrapper arround it which uses the function "backtrace" to check the stack. If it finds in the stack the addrses to break which was recentrly assigned, it will return NULL from there on, otherwise, it returns the usual malloc, realloc or calloc. 

On my fork, the test is failing for some reason I don't know. I assume there is memory leak, but for some reason I don't see it (I think the valgrind output should be outputed to the terminal, but nothing's there). I tested it locally some time ago, and found the valgrind log output and there are some memory leaks indeed. 

I copy the output of that output for you to see it:

==7385== 65 bytes in 1 blocks are definitely lost in loss record 4 of 11
==7385==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7385==    by 0x402D75: mallocWrapper (check_allocation.c:94)
==7385==    by 0x403BEF: UA_String_fromChars (ua_types.c:108)
==7385==    by 0x4B8D5D: createEndpoint (ua_config_default.c:91)
==7385==    by 0x4B9AF3: UA_ServerConfig_addEndpoint (ua_config_default.c:380)
==7385==    by 0x4BA10A: UA_ServerConfig_setMinimalCustomBuffer (ua_config_default.c:468)
==7385==    by 0x40291C: UA_ServerConfig_setMinimal (server_config_default.h:61)
==7385==    by 0x402968: UA_ServerConfig_setDefault (server_config_default.h:85)
==7385==    by 0x402A2B: functionToTest (check_allocation.c:53)
==7385==    by 0x403374: checkJose (check_allocation.c:127)
==7385==    by 0x4C54AA: tcase_run_tfun_nofork.isra.9 (in /media/sf_open62541/bin/posixTests/bin/tests/check_allocation)
==7385==    by 0x4C589C: srunner_run (in /media/sf_open62541/bin/posixTests/bin/tests/check_allocation)
==7385== 
==7385== 94 bytes in 2 blocks are definitely lost in loss record 5 of 11
==7385==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7385==    by 0x402F76: callocWrapper (check_allocation.c:99)
==7385==    by 0x408807: UA_Array_copy (ua_types.c:1279)
==7385==    by 0x403E9A: String_copy (ua_types.c:151)
==7385==    by 0x408058: UA_copy (ua_types.c:1142)
==7385==    by 0x4B8728: UA_String_copy (types_generated_handling.h:372)
==7385==    by 0x4B8D3B: createEndpoint (ua_config_default.c:90)
==7385==    by 0x4B9AF3: UA_ServerConfig_addEndpoint (ua_config_default.c:380)
==7385==    by 0x4BA10A: UA_ServerConfig_setMinimalCustomBuffer (ua_config_default.c:468)
==7385==    by 0x40291C: UA_ServerConfig_setMinimal (server_config_default.h:61)
==7385==    by 0x402968: UA_ServerConfig_setDefault (server_config_default.h:85)
==7385==    by 0x402A2B: functionToTest (check_allocation.c:53)
==7385== 
==7385== 972 (912 direct, 60 indirect) bytes in 2 blocks are definitely lost in loss record 7 of 11
==7385==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7385==    by 0x402F76: callocWrapper (check_allocation.c:99)
==7385==    by 0x4BE153: createEntry (ua_nodestore_hashmap.c:182)
==7385==    by 0x4BE469: UA_NodeMap_newNode (ua_nodestore_hashmap.c:234)
==7385==    by 0x451995: AddNode_raw (ua_services_nodemanagement.c:892)
==7385==    by 0x45288E: Operation_addNode_begin (ua_services_nodemanagement.c:1022)
==7385==    by 0x4554CB: UA_Server_addNode_begin (ua_services_nodemanagement.c:1444)
==7385==    by 0x47E4AC: function_namespace0_generated_62_begin (namespace0_generated.c:1468)
==7385==    by 0x4A1CA3: namespace0_generated (namespace0_generated.c:5029)
==7385==    by 0x426B4A: UA_Server_initNS0 (ua_server_ns0.c:777)
==7385==    by 0x420751: UA_Server_init (ua_server.c:325)
==7385==    by 0x420862: UA_Server_newWithConfig (ua_server.c:349)
==7385== 
==7385== 10,272 (6,208 direct, 4,064 indirect) bytes in 2 blocks are definitely lost in loss record 10 of 11
==7385==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7385==    by 0x402D75: mallocWrapper (check_allocation.c:94)
==7385==    by 0x4BF184: UA_Nodestore_HashMap (ua_nodestore_hashmap.c:469)
==7385==    by 0x4B8C49: UA_Server_new (ua_config_default.c:50)
==7385==    by 0x4029D6: functionToTest (check_allocation.c:49)
==7385==    by 0x403374: checkJose (check_allocation.c:127)
==7385==    by 0x4C54AA: tcase_run_tfun_nofork.isra.9 (in /media/sf_open62541/bin/posixTests/bin/tests/check_allocation)
==7385==    by 0x4C589C: srunner_run (in /media/sf_open62541/bin/posixTests/bin/tests/check_allocation)
==7385==    by 0x4036F3: main (check_allocation.c:167)
==7385== 
==7385== 13,016 (12,288 direct, 728 indirect) bytes in 4 blocks are definitely lost in loss record 11 of 11
==7385==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7385==    by 0x402F76: callocWrapper (check_allocation.c:99)
==7385==    by 0x408731: UA_Array_new (ua_types.c:1261)
==7385==    by 0x430A92: RefResult_init (ua_services_view.c:305)
==7385==    by 0x4319CC: browseWithContinuation (ua_services_view.c:542)
==7385==    by 0x431EAA: Operation_Browse (ua_services_view.c:605)
==7385==    by 0x44E907: copyAllChildren (ua_services_nodemanagement.c:560)
==7385==    by 0x44EB5C: addTypeChildren (ua_services_nodemanagement.c:590)
==7385==    by 0x45322A: recursiveTypeCheckAddChildren (ua_services_nodemanagement.c:1090)
==7385==    by 0x454913: AddNode_finish (ua_services_nodemanagement.c:1309)
==7385==    by 0x455561: UA_Server_addNode_finish (ua_services_nodemanagement.c:1454)
==7385==    by 0x49CCC1: function_namespace0_generated_173_finish (namespace0_generated.c:4552)


These are blocks of memory that did got allocated, and probably the breaking point was just a little later. 

For now, I didn't enable the test in the FULL namespace because the parsing took too much time that travis failed. 

The idea is to have a test that tries to run most of the code, so all breaking points are reached. For now I saw that 47 of 674 failure points were tested.

Just an example from the two first leaks:

CreateEnpoint is called here:

https://github.com/open62541/open62541/blob/51fc0b8517d931f1e05798d12052e929c488b506/plugins/ua_config_default.c#L380-L385

And goes here:

https://github.com/open62541/open62541/blob/51fc0b8517d931f1e05798d12052e929c488b506/plugins/ua_config_default.c#L90-L103

And if malloc fails at line 98, the strings from line 90 and 91 won't be deallocated