### PR TITLE
Allow to disable IPO on the commandline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,7 +552,7 @@ if(NOT UA_FORCE_CPP AND (CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID}" ST
 
         # IPO requires too much memory for unit tests
         # GCC docu recommends to compile all files with the same options, therefore ignore it completely
-        if(NOT UA_BUILD_UNIT_TESTS)
+        if(NOT UA_BUILD_UNIT_TESTS AND NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
             # needed to check if IPO is supported (check needs cmake > 3.9)
             if("${CMAKE_VERSION}" VERSION_GREATER 3.9)
                 cmake_policy(SET CMP0069 NEW) # needed as long as required cmake < 3.9


### PR DESCRIPTION
Only check for (and potentially enable) IPO if the variable has
not been set yet. This allows to disable IPO on the commandline.

Reasoning: a consumer of the open62541 static library might decide
to not enable IPO. Currently open62541 is, via the requirement
that all objects files are IPO, forcing the consumer to also enable
IPO.