### PR TITLE
Fix amalgamation

### DIFF
--- a/plugins/securityPolicies/securitypolicy_mbedtls_common.h
+++ b/plugins/securityPolicies/securitypolicy_mbedtls_common.h
@@ -9,7 +9,7 @@
 
 #include <open62541/plugin/securitypolicy.h>
 
-#ifdef UA_ENABLE_ENCRYPTION
+#ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
 
 #include <mbedtls/md.h>
 #include <mbedtls/x509_crt.h>


### PR DESCRIPTION
Missing mbedTLS headers would break the amalgamation build if UA_ENABLE_ENCRYPTION is used in combination with UA_ENABLE_ENCRYPTION_OPENSSL.