### PR TITLE
feat(server): Add modellingRulesOnInstances option, to omit HasModellingRule references in created instances

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -150,6 +150,16 @@ struct UA_ServerConfig {
     /* Node Lifecycle callbacks */
     UA_GlobalNodeLifecycle nodeLifecycle;
 
+    /** Copy the HasModellingRule reference in instances from the type
+     * definition in UA_Server_addObjectNode and UA_Server_addVariableNode.
+     * Part 3 - 6.4.4
+     * https://reference.opcfoundation.org/v104/Core/docs/Part3/6.4.4/#6.4.4.4
+     *   [...] it is not required that newly created or referenced instances
+     *   based on InstanceDeclarations have a ModellingRule, however, it is
+     *   allowed that they have any ModellingRule independent of the
+     *   ModellingRule of their InstanceDeclaration */
+    UA_Boolean modellingRulesOnInstances;
+
     /**
      * .. note:: See the section for :ref:`node lifecycle
      *    handling<node-lifecycle>`. */

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -191,6 +191,7 @@ setDefaultConfig(UA_ServerConfig *conf) {
     /* conf->nodeLifecycle.destructor = NULL; */
     /* conf->nodeLifecycle.createOptionalChild = NULL; */
     /* conf->nodeLifecycle.generateChildNodeId = NULL; */
+    conf->modellingRulesOnInstances = UA_TRUE;
 
     /* Limits for SecureChannels */
     conf->maxSecureChannels = 40;

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -13,6 +13,7 @@
  *    Copyright 2017 (c) frax2222
  *    Copyright 2017-2018 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Christian von Arnim
+ *    Copyright 2021 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and umati)
  *    Copyright 2017 (c) Henrik Norrman
  *    Copyright 2021 (c) Fraunhofer IOSB (Author: Andreas Ebner)
  */
@@ -630,9 +631,20 @@ copyChild(UA_Server *server, UA_Session *session,
          * addnode_finish. That way, we can call addnode_finish also on children that were
          * manually added by the user during addnode_begin and addnode_finish. */
         /* For now we keep all the modelling rule references and delete all others */
-        UA_ReferenceTypeSet reftypes_modellingrule =
-            UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASMODELLINGRULE);
-        UA_Node_deleteReferencesSubset(node, &reftypes_modellingrule);
+        const UA_NodeId nodeId_typesFolder= UA_NODEID_NUMERIC(0, UA_NS0ID_TYPESFOLDER);
+        const UA_ReferenceTypeSet reftypes_aggregates = 
+            UA_REFTYPESET(UA_REFERENCETYPEINDEX_AGGREGATES);
+        UA_ReferenceTypeSet reftypes_skipped;
+        /* Check if the hasModellingRule-reference is required (configured or node in an 
+            instance declaration) */
+        if(server->config.modellingRulesOnInstances ||
+         isNodeInTree(server, destinationNodeId, &nodeId_typesFolder, &reftypes_aggregates)) {
+            reftypes_skipped =
+                UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASMODELLINGRULE);
+        } else {
+            UA_ReferenceTypeSet_init(&reftypes_skipped);
+        }
+        UA_Node_deleteReferencesSubset(node, &reftypes_skipped);
 
         /* Add the node to the nodestore */
         UA_NodeId newNodeId;


### PR DESCRIPTION
As the current version of the CCT does not like it, if there are HasModellingRule references on instances (it thinks the node is part of an instance declaration in a type definition), I added an option to suppress these references.

Only Nodes, which are not under the Types folder can omit this reference. In the default configuraiton, HasModellingRule are created in instances as before.

