### PR TITLE
Add support for method calls with deferred completion.

### DIFF
--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -612,6 +612,8 @@ typedef struct {
     UA_MethodCallback method;
 #if UA_MULTITHREADING >= 100
     UA_Boolean async; /* Indicates an async method call */
+    UA_Boolean deferred; /* Indicates a method call with deferred completion, i.e.
+                            started by server thread but completed by some other thread */
 #endif
 } UA_MethodNode;
 

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1586,6 +1586,16 @@ UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
 * ready. See the examples in ``/examples/tutorial_server_method_async.c`` for
 * the usage.
 *
+* Marking a method as deferred has a similar but slightly different effect:
+* Here, the method is called immediately, but its result is not (yet) sent to the client.
+* Instead, the method can access its pending operation using
+* UA_Server_getLastAsyncResponse and pass ("defer") it to an arbitrary thread
+* or event handler. Eventually, this thread or event handler can call
+* UA_Server_sendAsyncResponse to send the final result to the client.
+* The advantage over the 'async' method call is that client code does not need
+* to block/wait in their UA_MethodCallback implementation until the result is
+* ready, while still maintaining only a constant number of worker threads.
+*
 * Note that the operation can time out (see the asyncOperationTimeout setting in
 * the server config) also when it has been retrieved by the worker. */
 
@@ -1595,6 +1605,11 @@ UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
 UA_StatusCode UA_EXPORT
 UA_Server_setMethodNodeAsync(UA_Server *server, const UA_NodeId id,
                              UA_Boolean isAsync);
+
+/* Set the deferred flag in a method node */
+UA_StatusCode UA_EXPORT
+UA_Server_setMethodNodeDeferred(UA_Server *server, const UA_NodeId id,
+                                UA_Boolean isDeferred);
 
 typedef enum {
     UA_ASYNCOPERATIONTYPE_INVALID, /* 0, the default */

--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -176,6 +176,7 @@ UA_MethodNode_copy(const UA_MethodNode *src, UA_MethodNode *dst) {
     dst->method = src->method;
 #if UA_MULTITHREADING >= 100
     dst->async = src->async;
+    dst->deferred = src->deferred;
 #endif
     return UA_STATUSCODE_GOOD;
 }

--- a/src/server/ua_server_async.h
+++ b/src/server/ua_server_async.h
@@ -54,10 +54,12 @@ struct UA_AsyncResponse {
 };
 
 typedef TAILQ_HEAD(UA_AsyncOperationQueue, UA_AsyncOperation) UA_AsyncOperationQueue;
+typedef TAILQ_HEAD(UA_AsyncResponseQueue, UA_AsyncResponse) UA_AsyncResponseQueue;
 
 typedef struct {
     /* Requests / Responses */
-    TAILQ_HEAD(, UA_AsyncResponse) asyncResponses;
+	UA_Lock asyncResponsesLock;
+	UA_AsyncResponseQueue asyncResponses;
     size_t asyncResponsesCount;
 
     /* Operations for the workers. The queues are all FIFO: Put in at the tail,
@@ -110,6 +112,14 @@ UA_Server_processServiceOperationsAsync(UA_Server *server, UA_Session *session,
                                         const UA_DataType *responseOperationsType,
                                         UA_AsyncResponse **ar)
 UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+
+/* Get the most recently created async response */
+UA_AsyncResponse*
+UA_Server_getLastAsyncResponse(UA_Server *server);
+
+/* Send async response to client. */
+UA_StatusCode
+UA_Server_sendAsyncResponse(UA_Server *server, UA_AsyncResponse *ar);
 
 #endif /* UA_MULTITHREADING >= 100 */
 


### PR DESCRIPTION
This change introduces the 'deferred' bit for method nodes. 

'deferred' method nodes are similar to 'async' methods, with the following difference:
Here, the method is called immediately (by the server thread instead of a worker), but its result is not (yet) sent to the client. Instead, the method can access its pending operation using UA_Server_getLastAsyncResponse and pass ("defer") it to an arbitrary thread or event handler. Eventually, this thread or event handler can call UA_Server_sendAsyncResponse to send the final result to the client. 

The advantage over the 'async' method call is that client code does not need to block/wait in their UA_MethodCallback implementation until the result is ready, while still maintaining only a constant number of worker threads.

Adds the following new API functions:
- UA_Server_setMethodNodeDeferred
- UA_Server_getLastAsyncResponse
- UA_Server_sendAsyncResponse
