### PR TITLE
feat(pubsub) support for all publisherIdTypes

### DIFF
--- a/examples/pubsub/server_pubsub_publisher_iop.c
+++ b/examples/pubsub/server_pubsub_publisher_iop.c
@@ -75,7 +75,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = Publisher_ID;
+    UA_UInt16 publisherId = Publisher_ID;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 

--- a/examples/pubsub/server_pubsub_publisher_rt_level.c
+++ b/examples/pubsub/server_pubsub_publisher_rt_level.c
@@ -51,7 +51,8 @@ addMinimalPubSubConfiguration(UA_Server * server){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    UA_UInt16 publisherId = 2234;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     /* Add one PublishedDataSet */
     UA_PublishedDataSetConfig publishedDataSetConfig;

--- a/examples/pubsub/server_pubsub_rt_field_information_model.c
+++ b/examples/pubsub/server_pubsub_rt_field_information_model.c
@@ -34,7 +34,8 @@ addMinimalPubSubConfiguration(UA_Server * server){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random();
+    UA_UInt32 publisherId = UA_UInt32_random();
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     /* Add one PublishedDataSet */
     UA_PublishedDataSetConfig publishedDataSetConfig;

--- a/examples/pubsub/server_pubsub_subscriber_rt_level.c
+++ b/examples/pubsub/server_pubsub_subscriber_rt_level.c
@@ -109,7 +109,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    UA_UInt32 publisherId = UA_UInt32_random();
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD)
         return retval;

--- a/examples/pubsub/tutorial_pubsub_connection.c
+++ b/examples/pubsub/tutorial_pubsub_connection.c
@@ -55,7 +55,8 @@ int main(void) {
      * defined UA_NetworkAddressUrlDataType. */
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random();
+    UA_UInt32 publisherId = UA_UInt32_random();
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     /* Connection options are given as Key/Value Pairs. The available options are
      * maybe standard or vendor defined. */
     UA_KeyValuePair connectionOptions[3];

--- a/examples/pubsub/tutorial_pubsub_mqtt_publish.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt_publish.c
@@ -77,7 +77,8 @@ addPubSubConnection(UA_Server *server, char *addressUrl) {
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     /* Changed to static publisherId from random generation to identify
      * the publisher on Subscriber side */
-    connectionConfig.publisherId.numeric = 2234;
+    UA_UInt16 publisherId = 2234;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
 
     /* configure options, set mqtt client id */
 #ifdef EXAMPLE_USE_MQTT_LOGIN

--- a/examples/pubsub/tutorial_pubsub_publish.c
+++ b/examples/pubsub/tutorial_pubsub_publish.c
@@ -46,9 +46,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    /* Changed to static publisherId from random generation to identify
-     * the publisher on Subscriber side */
-    connectionConfig.publisherId.numeric = 2234;
+    UA_UInt16 publisherId = 2234;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 

--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -52,7 +52,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    UA_UInt32 publisherId = UA_UInt32_random();
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD) {
         return retval;

--- a/examples/pubsub_realtime/pubsub_TSN_loopback.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback.c
@@ -283,7 +283,8 @@ addPubSubConnectionSubscriber(UA_Server *server, UA_NetworkAddressUrlDataType *n
     UA_NetworkAddressUrlDataType networkAddressUrlsubscribe = *networkAddressUrlSubscriber;
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlsubscribe, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = UA_UInt32_random();
+    UA_UInt32 publisherId                                   = UA_UInt32_random();
+    UA_Variant_setScalarCopy(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentSubscriber);
     if (retval == UA_STATUSCODE_GOOD)
          UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,"The PubSub Connection was created successfully!");
@@ -495,7 +496,8 @@ addPubSubConnection(UA_Server *server, UA_NetworkAddressUrlDataType *networkAddr
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = PUBLISHER_ID;
+    UA_UInt16 publisherId                                   = PUBLISHER_ID;
+    UA_Variant_setScalarCopy(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     /* ETF configuration settings */
     connectionConfig.etfConfiguration.socketPriority        = SOCKET_PRIORITY;
     connectionConfig.etfConfiguration.sotxtimeEnabled       = UA_TRUE;

--- a/examples/pubsub_realtime/pubsub_TSN_publisher.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher.c
@@ -284,7 +284,8 @@ addPubSubConnectionSubscriber(UA_Server *server, UA_NetworkAddressUrlDataType *n
     UA_NetworkAddressUrlDataType networkAddressUrlsubscribe = *networkAddressUrlSubscriber;
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlsubscribe, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = UA_UInt32_random();
+    UA_UInt32 publisherId                                   = UA_UInt32_random();
+    UA_Variant_setScalarCopy(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentSubscriber);
     if (retval == UA_STATUSCODE_GOOD)
          UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,"The PubSub Connection was created successfully!");
@@ -498,7 +499,8 @@ addPubSubConnection(UA_Server *server, UA_NetworkAddressUrlDataType *networkAddr
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = PUBLISHER_ID;
+    UA_UInt16 publisherId                                   = PUBLISHER_ID;
+    UA_Variant_setScalarCopy(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     /* ETF configuration settings */
     connectionConfig.etfConfiguration.socketPriority        = SOCKET_PRIORITY;
     connectionConfig.etfConfiguration.sotxtimeEnabled       = UA_TRUE;

--- a/examples/pubsub_realtime/pubsub_interrupt_publish.c
+++ b/examples/pubsub_realtime/pubsub_interrupt_publish.c
@@ -272,7 +272,8 @@ addPubSubConfiguration(UA_Server* server) {
         {UA_STRING(ETH_INTERFACE), UA_STRING(ETH_PUBLISH_ADDRESS)};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random();
+    UA_UInt32 publisherId                                   = UA_UInt32_random();
+    UA_Variant_setScalarCopy(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 
     UA_PublishedDataSetConfig publishedDataSetConfig;

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -147,11 +147,6 @@ _UA_BEGIN_DECLS
  * Take a look on the PubSub Tutorials for mor details about the API usage.
  */
 
-typedef enum {
-    UA_PUBSUB_PUBLISHERID_NUMERIC,
-    UA_PUBSUB_PUBLISHERID_STRING
-} UA_PublisherIdType;
-
 #ifdef UA_ENABLE_PUBSUB_ETH_UADP_ETF
 typedef struct {
     UA_Int32 socketPriority;
@@ -165,11 +160,7 @@ typedef struct {
 typedef struct {
     UA_String name;
     UA_Boolean enabled;
-    UA_PublisherIdType publisherIdType;
-    union { /* std: valid types UInt or String */
-        UA_UInt32 numeric;
-        UA_String string;
-    } publisherId;
+    UA_Variant publisherId;
     UA_String transportProfileUri;
     UA_Variant address;
     size_t connectionPropertiesSize;

--- a/src/pubsub/ua_pubsub_config.c
+++ b/src/pubsub/ua_pubsub_config.c
@@ -174,18 +174,12 @@ UA_PubSubManager_updatePubSubConfig(UA_Server* server, const UA_PubSubConfigurat
  */
 static UA_StatusCode
 UA_PubSubManager_setConnectionPublisherId(const UA_PubSubConnectionDataType *src, UA_PubSubConnectionConfig *dst) {
-    if(UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_STRING].typeId)) {
-        dst->publisherIdType = UA_PUBSUB_PUBLISHERID_STRING;
-        dst->publisherId.string = *(UA_String*)src->publisherId.data;
-    } else if(UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_BYTE].typeId) || 
-              UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_UINT16].typeId) || 
-              UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_UINT32].typeId)) {
-        dst->publisherIdType = UA_PUBSUB_PUBLISHERID_NUMERIC;
-        dst->publisherId.numeric =  *(UA_UInt32*)src->publisherId.data;
-    } else if(UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_UINT64].typeId)) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, 
-                    "[UA_PubSubManager_setConnectionPublisherId] PublisherId is UInt64 (not implemented); Recommended dataType for PublisherId: UInt32");
-        return UA_STATUSCODE_BADNOTIMPLEMENTED;
+    if(UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_STRING].typeId) ||
+       UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_BYTE].typeId) || 
+       UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_UINT16].typeId) || 
+       UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_UINT32].typeId) ||
+       UA_NodeId_equal(&src->publisherId.type->typeId, &UA_TYPES[UA_TYPES_UINT64].typeId) {
+        UA_Variant_copy(&dst->publisherId, src->config->publisherId);
     } else {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "[UA_PubSubManager_setConnectionPublisherId] PublisherId is not valid.");
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -1295,12 +1289,8 @@ UA_PubSubManager_generatePubSubConnectionDataType(UA_PubSubConnectionDataType *d
     for(index = 0; index < src->config->connectionPropertiesSize; index++) {
         UA_KeyValuePair_copy(&src->config->connectionProperties[index], &dst->connectionProperties[index]);
     }
-
-    if(src->config->publisherIdType == UA_PUBSUB_PUBLISHERID_NUMERIC) {
-        UA_Variant_setScalarCopy(&dst->publisherId, &src->config->publisherId.numeric, &UA_TYPES[UA_TYPES_UINT32]);
-    } else if(src->config->publisherIdType == UA_PUBSUB_PUBLISHERID_STRING) {
-        UA_Variant_setScalarCopy(&dst->publisherId, &src->config->publisherId.string, &UA_TYPES[UA_TYPES_STRING]);
-    }
+    
+    UA_Variant_copy(&dst->publisherId, &src->config->publisherId);
 
     /* Possibly, array size and dimensions of src->config->address and src->config->connectionTransportSettings 
        should be checked beforehand. */

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -31,6 +31,17 @@ UA_Server_addPubSubConnection(UA_Server *server,
                      "PubSub Connection creation failed. Requested transport layer not found.");
         return UA_STATUSCODE_BADNOTFOUND;
     }
