### PR TITLE
Fix segfault in ua_pki_openssl.c

### DIFF
--- a/plugins/securityPolicies/openssl/ua_pki_openssl.c
+++ b/plugins/securityPolicies/openssl/ua_pki_openssl.c
@@ -78,6 +78,8 @@ UA_CertificateVerification_clear (UA_CertificateVerification * cv) {
     UA_CertContext_sk_free (context);
     UA_free (context);
 
+    cv->context = NULL;
+
     return;
 }
 


### PR DESCRIPTION
If the value is not set to NULL, a heap-use-after-free occurs in UA_CertificateVerification_clear().