### PR TITLE
Fix: Build shared library with discovery multicast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,7 @@ if(UA_ENABLE_DISCOVERY_MULTICAST)
     # create a "fake" empty library to generate the export header macros
     add_library(libmdnsd ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
     set_property(TARGET libmdnsd PROPERTY LINKER_LANGUAGE CXX)
+    set_property(TARGET libmdnsd PROPERTY DEFINE_SYMBOL "MDNSD_DYNAMIC_LINKING_EXPORT")
     configure_file("deps/mdnsd/libmdnsd/mdnsd_config_extra.in"
                    "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config_extra")
     file(READ "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config_extra" MDNSD_CONFIG_EXTRA)

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -11,6 +11,7 @@
  *    Copyright 2017 (c) Henrik Norrman
  *    Copyright 2018 (c) Fabian Arndt, Root-Core
  *    Copyright 2017-2020 (c) HMS Industrial Networks AB (Author: Jonas Green)
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and umati)
  */
 
 #ifndef UA_SERVER_H_

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -16,6 +16,7 @@
  *    Copyright 2017 (c) Julian Grothoff
  *    Copyright 2017-2020 (c) HMS Industrial Networks AB (Author: Jonas Green)
  *    Copyright 2017 (c) Henrik Norrman
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and umati)
  */
 
 #include "ua_server_internal.h"

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -10,6 +10,7 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Mattias Bornhager
  *    Copyright 2019 (c) HMS Industrial Networks AB (Author: Jonas Green)
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
  */
 
 #ifndef UA_SUBSCRIPTION_H_

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2018 (c) Hilscher Gesellschaft für Systemautomation mbH (Author: Sameer AL-Qadasi)
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
  */
 
 /*****************************************************************************/

--- a/src/server/ua_subscription_events.c
+++ b/src/server/ua_subscription_events.c
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2018 (c) Ari Breitkreuz, fortiss GmbH
- *    Copyright 2020 (c) Christian von Arnim
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
  */
 
 #include "ua_server_internal.h"

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -7,6 +7,7 @@
  *    Copyright 2018 (c) Ari Breitkreuz, fortiss GmbH
  *    Copyright 2018 (c) Thomas Stalder, Blue Time Concept SA
  *    Copyright 2018 (c) Fabian Arndt, Root-Core
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
  */
 
 #include "ua_server_internal.h"

--- a/tests/server/check_server_alarmsconditions.c
+++ b/tests/server/check_server_alarmsconditions.c
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright 2020 (c) Christian von Arnim
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
  */
 
 #include <open62541/server.h>

--- a/tests/server/check_subscription_events.c
+++ b/tests/server/check_subscription_events.c
@@ -1,6 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
+ */
 
 #include <open62541/client_config_default.h>
 #include <open62541/client_subscriptions.h>


### PR DESCRIPTION
Fixes building shared library with multicast discovery.

Before this fix, `mdnsd_config.h` looks like this:
```c
#  ifndef MDNSD_EXPORT
#    ifdef libmdnsd_EXPORTS
        /* We are building this library */
#      define MDNSD_EXPORT __declspec(dllexport)
#    else
        /* We are using this library */
#      define MDNSD_EXPORT __declspec(dllimport)
#    endif
#  endif
```

Now it is the same as building mdns:
```c
#  ifndef MDNSD_EXPORT
#    ifdef MDNSD_DYNAMIC_LINKING_EXPORT
        /* We are building this library */
#      define MDNSD_EXPORT __declspec(dllexport)
#    else
        /* We are using this library */
#      define MDNSD_EXPORT __declspec(dllimport)
#    endif
#  endif
```
So these lines have the desired effect:
https://github.com/open62541/open62541/blob/19c006a330b110d9df4e71f680d2ac90eeedaf95/CMakeLists.txt#L1284-L1287


Added/updated copyright for these past commits by me:
40cb2f0e46ccdb04ecfe4fcf5a133257aeed3ab1
0c10b3ea408741abcb339bf53e9975969ae09c01
a524accc338c9611a5ec60bf595c1a587243b457
1e29c3329a0e4ef649b859da31b0562849277c7f
3598c1677e301de0f48c83b3948a1955aa5c8492

PS: Is it intended that Python and CMake files have no license header?