### PR TITLE
OpenSSL PEM support

### DIFF
--- a/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
+++ b/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2020 (c) Wind River Systems, Inc.
+ *    Copyright 2020 (c) basysKom GmbH
+ *
  */
 
 #ifndef SECURITYPOLICY_OPENSSL_COMMON_H_
@@ -13,6 +15,7 @@
 #ifdef UA_ENABLE_ENCRYPTION_OPENSSL
 
 #include <openssl/x509.h>
+#include <openssl/evp.h>
 
 _UA_BEGIN_DECLS
 
@@ -120,6 +123,18 @@ UA_StatusCode
 UA_OpenSSL_AES_128_CBC_Encrypt(const UA_ByteString *iv,
                                const UA_ByteString *key, 
                                UA_ByteString *data  /* [in/out]*/);
+
+EVP_PKEY *
+UA_OpenSSL_LoadPrivateKey(const UA_ByteString *privateKey);
+
+X509 *
+UA_OpenSSL_LoadCertificate(const UA_ByteString *certificate);
+
+X509 *
+UA_OpenSSL_LoadDerCertificate(const UA_ByteString *certificate);
+
+X509 *
+UA_OpenSSL_LoadPemCertificate(const UA_ByteString *certificate);
 
 _UA_END_DECLS
 

