### PR TITLE
[WIP] Provide callback for AccessLevel attribute

### DIFF
--- a/examples/tutorial_server_variable.c
+++ b/examples/tutorial_server_variable.c
@@ -42,6 +42,40 @@ addVariable(UA_Server *server) {
                               UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, NULL);
 }
 
+static UA_StatusCode myAccessLevelCallback(UA_Server *server,
+                                                const UA_NodeId *sessionId,
+                                                void *sessionContext,
+                                                const UA_NodeId *nodeId,
+                                                void *nodeContext, UA_Byte *accessLevel)
+{
+    *accessLevel=1;
+    return UA_STATUSCODE_GOOD;
+}
+
+static void
+addVariableWithAccessLevelCallback(UA_Server *server) {
+    /* Define the attribute of the myInteger variable node */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    UA_Int32 myInteger = 42;
+    UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
+    attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
+    
+    //attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+
+    /* Add the variable node to the information model */
+    UA_NodeId myStringId = UA_NODEID_STRING(1, "myNode");
+    UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "myNode");
+    UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    UA_Server_addVariableNode(
+        server, myStringId, parentNodeId, parentReferenceNodeId, myIntegerName,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, NULL);
+
+    UA_Server_setVariableNode_accessLevelCallback(
+        server, myStringId,
+        &myAccessLevelCallback);
+}
+
 static void
 addMatrixVariable(UA_Server *server) {
     UA_VariableAttributes attr = UA_VariableAttributes_default;
@@ -150,6 +184,7 @@ int main(void) {
     addMatrixVariable(server);
     writeVariable(server);
     writeWrongVariable(server);
+    addVariableWithAccessLevelCallback(server);
 
     UA_StatusCode retval = UA_Server_run(server, &running);
 

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -18,6 +18,7 @@
  * / OPC UA services to interact with the information model. */
 
 #include <open62541/util.h>
+
 #include "aa_tree.h"
 
 _UA_BEGIN_DECLS
@@ -100,15 +101,14 @@ struct UA_MonitoredItem;
 
 typedef struct {
     /* Can be NULL. May replace the nodeContext */
-    UA_StatusCode (*constructor)(UA_Server *server,
-                                 const UA_NodeId *sessionId, void *sessionContext,
-                                 const UA_NodeId *nodeId, void **nodeContext);
+    UA_StatusCode (*constructor)(UA_Server *server, const UA_NodeId *sessionId,
+                                 void *sessionContext, const UA_NodeId *nodeId,
+                                 void **nodeContext);
 
     /* Can be NULL. The context cannot be replaced since the node is destroyed
      * immediately afterwards anyway. */
-    void (*destructor)(UA_Server *server,
-                       const UA_NodeId *sessionId, void *sessionContext,
-                       const UA_NodeId *nodeId, void *nodeContext);
+    void (*destructor)(UA_Server *server, const UA_NodeId *sessionId,
+                       void *sessionContext, const UA_NodeId *nodeId, void *nodeContext);
 
     /* Can be NULL. Called during recursive node instantiation. While mandatory
      * child nodes are automatically created if not already present, optional child
@@ -126,10 +126,8 @@ typedef struct {
      *        node has to the new node.
      * @return Return UA_TRUE if the child node shall be instantiated,
      *         UA_FALSE otherwise. */
-    UA_Boolean (*createOptionalChild)(UA_Server *server,
-                                      const UA_NodeId *sessionId,
-                                      void *sessionContext,
-                                      const UA_NodeId *sourceNodeId,
+    UA_Boolean (*createOptionalChild)(UA_Server *server, const UA_NodeId *sessionId,
+                                      void *sessionContext, const UA_NodeId *sourceNodeId,
                                       const UA_NodeId *targetParentNodeId,
                                       const UA_NodeId *referenceTypeId);
 
@@ -147,8 +145,8 @@ typedef struct {
      * @param targetParentNodeId Parent node of the new node
      * @param referenceTypeId Identifies the reference type which that the parent
      *        node has to the new node. */
-    UA_StatusCode (*generateChildNodeId)(UA_Server *server,
-                                         const UA_NodeId *sessionId, void *sessionContext,
+    UA_StatusCode (*generateChildNodeId)(UA_Server *server, const UA_NodeId *sessionId,
+                                         void *sessionContext,
                                          const UA_NodeId *sourceNodeId,
                                          const UA_NodeId *targetParentNodeId,
                                          const UA_NodeId *referenceTypeId,
@@ -161,16 +159,16 @@ typedef struct {
  * Constructor and destructors for specific object and variable types. */
 typedef struct {
     /* Can be NULL. May replace the nodeContext */
-    UA_StatusCode (*constructor)(UA_Server *server,
-                                 const UA_NodeId *sessionId, void *sessionContext,
-                                 const UA_NodeId *typeNodeId, void *typeNodeContext,
-                                 const UA_NodeId *nodeId, void **nodeContext);
+    UA_StatusCode (*constructor)(UA_Server *server, const UA_NodeId *sessionId,
+                                 void *sessionContext, const UA_NodeId *typeNodeId,
+                                 void *typeNodeContext, const UA_NodeId *nodeId,
+                                 void **nodeContext);
 
     /* Can be NULL. May replace the nodeContext. */
-    void (*destructor)(UA_Server *server,
-                       const UA_NodeId *sessionId, void *sessionContext,
-                       const UA_NodeId *typeNodeId, void *typeNodeContext,
-                       const UA_NodeId *nodeId, void **nodeContext);
+    void (*destructor)(UA_Server *server, const UA_NodeId *sessionId,
+                       void *sessionContext, const UA_NodeId *typeNodeId,
+                       void *typeNodeContext, const UA_NodeId *nodeId,
+                       void **nodeContext);
 } UA_NodeTypeLifecycle;
 
 /**
@@ -208,7 +206,9 @@ typedef struct {
 
 /* The maximum number of ReferrenceTypes. Must be a multiple of 32. */
 #define UA_REFERENCETYPESET_MAX 128
-typedef struct { UA_UInt32 bits[UA_REFERENCETYPESET_MAX / 32]; } UA_ReferenceTypeSet;
+typedef struct {
+    UA_UInt32 bits[UA_REFERENCETYPESET_MAX / 32];
+} UA_ReferenceTypeSet;
 
 static UA_INLINE void
 UA_ReferenceTypeSet_init(UA_ReferenceTypeSet *set) {
@@ -261,8 +261,8 @@ UA_ReferenceTypeSet_contains(const UA_ReferenceTypeSet *set, UA_Byte index) {
 typedef struct {
     struct aa_entry idTreeEntry; /* Binary-Tree for fast lookup */
     struct aa_entry nameTreeEntry;
-    UA_UInt32 targetIdHash;      /* Hash of the target's NodeId */
-    UA_UInt32 targetNameHash;    /* Hash of the target's BrowseName */
+    UA_UInt32 targetIdHash;   /* Hash of the target's NodeId */
+    UA_UInt32 targetNameHash; /* Hash of the target's BrowseName */
     UA_ExpandedNodeId targetId;
 } UA_ReferenceTarget;
 
@@ -358,10 +358,7 @@ typedef struct {
 
 /* Indicates whether a variable contains data inline or whether it points to an
  * external data source */
-typedef enum {
-    UA_VALUESOURCE_DATA,
-    UA_VALUESOURCE_DATASOURCE
-} UA_ValueSource;
+typedef enum { UA_VALUESOURCE_DATA, UA_VALUESOURCE_DATASOURCE } UA_ValueSource;
 
 typedef struct {
     /* Called before the value attribute is read. It is possible to write into the
@@ -374,10 +371,9 @@ typedef struct {
      * @param data Points to the current node value.
      * @param range Points to the numeric range the client wants to read from
      *        (or NULL). */
-    void (*onRead)(UA_Server *server, const UA_NodeId *sessionId,
-                   void *sessionContext, const UA_NodeId *nodeid,
-                   void *nodeContext, const UA_NumericRange *range,
-                   const UA_DataValue *value);
+    void (*onRead)(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                   const UA_NodeId *nodeid, void *nodeContext,
+                   const UA_NumericRange *range, const UA_DataValue *value);
 
     /* Called after writing the value attribute. The node is re-opened after
      * writing so that the new value is visible in the callback.
@@ -393,10 +389,9 @@ typedef struct {
      *        by the type constructor(s).
      * @param range Points to the numeric range the client wants to write to (or
      *        NULL). */
-    void (*onWrite)(UA_Server *server, const UA_NodeId *sessionId,
-                    void *sessionContext, const UA_NodeId *nodeId,
-                    void *nodeContext, const UA_NumericRange *range,
-                    const UA_DataValue *data);
+    void (*onWrite)(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                    const UA_NodeId *nodeId, void *nodeContext,
+                    const UA_NumericRange *range, const UA_DataValue *data);
 } UA_ValueCallback;
 
 typedef struct {
@@ -475,7 +470,7 @@ typedef struct {
     /* Called before the value attribute is read. The external value source can be
      * be updated and/or locked during this notification call. After this function returns
      * to the core, the external value source is readed immediately.
-    */
+     */
     UA_StatusCode (*notificationRead)(UA_Server *server, const UA_NodeId *sessionId,
                                       void *sessionContext, const UA_NodeId *nodeid,
                                       void *nodeContext, const UA_NumericRange *range);
@@ -522,29 +517,36 @@ typedef struct {
     } backend;
 } UA_ValueBackend;
 
-#define UA_NODE_VARIABLEATTRIBUTES                                      \
-    /* Constraints on possible values */                                \
-    UA_NodeId dataType;                                                 \
-    UA_Int32 valueRank;                                                 \
-    size_t arrayDimensionsSize;                                         \
-    UA_UInt32 *arrayDimensions;                                         \
-                                                                        \
-    UA_ValueBackend valueBackend;                                       \
-                                                                        \
-    /* The current value */                                             \
-    UA_ValueSource valueSource;                                         \
-    union {                                                             \
-        struct {                                                        \
-            UA_DataValue value;                                         \
-            UA_ValueCallback callback;                                  \
-        } data;                                                         \
-        UA_DataSource dataSource;                                       \
+#define UA_NODE_VARIABLEATTRIBUTES                                                       \
+    /* Constraints on possible values */                                                 \
+    UA_NodeId dataType;                                                                  \
+    UA_Int32 valueRank;                                                                  \
+    size_t arrayDimensionsSize;                                                          \
+    UA_UInt32 *arrayDimensions;                                                          \
+                                                                                         \
+    UA_ValueBackend valueBackend;                                                        \
+                                                                                         \
+    /* The current value */                                                              \
+    UA_ValueSource valueSource;                                                          \
+    union {                                                                              \
+        struct {                                                                         \
+            UA_DataValue value;                                                          \
+            UA_ValueCallback callback;                                                   \
+        } data;                                                                          \
+        UA_DataSource dataSource;                                                        \
     } value;
+
+typedef UA_StatusCode (*UA_AccessLevelCallback)(UA_Server *server,
+                                                const UA_NodeId *sessionId,
+                                                void *sessionContext,
+                                                const UA_NodeId *nodeId,
+                                                void *nodeContext, UA_Byte* accessLevel);
 
 typedef struct {
     UA_NodeHead head;
     UA_NODE_VARIABLEATTRIBUTES
     UA_Byte accessLevel;
+    UA_AccessLevelCallback accessLevelCallback;
     UA_Double minimumSamplingInterval;
     UA_Boolean historizing;
 
@@ -596,13 +598,12 @@ typedef struct {
  * object types). For this, the NodeId of the method *and of the object
  * providing context* is part of a Call request message. */
 
-typedef UA_StatusCode
-(*UA_MethodCallback)(UA_Server *server, const UA_NodeId *sessionId,
-                     void *sessionContext, const UA_NodeId *methodId,
-                     void *methodContext, const UA_NodeId *objectId,
-                     void *objectContext, size_t inputSize,
-                     const UA_Variant *input, size_t outputSize,
-                     UA_Variant *output);
+typedef UA_StatusCode (*UA_MethodCallback)(UA_Server *server, const UA_NodeId *sessionId,
+                                           void *sessionContext,
+                                           const UA_NodeId *methodId, void *methodContext,
+                                           const UA_NodeId *objectId, void *objectContext,
+                                           size_t inputSize, const UA_Variant *input,
+                                           size_t outputSize, UA_Variant *output);
 
 typedef struct {
     UA_NodeHead head;
@@ -679,8 +680,8 @@ typedef struct {
  *    hierarchical_references [label="HierarchicalReferences\n(Abstract)"]
  *    references -> hierarchical_references
  *
- *    nonhierarchical_references [label="NonHierarchicalReferences\n(Abstract, Symmetric)"]
- *    references -> nonhierarchical_references
+ *    nonhierarchical_references [label="NonHierarchicalReferences\n(Abstract,
+ * Symmetric)"] references -> nonhierarchical_references
  *
  *    haschild [label="HasChild\n(Abstract)"]
  *    hierarchical_references -> haschild
@@ -843,26 +844,24 @@ typedef struct {
      * node types. The memory is managed by the nodestore. Therefore, the node
      * has to be removed via a special deleteNode function. (If the new node is
      * not added to the nodestore.) */
-    UA_Node * (*newNode)(void *nsCtx, UA_NodeClass nodeClass);
+    UA_Node *(*newNode)(void *nsCtx, UA_NodeClass nodeClass);
 
     void (*deleteNode)(void *nsCtx, UA_Node *node);
 
     /* ``Get`` returns a pointer to an immutable node. ``Release`` indicates
      * that the pointer is no longer accessed afterwards. */
-    const UA_Node * (*getNode)(void *nsCtx, const UA_NodeId *nodeId);
+    const UA_Node *(*getNode)(void *nsCtx, const UA_NodeId *nodeId);
 
     void (*releaseNode)(void *nsCtx, const UA_Node *node);
 
     /* Returns an editable copy of a node (needs to be deleted with the
      * deleteNode function or inserted / replaced into the nodestore). */
-    UA_StatusCode (*getNodeCopy)(void *nsCtx, const UA_NodeId *nodeId,
-                                 UA_Node **outNode);
+    UA_StatusCode (*getNodeCopy)(void *nsCtx, const UA_NodeId *nodeId, UA_Node **outNode);
 
     /* Inserts a new node into the nodestore. If the NodeId is zero, then a
      * fresh numeric NodeId is assigned. If insertion fails, the node is
      * deleted. */
-    UA_StatusCode (*insertNode)(void *nsCtx, UA_Node *node,
-                                UA_NodeId *addedNodeId);
+    UA_StatusCode (*insertNode)(void *nsCtx, UA_Node *node, UA_NodeId *addedNodeId);
 
     /* To replace a node, get an editable copy of the node, edit and replace
      * with this function. If the node was already replaced since the copy was
@@ -877,11 +876,10 @@ typedef struct {
     /* Maps the ReferenceTypeIndex used for the references to the NodeId of the
      * ReferenceType. The returned pointer is stable until the Nodestore is
      * deleted. */
-    const UA_NodeId * (*getReferenceTypeId)(void *nsCtx, UA_Byte refTypeIndex);
+    const UA_NodeId *(*getReferenceTypeId)(void *nsCtx, UA_Byte refTypeIndex);
 
     /* Execute a callback for every node in the nodestore. */
-    void (*iterate)(void *nsCtx, UA_NodestoreVisitor visitor,
-                    void *visitorCtx);
+    void (*iterate)(void *nsCtx, UA_NodestoreVisitor visitor, void *visitorCtx);
 } UA_Nodestore;
 
 /* Attributes must be of a matching type (VariableAttributes, ObjectAttributes,

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -962,6 +962,10 @@ UA_Server_setVariableNode_valueBackend(UA_Server *server,
                                        const UA_NodeId nodeId,
                                        const UA_ValueBackend valueBackend);
 
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_setVariableNode_accessLevelCallback(UA_Server *server, const UA_NodeId nodeId,
+                                     const UA_AccessLevelCallback accessLevelCallback);
+
 /**
  * .. _local-monitoreditems:
  *

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  *
  *    Copyright 2014-2018 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2015-2016 (c) Sten Grüner
@@ -16,13 +16,12 @@
  *    Copyright 2017 (c) Julian Grothoff
  *    Copyright 2017-2020 (c) HMS Industrial Networks AB (Author: Jonas Green)
  *    Copyright 2017 (c) Henrik Norrman
- *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and
- * umati)
+ *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and umati)
  */
 
 #include "ua_server_internal.h"
-#include "ua_services.h"
 #include "ua_types_encoding_binary.h"
+#include "ua_services.h"
 
 #ifdef UA_ENABLE_HISTORIZING
 #include <open62541/plugin/historydatabase.h>
@@ -36,14 +35,17 @@
  * where the underlying Subscription was detached during CloseSession. */
 
 static UA_UInt32
-getUserWriteMask(UA_Server *server, const UA_Session *session, const UA_NodeHead *head) {
+getUserWriteMask(UA_Server *server, const UA_Session *session,
+                 const UA_NodeHead *head) {
     if(session == &server->adminSession)
         return 0xFFFFFFFF; /* the local admin user has all rights */
     UA_UInt32 mask = head->writeMask;
     UA_UNLOCK(&server->serviceMutex);
-    mask &= server->config.accessControl.getUserRightsMask(
-        server, &server->config.accessControl, session ? &session->sessionId : NULL,
-        session ? session->sessionHandle : NULL, &head->nodeId, head->context);
+    mask &= server->config.accessControl.
+        getUserRightsMask(server, &server->config.accessControl,
+                          session ? &session->sessionId : NULL,
+                          session ? session->sessionHandle : NULL,
+                          &head->nodeId, head->context);
     UA_LOCK(&server->serviceMutex);
     return mask;
 }
@@ -51,22 +53,9 @@ getUserWriteMask(UA_Server *server, const UA_Session *session, const UA_NodeHead
 static UA_Byte
 getAccessLevel(UA_Server *server, const UA_Session *session,
                const UA_VariableNode *node) {
-    //
     if(session == &server->adminSession)
         return 0xFF; /* the local admin user has all rights */
-    if(node->accessLevelCallback) {
-        UA_Byte accessLevel = 0;
-        UA_StatusCode retval = node->accessLevelCallback(
-            server, &session->sessionId, session->sessionHandle, &node->head.nodeId,
-            node->head.context, &accessLevel);
-        if(UA_STATUSCODE_GOOD == retval) {
-            return accessLevel;
-        } else {
-            return 0x00;
-        }
-    } else {
-        return node->accessLevel;
-    }
+    return node->accessLevel;
 }
 
 static UA_Byte
@@ -74,11 +63,13 @@ getUserAccessLevel(UA_Server *server, const UA_Session *session,
                    const UA_VariableNode *node) {
     if(session == &server->adminSession)
         return 0xFF; /* the local admin user has all rights */
-    UA_Byte retval = getAccessLevel(server, session, node);
+    UA_Byte retval = node->accessLevel;
     UA_UNLOCK(&server->serviceMutex);
-    retval &= server->config.accessControl.getUserAccessLevel(
-        server, &server->config.accessControl, session ? &session->sessionId : NULL,
-        session ? session->sessionHandle : NULL, &node->head.nodeId, node->head.context);
+    retval &= server->config.accessControl.
+        getUserAccessLevel(server, &server->config.accessControl,
+                           session ? &session->sessionId : NULL,
+                           session ? session->sessionHandle : NULL,
+                           &node->head.nodeId, node->head.context);
     UA_LOCK(&server->serviceMutex);
     return retval;
 }
@@ -90,9 +81,12 @@ getUserExecutable(UA_Server *server, const UA_Session *session,
         return true; /* the local admin user has all rights */
     UA_UNLOCK(&server->serviceMutex);
     UA_Boolean userExecutable = node->executable;
-    userExecutable &= server->config.accessControl.getUserExecutable(
-        server, &server->config.accessControl, session ? &session->sessionId : NULL,
-        session ? session->sessionHandle : NULL, &node->head.nodeId, node->head.context);
+    userExecutable &=
+        server->config.accessControl.
+        getUserExecutable(server, &server->config.accessControl,
+                          session ? &session->sessionId : NULL,
+                          session ? session->sessionHandle : NULL,
+                          &node->head.nodeId, node->head.context);
     UA_LOCK(&server->serviceMutex);
     return userExecutable;
 }
@@ -105,20 +99,20 @@ static UA_StatusCode
 readIsAbstractAttribute(const UA_Node *node, UA_Variant *v) {
     const UA_Boolean *isAbstract;
     switch(node->head.nodeClass) {
-        case UA_NODECLASS_REFERENCETYPE:
-            isAbstract = &node->referenceTypeNode.isAbstract;
-            break;
-        case UA_NODECLASS_OBJECTTYPE:
-            isAbstract = &node->objectTypeNode.isAbstract;
-            break;
-        case UA_NODECLASS_VARIABLETYPE:
-            isAbstract = &node->variableTypeNode.isAbstract;
-            break;
-        case UA_NODECLASS_DATATYPE:
-            isAbstract = &node->dataTypeNode.isAbstract;
-            break;
-        default:
-            return UA_STATUSCODE_BADATTRIBUTEIDINVALID;
+    case UA_NODECLASS_REFERENCETYPE:
+        isAbstract = &node->referenceTypeNode.isAbstract;
+        break;
+    case UA_NODECLASS_OBJECTTYPE:
+        isAbstract = &node->objectTypeNode.isAbstract;
+        break;
+    case UA_NODECLASS_VARIABLETYPE:
+        isAbstract = &node->variableTypeNode.isAbstract;
+        break;
+    case UA_NODECLASS_DATATYPE:
+        isAbstract = &node->dataTypeNode.isAbstract;
+        break;
+    default:
+        return UA_STATUSCODE_BADATTRIBUTEIDINVALID;
     }
 
     return UA_Variant_setScalarCopy(v, isAbstract, &UA_TYPES[UA_TYPES_BOOLEAN]);
@@ -131,12 +125,13 @@ readValueAttributeFromNode(UA_Server *server, UA_Session *session,
     /* Update the value by the user callback */
     if(vn->value.data.callback.onRead) {
         UA_UNLOCK(&server->serviceMutex);
-        vn->value.data.callback.onRead(server, session ? &session->sessionId : NULL,
+        vn->value.data.callback.onRead(server,
+                                       session ? &session->sessionId : NULL,
                                        session ? session->sessionHandle : NULL,
                                        &vn->head.nodeId, vn->head.context, rangeptr,
                                        &vn->value.data.value);
         UA_LOCK(&server->serviceMutex);
-        vn = (const UA_VariableNode *)UA_NODESTORE_GET(server, &vn->head.nodeId);
+        vn = (const UA_VariableNode*)UA_NODESTORE_GET(server, &vn->head.nodeId);
         if(!vn)
             return UA_STATUSCODE_BADNODEIDUNKNOWN;
     }
@@ -164,10 +159,12 @@ readValueAttributeFromDataSource(UA_Server *server, UA_Session *session,
     UA_DataValue v2;
     UA_DataValue_init(&v2);
     UA_UNLOCK(&server->serviceMutex);
-    UA_StatusCode retval = vn->value.dataSource.read(
-        server, session ? &session->sessionId : NULL,
-        session ? session->sessionHandle : NULL, &vn->head.nodeId, vn->head.context,
-        sourceTimeStamp, rangeptr, &v2);
+    UA_StatusCode retval = vn->value.dataSource.
+        read(server,
+             session ? &session->sessionId : NULL,
+             session ? session->sessionHandle : NULL,
+             &vn->head.nodeId, vn->head.context,
+             sourceTimeStamp, rangeptr, &v2);
     UA_LOCK(&server->serviceMutex);
     if(v2.hasValue && v2.value.storageType == UA_VARIANT_DATA_NODELETE) {
         retval = UA_DataValue_copy(&v2, v);
@@ -196,23 +193,24 @@ readValueAttributeComplete(UA_Server *server, UA_Session *session,
     switch(vn->valueBackend.backendType) {
         case UA_VALUEBACKENDTYPE_INTERNAL:
             retval = readValueAttributeFromNode(server, session, vn, v, rangeptr);
-            // TODO change old structure to value backend
+            //TODO change old structure to value backend
             break;
         case UA_VALUEBACKENDTYPE_DATA_SOURCE_CALLBACK:
-            retval = readValueAttributeFromDataSource(server, session, vn, v, timestamps,
-                                                      rangeptr);
-            // TODO change old structure to value backend
+            retval = readValueAttributeFromDataSource(server, session, vn, v,
+                                                      timestamps, rangeptr);
+            //TODO change old structure to value backend
             break;
         case UA_VALUEBACKENDTYPE_EXTERNAL:
-            if(vn->valueBackend.backend.external.callback.notificationRead) {
-                retval = vn->valueBackend.backend.external.callback.notificationRead(
-                    server, session ? &session->sessionId : NULL,
-                    session ? session->sessionHandle : NULL, &vn->head.nodeId,
-                    vn->head.context, rangeptr);
+            if(vn->valueBackend.backend.external.callback.notificationRead){
+                retval = vn->valueBackend.backend.external.callback.
+                    notificationRead(server,
+                                     session ? &session->sessionId : NULL,
+                                     session ? session->sessionHandle : NULL,
+                                     &vn->head.nodeId, vn->head.context, rangeptr);
             } else {
                 retval = UA_STATUSCODE_BADNOTREADABLE;
             }
-            if(retval != UA_STATUSCODE_GOOD) {
+            if(retval != UA_STATUSCODE_GOOD){
                 retval = UA_STATUSCODE_BADNOTREADABLE;
                 break;
             }
@@ -253,23 +251,20 @@ readValueAttributeComplete(UA_Server *server, UA_Session *session,
 }
 
 UA_StatusCode
-readValueAttribute(UA_Server *server, UA_Session *session, const UA_VariableNode *vn,
-                   UA_DataValue *v) {
-    return readValueAttributeComplete(server, session, vn, UA_TIMESTAMPSTORETURN_NEITHER,
-                                      NULL, v);
+readValueAttribute(UA_Server *server, UA_Session *session,
+                   const UA_VariableNode *vn, UA_DataValue *v) {
+    return readValueAttributeComplete(server, session, vn,
+                                      UA_TIMESTAMPSTORETURN_NEITHER, NULL, v);
 }
 
-static const UA_String binEncoding = {sizeof("Default Binary") - 1,
-                                      (UA_Byte *)"Default Binary"};
-static const UA_String xmlEncoding = {sizeof("Default XML") - 1,
-                                      (UA_Byte *)"Default XML"};
-static const UA_String jsonEncoding = {sizeof("Default JSON") - 1,
-                                       (UA_Byte *)"Default JSON"};
+static const UA_String binEncoding = {sizeof("Default Binary")-1, (UA_Byte*)"Default Binary"};
+static const UA_String xmlEncoding = {sizeof("Default XML")-1, (UA_Byte*)"Default XML"};
+static const UA_String jsonEncoding = {sizeof("Default JSON")-1, (UA_Byte*)"Default JSON"};
 
-#define CHECK_NODECLASS(CLASS)                                                           \
-    if(!(node->head.nodeClass & (CLASS))) {                                              \
-        retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;                                    \
-        break;                                                                           \
+#define CHECK_NODECLASS(CLASS)                                  \
+    if(!(node->head.nodeClass & (CLASS))) {                     \
+        retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;           \
+        break;                                                  \
     }
 
 #ifdef UA_ENABLE_TYPEDESCRIPTION
@@ -315,8 +310,8 @@ getStructureDefinition(const UA_DataType *type, UA_StructureDefinition *def) {
             return UA_STATUSCODE_BADENCODINGERROR;
     }
     def->fieldsSize = type->membersSize;
-    def->fields =
-        (UA_StructureField *)UA_calloc(def->fieldsSize, sizeof(UA_StructureField));
+    def->fields = (UA_StructureField *)
+        UA_calloc(def->fieldsSize, sizeof(UA_StructureField));
     if(!def->fields) {
         UA_NodeId_clear(&def->defaultEncodingId);
         return UA_STATUSCODE_BADOUTOFMEMORY;
@@ -331,8 +326,7 @@ getStructureDefinition(const UA_DataType *type, UA_StructureDefinition *def) {
         def->fields[cnt].name = UA_STRING((char *)(uintptr_t)m->memberName);
         def->fields[cnt].description.locale = UA_STRING_NULL;
         def->fields[cnt].description.text = UA_STRING_NULL;
-        def->fields[cnt].dataType =
-            typelists[!m->namespaceZero][m->memberTypeIndex].typeId;
+        def->fields[cnt].dataType = typelists[!m->namespaceZero][m->memberTypeIndex].typeId;
         def->fields[cnt].maxStringLength = 0;
         def->fields[cnt].isOptional = m->isOptional;
     }
@@ -345,11 +339,11 @@ getStructureDefinition(const UA_DataType *type, UA_StructureDefinition *def) {
  * node has been released! */
 void
 ReadWithNode(const UA_Node *node, UA_Server *server, UA_Session *session,
-             UA_TimestampsToReturn timestampsToReturn, const UA_ReadValueId *id,
-             UA_DataValue *v) {
+             UA_TimestampsToReturn timestampsToReturn,
+             const UA_ReadValueId *id, UA_DataValue *v) {
     UA_LOG_NODEID_DEBUG(&node->head.nodeId,
                         UA_LOG_DEBUG_SESSION(&server->config.logger, session,
-                                             "Read attribute %" PRIi32 " of Node %.*s",
+                                             "Read attribute %"PRIi32 " of Node %.*s",
                                              id->attributeId, (int)nodeIdStr.length,
                                              nodeIdStr.data));
 
@@ -358,9 +352,9 @@ ReadWithNode(const UA_Node *node, UA_Server *server, UA_Session *session,
        !UA_String_equal(&binEncoding, &id->dataEncoding.name)) {
         if(UA_String_equal(&xmlEncoding, &id->dataEncoding.name) ||
            UA_String_equal(&jsonEncoding, &id->dataEncoding.name))
-            v->status = UA_STATUSCODE_BADDATAENCODINGUNSUPPORTED;
+           v->status = UA_STATUSCODE_BADDATAENCODINGUNSUPPORTED;
         else
-            v->status = UA_STATUSCODE_BADDATAENCODINGINVALID;
+           v->status = UA_STATUSCODE_BADDATAENCODINGINVALID;
         v->hasStatus = true;
         return;
     }
@@ -375,171 +369,163 @@ ReadWithNode(const UA_Node *node, UA_Server *server, UA_Session *session,
     /* Read the attribute */
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     switch(id->attributeId) {
-        case UA_ATTRIBUTEID_NODEID:
-            retval = UA_Variant_setScalarCopy(&v->value, &node->head.nodeId,
-                                              &UA_TYPES[UA_TYPES_NODEID]);
-            break;
-        case UA_ATTRIBUTEID_NODECLASS:
-            retval = UA_Variant_setScalarCopy(&v->value, &node->head.nodeClass,
-                                              &UA_TYPES[UA_TYPES_NODECLASS]);
-            break;
-        case UA_ATTRIBUTEID_BROWSENAME:
-            retval = UA_Variant_setScalarCopy(&v->value, &node->head.browseName,
-                                              &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
-            break;
-        case UA_ATTRIBUTEID_DISPLAYNAME:
-            retval = UA_Variant_setScalarCopy(&v->value, &node->head.displayName,
-                                              &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
-            break;
-        case UA_ATTRIBUTEID_DESCRIPTION:
-            retval = UA_Variant_setScalarCopy(&v->value, &node->head.description,
-                                              &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
-            break;
-        case UA_ATTRIBUTEID_WRITEMASK:
-            retval = UA_Variant_setScalarCopy(&v->value, &node->head.writeMask,
-                                              &UA_TYPES[UA_TYPES_UINT32]);
-            break;
-        case UA_ATTRIBUTEID_USERWRITEMASK: {
-            UA_UInt32 userWriteMask = getUserWriteMask(server, session, &node->head);
-            retval = UA_Variant_setScalarCopy(&v->value, &userWriteMask,
-                                              &UA_TYPES[UA_TYPES_UINT32]);
-            break;
+    case UA_ATTRIBUTEID_NODEID:
+        retval = UA_Variant_setScalarCopy(&v->value, &node->head.nodeId,
+                                          &UA_TYPES[UA_TYPES_NODEID]);
+        break;
+    case UA_ATTRIBUTEID_NODECLASS:
+        retval = UA_Variant_setScalarCopy(&v->value, &node->head.nodeClass,
+                                          &UA_TYPES[UA_TYPES_NODECLASS]);
+        break;
+    case UA_ATTRIBUTEID_BROWSENAME:
+        retval = UA_Variant_setScalarCopy(&v->value, &node->head.browseName,
+                                          &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
+        break;
+    case UA_ATTRIBUTEID_DISPLAYNAME:
+        retval = UA_Variant_setScalarCopy(&v->value, &node->head.displayName,
+                                          &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+        break;
+    case UA_ATTRIBUTEID_DESCRIPTION:
+        retval = UA_Variant_setScalarCopy(&v->value, &node->head.description,
+                                          &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+        break;
+    case UA_ATTRIBUTEID_WRITEMASK:
+        retval = UA_Variant_setScalarCopy(&v->value, &node->head.writeMask,
+                                          &UA_TYPES[UA_TYPES_UINT32]);
+        break;
+    case UA_ATTRIBUTEID_USERWRITEMASK: {
+        UA_UInt32 userWriteMask = getUserWriteMask(server, session, &node->head);
+        retval = UA_Variant_setScalarCopy(&v->value, &userWriteMask,
+                                          &UA_TYPES[UA_TYPES_UINT32]);
+        break; }
+    case UA_ATTRIBUTEID_ISABSTRACT:
+        retval = readIsAbstractAttribute(node, &v->value);
+        break;
+    case UA_ATTRIBUTEID_SYMMETRIC:
+        CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->referenceTypeNode.symmetric,
+                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        break;
+    case UA_ATTRIBUTEID_INVERSENAME:
+        CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->referenceTypeNode.inverseName,
+                                          &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+        break;
+    case UA_ATTRIBUTEID_CONTAINSNOLOOPS:
+        CHECK_NODECLASS(UA_NODECLASS_VIEW);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->viewNode.containsNoLoops,
+                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        break;
+    case UA_ATTRIBUTEID_EVENTNOTIFIER:
+        CHECK_NODECLASS(UA_NODECLASS_VIEW | UA_NODECLASS_OBJECT);
+        if(node->head.nodeClass == UA_NODECLASS_VIEW) {
+            retval = UA_Variant_setScalarCopy(&v->value, &node->viewNode.eventNotifier,
+                                              &UA_TYPES[UA_TYPES_BYTE]);
+        } else {
+            retval = UA_Variant_setScalarCopy(&v->value, &node->objectNode.eventNotifier,
+                                              &UA_TYPES[UA_TYPES_BYTE]);
         }
-        case UA_ATTRIBUTEID_ISABSTRACT:
-            retval = readIsAbstractAttribute(node, &v->value);
-            break;
-        case UA_ATTRIBUTEID_SYMMETRIC:
-            CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE);
-            retval =
-                UA_Variant_setScalarCopy(&v->value, &node->referenceTypeNode.symmetric,
-                                         &UA_TYPES[UA_TYPES_BOOLEAN]);
-            break;
-        case UA_ATTRIBUTEID_INVERSENAME:
-            CHECK_NODECLASS(UA_NODECLASS_REFERENCETYPE);
-            retval =
-                UA_Variant_setScalarCopy(&v->value, &node->referenceTypeNode.inverseName,
-                                         &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
-            break;
-        case UA_ATTRIBUTEID_CONTAINSNOLOOPS:
-            CHECK_NODECLASS(UA_NODECLASS_VIEW);
-            retval = UA_Variant_setScalarCopy(&v->value, &node->viewNode.containsNoLoops,
-                                              &UA_TYPES[UA_TYPES_BOOLEAN]);
-            break;
-        case UA_ATTRIBUTEID_EVENTNOTIFIER:
-            CHECK_NODECLASS(UA_NODECLASS_VIEW | UA_NODECLASS_OBJECT);
-            if(node->head.nodeClass == UA_NODECLASS_VIEW) {
-                retval = UA_Variant_setScalarCopy(
-                    &v->value, &node->viewNode.eventNotifier, &UA_TYPES[UA_TYPES_BYTE]);
-            } else {
-                retval = UA_Variant_setScalarCopy(
-                    &v->value, &node->objectNode.eventNotifier, &UA_TYPES[UA_TYPES_BYTE]);
-            }
-            break;
-        case UA_ATTRIBUTEID_VALUE: {
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            /* VariableTypes don't have the AccessLevel concept. Always allow
-             * reading the value. */
-            if(node->head.nodeClass == UA_NODECLASS_VARIABLE) {
-                /* The access to a value variable is granted via the AccessLevel
-                 * and UserAccessLevel attributes */
-                UA_Byte accessLevel =
-                    getAccessLevel(server, session, &node->variableNode);
-                if(!(accessLevel & (UA_ACCESSLEVELMASK_READ))) {
-                    retval = UA_STATUSCODE_BADNOTREADABLE;
-                    break;
-                }
-                accessLevel = getUserAccessLevel(server, session, &node->variableNode);
-                if(!(accessLevel & (UA_ACCESSLEVELMASK_READ))) {
-                    retval = UA_STATUSCODE_BADUSERACCESSDENIED;
-                    break;
-                }
-            }
-            retval = readValueAttributeComplete(server, session, &node->variableNode,
-                                                timestampsToReturn, &id->indexRange, v);
-            break;
-        }
-        case UA_ATTRIBUTEID_DATATYPE:
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            retval = UA_Variant_setScalarCopy(&v->value, &node->variableTypeNode.dataType,
-                                              &UA_TYPES[UA_TYPES_NODEID]);
-            break;
-        case UA_ATTRIBUTEID_VALUERANK:
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            retval = UA_Variant_setScalarCopy(
-                &v->value, &node->variableTypeNode.valueRank, &UA_TYPES[UA_TYPES_INT32]);
-            break;
-        case UA_ATTRIBUTEID_ARRAYDIMENSIONS:
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            retval = UA_Variant_setArrayCopy(
-                &v->value, node->variableTypeNode.arrayDimensions,
-                node->variableTypeNode.arrayDimensionsSize, &UA_TYPES[UA_TYPES_UINT32]);
-            break;
-        case UA_ATTRIBUTEID_ACCESSLEVEL:
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
+        break;
+    case UA_ATTRIBUTEID_VALUE: {
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        /* VariableTypes don't have the AccessLevel concept. Always allow
+         * reading the value. */
+        if(node->head.nodeClass == UA_NODECLASS_VARIABLE) {
+            /* The access to a value variable is granted via the AccessLevel
+             * and UserAccessLevel attributes */
             UA_Byte accessLevel = getAccessLevel(server, session, &node->variableNode);
-            retval = UA_Variant_setScalarCopy(&v->value, &accessLevel,
-                                              &UA_TYPES[UA_TYPES_BYTE]);
-            break;
-        case UA_ATTRIBUTEID_USERACCESSLEVEL: {
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
-            UA_Byte userAccessLevel =
-                getUserAccessLevel(server, session, &node->variableNode);
-            retval = UA_Variant_setScalarCopy(&v->value, &userAccessLevel,
-                                              &UA_TYPES[UA_TYPES_BYTE]);
-            break;
+            if(!(accessLevel & (UA_ACCESSLEVELMASK_READ))) {
+                retval = UA_STATUSCODE_BADNOTREADABLE;
+                break;
+            }
+            accessLevel = getUserAccessLevel(server, session, &node->variableNode);
+            if(!(accessLevel & (UA_ACCESSLEVELMASK_READ))) {
+                retval = UA_STATUSCODE_BADUSERACCESSDENIED;
+                break;
+            }
         }
-        case UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL:
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
-            retval = UA_Variant_setScalarCopy(&v->value,
-                                              &node->variableNode.minimumSamplingInterval,
-                                              &UA_TYPES[UA_TYPES_DOUBLE]);
-            break;
-        case UA_ATTRIBUTEID_HISTORIZING:
-            CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
-            retval = UA_Variant_setScalarCopy(&v->value, &node->variableNode.historizing,
-                                              &UA_TYPES[UA_TYPES_BOOLEAN]);
-            break;
-        case UA_ATTRIBUTEID_EXECUTABLE:
-            CHECK_NODECLASS(UA_NODECLASS_METHOD);
-            retval = UA_Variant_setScalarCopy(&v->value, &node->methodNode.executable,
-                                              &UA_TYPES[UA_TYPES_BOOLEAN]);
-            break;
-        case UA_ATTRIBUTEID_USEREXECUTABLE: {
-            CHECK_NODECLASS(UA_NODECLASS_METHOD);
-            UA_Boolean userExecutable =
-                getUserExecutable(server, session, &node->methodNode);
-            retval = UA_Variant_setScalarCopy(&v->value, &userExecutable,
-                                              &UA_TYPES[UA_TYPES_BOOLEAN]);
-            break;
-        }
-        case UA_ATTRIBUTEID_DATATYPEDEFINITION: {
-            CHECK_NODECLASS(UA_NODECLASS_DATATYPE);
+        retval = readValueAttributeComplete(server, session, &node->variableNode,
+                                            timestampsToReturn, &id->indexRange, v);
+        break;
+    }
+    case UA_ATTRIBUTEID_DATATYPE:
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->variableTypeNode.dataType,
+                                          &UA_TYPES[UA_TYPES_NODEID]);
+        break;
+    case UA_ATTRIBUTEID_VALUERANK:
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->variableTypeNode.valueRank,
+                                          &UA_TYPES[UA_TYPES_INT32]);
+        break;
+    case UA_ATTRIBUTEID_ARRAYDIMENSIONS:
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        retval = UA_Variant_setArrayCopy(&v->value, node->variableTypeNode.arrayDimensions,
+                                         node->variableTypeNode.arrayDimensionsSize,
+                                         &UA_TYPES[UA_TYPES_UINT32]);
+        break;
+    case UA_ATTRIBUTEID_ACCESSLEVEL:
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->variableNode.accessLevel,
+                                          &UA_TYPES[UA_TYPES_BYTE]);
+        break;
+    case UA_ATTRIBUTEID_USERACCESSLEVEL: {
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
+        UA_Byte userAccessLevel = getUserAccessLevel(server, session, &node->variableNode);
+        retval = UA_Variant_setScalarCopy(&v->value, &userAccessLevel,
+                                          &UA_TYPES[UA_TYPES_BYTE]);
+        break; }
+    case UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL:
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
+        retval = UA_Variant_setScalarCopy(&v->value,
+                                          &node->variableNode.minimumSamplingInterval,
+                                          &UA_TYPES[UA_TYPES_DOUBLE]);
+        break;
+    case UA_ATTRIBUTEID_HISTORIZING:
+        CHECK_NODECLASS(UA_NODECLASS_VARIABLE);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->variableNode.historizing,
+                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        break;
+    case UA_ATTRIBUTEID_EXECUTABLE:
+        CHECK_NODECLASS(UA_NODECLASS_METHOD);
+        retval = UA_Variant_setScalarCopy(&v->value, &node->methodNode.executable,
+                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        break;
+    case UA_ATTRIBUTEID_USEREXECUTABLE: {
+        CHECK_NODECLASS(UA_NODECLASS_METHOD);
+        UA_Boolean userExecutable =
+            getUserExecutable(server, session, &node->methodNode);
+        retval = UA_Variant_setScalarCopy(&v->value, &userExecutable,
+                                          &UA_TYPES[UA_TYPES_BOOLEAN]);
+        break; }
+    case UA_ATTRIBUTEID_DATATYPEDEFINITION: {
+        CHECK_NODECLASS(UA_NODECLASS_DATATYPE);
 
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-            const UA_DataType *type = findDataType(node, server->config.customDataTypes);
-            if(!type) {
-                retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
-                break;
-            }
-
-            if(UA_DATATYPEKIND_STRUCTURE == type->typeKind ||
-               UA_DATATYPEKIND_OPTSTRUCT == type->typeKind ||
-               UA_DATATYPEKIND_UNION == type->typeKind) {
-                UA_StructureDefinition def;
-                retval = getStructureDefinition(type, &def);
-                if(UA_STATUSCODE_GOOD != retval)
-                    break;
-                retval = UA_Variant_setScalarCopy(
-                    &v->value, &def, &UA_TYPES[UA_TYPES_STRUCTUREDEFINITION]);
-                UA_free(def.fields);
-                break;
-            }
-#endif
+        const UA_DataType *type =
+            findDataType(node, server->config.customDataTypes);
+        if(!type) {
             retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
             break;
         }
-        default:
-            retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
+
+        if(UA_DATATYPEKIND_STRUCTURE == type->typeKind ||
+           UA_DATATYPEKIND_OPTSTRUCT == type->typeKind ||
+           UA_DATATYPEKIND_UNION == type->typeKind) {
+            UA_StructureDefinition def;
+            retval = getStructureDefinition(type, &def);
+            if(UA_STATUSCODE_GOOD!=retval)
+                break;            
+            retval = UA_Variant_setScalarCopy(&v->value, &def,
+                                              &UA_TYPES[UA_TYPES_STRUCTUREDEFINITION]);
+            UA_free(def.fields);
+            break;
+        }
+#endif
+        retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
+        break; }
+    default:
+        retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
     }
 
     if(retval != UA_STATUSCODE_GOOD) {
@@ -592,15 +578,14 @@ Operation_Read(UA_Server *server, UA_Session *session, UA_ReadRequest *request,
 }
 
 void
-Service_Read(UA_Server *server, UA_Session *session, const UA_ReadRequest *request,
-             UA_ReadResponse *response) {
+Service_Read(UA_Server *server, UA_Session *session,
+             const UA_ReadRequest *request, UA_ReadResponse *response) {
     UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing ReadRequest");
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
     /* Check if the timestampstoreturn is valid */
     if(request->timestampsToReturn > UA_TIMESTAMPSTORETURN_NEITHER) {
-        response->responseHeader.serviceResult =
-            UA_STATUSCODE_BADTIMESTAMPSTORETURNINVALID;
+        response->responseHeader.serviceResult = UA_STATUSCODE_BADTIMESTAMPSTORETURNINVALID;
         return;
     }
 
@@ -619,10 +604,13 @@ Service_Read(UA_Server *server, UA_Session *session, const UA_ReadRequest *reque
 
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
-    response->responseHeader.serviceResult = UA_Server_processServiceOperations(
-        server, session, (UA_ServiceOperation)Operation_Read, request,
-        &request->nodesToReadSize, &UA_TYPES[UA_TYPES_READVALUEID],
-        &response->resultsSize, &UA_TYPES[UA_TYPES_DATAVALUE]);
+    response->responseHeader.serviceResult =
+        UA_Server_processServiceOperations(server, session,
+                                           (UA_ServiceOperation)Operation_Read,
+                                           request, &request->nodesToReadSize,
+                                           &UA_TYPES[UA_TYPES_READVALUEID],
+                                           &response->resultsSize,
+                                           &UA_TYPES[UA_TYPES_DATAVALUE]);
 }
 
 UA_DataValue
@@ -652,7 +640,7 @@ UA_Server_readWithSession(UA_Server *server, UA_Session *session,
 
 UA_DataValue
 readAttribute(UA_Server *server, const UA_ReadValueId *item,
-              UA_TimestampsToReturn timestamps) {
+               UA_TimestampsToReturn timestamps) {
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
     return UA_Server_readWithSession(server, &server->adminSession, item, timestamps);
 }
@@ -707,15 +695,16 @@ UA_Server_read(UA_Server *server, const UA_ReadValueId *item,
 UA_StatusCode
 __UA_Server_read(UA_Server *server, const UA_NodeId *nodeId,
                  const UA_AttributeId attributeId, void *v) {
-    UA_LOCK(&server->serviceMutex);
-    UA_StatusCode retval = readWithReadValue(server, nodeId, attributeId, v);
-    UA_UNLOCK(&server->serviceMutex);
-    return retval;
+   UA_LOCK(&server->serviceMutex);
+   UA_StatusCode retval = readWithReadValue(server, nodeId, attributeId, v);
+   UA_UNLOCK(&server->serviceMutex);
+   return retval;
 }
 
 UA_StatusCode
 readObjectProperty(UA_Server *server, const UA_NodeId objectId,
-                   const UA_QualifiedName propertyName, UA_Variant *value) {
+                   const UA_QualifiedName propertyName,
+                   UA_Variant *value) {
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
     /* Create a BrowsePath to get the target NodeId */
@@ -748,9 +737,11 @@ readObjectProperty(UA_Server *server, const UA_NodeId objectId,
     return retval;
 }
 
+
 UA_StatusCode
 UA_Server_readObjectProperty(UA_Server *server, const UA_NodeId objectId,
-                             const UA_QualifiedName propertyName, UA_Variant *value) {
+                             const UA_QualifiedName propertyName,
+                             UA_Variant *value) {
     UA_LOCK(&server->serviceMutex);
     UA_StatusCode retval = readObjectProperty(server, objectId, propertyName, value);
     UA_UNLOCK(&server->serviceMutex);
@@ -792,7 +783,7 @@ compatibleDataTypes(UA_Server *server, const UA_NodeId *dataType,
                     const UA_NodeId *constraintDataType) {
     /* Do not allow empty datatypes */
     if(UA_NodeId_isNull(dataType))
-        return false;
+       return false;
 
     /* No constraint or Variant / BaseDataType which allows any content */
     if(UA_NodeId_isNull(constraintDataType) ||
@@ -847,7 +838,7 @@ compatibleValueRankArrayDimensions(UA_Server *server, UA_Session *session,
         }
         return true;
     }
-
+    
     /* case >= 1, UA_VALUERANK_ONE_DIMENSION: the value is an array with the
        specified number of dimensions */
     if(arrayDimensionsSize != (size_t)valueRank) {
@@ -863,29 +854,28 @@ UA_Boolean
 compatibleValueRanks(UA_Int32 valueRank, UA_Int32 constraintValueRank) {
     /* Check if the valuerank of the variabletype allows the change. */
     switch(constraintValueRank) {
-        case UA_VALUERANK_SCALAR_OR_ONE_DIMENSION: /* the value can be a scalar or a
-                                                      one dimensional array */
-            if(valueRank != UA_VALUERANK_SCALAR &&
-               valueRank != UA_VALUERANK_ONE_DIMENSION)
-                return false;
-            break;
-        case UA_VALUERANK_ANY: /* the value can be a scalar or an array with any
-                                  number of dimensions */
-            break;
-        case UA_VALUERANK_SCALAR: /* the value is a scalar */
-            if(valueRank != UA_VALUERANK_SCALAR)
-                return false;
-            break;
-        case UA_VALUERANK_ONE_OR_MORE_DIMENSIONS: /* the value is an array with one
-                                                     or more dimensions */
-            if(valueRank < (UA_Int32)UA_VALUERANK_ONE_OR_MORE_DIMENSIONS)
-                return false;
-            break;
-        default: /* >= 1: the value is an array with the specified number of
-                     dimensions */
-            if(valueRank != constraintValueRank)
-                return false;
-            break;
+    case UA_VALUERANK_SCALAR_OR_ONE_DIMENSION: /* the value can be a scalar or a
+                                                  one dimensional array */
+        if(valueRank != UA_VALUERANK_SCALAR && valueRank != UA_VALUERANK_ONE_DIMENSION)
+            return false;
+        break;
+    case UA_VALUERANK_ANY: /* the value can be a scalar or an array with any
+                              number of dimensions */
+        break;
+    case UA_VALUERANK_SCALAR: /* the value is a scalar */
+        if(valueRank != UA_VALUERANK_SCALAR)
+            return false;
+        break;
+    case UA_VALUERANK_ONE_OR_MORE_DIMENSIONS: /* the value is an array with one
+                                                 or more dimensions */
+        if(valueRank < (UA_Int32) UA_VALUERANK_ONE_OR_MORE_DIMENSIONS)
+            return false;
+        break;
+    default: /* >= 1: the value is an array with the specified number of
+                 dimensions */
+        if(valueRank != constraintValueRank)
+            return false;
+        break;
     }
     return true;
 }
@@ -910,18 +900,18 @@ compatibleValueRankValue(UA_Int32 valueRank, const UA_Variant *value) {
     /* We cannot simply use compatibleValueRankArrayDimensions since we can have
      * defined ArrayDimensions for the value if the ValueRank is -2 */
     switch(valueRank) {
-        case UA_VALUERANK_SCALAR_OR_ONE_DIMENSION: /* The value can be a scalar or a
-                                                      one dimensional array */
-            return (arrayDims <= 1);
-        case UA_VALUERANK_ANY: /* The value can be a scalar or an array with any
-                                  number of dimensions */
-            return true;
-        case UA_VALUERANK_SCALAR: /* The value is a scalar */
-            return (arrayDims == 0);
-        case UA_VALUERANK_ONE_OR_MORE_DIMENSIONS:
-            return (arrayDims >= 1);
-        default:
-            break;
+    case UA_VALUERANK_SCALAR_OR_ONE_DIMENSION: /* The value can be a scalar or a
+                                                  one dimensional array */
+        return (arrayDims <= 1);
+    case UA_VALUERANK_ANY: /* The value can be a scalar or an array with any
+                              number of dimensions */
+        return true;
+    case UA_VALUERANK_SCALAR: /* The value is a scalar */
+        return (arrayDims == 0);
+    case UA_VALUERANK_ONE_OR_MORE_DIMENSIONS:
+        return (arrayDims >= 1);
+    default:
+        break;
     }
 
     UA_assert(valueRank >= UA_VALUERANK_ONE_OR_MORE_DIMENSIONS);
@@ -1020,7 +1010,8 @@ compatibleValue(UA_Server *server, UA_Session *session, const UA_NodeId *targetD
 /*****************/
 
 static void
-adjustValue(UA_Server *server, UA_Variant *value, const UA_NodeId *targetDataTypeId) {
+adjustValue(UA_Server *server, UA_Variant *value,
+            const UA_NodeId *targetDataTypeId) {
     const UA_DataType *targetDataType = UA_findDataType(targetDataTypeId);
     if(!targetDataType)
         return;
@@ -1028,8 +1019,9 @@ adjustValue(UA_Server *server, UA_Variant *value, const UA_NodeId *targetDataTyp
     /* A string is written to a byte array. the valuerank and array dimensions
      * are checked later */
     if(targetDataType == &UA_TYPES[UA_TYPES_BYTE] &&
-       value->type == &UA_TYPES[UA_TYPES_BYTESTRING] && UA_Variant_isScalar(value)) {
-        UA_ByteString *str = (UA_ByteString *)value->data;
+       value->type == &UA_TYPES[UA_TYPES_BYTESTRING] &&
+       UA_Variant_isScalar(value)) {
+        UA_ByteString *str = (UA_ByteString*)value->data;
         value->type = &UA_TYPES[UA_TYPES_BYTE];
         value->arrayLength = str->length;
         value->data = str->data;
@@ -1077,9 +1069,9 @@ writeArrayDimensionsAttribute(UA_Server *server, UA_Session *session,
     if(type->arrayDimensions &&
        !compatibleArrayDimensions(type->arrayDimensionsSize, type->arrayDimensions,
                                   arrayDimensionsSize, arrayDimensions)) {
-        UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                     "Array dimensions in the variable type do not match");
-        return UA_STATUSCODE_BADTYPEMISMATCH;
+       UA_LOG_DEBUG(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                    "Array dimensions in the variable type do not match");
+       return UA_STATUSCODE_BADTYPEMISMATCH;
     }
 
     /* Check if the current value is compatible with the array dimensions */
@@ -1104,19 +1096,20 @@ writeArrayDimensionsAttribute(UA_Server *server, UA_Session *session,
     UA_UInt32 *oldArrayDimensions = node->arrayDimensions;
     size_t oldArrayDimensionsSize = node->arrayDimensionsSize;
     retval = UA_Array_copy(arrayDimensions, arrayDimensionsSize,
-                           (void **)&node->arrayDimensions, &UA_TYPES[UA_TYPES_UINT32]);
+                           (void**)&node->arrayDimensions,
+                           &UA_TYPES[UA_TYPES_UINT32]);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
-    UA_Array_delete(oldArrayDimensions, oldArrayDimensionsSize,
-                    &UA_TYPES[UA_TYPES_UINT32]);
+    UA_Array_delete(oldArrayDimensions, oldArrayDimensionsSize, &UA_TYPES[UA_TYPES_UINT32]);
     node->arrayDimensionsSize = arrayDimensionsSize;
     return UA_STATUSCODE_GOOD;
 }
 
 /* Stack layout: ... | node | type */
 static UA_StatusCode
-writeValueRankAttribute(UA_Server *server, UA_Session *session, UA_VariableNode *node,
-                        const UA_VariableTypeNode *type, UA_Int32 valueRank) {
+writeValueRankAttribute(UA_Server *server, UA_Session *session,
+                        UA_VariableNode *node, const UA_VariableTypeNode *type,
+                        UA_Int32 valueRank) {
     UA_assert(node != NULL);
     UA_assert(type != NULL);
 
@@ -1161,8 +1154,9 @@ writeValueRankAttribute(UA_Server *server, UA_Session *session, UA_VariableNode 
 }
 
 static UA_StatusCode
-writeDataTypeAttribute(UA_Server *server, UA_Session *session, UA_VariableNode *node,
-                       const UA_VariableTypeNode *type, const UA_NodeId *dataType) {
+writeDataTypeAttribute(UA_Server *server, UA_Session *session,
+                       UA_VariableNode *node, const UA_VariableTypeNode *type,
+                       const UA_NodeId *dataType) {
     UA_assert(node != NULL);
     UA_assert(type != NULL);
 
@@ -1221,8 +1215,8 @@ static UA_StatusCode
 writeValueAttributeWithRange(UA_VariableNode *node, const UA_DataValue *value,
                              const UA_NumericRange *rangeptr) {
     /* Value on both sides? */
-    if(value->status != node->value.data.value.status || !value->hasValue ||
-       !node->value.data.value.hasValue)
+    if(value->status != node->value.data.value.status ||
+       !value->hasValue || !node->value.data.value.hasValue)
         return UA_STATUSCODE_BADINDEXRANGEINVALID;
 
     /* Make scalar a one-entry array for range matching */
@@ -1236,12 +1230,14 @@ writeValueAttributeWithRange(UA_VariableNode *node, const UA_DataValue *value,
 
     /* Check that the type is an exact match and not only "compatible" */
     if(!node->value.data.value.value.type || !v->type ||
-       !UA_NodeId_equal(&node->value.data.value.value.type->typeId, &v->type->typeId))
+       !UA_NodeId_equal(&node->value.data.value.value.type->typeId,
+                        &v->type->typeId))
         return UA_STATUSCODE_BADTYPEMISMATCH;
 
     /* Write the value */
-    UA_StatusCode retval = UA_Variant_setRangeCopy(&node->value.data.value.value, v->data,
-                                                   v->arrayLength, *rangeptr);
+    UA_StatusCode retval =
+        UA_Variant_setRangeCopy(&node->value.data.value.value,
+                                v->data, v->arrayLength, *rangeptr);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
@@ -1257,8 +1253,9 @@ writeValueAttributeWithRange(UA_VariableNode *node, const UA_DataValue *value,
 
 /* Stack layout: ... | node */
 static UA_StatusCode
-writeNodeValueAttribute(UA_Server *server, UA_Session *session, UA_VariableNode *node,
-                        const UA_DataValue *value, const UA_String *indexRange) {
+writeNodeValueAttribute(UA_Server *server, UA_Session *session,
+                        UA_VariableNode *node, const UA_DataValue *value,
+                        const UA_String *indexRange) {
     UA_assert(node != NULL);
     UA_assert(session != NULL);
 
@@ -1328,27 +1325,30 @@ writeNodeValueAttribute(UA_Server *server, UA_Session *session, UA_VariableNode 
                    node->head.nodeClass == UA_NODECLASS_VARIABLE &&
                    server->config.historyDatabase.setValue) {
                     UA_UNLOCK(&server->serviceMutex);
-                    server->config.historyDatabase.setValue(
-                        server, server->config.historyDatabase.context,
-                        &session->sessionId, session->sessionHandle, &node->head.nodeId,
-                        node->historizing, &adjustedValue);
+                    server->config.historyDatabase.
+                        setValue(server, server->config.historyDatabase.context,
+                                 &session->sessionId, session->sessionHandle,
+                                 &node->head.nodeId, node->historizing, &adjustedValue);
                     UA_LOCK(&server->serviceMutex);
                 }
 #endif
                 /* Callback after writing */
                 if(retval == UA_STATUSCODE_GOOD && node->value.data.callback.onWrite) {
                     UA_UNLOCK(&server->serviceMutex);
-                    node->value.data.callback.onWrite(
-                        server, &session->sessionId, session->sessionHandle,
-                        &node->head.nodeId, node->head.context, rangeptr, &adjustedValue);
+                    node->value.data.callback.
+                        onWrite(server, &session->sessionId, session->sessionHandle,
+                                &node->head.nodeId, node->head.context,
+                                rangeptr, &adjustedValue);
                     UA_LOCK(&server->serviceMutex);
+
                 }
             } else {
                 if(node->value.dataSource.write) {
                     UA_UNLOCK(&server->serviceMutex);
-                    retval = node->value.dataSource.write(
-                        server, &session->sessionId, session->sessionHandle,
-                        &node->head.nodeId, node->head.context, rangeptr, &adjustedValue);
+                    retval = node->value.dataSource.
+                        write(server, &session->sessionId, session->sessionHandle,
+                              &node->head.nodeId, node->head.context,
+                              rangeptr, &adjustedValue);
                     UA_LOCK(&server->serviceMutex);
                 } else {
                     retval = UA_STATUSCODE_BADWRITENOTSUPPORTED;
@@ -1360,14 +1360,15 @@ writeNodeValueAttribute(UA_Server *server, UA_Session *session, UA_VariableNode 
         case UA_VALUEBACKENDTYPE_DATA_SOURCE_CALLBACK:
             break;
         case UA_VALUEBACKENDTYPE_EXTERNAL:
-            if(node->valueBackend.backend.external.callback.userWrite == NULL) {
+            if(node->valueBackend.backend.external.callback.userWrite == NULL){
                 if(rangeptr)
                     UA_free(range.dimensions);
                 return UA_STATUSCODE_BADWRITENOTSUPPORTED;
             }
-            node->valueBackend.backend.external.callback.userWrite(
-                server, &session->sessionId, session->sessionHandle, &node->head.nodeId,
-                node->head.context, rangeptr, &adjustedValue);
+            node->valueBackend.backend.external.callback.
+                userWrite(server, &session->sessionId, session->sessionHandle,
+                          &node->head.nodeId, node->head.context,
+                          rangeptr, &adjustedValue);
             break;
     }
 
@@ -1380,20 +1381,20 @@ writeNodeValueAttribute(UA_Server *server, UA_Session *session, UA_VariableNode 
 static UA_StatusCode
 writeIsAbstractAttribute(UA_Node *node, UA_Boolean value) {
     switch(node->head.nodeClass) {
-        case UA_NODECLASS_OBJECTTYPE:
-            node->objectTypeNode.isAbstract = value;
-            break;
-        case UA_NODECLASS_REFERENCETYPE:
-            node->referenceTypeNode.isAbstract = value;
-            break;
-        case UA_NODECLASS_VARIABLETYPE:
-            node->variableTypeNode.isAbstract = value;
-            break;
-        case UA_NODECLASS_DATATYPE:
-            node->dataTypeNode.isAbstract = value;
-            break;
-        default:
-            return UA_STATUSCODE_BADNODECLASSINVALID;
+    case UA_NODECLASS_OBJECTTYPE:
+        node->objectTypeNode.isAbstract = value;
+        break;
+    case UA_NODECLASS_REFERENCETYPE:
+        node->referenceTypeNode.isAbstract = value;
+        break;
+    case UA_NODECLASS_VARIABLETYPE:
+        node->variableTypeNode.isAbstract = value;
+        break;
+    case UA_NODECLASS_DATATYPE:
+        node->dataTypeNode.isAbstract = value;
+        break;
+    default:
+        return UA_STATUSCODE_BADNODECLASSINVALID;
     }
     return UA_STATUSCODE_GOOD;
 }
@@ -1402,39 +1403,40 @@ writeIsAbstractAttribute(UA_Node *node, UA_Boolean value) {
 /* Write Service */
 /*****************/
 
-#define CHECK_DATATYPE_SCALAR(EXP_DT)                                                    \
-    if(!wvalue->value.hasValue ||                                                        \
-       &UA_TYPES[UA_TYPES_##EXP_DT] != wvalue->value.value.type ||                       \
-       !UA_Variant_isScalar(&wvalue->value.value)) {                                     \
-        retval = UA_STATUSCODE_BADTYPEMISMATCH;                                          \
-        break;                                                                           \
+#define CHECK_DATATYPE_SCALAR(EXP_DT)                                   \
+    if(!wvalue->value.hasValue ||                                       \
+       &UA_TYPES[UA_TYPES_##EXP_DT] != wvalue->value.value.type ||      \
+       !UA_Variant_isScalar(&wvalue->value.value)) {                    \
+        retval = UA_STATUSCODE_BADTYPEMISMATCH;                         \
+        break;                                                          \
     }
 
-#define CHECK_DATATYPE_ARRAY(EXP_DT)                                                     \
-    if(!wvalue->value.hasValue ||                                                        \
-       &UA_TYPES[UA_TYPES_##EXP_DT] != wvalue->value.value.type ||                       \
-       UA_Variant_isScalar(&wvalue->value.value)) {                                      \
-        retval = UA_STATUSCODE_BADTYPEMISMATCH;                                          \
-        break;                                                                           \
+#define CHECK_DATATYPE_ARRAY(EXP_DT)                                    \
+    if(!wvalue->value.hasValue ||                                       \
+       &UA_TYPES[UA_TYPES_##EXP_DT] != wvalue->value.value.type ||      \
+       UA_Variant_isScalar(&wvalue->value.value)) {                     \
+        retval = UA_STATUSCODE_BADTYPEMISMATCH;                         \
+        break;                                                          \
     }
 
-#define CHECK_NODECLASS_WRITE(CLASS)                                                     \
-    if((node->head.nodeClass & (CLASS)) == 0) {                                          \
-        retval = UA_STATUSCODE_BADNODECLASSINVALID;                                      \
-        break;                                                                           \
+#define CHECK_NODECLASS_WRITE(CLASS)                                    \
+    if((node->head.nodeClass & (CLASS)) == 0) {                         \
+        retval = UA_STATUSCODE_BADNODECLASSINVALID;                     \
+        break;                                                          \
     }
 
-#define CHECK_USERWRITEMASK(mask)                                                        \
-    if(!(userWriteMask & (mask))) {                                                      \
-        retval = UA_STATUSCODE_BADUSERACCESSDENIED;                                      \
-        break;                                                                           \
+#define CHECK_USERWRITEMASK(mask)                           \
+    if(!(userWriteMask & (mask))) {                         \
+        retval = UA_STATUSCODE_BADUSERACCESSDENIED;         \
+        break;                                              \
     }
 
-#define GET_NODETYPE                                                                     \
-    type = (const UA_VariableTypeNode *)getNodeType(server, &node->head);                \
-    if(!type) {                                                                          \
-        retval = UA_STATUSCODE_BADTYPEMISMATCH;                                          \
-        break;                                                                           \
+#define GET_NODETYPE                                \
+    type = (const UA_VariableTypeNode*)             \
+        getNodeType(server, &node->head);           \
+    if(!type) {                                     \
+        retval = UA_STATUSCODE_BADTYPEMISMATCH;     \
+        break;                                      \
     }
 
 /* Update a localized text. Don't touch the target if copying fails
@@ -1453,8 +1455,8 @@ updateLocalizedText(const UA_LocalizedText *source, UA_LocalizedText *target) {
 /* This function implements the main part of the write service and operates on a
    copy of the node (not in single-threaded mode). */
 static UA_StatusCode
-copyAttributeIntoNode(UA_Server *server, UA_Session *session, UA_Node *node,
-                      const UA_WriteValue *wvalue) {
+copyAttributeIntoNode(UA_Server *server, UA_Session *session,
+                      UA_Node *node, const UA_WriteValue *wvalue) {
     UA_assert(session != NULL);
     const void *value = wvalue->value.value.data;
     UA_UInt32 userWriteMask = getUserWriteMask(server, session, &node->head);
@@ -1462,154 +1464,149 @@ copyAttributeIntoNode(UA_Server *server, UA_Session *session, UA_Node *node,
 
     UA_LOG_NODEID_DEBUG(&node->head.nodeId,
                         UA_LOG_DEBUG_SESSION(&server->config.logger, session,
-                                             "Write attribute %" PRIi32 " of Node %.*s",
+                                             "Write attribute %"PRIi32 " of Node %.*s",
                                              wvalue->attributeId, (int)nodeIdStr.length,
                                              nodeIdStr.data));
 
     const UA_VariableTypeNode *type;
 
     switch(wvalue->attributeId) {
-        case UA_ATTRIBUTEID_NODEID:
-        case UA_ATTRIBUTEID_NODECLASS:
-        case UA_ATTRIBUTEID_USERWRITEMASK:
-        case UA_ATTRIBUTEID_USERACCESSLEVEL:
-        case UA_ATTRIBUTEID_USEREXECUTABLE:
-        case UA_ATTRIBUTEID_BROWSENAME: /* BrowseName is tracked in a binary tree
-                                           for fast lookup */
-            retval = UA_STATUSCODE_BADWRITENOTSUPPORTED;
-            break;
-        case UA_ATTRIBUTEID_DISPLAYNAME:
-            CHECK_USERWRITEMASK(UA_WRITEMASK_DISPLAYNAME);
-            CHECK_DATATYPE_SCALAR(LOCALIZEDTEXT);
-            retval = updateLocalizedText((const UA_LocalizedText *)value,
-                                         &node->head.displayName);
-            break;
-        case UA_ATTRIBUTEID_DESCRIPTION:
-            CHECK_USERWRITEMASK(UA_WRITEMASK_DESCRIPTION);
-            CHECK_DATATYPE_SCALAR(LOCALIZEDTEXT);
-            retval = updateLocalizedText((const UA_LocalizedText *)value,
-                                         &node->head.description);
-            break;
-        case UA_ATTRIBUTEID_WRITEMASK:
-            CHECK_USERWRITEMASK(UA_WRITEMASK_WRITEMASK);
-            CHECK_DATATYPE_SCALAR(UINT32);
-            node->head.writeMask = *(const UA_UInt32 *)value;
-            break;
-        case UA_ATTRIBUTEID_ISABSTRACT:
-            CHECK_USERWRITEMASK(UA_WRITEMASK_ISABSTRACT);
-            CHECK_DATATYPE_SCALAR(BOOLEAN);
-            retval = writeIsAbstractAttribute(node, *(const UA_Boolean *)value);
-            break;
-        case UA_ATTRIBUTEID_SYMMETRIC:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_REFERENCETYPE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_SYMMETRIC);
-            CHECK_DATATYPE_SCALAR(BOOLEAN);
-            node->referenceTypeNode.symmetric = *(const UA_Boolean *)value;
-            break;
-        case UA_ATTRIBUTEID_INVERSENAME:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_REFERENCETYPE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_INVERSENAME);
-            CHECK_DATATYPE_SCALAR(LOCALIZEDTEXT);
-            retval = updateLocalizedText((const UA_LocalizedText *)value,
-                                         &node->referenceTypeNode.inverseName);
-            break;
-        case UA_ATTRIBUTEID_CONTAINSNOLOOPS:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VIEW);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_CONTAINSNOLOOPS);
-            CHECK_DATATYPE_SCALAR(BOOLEAN);
-            node->viewNode.containsNoLoops = *(const UA_Boolean *)value;
-            break;
-        case UA_ATTRIBUTEID_EVENTNOTIFIER:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VIEW | UA_NODECLASS_OBJECT);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_EVENTNOTIFIER);
-            CHECK_DATATYPE_SCALAR(BYTE);
-            if(node->head.nodeClass == UA_NODECLASS_VIEW) {
-                node->viewNode.eventNotifier = *(const UA_Byte *)value;
-            } else {
-                node->objectNode.eventNotifier = *(const UA_Byte *)value;
+    case UA_ATTRIBUTEID_NODEID:
+    case UA_ATTRIBUTEID_NODECLASS:
+    case UA_ATTRIBUTEID_USERWRITEMASK:
+    case UA_ATTRIBUTEID_USERACCESSLEVEL:
+    case UA_ATTRIBUTEID_USEREXECUTABLE:
+    case UA_ATTRIBUTEID_BROWSENAME: /* BrowseName is tracked in a binary tree
+                                       for fast lookup */
+        retval = UA_STATUSCODE_BADWRITENOTSUPPORTED;
+        break;
+    case UA_ATTRIBUTEID_DISPLAYNAME:
+        CHECK_USERWRITEMASK(UA_WRITEMASK_DISPLAYNAME);
+        CHECK_DATATYPE_SCALAR(LOCALIZEDTEXT);
+        retval = updateLocalizedText((const UA_LocalizedText *)value,
+                                     &node->head.displayName);
+        break;
+    case UA_ATTRIBUTEID_DESCRIPTION:
+        CHECK_USERWRITEMASK(UA_WRITEMASK_DESCRIPTION);
+        CHECK_DATATYPE_SCALAR(LOCALIZEDTEXT);
+        retval = updateLocalizedText((const UA_LocalizedText *)value,
+                                     &node->head.description);
+        break;
+    case UA_ATTRIBUTEID_WRITEMASK:
+        CHECK_USERWRITEMASK(UA_WRITEMASK_WRITEMASK);
+        CHECK_DATATYPE_SCALAR(UINT32);
+        node->head.writeMask = *(const UA_UInt32*)value;
+        break;
+    case UA_ATTRIBUTEID_ISABSTRACT:
+        CHECK_USERWRITEMASK(UA_WRITEMASK_ISABSTRACT);
+        CHECK_DATATYPE_SCALAR(BOOLEAN);
+        retval = writeIsAbstractAttribute(node, *(const UA_Boolean*)value);
+        break;
+    case UA_ATTRIBUTEID_SYMMETRIC:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_REFERENCETYPE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_SYMMETRIC);
+        CHECK_DATATYPE_SCALAR(BOOLEAN);
+        node->referenceTypeNode.symmetric = *(const UA_Boolean*)value;
+        break;
+    case UA_ATTRIBUTEID_INVERSENAME:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_REFERENCETYPE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_INVERSENAME);
+        CHECK_DATATYPE_SCALAR(LOCALIZEDTEXT);
+        retval = updateLocalizedText((const UA_LocalizedText *)value,
+                                     &node->referenceTypeNode.inverseName);
+        break;
+    case UA_ATTRIBUTEID_CONTAINSNOLOOPS:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VIEW);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_CONTAINSNOLOOPS);
+        CHECK_DATATYPE_SCALAR(BOOLEAN);
+        node->viewNode.containsNoLoops = *(const UA_Boolean*)value;
+        break;
+    case UA_ATTRIBUTEID_EVENTNOTIFIER:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VIEW | UA_NODECLASS_OBJECT);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_EVENTNOTIFIER);
+        CHECK_DATATYPE_SCALAR(BYTE);
+        if(node->head.nodeClass == UA_NODECLASS_VIEW) {
+            node->viewNode.eventNotifier = *(const UA_Byte*)value;
+        } else {
+            node->objectNode.eventNotifier = *(const UA_Byte*)value;
+        }
+        break;
+    case UA_ATTRIBUTEID_VALUE:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        if(node->head.nodeClass == UA_NODECLASS_VARIABLE) {
+            /* The access to a value variable is granted via the AccessLevel
+             * and UserAccessLevel attributes */
+            UA_Byte accessLevel = getAccessLevel(server, session, &node->variableNode);
+            if(!(accessLevel & (UA_ACCESSLEVELMASK_WRITE))) {
+                retval = UA_STATUSCODE_BADNOTWRITABLE;
+                break;
             }
-            break;
-        case UA_ATTRIBUTEID_VALUE:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            if(node->head.nodeClass == UA_NODECLASS_VARIABLE) {
-                /* The access to a value variable is granted via the AccessLevel
-                 * and UserAccessLevel attributes */
-                UA_Byte accessLevel =
-                    getAccessLevel(server, session, &node->variableNode);
-                if(!(accessLevel & (UA_ACCESSLEVELMASK_WRITE))) {
-                    retval = UA_STATUSCODE_BADNOTWRITABLE;
-                    break;
-                }
-                accessLevel = getUserAccessLevel(server, session, &node->variableNode);
-                if(!(accessLevel & (UA_ACCESSLEVELMASK_WRITE))) {
-                    retval = UA_STATUSCODE_BADUSERACCESSDENIED;
-                    break;
-                }
-            } else { /* UA_NODECLASS_VARIABLETYPE */
-                CHECK_USERWRITEMASK(UA_WRITEMASK_VALUEFORVARIABLETYPE);
+            accessLevel = getUserAccessLevel(server, session, &node->variableNode);
+            if(!(accessLevel & (UA_ACCESSLEVELMASK_WRITE))) {
+                retval = UA_STATUSCODE_BADUSERACCESSDENIED;
+                break;
             }
-            retval = writeNodeValueAttribute(server, session, &node->variableNode,
-                                             &wvalue->value, &wvalue->indexRange);
-            break;
-        case UA_ATTRIBUTEID_DATATYPE:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_DATATYPE);
-            CHECK_DATATYPE_SCALAR(NODEID);
-            GET_NODETYPE;
-            retval = writeDataTypeAttribute(server, session, &node->variableNode, type,
-                                            (const UA_NodeId *)value);
-            UA_NODESTORE_RELEASE(server, (const UA_Node *)type);
-            break;
-        case UA_ATTRIBUTEID_VALUERANK:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_VALUERANK);
-            CHECK_DATATYPE_SCALAR(INT32);
-            GET_NODETYPE;
-            retval = writeValueRankAttribute(server, session, &node->variableNode, type,
-                                             *(const UA_Int32 *)value);
-            UA_NODESTORE_RELEASE(server, (const UA_Node *)type);
-            break;
-        case UA_ATTRIBUTEID_ARRAYDIMENSIONS:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_ARRRAYDIMENSIONS);
-            CHECK_DATATYPE_ARRAY(UINT32);
-            GET_NODETYPE;
-            retval = writeArrayDimensionsAttribute(server, session, &node->variableNode,
-                                                   type, wvalue->value.value.arrayLength,
-                                                   (UA_UInt32 *)wvalue->value.value.data);
-            UA_NODESTORE_RELEASE(server, (const UA_Node *)type);
-            break;
-        case UA_ATTRIBUTEID_ACCESSLEVEL:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_ACCESSLEVEL);
-            CHECK_DATATYPE_SCALAR(BYTE);
-            if(node->variableNode.accessLevelCallback)
-            {
-                retval = UA_STATUSCODE_BADNOTIMPLEMENTED;
-            }
-            node->variableNode.accessLevel = *(const UA_Byte *)value;
-            break;
-        case UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_MINIMUMSAMPLINGINTERVAL);
-            CHECK_DATATYPE_SCALAR(DOUBLE);
-            node->variableNode.minimumSamplingInterval = *(const UA_Double *)value;
-            break;
-        case UA_ATTRIBUTEID_HISTORIZING:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_HISTORIZING);
-            CHECK_DATATYPE_SCALAR(BOOLEAN);
-            node->variableNode.historizing = *(const UA_Boolean *)value;
-            break;
-        case UA_ATTRIBUTEID_EXECUTABLE:
-            CHECK_NODECLASS_WRITE(UA_NODECLASS_METHOD);
-            CHECK_USERWRITEMASK(UA_WRITEMASK_EXECUTABLE);
-            CHECK_DATATYPE_SCALAR(BOOLEAN);
-            node->methodNode.executable = *(const UA_Boolean *)value;
-            break;
-        default:
-            retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
-            break;
+        } else { /* UA_NODECLASS_VARIABLETYPE */
+            CHECK_USERWRITEMASK(UA_WRITEMASK_VALUEFORVARIABLETYPE);
+        }
+        retval = writeNodeValueAttribute(server, session, &node->variableNode,
+                                         &wvalue->value, &wvalue->indexRange);
+        break;
+    case UA_ATTRIBUTEID_DATATYPE:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_DATATYPE);
+        CHECK_DATATYPE_SCALAR(NODEID);
+        GET_NODETYPE;
+        retval = writeDataTypeAttribute(server, session, &node->variableNode,
+                                        type, (const UA_NodeId*)value);
+        UA_NODESTORE_RELEASE(server, (const UA_Node*)type);
+        break;
+    case UA_ATTRIBUTEID_VALUERANK:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_VALUERANK);
+        CHECK_DATATYPE_SCALAR(INT32);
+        GET_NODETYPE;
+        retval = writeValueRankAttribute(server, session, &node->variableNode,
+                                         type, *(const UA_Int32*)value);
+        UA_NODESTORE_RELEASE(server, (const UA_Node*)type);
+        break;
+    case UA_ATTRIBUTEID_ARRAYDIMENSIONS:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE | UA_NODECLASS_VARIABLETYPE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_ARRRAYDIMENSIONS);
+        CHECK_DATATYPE_ARRAY(UINT32);
+        GET_NODETYPE;
+        retval = writeArrayDimensionsAttribute(server, session, &node->variableNode,
+                                               type, wvalue->value.value.arrayLength,
+                                               (UA_UInt32 *)wvalue->value.value.data);
+        UA_NODESTORE_RELEASE(server, (const UA_Node*)type);
+        break;
+    case UA_ATTRIBUTEID_ACCESSLEVEL:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_ACCESSLEVEL);
+        CHECK_DATATYPE_SCALAR(BYTE);
+        node->variableNode.accessLevel = *(const UA_Byte*)value;
+        break;
+    case UA_ATTRIBUTEID_MINIMUMSAMPLINGINTERVAL:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_MINIMUMSAMPLINGINTERVAL);
+        CHECK_DATATYPE_SCALAR(DOUBLE);
+        node->variableNode.minimumSamplingInterval = *(const UA_Double*)value;
+        break;
+    case UA_ATTRIBUTEID_HISTORIZING:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_VARIABLE);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_HISTORIZING);
+        CHECK_DATATYPE_SCALAR(BOOLEAN);
+        node->variableNode.historizing = *(const UA_Boolean*)value;
+        break;
+    case UA_ATTRIBUTEID_EXECUTABLE:
+        CHECK_NODECLASS_WRITE(UA_NODECLASS_METHOD);
+        CHECK_USERWRITEMASK(UA_WRITEMASK_EXECUTABLE);
+        CHECK_DATATYPE_SCALAR(BOOLEAN);
+        node->methodNode.executable = *(const UA_Boolean*)value;
+        break;
+    default:
+        retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
+        break;
     }
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO_SESSION(&server->config.logger, session,
@@ -1625,14 +1622,16 @@ Operation_Write(UA_Server *server, UA_Session *session, void *context,
     UA_assert(session != NULL);
     *result = UA_Server_editNode(server, session, &wv->nodeId,
                                  (UA_EditNodeCallback)copyAttributeIntoNode,
-                                 (void *)(uintptr_t)wv);
+                                 (void*)(uintptr_t)wv);
 }
 
 void
-Service_Write(UA_Server *server, UA_Session *session, const UA_WriteRequest *request,
+Service_Write(UA_Server *server, UA_Session *session,
+              const UA_WriteRequest *request,
               UA_WriteResponse *response) {
     UA_assert(session != NULL);
-    UA_LOG_DEBUG_SESSION(&server->config.logger, session, "Processing WriteRequest");
+    UA_LOG_DEBUG_SESSION(&server->config.logger, session,
+                         "Processing WriteRequest");
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
     if(server->config.maxNodesPerWrite != 0 &&
@@ -1643,10 +1642,13 @@ Service_Write(UA_Server *server, UA_Session *session, const UA_WriteRequest *req
 
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
-    response->responseHeader.serviceResult = UA_Server_processServiceOperations(
-        server, session, (UA_ServiceOperation)Operation_Write, NULL,
-        &request->nodesToWriteSize, &UA_TYPES[UA_TYPES_WRITEVALUE],
-        &response->resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
+    response->responseHeader.serviceResult =
+        UA_Server_processServiceOperations(server, session,
+                                           (UA_ServiceOperation)Operation_Write, NULL,
+                                           &request->nodesToWriteSize,
+                                           &UA_TYPES[UA_TYPES_WRITEVALUE],
+                                           &response->resultsSize,
+                                           &UA_TYPES[UA_TYPES_STATUSCODE]);
 }
 
 UA_StatusCode
@@ -1661,20 +1663,20 @@ UA_Server_write(UA_Server *server, const UA_WriteValue *value) {
 /* Convenience function to be wrapped into inline functions */
 UA_StatusCode
 __UA_Server_write(UA_Server *server, const UA_NodeId *nodeId,
-                  const UA_AttributeId attributeId, const UA_DataType *attr_type,
-                  const void *attr) {
+                  const UA_AttributeId attributeId,
+                  const UA_DataType *attr_type, const void *attr) {
     UA_LOCK(&server->serviceMutex);
-    UA_StatusCode res = writeAttribute(server, &server->adminSession, nodeId, attributeId,
-                                       attr, attr_type);
+    UA_StatusCode res = writeAttribute(server, &server->adminSession,
+                                       nodeId, attributeId, attr, attr_type);
     UA_UNLOCK(&server->serviceMutex);
     return res;
 }
 
 /* Internal convenience function */
 UA_StatusCode
-writeAttribute(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId,
-               const UA_AttributeId attributeId, const void *attr,
-               const UA_DataType *attr_type) {
+writeAttribute(UA_Server *server, UA_Session *session,
+               const UA_NodeId *nodeId, const UA_AttributeId attributeId,
+               const void *attr, const UA_DataType *attr_type) {
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
     UA_WriteValue wvalue;
@@ -1683,12 +1685,13 @@ writeAttribute(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId,
     wvalue.attributeId = attributeId;
     wvalue.value.hasValue = true;
     if(attr_type == &UA_TYPES[UA_TYPES_VARIANT]) {
-        wvalue.value.value = *(const UA_Variant *)attr;
+        wvalue.value.value = *(const UA_Variant*)attr;
     } else if(attr_type == &UA_TYPES[UA_TYPES_DATAVALUE]) {
-        wvalue.value = *(const UA_DataValue *)attr;
+        wvalue.value = *(const UA_DataValue*)attr;
     } else {
         /* hacked cast. the target WriteValue is used as const anyway */
-        UA_Variant_setScalar(&wvalue.value.value, (void *)(uintptr_t)attr, attr_type);
+        UA_Variant_setScalar(&wvalue.value.value,
+                             (void*)(uintptr_t)attr, attr_type);
     }
 
     UA_StatusCode res = UA_STATUSCODE_GOOD;
@@ -1697,12 +1700,17 @@ writeAttribute(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId,
 }
 
 #ifdef UA_ENABLE_HISTORIZING
-typedef void (*UA_HistoryDatabase_readFunc)(
-    UA_Server *server, void *hdbContext, const UA_NodeId *sessionId, void *sessionContext,
-    const UA_RequestHeader *requestHeader, const void *historyReadDetails,
-    UA_TimestampsToReturn timestampsToReturn, UA_Boolean releaseContinuationPoints,
-    size_t nodesToReadSize, const UA_HistoryReadValueId *nodesToRead,
-    UA_HistoryReadResponse *response, void *const *const historyData);
+typedef void
+ (*UA_HistoryDatabase_readFunc)(UA_Server *server, void *hdbContext,
+                                const UA_NodeId *sessionId, void *sessionContext,
+                                const UA_RequestHeader *requestHeader,
+                                const void *historyReadDetails,
+                                UA_TimestampsToReturn timestampsToReturn,
+                                UA_Boolean releaseContinuationPoints,
+                                size_t nodesToReadSize,
+                                const UA_HistoryReadValueId *nodesToRead,
+                                UA_HistoryReadResponse *response,
+                                void * const * const historyData);
 
 void
 Service_HistoryRead(UA_Server *server, UA_Session *session,
@@ -1720,38 +1728,36 @@ Service_HistoryRead(UA_Server *server, UA_Session *session,
     UA_HistoryDatabase_readFunc readHistory = NULL;
     switch(request->historyReadDetails.content.decoded.type->typeIndex) {
         case UA_TYPES_READRAWMODIFIEDDETAILS: {
-            UA_ReadRawModifiedDetails *details =
-                (UA_ReadRawModifiedDetails *)
-                    request->historyReadDetails.content.decoded.data;
+            UA_ReadRawModifiedDetails *details = (UA_ReadRawModifiedDetails*)
+                request->historyReadDetails.content.decoded.data;
             if(!details->isReadModified) {
-                readHistory =
-                    (UA_HistoryDatabase_readFunc)server->config.historyDatabase.readRaw;
+                readHistory = (UA_HistoryDatabase_readFunc)
+                    server->config.historyDatabase.readRaw;
             } else {
                 historyDataType = &UA_TYPES[UA_TYPES_HISTORYMODIFIEDDATA];
                 readHistory = (UA_HistoryDatabase_readFunc)
-                                  server->config.historyDatabase.readModified;
+                    server->config.historyDatabase.readModified;
             }
             break;
         }
         case UA_TYPES_READEVENTDETAILS:
             historyDataType = &UA_TYPES[UA_TYPES_HISTORYEVENT];
-            readHistory =
-                (UA_HistoryDatabase_readFunc)server->config.historyDatabase.readEvent;
+            readHistory = (UA_HistoryDatabase_readFunc)
+                server->config.historyDatabase.readEvent;
             break;
         case UA_TYPES_READPROCESSEDDETAILS:
-            readHistory =
-                (UA_HistoryDatabase_readFunc)server->config.historyDatabase.readProcessed;
+            readHistory = (UA_HistoryDatabase_readFunc)
+                server->config.historyDatabase.readProcessed;
             break;
         case UA_TYPES_READATTIMEDETAILS:
-            readHistory =
-                (UA_HistoryDatabase_readFunc)server->config.historyDatabase.readAtTime;
+            readHistory = (UA_HistoryDatabase_readFunc)
+                server->config.historyDatabase.readAtTime;
             break;
     }
 
     if(!readHistory) {
         /* TODO handle more request->historyReadDetails.content.decoded.type types */
-        response->responseHeader.serviceResult =
-            UA_STATUSCODE_BADHISTORYOPERATIONUNSUPPORTED;
+        response->responseHeader.serviceResult = UA_STATUSCODE_BADHISTORYOPERATIONUNSUPPORTED;
         return;
     }
 
@@ -1770,15 +1776,16 @@ Service_HistoryRead(UA_Server *server, UA_Session *session,
 
     /* Allocate a temporary array to forward the result pointers to the
      * backend */
-    void **historyData = (void **)UA_calloc(request->nodesToReadSize, sizeof(void *));
+    void **historyData = (void **)
+        UA_calloc(request->nodesToReadSize, sizeof(void*));
     if(!historyData) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return;
     }
 
     /* Allocate the results array */
-    response->results = (UA_HistoryReadResult *)UA_Array_new(
-        request->nodesToReadSize, &UA_TYPES[UA_TYPES_HISTORYREADRESULT]);
+    response->results = (UA_HistoryReadResult*)
+        UA_Array_new(request->nodesToReadSize, &UA_TYPES[UA_TYPES_HISTORYREADRESULT]);
     if(!response->results) {
         UA_free(historyData);
         response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -1787,31 +1794,34 @@ Service_HistoryRead(UA_Server *server, UA_Session *session,
     response->resultsSize = request->nodesToReadSize;
 
     for(size_t i = 0; i < response->resultsSize; ++i) {
-        void *data = UA_new(historyDataType);
-        UA_ExtensionObject_setValue(&response->results[i].historyData, data,
-                                    historyDataType);
+        void * data = UA_new(historyDataType);
+        UA_ExtensionObject_setValue(&response->results[i].historyData,
+                                    data, historyDataType);
         historyData[i] = data;
     }
     UA_UNLOCK(&server->serviceMutex);
-    readHistory(server, server->config.historyDatabase.context, &session->sessionId,
-                session->sessionHandle, &request->requestHeader,
+    readHistory(server, server->config.historyDatabase.context,
+                &session->sessionId, session->sessionHandle,
+                &request->requestHeader,
                 request->historyReadDetails.content.decoded.data,
-                request->timestampsToReturn, request->releaseContinuationPoints,
-                request->nodesToReadSize, request->nodesToRead, response, historyData);
+                request->timestampsToReturn,
+                request->releaseContinuationPoints,
+                request->nodesToReadSize, request->nodesToRead,
+                response, historyData);
     UA_LOCK(&server->serviceMutex);
     UA_free(historyData);
 }
 
 void
 Service_HistoryUpdate(UA_Server *server, UA_Session *session,
-                      const UA_HistoryUpdateRequest *request,
-                      UA_HistoryUpdateResponse *response) {
+                    const UA_HistoryUpdateRequest *request,
+                    UA_HistoryUpdateResponse *response) {
     UA_assert(session != NULL);
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
     response->resultsSize = request->historyUpdateDetailsSize;
-    response->results = (UA_HistoryUpdateResult *)UA_Array_new(
-        response->resultsSize, &UA_TYPES[UA_TYPES_HISTORYUPDATERESULT]);
+    response->results = (UA_HistoryUpdateResult*)
+        UA_Array_new(response->resultsSize, &UA_TYPES[UA_TYPES_HISTORYUPDATERESULT]);
     if(!response->results) {
         response->resultsSize = 0;
         response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -1835,10 +1845,12 @@ Service_HistoryUpdate(UA_Server *server, UA_Session *session,
                 continue;
             }
             UA_UNLOCK(&server->serviceMutex);
-            server->config.historyDatabase.updateData(
-                server, server->config.historyDatabase.context, &session->sessionId,
-                session->sessionHandle, &request->requestHeader,
-                (UA_UpdateDataDetails *)updateDetailsData, &response->results[i]);
+            server->config.historyDatabase.
+                updateData(server, server->config.historyDatabase.context,
+                           &session->sessionId, session->sessionHandle,
+                           &request->requestHeader,
+                           (UA_UpdateDataDetails*)updateDetailsData,
+                           &response->results[i]);
             UA_LOCK(&server->serviceMutex);
             continue;
         }
@@ -1849,10 +1861,12 @@ Service_HistoryUpdate(UA_Server *server, UA_Session *session,
                 continue;
             }
             UA_UNLOCK(&server->serviceMutex);
-            server->config.historyDatabase.deleteRawModified(
-                server, server->config.historyDatabase.context, &session->sessionId,
-                session->sessionHandle, &request->requestHeader,
-                (UA_DeleteRawModifiedDetails *)updateDetailsData, &response->results[i]);
+            server->config.historyDatabase.
+                deleteRawModified(server, server->config.historyDatabase.context,
+                                  &session->sessionId, session->sessionHandle,
+                                  &request->requestHeader,
+                                  (UA_DeleteRawModifiedDetails*)updateDetailsData,
+                                  &response->results[i]);
             UA_LOCK(&server->serviceMutex);
             continue;
         }
@@ -1875,7 +1889,8 @@ UA_Server_writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
 
 UA_StatusCode
 writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
-                    const UA_QualifiedName propertyName, const UA_Variant value) {
+                    const UA_QualifiedName propertyName,
+                    const UA_Variant value) {
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
     UA_RelativePathElement rpe;
     UA_RelativePathElement_init(&rpe);
@@ -1911,7 +1926,7 @@ UA_Server_writeObjectProperty_scalar(UA_Server *server, const UA_NodeId objectId
                                      const void *value, const UA_DataType *type) {
     UA_Variant var;
     UA_Variant_init(&var);
-    UA_Variant_setScalar(&var, (void *)(uintptr_t)value, type);
+    UA_Variant_setScalar(&var, (void*)(uintptr_t)value, type);
     UA_LOCK(&server->serviceMutex);
     UA_StatusCode retval = writeObjectProperty(server, objectId, propertyName, var);
     UA_UNLOCK(&server->serviceMutex);

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -2271,6 +2271,34 @@ UA_Server_setVariableNode_dataSource(UA_Server *server, const UA_NodeId nodeId,
     return retval;
 }
 
+static UA_StatusCode
+setAccessLevelCallback(UA_Server *server, UA_Session *session, UA_VariableNode *node,
+              UA_AccessLevelCallback* accessLevelCallback) {
+    if(node->head.nodeClass != UA_NODECLASS_VARIABLE)
+        return UA_STATUSCODE_BADNODECLASSINVALID;
+    node->accessLevelCallback = *accessLevelCallback;
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+setVariableNode_accessLevelCallback(UA_Server *server, const UA_NodeId nodeId,
+                           const UA_AccessLevelCallback accessLevelCallback) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+    return UA_Server_editNode(
+        server, &server->adminSession, &nodeId, (UA_EditNodeCallback)setAccessLevelCallback, (UA_AccessLevelCallback*)(uintptr_t)&accessLevelCallback);
+}
+
+UA_StatusCode
+UA_Server_setVariableNode_accessLevelCallback(
+    UA_Server *server, const UA_NodeId nodeId,
+    const UA_AccessLevelCallback accessLevelCallback)
+{
+    UA_LOCK(&server->serviceMutex);
+    UA_StatusCode retval = setVariableNode_accessLevelCallback(server, nodeId, accessLevelCallback);
+    UA_UNLOCK(&server->serviceMutex);
+    return retval;
+}
+
 /******************************/
 /* Set External Value Source  */
 /******************************/


### PR DESCRIPTION
In some situations the write access to a variable node is not possible, e.g. the backend is not connected or device is in a state where change of a certain variable is not possible. For such use cases a callback could be provided, which calculates the accessLevel.

Todos:
add tests
same callback should be possible for the executable flag for methods
Move accessLevel and Callback in an union type