### PR TITLE
fix(server): Add decrement for monitoredItemSize when deleting monitoredItem

### DIFF
--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -649,6 +649,9 @@ Operation_DeleteMonitoredItem(UA_Server *server, UA_Session *session, UA_Subscri
         *result = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
         return;
     }
+	
+    mon->subscription->monitoredItemsSize--;
+    server->numMonitoredItems--;
     UA_MonitoredItem_delete(server, mon);
 }
 


### PR DESCRIPTION
having a limited monitoredItemSize leads to a problem when removing monitoredItems without deleting the subscribtion. No further monitoredItems can be added because the server doesn't decrement the stored monitoredItemsSize on monitoredItemDelete. However, deleting the subscribtion sets monitoredItemsSize to 0 again.
This bug is found by running the OPC UA CTT on a server with limited maxMonitoredItemsPerSubscription.