### PR TITLE
Fix(ci) for ubuntu20.04

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   standard:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -12,7 +12,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install -y -qq python-sphinx graphviz check
+        sudo apt install -y -qq python3-sphinx graphviz check
         sudo apt install -y -qq tcc clang-10 clang++-10 clang-tools-10 valgrind
         sudo apt install -y -qq libmbedtls-dev openssl
     - name: Debug Build & Unit Tests (gcc)

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -11,14 +11,14 @@ jobs:
         submodules: true
     - name: Install Dependencies
       run: |
-        sudo apt update
-        sudo apt install -y -qq python3-sphinx graphviz check
-        sudo apt install -y -qq tcc clang-10 clang++-10 clang-tools-10 valgrind
-        sudo apt install -y -qq libmbedtls-dev openssl
+        sudo apt-get update
+        sudo apt-get install -y -qq python3-sphinx graphviz check
+        sudo apt-get install -y -qq tcc clang-11 clang-tools-11 valgrind
+        sudo apt-get install -y -qq libmbedtls-dev openssl
     - name: Debug Build & Unit Tests (gcc)
       run: source tools/ci.sh && unit_tests
     - name: Debug Build & Unit Tests (clang)
-      run: source tools/ci.sh && CC=clang-10 CXX=clang++-10 unit_tests
+      run: source tools/ci.sh && CC=clang-11 CXX=clang++-11 unit_tests
     - name: Debug Build & Unit Tests (tcc)
       run: source tools/ci.sh && CC=tcc unit_tests
     - name: Encryption (MbedTLS) Build & Unit Tests (gcc)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -134,7 +134,7 @@ function unit_tests_valgrind {
 
 function build_clang_analyzer {
     mkdir -p build; cd build; rm -rf *
-    scan-build-10 cmake -DCMAKE_BUILD_TYPE=Debug \
+    scan-build-11 cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
           -DUA_ENABLE_DISCOVERY=ON \
@@ -147,5 +147,5 @@ function build_clang_analyzer {
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           ..
-    scan-build-10 make ${MAKEOPTS}
+    scan-build-11 make ${MAKEOPTS}
 }


### PR DESCRIPTION
Update to ubuntu 20.04 for github actions (latest)
As python2-sphinx and clang++-10 is no longer available, I used python3 and clang-11

The exact version for ubuntu is set, as latest is sometimes ubuntu18.04 and sometimes ubuntu20.04 depending on the repository.

PS: Should the 1.2 branch stay on ubuntu18.04? If not, I can move this to 1.2.