### PR TITLE
fix(debian): a tools script depends on python3 so package must as well

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -37,7 +37,7 @@ Description: Open source implementation of OPC UA - development files
 Package: libopen62541-<soname>-tools
 Section: libdevel
 Architecture: all
-Depends: ${misc:Depends}, python
+Depends: ${misc:Depends}, python3
 Recommends: libopen62541-<soname>-dev
 Description: Open source implementation of OPC UA - tools
  open62541 (http://open62541.org) is an open source and free implementation


### PR DESCRIPTION
`tools/certs/create_self-signed.py` depends on `python3` so the package `libopen62541-1-tools` must depend on `python3 `as well