### PR TITLE
Fix keyLen may be used uninitialized

### DIFF
--- a/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
+++ b/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
@@ -246,7 +246,7 @@ UA_Asym_Aes128Sha256RsaOaep_getRemoteSignatureSize(const UA_SecurityPolicy *secu
 
     const Channel_Context_Aes128Sha256RsaOaep *cc =
         (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
     UA_assert(keyLen == 256); /* 256 bytes 2048 bit */
     return (size_t)keyLen;
@@ -260,7 +260,7 @@ UA_AsySig_Aes128Sha256RsaOaep_getLocalSignatureSize(const UA_SecurityPolicy *sec
 
     Policy_Context_Aes128Sha256RsaOaep *pc =
         (Policy_Context_Aes128Sha256RsaOaep *)securityPolicy->policyContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Private_GetKeyLength(pc->localPrivateKey, &keyLen);
     UA_assert(keyLen == 256); /* 256 bytes 2048 bits */
 
@@ -275,7 +275,7 @@ UA_AsymEn_Aes128Sha256RsaOaep_getRemotePlainTextBlockSize(const UA_SecurityPolic
 
     const Channel_Context_Aes128Sha256RsaOaep *cc =
         (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
     return (size_t)keyLen - UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN;
 }
@@ -288,7 +288,7 @@ UA_AsymEn_Aes128Sha256RsaOaep_getRemoteBlockSize(const UA_SecurityPolicy *securi
 
     const Channel_Context_Aes128Sha256RsaOaep *cc =
         (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
     return (size_t)keyLen;
 }
@@ -301,7 +301,7 @@ UA_AsymEn_Aes128Sha256RsaOaep_getRemoteKeyLength(const UA_SecurityPolicy *securi
 
     const Channel_Context_Aes128Sha256RsaOaep *cc =
         (const Channel_Context_Aes128Sha256RsaOaep *)channelContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
     return (size_t)keyLen * 8;
 }
@@ -539,7 +539,7 @@ UA_AsymEn_Aes128Sha256RsaOaep_getLocalKeyLength(const UA_SecurityPolicy *securit
 
     Policy_Context_Aes128Sha256RsaOaep *pc =
         (Policy_Context_Aes128Sha256RsaOaep *)securityPolicy->policyContext;
-    UA_Int32 keyLen;
+    UA_Int32 keyLen = 0;
     UA_Openssl_RSA_Private_GetKeyLength(pc->localPrivateKey, &keyLen);
     UA_assert(keyLen == 256); /* 256 bytes 2048 bits */
 


### PR DESCRIPTION
Compiling open62541 with AMALGAMATION and OPENSSL cause :
```
../../src/libs/open62541.c: In function ‘UA_AsySig_Aes128Sha256RsaOaep_getLocalSignatureSize’:
../../src/libs/open62541.c:60261:12: error: ‘keyLen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return (size_t)keyLen;
            ^~~~~~~~~~~~~~
../../src/libs/open62541.c: In function ‘UA_AsymEn_Aes128Sha256RsaOaep_getLocalKeyLength’:
../../src/libs/open62541.c:60540:12: error: ‘keyLen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return (size_t)keyLen * 8;
            ^~~~~~~~~~~~~~
../../src/libs/open62541.c: In function ‘UA_AsymEn_Aes128Sha256RsaOaep_getRemoteBlockSize’:
../../src/libs/open62541.c:60287:12: error: ‘keyLen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return (size_t)keyLen;
            ^~~~~~~~~~~~~~
../../src/libs/open62541.c: In function ‘UA_Asym_Aes128Sha256RsaOaep_getRemoteSignatureSize’:
../../src/libs/open62541.c:60287:12: error: ‘keyLen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return (size_t)keyLen;
            ^~~~~~~~~~~~~~
../../src/libs/open62541.c:60285:14: note: ‘keyLen’ was declared here
     UA_Int32 keyLen;
              ^~~~~~
../../src/libs/open62541.c: In function ‘UA_AsymEn_Aes128Sha256RsaOaep_getRemoteKeyLength’:
../../src/libs/open62541.c:60300:12: error: ‘keyLen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return (size_t)keyLen * 8;
            ^~~~~~~~~~~~~~
../../src/libs/open62541.c: In function ‘UA_AsymEn_Aes128Sha256RsaOaep_getRemotePlainTextBlockSize’:
../../src/libs/open62541.c:60274:12: error: ‘keyLen’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return (size_t)keyLen - UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN;
            ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

The patch fix the issue.