### PR TITLE
fix empty-body

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1607,10 +1607,11 @@ copyAttributeIntoNode(UA_Server *server, UA_Session *session,
         retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
         break;
     }
-    if(retval != UA_STATUSCODE_GOOD)
+    if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO_SESSION(&server->config.logger, session,
                             "WriteRequest returned status code %s",
                             UA_StatusCode_name(retval));
+    }
     return retval;
 }
 

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -330,12 +330,13 @@ typeCheckVariableNode(UA_Server *server, UA_Session *session,
             /* Try to generate a default value if that is configured */
             if(server->config.allowEmptyVariables == UA_RULEHANDLING_DEFAULT) {
                 retval = setDefaultValue(server, node);
-                if(retval != UA_STATUSCODE_GOOD)
+                if(retval != UA_STATUSCODE_GOOD) {
                     UA_LOG_NODEID_INFO(&node->head.nodeId,
                     UA_LOG_INFO_SESSION(&server->config.logger, session,
                                         "AddNode (%.*s): Could not create a default value "
                                         "with StatusCode %s", (int)nodeIdStr.length,
                                         nodeIdStr.data, UA_StatusCode_name(retval)));
+                }
 
                 /* Reread the current value for compat tests below */
                 UA_DataValue_clear(&value);


### PR DESCRIPTION
Compiling open62541 with UA_ENABLE_AMALGAMATION=ON and  UA_LOGLEVEL=400 cause the error :

```
Scanning dependencies of target open62541-object
[ 65%] Building C object CMakeFiles/open62541-object.dir/open62541.c.o
/home/btc/open62541/b/open62541.c: In function ‘copyAttributeIntoNode’:
/home/btc/open62541/b/open62541.c:37890:56: error: suggest braces around empty body in an ‘if’ statement [-Werror=empty-body]
                             UA_StatusCode_name(retval));
                                                        ^
/home/btc/open62541/b/open62541.c: In function ‘typeCheckVariableNode’:
/home/btc/open62541/b/open62541.c:40887:85: error: suggest braces around empty body in an ‘if’ statement [-Werror=empty-body]
                                         nodeIdStr.data, UA_StatusCode_name(retval)));
                                                                                     ^
/home/btc/open62541/b/open62541.c: At top level:
cc1: error: unrecognized command line option ‘-Wno-static-in-inline’ [-Werror]
cc1: all warnings being treated as errors
```

The patch fix the issue