### PR TITLE
docs: fix simple typo, endpoit -> endpoint

### DIFF
--- a/include/open62541/plugin/securitypolicy.h
+++ b/include/open62541/plugin/securitypolicy.h
@@ -194,7 +194,7 @@ typedef struct {
                                                UA_ByteString *thumbprint)
     UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
-    /* Compares the supplied certificate with the certificate in the endpoit context.
+    /* Compares the supplied certificate with the certificate in the endpoint context.
      *
      * @param securityPolicy the policy data that contains the certificate
      *                       to compare to.

--- a/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
+++ b/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
@@ -198,7 +198,7 @@ UA_AsySig_Aes128Sha256RsaOaep_Verify(const UA_SecurityPolicy *securityPolicy,
 }
 
 /* Compares the supplied certificate with the certificate
- * in the endpoit context
+ * in the endpoint context
  */
 
 static UA_StatusCode

--- a/plugins/crypto/openssl/ua_openssl_basic256.c
+++ b/plugins/crypto/openssl/ua_openssl_basic256.c
@@ -173,7 +173,7 @@ UA_ChannelModule_Basic256_Delete_Context (void * channelContext) {
 }
 
 /* Compares the supplied certificate with the certificate 
- * in the endpoit context 
+ * in the endpoint context 
  */
 
 static UA_StatusCode

--- a/plugins/crypto/openssl/ua_openssl_basic256sha256.c
+++ b/plugins/crypto/openssl/ua_openssl_basic256sha256.c
@@ -200,7 +200,7 @@ UA_AsySig_Basic256Sha256_Verify (const UA_SecurityPolicy * securityPolicy,
 }
 
 /* Compares the supplied certificate with the certificate 
- * in the endpoit context 
+ * in the endpoint context 
  */
 
 static UA_StatusCode


### PR DESCRIPTION
There is a small typo in include/open62541/plugin/securitypolicy.h, plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c, plugins/crypto/openssl/ua_openssl_basic256.c, plugins/crypto/openssl/ua_openssl_basic256sha256.c.

Should read `endpoint` rather than `endpoit`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md