### PR TITLE
refactor(pubsub): Sane include order for PubSub definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,12 +734,12 @@ set(exported_headers ${exported_headers}
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/accesscontrol.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/pki.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/securitypolicy.h
-                     ${PROJECT_SOURCE_DIR}/include/open62541/server_pubsub.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/pubsub.h
                      ${PROJECT_SOURCE_DIR}/deps/ziptree.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/nodestore.h
                      ${historizing_exported_headers}
                      ${PROJECT_SOURCE_DIR}/include/open62541/server.h
+                     ${PROJECT_SOURCE_DIR}/include/open62541/server_pubsub.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/client.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/client_highlevel.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/client_subscriptions.h

--- a/include/open62541/plugin/pubsub.h
+++ b/include/open62541/plugin/pubsub.h
@@ -8,7 +8,8 @@
 #ifndef UA_PLUGIN_PUBSUB_H_
 #define UA_PLUGIN_PUBSUB_H_
 
-#include <open62541/server_pubsub.h>
+#include <open62541/types.h>
+#include <open62541/types_generated.h>
 
 _UA_BEGIN_DECLS
 
@@ -29,6 +30,12 @@ _UA_BEGIN_DECLS
  * with different network implementations like UDP, MQTT, AMQP. The channel
  * provides basis services like send, regist, unregist, receive, close. */
 
+struct UA_PubSubConnectionConfig;
+typedef struct UA_PubSubConnectionConfig UA_PubSubConnectionConfig;
+
+struct UA_PubSubChannel;
+typedef struct UA_PubSubChannel UA_PubSubChannel;
+
 typedef enum {
     UA_PUBSUB_CHANNEL_RDY,
     UA_PUBSUB_CHANNEL_PUB,
@@ -37,9 +44,6 @@ typedef enum {
     UA_PUBSUB_CHANNEL_ERROR,
     UA_PUBSUB_CHANNEL_CLOSED
 } UA_PubSubChannelState;
-
-struct UA_PubSubChannel;
-typedef struct UA_PubSubChannel UA_PubSubChannel;
 
 /* Interface structure between network plugin and internal implementation */
 struct UA_PubSubChannel {
@@ -88,19 +92,6 @@ typedef struct {
     UA_String transportProfileUri;
     UA_PubSubChannel *(*createPubSubChannel)(UA_PubSubConnectionConfig *connectionConfig);
 } UA_PubSubTransportLayer;
-
-/**
- * The UA_ServerConfig_addPubSubTransportLayer is used to add a transport layer
- * to the server configuration. The list memory is allocated and will be freed
- * with UA_PubSubManager_delete.
- *
- * .. note:: If the UA_String transportProfileUri was dynamically allocated
- *           the memory has to be freed when no longer required.
- *
- * .. note:: This has to be done before the server is started with UA_Server_run. */
-UA_StatusCode UA_EXPORT
-UA_ServerConfig_addPubSubTransportLayer(UA_ServerConfig *config,
-                                        UA_PubSubTransportLayer *pubsubTransportLayer);
 
 #endif /* UA_ENABLE_PUBSUB */
 

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -295,6 +295,7 @@ UA_ServerConfig_setCustomHostname(UA_ServerConfig *config,
     UA_String_clear(&config->customHostname);
     UA_String_copy(&customHostname, &config->customHostname);
 }
+
 /**
  * .. _server-lifecycle:
  *
@@ -1679,5 +1680,9 @@ UA_ServerStatistics UA_EXPORT
 UA_Server_getStatistics(UA_Server *server);
 
 _UA_END_DECLS
+
+#ifdef UA_ENABLE_PUBSUB
+#include <open62541/server_pubsub.h>
+#endif
 
 #endif /* UA_SERVER_H_ */

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -10,8 +10,9 @@
 #define UA_SERVER_PUBSUB_H
 
 #include <open62541/util.h>
-#include <open62541/types.h>
-#include <open62541/types_generated.h>
+#include <open62541/server.h>
+
+#include <open62541/plugin/pubsub.h>
 
 _UA_BEGIN_DECLS
 
@@ -162,7 +163,7 @@ typedef struct {
 } UA_ETFConfiguration;
 #endif
 
-typedef struct {
+struct UA_PubSubConnectionConfig {
     UA_String name;
     UA_Boolean enabled;
     UA_PublisherIdType publisherIdType;
@@ -179,7 +180,21 @@ typedef struct {
     /* ETF related connection configuration - Not in PubSub specfication */
     UA_ETFConfiguration etfConfiguration;
 #endif
-} UA_PubSubConnectionConfig;
+};
+
+/**
+ * The UA_ServerConfig_addPubSubTransportLayer is used to add a transport layer
+ * to the server configuration. The list memory is allocated and will be freed
+ * with UA_PubSubManager_delete.
+ *
+ * .. note:: If the UA_String transportProfileUri was dynamically allocated
+ *           the memory has to be freed when no longer required.
+ *
+ * .. note:: This has to be done before the server is started with UA_Server_run. */
+
+UA_StatusCode UA_EXPORT
+UA_ServerConfig_addPubSubTransportLayer(UA_ServerConfig *config,
+                                        UA_PubSubTransportLayer *pubsubTransportLayer);
 
 UA_StatusCode UA_EXPORT
 UA_Server_addPubSubConnection(UA_Server *server,

--- a/plugins/ua_network_pubsub_mqtt.c
+++ b/plugins/ua_network_pubsub_mqtt.c
@@ -13,6 +13,9 @@
  * "ua_mqtt_pal.c" forwards the network calls (send/recv) to UA_Connection (TCP).
  */
 
+#include <open62541/server_pubsub.h>
+#include <open62541/util.h>
+
 #include "mqtt/ua_mqtt_adapter.h"
 #include "open62541/plugin/log_stdout.h"
 

--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -7,9 +7,11 @@
  *   Copyright (c) 2019-2020 Kalycito Infotech Private Limited
  */
 
+#include <open62541/server_pubsub.h>
+#include <open62541/util.h>
+
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pubsub_ethernet.h>
-#include <open62541/util.h>
 
 #if defined(__vxworks) || defined(__VXWORKS__)
 #include <netpacket/packet.h>

--- a/plugins/ua_pubsub_ethernet_etf.c
+++ b/plugins/ua_pubsub_ethernet_etf.c
@@ -5,9 +5,11 @@
  *   Copyright (c) 2019-2020 Kalycito Infotech Private Limited
  */
 
+#include <open62541/server_pubsub.h>
+#include <open62541/util.h>
+
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pubsub_ethernet_etf.h>
-#include <open62541/util.h>
 
 #if defined(__vxworks) || defined(__VXWORKS__)
 #include <netpacket/packet.h>

--- a/plugins/ua_pubsub_ethernet_xdp.c
+++ b/plugins/ua_pubsub_ethernet_xdp.c
@@ -5,10 +5,11 @@
  *   Copyright (c) 2019-2020 Kalycito Infotech Private Limited
  */
 
-#include <open62541/plugin/log_stdout.h>
-#include <open62541/plugin/pubsub_ethernet_xdp.h>
 #include <open62541/server_pubsub.h>
 #include <open62541/util.h>
+
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/plugin/pubsub_ethernet_xdp.h>
 
 #if defined(__vxworks) || defined(__VXWORKS__)
 #include <netpacket/packet.h>

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -8,9 +8,11 @@
  * Copyright (c) 2020 Kalycito Infotech Private Limited
  */
 
+#include <open62541/server_pubsub.h>
+#include <open62541/util.h>
+
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pubsub_udp.h>
-#include <open62541/util.h>
 
 /* UDP multicast network layer specific internal data */
 typedef struct {


### PR DESCRIPTION
The plugin header is freestanding. The server_pubsub.h adds definitions
on top of server.h.