--- a/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
+++ b/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
@@ -35,7 +35,7 @@ UA_Openssl_X509_GetCertificateThumbprint(const UA_ByteString *certficate,
                                          bool bThumbPrint);
 UA_StatusCode
 UA_Openssl_RSA_Oaep_Decrypt(UA_ByteString *data,
-                            const UA_ByteString *privateKey);   
+                            EVP_PKEY *privateKey);
 UA_StatusCode
 UA_Openssl_RSA_OAEP_Encrypt(UA_ByteString *data, /* The data that is encrypted. 
                                                     The encrypted data will overwrite 
@@ -52,7 +52,7 @@ UA_Openssl_RSA_Public_GetKeyLength(X509 *publicKeyX509, UA_Int32 *keyLen);
 
 UA_StatusCode 
 UA_Openssl_RSA_PKCS1_V15_SHA256_Sign(const UA_ByteString *data,
-                                     const UA_ByteString *privateKey,
+                                     EVP_PKEY *privateKey,
                                      UA_ByteString *outSignature);
 
 UA_StatusCode
@@ -79,7 +79,7 @@ UA_StatusCode
 UA_OpenSSL_X509_compare(const UA_ByteString *cert, const X509 *b);
 
 UA_StatusCode 
-UA_Openssl_RSA_Private_GetKeyLength(const UA_ByteString *privateKey,
+UA_Openssl_RSA_Private_GetKeyLength(EVP_PKEY *privateKey,
                                     UA_Int32 *keyLen) ;
 
 UA_StatusCode
@@ -89,7 +89,7 @@ UA_OpenSSL_RSA_PKCS1_V15_SHA1_Verify(const UA_ByteString *msg,
 
 UA_StatusCode 
 UA_Openssl_RSA_PKCS1_V15_SHA1_Sign(const UA_ByteString *message,
-                                   const UA_ByteString *privateKey,
+                                   EVP_PKEY *privateKey,
                                    UA_ByteString *outSignature);
 UA_StatusCode 
 UA_Openssl_Random_Key_PSHA1_Derive(const UA_ByteString *secret,
@@ -107,7 +107,7 @@ UA_OpenSSL_HMAC_SHA1_Sign(const UA_ByteString *message,
 
 UA_StatusCode
 UA_Openssl_RSA_PKCS1_V15_Decrypt(UA_ByteString *data, 
-                                 const UA_ByteString *privateKey);
+                                 EVP_PKEY *privateKey);
 
 UA_StatusCode
 UA_Openssl_RSA_PKCS1_V15_Encrypt(UA_ByteString *data, 

--- a/plugins/securityPolicies/openssl/ua_openssl_basic128rsa15.c
+++ b/plugins/securityPolicies/openssl/ua_openssl_basic128rsa15.c
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2020 (c) Wind River Systems, Inc.
+ *    Copyright 2020 (c) basysKom GmbH
  */
 
 /*
@@ -65,6 +66,12 @@ UA_Policy_Basic128Rsa15_New_Context (UA_SecurityPolicy * securityPolicy,
     if (retval != UA_STATUSCODE_GOOD) {
         UA_free (context);
         return retval; 
+    }
+
+    EVP_PKEY * evpKey = UA_OpenSSL_LoadPrivateKey(&context->localPrivateKey);
+    EVP_PKEY_free(evpKey);
+    if (evpKey == NULL) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
     retval = UA_Openssl_X509_GetCertificateThumbprint (
@@ -135,9 +142,7 @@ UA_ChannelModule_Basic128Rsa15_New_Context (const UA_SecurityPolicy * securityPo
     }
 
     /* decode to X509 */
-    const unsigned char * pData = context->remoteCertificate.data;    
-    context->remoteCertificateX509 = d2i_X509 (NULL, &pData, 
-                                    (long) context->remoteCertificate.length);
+    context->remoteCertificateX509 = UA_OpenSSL_LoadCertificate(&context->remoteCertificate);
     if (context->remoteCertificateX509 == NULL) {
         UA_ByteString_clear (&context->remoteCertificate); 
         UA_free (context);

--- a/plugins/securityPolicies/openssl/ua_openssl_basic256.c
+++ b/plugins/securityPolicies/openssl/ua_openssl_basic256.c
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2020 (c) Wind River Systems, Inc.
+ *    Copyright 2020 (c) basysKom GmbH
  */
 
 /*
@@ -64,6 +65,12 @@ UA_Policy_Basic256_New_Context (UA_SecurityPolicy * securityPolicy,
     if (retval != UA_STATUSCODE_GOOD) {
         UA_free (context);
         return retval; 
+    }
+
+    EVP_PKEY * evpKey = UA_OpenSSL_LoadPrivateKey(&context->localPrivateKey);
+    EVP_PKEY_free(evpKey);
+    if (evpKey == NULL) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
     retval = UA_Openssl_X509_GetCertificateThumbprint (
@@ -134,9 +141,7 @@ UA_ChannelModule_Basic256_New_Context (const UA_SecurityPolicy * securityPolicy,
     }
 
     /* decode to X509 */
-    const unsigned char * pData = context->remoteCertificate.data;    
-    context->remoteCertificateX509 = d2i_X509 (NULL, &pData, 
-                                    (long) context->remoteCertificate.length);
+    context->remoteCertificateX509 = UA_OpenSSL_LoadCertificate(&context->remoteCertificate);
     if (context->remoteCertificateX509 == NULL) {
         UA_ByteString_clear (&context->remoteCertificate); 
         UA_free (context);

--- a/plugins/securityPolicies/openssl/ua_openssl_basic256sha256.c
+++ b/plugins/securityPolicies/openssl/ua_openssl_basic256sha256.c
@@ -36,7 +36,7 @@ modification history
 #define UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH 512
 
 typedef struct {
-    UA_ByteString             localPrivateKey;
+    EVP_PKEY *                localPrivateKey;
     UA_ByteString             localCertThumbprint;
     const UA_Logger *         logger;    
 } Policy_Context_Basic256Sha256;
@@ -65,28 +65,20 @@ UA_Policy_New_Context (UA_SecurityPolicy * securityPolicy,
     if (context == NULL) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-
-    /* copy the local private key and add a NULL to the end */
     
-    UA_StatusCode retval = UA_copyCertificate (&context->localPrivateKey,
-                                               &localPrivateKey);
-    if (retval != UA_STATUSCODE_GOOD) {
-        UA_free (context);
-        return retval; 
-    }
+    context->localPrivateKey = UA_OpenSSL_LoadPrivateKey(&localPrivateKey);
 
-    EVP_PKEY * evpKey = UA_OpenSSL_LoadPrivateKey(&context->localPrivateKey);
-    EVP_PKEY_free(evpKey);
-    if (evpKey == NULL) {
+    if (!context->localPrivateKey) {
+        UA_free (context);
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    retval = UA_Openssl_X509_GetCertificateThumbprint (
+    UA_StatusCode retval = UA_Openssl_X509_GetCertificateThumbprint (
                          &securityPolicy->localCertificate,
                          &context->localCertThumbprint, true
                          );
     if (retval != UA_STATUSCODE_GOOD) {
-        UA_ByteString_deleteMembers (&context->localPrivateKey);
+        EVP_PKEY_free(context->localPrivateKey);
         UA_free (context);
         return retval; 
     }
@@ -110,7 +102,7 @@ UA_Policy_Clear_Context (UA_SecurityPolicy *policy) {
 
     Policy_Context_Basic256Sha256 * pc = (Policy_Context_Basic256Sha256 *)
         policy->policyContext;
-    UA_ByteString_deleteMembers (&pc->localPrivateKey);
+    EVP_PKEY_free(pc->localPrivateKey);
     UA_ByteString_deleteMembers (&pc->localCertThumbprint);
     UA_free (pc);        
     return;
@@ -247,7 +239,7 @@ UA_Asym_Basic256Sha256_Decrypt (const UA_SecurityPolicy *securityPolicy,
     Channel_Context_Basic256Sha256 * cc = (Channel_Context_Basic256Sha256 *)
                                            channelContext;
     UA_StatusCode ret = UA_Openssl_RSA_Oaep_Decrypt (data, 
-                        &cc->policyContext->localPrivateKey);
+                        cc->policyContext->localPrivateKey);
     return ret;                        
 }
 
@@ -259,7 +251,7 @@ UA_Asym_Basic256Sha256_getRemoteSignatureSize (
         return UA_STATUSCODE_BADINTERNALERROR;
 
     const Channel_Context_Basic256Sha256 * cc = (const Channel_Context_Basic256Sha256 *) channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength (cc->remoteCertificateX509, &keyLen);
     UA_assert (keyLen == 256); /* 256 bytes 2048 bit */
     return (size_t) keyLen; 
@@ -273,8 +265,8 @@ UA_AsySig_Basic256Sha256_getLocalSignatureSize (const UA_SecurityPolicy *securit
 
     Policy_Context_Basic256Sha256 * pc = 
                (Policy_Context_Basic256Sha256 *) securityPolicy->policyContext;
-    UA_Int32 keyLen;
-    UA_Openssl_RSA_Private_GetKeyLength (&pc->localPrivateKey, &keyLen);
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Private_GetKeyLength (pc->localPrivateKey, &keyLen);
     UA_assert (keyLen == 256); /* 256 bytes 2048 bits */
 
     return (size_t) keyLen; 
@@ -287,7 +279,7 @@ UA_AsymEn_Basic256Sha256_getRemotePlainTextBlockSize (const UA_SecurityPolicy *s
         return UA_STATUSCODE_BADINTERNALERROR;
 
     const Channel_Context_Basic256Sha256 * cc = (const Channel_Context_Basic256Sha256 *) channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength (cc->remoteCertificateX509, &keyLen);
     return (size_t) keyLen - UA_SECURITYPOLICY_BASIC256SHA256_RSAPADDING_LEN;
 }
@@ -299,7 +291,7 @@ UA_AsymEn_Basic256Sha256_getRemoteBlockSize (const UA_SecurityPolicy *securityPo
         return UA_STATUSCODE_BADINTERNALERROR;
 
     const Channel_Context_Basic256Sha256 * cc = (const Channel_Context_Basic256Sha256 *) channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength (cc->remoteCertificateX509, &keyLen);
     return (size_t) keyLen;
 }
@@ -311,7 +303,7 @@ UA_AsymEn_Basic256Sha256_getRemoteKeyLength (const UA_SecurityPolicy *securityPo
         return UA_STATUSCODE_BADINTERNALERROR;
 
     const Channel_Context_Basic256Sha256 * cc = (const Channel_Context_Basic256Sha256 *) channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength (cc->remoteCertificateX509, &keyLen);
     return (size_t) keyLen * 8;
 }
@@ -445,7 +437,7 @@ UA_AsySig_Basic256Sha256_sign (const UA_SecurityPolicy * securityPolicy,
         return UA_STATUSCODE_BADINTERNALERROR; 
     Policy_Context_Basic256Sha256 * pc = 
                (Policy_Context_Basic256Sha256 *) securityPolicy->policyContext;
-    return UA_Openssl_RSA_PKCS1_V15_SHA256_Sign (message, &pc->localPrivateKey,
+    return UA_Openssl_RSA_PKCS1_V15_SHA256_Sign (message, pc->localPrivateKey,
                                                  signature);
 }
 
@@ -547,8 +539,8 @@ UA_AsymEn_Basic256Sha256_getLocalKeyLength (const UA_SecurityPolicy * securityPo
 
     Policy_Context_Basic256Sha256 * pc = 
                (Policy_Context_Basic256Sha256 *) securityPolicy->policyContext;
-    UA_Int32 keyLen;
-    UA_Openssl_RSA_Private_GetKeyLength (&pc->localPrivateKey, &keyLen);
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Private_GetKeyLength (pc->localPrivateKey, &keyLen);
     UA_assert (keyLen == 256); /* 256 bytes 2048 bits */
 
     return (size_t) keyLen * 8; 


### PR DESCRIPTION
PEM currently does not work for the local certificate because the UA_ByteString holding the certificate file content is sent directly to the communication partner and part 6 states that a certificate must be DER encoded.

If necessary, this could be made possible by converting a loaded PEM encoded local certificate to DER.