### PR TITLE
Fix(Server): Check EncryptionAlgorithm is empty

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -666,6 +666,11 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
            if(securityPolicy != channel->securityPolicy)
                securityPolicy->channelModule.deleteContext(tempChannelContext);
        }
+       /* If SecurityPolicy is None there shall be no EncryptionAlgorithm  */
+       else if( userToken->encryptionAlgorithm.length != 0 ) {
+          response->responseHeader.serviceResult = UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+          return;
+       }
 
        if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
            UA_LOG_WARNING_SESSION(&server->config.logger, session, "ActivateSession: "


### PR DESCRIPTION
According to OPCUA spec 1.04 Part 4 page 162 the
EncryptionAlgorithm field in the UserIdentityToken shall be
"No encryption" if the SecurityPolicy is "None".
Currently the stack does not care about this field if the
SecurityPolicy is "None".

This triggers an error in OPC UA CTT Version 1.4.9.396
Security - Security User Name Password - Test Case 010.
In this test the EncryptionAlgorithm in the
UserIdentityToken is set to "abc123" and the test expects
the login attempt to fail.