### PR TITLE
PubSub component getState

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -433,6 +433,11 @@ UA_StatusCode UA_EXPORT
 UA_Server_updateWriterGroupConfig(UA_Server *server, UA_NodeId writerGroupIdentifier,
                                   const UA_WriterGroupConfig *config);
 
+/* Get state of WriterGroup */
+UA_StatusCode UA_EXPORT
+UA_Server_WriterGroup_getState(UA_Server *server, UA_NodeId writerGroupIdentifier,
+                               UA_PubSubState *state);
+
 UA_StatusCode UA_EXPORT
 UA_Server_removeWriterGroup(UA_Server *server, const UA_NodeId writerGroup);
 
@@ -490,6 +495,11 @@ UA_Server_addDataSetWriter(UA_Server *server,
 UA_StatusCode UA_EXPORT
 UA_Server_getDataSetWriterConfig(UA_Server *server, const UA_NodeId dsw,
                                  UA_DataSetWriterConfig *config);
+
+/* Get state of DataSetWriter */
+UA_StatusCode UA_EXPORT
+UA_Server_DataSetWriter_getState(UA_Server *server, UA_NodeId dataSetWriterIdentifier,
+                               UA_PubSubState *state);
 
 UA_StatusCode UA_EXPORT
 UA_Server_removeDataSetWriter(UA_Server *server, const UA_NodeId dsw);
@@ -595,6 +605,11 @@ UA_StatusCode UA_EXPORT
 UA_Server_DataSetReader_getConfig(UA_Server *server, UA_NodeId dataSetReaderIdentifier,
                                   UA_DataSetReaderConfig *config);
 
+/* Get state of DataSetReader */
+UA_StatusCode UA_EXPORT
+UA_Server_DataSetReader_getState(UA_Server *server, UA_NodeId dataSetReaderIdentifier,
+                               UA_PubSubState *state);
+
 /**
  * ReaderGroup
  * -----------
@@ -637,6 +652,11 @@ UA_Server_removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier);
 UA_StatusCode UA_EXPORT
 UA_Server_ReaderGroup_getConfig(UA_Server *server, UA_NodeId readerGroupIdentifier,
                                UA_ReaderGroupConfig *config);
+
+/* Get state of ReaderGroup */
+UA_StatusCode UA_EXPORT
+UA_Server_ReaderGroup_getState(UA_Server *server, UA_NodeId readerGroupIdentifier,
+                               UA_PubSubState *state);
 
 /* Add ReaderGroup to the created connection */
 UA_StatusCode UA_EXPORT

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -596,6 +596,12 @@ UA_LOCALIZEDTEXT_ALLOC(const char *locale, const char *text) {
     lt.text = UA_STRING_ALLOC(text); return lt;
 }
 
+/* 
+ * Check if the StatusCode is bad.
+ * @return Returns UA_TRUE if StatusCode is bad, else UA_FALSE. */
+UA_EXPORT UA_Boolean
+UA_StatusCode_isBad(const UA_StatusCode code);
+
 /**
  * .. _numericrange:
  *

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -374,6 +374,19 @@ UA_Server_ReaderGroup_getConfig(UA_Server *server, UA_NodeId readerGroupIdentifi
     return UA_STATUSCODE_GOOD;
 }
 
+UA_StatusCode
+UA_Server_ReaderGroup_getState(UA_Server *server, UA_NodeId readerGroupIdentifier,
+                               UA_PubSubState *state)
+{
+    if((server == NULL) || (state == NULL)) 
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    UA_ReaderGroup *currentReaderGroup = UA_ReaderGroup_findRGbyId(server, readerGroupIdentifier);
+    if(currentReaderGroup == NULL) 
+        return UA_STATUSCODE_BADNOTFOUND;
+    *state = currentReaderGroup->state;
+    return UA_STATUSCODE_GOOD;
+}
+
 static void
 UA_Server_ReaderGroup_clear(UA_Server* server, UA_ReaderGroup *readerGroup) {
     /* To Do Call UA_ReaderGroupConfig_delete */
@@ -1086,6 +1099,19 @@ UA_DataSetReaderConfig_copy(const UA_DataSetReaderConfig *src,
            return retVal;
     }
 
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_DataSetReader_getState(UA_Server *server, UA_NodeId dataSetReaderIdentifier,
+                               UA_PubSubState *state) {
+
+    if((server == NULL) || (state == NULL))
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    UA_DataSetReader *currentDataSetReader = UA_ReaderGroup_findDSRbyId(server, dataSetReaderIdentifier);
+    if(currentDataSetReader == NULL) 
+        return UA_STATUSCODE_BADNOTFOUND;
+    *state = currentDataSetReader->state;
     return UA_STATUSCODE_GOOD;
 }
 

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -841,6 +841,18 @@ UA_Server_getDataSetWriterConfig(UA_Server *server, const UA_NodeId dsw,
     return retVal;
 }
 
+UA_StatusCode
+UA_Server_DataSetWriter_getState(UA_Server *server, UA_NodeId dataSetWriterIdentifier,
+                               UA_PubSubState *state) {
+    if((server == NULL) || (state == NULL))
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    UA_DataSetWriter *currentDataSetWriter = UA_DataSetWriter_findDSWbyId(server, dataSetWriterIdentifier);
+    if(currentDataSetWriter == NULL)
+        return UA_STATUSCODE_BADNOTFOUND;
+    *state = currentDataSetWriter->state;
+    return UA_STATUSCODE_GOOD;
+}
+
 UA_DataSetWriter *
 UA_DataSetWriter_findDSWbyId(UA_Server *server, UA_NodeId identifier) {
     UA_PubSubConnection *pubSubConnection;
@@ -1042,6 +1054,18 @@ UA_Server_updateWriterGroupConfig(UA_Server *server, UA_NodeId writerGroupIdenti
         UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER,
                        "No or unsupported WriterGroup update.");
     }
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_WriterGroup_getState(UA_Server *server, UA_NodeId writerGroupIdentifier,
+                               UA_PubSubState *state) {
+    if((server == NULL) || (state == NULL))
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    UA_WriterGroup *currentWriterGroup = UA_WriterGroup_findWGbyId(server, writerGroupIdentifier);
+    if(currentWriterGroup == NULL)
+        return UA_STATUSCODE_BADNOTFOUND;
+    *state = currentWriterGroup->state;
     return UA_STATUSCODE_GOOD;
 }
 

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -988,6 +988,15 @@ DiagnosticInfo_copy(UA_DiagnosticInfo const *src, UA_DiagnosticInfo *dst,
     return retval;
 }
 
+/* StatusCode */
+UA_Boolean
+UA_StatusCode_isBad(const UA_StatusCode code) {
+    if ((code & 0x80000000) != 0) {
+        return UA_TRUE;
+    }
+    return UA_FALSE;
+} 
+
 /********************/
 /* Structured Types */
 /********************/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -350,6 +350,9 @@ if(UA_ENABLE_PUBSUB)
     add_executable(check_pubsub_publish_uadp pubsub/check_pubsub_publish_uadp.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-plugins>)
     target_link_libraries(check_pubsub_publish_uadp ${LIBS})
     add_test_valgrind(pubsub_publish ${TESTS_BINARY_DIR}/check_pubsub_publish_uadp)
+    add_executable(check_pubsub_get_state pubsub/check_pubsub_get_state.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-plugins>)
+    target_link_libraries(check_pubsub_get_state ${LIBS})
+    add_test_valgrind(check_pubsub_get_state ${TESTS_BINARY_DIR}/check_pubsub_get_state)
 
     #Link libraries for executing subscriber unit test
     add_executable(check_pubsub_subscribe pubsub/check_pubsub_subscribe.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-plugins>)

--- a/tests/check_types_builtin.c
+++ b/tests/check_types_builtin.c
@@ -1507,6 +1507,21 @@ START_TEST(UA_ExtensionObject_encodeDecodeShallWorkOnExtensionObject) {
 }
 END_TEST
 
+START_TEST(UA_StatusCode_utils) {
+
+    ck_assert(UA_TRUE == UA_StatusCode_isBad(UA_STATUSCODE_BADINTERNALERROR));
+    ck_assert(UA_TRUE == UA_StatusCode_isBad(UA_STATUSCODE_BADOUTOFMEMORY));
+    ck_assert(UA_TRUE == UA_StatusCode_isBad(UA_STATUSCODE_BADTIMEOUT));
+
+    ck_assert(UA_FALSE == UA_StatusCode_isBad(UA_STATUSCODE_GOOD));
+    ck_assert(UA_FALSE == UA_StatusCode_isBad(UA_STATUSCODE_GOODNODATA));
+    ck_assert(UA_FALSE == UA_StatusCode_isBad(UA_STATUSCODE_GOODOVERLOAD));
+
+    ck_assert(UA_TRUE == UA_StatusCode_isBad((UA_StatusCode) -1));
+    ck_assert(UA_FALSE == UA_StatusCode_isBad((UA_StatusCode) 1));
+
+} END_TEST
+
 static Suite *testSuite_builtin(void) {
     Suite *s = suite_create("Built-in Data Types 62541-6 Table 1");
 
@@ -1588,6 +1603,11 @@ static Suite *testSuite_builtin(void) {
     tcase_add_test(tc_copy, UA_LocalizedText_copycstringShallWorkOnInputExample);
     tcase_add_test(tc_copy, UA_DataValue_copyShallWorkOnInputExample);
     suite_add_tcase(s, tc_copy);
+
+    TCase *tc_utils = tcase_create("utils");
+    tcase_add_test(tc_utils, UA_StatusCode_utils);
+    suite_add_tcase(s, tc_utils);
+
     return s;
 }
 

--- a/tests/pubsub/check_pubsub_get_state.c
+++ b/tests/pubsub/check_pubsub_get_state.c
@@ -1,0 +1,435 @@
+#include <check.h>
+#include <assert.h>
+
+#include <open62541/plugin/pubsub_udp.h>
+#include <open62541/server_config_default.h>
+#include <open62541/server_pubsub.h>
+#include <open62541/plugin/log_stdout.h>
+
+#include "ua_pubsub.h"
+
+static UA_Server *server = NULL;
+
+/***************************************************************************************************/
+static void setup(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "setup");
+
+    server = UA_Server_new();
+    assert(server != 0);
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_ServerConfig_setDefault(config);
+
+    config->pubsubTransportLayers = (UA_PubSubTransportLayer*)
+        UA_malloc(sizeof(UA_PubSubTransportLayer));
+    assert(config->pubsubTransportLayers != 0);
+    config->pubsubTransportLayers[0] = UA_PubSubTransportLayerUDPMP();
+    config->pubsubTransportLayersSize++;
+
+    UA_Server_run_startup(server);
+}
+
+/***************************************************************************************************/
+static void teardown(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "teardown");
+
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+
+/***************************************************************************************************/
+/* utility functions to setup the PubSub configuration */
+
+/***************************************************************************************************/
+static void AddConnection(
+    char *pName, 
+    UA_UInt32 PublisherId,
+    UA_NodeId *opConnectionId) {
+
+    assert(pName != 0);
+    assert(opConnectionId != 0);
+
+    UA_PubSubConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
+    connectionConfig.name = UA_STRING(pName);
+    connectionConfig.enabled = UA_TRUE;
+    connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
+    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING("opc.udp://224.0.0.22:4840/")};
+    UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+
+    connectionConfig.publisherIdType = UA_PUBSUB_PUBLISHERID_NUMERIC;
+    connectionConfig.publisherId.numeric = PublisherId;
+
+    ck_assert(UA_Server_addPubSubConnection(server, &connectionConfig, opConnectionId) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_PubSubConnection_regist(server, opConnectionId) == UA_STATUSCODE_GOOD);
+}
+
+/***************************************************************************************************/
+static void AddWriterGroup(
+    UA_NodeId *pConnectionId,
+    char *pName, 
+    UA_UInt32 WriterGroupId,
+    UA_Duration PublishingInterval,
+    UA_NodeId *opWriterGroupId) {
+
+    assert(pConnectionId != 0);
+    assert(pName != 0);
+    assert(opWriterGroupId != 0);
+
+    UA_WriterGroupConfig writerGroupConfig;
+    memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
+    writerGroupConfig.name = UA_STRING(pName);
+    writerGroupConfig.publishingInterval = PublishingInterval;
+    writerGroupConfig.enabled = UA_FALSE;
+    writerGroupConfig.writerGroupId = (UA_UInt16) WriterGroupId;
+    writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
+    writerGroupConfig.messageSettings.encoding             = UA_EXTENSIONOBJECT_DECODED;
+    writerGroupConfig.messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE];
+    UA_UadpWriterGroupMessageDataType *writerGroupMessage  = UA_UadpWriterGroupMessageDataType_new();
+    writerGroupMessage->networkMessageContentMask          = (UA_UadpNetworkMessageContentMask)(UA_UADPNETWORKMESSAGECONTENTMASK_PUBLISHERID |
+                                                              (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_GROUPHEADER |
+                                                              (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_WRITERGROUPID |
+                                                              (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_PAYLOADHEADER);
+    writerGroupConfig.messageSettings.content.decoded.data = writerGroupMessage;
+    ck_assert(UA_Server_addWriterGroup(server, *pConnectionId, &writerGroupConfig, opWriterGroupId) == UA_STATUSCODE_GOOD);
+    UA_UadpWriterGroupMessageDataType_delete(writerGroupMessage);
+}
+
+/***************************************************************************************************/
+static void AddPublishedDataSet(
+    UA_NodeId *pWriterGroupId,
+    char *pPublishedDataSetName, 
+    char *pDataSetWriterName,
+    UA_UInt32 DataSetWriterId,
+    UA_NodeId *opPublishedDataSetId, 
+    UA_NodeId *opPublishedVarId,
+    UA_NodeId *opDataSetWriterId) {
+
+    assert(pWriterGroupId != 0);
+    assert(pPublishedDataSetName != 0);
+    assert(pDataSetWriterName != 0);
+    assert(opPublishedDataSetId != 0);
+    assert(opPublishedVarId != 0);
+    assert(opDataSetWriterId != 0);
+
+    UA_PublishedDataSetConfig pdsConfig;
+    memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
+    pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
+    pdsConfig.name = UA_STRING(pPublishedDataSetName);
+    UA_AddPublishedDataSetResult result = UA_Server_addPublishedDataSet(server, &pdsConfig, opPublishedDataSetId);
+    ck_assert(result.addResult == UA_STATUSCODE_GOOD);
+
+    /* Create variable to publish integer data */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.description           = UA_LOCALIZEDTEXT("en-US","Published Int32");
+    attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Int32");
+    attr.dataType              = UA_TYPES[UA_TYPES_INT32].typeId;
+    UA_Int32 publisherData     = 42;
+    UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert(UA_Server_addVariableNode(server, UA_NODEID_NULL,
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                        UA_QUALIFIEDNAME(1, "Published Int32"),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                        attr, NULL, opPublishedVarId) == UA_STATUSCODE_GOOD);
+
+    UA_NodeId dataSetFieldId;
+    UA_DataSetFieldConfig dataSetFieldConfig;
+    memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
+    dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
+    dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Int32 Publish var");
+    dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
+    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = *opPublishedVarId;
+    dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
+    UA_DataSetFieldResult PdsFieldResult = UA_Server_addDataSetField(server, *opPublishedDataSetId,
+                              &dataSetFieldConfig, &dataSetFieldId);
+    ck_assert(PdsFieldResult.result == UA_STATUSCODE_GOOD);
+
+    UA_DataSetWriterConfig dataSetWriterConfig;
+    memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
+    dataSetWriterConfig.name = UA_STRING(pDataSetWriterName);
+    dataSetWriterConfig.dataSetWriterId = (UA_UInt16) DataSetWriterId;
+    dataSetWriterConfig.keyFrameCount = 10;
+    ck_assert(UA_Server_addDataSetWriter(server, *pWriterGroupId, *opPublishedDataSetId, &dataSetWriterConfig, opDataSetWriterId) == UA_STATUSCODE_GOOD);
+}
+
+/***************************************************************************************************/
+static void AddReaderGroup(
+    UA_NodeId *pConnectionId,
+    char *pName, 
+    UA_NodeId *opReaderGroupId) {
+
+    assert(pConnectionId != 0);
+    assert(pName != 0);
+    assert(opReaderGroupId != 0);
+
+    UA_ReaderGroupConfig readerGroupConfig;
+    memset (&readerGroupConfig, 0, sizeof(UA_ReaderGroupConfig));
+    readerGroupConfig.name = UA_STRING(pName);
+    ck_assert(UA_Server_addReaderGroup(server, *pConnectionId, &readerGroupConfig,
+                                       opReaderGroupId) == UA_STATUSCODE_GOOD);
+}
+
+/***************************************************************************************************/
+static void AddDataSetReader(
+    UA_NodeId *pReaderGroupId,
+    char *pName, 
+    UA_UInt32 PublisherId,
+    UA_UInt32 WriterGroupId,
+    UA_UInt32 DataSetWriterId,
+    UA_Duration MessageReceiveTimeout,
+    UA_NodeId *opSubscriberVarId,
+    UA_NodeId *opDataSetReaderId) {
+
+    assert(pReaderGroupId != 0);
+    assert(pName != 0);
+    assert(opSubscriberVarId != 0);
+    assert(opDataSetReaderId != 0);
+
+    UA_DataSetReaderConfig readerConfig;
+    memset (&readerConfig, 0, sizeof(UA_DataSetReaderConfig));
+    readerConfig.name = UA_STRING(pName);
+    UA_Variant_setScalar(&readerConfig.publisherId, (UA_UInt16*) &PublisherId, &UA_TYPES[UA_TYPES_UINT16]);
+    readerConfig.writerGroupId    = (UA_UInt16) WriterGroupId;
+    readerConfig.dataSetWriterId  = (UA_UInt16) DataSetWriterId;
+    readerConfig.messageReceiveTimeout = MessageReceiveTimeout;
+
+    UA_DataSetMetaDataType_init(&readerConfig.dataSetMetaData);
+    UA_DataSetMetaDataType *pDataSetMetaData = &readerConfig.dataSetMetaData;
+    pDataSetMetaData->name = UA_STRING (pName);
+    pDataSetMetaData->fieldsSize = 1;
+    pDataSetMetaData->fields = (UA_FieldMetaData*) UA_Array_new (pDataSetMetaData->fieldsSize,
+                         &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+
+    UA_FieldMetaData_init (&pDataSetMetaData->fields[0]);
+    UA_NodeId_copy (&UA_TYPES[UA_TYPES_INT32].typeId,
+                    &pDataSetMetaData->fields[0].dataType);
+    pDataSetMetaData->fields[0].builtInType = UA_NS0ID_INT32;
+    pDataSetMetaData->fields[0].name =  UA_STRING ("Int32 Var");
+    pDataSetMetaData->fields[0].valueRank = -1;
+    ck_assert(UA_Server_addDataSetReader(server, *pReaderGroupId, &readerConfig,
+                                         opDataSetReaderId) == UA_STATUSCODE_GOOD);
+
+    /* Variable to subscribe data */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
+    attr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
+    attr.dataType    = UA_TYPES[UA_TYPES_INT32].typeId;
+    UA_Int32 SubscriberData = 0;
+    UA_Variant_setScalar(&attr.value, &SubscriberData, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert(UA_Server_addVariableNode(server, UA_NODEID_NULL,
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Int32"),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, opSubscriberVarId) == UA_STATUSCODE_GOOD);
+
+    UA_FieldTargetVariable *pTargetVariables =  (UA_FieldTargetVariable *)
+        UA_calloc(readerConfig.dataSetMetaData.fieldsSize, sizeof(UA_FieldTargetVariable));
+    assert(pTargetVariables != 0);
+    
+    UA_FieldTargetDataType_init(&pTargetVariables[0].targetVariable);
+
+    pTargetVariables[0].targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
+    pTargetVariables[0].targetVariable.targetNodeId = *opSubscriberVarId;
+
+    ck_assert(UA_Server_DataSetReader_createTargetVariables(server, *opDataSetReaderId,
+        readerConfig.dataSetMetaData.fieldsSize, pTargetVariables) == UA_STATUSCODE_GOOD);
+    
+    UA_FieldTargetDataType_clear(&pTargetVariables[0].targetVariable);
+    UA_free(pTargetVariables);
+    pTargetVariables = 0;
+
+    UA_free(pDataSetMetaData->fields);
+    pDataSetMetaData->fields = 0;
+}
+
+/***************************************************************************************************/
+START_TEST(Test_normal_operation) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "START: Test_normal_operation");
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "configure pubsub");
+
+    /* setup Connection 1: writer */
+    UA_NodeId ConnId_1;
+    UA_NodeId_init(&ConnId_1);
+    UA_UInt32 PublisherNo_Conn1 = 1;
+    AddConnection("Conn1", PublisherNo_Conn1, &ConnId_1);
+
+    UA_NodeId WGId_Conn1_WG1;
+    UA_NodeId_init(&WGId_Conn1_WG1);
+    UA_UInt32 WGNo_Conn1_WG1 = 1;
+    UA_Duration PublishingInterval_Conn1_WG1 = 500.0;
+    AddWriterGroup(&ConnId_1, "Conn1_WG1", WGNo_Conn1_WG1, PublishingInterval_Conn1_WG1, &WGId_Conn1_WG1);
+
+    UA_NodeId DsWId_Conn1_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+    UA_NodeId VarId_Conn1_WG1_DS1;
+    UA_NodeId_init(&VarId_Conn1_WG1_DS1);
+    UA_NodeId PDSId_Conn1_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+    UA_UInt32 DSWNo_Conn1_WG1_DS1 = 1;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1, 
+        &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
+
+    /* setup Connection 1: reader */
+    UA_NodeId RGId_Conn1_RG1;
+    UA_NodeId_init(&RGId_Conn1_RG1);
+    AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+
+    UA_NodeId DSRId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+    UA_NodeId VarId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
+    UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 350.0;
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1, 
+        MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
+
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check state");
+    UA_PubSubState state = UA_PUBSUBSTATE_ERROR;
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_WriterGroup_getState(server, WGId_Conn1_WG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetWriter_getState(server, DsWId_Conn1_WG1_DS1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_ReaderGroup_getState(server, RGId_Conn1_RG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "set groups operational");
+
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_WriterGroup_getState(server, WGId_Conn1_WG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetWriter_getState(server, DsWId_Conn1_WG1_DS1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_ReaderGroup_getState(server, RGId_Conn1_RG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "set groups disabled");
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_WriterGroup_getState(server, WGId_Conn1_WG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetWriter_getState(server, DsWId_Conn1_WG1_DS1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+
+    ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_ReaderGroup_getState(server, RGId_Conn1_RG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_DISABLED, state);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_normal_operation");
+
+} END_TEST
+
+
+/***************************************************************************************************/
+START_TEST(Test_corner_cases) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "START: Test_corner_cases");
+
+    UA_NodeId id = UA_NODEID_NULL;
+
+    UA_PubSubState state = UA_PUBSUBSTATE_ERROR;
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_WriterGroup_getState(0, id, 0));
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_WriterGroup_getState(server, id, 0));
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_WriterGroup_getState(0, id, &state));
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_WriterGroup_getState(server, id, &state));
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "configure pubsub");
+
+    /* setup Connection 1: writer */
+    UA_NodeId ConnId_1;
+    UA_NodeId_init(&ConnId_1);
+    UA_UInt32 PublisherNo_Conn1 = 1;
+    AddConnection("Conn1", PublisherNo_Conn1, &ConnId_1);
+
+    UA_NodeId WGId_Conn1_WG1;
+    UA_NodeId_init(&WGId_Conn1_WG1);
+    UA_UInt32 WGNo_Conn1_WG1 = 1;
+    UA_Duration PublishingInterval_Conn1_WG1 = 500.0;
+    AddWriterGroup(&ConnId_1, "Conn1_WG1", WGNo_Conn1_WG1, PublishingInterval_Conn1_WG1, &WGId_Conn1_WG1);
+
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+
+    UA_NodeId DsWId_Conn1_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+    UA_NodeId VarId_Conn1_WG1_DS1;
+    UA_NodeId_init(&VarId_Conn1_WG1_DS1);
+    UA_NodeId PDSId_Conn1_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+    UA_UInt32 DSWNo_Conn1_WG1_DS1 = 1;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1, 
+        &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_WriterGroup_getState(server, WGId_Conn1_WG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+    /* DataSetWriter is should be operational as well */
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetWriter_getState(server, DsWId_Conn1_WG1_DS1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+
+    /* setup Connection 1: reader */
+    UA_NodeId RGId_Conn1_RG1;
+    UA_NodeId_init(&RGId_Conn1_RG1);
+    AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
+
+    UA_NodeId DSRId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+    UA_NodeId VarId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
+    UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 350.0;
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1, 
+        MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_ReaderGroup_getState(server, RGId_Conn1_RG1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+    /* DataSetReader should be operational as well */
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state));
+    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+
+    /* test wrong nodeIds */
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_DataSetReader_getState(server, RGId_Conn1_RG1, &state));
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_DataSetWriter_getState(server, RGId_Conn1_RG1, &state));
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_ReaderGroup_getState(server, WGId_Conn1_WG1, &state));
+    ck_assert(UA_STATUSCODE_GOOD != UA_Server_WriterGroup_getState(server, RGId_Conn1_RG1, &state));
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_corner_cases");
+
+} END_TEST
+
+/***************************************************************************************************/
+int main(void) {
+
+    TCase *tc_normal_operation = tcase_create("normal_operation");
+    tcase_add_checked_fixture(tc_normal_operation, setup, teardown);
+    tcase_add_test(tc_normal_operation, Test_normal_operation);
+
+    TCase *tc_corner_cases = tcase_create("corner cases");
+    tcase_add_checked_fixture(tc_corner_cases, setup, teardown);
+    tcase_add_test(tc_corner_cases, Test_corner_cases);
+
+    Suite *s = suite_create("PubSub getState test suite");
+    suite_add_tcase(s, tc_normal_operation);
+    suite_add_tcase(s, tc_corner_cases);
+
+    /* TODO: how to provoke and test an error state? */
+
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Added a getState method for following PubSub components:
ReaderGroup, DataSetReader, WriterGroup, DataSetWriter

Open questions:

- Naming convention of PubSub public functions
e.g.: UA_Server_removeWriterGroup vs. UA_Server_updateWriterGroupConfig
or UA_Server_getDataSetWriterConfig vs. UA_Server_DataSetWriter_getState

- UA_Server_setWriterGroupOperational and UA_Server_setReaderGroupOperational
These functions set the linked DataSetWriters and -Readers state as well
But in most tutorials the DataSetWriters- and Readers have been added after setting the group to operational, so their state is still disabled. Calling setOperational() function again does not change this at the moment, because nothing happens if the state is already operational
Shall we change the setOperational() methods to set the states of all subcomponents again to operational, even if the group is already operational?
I think this could be a use case if someone wants to add a DataSetWriter- or Reader to an existing group at runtime.
Or shall we add a description that setOperational shall only be done after adding all DataSetWriters or -Readers?

- WriterGroup publishCallback error handling
In case of an error shall we stop the callback?
