### PR TITLE
Handle nodesets without datatypes (#4054)

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -309,8 +309,10 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
     for arr in set(typesArray):
         if arr == "UA_TYPES":
             continue
+        writec("if(" + arr + "_COUNT > 0) {")
         writec("custom" + arr + ".next = UA_Server_getConfig(server)->customDataTypes;")
         writec("UA_Server_getConfig(server)->customDataTypes = &custom" + arr + ";\n")
+        writec("}")
 
     if functionNumber > 0:
 

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -400,6 +400,8 @@ _UA_BEGIN_DECLS
                         self.printh(self.print_datatype_typedef(t) + "\n")
                     self.printh(
                         "#define UA_" + makeCIdentifier(self.parser.outname.upper() + "_" + t.name.upper()) + " " + str(i))
+        else:
+            self.printh("#define UA_" + self.parser.outname.upper() + " NULL")
 
         self.printh('''
 


### PR DESCRIPTION
This handles nodesets without datatypes (e.g. machinery, #4054). So this code does no longer causes errors:
```c
static UA_DataTypeArray customUA_TYPES_MACHINERY = {
    NULL,
    UA_TYPES_MACHINERY_COUNT,
    UA_TYPES_MACHINERY
};
```


I've also noticed (but not modified), that the types are added multiple times, if nodesets depend on others, e.g. (Industrial Automation depends on DI):

- Calling namespace_di_generated add UA_TYPES_DI
- Calling namespace_ia_generated add UA_TYPES_IA and UA_TYPES_DI (again)

Is this intended? As `namespace_di_generated` must be called before `namespace_ia_generated` this seems to be redundant.

The `if(UA_TYPES_MACHINERY_COUNT)` is required, as the corresponding python-Variable is only available in `backend_open62541_typedefinitions.py` and not in `backend_open62541.py`

PS: Is using a template engine like jinja (https://jinja.palletsprojects.com/en/2.11.x/) an option for the nodeset generation? It would require developers to install a library, but the nodeset generation code shoule be easier.