### PR TITLE
Bugfix: setting up of encodingMask from DiagnosticInfo 

### DIFF
--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -1230,8 +1230,9 @@ ENCODE_BINARY(DiagnosticInfo) {
     encodingMask |= (u8)(src->hasLocalizedText << 2u);
     encodingMask |= (u8)(src->hasLocale << 3u);
     encodingMask |= (u8)(src->hasAdditionalInfo << 4u);
-    encodingMask |= (u8)(src->hasInnerDiagnosticInfo << 5u);
-
+    encodingMask |= (u8)(src->hasInnerStatusCode << 5u);
+    encodingMask |= (u8)(src->hasInnerDiagnosticInfo << 6u);
+    
     /* Encode the numeric content */
     status ret = ENCODE_DIRECT(&encodingMask, Byte);
     if(src->hasSymbolicId)


### PR DESCRIPTION
DiagnosticInfo Encoding Mask description: ..., 0x20 InnerStatusCode, 0x40 InnerDiagnosticInfo
actual DiagnosticInfo Encoding: ..., 0x20 InnerDiagnosticInfo and InnerStatusCode is missing
