### PR TITLE
Fix python regex removing all content

### DIFF
--- a/tools/valgrind_check_error.py
+++ b/tools/valgrind_check_error.py
@@ -60,7 +60,7 @@ log_content = replace_re.sub('', log_content)
 
 # Try to parse the output. Look for the following line:
 # ==17054== FILE DESCRIPTORS: 5 open at exit.
-descriptors_re = re.compile(r".*==(\d+)==\s+FILE DESCRIPTORS: (\d+) open at exit\..*", re.DOTALL)
+descriptors_re = re.compile(r".*==(\d+)==\s+FILE DESCRIPTORS: (\d+) open at exit\..*")
 m = descriptors_re.match(log_content)
 
 if not m:


### PR DESCRIPTION
Do not use re.DOTALL so only one line will match and the rest of the content is kept

THis is the reason valgrind is not outputing the content when a failure occur. This can be seen in #3841 where the jobs now output the content after the same change was pushed there