### PR TITLE
fix(core): Fix clash between beeafc02e9f98c52f0dee2364620f5c3527da5db…

### DIFF
--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -34,6 +34,8 @@
 # include <malloc.h>
 #endif
 
+#include <open62541/architecture_definitions.h>
+
 #include <stdio.h>
 #include <errno.h>
 #include <winsock2.h>


### PR DESCRIPTION
Fix build error in MSVC due to non-defined UA_INLINE and UA_assert macros.
Fix clash between the two following commits:
* beeafc02e9f98c52f0dee2364620f5c3527da5db, adding function using UA_INLINE and UA_assert macros.
* 7d1d21a88ca1a89ae7bddc4e64c2c52330fdf6ff removing #include <open62541/architecture_base.h>, needed to use UA_INLINE and UA_assert.
Since open62541/architecture_base.h was definitely removed, open62541/architecture_definitions.h was included instead.