+    
+    if(!(connectionConfig->publisherId.type == &UA_TYPES[UA_TYPES_BYTE] ||
+         connectionConfig->publisherId.type == &UA_TYPES[UA_TYPES_UINT16] ||
+         connectionConfig->publisherId.type == &UA_TYPES[UA_TYPES_UINT32] ||
+         connectionConfig->publisherId.type == &UA_TYPES[UA_TYPES_UINT64] ||
+         connectionConfig->publisherId.type == &UA_TYPES[UA_TYPES_STRING] ||
+         UA_Variant_isEmpty(&connectionConfig->publisherId))) {
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "PubSub Connection creation failed. Invalid PublisherIdType.");
+        return UA_STATUSCODE_BADTYPEMISMATCH;
+    }
 
     /* Create a copy of the connection config */
     UA_PubSubConnectionConfig *tmpConnectionConfig = (UA_PubSubConnectionConfig *)
@@ -46,6 +57,11 @@ UA_Server_addPubSubConnection(UA_Server *server,
         UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "PubSub Connection creation failed. Could not copy the config.");
         return retval;
+    }
+
+    if(UA_Variant_isEmpty(&tmpConnectionConfig->publisherId)){
+        UA_Byte publisherId = 0;
+        UA_Variant_setScalarCopy(&tmpConnectionConfig->publisherId, &publisherId, &UA_TYPES[UA_TYPES_BYTE]);
     }
 
     /* Create new connection and add to UA_PubSubManager */

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -111,13 +111,7 @@ onRead(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
             UA_PubSubConnection_findConnectionbyId(server, *myNodeId);
         switch(nodeContext->elementClassiefier) {
         case UA_NS0ID_PUBSUBCONNECTIONTYPE_PUBLISHERID:
-            if(pubSubConnection->config->publisherIdType == UA_PUBSUB_PUBLISHERID_STRING) {
-                UA_Variant_setScalar(&value, &pubSubConnection->config->publisherId.numeric,
-                                     &UA_TYPES[UA_TYPES_STRING]);
-            } else {
-                UA_Variant_setScalar(&value, &pubSubConnection->config->publisherId.numeric,
-                                     &UA_TYPES[UA_TYPES_UINT32]);
-            }
+            UA_Variant_copy(&pubSubConnection->config->publisherId, &value);
             break;
         default:
             UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER,
@@ -367,16 +361,7 @@ addPubSubConnectionAction(UA_Server *server,
     //connectionConfig.enabled = pubSubConnectionDataType.enabled;
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlDataType,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    if(pubSubConnectionDataType.publisherId.type == &UA_TYPES[UA_TYPES_UINT32]){
-        connectionConfig.publisherId.numeric = * ((UA_UInt32 *) pubSubConnectionDataType.publisherId.data);
-    } else if(pubSubConnectionDataType.publisherId.type == &UA_TYPES[UA_TYPES_STRING]){
-        connectionConfig.publisherIdType = UA_PUBSUB_PUBLISHERID_STRING;
-        UA_String_copy((UA_String *) pubSubConnectionDataType.publisherId.data, &connectionConfig.publisherId.string);
-    } else {
-        UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER, "Unsupported PublisherId Type used.");
-        //TODO what's the best default behaviour here?
-        connectionConfig.publisherId.numeric = 0;
-    }
+    UA_Variant_copy(&pubSubConnectionDataType.publisherId, &connectionConfig.publisherId);
     //call API function and create the connection
     UA_NodeId connectionId;
 

--- a/tests/pubsub/check_pubsub_connection_ethernet.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet.c
@@ -162,7 +162,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("Ethernet Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalarCopy(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -193,7 +194,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("Ethernet Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalarCopy(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_connection_ethernet_etf.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet_etf.c
@@ -171,7 +171,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("Ethernet ETF Connection");
     connectionConf.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalar(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -205,7 +206,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("Ethernet ETF Connection");
     connectionConf.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalar(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_connection_mqtt.c
+++ b/tests/pubsub/check_pubsub_connection_mqtt.c
@@ -147,7 +147,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("MQTT Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-mqtt");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalar(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -179,7 +180,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("MQTT Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-mqtt");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalar(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_connection_udp.c
+++ b/tests/pubsub/check_pubsub_connection_udp.c
@@ -134,7 +134,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("UADP Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalar(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -165,7 +166,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("UADP Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalar(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_connection_xdp.c
+++ b/tests/pubsub/check_pubsub_connection_xdp.c
@@ -188,7 +188,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("XDP Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalarCopy(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -219,7 +220,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("XDP Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    UA_UInt32 publisherId = 223344;
+    UA_Variant_setScalarCopy(&connectionConf.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
@@ -33,7 +33,8 @@ addMinimalPubSubConfiguration(void){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    UA_UInt16 publisherId = 2234;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;

--- a/tests/pubsub/check_pubsub_publish_ethernet.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet.c
@@ -66,7 +66,8 @@ START_TEST(EthernetSendWithoutVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    UA_UInt16 publisherId = PUBLISHER_ID;
+    UA_Variant_setScalarCopy(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
     connection = UA_PubSubConnection_findConnectionbyId(server, connection_test);
     /* Remove the connection if invalid*/
@@ -94,7 +95,8 @@ START_TEST(EthernetSendWithVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    UA_UInt16 publisherId = PUBLISHER_ID;
+    UA_Variant_setScalarCopy(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
     connection = UA_PubSubConnection_findConnectionbyId(server, connection_test);
     /* Remove the connection if invalid*/

--- a/tests/pubsub/check_pubsub_publish_ethernet_etf.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet_etf.c
@@ -74,7 +74,8 @@ START_TEST(EthernetSendWithoutVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    UA_UInt16 publisherId = PUBLISHER_ID;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     /* ETF configuration settings */
     connectionConfig.etfConfiguration.socketPriority = SOCKET_PRIORITY;
     connectionConfig.etfConfiguration.sotxtimeEnabled = UA_TRUE;
@@ -120,7 +121,8 @@ START_TEST(EthernetSendWithVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    UA_UInt16 publisherId = PUBLISHER_ID;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     /* ETF configuration settings */
     connectionConfig.etfConfiguration.socketPriority = SOCKET_PRIORITY;
     connectionConfig.etfConfiguration.sotxtimeEnabled = UA_TRUE;

--- a/tests/pubsub/check_pubsub_publish_rt_levels.c
+++ b/tests/pubsub/check_pubsub_publish_rt_levels.c
@@ -30,7 +30,8 @@ addMinimalPubSubConfiguration(void){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random();
+    UA_UInt32 publisherId = UA_UInt32_random();
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT32]);
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;

--- a/tests/pubsub/check_pubsub_publish_uadp.c
+++ b/tests/pubsub/check_pubsub_publish_uadp.c
@@ -35,7 +35,8 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    connectionConfig.publisherId.numeric = 62541;
+    UA_UInt16 publisherId = 62541;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
     UA_PublishedDataSetConfig publishedDataSetConfig;

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -59,7 +59,8 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    UA_UInt16 publisherId = PUBLISHER_ID;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
     UA_PubSubConnection_regist(server, &connection_test);
 }

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -34,7 +34,8 @@ addMinimalPubSubConfiguration(void){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    UA_UInt16 publisherId = 2234;
+    UA_Variant_setScalar(&connectionConfig.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;


### PR DESCRIPTION
For the usecase of UInt32 and the like i decided to implement the support of all PublisherIdTypes:

- Byte
- UInt16
- UInt32
- UInt64
- String

Previously, while creating a new pubsub connection, there was a union in [UA_PubSubConnectionConfig](https://github.com/open62541/open62541/blob/52db1ca7a44758c86ec3df00945f5c03771eb6dd/include/open62541/server_pubsub.h#L167) and an [enum](https://github.com/open62541/open62541/blob/52db1ca7a44758c86ec3df00945f5c03771eb6dd/include/open62541/server_pubsub.h#L166) to keep track of the type.

On the other hand when creating a dataset reader on the subscriber side there was the use of a [variant](https://github.com/open62541/open62541/blob/52db1ca7a44758c86ec3df00945f5c03771eb6dd/include/open62541/server_pubsub.h#L515). 

Since for implementing i had to choose one, i picked the variant for consitency. The UA_PubSubConnectionDataType in types_generated.h generates a variant aswell so i saw that fit, which enables basic variant copy from UA_PubSubConnectionDataType to UA_PubSubConnectionConfig in [this case](https://github.com/open62541/open62541/blob/52db1ca7a44758c86ec3df00945f5c03771eb6dd/src/pubsub/ua_pubsub_ns0.c#L348).

For the case of an empty Variant i added a check where it sets the VariantType to Byte with a value of zero.

I'll happily add tests for each PublisherIdType or change to union if you see it a better fit.