### PR TITLE
feat(pubsub) allow subscribing to NetworkMessages with multiple DataSetMessages

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -666,36 +666,35 @@ UA_Server_setReaderGroupDisabled(UA_Server *server, const UA_NodeId readerGroupI
 }
 
 static UA_StatusCode
-checkReaderIdentifier(UA_Server *server, UA_NetworkMessage *pMsg, UA_DataSetReader *reader) {
-    if(!pMsg->groupHeaderEnabled &&
-       !pMsg->groupHeader.writerGroupIdEnabled &&
-       !pMsg->payloadHeaderEnabled) {
-        UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                    "Cannot process DataSetReader without WriterGroup"
-                    "and DataSetWriter identifiers");
-        return UA_STATUSCODE_BADNOTIMPLEMENTED;
+checkReaderIdentifier(UA_Server *server, UA_NetworkMessage *pMsg, UA_DataSetReader *reader, UA_UInt16 dataSetWriterId) {
+
+    if(pMsg->groupHeaderEnabled &&
+       pMsg->groupHeader.writerGroupIdEnabled && 
+       (reader->config.writerGroupId != pMsg->groupHeader.writerGroupId)) {
+        return UA_STATUSCODE_BADNOTFOUND;
     }
 
-    if((reader->config.writerGroupId == pMsg->groupHeader.writerGroupId) &&
-       (reader->config.dataSetWriterId == *pMsg->payloadHeader.dataSetPayloadHeader.dataSetWriterIds)) {
-        UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_SERVER,
+    if(pMsg->payloadHeaderEnabled && (reader->config.dataSetWriterId != dataSetWriterId)) {
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+
+    UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "DataSetReader found. Process NetworkMessage");
-        return UA_STATUSCODE_GOOD;
-    }
 
-    return UA_STATUSCODE_BADNOTFOUND;
+    return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-getReaderFromIdentifier(UA_Server *server, UA_NetworkMessage *pMsg,
-                        UA_DataSetReader **dataSetReader, UA_PubSubConnection *pConnection) {
+getReadersFromIdentifier(UA_Server *server, UA_NetworkMessage *pMsg, UA_PubSubConnection *pConnection, UA_UInt16 dataSetWriterId,
+                        UA_DataSetReader ***dataSetReaders, UA_Byte* dataSetReaderCount) {
     UA_StatusCode retval = UA_STATUSCODE_BADNOTFOUND;
     if(!pMsg->publisherIdEnabled) {
         UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                     "Cannot process DataSetReader without PublisherId");
         return UA_STATUSCODE_BADNOTIMPLEMENTED; /* TODO: Handle DSR without PublisherId */
     }
-
+    UA_DataSetReader** tmpDataSetReaders = NULL;
+    UA_Byte dsrCount = 0;
     UA_ReaderGroup* readerGroup;
     LIST_FOREACH(readerGroup, &pConnection->readerGroups, listEntry) {
         UA_DataSetReader *tmpReader;
@@ -705,28 +704,28 @@ getReaderFromIdentifier(UA_Server *server, UA_NetworkMessage *pMsg,
                 if(tmpReader->config.publisherId.type == &UA_TYPES[UA_TYPES_BYTE] &&
                    pMsg->publisherIdType == UA_PUBLISHERDATATYPE_BYTE &&
                    pMsg->publisherId.publisherIdByte == *(UA_Byte*)tmpReader->config.publisherId.data) {
-                    retval = checkReaderIdentifier(server, pMsg, tmpReader);
+                    retval = checkReaderIdentifier(server, pMsg, tmpReader, dataSetWriterId);
                 }
                 break;
             case UA_PUBLISHERDATATYPE_UINT16:
                 if(tmpReader->config.publisherId.type == &UA_TYPES[UA_TYPES_UINT16] &&
                    pMsg->publisherIdType == UA_PUBLISHERDATATYPE_UINT16 &&
                    pMsg->publisherId.publisherIdUInt16 == *(UA_UInt16*) tmpReader->config.publisherId.data) {
-                    retval = checkReaderIdentifier(server, pMsg, tmpReader);
+                    retval = checkReaderIdentifier(server, pMsg, tmpReader, dataSetWriterId);
                 }
                 break;
             case UA_PUBLISHERDATATYPE_UINT32:
                 if(tmpReader->config.publisherId.type == &UA_TYPES[UA_TYPES_UINT32] &&
                    pMsg->publisherIdType == UA_PUBLISHERDATATYPE_UINT32 &&
                    pMsg->publisherId.publisherIdUInt32 == *(UA_UInt32*)tmpReader->config.publisherId.data) {
-                    retval = checkReaderIdentifier(server, pMsg, tmpReader);
+                    retval = checkReaderIdentifier(server, pMsg, tmpReader, dataSetWriterId);
                 }
                 break;
             case UA_PUBLISHERDATATYPE_UINT64:
                 if(tmpReader->config.publisherId.type == &UA_TYPES[UA_TYPES_UINT64] &&
                    pMsg->publisherIdType == UA_PUBLISHERDATATYPE_UINT64 &&
                    pMsg->publisherId.publisherIdUInt64 == *(UA_UInt64*)tmpReader->config.publisherId.data) {
-                    retval = checkReaderIdentifier(server, pMsg, tmpReader);
+                    retval = checkReaderIdentifier(server, pMsg, tmpReader, dataSetWriterId);
                 }
                 break;
             case UA_PUBLISHERDATATYPE_STRING:
@@ -734,7 +733,7 @@ getReaderFromIdentifier(UA_Server *server, UA_NetworkMessage *pMsg,
                    pMsg->publisherIdType == UA_PUBLISHERDATATYPE_STRING &&
                    UA_String_equal(&pMsg->publisherId.publisherIdString,
                                    (UA_String*)tmpReader->config.publisherId.data)) {
-                    retval = checkReaderIdentifier(server, pMsg, tmpReader);
+                    retval = checkReaderIdentifier(server, pMsg, tmpReader, dataSetWriterId);
                 }
                 break;
             default:
@@ -742,12 +741,21 @@ getReaderFromIdentifier(UA_Server *server, UA_NetworkMessage *pMsg,
             }
 
             if(retval == UA_STATUSCODE_GOOD) {
-                *dataSetReader = tmpReader;
-                return UA_STATUSCODE_GOOD;
+                ++dsrCount;
+                tmpDataSetReaders = (UA_DataSetReader**)UA_realloc(tmpDataSetReaders, sizeof(UA_DataSetReader*) * dsrCount);
+                if(tmpDataSetReaders == NULL) {
+                    return UA_STATUSCODE_BADOUTOFMEMORY;
+                }
+                tmpDataSetReaders[dsrCount-1] = tmpReader;
             }
         }
     }
 
+    *dataSetReaders = tmpDataSetReaders;
+    *dataSetReaderCount = dsrCount; 
+    if(dsrCount > 0)
+        return UA_STATUSCODE_GOOD;
+    
     UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                 "Dataset reader not found. Check PublisherID, WriterGroupID and DatasetWriterID");
     return UA_STATUSCODE_BADNOTFOUND;
@@ -849,7 +857,9 @@ void UA_ReaderGroup_subscribeCallback(UA_Server *server, UA_ReaderGroup *readerG
             do {
                 UA_NetworkMessage currentNetworkMessage;
                 memset(&currentNetworkMessage, 0, sizeof(UA_NetworkMessage));
-                UA_NetworkMessage_decodeBinary(&buffer, &currentPosition, &currentNetworkMessage);
+                UA_StatusCode retVal = UA_NetworkMessage_decodeBinary(&buffer, &currentPosition, &currentNetworkMessage);
+                if(retVal != UA_STATUSCODE_GOOD)
+                	break;
                 UA_Server_processNetworkMessage(server, &currentNetworkMessage, connection);
                 UA_NetworkMessage_deleteMembers(&currentNetworkMessage);
             } while((buffer.length) > currentPosition);
@@ -1409,27 +1419,34 @@ UA_Server_processNetworkMessage(UA_Server *server, UA_NetworkMessage *pMsg,
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(!pMsg || !pConnection)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-
-    /* To Do Handle multiple DataSetMessage for one NetworkMessage */
+    
     /* To Do The condition pMsg->dataSetClassIdEnabled
      * Here some filtering is possible */
-
-    UA_DataSetReader *dataSetReader;
-    retval = getReaderFromIdentifier(server, pMsg, &dataSetReader, pConnection);
-    if(retval != UA_STATUSCODE_GOOD) {
-        return retval;
-    }
-
-    UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                 "DataSetReader found with PublisherId");
-
-    UA_Byte anzDataSets = 1;
+    UA_Byte dsmCount = 1;
     if(pMsg->payloadHeaderEnabled)
-        anzDataSets = pMsg->payloadHeader.dataSetPayloadHeader.count;
-    for(UA_Byte iterator = 0; iterator < anzDataSets; iterator++) {
+        dsmCount = pMsg->payloadHeader.dataSetPayloadHeader.count;
+    for(UA_Byte i = 0; i < dsmCount; i++)
+    {
+        UA_DataSetReader** dataSetReaders = NULL;
+        UA_Byte dsrCount = 0;
+        UA_UInt16 dataSetWriterId = 0;
+        if(pMsg->payloadHeaderEnabled) {
+            dataSetWriterId = pMsg->payloadHeader.dataSetPayloadHeader.dataSetWriterIds[i];
+        }
+        retval = getReadersFromIdentifier(server, pMsg, pConnection, dataSetWriterId, &dataSetReaders, &dsrCount);
+        if(retval != UA_STATUSCODE_GOOD)
+            continue;
+
+        UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                    "DataSetReader found with PublisherId");
+
         UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_SERVER, "Process Msg with DataSetReader!");
-        UA_Server_DataSetReader_process(server, dataSetReader,
-                                        &pMsg->payload.dataSetPayload.dataSetMessages[iterator]);
+        for(UA_Byte j = 0; j < dsrCount; j++) {
+            UA_Server_DataSetReader_process(server, dataSetReaders[j],
+                                            &pMsg->payload.dataSetPayload.dataSetMessages[i]);
+        }
+        if(dataSetReaders != NULL)
+            UA_free(dataSetReaders);
     }
 
     /* To Do Handle when dataSetReader parameters are null for publisherId

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -16,17 +16,21 @@
 #include "ua_pubsub.h"
 #include "ua_server_internal.h"
 
-#define UA_SUBSCRIBER_PORT       4801    /* Port for Subscriber*/
-#define PUBLISH_INTERVAL         5       /* Publish interval*/
-#define PUBLISHER_ID             2234    /* Publisher Id*/
-#define DATASET_WRITER_ID        62541   /* DataSet Writer Id*/
-#define WRITER_GROUP_ID          100     /* Writer group Id  */
-#define PUBLISHER_DATA           42      /* Published data */
-#define PUBLISHVARIABLE_NODEID   1000    /* Published data nodeId */
-#define SUBSCRIBEOBJECT_NODEID   1001    /* Object nodeId */
-#define SUBSCRIBEVARIABLE_NODEID 1002    /* Subscribed data nodeId */
-#define READERGROUP_COUNT        2       /* Value to add readergroup to connection */
-#define CHECK_READERGROUP_COUNT  3       /* Value to check readergroup count */
+#define UA_SUBSCRIBER_PORT          4801    /* Port for Subscriber*/
+#define PUBLISH_INTERVAL            5       /* Publish interval*/
+#define PUBLISHER_ID                2234    /* Publisher Id*/
+#define DATASET_WRITER_ID           62541   /* DataSet Writer Id*/
+#define DATASET_WRITER_ID2          62542   /* DataSet Writer Id*/
+#define WRITER_GROUP_ID             100     /* Writer group Id  */
+#define PUBLISHER_DATA              42      /* Published data */
+#define PUBLISHER_DATA2             43      /* Published data */
+#define PUBLISHVARIABLE_NODEID      1000    /* Published data nodeId */
+#define PUBLISHVARIABLE_NODEID2     1001    /* Published data nodeId */
+#define SUBSCRIBEOBJECT_NODEID      1002    /* Object nodeId */
+#define SUBSCRIBEVARIABLE_NODEID    1003    /* Subscribed data nodeId */
+#define SUBSCRIBEVARIABLE_NODEID2   1004    /* Subscribed data nodeId */
+#define READERGROUP_COUNT           2       /* Value to add readergroup to connection */
+#define CHECK_READERGROUP_COUNT     3       /* Value to check readergroup count */
 
 /* Global declaration for test cases  */
 UA_Server *server = NULL;
@@ -1340,6 +1344,440 @@ START_TEST(SinglePublishSubscribewithValidIdentifiers) {
         UA_Variant_delete(publishedNodeData);
     } END_TEST
 
+START_TEST(SinglePublishSubscribeMultipleDataSetReaders) {
+        /* To check status after running both publisher and subscriber */
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+        UA_PublishedDataSetConfig pdsConfig;
+        UA_NodeId dataSetWriter;
+        UA_NodeId readerIdentifier[2];
+        UA_NodeId writerGroup;
+        UA_DataSetReaderConfig readerConfig;
+
+        /* Published DataSets */
+        memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
+        pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
+        pdsConfig.name = UA_STRING("PublishedDataSet Test");
+        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetTest);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Create variables to publish integer data */
+        UA_NodeId publisherNode;
+        UA_VariableAttributes attr = UA_VariableAttributes_default;
+        attr.description           = UA_LOCALIZEDTEXT("en-US","Published Integer");
+        attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Integer");
+        attr.dataType              = UA_TYPES[UA_TYPES_UINT32].typeId;
+        attr.accessLevel           = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+        UA_UInt32 publisherData    = PUBLISHER_DATA;
+        UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_UINT32]);
+        retVal                     = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                                               UA_QUALIFIEDNAME(1, "Published Integer"),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                                               attr, NULL, &publisherNode);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Data Set Field */
+        UA_NodeId dataSetFieldIdent;
+        UA_DataSetFieldConfig dataSetFieldConfig;
+        memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
+        dataSetFieldConfig.dataSetFieldType              = UA_PUBSUB_DATASETFIELD_VARIABLE;
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Published Integer");
+        dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
+        dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
+        UA_Server_addDataSetField (server, publishedDataSetTest, &dataSetFieldConfig, &dataSetFieldIdent);
+
+
+        /* Writer group */
+        UA_WriterGroupConfig writerGroupConfig;
+        memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
+        writerGroupConfig.name               = UA_STRING("WriterGroup Test");
+        writerGroupConfig.publishingInterval = PUBLISH_INTERVAL;
+        writerGroupConfig.enabled            = UA_FALSE;
+        writerGroupConfig.writerGroupId      = WRITER_GROUP_ID;
+        writerGroupConfig.encodingMimeType   = UA_PUBSUB_ENCODING_UADP;
+        writerGroupConfig.maxEncapsulatedDataSetMessageCount = 2;
+        /* Message settings in WriterGroup to include necessary headers */
+        writerGroupConfig.messageSettings.encoding             = UA_EXTENSIONOBJECT_DECODED;
+        writerGroupConfig.messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE];
+        UA_UadpWriterGroupMessageDataType *writerGroupMessage  = UA_UadpWriterGroupMessageDataType_new();
+        writerGroupMessage->networkMessageContentMask          = (UA_UadpNetworkMessageContentMask)(UA_UADPNETWORKMESSAGECONTENTMASK_PUBLISHERID |
+                                                                  (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_GROUPHEADER |
+                                                                  (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_WRITERGROUPID |
+                                                                  (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_PAYLOADHEADER);
+        writerGroupConfig.messageSettings.content.decoded.data = writerGroupMessage;
+        retVal |= UA_Server_addWriterGroup(server, connection_test, &writerGroupConfig, &writerGroup);
+        UA_Server_setWriterGroupOperational(server, writerGroup);
+        UA_UadpWriterGroupMessageDataType_delete(writerGroupMessage);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* DataSetWriters */
+        UA_DataSetWriterConfig dataSetWriterConfig;
+        memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
+        dataSetWriterConfig.name            = UA_STRING("DataSetWriter Test");
+        dataSetWriterConfig.dataSetWriterId = DATASET_WRITER_ID;
+        dataSetWriterConfig.keyFrameCount   = 10;
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup, publishedDataSetTest, &dataSetWriterConfig, &dataSetWriter);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Reader Group */
+        UA_ReaderGroupConfig readerGroupConfig;
+        memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
+        readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
+        retVal |=  UA_Server_addReaderGroup(server, connection_test, &readerGroupConfig, &readerGroupTest);
+        UA_Server_setReaderGroupOperational(server, readerGroupTest);
+        /* Data Set Reader */
+        /* Parameters to filter received NetworkMessage */
+        memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
+        readerConfig.name             = UA_STRING ("DataSetReader Test 1");
+        UA_UInt16 publisherIdentifier = PUBLISHER_ID;
+        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+        readerConfig.publisherId.data = &publisherIdentifier;
+        readerConfig.writerGroupId    = WRITER_GROUP_ID;
+        readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
+        /* Setting up Meta data configuration in DataSetReader */
+        UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
+        /* FilltestMetadata function in subscriber implementation */
+        UA_DataSetMetaDataType_init (pMetaData);
+        pMetaData->name       = UA_STRING ("DataSet Test");
+        /* Static definition of number of fields size to 1 to create one
+        targetVariable */
+        pMetaData->fieldsSize = 1;
+        pMetaData->fields     = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
+                                                                 &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+        /* Unsigned Integer DataType */
+        UA_FieldMetaData_init (&pMetaData->fields[0]);
+        UA_NodeId_copy (&UA_TYPES[UA_TYPES_UINT32].typeId,
+                        &pMetaData->fields[0].dataType);
+        pMetaData->fields[0].builtInType = UA_NS0ID_UINT32;
+        pMetaData->fields[0].valueRank   = -1; /* scalar */
+        retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
+                                             &readerIdentifier[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        readerConfig.name             = UA_STRING ("DataSetReader Test 2");
+        readerConfig.writerGroupId    = WRITER_GROUP_ID;
+        readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
+        retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
+                                             &readerIdentifier[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+
+        /* Add Subscribed Variables */
+        UA_NodeId folderId;
+        UA_NodeId newnodeId[2];
+        UA_String folderName      = readerConfig.dataSetMetaData.name;
+        UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+        UA_QualifiedName folderBrowseName;
+        if (folderName.length > 0) {
+            oAttr.displayName.locale        = UA_STRING ("en-US");
+            oAttr.displayName.text          = folderName;
+            folderBrowseName.namespaceIndex = 1;
+            folderBrowseName.name           = folderName;
+        }
+        else {
+            oAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Variables");
+            folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
+        }
+
+        retVal = UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                         folderBrowseName, UA_NODEID_NUMERIC(0,
+                                         UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Variable to subscribe data */
+        UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+        vAttr.displayName.locale    = UA_STRING ("en-US");
+        vAttr.displayName.text      = UA_STRING ("Subscribed Integer 1");
+        vAttr.valueRank             = -1;
+        retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID),
+                                           UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Integer 1"),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        vAttr.displayName.text      = UA_STRING ("Subscribed Integer 2");
+        retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID2),
+                                           UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Integer 2"),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_FieldTargetVariable targetVar;
+        memset(&targetVar, 0, sizeof(UA_FieldTargetVariable));
+        /* For creating Targetvariable */
+        UA_FieldTargetDataType_init(&targetVar.targetVariable);
+        targetVar.targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
+        targetVar.targetVariable.targetNodeId = newnodeId[0];
+        retVal |= UA_Server_DataSetReader_createTargetVariables(server, readerIdentifier[0],
+                                                                1, &targetVar);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        targetVar.targetVariable.targetNodeId = newnodeId[1];
+        retVal |= UA_Server_DataSetReader_createTargetVariables(server, readerIdentifier[1],
+                                                                1, &targetVar);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_FieldTargetDataType_clear(&targetVar.targetVariable);
+        UA_free(pMetaData->fields);
+        /* run server - publisher and subscriber */
+        UA_Server_run_iterate(server,true);
+
+        /* Read data sent by the Publisher */
+        UA_Variant *publishedNodeData = UA_Variant_new();
+        retVal                        = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID), &publishedNodeData[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+
+        /* Read data received by the Subscriber */
+        UA_Variant *subscribedNodeData = (UA_Variant*)UA_Array_new(2, &UA_TYPES[UA_TYPES_VARIANT]);
+        retVal                         = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID), &subscribedNodeData[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        retVal                         = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID2), &subscribedNodeData[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+
+        /* Check if data sent from Publisher is being received by Subscriber */
+        ck_assert_int_eq(*(UA_UInt32 *)publishedNodeData->data, *(UA_UInt32 *)subscribedNodeData[0].data);
+        ck_assert_int_eq(*(UA_UInt32 *)publishedNodeData->data, *(UA_UInt32 *)subscribedNodeData[1].data);
+        UA_Array_delete(subscribedNodeData, 2, &UA_TYPES[UA_TYPES_VARIANT]);
+        UA_Variant_delete(publishedNodeData);
+    } END_TEST
+
+START_TEST(PublishSubscribeMultipleDataSetMessages) {
+        /* To check status after running both publisher and subscriber */
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+        UA_PublishedDataSetConfig pdsConfig;
+        UA_NodeId dataSetWriter[2];
+        UA_NodeId readerIdentifier[2];
+        UA_NodeId writerGroup;
+        UA_DataSetReaderConfig readerConfig;
+        UA_NodeId publishedDataSet[2];
+
+        /* Published DataSets */
+        memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
+        pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
+        pdsConfig.name = UA_STRING("PublishedDataSet Test 1");
+        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        pdsConfig.name = UA_STRING("PublishedDataSet Test 2");
+        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Create variables to publish integer data */
+        UA_NodeId publisherNode[2];
+        UA_VariableAttributes attr = UA_VariableAttributes_default;
+        attr.description           = UA_LOCALIZEDTEXT("en-US","Published Integer 1");
+        attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Integer 1");
+        attr.dataType              = UA_TYPES[UA_TYPES_UINT32].typeId;
+        attr.accessLevel           = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+        UA_UInt32 publisherData    = PUBLISHER_DATA;
+        UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_UINT32]);
+        retVal                     = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                                               UA_QUALIFIEDNAME(1, "Published Integer 1"),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                                               attr, NULL, &publisherNode[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        attr.description           = UA_LOCALIZEDTEXT("en-US","Published Integer 2");
+        attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Integer 2");
+        publisherData              = PUBLISHER_DATA2;
+        UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_UINT32]);
+        retVal                     = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID2),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                                               UA_QUALIFIEDNAME(1, "Published Integer 2"),
+                                                               UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                                               attr, NULL, &publisherNode[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Data Set Fields */
+        UA_NodeId dataSetFieldIdent[2];
+        UA_DataSetFieldConfig dataSetFieldConfig;
+        memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
+        dataSetFieldConfig.dataSetFieldType              = UA_PUBSUB_DATASETFIELD_VARIABLE;
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Published Integer 1");
+        dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode[0];
+        dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
+        UA_Server_addDataSetField (server, publishedDataSet[0], &dataSetFieldConfig, &dataSetFieldIdent[0]);
+
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Published Integer 2");
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode[1];
+        UA_Server_addDataSetField (server, publishedDataSet[1], &dataSetFieldConfig, &dataSetFieldIdent[1]);
+
+
+        /* Writer group */
+        UA_WriterGroupConfig writerGroupConfig;
+        memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
+        writerGroupConfig.name               = UA_STRING("WriterGroup Test");
+        writerGroupConfig.publishingInterval = PUBLISH_INTERVAL;
+        writerGroupConfig.enabled            = UA_FALSE;
+        writerGroupConfig.writerGroupId      = WRITER_GROUP_ID;
+        writerGroupConfig.encodingMimeType   = UA_PUBSUB_ENCODING_UADP;
+        writerGroupConfig.maxEncapsulatedDataSetMessageCount = 2;
+        /* Message settings in WriterGroup to include necessary headers */
+        writerGroupConfig.messageSettings.encoding             = UA_EXTENSIONOBJECT_DECODED;
+        writerGroupConfig.messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE];
+        UA_UadpWriterGroupMessageDataType *writerGroupMessage  = UA_UadpWriterGroupMessageDataType_new();
+        writerGroupMessage->networkMessageContentMask          = (UA_UadpNetworkMessageContentMask)(UA_UADPNETWORKMESSAGECONTENTMASK_PUBLISHERID |
+                                                                  (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_GROUPHEADER |
+                                                                  (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_WRITERGROUPID |
+                                                                  (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_PAYLOADHEADER);
+        writerGroupConfig.messageSettings.content.decoded.data = writerGroupMessage;
+        retVal |= UA_Server_addWriterGroup(server, connection_test, &writerGroupConfig, &writerGroup);
+        UA_Server_setWriterGroupOperational(server, writerGroup);
+        UA_UadpWriterGroupMessageDataType_delete(writerGroupMessage);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* DataSetWriters */
+        UA_DataSetWriterConfig dataSetWriterConfig;
+        memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
+        dataSetWriterConfig.name            = UA_STRING("DataSetWriter Test 1");
+        dataSetWriterConfig.dataSetWriterId = DATASET_WRITER_ID;
+        dataSetWriterConfig.keyFrameCount   = 10;
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup, publishedDataSet[0], &dataSetWriterConfig, &dataSetWriter[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        dataSetWriterConfig.name            = UA_STRING("DataSetWriter Test 2");
+        dataSetWriterConfig.dataSetWriterId = DATASET_WRITER_ID2;
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup, publishedDataSet[1], &dataSetWriterConfig, &dataSetWriter[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Reader Group */
+        UA_ReaderGroupConfig readerGroupConfig;
+        memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
+        readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
+        retVal |=  UA_Server_addReaderGroup(server, connection_test, &readerGroupConfig, &readerGroupTest);
+        UA_Server_setReaderGroupOperational(server, readerGroupTest);
+        /* Data Set Reader */
+        /* Parameters to filter received NetworkMessage */
+        memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
+        readerConfig.name             = UA_STRING ("DataSetReader Test 1");
+        UA_UInt16 publisherIdentifier = PUBLISHER_ID;
+        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+        readerConfig.publisherId.data = &publisherIdentifier;
+        readerConfig.writerGroupId    = WRITER_GROUP_ID;
+        readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
+        /* Setting up Meta data configuration in DataSetReader */
+        UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
+        /* FilltestMetadata function in subscriber implementation */
+        UA_DataSetMetaDataType_init (pMetaData);
+        pMetaData->name       = UA_STRING ("DataSet Test");
+        /* Static definition of number of fields size to 1 to create one
+        targetVariable */
+        pMetaData->fieldsSize = 1;
+        pMetaData->fields     = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
+                                                                 &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+        /* Unsigned Integer DataType */
+        UA_FieldMetaData_init (&pMetaData->fields[0]);
+        UA_NodeId_copy (&UA_TYPES[UA_TYPES_UINT32].typeId,
+                        &pMetaData->fields[0].dataType);
+        pMetaData->fields[0].builtInType = UA_NS0ID_UINT32;
+        pMetaData->fields[0].valueRank   = -1; /* scalar */
+        retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
+                                             &readerIdentifier[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        readerConfig.name             = UA_STRING ("DataSetReader Test 2");
+        readerConfig.writerGroupId    = WRITER_GROUP_ID;
+        readerConfig.dataSetWriterId  = DATASET_WRITER_ID2;
+        retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
+                                             &readerIdentifier[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Add Subscribed Variables */
+        UA_NodeId folderId;
+        UA_NodeId newnodeId[2];
+        UA_String folderName      = readerConfig.dataSetMetaData.name;
+        UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+        UA_QualifiedName folderBrowseName;
+        if (folderName.length > 0) {
+            oAttr.displayName.locale        = UA_STRING ("en-US");
+            oAttr.displayName.text          = folderName;
+            folderBrowseName.namespaceIndex = 1;
+            folderBrowseName.name           = folderName;
+        }
+        else {
+            oAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Variables");
+            folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
+        }
+
+        retVal = UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                         UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                         folderBrowseName, UA_NODEID_NUMERIC(0,
+                                         UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Variable to subscribe data */
+        UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+        vAttr.displayName.locale    = UA_STRING ("en-US");
+        vAttr.displayName.text      = UA_STRING ("Subscribed Integer 1");
+        vAttr.valueRank             = -1;
+        retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID),
+                                           UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Integer 1"),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        vAttr.displayName.text      = UA_STRING ("Subscribed Integer 2");
+        retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID2),
+                                           UA_NODEID_NUMERIC(1, SUBSCRIBEOBJECT_NODEID),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Integer 2"),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_FieldTargetVariable targetVar;
+        memset(&targetVar, 0, sizeof(UA_FieldTargetVariable));
+        /* For creating Targetvariables */
+        UA_FieldTargetDataType_init(&targetVar.targetVariable);
+        targetVar.targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
+        targetVar.targetVariable.targetNodeId = newnodeId[0];
+        retVal |= UA_Server_DataSetReader_createTargetVariables(server, readerIdentifier[0],
+                                                                1, &targetVar);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        targetVar.targetVariable.targetNodeId = newnodeId[1];
+        retVal |= UA_Server_DataSetReader_createTargetVariables(server, readerIdentifier[1],
+                                                                1, &targetVar);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_FieldTargetDataType_clear(&targetVar.targetVariable);
+        UA_free(pMetaData->fields);
+        /* run server - publisher and subscriber */
+        UA_Server_run_iterate(server,true);
+
+        /* Read data sent by the Publisher */
+        UA_Variant *publishedNodeData = (UA_Variant*)UA_Array_new(2, &UA_TYPES[UA_TYPES_VARIANT]);
+        retVal                        = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID), &publishedNodeData[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        retVal                        = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, PUBLISHVARIABLE_NODEID2), &publishedNodeData[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Read data received by the Subscriber */
+        UA_Variant *subscribedNodeData = (UA_Variant*)UA_Array_new(2, &UA_TYPES[UA_TYPES_VARIANT]);
+        retVal                         = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID), &subscribedNodeData[0]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        retVal                         = UA_Server_readValue(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID2), &subscribedNodeData[1]);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        /* Check if data sent from Publisher is being received by Subscriber */
+        ck_assert_int_eq(*(UA_UInt32 *)publishedNodeData[0].data, *(UA_UInt32 *)subscribedNodeData[0].data);
+        ck_assert_int_eq(*(UA_UInt32 *)publishedNodeData[1].data, *(UA_UInt32 *)subscribedNodeData[1].data);
+        UA_Array_delete(subscribedNodeData, 2, &UA_TYPES[UA_TYPES_VARIANT]);
+        UA_Array_delete(publishedNodeData, 2, &UA_TYPES[UA_TYPES_VARIANT]);
+    } END_TEST    
+
 int main(void) {
     TCase *tc_add_pubsub_readergroup = tcase_create("PubSub readerGroup items handling");
     tcase_add_checked_fixture(tc_add_pubsub_readergroup, setup, teardown);
@@ -1376,6 +1814,8 @@ int main(void) {
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeInt64);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeBool);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribewithValidIdentifiers);
+    tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeMultipleDataSetReaders);
+    tcase_add_test(tc_pubsub_publish_subscribe, PublishSubscribeMultipleDataSetMessages);
 
     Suite *suite = suite_create("PubSub readerGroups/reader/Fields handling and publishing");
     suite_add_tcase(suite, tc_add_pubsub_readergroup);


### PR DESCRIPTION
getReadersFromIdentifier returns all fitting readers in an array together with it's size, so that for each datasetmessage we can iterate over the fitting readers and process the message for each of them. The filtering is also adjusted to reject when not matching, so that in the case of missing headers the ids that would have been contained in these headers are not relevant for filtering out readers.