### PR TITLE
[REVIEW] Locale ids support in the server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 This changelog reports changes visible through the public API. Internal refactorings and bug
 fixes are not reported here.
 
+2022-07-14 Jannis Voelker <jannis.voelker at basyskom.com>
+
+ * LocaleId support in the server
+
+   The server now supports that descriptions and display names for
+   different locales are written to a node. The server selects a
+   suitable localization depending on the locale ids that are set for
+   the current session.
+
+   Locales are added simply by writing a LocalizedText value with a
+   different locale. A locale can be removed by writing a
+   LocalizedText value of the corresponding locale and with an empty
+   text.
+
+   The change was done with pull request #4165.
+
 2022-07-07 Andreas Eckerstorfer <estr at keba.com>
 
  * PubSub publisher id types

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -402,8 +402,17 @@ struct UA_NodeHead {
     UA_NodeId nodeId;
     UA_NodeClass nodeClass;
     UA_QualifiedName browseName;
+
+    /* A node can have different localizations for displayName and description.
+     * The server selects a suitable localization depending on the locale ids
+     * that are set for the current session.
+     *
+     * Locales are added simply by writing a LocalizedText value with a new
+     * locale. A locale can be removed by writing a LocalizedText value of the
+     * corresponding locale with an empty text field. */
     UA_LocalizedTextListEntry *displayName;
     UA_LocalizedTextListEntry *description;
+
     UA_UInt32 writeMask;
     size_t referencesSize;
     UA_NodeReferenceKind *references;

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -391,13 +391,19 @@ UA_NodeReferenceKind_findTarget(const UA_NodeReferenceKind *rk,
 UA_EXPORT UA_StatusCode
 UA_NodeReferenceKind_switch(UA_NodeReferenceKind *rk);
 
+/* Singly-linked LocalizedText list */
+typedef struct UA_LocalizedTextListEntry {
+    struct UA_LocalizedTextListEntry *next;
+    UA_LocalizedText localizedText;
+} UA_LocalizedTextListEntry;
+
 /* Every Node starts with these attributes */
 struct UA_NodeHead {
     UA_NodeId nodeId;
     UA_NodeClass nodeClass;
     UA_QualifiedName browseName;
-    UA_LocalizedText displayName;
-    UA_LocalizedText description;
+    UA_LocalizedTextListEntry *displayName;
+    UA_LocalizedTextListEntry *description;
     UA_UInt32 writeMask;
     size_t referencesSize;
     UA_NodeReferenceKind *references;

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -488,36 +488,52 @@ UA_Server_removeCallback(UA_Server *server, UA_UInt64 callbackId);
 UA_EXPORT UA_StatusCode UA_THREADSAFE
 UA_Server_closeSession(UA_Server *server, const UA_NodeId *sessionId);
 
-/* Session Parameters: Besides the user-definable session context pointer,
- * so-called session parameters are a way to attach key-value parameters to a
- * session. This enables "plugins" to attach data to a session without impacting
- * the user-definedable session context pointer. */
+/**
+ * Session attributes: Besides the user-definable session context pointer (set
+ * by the AccessControl plugin when the Session is created), a session carries
+ * attributes in a key-value list. Some attributes are present in every session
+ * and shown in the list below. Additional attributes can be manually set as
+ * meta-data.
+ *
+ * Always present as session attributes are:
+ *
+ * - 0:localeIds [UA_String]: List of preferred languages (read-only)
+ * - 0:clientDescription [UA_ApplicationDescription]: Client description (read-only)
+ * - 0:sessionName [String] Client-defined name of the session (read-only)
+ */
 
+/* Returns a shallow copy of the attribute. Don't _clear or _delete the value
+ * variant. Don't use the value once the Session could be already closed in the
+ * background or the attribute of the session replaced. Hence don't use this in a
+ * multi-threaded application. */
+UA_EXPORT UA_StatusCode
+UA_Server_getSessionAttribute(UA_Server *server, const UA_NodeId *sessionId,
+                              const UA_QualifiedName key, UA_Variant *outValue);
+
+/* Return a deep copy of the attribute */
 UA_EXPORT UA_StatusCode UA_THREADSAFE
-UA_Server_setSessionParameter(UA_Server *server, const UA_NodeId *sessionId,
-                              const UA_QualifiedName key,
-                              const UA_Variant *value);
-
-UA_EXPORT void UA_THREADSAFE
-UA_Server_deleteSessionParameter(UA_Server *server, const UA_NodeId *sessionId,
-                                 const UA_QualifiedName key);
-
-/* Returns NULL if the session or the parameter are not defined. Returns a deep
- * copy otherwise */
-UA_EXPORT UA_StatusCode UA_THREADSAFE
-UA_Server_getSessionParameter(UA_Server *server, const UA_NodeId *sessionId,
-                              const UA_QualifiedName key,
-                              UA_Variant *outValue);
+UA_Server_getSessionAttributeCopy(UA_Server *server, const UA_NodeId *sessionId,
+                                  const UA_QualifiedName key, UA_Variant *outValue);
 
 /* Returns NULL if the parameter is not defined or not a scalar or not of the
- * right datatype. Otherwise a deep copy of the scalar value is filled at the
- * target location of the void pointer. */
-UA_EXPORT UA_StatusCode UA_THREADSAFE
-UA_Server_getSessionParameter_scalar(UA_Server *server,
+ * right datatype. Otherwise a shallow copy of the scalar value is created at
+ * the target location of the void pointer. Hence don't use this in a
+ * multi-threaded application. */
+UA_EXPORT UA_StatusCode
+UA_Server_getSessionAttribute_scalar(UA_Server *server,
                                      const UA_NodeId *sessionId,
                                      const UA_QualifiedName key,
                                      const UA_DataType *type,
                                      void *outValue);
+
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_setSessionAttribute(UA_Server *server, const UA_NodeId *sessionId,
+                              const UA_QualifiedName key,
+                              const UA_Variant *value);
+
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_deleteSessionAttribute(UA_Server *server, const UA_NodeId *sessionId,
+                                 const UA_QualifiedName key);
 
 /**
  * Reading and Writing Node Attributes

--- a/include/open62541/util.h
+++ b/include/open62541/util.h
@@ -64,7 +64,7 @@ UA_KeyValueMap_getScalar(const UA_KeyValuePair *map, size_t mapSize,
                          const UA_DataType *type);
 
 /* Remove a single entry. To delete the entire map, use UA_Array_delete. */
-UA_EXPORT void
+UA_EXPORT UA_StatusCode
 UA_KeyValueMap_delete(UA_KeyValuePair **map, size_t *mapSize,
                       const UA_QualifiedName key);
 

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -720,6 +720,25 @@ UA_NODESTORE_GETFROMREF(UA_Server *server, UA_NodePointer target) {
     server->config.nodestore.getReferenceTypeId(server->config.nodestore.context, \
                                                 index)
 
+/* Handling of Locales */
+
+/* Returns a shallow copy */
+UA_LocalizedText
+UA_Session_getNodeDisplayName(const UA_Session *session,
+                              const UA_NodeHead *head);
+
+UA_LocalizedText
+UA_Session_getNodeDescription(const UA_Session *session,
+                              const UA_NodeHead *head);
+
+UA_StatusCode
+UA_Node_insertOrUpdateDisplayName(UA_NodeHead *head,
+                                  const UA_LocalizedText *value);
+
+UA_StatusCode
+UA_Node_insertOrUpdateDescription(UA_NodeHead *head,
+                                  const UA_LocalizedText *value);
+
 _UA_END_DECLS
 
 #endif /* UA_SERVER_INTERNAL_H_ */

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -171,6 +171,9 @@ UA_Server_getSessionById(UA_Server *server, const UA_NodeId *sessionId) {
         return &current->session;
     }
 
+    if(UA_NodeId_equal(sessionId, &server->adminSession.sessionId))
+        return &server->adminSession;
+
     return NULL;
 }
 

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -834,19 +834,26 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
     }
 
     /* Set the locale */
-    response->responseHeader.serviceResult |=
-        UA_Array_copy(request->localeIds, request->localeIdsSize,
-                      (void**)&tmpLocaleIds, &UA_TYPES[UA_TYPES_STRING]);
-    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-        UA_Session_detachFromSecureChannel(session);
-        UA_LOG_WARNING_SESSION(&server->config.logger, session,
-                               "ActivateSession: Could not store the Session LocaleIds");
-        goto rejected;
+
+    /* Part 4, §5.6.3.2: This parameter only needs to be specified during the first call to
+     * ActivateSession during a single application Session. If it is not specified the
+     * Server shall keep using the current localeIds for the Session.
+    */
+    if(request->localeIdsSize > 0) {
+        response->responseHeader.serviceResult |=
+            UA_Array_copy(request->localeIds, request->localeIdsSize,
+                          (void**)&tmpLocaleIds, &UA_TYPES[UA_TYPES_STRING]);
+        if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+            UA_Session_detachFromSecureChannel(session);
+            UA_LOG_WARNING_SESSION(&server->config.logger, session,
+                                   "ActivateSession: Could not store the Session LocaleIds");
+            goto rejected;
+        }
+        UA_Array_delete(session->localeIds, session->localeIdsSize,
+                        &UA_TYPES[UA_TYPES_STRING]);
+        session->localeIds = tmpLocaleIds;
+        session->localeIdsSize = request->localeIdsSize;
     }
-    UA_Array_delete(session->localeIds, session->localeIdsSize,
-                    &UA_TYPES[UA_TYPES_STRING]);
-    session->localeIds = tmpLocaleIds;
-    session->localeIdsSize = request->localeIdsSize;
 
     UA_Session_updateLifetime(session);
 

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -51,8 +51,8 @@ typedef struct {
     UA_UInt16         availableContinuationPoints;
     ContinuationPoint *continuationPoints;
 
-    size_t paramsSize;
-    UA_KeyValuePair *params;
+    size_t attributesSize;
+    UA_KeyValuePair *attributes;
 
     /* Localization information */
     size_t localeIdsSize;

--- a/src/ua_util.c
+++ b/src/ua_util.c
@@ -275,7 +275,7 @@ UA_KeyValueMap_getScalar(const UA_KeyValuePair *map, size_t mapSize,
     return v->data;
 }
 
-void
+UA_StatusCode
 UA_KeyValueMap_delete(UA_KeyValuePair **map, size_t *mapSize,
                       const UA_QualifiedName key) {
     UA_KeyValuePair *m = *map;
@@ -301,6 +301,7 @@ UA_KeyValueMap_delete(UA_KeyValuePair **map, size_t *mapSize,
                            * array around. Resize never fails when reducing
                            * the size to zero. Reduce the size integer in
                            * any case. */
-        break;
+        return UA_STATUSCODE_GOOD;
     }
+    return UA_STATUSCODE_BADNOTFOUND;
 }

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -384,14 +384,25 @@ START_TEST(Client_activateSessionLocaleIds) {
     UA_ClientConfig *config = UA_Client_getConfig(client);
     UA_ClientConfig_setDefault(config);
 
-    config->sessionLocaleIdsSize = 1;
-    config->sessionLocaleIds = (UA_LocaleId*)UA_Array_new(1, &UA_TYPES[UA_TYPES_LOCALEID]);
+    config->sessionLocaleIdsSize = 2;
+    config->sessionLocaleIds = (UA_LocaleId*)UA_Array_new(2, &UA_TYPES[UA_TYPES_LOCALEID]);
     config->sessionLocaleIds[0] = UA_STRING_ALLOC("en");
+    config->sessionLocaleIds[1] = UA_STRING_ALLOC("fr");
 
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     ck_assert_uint_eq(server->sessionCount, 1);
+
+    UA_QualifiedName key = {0, UA_STRING_STATIC("localeIds")};
+    UA_Variant locales;
+    UA_Server_getSessionAttribute(server, &server->sessions.lh_first->session.sessionId,
+                                  key, &locales);
+
+    ck_assert_uint_eq(locales.arrayLength, 2);
+    UA_String *localeIds = (UA_String*)locales.data;
+    ck_assert(UA_String_equal(&localeIds[0], &config->sessionLocaleIds[0]));
+    ck_assert(UA_String_equal(&localeIds[1], &config->sessionLocaleIds[1]));
 
     UA_Client_delete(client);
 

--- a/tests/server/check_server_alarmsconditions.c
+++ b/tests/server/check_server_alarmsconditions.c
@@ -104,12 +104,14 @@ START_TEST(splitCreation) {
     UA_Variant_init(&enabledStateVariant);
     retval = UA_Server_readValue(server_ac, var, &enabledStateVariant);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_msg(UA_Variant_hasScalarType(
-        &enabledStateVariant,
-        &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]),
+    ck_assert_msg(UA_Variant_hasScalarType(&enabledStateVariant, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]),
         "Unexpected Data Type of EnabledState");
+
     const UA_LocalizedText* enabledState = (UA_LocalizedText*)enabledStateVariant.data;
-    ck_assert_str_eq((const char*)enabledState->text.data, "Disabled");
+    UA_String disabledStr = UA_STRING("Disabled");
+    ck_assert(UA_String_equal(&enabledState->text, &disabledStr));
+
+    UA_Variant_clear(&enabledStateVariant);
 
     retval = UA_Server_deleteCondition(
         server_ac,

--- a/tests/server/check_services_view.c
+++ b/tests/server/check_services_view.c
@@ -303,6 +303,70 @@ START_TEST(Service_Browse_Recursive) {
 }
 END_TEST
 
+START_TEST(Service_Browse_Localization) {
+    UA_Server *server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+
+    UA_NodeId outerObjectId = UA_NODEID_STRING(1, "EntryPoint");
+
+    {
+        UA_ObjectAttributes attr = UA_ObjectAttributes_default;
+        attr.displayName = UA_LOCALIZEDTEXT("en-US", "EntryPoint");
+        UA_QualifiedName browseName = UA_QUALIFIEDNAME(0, "EntryPoint");
+        UA_StatusCode result = UA_Server_addObjectNode(server, outerObjectId, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                                       UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), browseName,
+                                                       UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE), attr, NULL, NULL);
+        ck_assert_int_eq(result, UA_STATUSCODE_GOOD);
+    }
+
+    UA_ObjectAttributes attr = UA_ObjectAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "MyDisplayName");
+    UA_NodeId objectId = UA_NODEID_STRING(1, "LocalizedObject");
+    UA_QualifiedName browseName = UA_QUALIFIEDNAME(0, "LocalizedObject");
+    UA_StatusCode result = UA_Server_addObjectNode(server, objectId, outerObjectId,
+                                                   UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), browseName,
+                                                   UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE), attr, NULL, NULL);
+    ck_assert_int_eq(result, UA_STATUSCODE_GOOD);
+
+    UA_LocalizedText germanDisplayName = UA_LOCALIZEDTEXT("de-DE", "MeinAnzeigeName");
+    result = UA_Server_writeDisplayName(server, objectId, germanDisplayName);
+    ck_assert_int_eq(result, UA_STATUSCODE_GOOD);
+
+    UA_BrowseDescription bd;
+    UA_BrowseDescription_init(&bd);
+    bd.nodeId = outerObjectId;
+    bd.resultMask = UA_BROWSERESULTMASK_ALL;
+    bd.nodeClassMask = UA_NODECLASS_OBJECT;
+    bd.browseDirection = UA_BROWSEDIRECTION_FORWARD;
+    bd.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
+
+    /* Expect the english display name */
+    server->adminSession.localeIdsSize = 1;
+    server->adminSession.localeIds = UA_LocaleId_new();
+    *server->adminSession.localeIds = UA_STRING_ALLOC("en-US");
+
+    UA_BrowseResult br = UA_Server_browse(server, 100, &bd);
+    ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(br.referencesSize, 1);
+    ck_assert(UA_String_equal(&br.references->displayName.locale, &attr.displayName.locale));
+    ck_assert(UA_String_equal(&br.references->displayName.text, &attr.displayName.text));
+    UA_BrowseResult_clear(&br);
+
+    /* Expect the german display name */
+    UA_LocaleId_clear(server->adminSession.localeIds);
+    *server->adminSession.localeIds = UA_STRING_ALLOC("de-DE");
+
+    br = UA_Server_browse(server, 100, &bd);
+    ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(br.referencesSize, 1);
+    ck_assert(UA_String_equal(&br.references->displayName.locale, &germanDisplayName.locale));
+    ck_assert(UA_String_equal(&br.references->displayName.text, &germanDisplayName.text));
+    UA_BrowseResult_clear(&br);
+
+    UA_Server_delete(server);
+}
+END_TEST
+
 START_TEST(Service_TranslateBrowsePathsToNodeIds) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));
