### PR TITLE
Fix memory issues in the historical data plugins

### DIFF
--- a/plugins/historydata/ua_history_data_backend_memory.c
+++ b/plugins/historydata/ua_history_data_backend_memory.c
@@ -556,6 +556,7 @@ deleteMembers_backend_memory(UA_HistoryDataBackend *backend)
     if (backend == NULL || backend->context == NULL)
         return;
     UA_MemoryStoreContext_deleteMembers((UA_MemoryStoreContext*)backend->context);
+    UA_free(backend->context);
 }
 
 

--- a/plugins/historydata/ua_history_data_gathering_default.c
+++ b/plugins/historydata/ua_history_data_gathering_default.c
@@ -129,6 +129,7 @@ registerNodeId_gathering_default(UA_Server *server,
             ctx->storeSize = 0;
             return UA_STATUSCODE_BADOUTOFMEMORY;
         }
+        memset(&ctx->dataStore[ctx->storeSize], 0, (newStoreSize - ctx->storeSize) * sizeof(UA_NodeIdStoreContextItem_gathering_default));
         ctx->storeSize = newStoreSize;
     }
     UA_NodeId_copy(nodeId, &ctx->dataStore[ctx->storeEnd].nodeId);


### PR DESCRIPTION
- The members of the context are freed, but the context itself is not.
- After extending memory with realloc, the new memory is not initialized