### PR TITLE
[Review] feat(server): Add user token signature check for x509 identity token

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,7 +24,7 @@ OPC UA Stack
 | **Authentication**                      |                    |                      |
 | Anonymous                               | :heavy_check_mark: |                      |
 | User Name Password                      | :heavy_check_mark: |                      |
-| X509 Certificate                        |     :new_moon:     |                      |
+| X509 Certificate                        | :heavy_check_mark: |                      |
 
 OPC UA Server
 -------------

--- a/examples/access_control/server_access_control.c
+++ b/examples/access_control/server_access_control.c
@@ -62,7 +62,7 @@ int main(void) {
 
     /* Disable anonymous logins, enable two user/password logins */
     config->accessControl.clear(&config->accessControl);
-    UA_StatusCode retval = UA_AccessControl_default(config, false,
+    UA_StatusCode retval = UA_AccessControl_default(config, false, NULL,
              &config->securityPolicies[config->securityPoliciesSize-1].policyUri, 2, logins);
     if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;

--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -734,7 +734,13 @@ UA_CertificateVerification_CertFolders(UA_CertificateVerification * cv,
     cv->verifyApplicationURI = UA_CertificateVerification_VerifyApplicationURI;
     cv->clear = UA_CertificateVerification_clear;
     cv->context = context;
-    cv->verifyCertificate = UA_CertificateVerification_Verify;
+    if(trustListFolder == NULL &&
+       issuerListFolder == NULL &&
+       revocationListFolder == NULL) {
+        cv->verifyCertificate = UA_VerifyCertificateAllowAll;
+    } else {
+        cv->verifyCertificate = UA_CertificateVerification_Verify;
+    }
 
     /* Only set the folder paths. They will be reloaded during runtime. */
 

--- a/plugins/include/open62541/plugin/accesscontrol_default.h
+++ b/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -19,9 +19,14 @@ typedef struct {
 } UA_UsernamePasswordLogin;
 
 /* Default access control. The log-in can be anonymous or username-password. A
- * logged-in user has all access rights. */
+ * logged-in user has all access rights.
+ *
+ * The certificate verification plugin lifecycle is moved to the access control
+ * system. So it is cleared up eventually together with the AccessControl. */
 UA_EXPORT UA_StatusCode
-UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
+UA_AccessControl_default(UA_ServerConfig *config,
+                         UA_Boolean allowAnonymous,
+                         UA_CertificateVerification *verifyX509,
                          const UA_ByteString *userTokenPolicyUri,
                          size_t usernamePasswordLoginSize,
                          const UA_UsernamePasswordLogin *usernamePasswordLogin);

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -21,11 +21,14 @@ typedef struct {
     UA_Boolean allowAnonymous;
     size_t usernamePasswordLoginSize;
     UA_UsernamePasswordLogin *usernamePasswordLogin;
+    UA_CertificateVerification verifyX509;
 } AccessControlContext;
 
 #define ANONYMOUS_POLICY "open62541-anonymous-policy"
+#define CERTIFICATE_POLICY "open62541-certificate-policy"
 #define USERNAME_POLICY "open62541-username-policy"
 const UA_String anonymous_policy = UA_STRING_STATIC(ANONYMOUS_POLICY);
+const UA_String certificate_policy = UA_STRING_STATIC(CERTIFICATE_POLICY);
 const UA_String username_policy = UA_STRING_STATIC(USERNAME_POLICY);
 
 /************************/
@@ -108,6 +111,22 @@ activateSession_default(UA_Server *server, UA_AccessControl *ac,
             UA_ByteString_copy(&userToken->userName, username);
         *sessionContext = username;
         return UA_STATUSCODE_GOOD;
+    }
+
+    /* x509 certificate */
+    if(userIdentityToken->content.decoded.type == &UA_TYPES[UA_TYPES_X509IDENTITYTOKEN]) {
+        const UA_X509IdentityToken *userToken = (UA_X509IdentityToken*)
+            userIdentityToken->content.decoded.data;
+
+        if(!UA_String_equal(&userToken->policyId, &certificate_policy))
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+
+        if(!context->verifyX509.verifyCertificate)
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+
+        return context->verifyX509.
+            verifyCertificate(context->verifyX509.context,
+                              &userToken->certificateData);
     }
 
     /* Unsupported token type */
@@ -240,13 +259,19 @@ static void clear_default(UA_AccessControl *ac) {
         }
         if(context->usernamePasswordLoginSize > 0)
             UA_free(context->usernamePasswordLogin);
+
+        if(context->verifyX509.clear)
+            context->verifyX509.clear(&context->verifyX509);
+
         UA_free(ac->context);
         ac->context = NULL;
     }
 }
 
 UA_StatusCode
-UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
+UA_AccessControl_default(UA_ServerConfig *config,
+                         UA_Boolean allowAnonymous,
+                         UA_CertificateVerification *verifyX509,
                          const UA_ByteString *userTokenPolicyUri,
                          size_t usernamePasswordLoginSize,
                          const UA_UsernamePasswordLogin *usernamePasswordLogin) {
@@ -254,7 +279,7 @@ UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
                    "AccessControl: Unconfigured AccessControl. Users have all permissions.");
     UA_AccessControl *ac = &config->accessControl;
 
-    if (ac->clear)
+    if(ac->clear)
         clear_default(ac);
     
     ac->clear = clear_default;
@@ -294,6 +319,16 @@ UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
                     "AccessControl: Anonymous login is enabled");
     }
 
