### PR TITLE
Support self containing structs in the nodeset compiler

### DIFF
--- a/examples/custom_datatype/custom_datatype.h
+++ b/examples/custom_datatype/custom_datatype.h
@@ -187,7 +187,7 @@ static UA_DataTypeMember Uni_members[2] = {
     {
         UA_TYPES_DOUBLE,            /* .memberTypeIndex, points into UA_TYPES since
                                     namespaceZero is true */
-        sizeof(UA_UInt32),          /* .padding */
+        offsetof(Uni, fields.optionA), /* .padding */
         true,                       /* .namespaceZero, see .memberTypeIndex */
         false,                      /* .isArray */
         false                       /* .isOptional */
@@ -196,7 +196,7 @@ static UA_DataTypeMember Uni_members[2] = {
     {
         UA_TYPES_STRING,            /* .memberTypeIndex, points into UA_TYPES since
                                     namespaceZero is true */
-        sizeof(UA_UInt32),          /* .padding */
+        offsetof(Uni, fields.optionB), /* .padding */
         true,                       /* .namespaceZero, see .memberTypeIndex */
         false,                      /* .isArray */
         false                       /* .isOptional */

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1147,11 +1147,26 @@ copyUnion(const void *src, void *dst, const UA_DataType *type) {
     const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     const UA_DataTypeMember *m = &type->members[selection-1];
     const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
-    ptrs += UA_TYPES[UA_TYPES_UINT32].memSize;
-    ptrd += UA_TYPES[UA_TYPES_UINT32].memSize;
     ptrs += m->padding;
     ptrd += m->padding;
-    return UA_copy((const void *) ptrs, (void *) ptrd, mt);
+
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+
+    if (m->isArray) {
+        size_t *dst_size = (size_t*)ptrd;
+        const size_t size = *((const size_t*)ptrs);
+        ptrs += sizeof(size_t);
+        ptrd += sizeof(size_t);
+        retval = UA_Array_copy(*(void* const*)ptrs, size, (void**)ptrd, mt);
+        if(retval == UA_STATUSCODE_GOOD)
+            *dst_size = size;
+        else
+            *dst_size = 0;
+    } else {
+        retval = copyJumpTable[mt->typeKind]((const void *)ptrs, (void *)ptrd, mt);
+    }
+
+    return retval;
 }
 
 static UA_StatusCode
@@ -1251,9 +1266,14 @@ clearUnion(void *p, const UA_DataType *type) {
     const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     const UA_DataTypeMember *m = &type->members[selection-1];
     const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
-    ptr += UA_TYPES[UA_TYPES_UINT32].memSize;
     ptr += m->padding;
-    UA_clear((void *) ptr, mt);
+    if (m->isArray) {
+        size_t length = *(size_t *)ptr;
+        ptr += sizeof(size_t);
+        UA_Array_delete(*(void **)ptr, length, mt);
+    } else {
+        UA_clear((void *) ptr, mt);
+    }
 }
 
 static void nopClear(void *p, const UA_DataType *type) { }

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -274,7 +274,7 @@ static const UA_DataType selfContainingUnionType = {
     UA_DATATYPEKIND_UNION, /* .typeKind */
     false, /* .pointerFree */
     false, /* .overlayable */
-    3, /* .membersSize */
+    2, /* .membersSize */
     SelfContainingUnion_members  /* .members */
     UA_TYPENAME("SelfContainingStruct") /* .typeName */
 };

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -198,7 +198,7 @@ typedef struct {
 static UA_DataTypeMember Uni_members[2] = {
         {
                 UA_TYPES_DOUBLE,
-                sizeof(UA_UInt32),
+                offsetof(Uni, fields.optionA),
                 true,
                 false,
                 false
@@ -206,7 +206,7 @@ static UA_DataTypeMember Uni_members[2] = {
         },
         {
                 UA_TYPES_STRING,
-                sizeof(UA_UInt32),
+                offsetof(Uni, fields.optionB),
                 true,
                 false,
                 false
@@ -228,6 +228,58 @@ static const UA_DataType UniType = {
 };
 
 const UA_DataTypeArray customDataTypesUnion = {&customDataTypesOptArrayStruct, 2, &UniType};
+
+typedef enum {
+    UA_SELFCONTAININGUNIONSWITCH_NONE = 0,
+    UA_SELFCONTAININGUNIONSWITCH_DOUBLE = 1,
+    UA_SELFCONTAININGUNIONSWITCH_ARRAY = 2,
+    __UA_SELFCONTAININGUNIONSWITCH_FORCE32BIT = 0x7fffffff
+} UA_SelfContainingUnionSwitch;
+
+typedef struct UA_SelfContainingUnion UA_SelfContainingUnion;
+struct UA_SelfContainingUnion {
+    UA_SelfContainingUnionSwitch switchField;
+    union {
+        UA_Double _double;
+        struct {
+            size_t arraySize;
+            UA_SelfContainingUnion *array;
+        } array;
+    } fields;
+};
+
+static UA_DataTypeMember SelfContainingUnion_members[2] = {
+{
+    UA_TYPES_DOUBLE, /* .memberTypeIndex */
+    offsetof(UA_SelfContainingUnion, fields._double), /* .padding */
+    true, /* .namespaceZero */
+    false, /* .isArray */
+    false  /* .isOptional */
+    UA_TYPENAME("_double") /* .memberName */
+},
+{
+    0, /* .memberTypeIndex */
+    offsetof(UA_SelfContainingUnion, fields.array), /* .padding */
+    false, /* .namespaceZero */
+    true, /* .isArray */
+    false  /* .isOptional */
+    UA_TYPENAME("Array") /* .memberName */
+},};
+
+static const UA_DataType selfContainingUnionType = {
+    {2, UA_NODEIDTYPE_NUMERIC, {4002LU}}, /* .typeId */
+    {2, UA_NODEIDTYPE_NUMERIC, {0}}, /* .binaryEncodingId */
+    sizeof(UA_SelfContainingUnion), /* .memSize */
+    0, /* .typeIndex */
+    UA_DATATYPEKIND_UNION, /* .typeKind */
+    false, /* .pointerFree */
+    false, /* .overlayable */
+    3, /* .membersSize */
+    SelfContainingUnion_members  /* .members */
+    UA_TYPENAME("SelfContainingStruct") /* .typeName */
+};
+
+const UA_DataTypeArray customDataTypesSelfContainingUnion = {NULL, 1, &selfContainingUnionType};
 
 START_TEST(parseCustomScalar) {
     Point p;
@@ -531,6 +583,99 @@ START_TEST(parseCustomUnion) {
         UA_ByteString_clear(&buf);
     } END_TEST
 
+START_TEST(parseSelfContainingUnionNormalMember) {
+        UA_StatusCode retval;
+        UA_SelfContainingUnion s;
+        s.switchField = UA_SELFCONTAININGUNIONSWITCH_DOUBLE;
+        s.fields._double = 42.0;
+
+        UA_Variant var;
+        UA_Variant_init(&var);
+        retval = UA_Variant_setScalarCopy(&var, &s, &selfContainingUnionType);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+
+        size_t lengthOfUnion = UA_calcSizeBinary(&s, &selfContainingUnionType);
+        //check if 12 is the right size
+        ck_assert_uint_eq(lengthOfUnion, 12);
+
+        size_t buflen = UA_calcSizeBinary(&var, &UA_TYPES[UA_TYPES_VARIANT]);
+        UA_ByteString buf;
+        retval = UA_ByteString_allocBuffer(&buf, buflen);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+
+        UA_Byte *pos = buf.data;
+        const UA_Byte *end = &buf.data[buf.length];
+        retval = UA_encodeBinary(&var, &UA_TYPES[UA_TYPES_VARIANT],
+                                 &pos, &end, NULL, NULL);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+
+        UA_Variant var2;
+        size_t offset = 0;
+        retval = UA_decodeBinary(&buf, &offset, &var2, &UA_TYPES[UA_TYPES_VARIANT], &customDataTypesSelfContainingUnion);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+        ck_assert(var2.type == &selfContainingUnionType);
+
+        UA_SelfContainingUnion *s2 = (UA_SelfContainingUnion *) var2.data;
+        ck_assert(s2->switchField = UA_SELFCONTAININGUNIONSWITCH_DOUBLE);
+        ck_assert(fabs(s2->fields._double - 42.0) < 0.005);
+
+        UA_Variant_clear(&var);
+        UA_Variant_clear(&var2);
+        UA_ByteString_clear(&buf);
+    } END_TEST
+
+START_TEST(parseSelfContainingUnionSelfMember) {
+        UA_StatusCode retval;
+        UA_SelfContainingUnion s;
+        s.switchField = UA_SELFCONTAININGUNIONSWITCH_ARRAY;
+        s.fields.array.arraySize = 2;
+        s.fields.array.array = (UA_SelfContainingUnion *)UA_calloc(2, sizeof(UA_SelfContainingUnion));
+        s.fields.array.array[0].switchField = UA_SELFCONTAININGUNIONSWITCH_DOUBLE;
+        s.fields.array.array[0].fields._double = 23.0;
+        s.fields.array.array[1].switchField = UA_SELFCONTAININGUNIONSWITCH_DOUBLE;
+        s.fields.array.array[1].fields._double = 42.0;
+
+        UA_Variant var;
+        UA_Variant_init(&var);
+        retval = UA_Variant_setScalarCopy(&var, &s, &selfContainingUnionType);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+
+        size_t lengthOfUnion = UA_calcSizeBinary(&s, &selfContainingUnionType);
+        //check if 32 is the right size
+        ck_assert_uint_eq(lengthOfUnion, 32);
+
+        UA_free(s.fields.array.array);
+
+        size_t buflen = UA_calcSizeBinary(&var, &UA_TYPES[UA_TYPES_VARIANT]);
+        UA_ByteString buf;
+        retval = UA_ByteString_allocBuffer(&buf, buflen);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+
+        UA_Byte *pos = buf.data;
+        const UA_Byte *end = &buf.data[buf.length];
+        retval = UA_encodeBinary(&var, &UA_TYPES[UA_TYPES_VARIANT],
+                                 &pos, &end, NULL, NULL);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+
+        UA_Variant var2;
+        size_t offset = 0;
+        retval = UA_decodeBinary(&buf, &offset, &var2, &UA_TYPES[UA_TYPES_VARIANT], &customDataTypesSelfContainingUnion);
+        ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+        ck_assert(var2.type == &selfContainingUnionType);
+
+        UA_SelfContainingUnion *s2 = (UA_SelfContainingUnion *) var2.data;
+        ck_assert(s2->switchField = UA_SELFCONTAININGUNIONSWITCH_ARRAY);
+        ck_assert(s2->fields.array.arraySize == 2);
+        ck_assert(s2->fields.array.array[0].switchField == UA_SELFCONTAININGUNIONSWITCH_DOUBLE);
+        ck_assert(fabs(s2->fields.array.array[0].fields._double - 23.0) < 0.005);
+        ck_assert(s2->fields.array.array[1].switchField == UA_SELFCONTAININGUNIONSWITCH_DOUBLE);
+        ck_assert(fabs(s2->fields.array.array[1].fields._double - 42.0) < 0.005);
+
+        UA_Variant_clear(&var);
+        UA_Variant_clear(&var2);
+        UA_ByteString_clear(&buf);
+    } END_TEST
+
 int main(void) {
     Suite *s  = suite_create("Test Custom DataType Encoding");
     TCase *tc = tcase_create("test cases");
@@ -539,6 +684,8 @@ int main(void) {
     tcase_add_test(tc, parseCustomArray);
     tcase_add_test(tc, parseCustomStructureWithOptionalFields);
     tcase_add_test(tc, parseCustomUnion);
+    tcase_add_test(tc, parseSelfContainingUnionNormalMember);
+    tcase_add_test(tc, parseSelfContainingUnionSelfMember);
     tcase_add_test(tc, parseCustomStructureWithOptionalFieldsWithArrayNotContained);
     tcase_add_test(tc, parseCustomStructureWithOptionalFieldsWithArrayContained);
     suite_add_tcase(s, tc);

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -9,6 +9,7 @@
 #include "check.h"
 #include "testing_clock.h"
 #include "tests/namespace_tests_testnodeset_generated.h"
+#include "tests/types_tests_testnodeset_generated_handling.h"
 #include "unistd.h"
 
 UA_Server *server = NULL;
@@ -47,6 +48,21 @@ START_TEST(checkScalarValues) {
     UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 10005), &out);
     ck_assert(out.data != NULL); /* a default value is generated */
     UA_Variant_clear(&out);
+}
+END_TEST
+
+START_TEST(checkSelfContainingUnion) {
+    UA_Variant in;
+    UA_Variant_init(&in);
+
+    UA_SelfContainingUnion data;
+    UA_SelfContainingUnion_init(&data);
+
+    UA_Variant_setScalar(&in, &data, &UA_TYPES_TESTS_TESTNODESET[UA_TYPES_TESTS_TESTNODESET_SELFCONTAININGUNION]);
+
+    UA_StatusCode result = UA_Server_writeValue(server, UA_NODEID_NUMERIC(2, 5110), in);
+
+    ck_assert(result == UA_STATUSCODE_GOOD);
 }
 END_TEST
 
@@ -133,6 +149,7 @@ static Suite *testSuite_Client(void) {
     tcase_add_unchecked_fixture(tc_server, setup, teardown);
     tcase_add_test(tc_server, Server_addTestNodeset);
     tcase_add_test(tc_server, checkScalarValues);
+    tcase_add_test(tc_server, checkSelfContainingUnion);
     tcase_add_test(tc_server, check1dimValues);
     tcase_add_test(tc_server, readValueRank);
     tcase_add_test(tc_server, checkFrameValues);

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -58,6 +58,13 @@ START_TEST(checkSelfContainingUnion) {
     UA_SelfContainingUnion data;
     UA_SelfContainingUnion_init(&data);
 
+    data.fields._double = 23.0;
+
+    data.switchField = UA_SELFCONTAININGUNIONSWITCH_DOUBLE;
+
+    data.fields.array.arraySize = 0;
+    data.fields.array.array = NULL;
+
     UA_Variant_setScalar(&in, &data, &UA_TYPES_TESTS_TESTNODESET[UA_TYPES_TESTS_TESTNODESET_SELFCONTAININGUNION]);
 
     UA_StatusCode result = UA_Server_writeValue(server, UA_NODEID_NUMERIC(2, 5110), in);

--- a/tests/nodeset-compiler/testnodeset.csv
+++ b/tests/nodeset-compiler/testnodeset.csv
@@ -14,3 +14,4 @@ BaseDataTypes_String1_scalar,16001,Variable
 BaseDataTypes_ByteString_Scalar,16002,Variable
 PointWithArray,3003,DataType
 NestedPoint,10008,DataType
+SelfContainingUnion,4002,DataType

--- a/tests/nodeset-compiler/testnodeset.xml
+++ b/tests/nodeset-compiler/testnodeset.xml
@@ -17,6 +17,7 @@
         <Alias Alias="Argument">i=296</Alias>
         <Alias Alias="Point3D">ns=1;i=3002</Alias>
         <Alias Alias="Point">ns=1;i=10001</Alias>
+        <Alias Alias="SelfContainingUnion">ns=1;i=4002</Alias>
     </Aliases>
     <Extensions>
         <Extension>
@@ -345,7 +346,24 @@
                 </uax:ExtensionObject>
             </uax:ListOfExtensionObject>
         </Value>
-    </UAVariable>    
+    </UAVariable>
+    <UADataType NodeId="ns=1;i=4002" BrowseName="1:SelfContainingUnion">
+        <DisplayName>SelfContainingUnion</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=12756</Reference>
+        </References>
+        <Definition Name="1:SelfContainingUnion" IsUnion="true">
+            <Field DataType="Double" Name="Double"/>
+            <Field DataType="SelfContainingUnion" ValueRank="1" ArrayDimensions="0" Name="Array"/>
+        </Definition>
+    </UADataType>
+    <UAVariable DataType="SelfContainingUnion" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=5110" BrowseName="1:SelfContainingUnion_scalar_init" AccessLevel="3">
+        <DisplayName>SelfContainingUnion_scalar_init</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
     <UAVariable DataType="Double" ParentNodeId="ns=1;i=5100" NodeId="ns=1;i=5101" BrowseName="1:Double_init" AccessLevel="3">
         <DisplayName>Double_init</DisplayName>
         <References>

--- a/tests/nodeset-compiler/testtypes.bsd
+++ b/tests/nodeset-compiler/testtypes.bsd
@@ -57,4 +57,11 @@
     <opc:Field Name="array1" TypeName="opc:Double" LengthField="array1Size" />
   </opc:StructuredType>
 
+  <opc:StructuredType BaseType="ua:Union" Name="SelfContainingUnion">
+    <opc:Field TypeName="opc:UInt32" Name="SwitchField"/>
+    <opc:Field SwitchField="SwitchField" TypeName="opc:Double" SwitchValue="1" Name="Double"/>
+    <opc:Field SwitchField="SwitchField" TypeName="opc:Int32" SwitchValue="2" Name="NoOfArray"/>
+    <opc:Field LengthField="NoOfArray" SwitchField="SwitchField" TypeName="tns:SelfContainingUnion" SwitchValue="2" Name="Array"/>
+  </opc:StructuredType>
+
 </opc:TypeDictionary>

--- a/tools/cmake/macros_public.cmake
+++ b/tools/cmake/macros_public.cmake
@@ -511,6 +511,7 @@ function(ua_generate_nodeset_and_datatypes)
                 string(REPLACE "-" "_" DEPENDS_NAME "${f}")
                 string(TOUPPER "${DEPENDS_NAME}" DEPENDS_NAME)
                 get_property(DEPENDS_NAMESPACE_MAP GLOBAL PROPERTY "UA_GEN_DT_DEPENDS_NAMESPACE_MAP_${DEPENDS_NAME}")
+
                 if(NOT DEPENDS_NAMESPACE_MAP OR "${DEPENDS_NAMESPACE_MAP}" STREQUAL "")
                     message(FATAL_ERROR "Nodeset dependency ${f} needs to be generated before ${UA_GEN_NAME}")
                 endif()
@@ -544,6 +545,23 @@ function(ua_generate_nodeset_and_datatypes)
             TARGET_SUFFIX "ids-${UA_GEN_NAME}"
         )
         set(NODESET_DEPENDS_TARGET ${NODESET_DEPENDS_TARGET} "${UA_GEN_TARGET_PREFIX}-ids-${UA_GEN_NAME}")
+    else() # Handle nodesets without types in the dependency chain
+        if (UA_GEN_DEPENDS AND NOT "${UA_GEN_DEPENDS}" STREQUAL "")
+            foreach(f ${UA_GEN_DEPENDS})
+                string(REPLACE "-" "_" DEPENDS_NAME "${f}")
+                string(TOUPPER "${DEPENDS_NAME}" DEPENDS_NAME)
+                get_property(DEPENDS_NAMESPACE_MAP GLOBAL PROPERTY "UA_GEN_DT_DEPENDS_NAMESPACE_MAP_${DEPENDS_NAME}")
+
+                set(NAMESPACE_MAP_DEPENDS ${NAMESPACE_MAP_DEPENDS} "${DEPENDS_NAMESPACE_MAP}")
+            endforeach()
+        endif()
+
+        # Use namespace 0 as default value
+        if (NOT NAMESPACE_MAP_DEPENDS OR "${NAMESPACE_MAP_DEPENDS}" STREQUAL "")
+            set(NAMESPACE_MAP_DEPENDS "0:http://opcfoundation.org/UA/")
+        endif()
+
+        set_property(GLOBAL PROPERTY "UA_GEN_DT_DEPENDS_NAMESPACE_MAP_${GEN_NAME_UPPER}" ${NAMESPACE_MAP_DEPENDS})
     endif()
 
     # Create a list of nodesets on which this nodeset depends on

--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -17,7 +17,12 @@ def generateBooleanCode(value):
 
 # Strip invalid characters to create valid C identifiers (variable names etc):
 def makeCIdentifier(value):
-    return re.sub(r'[^\w]', '', value)
+    keywords = frozenset(["double", "int", "float", "char"])
+    sanitized = re.sub(r'[^\w]', '', value)
+    if sanitized in keywords:
+        return "_" + sanitized
+    else:
+        return sanitized
 
 # Escape C strings:
 def makeCLiteral(value):

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -289,7 +289,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, i
         values = []
     for idx,subv in enumerate(values):
         encField = node.encodingRule[idx]
-        memberName = lowerFirstChar(encField[0])
+        memberName = makeCIdentifier(lowerFirstChar(encField[0]))
 
         # Check if this is an array
         accessor = "." if isArrayElement else "->"
@@ -298,7 +298,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, i
             if len(subv) == 0:
                 continue
             logger.info("ExtensionObject contains array")
-            memberName = lowerFirstChar(encField[0])
+            memberName = makeCIdentifier(lowerFirstChar(encField[0]))
             encTypeString = "UA_" + subv[0].__class__.__name__
             instanceNameSafe = makeCIdentifier(instanceName)
             code.append("UA_STACKARRAY(" + encTypeString + ", " + instanceNameSafe + "_" + memberName+", {0});".format(len(subv)))
@@ -322,7 +322,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, i
                 code.append(generateNodeValueCode(valueName,
                             subv, instanceName,valueName, global_var_code, asIndirect=False))
         else:
-            memberName = lowerFirstChar(encField[0])
+            memberName = makeCIdentifier(lowerFirstChar(encField[0]))
             code.append(generateNodeValueCode(instanceName + accessor + memberName + "Size", subv,
                                               instanceName,valueName, global_var_code, asIndirect=False))
 

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -269,7 +269,11 @@ class CGenerator(object):
             returnstr += "\n\n"
         if len(struct.members) == 0:
             return "typedef void * UA_%s;" % makeCIdentifier(struct.name)
-        returnstr += "typedef struct {\n"
+        if struct.is_recursive:
+            returnstr += "typedef struct UA_%s UA_%s;\n" % (makeCIdentifier(struct.name), makeCIdentifier(struct.name))
+            returnstr += "struct UA_%s {\n" % makeCIdentifier(struct.name)
+        else:
+            returnstr += "typedef struct {\n"
         if struct.is_union:
             returnstr += "    UA_%sSwitch switchField;\n" % struct.name
             returnstr += "    union {\n"
@@ -292,7 +296,10 @@ class CGenerator(object):
             count += 1
         if struct.is_union:
             returnstr += "    } fields;\n"
-        return returnstr + "} UA_%s;" % makeCIdentifier(struct.name)
+        if struct.is_recursive:
+            return returnstr + "};"
+        else:
+            return returnstr + "} UA_%s;" % makeCIdentifier(struct.name)
 
     @staticmethod
     def print_datatype_typedef(datatype):

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -44,8 +44,12 @@ def makeCLiteral(value):
 
 # Strip invalid characters to create valid C identifiers (variable names etc):
 def makeCIdentifier(value):
-    return re.sub(r'[^\w]', '', value)
-
+    keywords = frozenset(["double", "int", "float", "char"])
+    sanitized = re.sub(r'[^\w]', '', value)
+    if sanitized in keywords:
+        return "_" + sanitized
+    else:
+        return sanitized
 
 def getNodeidTypeAndId(nodeId):
     if not nodeId:

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -153,15 +153,10 @@ class CGenerator(object):
         if len(datatype.members) == 0:
             return "#define %s_members NULL" % (idName)
         isUnion = isinstance(datatype, StructType) and datatype.is_union
-        if isUnion:
-            members = "static UA_DataTypeMember %s_members[%s] = {" % (idName, len(datatype.members)-1)
-        else:
-            members = "static UA_DataTypeMember %s_members[%s] = {" % (idName, len(datatype.members))
+        members = "static UA_DataTypeMember %s_members[%s] = {" % (idName, len(datatype.members))
         before = None
         size = len(datatype.members)
         for i, member in enumerate(datatype.members):
-            if isUnion and i == 0:
-                continue
             member_name = makeCIdentifier(member.name)
             member_name_capital = member_name
             if len(member_name) > 0:
@@ -265,8 +260,7 @@ class CGenerator(object):
             obj.elements['None'] = str(0)
             count = 0
             for member in struct.members:
-                if(count > 0):
-                    obj.elements[member.name] = str(count)
+                obj.elements[member.name] = str(count)
                 count += 1
             returnstr += CGenerator.print_enum_typedef(obj)
             returnstr += "\n\n"
@@ -280,7 +274,6 @@ class CGenerator(object):
         if struct.is_union:
             returnstr += "    UA_%sSwitch switchField;\n" % struct.name
             returnstr += "    union {\n"
-        count = 0
         for member in struct.members:
             if member.is_array:
                 if struct.is_union:
@@ -293,16 +286,14 @@ class CGenerator(object):
                 if struct.is_union:
                     returnstr += "        } " + makeCIdentifier(member.name) + ";\n"
             elif struct.is_union:
-                if count > 0:
-                    returnstr += "        UA_%s %s;\n" % (
-                    makeCIdentifier(member.member_type.name), makeCIdentifier(member.name))
+                returnstr += "        UA_%s %s;\n" % (
+                makeCIdentifier(member.member_type.name), makeCIdentifier(member.name))
             elif member.is_optional:
                 returnstr += "    UA_%s *%s;\n" % (
                     makeCIdentifier(member.member_type.name), makeCIdentifier(member.name))
             else:
                 returnstr += "    UA_%s %s;\n" % (
                     makeCIdentifier(member.member_type.name), makeCIdentifier(member.name))
-            count += 1
         if struct.is_union:
             returnstr += "    } fields;\n"
         if struct.is_recursive:

--- a/tools/nodeset_compiler/type_parser.py
+++ b/tools/nodeset_compiler/type_parser.py
@@ -154,6 +154,7 @@ class StructType(Type):
         Type.__init__(self, outname, xml, namespace)
         length_fields = []
         optional_fields = []
+        switch_fields = []
         self.is_recursive = False
 
         typename = type_aliases.get(xml.get("Name"), xml.get("Name"))
@@ -165,6 +166,10 @@ class StructType(Type):
             if length_field:
                 length_fields.append(length_field)
         for child in xml:
+            switch_field = child.get("SwitchField")
+            if switch_field:
+                switch_fields.append(switch_field)
+        for child in xml:
             child_type = child.get("TypeName")
             if child_type and get_type_name(child_type)[1] == "Bit":
                 optional_fields.append(child.get("Name"))
@@ -174,6 +179,8 @@ class StructType(Type):
             if child.get("Name") in length_fields:
                 continue
             if get_type_name(child.get("TypeName"))[1] == "Bit":
+                continue
+            if self.is_union and child.get("Name") in switch_fields:
                 continue
             switch_field = child.get("SwitchField")
             if switch_field and switch_field in optional_fields:


### PR DESCRIPTION
This is my suggestion on how to handle the problem described in #3973.

There are two important things to observe with self containing structs:
- The field must be an array (which means that the member will become a pointer)
- A forward declaration must be added instead of doing definition and typedef in one step

The second commit in this PR is related to problems that occur if a struct has a field named "Double", "Int", "Float" or "Char".