### PR TITLE
Update tutorial_pubsub_mqtt.c

### DIFF
--- a/examples/pubsub/tutorial_pubsub_mqtt.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt.c
@@ -178,7 +178,7 @@ addWriterGroup(UA_Server *server) {
     UA_ExtensionObject transportSettings;
     memset(&transportSettings, 0, sizeof(UA_ExtensionObject));
     transportSettings.encoding = UA_EXTENSIONOBJECT_DECODED;
-    transportSettings.content.decoded.type = &UA_TYPES[UA_TYPES_BROKERWRITERGROUPTRANSPORTDATATYPE];
+    transportSettings.content.decoded.type = &UA_TYPES[UA_TYPES_BROKERDATASETREADERTRANSPORTDATATYPE];
     transportSettings.content.decoded.data = &brokerTransportSettings;
     
     writerGroupConfig.transportSettings = transportSettings;


### PR DESCRIPTION
based on the condition checked in open62541.h line 89311 function name: UA_PubSubChannelMQTT_regist(), it is comparing transportSettings->content.decoded.type->typeIndex == UA_TYPES_BROKERDATASETREADERTRANSPORTDATATYPE); however the sample code initialise decoded.type wrongly.

After making the above change, i can now subscribe to the json message on the MQTT broker successfully.