### PR TITLE
Fix(Server): Return timestamp if requested even if status code != suc…

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -496,14 +496,13 @@ ReadWithNode(const UA_Node *node, UA_Server *server, UA_Session *session,
         retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
     }
 
-    /* Return error code when reading has failed */
     if(retval != UA_STATUSCODE_GOOD) {
+        /* Reading has failed but can not return because we may need to add timestamp */
         v->hasStatus = true;
         v->status = retval;
-        return;
+    } else {
+        v->hasValue = true;
     }
-
-    v->hasValue = true;
 
     /* Create server timestamp */
     if(timestampsToReturn == UA_TIMESTAMPSTORETURN_SERVER ||


### PR DESCRIPTION
…cess.

When running CTT it request a read value with
TimestampToReturn: Both (0x00000002) and the module
answer with BadUserAccessDenied and no source/server
timestamps. This results in that OPC UA CTT test
Attribute Services - Attribute read - 012 failes.

The module is configured with namespace 5 as write and
browse (not read) for a testuser and OPC UA CTT Settings
--> NodeIds --> SecurityAccess -->
AccessLevel_CurrentRead_NotUser is configured to a
nodeid in that ns.

It seems that the timestamp if requested always should
be returned according to the OPC UA (release 1.04)
specification part 4 chapter 7.7.1 table 131-DataValue:
Value - The data value. If the StatusCode indicates
        an error then the value is to be ignored and
        the Server shall set it to null.
SourceTimestamp - The source timestamp for the value.
ServerTimestamp - The server timestamp for the value.

It says nothing about what's happens with source/server
timestamp (like in Values) in the event of an error
code and therefor interprets it as source/server
timestamp always should be included.