+    /* Allow x509 certificates? Move the plugin over. */
+    if(verifyX509) {
+        context->verifyX509 = *verifyX509;
+        memset(verifyX509, 0, sizeof(UA_CertificateVerification));
+    } else {
+        memset(&context->verifyX509, 0, sizeof(UA_CertificateVerification));
+        UA_LOG_INFO(&config->logger, UA_LOGCATEGORY_SERVER,
+                    "AccessControl: x509 certificate user authentication is enabled");
+    }
+
     /* Copy username/password to the access control plugin */
     if(usernamePasswordLoginSize > 0) {
         context->usernamePasswordLogin = (UA_UsernamePasswordLogin*)
@@ -302,14 +337,18 @@ UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
             return UA_STATUSCODE_BADOUTOFMEMORY;
         context->usernamePasswordLoginSize = usernamePasswordLoginSize;
         for(size_t i = 0; i < usernamePasswordLoginSize; i++) {
-            UA_String_copy(&usernamePasswordLogin[i].username, &context->usernamePasswordLogin[i].username);
-            UA_String_copy(&usernamePasswordLogin[i].password, &context->usernamePasswordLogin[i].password);
+            UA_String_copy(&usernamePasswordLogin[i].username,
+                           &context->usernamePasswordLogin[i].username);
+            UA_String_copy(&usernamePasswordLogin[i].password,
+                           &context->usernamePasswordLogin[i].password);
         }
     }
 
     /* Set the allowed policies */
     size_t policies = 0;
     if(allowAnonymous)
+        policies++;
+    if(verifyX509)
         policies++;
     if(usernamePasswordLoginSize > 0)
         policies++;
@@ -324,6 +363,14 @@ UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
     if(allowAnonymous) {
         ac->userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_ANONYMOUS;
         ac->userTokenPolicies[policies].policyId = UA_STRING_ALLOC(ANONYMOUS_POLICY);
+        if (!ac->userTokenPolicies[policies].policyId.data)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        policies++;
+    }
+
+    if(verifyX509) {
+        ac->userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_CERTIFICATE;
+        ac->userTokenPolicies[policies].policyId = UA_STRING_ALLOC(CERTIFICATE_POLICY);
         if (!ac->userTokenPolicies[policies].policyId.data)
             return UA_STATUSCODE_BADOUTOFMEMORY;
         policies++;

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -456,9 +456,9 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     }
 
     /* Initialize the Access Control plugin */
-    retval = UA_AccessControl_default(config, true,
-                &config->securityPolicies[config->securityPoliciesSize-1].policyUri,
-                usernamePasswordsSize, usernamePasswords);
+    retval = UA_AccessControl_default(config, true, NULL,
+                                      &config->securityPolicies[config->securityPoliciesSize-1].policyUri,
+                                      usernamePasswordsSize, usernamePasswords);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(config);
         return retval;
