### PR TITLE
Fix: Delete new notification

### DIFF
--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -163,17 +163,20 @@ UA_Notification_new(void) {
 void
 UA_Notification_delete(UA_Server *server, UA_Notification *n) {
     UA_assert(n != UA_SUBSCRIPTION_QUEUE_SENTINEL);
-    UA_Notification_dequeueMon(server, n);
-    UA_Notification_dequeueSub(n);
-    switch(n->mon->attributeId) {
+    if(n->mon != NULL)
+    {
+        UA_Notification_dequeueMon(server, n);
+        UA_Notification_dequeueSub(n);
+        switch(n->mon->attributeId) {
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
-    case UA_ATTRIBUTEID_EVENTNOTIFIER:
-        UA_EventFieldList_clear(&n->data.event);
-        break;
+        case UA_ATTRIBUTEID_EVENTNOTIFIER:
+            UA_EventFieldList_clear(&n->data.event);
+            break;
 #endif
-    default:
-        UA_MonitoredItemNotification_clear(&n->data.dataChange);
-        break;
+        default:
+            UA_MonitoredItemNotification_clear(&n->data.dataChange);
+            break;
+        }
     }
     UA_free(n);
 }


### PR DESCRIPTION
This enable deleting new notifications, that have no values assigned, e.g. 
```cpp
UA_Notification *pNotification = UA_Notification_new();
// Do nothing with the notification
UA_Notification_delte(pServer, pNotification);
```

This was the case here:
https://github.com/open62541/open62541/blob/03a655667e91cd5ccb8221d919fa2ac6d5a00698/src/server/ua_subscription_events.c#L486-L496

