### PR TITLE
fix(plugin): use of uninitialized value

### DIFF
--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -386,7 +386,7 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
     UA_UInt64       currentTimeValue = 0;
     UA_UInt64       maxTimeValue = 0;
     UA_Int32        receiveFlags;
-    UA_StatusCode   retval;
+    UA_StatusCode   retval = UA_STATUSCODE_GOOD;
     UA_UInt16       rcvCount = 0;
 
     memset(&tmptv, 0, sizeof(tmptv));


### PR DESCRIPTION
UA_PubSubChannelEthernet_receive() returns an uninitialized value
(retval), if  there is more data available than fits into the
message buffer.

Control flow in case of the error:

Receive buffer size is 4096 - see UA_ReaderGroup_subscribeCallback.
timeout > 0
select resultsize > 0
recvmsg datalen > 0
remainingMessageLength >= 1496 -> false -> there is still more data