### PR TITLE
fix(server) subscription events double lock in multithreading environments

### DIFF
--- a/src/server/ua_subscription_events.c
+++ b/src/server/ua_subscription_events.c
@@ -319,8 +319,8 @@ UA_Server_evaluateWhereClauseContentFilter(
                 UA_Variant typeNodeIdVariant;
                 UA_Variant_init(&typeNodeIdVariant);
                 UA_StatusCode readStatusCode =
-                    UA_Server_readObjectProperty(server, *eventNode,
-                                                 eventTypeQualifiedName, &typeNodeIdVariant);
+                    readObjectProperty(server, *eventNode, eventTypeQualifiedName,
+                                       &typeNodeIdVariant);
                 if(readStatusCode != UA_STATUSCODE_GOOD)
                     return readStatusCode;
 


### PR DESCRIPTION
The current event implementation uses UA_Server_readProperty which can lead to a double lock situation and therefore to a server crash. Since UA_Server_readProperty is used in an internal function we can switch to the internal readProperty which uses no locks.