@@ -704,7 +704,12 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
         return retval;
     }
 
-    retval = UA_AccessControl_default(conf, true,
+    UA_CertificateVerification accessControlVerification;
+    retval = UA_CertificateVerification_Trustlist(&accessControlVerification,
+                                                  trustList, trustListSize,
+                                                  issuerList, issuerListSize,
+                                                  revocationList, revocationListSize);
+    retval |= UA_AccessControl_default(conf, true, &accessControlVerification,
                 &conf->securityPolicies[conf->securityPoliciesSize-1].policyUri,
                 usernamePasswordsSize, usernamePasswords);
     if(retval != UA_STATUSCODE_GOOD) {

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -388,39 +388,35 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
 }
 
 static UA_StatusCode
-checkSignature(const UA_Server *server, const UA_SecureChannel *channel,
-               UA_Session *session, const UA_ActivateSessionRequest *request) {
-    if(channel->securityMode != UA_MESSAGESECURITYMODE_SIGN &&
-       channel->securityMode != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
-        return UA_STATUSCODE_GOOD;
-
-    /* Check for zero signature length in client signature */
-    if(request->clientSignature.signature.length == 0)
+checkSignature(const UA_Server *server, const UA_SecurityPolicy *securityPolicy,
+               void *channelContext, const UA_ByteString *serverNonce,
+               const UA_SignatureData *signature) {
+    /* Check for zero signature length */
+    if(signature->signature.length == 0)
         return UA_STATUSCODE_BADAPPLICATIONSIGNATUREINVALID;
 
-    if(!channel->securityPolicy)
+    if(!securityPolicy)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    const UA_SecurityPolicy *securityPolicy = channel->securityPolicy;
     const UA_ByteString *localCertificate = &securityPolicy->localCertificate;
-
+    /* Data to verify is calculated by appending the serverNonce to the local certificate */
     UA_ByteString dataToVerify;
-    size_t dataToVerifySize = localCertificate->length + session->serverNonce.length;
+    size_t dataToVerifySize = localCertificate->length + serverNonce->length;
     UA_StatusCode retval = UA_ByteString_allocBuffer(&dataToVerify, dataToVerifySize);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
     memcpy(dataToVerify.data, localCertificate->data, localCertificate->length);
     memcpy(dataToVerify.data + localCertificate->length,
-           session->serverNonce.data, session->serverNonce.length);
+           serverNonce->data, serverNonce->length);
     retval = securityPolicy->certificateSigningAlgorithm.
-        verify(channel->channelContext, &dataToVerify,
-               &request->clientSignature.signature);
+        verify(channelContext, &dataToVerify, &signature->signature);
     UA_ByteString_clear(&dataToVerify);
     return retval;
 }
 
 #ifdef UA_ENABLE_ENCRYPTION
+
 static UA_StatusCode
 decryptPassword(UA_SecurityPolicy *securityPolicy, void *tempChannelContext,
                 const UA_ByteString *serverNonce, UA_UserNameIdentityToken *userToken) {
@@ -590,14 +586,18 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         goto rejected;
     }
 
-    /* Check if the signature corresponds to the ServerNonce that was last sent
-     * to the client */
-    response->responseHeader.serviceResult = checkSignature(server, channel, session, request);
-    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-        UA_LOG_WARNING_SESSION(&server->config.logger, session,
-                               "ActivateSession: Signature check failed with StatusCode %s",
-                               UA_StatusCode_name(response->responseHeader.serviceResult));
-        goto securityRejected;
+    /* Check the client signature */
+    if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
+       channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT) {
+        response->responseHeader.serviceResult =
+            checkSignature(server, channel->securityPolicy, channel->channelContext,
+                           &session->serverNonce, &request->clientSignature);
+        if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+            UA_LOG_WARNING_SESSION(&server->config.logger, session,
+                                   "ActivateSession: Client signature check failed with StatusCode %s",
+                                   UA_StatusCode_name(response->responseHeader.serviceResult));
+            goto securityRejected;
+        }
     }
 
     /* Find the matching Endpoint with UserTokenPolicy */
