### PR TITLE
Fix PEM certificate handling for SecurityPolicy None

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,7 +798,6 @@ set(default_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_log_stdout.c
                            ${PROJECT_SOURCE_DIR}/plugins/ua_nodestore_ziptree.c
                            ${PROJECT_SOURCE_DIR}/plugins/ua_nodestore_hashmap.c
                            ${PROJECT_SOURCE_DIR}/plugins/ua_config_default.c
-                           ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_none.c
 )
 
 # Syslog-logging on Linux and Unices
@@ -819,10 +818,24 @@ endif()
 
 # Always include encryption plugins into the amalgamation
 # Use guards in the files to ensure that UA_ENABLE_ENCRYPTON_MBEDTLS and UA_ENABLE_ENCRYPTION_OPENSSL are honored.
+
 if(UA_ENABLE_ENCRYPTION_MBEDTLS OR UA_ENABLE_AMALGAMATION)
 list(APPEND default_plugin_sources
-     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/securitypolicy_mbedtls_common.h
-     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/securitypolicy_mbedtls_common.c
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/securitypolicy_mbedtls_common.h
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/securitypolicy_mbedtls_common.c)
+endif()
+
+if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_AMALGAMATION)
+list(APPEND default_plugin_sources
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c)
+endif()
+
+list(APPEND default_plugin_sources
+    ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_none.c)
+
+if(UA_ENABLE_ENCRYPTION_MBEDTLS OR UA_ENABLE_AMALGAMATION)
+list(APPEND default_plugin_sources
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic128rsa15.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/ua_securitypolicy_basic256sha256.c)
@@ -830,8 +843,6 @@ endif()
 
 if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_AMALGAMATION)
 list(APPEND default_plugin_sources
-     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/securitypolicy_openssl_common.h
-     ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic128rsa15.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic256.c
      ${PROJECT_SOURCE_DIR}/plugins/securityPolicies/openssl/ua_openssl_basic256sha256.c

--- a/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c
+++ b/plugins/securityPolicies/openssl/securitypolicy_openssl_common.c
@@ -939,8 +939,10 @@ UA_StatusCode
 UA_OpenSSL_LoadLocalCertificate(const UA_ByteString *certificate, UA_ByteString *target) {
     X509 *cert = UA_OpenSSL_LoadCertificate(certificate);
 
-    if (!cert)
+    if (!cert) {
+        UA_ByteString_init(target);
         return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
 
     unsigned char *derData = NULL;
     int length = i2d_X509(cert, &derData);
@@ -953,6 +955,8 @@ UA_OpenSSL_LoadLocalCertificate(const UA_ByteString *certificate, UA_ByteString 
         UA_ByteString_copy(&temp, target);
         OPENSSL_free(derData);
         return UA_STATUSCODE_GOOD;
+    } else {
+        UA_ByteString_init(target);
     }
 
     return UA_STATUSCODE_BADINVALIDARGUMENT;

--- a/plugins/securityPolicies/securitypolicy_mbedtls_common.c
+++ b/plugins/securityPolicies/securitypolicy_mbedtls_common.c
@@ -267,6 +267,8 @@ UA_StatusCode UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData, UA_
         tmp.length = cert.raw.len;
 
         result = UA_ByteString_copy(&tmp, target);
+    } else {
+        UA_ByteString_init(target);
     }
 
     UA_ByteString_clear(&data);

--- a/plugins/securityPolicies/ua_securitypolicy_none.c
+++ b/plugins/securityPolicies/ua_securitypolicy_none.c
@@ -7,6 +7,14 @@
 
 #include <open62541/plugin/securitypolicy_default.h>
 
+#ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
+#include "securitypolicy_mbedtls_common.h"
+#endif
+
+#ifdef UA_ENABLE_ENCRYPTION_OPENSSL
+#include "openssl/securitypolicy_openssl_common.h"
+#endif
+
 static UA_StatusCode
 verify_none(const UA_SecurityPolicy *securityPolicy,
             void *channelContext,
@@ -132,7 +140,14 @@ UA_SecurityPolicy_None(UA_SecurityPolicy *policy, const UA_ByteString localCerti
     policy->policyContext = (void *)(uintptr_t)logger;
     policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#None");
     policy->logger = logger;
+
+#ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
+    UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
+#elif defined(UA_ENABLE_ENCRYPTION_OPENSSL)
+    UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
+#else
     UA_ByteString_copy(&localCertificate, &policy->localCertificate);
+#endif
 
     policy->symmetricModule.generateKey = generateKey_none;
     policy->symmetricModule.generateNonce = generateNonce_none;


### PR DESCRIPTION
If UA_ENABLE_ENCRYPTION_MBEDTLS is set, SecurityPolicy None will still just copy the certificate data.
If the input is PEM, the trailing null byte is not added and mbedTLS will fail to parse the data. This breaks the application URI check on server start.

In case of UA_ENABLE_ENCRYPTION_OPENSSL, there is a similar problem
if the PEM data is just copied into the local certificate byte string.