### PR TITLE
Fix pkg-config include configuration directory

### DIFF
--- a/open62541.pc.in
+++ b/open62541.pc.in
@@ -12,4 +12,4 @@ Name: open62541
 Description: open62541 is an open source C (C99) implementation of OPC UA
 Version: @OPEN62541_VER_MAJOR@.@OPEN62541_VER_MINOR@.@OPEN62541_VER_PATCH@
 Libs: -L${libdir} -lopen62541
-Cflags: -I${includedir}/open62541
+Cflags: -I${includedir}


### PR DESCRIPTION
The current generated pkg-config file seems to be incorrect and this breaks the library usage for systems that rely on pkg-config output for autoconfiguration.

The template now includes:
```
prefix=@CMAKE_INSTALL_PREFIX@
...
includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
...
Cflags: -I${includedir}/open62541
```
So points to `include/open62541`. But then in some include files, for example `client.h` it is assumed to be one level under, for example:

```
#define UA_CLIENT_H_

#include <open62541/config.h>
#include <open62541/nodeids.h>
#include <open62541/types.h>
```
Or in similar way in example `client.c`:
```
#include <open62541/client_config_default.h>
#include <open62541/client_highlevel.h>
```

This PR fixes the pkg-config template file.

To reproduce one should do a build using pkg-config and not CMake once the library is installed, for example under `examples` (just build phase, not linking):
```
cc `pkg-config --cflags-only-I open62541`  client.c
```
(note: make sure the .pc file is in your `PKG_CONFIG_PATH` so pkg-config can pick it up)