### PR TITLE
Fix: Prevent array size 0, when no types are defined in a bsd file

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -382,7 +382,7 @@ _UA_BEGIN_DECLS
             totalCount += len(self.filtered_types[ns])
         self.printh("#define UA_" + self.parser.outname.upper() + "_COUNT %s" % (str(totalCount)))
 
-        if len(self.filtered_types) > 0:
+        if totalCount > 0:
 
             self.printh(
                 "extern UA_EXPORT const UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
@@ -448,14 +448,16 @@ _UA_END_DECLS
 
 #include "''' + self.parser.outname + '''_generated.h"''')
 
+        totalCount = 0
         for ns in self.filtered_types:
+            totalCount += len(self.filtered_types[ns])
             for i, t_name in enumerate(self.filtered_types[ns]):
                 t = self.filtered_types[ns][t_name]
                 self.printc("")
                 self.printc("/* " + t.name + " */")
                 self.printc(CGenerator.print_members(t, self.namespaceMap))
 
-        if len(self.filtered_types) > 0:
+        if totalCount > 0:
             self.printc(
                 "const UA_DataType UA_%s[UA_%s_COUNT] = {" % (self.parser.outname.upper(), self.parser.outname.upper()))
 


### PR DESCRIPTION
This fixes C2466 in Visual Studio, when compiling an bsd-File without types:


```xml
<opc:TypeDictionary xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://opcfoundation.org/UA/Machinery/" DefaultByteOrder="LittleEndian" xmlns:opc="http://opcfoundation.org/BinarySchema/" xmlns:ua="http://opcfoundation.org/UA/" TargetNamespace="http://opcfoundation.org/UA/Machinery/">
    <opc:Import Namespace="http://opcfoundation.org/UA/"/>
</opc:TypeDictionary>
```


>types_machinery_generated.h(22,79): error C2466: Zuordnung eines Arrays der konstanten Größe 0 nicht möglich.


```C

#ifndef TYPES_MACHINERY_GENERATED_H_
#define TYPES_MACHINERY_GENERATED_H_

#ifdef UA_ENABLE_AMALGAMATION
#include "open62541.h"
#else
#include <open62541/types.h>
#include <open62541/types_generated.h>

#endif

_UA_BEGIN_DECLS


/**
 * Every type is assigned an index in an array containing the type descriptions.
 * These descriptions are used during type handling (copying, deletion,
 * binary encoding, ...). */
#define UA_TYPES_MACHINERY_COUNT 0
extern UA_EXPORT const UA_DataType UA_TYPES_MACHINERY[UA_TYPES_MACHINERY_COUNT]; // <-- Here is the array with size 0


_UA_END_DECLS

#endif /* TYPES_MACHINERY_GENERATED_H_ */
```