### PR TITLE
Add support for PEM encoded local certificates

### DIFF
--- a/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c
+++ b/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c
@@ -174,8 +174,8 @@ UA_Openssl_X509_GetCertificateThumbprint (const UA_ByteString * certficate,
             return UA_STATUSCODE_BADINTERNALERROR;
         }
     }
-    // The client certificate must be DER encoded
-    X509 * x509Certificate = UA_OpenSSL_LoadDerCertificate(certficate);
+    X509 * x509Certificate = UA_OpenSSL_LoadCertificate(certficate);
+
     if (x509Certificate == NULL) {
         if (bThumbPrint) {
             UA_ByteString_deleteMembers (pThumbprint);
@@ -934,5 +934,26 @@ UA_OpenSSL_LoadPemCertificate(const UA_ByteString *certificate) {
 
     return result;
 }
+
+UA_StatusCode
+UA_OpenSSL_LoadLocalCertificate(const UA_ByteString *certificate, UA_ByteString *target) {
+    X509 *cert = UA_OpenSSL_LoadCertificate(certificate);
+
+    if (!cert)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    unsigned char *derData = NULL;
+    int length = i2d_X509(cert, &derData);
+    X509_free(cert);
+
+    if (length > 0) {
+        target->length = (size_t) length;
+        target->data = derData;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    return UA_STATUSCODE_BADINVALIDARGUMENT;
+}
+
 
 #endif

--- a/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
+++ b/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
@@ -136,6 +136,9 @@ UA_OpenSSL_LoadDerCertificate(const UA_ByteString *certificate);
 X509 *
 UA_OpenSSL_LoadPemCertificate(const UA_ByteString *certificate);
 
+UA_StatusCode
+UA_OpenSSL_LoadLocalCertificate(const UA_ByteString *certificate, UA_ByteString *target);
+
 _UA_END_DECLS
 
 #endif /* UA_ENABLE_ENCRYPTION_OPENSSL */

--- a/plugins/securityPolicies/openssl/ua_openssl_basic128rsa15.c
+++ b/plugins/securityPolicies/openssl/ua_openssl_basic128rsa15.c
@@ -564,9 +564,8 @@ UA_SecurityPolicy_Basic128Rsa15 (UA_SecurityPolicy * policy,
     channelModule->setRemoteSymIv = UA_ChannelModule_Basic128Rsa15_setRemoteSymIv;
     channelModule->compareCertificate = UA_ChannelModule_Basic128Rsa15_compareCertificate;    
 
-    /* Copy the certificate and add a NULL to the end */
+    retval = UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
 
-    retval = UA_copyCertificate (&policy->localCertificate, &localCertificate);
     if (retval != UA_STATUSCODE_GOOD)
         return retval;
 

--- a/plugins/securityPolicies/openssl/ua_openssl_basic256.c
+++ b/plugins/securityPolicies/openssl/ua_openssl_basic256.c
@@ -566,9 +566,8 @@ UA_SecurityPolicy_Basic256 (UA_SecurityPolicy * policy,
     channelModule->setRemoteSymIv = UA_ChannelModule_Basic256_setRemoteSymIv;
     channelModule->compareCertificate = UA_ChannelModule_Basic256_compareCertificate;
 
-    /* Copy the certificate and add a NULL to the end */
+    retval = UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
 
-    retval = UA_copyCertificate (&policy->localCertificate, &localCertificate);
     if (retval != UA_STATUSCODE_GOOD)
         return retval;
 

--- a/plugins/securityPolicies/openssl/ua_openssl_basic256sha256.c
+++ b/plugins/securityPolicies/openssl/ua_openssl_basic256sha256.c
@@ -579,9 +579,8 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy * policy,
     channelModule->setRemoteSymIv = UA_ChannelM_Basic256Sha256_setRemoteSymIv;
     channelModule->compareCertificate = UA_ChannelM_Basic256Sha256_compareCertificate;
 
-    /* Copy the certificate and add a NULL to the end */
+    retval = UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
 
-    retval = UA_copyCertificate (&policy->localCertificate, &localCertificate);
     if (retval != UA_STATUSCODE_GOOD)
         return retval;
 

--- a/plugins/securityPolicies/securitypolicy_mbedtls_common.c
+++ b/plugins/securityPolicies/securitypolicy_mbedtls_common.c
@@ -241,4 +241,30 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
     return UA_STATUSCODE_GOOD;
 }
 
+int UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target)
+{
+    return mbedtls_pk_parse_key(target, key->data, key->length, NULL, 0);
+}
+
+UA_StatusCode UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData, UA_ByteString *target)
+{
+    mbedtls_x509_crt cert;
+    mbedtls_x509_crt_init(&cert);
+
+    int mbedErr = mbedtls_x509_crt_parse(&cert, certData->data, certData->length);
+
+    UA_StatusCode result = UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    if (!mbedErr) {
+        UA_ByteString tmp;
+        tmp.data = cert.raw.p;
+        tmp.length = cert.raw.len;
+
+        result = UA_ByteString_copy(&tmp, target);
+    }
+
+    mbedtls_x509_crt_free(&cert);
+    return result;
+}
+
 #endif

--- a/plugins/securityPolicies/securitypolicy_mbedtls_common.h
+++ b/plugins/securityPolicies/securitypolicy_mbedtls_common.h
@@ -64,6 +64,10 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
                         mbedtls_ctr_drbg_context *drbgContext,
                         UA_ByteString *data);
 
+int UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target);
+
+UA_StatusCode UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData, UA_ByteString *target);
+
 _UA_END_DECLS
 
 #endif

