### PR TITLE
fix(arch): Fix architecture definitions for Embarcadero C++Builder clang/win32

### DIFF
--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -124,7 +124,7 @@ void UA_sleep_ms(unsigned long ms);
 # define UA_realloc realloc
 #endif
 
-#ifdef(__CODEGEARC__)
+#ifdef __CODEGEARC__
 #define _snprintf_s(a,b,c,...) snprintf(a,b,__VA_ARGS__)
 #endif
 

--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -124,6 +124,10 @@ void UA_sleep_ms(unsigned long ms);
 # define UA_realloc realloc
 #endif
 
+#ifdef(__CODEGEARC__)
+#define _snprintf_s(a,b,c,...) snprintf(a,b,__VA_ARGS__)
+#endif
+
 /* 3rd Argument is the string */
 #define UA_snprintf(source, size, ...) _snprintf_s(source, size, _TRUNCATE, __VA_ARGS__)
 #define UA_strncasecmp _strnicmp

--- a/arch/win32/ua_clock.c
+++ b/arch/win32/ua_clock.c
@@ -46,7 +46,7 @@ UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
     time_t gmt, rawtime = time(NULL);
 
     struct tm ptm;
-    gmtime_s(&ptm, &rawtime);
+    gmtime_s(&rawtime, &ptm);
     // Request that mktime() looksup dst in timezone database
     ptm.tm_isdst = -1;
     gmt = mktime(&ptm);

--- a/arch/win32/ua_clock.c
+++ b/arch/win32/ua_clock.c
@@ -46,7 +46,11 @@ UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
     time_t gmt, rawtime = time(NULL);
 
     struct tm ptm;
+#ifdef __CODEGEARC__
     gmtime_s(&rawtime, &ptm);
+#else
+    gmtime_s(&ptm, &rawtime);
+#endif    
     // Request that mktime() looksup dst in timezone database
     ptm.tm_isdst = -1;
     gmt = mktime(&ptm);

--- a/include/open62541/architecture_definitions.h
+++ b/include/open62541/architecture_definitions.h
@@ -191,6 +191,8 @@ extern void * (*UA_reallocSingleton)(void *ptr, size_t size);
 # define UA_RESTRICT __restrict
 #elif defined(__GNUC__)
 # define UA_RESTRICT __restrict__
+#elif defined(__CODEGEARC__)
+# define UA_RESTRICT _RESTRICT
 #else
 # define UA_RESTRICT restrict
 #endif


### PR DESCRIPTION
Embarcadero C++Builder 10.4 (clang 5.0 / win32) has a few incompatibilities in its standard library, which prevents building Open62541 on this compiler.

I would like to suggest two small additions to the architecture definition files to fix build on this compiler. The changes do not break existing behavior and are guarded by `#ifdef __CODEGEARC__` to only become active for this compiler.

I would also like to add a fix for a bug in the gmtime_s() call in the arch/win32/ua_clock.c file - the call uses the wrong parameter order.