### PR TITLE
Change the Python shebangs to Python version 3 explicitly.

### DIFF
--- a/tools/certs/create_self-signed.py
+++ b/tools/certs/create_self-signed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ### This Source Code Form is subject to the terms of the Mozilla Public

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ### This Source Code Form is subject to the terms of the Mozilla Public

--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ### This Source Code Form is subject to the terms of the Mozilla Public

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ### This Source Code Form is subject to the terms of the Mozilla Public

--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ### This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
I tried to build the RPM for Fedora Linux, but got the following error:

```
+ /usr/lib/rpm/redhat/brp-mangle-shebangs
*** ERROR: ambiguous python shebang in /usr/share/open62541/tools/certs/create_self-signed.py: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in /usr/share/open62541/tools/nodeset_compiler/nodeset_compiler.py: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
Fehler: Fehler-Status beim Beenden von /var/tmp/rpm-tmp.7d5fka (%install)
```

Therefore it makes sense to change the shebangs in the Python scripts explicitly to version 3.
