### PR TITLE
Fix sporadically failing connection attempt to server (1.2)

### DIFF
--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -96,6 +96,12 @@ UA_Server_cleanupTimedOutSecureChannels(UA_Server *server,
             continue;
         }
 
+        /* Is the SecurityToken already created? */
+        if(entry->channel.securityToken.createdAt == 0) {
+        	/* No -> channel is still in progress of being opened, do not remove */
+        	continue;
+        }
+
         /* Has the SecurityToken timed out? */
         UA_DateTime timeout =
             entry->channel.securityToken.createdAt +


### PR DESCRIPTION
(supersedes #4085)

With bad timing, a secure channel was "garbage collected" by the `UA_Server_cleanup `timer (runs every 10 seconds) while the channel was still being established.

This issue was detected by our stress tests that continuously connect and disconnect to the same server instance. It is easily reproducible by changing the `UA_Server_cleanup `interval to some small number, e.g. 

    /* Add a regular callback for cleanup and maintenance. With a 10s interval. */
    UA_Server_addRepeatedCallback(server, (UA_ServerCallback)UA_Server_cleanup, NULL,
                                  0.001, NULL);