@@ -638,14 +638,13 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
             * used for the password from the SecureChannel */
            void *tempChannelContext = channel->channelContext;
            if(securityPolicy != channel->securityPolicy) {
-               /* TODO: This is a hack. We use our own certificate to create a
-                * channel context. Because the client does not provide one in a
-                * #None SecureChannel. We should not need a ChannelContext at all
-                * for asymmetric decryption where the remote certificate is not
+               /* We use our own certificate to create a temporary channel
+                * context. Because the client does not provide one in a #None
+                * SecureChannel. We should not need a ChannelContext at all for
+                * asymmetric decryption where the remote certificate is not
                 * used. */
                UA_UNLOCK(&server->serviceMutex);
-               response->responseHeader.serviceResult =
-                   securityPolicy->channelModule.
+               response->responseHeader.serviceResult = securityPolicy->channelModule.
                    newContext(securityPolicy, &securityPolicy->localCertificate,
                               &tempChannelContext);
                UA_LOCK(&server->serviceMutex);
@@ -663,13 +662,15 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
                decryptPassword(securityPolicy, tempChannelContext, &session->serverNonce, userToken);
 
            /* Remove the temporary channel context */
-           if(securityPolicy != channel->securityPolicy)
+           if(securityPolicy != channel->securityPolicy) {
+               UA_UNLOCK(&server->serviceMutex);
                securityPolicy->channelModule.deleteContext(tempChannelContext);
-       }
-       /* If SecurityPolicy is None there shall be no EncryptionAlgorithm  */
-       else if( userToken->encryptionAlgorithm.length != 0 ) {
-          response->responseHeader.serviceResult = UA_STATUSCODE_BADIDENTITYTOKENINVALID;
-          return;
+               UA_LOCK(&server->serviceMutex);
+           }
+       } else if(userToken->encryptionAlgorithm.length != 0) {
+           /* If SecurityPolicy is None there shall be no EncryptionAlgorithm  */
+           response->responseHeader.serviceResult = UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+           return;
        }
 
        if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {


### PR DESCRIPTION
To support x509 certificates as user identity tokens, two things are needed:

1) Verify the user token signature (verify user is in possesion of private key).

2) Verify the user token (certificate) is trusted.

This PR implements step 1. Step 2 is left to the library user, to be implemented in the access control plugin.

See issue #3962 for discussion with @jpfr.

NOTE : the library user also needs to add the certificate token policy to the server configuration as follows:

```c
UA_ServerConfig * config = UA_Server_getConfig(server);
UA_AccessControl * ac = &config->accessControl;

// add support for certificate user token (not supported yet by open62541)

// delete old list of supported tokens
UA_Array_delete((void*)(uintptr_t)ac->userTokenPolicies,
	ac->userTokenPoliciesSize,
	&UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
// cerate new list of suported tokens
ac->userTokenPolicies     = NULL;
ac->userTokenPoliciesSize = 3; // support anon, user/pass and certs
ac->userTokenPolicies     = (UA_UserTokenPolicy*)
	UA_Array_new(ac->userTokenPoliciesSize, &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
// support anonymous
ac->userTokenPolicies[0].tokenType = UA_USERTOKENTYPE_ANONYMOUS;
ac->userTokenPolicies[0].policyId  = UA_STRING_ALLOC(ANONYMOUS_POLICY);
// support username and password
ac->userTokenPolicies[1].tokenType = UA_USERTOKENTYPE_USERNAME;
ac->userTokenPolicies[1].policyId  = UA_STRING_ALLOC(USERNAME_POLICY);
// support certs
ac->userTokenPolicies[2].tokenType = UA_USERTOKENTYPE_CERTIFICATE;
ac->userTokenPolicies[2].policyId  = UA_STRING_ALLOC(CERTIFICATE_POLICY);
// because we added cert support, we need to re-allocate the endpoints
for (size_t i = 0; i < config->endpointsSize; ++i)
	UA_EndpointDescription_deleteMembers(&config->endpoints[i]);
UA_free(config->endpoints);
config->endpoints     = NULL;
config->endpointsSize = 0;
st = UA_ServerConfig_addAllEndpoints(config);
```