### PR TITLE
[Review] Send ethernet packets with ethertype 0xb62c in PubSub

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -22,7 +22,8 @@
 #include "ua_types_encoding_binary.h"
 #endif
 
-#define UA_MAX_SIZENAME 64  /* Max size of Qualified Name of Subscribed Variable */
+#define UA_MAX_SIZENAME           64  /* Max size of Qualified Name of Subscribed Variable */
+#define MIN_PAYLOAD_SIZE_ETHERNET 46
 
 /* Clear ReaderGroup */
 static void
@@ -874,14 +875,16 @@ void UA_ReaderGroup_subscribeCallback(UA_Server *server, UA_ReaderGroup *readerG
         return;
     }
 
-    size_t currentPosition = 0;
     if(buffer.length > 0) {
+        size_t currentPosition = 0;
+        size_t previousPosition = 0;
         if (readerGroup->config.rtLevel == UA_PUBSUB_RT_FIXED_SIZE) {
             do {
                 /* Considering max DSM as 1
                 * TODO:
                 * Process with the static value source
                 */
+                size_t paddingBytes = 0;
                 UA_DataSetReader *dataSetReader = LIST_FIRST(&readerGroup->readers);
                 /* Decode only the necessary offset and update the networkMessage */
                 if(UA_NetworkMessage_updateBufferedNwMessage(&dataSetReader->bufferedMessage, &buffer, &currentPosition) != UA_STATUSCODE_GOOD) {
@@ -916,6 +919,17 @@ void UA_ReaderGroup_subscribeCallback(UA_Server *server, UA_ReaderGroup *readerG
                         UA_DataValue_clear(&dsm->data.keyFrameData.dataSetFields[i]);
                     }
                 }
+
+                /* Minimum ethernet packet size is 64 bytes where the header size is 14 bytes and FCS size is 4 bytes
+                 * so remaining minimum payload size of ethernet packet is 46 bytes */
+                /* TODO: Need to handle padding bytes for UDP */
+                if (((currentPosition - previousPosition) < MIN_PAYLOAD_SIZE_ETHERNET) &&
+                    (strncmp((const char *)connection->config->transportProfileUri.data, "http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp", (size_t)(connection->config->transportProfileUri.length)) == 0)) {
+                    paddingBytes = (MIN_PAYLOAD_SIZE_ETHERNET - (currentPosition - previousPosition));
+                    currentPosition += paddingBytes; /* During multiple receive, move the position to handle padding bytes */
+                }
+
+                previousPosition = currentPosition;
             } while((buffer.length) > currentPosition);
             UA_ByteString_clear(&buffer);
             return;
@@ -923,14 +937,26 @@ void UA_ReaderGroup_subscribeCallback(UA_Server *server, UA_ReaderGroup *readerG
         else {
             UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_USERLAND, "Message received:");
             do {
+                size_t paddingBytes = 0;
                 UA_NetworkMessage currentNetworkMessage;
                 memset(&currentNetworkMessage, 0, sizeof(UA_NetworkMessage));
                 UA_NetworkMessage_decodeBinary(&buffer, &currentPosition, &currentNetworkMessage);
                 UA_Server_processNetworkMessage(server, &currentNetworkMessage, connection);
                 UA_NetworkMessage_clear(&currentNetworkMessage);
+
+                /* Minimum ethernet packet size is 64 bytes where the header size is 14 bytes and FCS size is 4 bytes
+                 * so remaining minimum payload size of ethernet packet is 46 bytes */
+                /* TODO: Need to handle padding bytes for UDP */
+                if (((currentPosition - previousPosition) < MIN_PAYLOAD_SIZE_ETHERNET) &&
+                    (strncmp((const char *)connection->config->transportProfileUri.data, "http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp", (size_t)(connection->config->transportProfileUri.length)) == 0)) {
+                    paddingBytes = (MIN_PAYLOAD_SIZE_ETHERNET - (currentPosition - previousPosition));
+                    currentPosition += paddingBytes; /* During multiple receive, move the position to handle padding bytes */
+                }
+
+                previousPosition = currentPosition;
             } while((buffer.length) > currentPosition);
         }
-    } 
+    }
     UA_ByteString_clear(&buffer);
 }
 


### PR DESCRIPTION
 - Changed ethertype from LLC to ETHERTYPE_UADP(0xb62c) according to PubSub Specification
 - Handled the padding bytes in the src file