@@ -440,6 +504,7 @@ static Suite *testSuite_Service_TranslateBrowsePathsToNodeIds(void) {
     tcase_add_test(tc_browse, Service_Browse_ReferenceTypes);
     tcase_add_test(tc_browse, Service_Browse_WithMaxResults);
     tcase_add_test(tc_browse, Service_Browse_Recursive);
+    tcase_add_test(tc_browse, Service_Browse_Localization);
     suite_add_tcase(s, tc_browse);
 
     TCase *tc_translate = tcase_create("TranslateBrowsePathsToNodeIds");
@@ -450,6 +515,7 @@ static Suite *testSuite_Service_TranslateBrowsePathsToNodeIds(void) {
     tcase_add_test(tc_translate, BrowseSimplifiedBrowsePath);
 
     suite_add_tcase(s, tc_translate);
+
     return s;
 }
 


### PR DESCRIPTION
This is a first start at supporting locale IDs
- The locale IDs from ActivateSession are stored in the UA_Session
- The server is extended with a getter for the locale IDs of a session

The client-side support has been cherry-picked from #4153.

This should be sufficient for the Value attribute of custom Variable nodes.
The BrowseName and Description attributes still need a different solution. I see the following options:
- The user can pass an array or map for both attributes instead of the scalar UA_LocalizedText and the server does the selection according to Part 4, 5.6.3.2
- Additional, optional callbacks for reading BrowseName and Description

I would prefer the second solution because this can be realized with less memory footprint (no need to duplicate values for nodes with the same display name or description).