### PR TITLE
Add UA_Client_modifyAsyncCallback

### DIFF
--- a/include/open62541/client.h
+++ b/include/open62541/client.h
@@ -12,6 +12,7 @@
  *    Copyright 2017 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2018 (c) Thomas Stalder, Blue Time Concept SA
  *    Copyright 2018 (c) Kalycito Infotech Private Limited
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart
  */
 
 #ifndef UA_CLIENT_H_
@@ -587,6 +588,21 @@ UA_StatusCode UA_EXPORT
 UA_Client_sendAsyncRequest(UA_Client *client, const void *request,
         const UA_DataType *requestType, UA_ClientAsyncServiceCallback callback,
         const UA_DataType *responseType, void *userdata, UA_UInt32 *requestId);
+
+/**
+ * Set new userdata and callback for an existing request.
+ *
+ * @param client Pointer to the UA_Client
+ * @param requestId RequestId of the request, which was returned by
+ *        UA_Client_sendAsyncRequest before
+ * @param userdata The new userdata.
+ * @param callback The new callback
+ * @return UA_StatusCode UA_STATUSCODE_GOOD on success
+ *         UA_STATUSCODE_BADNOTFOUND when no request with requestId is found.
+ */
+UA_StatusCode UA_EXPORT
+UA_Client_modifyAsyncCallback(UA_Client *client, UA_UInt32 requestId,
+        void *userdata, UA_ClientAsyncServiceCallback callback);
 
 /* Listen on the network and process arriving asynchronous responses in the
  * background. Internal housekeeping, renewal of SecureChannels and subscription

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -15,6 +15,7 @@
  *    Copyright 2016 (c) Lykurg
  *    Copyright 2017 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2018 (c) Kalycito Infotech Private Limited
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart
  */
 
 #include <open62541/types_generated_encoding_binary.h>
@@ -504,6 +505,20 @@ void UA_Client_AsyncService_removeAll(UA_Client *client, UA_StatusCode statusCod
     }
 }
 
+UA_StatusCode UA_Client_modifyAsyncCallback(UA_Client *client, UA_UInt32 requestId,
+        void *userdata, UA_ClientAsyncServiceCallback callback) {
+    AsyncServiceCall *ac;
+    LIST_FOREACH(ac, &client->asyncServiceCalls, pointers) {
+        if(ac->requestId == requestId) {
+            ac->callback = callback;
+            ac->userdata = userdata;
+            return UA_STATUSCODE_GOOD;
+        }
+    }
+
+    return UA_STATUSCODE_BADNOTFOUND;
+}
+
 UA_StatusCode
 __UA_Client_AsyncServiceEx(UA_Client *client, const void *request,
                            const UA_DataType *requestType,
@@ -514,7 +529,7 @@ __UA_Client_AsyncServiceEx(UA_Client *client, const void *request,
     if(client->channel.state != UA_SECURECHANNELSTATE_OPEN) {
         UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
                     "SecureChannel must be connected before sending requests");
-		return UA_STATUSCODE_BADSERVERNOTCONNECTED;
+        return UA_STATUSCODE_BADSERVERNOTCONNECTED;
     }
 
     /* Prepare the entry for the linked list */


### PR DESCRIPTION
This pull request adds a new function `UA_Client_modifyAsyncCallback`, which can modify the callback of an ongoing async request. 
So a user can modify a callback, when the original callback/ userdata is no longer valid.

In my use case I have an instance, which issues a method call on construction. When the instance is destroyed, before the request is completed, the callback/userdata-Information is no longer valid (userdata is the this-pointer of the instance). With this method, I do set the async callback and userdata to NULL in the destructor, so the response is ignored.