### PR TITLE
fix(server): Keep Server Namespaces Object

### DIFF
--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -1014,7 +1014,6 @@ UA_Server_initNS0(UA_Server *server) {
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DICTIONARIES), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_ESTIMATEDRETURNTIME), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME), true);
-    UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_NAMESPACES), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_REQUESTSERVERSTATECHANGE), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_RESENDDATA), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVERCONFIGURATION), true);


### PR DESCRIPTION
After bdb233e810a7c9f5187c2e53f0 several nodes are always removed, so the "FULL" Namespac 0 is no longer full and loading companion specifications complies about missing parent:
e.g. from here: https://github.com/umati/Sample-Server/pull/129/checks?check_run_id=2093072456#step:6:25
```c++
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=3;i=15001): Parent node not found
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=3;i=15001): The parent reference for is invalid
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=4;i=5008): Parent node not found
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=4;i=5008): The parent reference for is invalid
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=5;i=5001): Parent node not found
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=5;i=5001): The parent reference for is invalid
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=6;i=120): Parent node not found
[2021-03-12 07:45:03.878 (UTC+0000)] info/session	SecureChannel 0 | Session g=00000001-0000-0000-0000-000000000000 | AddNode (ns=6;i=120): The parent reference for is invalid
```

There are several other nodes removed: We may need to consider to keep them also:
https://github.com/open62541/open62541/commit/bdb233e810a7c9f5187c2e53f021c71abdefba80#diff-78df7143ea0c91caf7c6e0969cd003ad1265cbdb359a2fa529228c5263734dfe