### PR TITLE
Backport support of encryption in debian packages

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -10,7 +10,8 @@ Build-Depends: debhelper (>= 9),
  texlive-fonts-recommended,
  texlive-latex-extra,
  texlive-plain-generic | texlive-generic-extra,
- latexmk
+ latexmk,
+ libmbedtls-dev
 Standards-Version: 4.4.1
 Section: libs
 Homepage: https://open62541.org/

--- a/debian/rules-template
+++ b/debian/rules-template
@@ -5,7 +5,7 @@ export DH_VERBOSE = 1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-pie
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL -DUA_ENABLE_AMALGAMATION=OFF -DUA_PACK_DEBIAN=ON
+	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL -DUA_ENABLE_ENCRYPTION=ON -DUA_ENABLE_AMALGAMATION=OFF -DUA_PACK_DEBIAN=ON
 
 override_dh_auto_test:
 	dh_auto_test -- ARGS+=--output-on-failure


### PR DESCRIPTION
This PR extends the packaging configurations to enable the use of stable (1.1) debian packages togetehr with mbedtls based encryption support.