--- a/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
@@ -6,6 +6,7 @@
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
  *    Copyright 2018 (c) HMS Industrial Networks AB (Author: Jonas Green)
  *    Copyright 2020 (c) Wind River Systems, Inc.
+ *    Copyright 2020 (c) basysKom GmbH
  * 
  */
 
@@ -624,12 +625,10 @@ updateCertificateAndPrivateKey_sp_basic128rsa15(UA_SecurityPolicy *securityPolic
 
     UA_ByteString_deleteMembers(&securityPolicy->localCertificate);
 
-    UA_StatusCode retval = UA_ByteString_allocBuffer(&securityPolicy->localCertificate, newCertificate.length + 1);
-    if(retval != UA_STATUSCODE_GOOD)
+    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&newCertificate, &securityPolicy->localCertificate);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    memcpy(securityPolicy->localCertificate.data, newCertificate.data, newCertificate.length);
-    securityPolicy->localCertificate.data[newCertificate.length] = '\0';
-    securityPolicy->localCertificate.length--;
 
     /* Set the new private key */
     mbedtls_pk_free(&pc->localPrivateKey);
@@ -754,14 +753,10 @@ UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy, const UA_ByteString l
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
     UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
 
-    /* Copy the certificate and add a NULL to the end */
-    UA_StatusCode retval =
-        UA_ByteString_allocBuffer(&policy->localCertificate, localCertificate.length + 1);
-    if(retval != UA_STATUSCODE_GOOD)
+    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    memcpy(policy->localCertificate.data, localCertificate.data, localCertificate.length);
-    policy->localCertificate.data[localCertificate.length] = '\0';
-    policy->localCertificate.length--;
 
     /* AsymmetricModule */
     UA_SecurityPolicySignatureAlgorithm *asym_signatureAlgorithm =

--- a/plugins/securityPolicies/ua_securitypolicy_basic256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256.c
@@ -6,6 +6,7 @@
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
  *    Copyright 2020 (c) Wind River Systems, Inc.
+ *    Copyright 2020 (c) basysKom GmbH
  *
  */
 
@@ -573,13 +574,10 @@ updateCertificateAndPrivateKey_sp_basic256(UA_SecurityPolicy *securityPolicy,
 
     UA_ByteString_deleteMembers(&securityPolicy->localCertificate);
 
-    UA_StatusCode retval = UA_ByteString_allocBuffer(&securityPolicy->localCertificate,
-                                                     newCertificate.length + 1);
-    if(retval != UA_STATUSCODE_GOOD)
+    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&newCertificate, &securityPolicy->localCertificate);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    memcpy(securityPolicy->localCertificate.data, newCertificate.data, newCertificate.length);
-    securityPolicy->localCertificate.data[newCertificate.length] = '\0';
-    securityPolicy->localCertificate.length--;
 
     /* Set the new private key */
     mbedtls_pk_free(&pc->localPrivateKey);
@@ -703,14 +701,10 @@ UA_SecurityPolicy_Basic256(UA_SecurityPolicy *policy, const UA_ByteString localC
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
     UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
 
-    /* Copy the certificate and add a NULL to the end */
-    UA_StatusCode retval =
-        UA_ByteString_allocBuffer(&policy->localCertificate, localCertificate.length + 1);
-    if(retval != UA_STATUSCODE_GOOD)
+    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    memcpy(policy->localCertificate.data, localCertificate.data, localCertificate.length);
-    policy->localCertificate.data[localCertificate.length] = '\0';
-    policy->localCertificate.length--;
 
     /* AsymmetricModule */
     UA_SecurityPolicySignatureAlgorithm *asym_signatureAlgorithm =

--- a/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
+++ b/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c
@@ -6,6 +6,7 @@
  *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
  *    Copyright 2018 (c) HMS Industrial Networks AB (Author: Jonas Green)
  *    Copyright 2020 (c) Wind River Systems, Inc.
+ *    Copyright 2020 (c) basysKom GmbH
  */
 
 #include <open62541/plugin/securitypolicy_default.h>
@@ -616,13 +617,10 @@ updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPoli
 
     UA_ByteString_deleteMembers(&securityPolicy->localCertificate);
 
-    UA_StatusCode retval = UA_ByteString_allocBuffer(&securityPolicy->localCertificate,
-                                                     newCertificate.length + 1);
-    if(retval != UA_STATUSCODE_GOOD)
+    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&newCertificate, &securityPolicy->localCertificate);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    memcpy(securityPolicy->localCertificate.data, newCertificate.data, newCertificate.length);
-    securityPolicy->localCertificate.data[newCertificate.length] = '\0';
-    securityPolicy->localCertificate.length--;
 
     /* Set the new private key */
     mbedtls_pk_free(&pc->localPrivateKey);
@@ -745,14 +743,10 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_ByteString 
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
     UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
 
-    /* Copy the certificate and add a NULL to the end */
-    UA_StatusCode retval =
-        UA_ByteString_allocBuffer(&policy->localCertificate, localCertificate.length + 1);
-    if(retval != UA_STATUSCODE_GOOD)
+    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    memcpy(policy->localCertificate.data, localCertificate.data, localCertificate.length);
-    policy->localCertificate.data[localCertificate.length] = '\0';
-    policy->localCertificate.length--;
 
     /* AsymmetricModule */
     UA_SecurityPolicySignatureAlgorithm *asym_signatureAlgorithm =


### PR DESCRIPTION
The buffer containing the local certificate is directly added to OPC UA messages without further conversion.
According to Part 6 of the specification, the required encoding for certificates is DER, so a conversion is necessary for PEM encoded local certificates.