### PR TITLE
Support all publisher Id types at connection configuration

### DIFF
--- a/examples/pubsub/monitoring/server_pubsub_subscribe_custom_monitoring.c
+++ b/examples/pubsub/monitoring/server_pubsub_subscribe_custom_monitoring.c
@@ -2,17 +2,17 @@
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
 /**
- * This example can be used to receive and display values that are published 
- * by tutorial_pubsub_publish example in the TargetVariables of Subscriber 
+ * This example can be used to receive and display values that are published
+ * by tutorial_pubsub_publish example in the TargetVariables of Subscriber
  * Information Model.
- * 
+ *
  * Additionally this example shows the usage of the PubSub monitoring implementation.
- * The application can provide the pubsubStateChangeCallback to get notifications 
- * about specific PubSub state changes or timeouts. Currently only the 
+ * The application can provide the pubsubStateChangeCallback to get notifications
+ * about specific PubSub state changes or timeouts. Currently only the
  * MessageReceiveTimeout handling of a DataSetReader is implemented.
- * Stop the tutorial_pubsub_publish example during operation to trigger the 
+ * Stop the tutorial_pubsub_publish example during operation to trigger the
  * MessageReceiveTimeout and check the callback invocation.
- * 
+ *
  * Per default the monitoring backend is provided by the open62541 sdk.
  * An application can provide it's own monitoring backend (e.g. linux timers),
  * by setting the monitoring callbacks. This option can be tested with
@@ -55,9 +55,9 @@ typedef struct MonitoringParams {
     UA_ServerCallback callback;
 } TMonitoringParams;
 
-/* In this example we only configure 1 DataSetReader and therefore only provide 1 
+/* In this example we only configure 1 DataSetReader and therefore only provide 1
 data structure for monitoring params. This example only works with 1 DataSetReader for simplicity's sake.
-If more DataSetReaders shall be configured one can create a new data structure at every pubSubComponent_createMonitoring() call and 
+If more DataSetReaders shall be configured one can create a new data structure at every pubSubComponent_createMonitoring() call and
 administer them with a list/map/vector ....  */
 TMonitoringParams monitoringParams;
 
@@ -81,7 +81,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD) {
         return retval;
@@ -259,13 +260,13 @@ static void stopHandler(int sign) {
 
 /* Provide a callback to get notifications about specific PubSub state changes or timeouts.
     Currently only the MessageReceiveTimeout of the subscriber is supported.
-    Stop the tutorial_pubsub_publish example during operation to trigger the MessageReceiveTimeout and 
+    Stop the tutorial_pubsub_publish example during operation to trigger the MessageReceiveTimeout and
     check the callback invocation here */
 static void
 pubsubStateChangeCallback(UA_NodeId *pubsubComponentId,
                                       UA_PubSubState state,
                                       UA_StatusCode code) {
-    
+
     if (pubsubComponentId == 0) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "pubsubStateChangeCallback(): Null pointer error. Internal error");
         return;
@@ -289,7 +290,7 @@ monitoringCallbackHandler(union sigval val)
 
 /* Custom monitoring backend implementation: only 1 DataSetReader is supported */
 static UA_StatusCode
-pubSubComponent_createMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType, 
+pubSubComponent_createMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType,
                                     UA_PubSubMonitoringType eMonitoringType, void *data, UA_ServerCallback callback) {
     if ((!server) || (!data)) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -320,7 +321,7 @@ pubSubComponent_createMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubCompo
 }
 
 static UA_StatusCode
-pubSubComponent_startMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType, 
+pubSubComponent_startMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType,
                                     UA_PubSubMonitoringType eMonitoringType, void *data) {
     if ((!server) || (!data)) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -346,7 +347,7 @@ pubSubComponent_startMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubCompon
 }
 
 static UA_StatusCode
-pubSubComponent_stopMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType, 
+pubSubComponent_stopMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType,
                                     UA_PubSubMonitoringType eMonitoringType, void *data) {
     if ((!server) || (!data)) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -372,7 +373,7 @@ pubSubComponent_stopMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubCompone
 }
 
 static UA_StatusCode
-pubSubComponent_updateMonitoringInterval(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType, 
+pubSubComponent_updateMonitoringInterval(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType,
                                             UA_PubSubMonitoringType eMonitoringType, void *data)
 {
     if ((!server) || (!data)) {
@@ -407,7 +408,7 @@ pubSubComponent_updateMonitoringInterval(UA_Server *server, UA_NodeId Id, UA_Pub
 }
 
 static UA_StatusCode
-pubSubComponent_deleteMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType, 
+pubSubComponent_deleteMonitoring(UA_Server *server, UA_NodeId Id, UA_PubSubComponentEnumType eComponentType,
                                     UA_PubSubMonitoringType eMonitoringType, void *data) {
     if ((!server) || (!data)) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;

--- a/examples/pubsub/pubsub_publish_encrypted.c
+++ b/examples/pubsub/pubsub_publish_encrypted.c
@@ -30,7 +30,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 

--- a/examples/pubsub/pubsub_publish_encrypted_tpm.c
+++ b/examples/pubsub/pubsub_publish_encrypted_tpm.c
@@ -39,7 +39,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 

--- a/examples/pubsub/pubsub_publish_encrypted_tpm_keystore.c
+++ b/examples/pubsub/pubsub_publish_encrypted_tpm_keystore.c
@@ -41,7 +41,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 

--- a/examples/pubsub/pubsub_subscribe_encrypted.c
+++ b/examples/pubsub/pubsub_subscribe_encrypted.c
@@ -57,7 +57,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD) {
         return retval;

--- a/examples/pubsub/pubsub_subscribe_encrypted_tpm.c
+++ b/examples/pubsub/pubsub_subscribe_encrypted_tpm.c
@@ -62,7 +62,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD) {
         return retval;

--- a/examples/pubsub/pubsub_subscribe_encrypted_tpm_keystore.c
+++ b/examples/pubsub/pubsub_subscribe_encrypted_tpm_keystore.c
@@ -64,7 +64,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD) {
         return retval;

--- a/examples/pubsub/server_pubsub_publisher_iop.c
+++ b/examples/pubsub/server_pubsub_publisher_iop.c
@@ -75,7 +75,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = Publisher_ID;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = Publisher_ID;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 
@@ -672,7 +673,7 @@ timerCallback(UA_Server *server, void *data) {
     UA_Variant_setScalar(&tmpVari, &ds2DoubleVal, &UA_TYPES[UA_TYPES_DOUBLE]);
     UA_Server_writeValue(server, ds2DoubleId, tmpVari);
 
-    // String 
+    // String
     UA_Variant_init(&tmpVari);
     ds2StringIndex++;
     if(ds2StringIndex >= ds2StringArrayLen)
@@ -681,7 +682,7 @@ timerCallback(UA_Server *server, void *data) {
     UA_Variant_setScalar(&tmpVari, &ds2StringArray[ds2StringIndex], &UA_TYPES[UA_TYPES_STRING]);
     UA_Server_writeValue(server, ds2StringId, tmpVari);
 
-    // ByteString 
+    // ByteString
     UA_Variant_init(&tmpVari);
     UA_ByteString bs;
     UA_ByteString_init(&bs);
@@ -693,7 +694,7 @@ timerCallback(UA_Server *server, void *data) {
     UA_Server_writeValue(server, ds2ByteStringId, tmpVari);
     UA_ByteString_clear(&bs);
 
-    // Guid 
+    // Guid
     UA_Variant_init(&tmpVari);
     UA_Guid g = UA_Guid_random();
     UA_Variant_setScalar(&tmpVari, &g, &UA_TYPES[UA_TYPES_GUID]);
@@ -730,7 +731,7 @@ static int run(UA_String *transportProfile,
 #endif
 
     addPubSubConnection(server, transportProfile, networkAddressUrl);
-    
+
     /* Create a PublishedDataSet based on a PublishedDataSetConfig. */
     UA_PublishedDataSetConfig publishedDataSetConfig;
     publishedDataSetConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
@@ -757,13 +758,13 @@ static int run(UA_String *transportProfile,
     UA_Server_setWriterGroupOperational(server, writerGroupIdent);
 
     /* Create a new Writer and connect it with an existing PublishedDataSet */
-    // DataSetWriter ID 1 with Variant Encoding 
+    // DataSetWriter ID 1 with Variant Encoding
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(UA_DataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSet 1 DataSetWriter");
     dataSetWriterConfig.dataSetWriterId = 1;
     //The creation of delta messages is configured in the following line. Value
-    // 0 -> no delta messages are created. 
+    // 0 -> no delta messages are created.
     dataSetWriterConfig.keyFrameCount = 10;
 
     UA_NodeId writerIdentifier;
@@ -788,7 +789,7 @@ static int run(UA_String *transportProfile,
     dataSetWriterConfig2.name = UA_STRING("DataSet 2 DataSetWriter");
     dataSetWriterConfig2.dataSetWriterId = 2;
     //The creation of delta messages is configured in the following line. Value
-    // 0 -> no delta messages are created. 
+    // 0 -> no delta messages are created.
     dataSetWriterConfig2.keyFrameCount = 10;
 
     UA_NodeId writerIdentifier2;

--- a/examples/pubsub/server_pubsub_publisher_rt_level.c
+++ b/examples/pubsub/server_pubsub_publisher_rt_level.c
@@ -52,7 +52,8 @@ addMinimalPubSubConfiguration(UA_Server * server){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     /* Add one PublishedDataSet */
     UA_PublishedDataSetConfig publishedDataSetConfig;

--- a/examples/pubsub/server_pubsub_publisher_rt_level_raw.c
+++ b/examples/pubsub/server_pubsub_publisher_rt_level_raw.c
@@ -54,7 +54,8 @@ addMinimalPubSubConfiguration(UA_Server * server){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     /* Add one PublishedDataSet */
     UA_PublishedDataSetConfig publishedDataSetConfig;

--- a/examples/pubsub/server_pubsub_rt_field_information_model.c
+++ b/examples/pubsub/server_pubsub_rt_field_information_model.c
@@ -34,7 +34,8 @@ addMinimalPubSubConfiguration(UA_Server * server){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     /* Add one PublishedDataSet */
     UA_PublishedDataSetConfig publishedDataSetConfig;

--- a/examples/pubsub/server_pubsub_subscriber_rt_level.c
+++ b/examples/pubsub/server_pubsub_subscriber_rt_level.c
@@ -180,7 +180,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD)
         return retval;

--- a/examples/pubsub/tutorial_pubsub_connection.c
+++ b/examples/pubsub/tutorial_pubsub_connection.c
@@ -50,7 +50,8 @@ int main(void) {
      * defined UA_NetworkAddressUrlDataType. */
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     /* Connection options are given as Key/Value Pairs. The available options are
      * maybe standard or vendor defined. */
     UA_KeyValuePair connectionOptions[3];

--- a/examples/pubsub/tutorial_pubsub_publish.c
+++ b/examples/pubsub/tutorial_pubsub_publish.c
@@ -48,7 +48,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     /* Changed to static publisherId from random generation to identify
      * the publisher on Subscriber side */
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 

--- a/examples/pubsub/tutorial_pubsub_publish_raw.c
+++ b/examples/pubsub/tutorial_pubsub_publish_raw.c
@@ -92,7 +92,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     /* Changed to static publisherId from random generation to identify
      * the publisher on Subscriber side */
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 }
 

--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -71,7 +71,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD) {
         return retval;

--- a/examples/pubsub/tutorial_pubsub_subscribe_raw.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe_raw.c
@@ -62,7 +62,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.enabled = UA_TRUE;
     UA_Variant_setScalar(&connectionConfig.address, networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random ();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionIdentifier);
     if (retval != UA_STATUSCODE_GOOD) {
         return retval;

--- a/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_publisher.c
+++ b/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_publisher.c
@@ -254,7 +254,8 @@ addPubSubConnection(UA_Server *server, UA_NetworkAddressUrlDataType *networkAddr
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = PUBLISHER_ID;
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16          = PUBLISHER_ID;
     /* Connection options are given as Key/Value Pairs - Sockprio and Txtime */
     UA_KeyValuePair connectionOptions[2];
     connectionOptions[0].key = UA_QUALIFIEDNAME(0, "sockpriority");

--- a/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_subscriber.c
+++ b/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_subscriber.c
@@ -240,7 +240,8 @@ addPubSubConnectionSubscriber(UA_Server *server, UA_NetworkAddressUrlDataType *n
     UA_NetworkAddressUrlDataType networkAddressUrlsubscribe = *networkAddressUrlSubscriber;
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlsubscribe, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = UA_UInt32_random();
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32          = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentSubscriber);
     if (retval == UA_STATUSCODE_GOOD)
          UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,"The PubSub Connection was created successfully!");

--- a/examples/pubsub_realtime/pubsub_TSN_loopback.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback.c
@@ -448,7 +448,8 @@ addPubSubConnectionSubscriber(UA_Server *server, UA_NetworkAddressUrlDataType *n
     UA_NetworkAddressUrlDataType networkAddressUrlsubscribe = *networkAddressUrlSubscriber;
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlsubscribe, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = UA_UInt32_random();
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32          = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentSubscriber);
     if (retval == UA_STATUSCODE_GOOD)
          UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,"The PubSub Connection was created successfully!");
@@ -695,7 +696,8 @@ addPubSubConnection(UA_Server *server, UA_NetworkAddressUrlDataType *networkAddr
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = PUBLISHER_ID;
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16          = PUBLISHER_ID;
     /* Connection options are given as Key/Value Pairs - Sockprio and Txtime */
     UA_KeyValuePair connectionOptions[2];
     connectionOptions[0].key                  = UA_QUALIFIEDNAME(0, "sockpriority");

--- a/examples/pubsub_realtime/pubsub_TSN_loopback_single_thread.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback_single_thread.c
@@ -113,8 +113,8 @@
 #endif
 #define             CLOCKID                               CLOCK_MONOTONIC
 #define             ETH_TRANSPORT_PROFILE                 "http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp"
-#define             UDP_TRANSPORT_PROFILE                 "http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp"                               
-             
+#define             UDP_TRANSPORT_PROFILE                 "http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp"
+
 /* If the Hardcoded publisher/subscriber MAC addresses need to be changed,
  * change PUBLISHING_MAC_ADDRESS and SUBSCRIBING_MAC_ADDRESS
  */
@@ -349,7 +349,8 @@ addPubSubConnectionSubscriber(UA_Server *server, UA_String *transportProfile,
     UA_NetworkAddressUrlDataType networkAddressUrlsubscribe = *networkAddressUrlSubscriber;
     connectionConfig.transportProfileUri                    = *transportProfile;
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlsubscribe, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = UA_UInt32_random();
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32          = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentSubscriber);
     if (retval == UA_STATUSCODE_GOOD)
          UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,"The PubSub Connection was created successfully!");
@@ -584,7 +585,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.transportProfileUri                    = *transportProfile;
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = PUBLISHER_ID;
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16          = PUBLISHER_ID;
 
 #ifdef UA_ENABLE_PUBSUB_ETH_UADP
     /* Connection options are given as Key/Value Pairs - Sockprio and Txtime */
@@ -870,7 +872,7 @@ void userApplication(UA_UInt64 monotonicOffsetValue) {
 #endif
     }
 
-    /* *runningPub variable made false and send to the publisher application which is running in another node 
+    /* *runningPub variable made false and send to the publisher application which is running in another node
        which will close the application during blocking socket condition */
     if (signalTerm == UA_TRUE) {
 #ifdef TWO_WAY_COMMUNICATION

--- a/examples/pubsub_realtime/pubsub_TSN_publisher.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher.c
@@ -75,6 +75,7 @@
 
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
+#include <open62541/server_pubsub.h>
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/log.h>
 #include <open62541/types_generated.h>
@@ -450,7 +451,8 @@ addPubSubConnectionSubscriber(UA_Server *server, UA_NetworkAddressUrlDataType *n
     UA_NetworkAddressUrlDataType networkAddressUrlsubscribe = *networkAddressUrlSubscriber;
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlsubscribe, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = UA_UInt32_random();
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32          = UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentSubscriber);
     if (retval == UA_STATUSCODE_GOOD)
          UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,"The PubSub Connection was created successfully!");
@@ -699,7 +701,8 @@ addPubSubConnection(UA_Server *server, UA_NetworkAddressUrlDataType *networkAddr
     connectionConfig.transportProfileUri                    = UA_STRING(ETH_TRANSPORT_PROFILE);
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = PUBLISHER_ID;
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16          = PUBLISHER_ID;
     /* Connection options are given as Key/Value Pairs - Sockprio and Txtime */
     UA_KeyValuePair connectionOptions[2];
     connectionOptions[0].key                  = UA_QUALIFIEDNAME(0, "sockpriority");

--- a/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
@@ -361,7 +361,8 @@ addPubSubConnectionSubscriber(UA_Server *server, UA_String *transportProfile,
 
     connectionConfig.transportProfileUri                    = *transportProfile;
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrlsubscribe, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = UA_UInt32_random();
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16          = (UA_UInt16) UA_UInt32_random();
     retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentSubscriber);
     if (retval == UA_STATUSCODE_GOOD)
          UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,"The PubSub Connection was created successfully!");
@@ -584,7 +585,7 @@ addDataSetReader(UA_Server *server) {
  * Create connection, writergroup, datasetwriter and publisheddataset for Publisher thread.
  */
 static void
-addPubSubConnection(UA_Server *server, UA_String *transportProfile, 
+addPubSubConnection(UA_Server *server, UA_String *transportProfile,
                     UA_NetworkAddressUrlDataType *networkAddressUrlPub){
     /* Details about the connection configuration and handling are located
      * in the pubsub connection tutorial */
@@ -596,7 +597,8 @@ addPubSubConnection(UA_Server *server, UA_String *transportProfile,
     connectionConfig.transportProfileUri                    = *transportProfile;
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric                    = PUBLISHER_ID;
+    connectionConfig.publisherIdType                        = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16          = PUBLISHER_ID;
 #ifdef UA_ENABLE_PUBSUB_ETH_UADP
     /* Connection options are given as Key/Value Pairs - Sockprio and Txtime */
     UA_KeyValuePair connectionOptions[2];
@@ -832,7 +834,7 @@ void userApplicationPublisher(UA_UInt64 monotonicOffsetValue) {
             updateMeasurementsPublisher(dataModificationTime, *pubCounterData, monotonicOffsetValue);
     }
 
-    /* *runningPub variable made false and send to the publisher application which is running in another node 
+    /* *runningPub variable made false and send to the publisher application which is running in another node
        which will close the application during blocking socket condition */
     if (signalTerm == UA_TRUE) {
         *runningPub = UA_FALSE;
@@ -866,7 +868,7 @@ updateMeasurementsSubscriber(struct timespec receive_time, UA_UInt64 counterValu
 }
 
 /**
- * userApplicationSubscriber function is used to read the data from Information Model for the Subscriber and 
+ * userApplicationSubscriber function is used to read the data from Information Model for the Subscriber and
  * writes the updated counterdata in distinct csv files
  **/
 void userApplicationSubscriber(UA_UInt64 monotonicOffsetValue) {
@@ -1484,7 +1486,7 @@ int main(int argc, char **argv) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,"\nTotal Packet Loss Count of publisher application :%"PRIu64"\n", \
                 threadArgPubSub1->packetLossCount);
     UA_Server_unfreezeReaderGroupConfiguration(server, readerGroupIdentifier);
-#endif  
+#endif
     returnValue = pthread_join(pubAppThreadID, NULL);
     if (returnValue != 0)
         UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,"\nPthread Join Failed for pubApp thread:%d\n", returnValue);

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -138,18 +138,26 @@ typedef enum  {
 } UA_PubSubComponentEnumType;
 
 typedef enum {
-    UA_PUBSUB_PUBLISHERID_NUMERIC,
-    UA_PUBSUB_PUBLISHERID_STRING
+    UA_PUBLISHERIDTYPE_BYTE = 0,
+    UA_PUBLISHERIDTYPE_UINT16 = 1,
+    UA_PUBLISHERIDTYPE_UINT32 = 2,
+    UA_PUBLISHERIDTYPE_UINT64 = 3,
+    UA_PUBLISHERIDTYPE_STRING = 4
 } UA_PublisherIdType;
+
+typedef union { /* std: valid types UInt or String */
+    UA_Byte byte;
+    UA_UInt16 uint16;
+    UA_UInt32 uint32;
+    UA_UInt64 uint64;
+    UA_String string;
+} UA_PublisherId;
 
 struct UA_PubSubConnectionConfig {
     UA_String name;
     UA_Boolean enabled;
     UA_PublisherIdType publisherIdType;
-    union { /* std: valid types UInt or String */
-        UA_UInt32 numeric;
-        UA_String string;
-    } publisherId;
+    UA_PublisherId publisherId;
     UA_String transportProfileUri;
     UA_Variant address;
     size_t connectionPropertiesSize;

--- a/plugins/crypto/openssl/ua_openssl_basic256sha256.c
+++ b/plugins/crypto/openssl/ua_openssl_basic256sha256.c
@@ -221,7 +221,7 @@ UA_Asym_Basic256Sha256_getRemoteSignatureSize(const void *channelContext) {
     const Channel_Context_Basic256Sha256 * cc =
         (const Channel_Context_Basic256Sha256 *) channelContext;
     UA_Int32 keyLen = 0;
-    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    UA_Openssl_RSA_Public_GetKeyLength (cc->remoteCertificateX509, &keyLen);
     return (size_t) keyLen; 
 }
 
@@ -234,7 +234,7 @@ UA_AsySig_Basic256Sha256_getLocalSignatureSize(const void *channelContext) {
         (const Channel_Context_Basic256Sha256 *) channelContext;
     Policy_Context_Basic256Sha256 * pc = cc->policyContext;
     UA_Int32 keyLen = 0;
-    UA_Openssl_RSA_Private_GetKeyLength(pc->localPrivateKey, &keyLen);
+    UA_Openssl_RSA_Private_GetKeyLength (pc->localPrivateKey, &keyLen);
     return (size_t) keyLen; 
 }
 
@@ -468,7 +468,7 @@ UA_AsymEn_Basic256Sha256_getLocalKeyLength(const void *channelContext) {
         (const Channel_Context_Basic256Sha256 *) channelContext;
     Policy_Context_Basic256Sha256 *pc = cc->policyContext;
     UA_Int32 keyLen = 0;
-    UA_Openssl_RSA_Private_GetKeyLength(pc->localPrivateKey, &keyLen);
+    UA_Openssl_RSA_Private_GetKeyLength (pc->localPrivateKey, &keyLen);
     return (size_t) keyLen * 8; 
 }
 

--- a/src/pubsub/ua_pubsub_config.c
+++ b/src/pubsub/ua_pubsub_config.c
@@ -547,7 +547,7 @@ createReaderGroup(UA_Server *server,
     memset(&config, 0, sizeof(UA_ReaderGroupConfig));
 
     config.name = readerGroupParameters->name;
-    config.securityParameters.securityMode = readerGroupParameters->securityMode;
+    config.securityMode = readerGroupParameters->securityMode;
 
     UA_NodeId readerGroupIdent;
     UA_StatusCode res =

--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -111,17 +111,17 @@ UA_NetworkMessage_updateBufferedNwMessage(UA_NetworkMessageOffsetBuffer *buffer,
             break;
         case UA_PUBSUB_OFFSETTYPE_PUBLISHERID:
             switch (buffer->nm->publisherIdType) {
-            case UA_PUBLISHERDATATYPE_BYTE:
-                rv = UA_Byte_decodeBinary(src, &offset, &(buffer->nm->publisherId.publisherIdByte));
+            case UA_PUBLISHERIDTYPE_BYTE:
+                rv = UA_Byte_decodeBinary(src, &offset, &(buffer->nm->publisherId.byte));
                 break;
-            case UA_PUBLISHERDATATYPE_UINT16:
-                rv = UA_UInt16_decodeBinary(src, &offset, &(buffer->nm->publisherId.publisherIdUInt16));
+            case UA_PUBLISHERIDTYPE_UINT16:
+                rv = UA_UInt16_decodeBinary(src, &offset, &(buffer->nm->publisherId.uint16));
                 break;
-            case UA_PUBLISHERDATATYPE_UINT32:
-                rv = UA_UInt32_decodeBinary(src, &offset, &(buffer->nm->publisherId.publisherIdUInt32));
+            case UA_PUBLISHERIDTYPE_UINT32:
+                rv = UA_UInt32_decodeBinary(src, &offset, &(buffer->nm->publisherId.uint32));
                 break;
-            case UA_PUBLISHERDATATYPE_UINT64:
-                rv = UA_UInt64_decodeBinary(src, &offset, &(buffer->nm->publisherId.publisherIdUInt64));
+            case UA_PUBLISHERIDTYPE_UINT64:
+                rv = UA_UInt64_decodeBinary(src, &offset, &(buffer->nm->publisherId.uint64));
                 break;
             default:
                 return UA_STATUSCODE_BADNOTSUPPORTED;
@@ -239,24 +239,24 @@ UA_NetworkMessageHeader_encodeBinary(const UA_NetworkMessage *src, UA_Byte **buf
     // PublisherId
     if(src->publisherIdEnabled) {
         switch (src->publisherIdType) {
-        case UA_PUBLISHERDATATYPE_BYTE:
-            rv = UA_Byte_encodeBinary(&(src->publisherId.publisherIdByte), bufPos, bufEnd);
+        case UA_PUBLISHERIDTYPE_BYTE:
+            rv = UA_Byte_encodeBinary(&(src->publisherId.byte), bufPos, bufEnd);
             break;
 
-        case UA_PUBLISHERDATATYPE_UINT16:
-            rv = UA_UInt16_encodeBinary(&(src->publisherId.publisherIdUInt16), bufPos, bufEnd);
+        case UA_PUBLISHERIDTYPE_UINT16:
+            rv = UA_UInt16_encodeBinary(&(src->publisherId.uint16), bufPos, bufEnd);
             break;
 
-        case UA_PUBLISHERDATATYPE_UINT32:
-            rv = UA_UInt32_encodeBinary(&(src->publisherId.publisherIdUInt32), bufPos, bufEnd);
+        case UA_PUBLISHERIDTYPE_UINT32:
+            rv = UA_UInt32_encodeBinary(&(src->publisherId.uint32), bufPos, bufEnd);
             break;
 
-        case UA_PUBLISHERDATATYPE_UINT64:
-            rv = UA_UInt64_encodeBinary(&(src->publisherId.publisherIdUInt64), bufPos, bufEnd);
+        case UA_PUBLISHERIDTYPE_UINT64:
+            rv = UA_UInt64_encodeBinary(&(src->publisherId.uint64), bufPos, bufEnd);
             break;
 
-        case UA_PUBLISHERDATATYPE_STRING:
-            rv = UA_String_encodeBinary(&(src->publisherId.publisherIdString), bufPos, bufEnd);
+        case UA_PUBLISHERIDTYPE_STRING:
+            rv = UA_String_encodeBinary(&(src->publisherId.string), bufPos, bufEnd);
             break;
 
         default:
@@ -544,7 +544,7 @@ UA_NetworkMessageHeader_decodeBinary(const UA_ByteString *src, size_t *offset, U
         rv = UA_Byte_decodeBinary(src, offset, &decoded);
         UA_CHECK_STATUS(rv, return rv);
 
-        dst->publisherIdType = (UA_PublisherIdDatatype)(decoded & NM_PUBLISHER_ID_MASK);
+        dst->publisherIdType = (UA_PublisherIdType)(decoded & NM_PUBLISHER_ID_MASK);
         if((decoded & NM_DATASET_CLASSID_ENABLED_MASK) != 0)
             dst->dataSetClassIdEnabled = true;
 
@@ -576,24 +576,24 @@ UA_NetworkMessageHeader_decodeBinary(const UA_ByteString *src, size_t *offset, U
 
     if(dst->publisherIdEnabled) {
         switch (dst->publisherIdType) {
-            case UA_PUBLISHERDATATYPE_BYTE:
-                rv = UA_Byte_decodeBinary(src, offset, &(dst->publisherId.publisherIdByte));
+            case UA_PUBLISHERIDTYPE_BYTE:
+                rv = UA_Byte_decodeBinary(src, offset, &(dst->publisherId.byte));
                 break;
 
-            case UA_PUBLISHERDATATYPE_UINT16:
-                rv = UA_UInt16_decodeBinary(src, offset, &(dst->publisherId.publisherIdUInt16));
+            case UA_PUBLISHERIDTYPE_UINT16:
+                rv = UA_UInt16_decodeBinary(src, offset, &(dst->publisherId.uint16));
                 break;
 
-            case UA_PUBLISHERDATATYPE_UINT32:
-                rv = UA_UInt32_decodeBinary(src, offset, &(dst->publisherId.publisherIdUInt32));
+            case UA_PUBLISHERIDTYPE_UINT32:
+                rv = UA_UInt32_decodeBinary(src, offset, &(dst->publisherId.uint32));
                 break;
 
-            case UA_PUBLISHERDATATYPE_UINT64:
-                rv = UA_UInt64_decodeBinary(src, offset, &(dst->publisherId.publisherIdUInt64));
+            case UA_PUBLISHERIDTYPE_UINT64:
+                rv = UA_UInt64_decodeBinary(src, offset, &(dst->publisherId.uint64));
                 break;
 
-            case UA_PUBLISHERDATATYPE_STRING:
-                rv = UA_String_decodeBinary(src, offset, &(dst->publisherId.publisherIdString));
+            case UA_PUBLISHERIDTYPE_STRING:
+                rv = UA_String_decodeBinary(src, offset, &(dst->publisherId.string));
                 break;
 
             default:
@@ -946,24 +946,24 @@ UA_NetworkMessage_calcSizeBinary(UA_NetworkMessage *p, UA_NetworkMessageOffsetBu
             offsetBuffer->offsets[pos].contentType = UA_PUBSUB_OFFSETTYPE_PUBLISHERID;
         }
         switch (p->publisherIdType) {
-            case UA_PUBLISHERDATATYPE_BYTE:
-                size += UA_Byte_calcSizeBinary(&p->publisherId.publisherIdByte);
+            case UA_PUBLISHERIDTYPE_BYTE:
+                size += UA_Byte_calcSizeBinary(&p->publisherId.byte);
                 break;
 
-            case UA_PUBLISHERDATATYPE_UINT16:
-                size += UA_UInt16_calcSizeBinary(&p->publisherId.publisherIdUInt16);
+            case UA_PUBLISHERIDTYPE_UINT16:
+                size += UA_UInt16_calcSizeBinary(&p->publisherId.uint16);
                 break;
 
-            case UA_PUBLISHERDATATYPE_UINT32:
-                size += UA_UInt32_calcSizeBinary(&p->publisherId.publisherIdUInt32);
+            case UA_PUBLISHERIDTYPE_UINT32:
+                size += UA_UInt32_calcSizeBinary(&p->publisherId.uint32);
                 break;
 
-            case UA_PUBLISHERDATATYPE_UINT64:
-                size += UA_UInt64_calcSizeBinary(&p->publisherId.publisherIdUInt64);
+            case UA_PUBLISHERIDTYPE_UINT64:
+                size += UA_UInt64_calcSizeBinary(&p->publisherId.uint64);
                 break;
 
-            case UA_PUBLISHERDATATYPE_STRING:
-                size += UA_String_calcSizeBinary(&p->publisherId.publisherIdString);
+            case UA_PUBLISHERIDTYPE_STRING:
+                size += UA_String_calcSizeBinary(&p->publisherId.string);
                 break;
         }
     }
@@ -1131,8 +1131,8 @@ UA_NetworkMessage_clear(UA_NetworkMessage* p) {
            UA_String_clear(&p->messageId);
     }
 
-    if(p->publisherIdEnabled && p->publisherIdType == UA_PUBLISHERDATATYPE_STRING){
-       UA_String_clear(&p->publisherId.publisherIdString);
+    if(p->publisherIdEnabled && p->publisherIdType == UA_PUBLISHERIDTYPE_STRING){
+       UA_String_clear(&p->publisherId.string);
     }
 
     memset(p, 0, sizeof(UA_NetworkMessage));
@@ -1146,10 +1146,10 @@ UA_Boolean
 UA_NetworkMessage_ExtendedFlags1Enabled(const UA_NetworkMessage* src) {
     UA_Boolean retval = false;
 
-    if((src->publisherIdType != UA_PUBLISHERDATATYPE_BYTE) 
-        || src->dataSetClassIdEnabled 
-        || src->securityEnabled 
-        || src->timestampEnabled 
+    if((src->publisherIdType != UA_PUBLISHERIDTYPE_BYTE)
+        || src->dataSetClassIdEnabled
+        || src->securityEnabled
+        || src->timestampEnabled
         || src->picosecondsEnabled
         || UA_NetworkMessage_ExtendedFlags2Enabled(src))
     {

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -12,6 +12,9 @@
 #include <open62541/types.h>
 #include <open62541/types_generated.h>
 #include <open62541/plugin/securitypolicy.h>
+#include <open62541/server_pubsub.h>
+
+#ifdef UA_ENABLE_PUBSUB
 
 _UA_BEGIN_DECLS
 
@@ -92,14 +95,6 @@ typedef struct {
 } UA_DataSetPayload;
 
 typedef enum {
-    UA_PUBLISHERDATATYPE_BYTE = 0,
-    UA_PUBLISHERDATATYPE_UINT16 = 1,
-    UA_PUBLISHERDATATYPE_UINT32 = 2,
-    UA_PUBLISHERDATATYPE_UINT64 = 3,
-    UA_PUBLISHERDATATYPE_STRING = 4
-} UA_PublisherIdDatatype;
-
-typedef enum {
     UA_NETWORKMESSAGE_DATASET = 0,
     UA_NETWORKMESSAGE_DISCOVERY_REQUEST = 1,
     UA_NETWORKMESSAGE_DISCOVERY_RESPONSE = 2
@@ -142,7 +137,6 @@ typedef struct {
     UA_Boolean publisherIdEnabled;
     UA_Boolean groupHeaderEnabled;
     UA_Boolean payloadHeaderEnabled;
-    UA_PublisherIdDatatype publisherIdType;
     UA_Boolean dataSetClassIdEnabled;
     UA_Boolean securityEnabled;
     UA_Boolean timestampEnabled;
@@ -150,16 +144,11 @@ typedef struct {
     UA_Boolean chunkMessage;
     UA_Boolean promotedFieldsEnabled;
     UA_NetworkMessageType networkMessageType;
-    union {
-        UA_Byte publisherIdByte;
-        UA_UInt16 publisherIdUInt16;
-        UA_UInt32 publisherIdUInt32;
-        UA_UInt64 publisherIdUInt64;
-        UA_Guid publisherIdGuid;
-        UA_String publisherIdString;
-    } publisherId;
+    UA_PublisherIdType publisherIdType;
+    UA_PublisherId publisherId; /* publisherId is a shallow copy of the PublisherId from connection configuration
+        -> the configuration needs to be stable during publishing process
+        -> it must not be cleaned after network message has been sent */
     UA_Guid dataSetClassId;
-
     UA_NetworkMessageGroupHeader groupHeader;
 
     union {
@@ -349,5 +338,7 @@ UA_StatusCode UA_NetworkMessage_decodeJson(UA_NetworkMessage *dst, const UA_Byte
 #endif
 
 _UA_END_DECLS
+
+#endif /* UA_ENABLE_PUBSUB */
 
 #endif /* UA_PUBSUB_NETWORKMESSAGE_H_ */

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -275,25 +275,27 @@ UA_DataSetReader_generateNetworkMessage(UA_PubSubConnection *pubSubConnection, U
     if(!UA_DataType_isNumeric(dataSetReader->config.publisherId.type))
         return UA_STATUSCODE_BADNOTSUPPORTED;
 
-    switch(dataSetReader->config.publisherId.type->typeKind) {
-    case UA_DATATYPEKIND_BYTE:
-        nm->publisherIdType = UA_PUBLISHERDATATYPE_BYTE;
-        nm->publisherId.publisherIdByte = *(UA_Byte *) dataSetReader->config.publisherId.data;
-        break;
-    case UA_DATATYPEKIND_UINT16:
-        nm->publisherIdType = UA_PUBLISHERDATATYPE_UINT16;
-        nm->publisherId.publisherIdUInt16 = *(UA_UInt16 *) dataSetReader->config.publisherId.data;
-        break;
-    case UA_DATATYPEKIND_UINT32:
-        nm->publisherIdType = UA_PUBLISHERDATATYPE_UINT32;
-        nm->publisherId.publisherIdUInt32 = *(UA_UInt32 *) dataSetReader->config.publisherId.data;
-        break;
-    case UA_DATATYPEKIND_UINT64:
-        nm->publisherIdType = UA_PUBLISHERDATATYPE_UINT64;
-        nm->publisherId.publisherIdUInt64 = *(UA_UInt64 *) dataSetReader->config.publisherId.data;
-        break;
-    default:
-        return UA_STATUSCODE_BADNOTSUPPORTED;
+    if (nm->publisherIdEnabled) {
+        switch(dataSetReader->config.publisherId.type->typeKind) {
+        case UA_DATATYPEKIND_BYTE:
+            nm->publisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+            nm->publisherId.byte = *(UA_Byte *) dataSetReader->config.publisherId.data;
+            break;
+        case UA_DATATYPEKIND_UINT16:
+            nm->publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+            nm->publisherId.uint16 = *(UA_UInt16 *) dataSetReader->config.publisherId.data;
+            break;
+        case UA_DATATYPEKIND_UINT32:
+            nm->publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+            nm->publisherId.uint32 = *(UA_UInt32 *) dataSetReader->config.publisherId.data;
+            break;
+        case UA_DATATYPEKIND_UINT64:
+            nm->publisherIdType = UA_PUBLISHERIDTYPE_UINT64;
+            nm->publisherId.uint64 = *(UA_UInt64 *) dataSetReader->config.publisherId.data;
+            break;
+        default:
+            return UA_STATUSCODE_BADNOTSUPPORTED;
+        }
     }
 
     if(nm->groupHeader.sequenceNumberEnabled)
@@ -340,35 +342,29 @@ checkReaderIdentifier(UA_Server *server, UA_NetworkMessage *msg,
     }
 
     switch(msg->publisherIdType) {
-    case UA_PUBLISHERDATATYPE_BYTE:
+    case UA_PUBLISHERIDTYPE_BYTE:
         if(reader->config.publisherId.type == &UA_TYPES[UA_TYPES_BYTE] &&
-           msg->publisherIdType == UA_PUBLISHERDATATYPE_BYTE &&
-           msg->publisherId.publisherIdByte == *(UA_Byte*)reader->config.publisherId.data)
+           msg->publisherId.byte == *(UA_Byte*)reader->config.publisherId.data)
             break;
         return UA_STATUSCODE_BADNOTFOUND;
-    case UA_PUBLISHERDATATYPE_UINT16:
+    case UA_PUBLISHERIDTYPE_UINT16:
         if(reader->config.publisherId.type == &UA_TYPES[UA_TYPES_UINT16] &&
-           msg->publisherIdType == UA_PUBLISHERDATATYPE_UINT16 &&
-           msg->publisherId.publisherIdUInt16 == *(UA_UInt16*)reader->config.publisherId.data)
+           msg->publisherId.uint16 == *(UA_UInt16*)reader->config.publisherId.data)
             break;
         return UA_STATUSCODE_BADNOTFOUND;
-    case UA_PUBLISHERDATATYPE_UINT32:
+    case UA_PUBLISHERIDTYPE_UINT32:
         if(reader->config.publisherId.type == &UA_TYPES[UA_TYPES_UINT32] &&
-           msg->publisherIdType == UA_PUBLISHERDATATYPE_UINT32 &&
-           msg->publisherId.publisherIdUInt32 == *(UA_UInt32*)reader->config.publisherId.data)
+           msg->publisherId.uint32 == *(UA_UInt32*)reader->config.publisherId.data)
             break;
         return UA_STATUSCODE_BADNOTFOUND;
-    case UA_PUBLISHERDATATYPE_UINT64:
+    case UA_PUBLISHERIDTYPE_UINT64:
         if(reader->config.publisherId.type == &UA_TYPES[UA_TYPES_UINT64] &&
-           msg->publisherIdType == UA_PUBLISHERDATATYPE_UINT64 &&
-           msg->publisherId.publisherIdUInt64 == *(UA_UInt64*)reader->config.publisherId.data)
+           msg->publisherId.uint64 == *(UA_UInt64*)reader->config.publisherId.data)
             break;
         return UA_STATUSCODE_BADNOTFOUND;
-    case UA_PUBLISHERDATATYPE_STRING:
+    case UA_PUBLISHERIDTYPE_STRING:
         if(reader->config.publisherId.type == &UA_TYPES[UA_TYPES_STRING] &&
-           msg->publisherIdType == UA_PUBLISHERDATATYPE_STRING &&
-           UA_String_equal(&msg->publisherId.publisherIdString,
-                           (UA_String*)reader->config.publisherId.data))
+           UA_String_equal(&msg->publisherId.string, (UA_String*)reader->config.publisherId.data))
             break;
         return UA_STATUSCODE_BADNOTFOUND;
     default:
@@ -1418,10 +1414,8 @@ decodeAndProcessNetworkMessageRT(UA_Server *server, UA_ReaderGroup *readerGroup,
         goto cleanup;
     }
 
-    /* Check the decoded message is the expected one
-     * TODO: PublisherID check after modification in NM to support all datatypes */
-    if(nm->groupHeader.writerGroupId != dataSetReader->config.writerGroupId ||
-       *nm->payloadHeader.dataSetPayloadHeader.dataSetWriterIds != dataSetReader->config.dataSetWriterId) {
+    /* Check the decoded message is the expected one */
+    if (checkReaderIdentifier(server, nm, dataSetReader) != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                     "PubSub receive. Unknown message received. Will not be processed.");
         res = UA_STATUSCODE_UNCERTAIN;

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -39,6 +39,9 @@ UA_PubSubConnectionConfig_copy(const UA_PubSubConnectionConfig *src,
                                UA_PubSubConnectionConfig *dst) {
     UA_StatusCode res = UA_STATUSCODE_GOOD;
     memcpy(dst, src, sizeof(UA_PubSubConnectionConfig));
+    if (src->publisherIdType == UA_PUBLISHERIDTYPE_STRING) {
+        res |= UA_String_copy(&src->publisherId.string, &dst->publisherId.string);
+    }
     res |= UA_String_copy(&src->name, &dst->name);
     res |= UA_Variant_copy(&src->address, &dst->address);
     res |= UA_String_copy(&src->transportProfileUri, &dst->transportProfileUri);
@@ -87,6 +90,9 @@ UA_PubSubConnection_findConnectionbyId(UA_Server *server, UA_NodeId connectionId
 
 void
 UA_PubSubConnectionConfig_clear(UA_PubSubConnectionConfig *connectionConfig) {
+    if (connectionConfig->publisherIdType == UA_PUBLISHERIDTYPE_STRING) {
+        UA_String_clear(&connectionConfig->publisherId.string);
+    }
     UA_String_clear(&connectionConfig->name);
     UA_String_clear(&connectionConfig->transportProfileUri);
     UA_Variant_clear(&connectionConfig->connectionTransportSettings);

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -903,15 +903,11 @@ generateNetworkMessage(UA_PubSubConnection *connection, UA_WriterGroup *wg,
 
     networkMessage->version = 1;
     networkMessage->networkMessageType = UA_NETWORKMESSAGE_DATASET;
-    if(connection->config->publisherIdType == UA_PUBSUB_PUBLISHERID_NUMERIC) {
-        networkMessage->publisherIdType = UA_PUBLISHERDATATYPE_UINT16;
-        networkMessage->publisherId.publisherIdUInt32 =
-            connection->config->publisherId.numeric;
-    } else if(connection->config->publisherIdType == UA_PUBSUB_PUBLISHERID_STRING) {
-        networkMessage->publisherIdType = UA_PUBLISHERDATATYPE_STRING;
-        networkMessage->publisherId.publisherIdString =
-            connection->config->publisherId.string;
-    }
+    networkMessage->publisherIdType = connection->config->publisherIdType;
+    /* shallow copy of the PublisherId from connection configuration
+        -> the configuration needs to be stable during publishing process
+        -> it must not be cleaned after network message has been sent */
+    networkMessage->publisherId = connection->config->publisherId;
 
     if(networkMessage->groupHeader.sequenceNumberEnabled)
         networkMessage->groupHeader.sequenceNumber = wg->sequenceNumber;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -426,6 +426,9 @@ if(UA_ENABLE_PUBSUB)
     add_executable(check_pubsub_get_state pubsub/check_pubsub_get_state.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
     target_link_libraries(check_pubsub_get_state ${LIBS})
     add_test_valgrind(check_pubsub_get_state ${TESTS_BINARY_DIR}/check_pubsub_get_state)
+    add_executable(check_pubsub_publisherid pubsub/check_pubsub_publisherid.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+    target_link_libraries(check_pubsub_publisherid ${LIBS})
+    add_test_valgrind(check_pubsub_publisherid ${TESTS_BINARY_DIR}/check_pubsub_publisherid)
 
     #Link libraries for executing subscriber unit test
     add_executable(check_pubsub_subscribe pubsub/check_pubsub_subscribe.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)

--- a/tests/pubsub/check_pubsub_configuration.c
+++ b/tests/pubsub/check_pubsub_configuration.c
@@ -32,7 +32,8 @@ static void teardown(void) {
 }
 
 START_TEST(AddPublisherUsingBinaryFile) {
-    UA_ByteString publisherConfiguration = loadFile("../tests/pubsub/check_publisher_configuration.bin");
+    UA_ByteString publisherConfiguration = loadFile("../../tests/pubsub/check_publisher_configuration.bin");
+    ck_assert(publisherConfiguration.length > 0);
     UA_StatusCode retVal = UA_PubSubManager_loadPubSubConfigFromByteString(server, publisherConfiguration);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_PubSubConnection *connection;
@@ -64,7 +65,8 @@ START_TEST(AddPublisherUsingBinaryFile) {
 } END_TEST
 
 START_TEST(AddSubscriberUsingBinaryFile) {
-    UA_ByteString subscriberConfiguration = loadFile("../tests/pubsub/check_subscriber_configuration.bin");
+    UA_ByteString subscriberConfiguration = loadFile("../../tests/pubsub/check_subscriber_configuration.bin");
+    ck_assert(subscriberConfiguration.length > 0);
     UA_StatusCode retVal = UA_PubSubManager_loadPubSubConfigFromByteString(server, subscriberConfiguration);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_PubSubConnection *connection;

--- a/tests/pubsub/check_pubsub_connection_ethernet.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet.c
@@ -161,7 +161,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("Ethernet Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    connectionConf.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConf.publisherId.uint32 = 223344;
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -192,7 +193,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("Ethernet Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    connectionConf.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConf.publisherId.uint32 = 223344;
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_connection_ethernet_etf.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet_etf.c
@@ -201,7 +201,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("Ethernet ETF Connection");
     connectionConf.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    connectionConf.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConf.publisherId.uint32 = 223344;
     connectionConf.connectionPropertiesSize = 5;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -239,7 +240,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("Ethernet ETF Connection");
     connectionConf.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    connectionConf.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConf.publisherId.uint32 = 223344;
     connectionConf.connectionPropertiesSize = 5;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_connection_udp.c
+++ b/tests/pubsub/check_pubsub_connection_udp.c
@@ -189,7 +189,8 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
     connectionConf.name = UA_STRING("UADP Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    connectionConf.publisherIdType = UA_PUBLISHERIDTYPE_UINT64;
+    connectionConf.publisherId.uint64 = 223344;
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;
@@ -220,7 +221,8 @@ START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     connectionConf.name = UA_STRING("UADP Connection");
     connectionConf.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConf.enabled = true;
-    connectionConf.publisherId.numeric = 223344;
+    connectionConf.publisherIdType = UA_PUBLISHERIDTYPE_UINT64;
+    connectionConf.publisherId.uint64 = 223344;
     connectionConf.connectionPropertiesSize = 3;
     connectionConf.connectionProperties = connectionOptions;
     connectionConf.address = address;

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -74,7 +74,8 @@ setup(void) {
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
 
     logger = &server->config.logger;

--- a/tests/pubsub/check_pubsub_encoding.c
+++ b/tests/pubsub/check_pubsub_encoding.c
@@ -44,7 +44,7 @@ START_TEST(UA_PubSub_EnDecode_ShallWorkOn1DS1ValueVariantKeyFrame) {
     memset(bufPos, 0, msgSize);
     const UA_Byte *bufEnd = &(buffer.data[buffer.length]);
     rv = UA_NetworkMessage_encodeBinary(&m, &bufPos, bufEnd, NULL);
-    
+
     ck_assert_int_eq(rv, UA_STATUSCODE_GOOD);
 
     UA_NetworkMessage m2;
@@ -826,9 +826,9 @@ START_TEST(UA_PubSub_EnDecode_ShallWorkOn1DS2ValuesVariantDeltaFramePublDSCID) {
     m.version = 1;
     m.networkMessageType = UA_NETWORKMESSAGE_DATASET;
     m.publisherIdEnabled = true;
-    m.publisherIdType = UA_PUBLISHERDATATYPE_UINT32;
+    m.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
     UA_UInt32 publisherId = 1469;
-    m.publisherId.publisherIdUInt32 = publisherId;
+    m.publisherId.uint32 = publisherId;
     m.dataSetClassIdEnabled = true;
     UA_Guid dataSetClassId = UA_Guid_random();
     m.dataSetClassId = dataSetClassId;
@@ -892,7 +892,7 @@ START_TEST(UA_PubSub_EnDecode_ShallWorkOn1DS2ValuesVariantDeltaFramePublDSCID) {
     ck_assert(m.promotedFieldsEnabled == m2.promotedFieldsEnabled);
     ck_assert(m.publisherIdEnabled == m2.publisherIdEnabled);
     ck_assert_int_eq(m2.publisherIdType, m.publisherIdType);
-    ck_assert_uint_eq(m2.publisherId.publisherIdUInt32, publisherId);
+    ck_assert_uint_eq(m2.publisherId.uint32, publisherId);
     ck_assert(m.securityEnabled == m2.securityEnabled);
     ck_assert(m.chunkMessage == m2.chunkMessage);
 
@@ -1023,7 +1023,7 @@ START_TEST(UA_PubSub_EnDecode_ShallWorkOn1DS2ValuesVariantKeyFrameTSProm) {
     m.promotedFieldsEnabled = true;
     m.promotedFieldsSize = 1;
     m.promotedFields = (UA_Variant*)UA_Array_new(m.promotedFieldsSize, &UA_TYPES[UA_TYPES_VARIANT]);
-    
+
     UA_DataSetMessage dmkf;
     memset(&dmkf, 0, sizeof(UA_DataSetMessage));
     dmkf.header.dataSetMessageValid = true;
@@ -1364,13 +1364,13 @@ int main(void) {
 
     TCase *tc_ende2 = tcase_create("encode_decode2DS");
     tcase_add_test(tc_ende2, UA_PubSub_EnDecode_ShallWorkOn2DSVariant);
-    
-    Suite *s = suite_create("PubSub NetworkMessage");   
+
+    Suite *s = suite_create("PubSub NetworkMessage");
     suite_add_tcase(s, tc_encode);
     suite_add_tcase(s, tc_decode);
     suite_add_tcase(s, tc_ende1);
     suite_add_tcase(s, tc_ende2);
-    
+
     SRunner *sr = srunner_create(s);
     srunner_set_fork_status(sr, CK_NOFORK);
     srunner_run_all(sr,CK_NORMAL);

--- a/tests/pubsub/check_pubsub_encoding_json.c
+++ b/tests/pubsub/check_pubsub_encoding_json.c
@@ -34,8 +34,8 @@ START_TEST(UA_PubSub_EncodeAllOptionalFields) {
 
     /* enable publisherId */
     m.publisherIdEnabled = true;
-    m.publisherIdType = UA_PUBLISHERDATATYPE_UINT16;
-    m.publisherId.publisherIdUInt16 = 65535;
+    m.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    m.publisherId.uint16 = 65535;
 
     /* enable dataSetClassId */
     m.dataSetClassIdEnabled = true;

--- a/tests/pubsub/check_pubsub_encrypted_rt_levels.c
+++ b/tests/pubsub/check_pubsub_encrypted_rt_levels.c
@@ -51,7 +51,8 @@ addMinimalPubSubConfiguration(void){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;

--- a/tests/pubsub/check_pubsub_get_state.c
+++ b/tests/pubsub/check_pubsub_get_state.c
@@ -37,7 +37,7 @@ static void teardown(void) {
 
 /***************************************************************************************************/
 static void AddConnection(
-    char *pName, 
+    char *pName,
     UA_UInt32 PublisherId,
     UA_NodeId *opConnectionId) {
 
@@ -53,8 +53,8 @@ static void AddConnection(
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
 
-    connectionConfig.publisherIdType = UA_PUBSUB_PUBLISHERID_NUMERIC;
-    connectionConfig.publisherId.numeric = PublisherId;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = PublisherId;
 
     ck_assert(UA_Server_addPubSubConnection(server, &connectionConfig, opConnectionId) == UA_STATUSCODE_GOOD);
     ck_assert(UA_PubSubConnection_regist(server, opConnectionId) == UA_STATUSCODE_GOOD);
@@ -63,7 +63,7 @@ static void AddConnection(
 /***************************************************************************************************/
 static void AddWriterGroup(
     UA_NodeId *pConnectionId,
-    char *pName, 
+    char *pName,
     UA_UInt32 WriterGroupId,
     UA_Duration PublishingInterval,
     UA_NodeId *opWriterGroupId) {
@@ -94,10 +94,10 @@ static void AddWriterGroup(
 /***************************************************************************************************/
 static void AddPublishedDataSet(
     UA_NodeId *pWriterGroupId,
-    char *pPublishedDataSetName, 
+    char *pPublishedDataSetName,
     char *pDataSetWriterName,
     UA_UInt32 DataSetWriterId,
-    UA_NodeId *opPublishedDataSetId, 
+    UA_NodeId *opPublishedDataSetId,
     UA_NodeId *opPublishedVarId,
     UA_NodeId *opDataSetWriterId) {
 
@@ -152,7 +152,7 @@ static void AddPublishedDataSet(
 /***************************************************************************************************/
 static void AddReaderGroup(
     UA_NodeId *pConnectionId,
-    char *pName, 
+    char *pName,
     UA_NodeId *opReaderGroupId) {
 
     assert(pConnectionId != 0);
@@ -169,7 +169,7 @@ static void AddReaderGroup(
 /***************************************************************************************************/
 static void AddDataSetReader(
     UA_NodeId *pReaderGroupId,
-    char *pName, 
+    char *pName,
     UA_UInt32 PublisherId,
     UA_UInt32 WriterGroupId,
     UA_UInt32 DataSetWriterId,
@@ -221,7 +221,7 @@ static void AddDataSetReader(
     UA_FieldTargetVariable *pTargetVariables =  (UA_FieldTargetVariable *)
         UA_calloc(readerConfig.dataSetMetaData.fieldsSize, sizeof(UA_FieldTargetVariable));
     assert(pTargetVariables != 0);
-    
+
     UA_FieldTargetDataType_init(&pTargetVariables[0].targetVariable);
 
     pTargetVariables[0].targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
@@ -229,7 +229,7 @@ static void AddDataSetReader(
 
     ck_assert(UA_Server_DataSetReader_createTargetVariables(server, *opDataSetReaderId,
         readerConfig.dataSetMetaData.fieldsSize, pTargetVariables) == UA_STATUSCODE_GOOD);
-    
+
     UA_FieldTargetDataType_clear(&pTargetVariables[0].targetVariable);
     UA_free(pTargetVariables);
     pTargetVariables = 0;
@@ -264,7 +264,7 @@ START_TEST(Test_normal_operation) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
     UA_UInt32 DSWNo_Conn1_WG1_DS1 = 1;
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
 
     /* setup Connection 1: reader */
@@ -277,7 +277,7 @@ START_TEST(Test_normal_operation) {
     UA_NodeId VarId_Conn1_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 350.0;
-    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1, 
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1,
         MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
 
 
@@ -362,7 +362,7 @@ START_TEST(Test_corner_cases) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
     UA_UInt32 DSWNo_Conn1_WG1_DS1 = 1;
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
 
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_WriterGroup_getState(server, WGId_Conn1_WG1, &state));
@@ -383,7 +383,7 @@ START_TEST(Test_corner_cases) {
     UA_NodeId VarId_Conn1_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 350.0;
-    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1, 
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1,
         MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
 
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_ReaderGroup_getState(server, RGId_Conn1_RG1, &state));

--- a/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
@@ -33,7 +33,8 @@ addMinimalPubSubConfiguration(void){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;

--- a/tests/pubsub/check_pubsub_publish_ethernet.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet.c
@@ -58,7 +58,8 @@ START_TEST(EthernetSendWithoutVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = PUBLISHER_ID;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
     connection = UA_PubSubConnection_findConnectionbyId(server, connection_test);
     /* Remove the connection if invalid*/
@@ -86,7 +87,8 @@ START_TEST(EthernetSendWithVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = PUBLISHER_ID;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
     connection = UA_PubSubConnection_findConnectionbyId(server, connection_test);
     /* Remove the connection if invalid*/

--- a/tests/pubsub/check_pubsub_publish_ethernet_etf.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet_etf.c
@@ -71,7 +71,8 @@ START_TEST(EthernetSendWithoutVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = PUBLISHER_ID;
     /* Connection options are given as Key/Value Pairs - Sockprio and Txtime */
     UA_KeyValuePair connectionOptions[2];
     connectionOptions[0].key = UA_QUALIFIEDNAME(0, "sockpriority");
@@ -123,7 +124,8 @@ START_TEST(EthernetSendWithVLANTag) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING(TRANSPORT_PROFILE_URI);
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = PUBLISHER_ID;
     /* Connection options are given as Key/Value Pairs - Sockprio and Txtime */
     UA_KeyValuePair connectionOptions[2];
     connectionOptions[0].key = UA_QUALIFIEDNAME(0, "sockpriority");

--- a/tests/pubsub/check_pubsub_publish_rt_levels.c
+++ b/tests/pubsub/check_pubsub_publish_rt_levels.c
@@ -30,7 +30,8 @@ addMinimalPubSubConfiguration(void){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;

--- a/tests/pubsub/check_pubsub_publish_uadp.c
+++ b/tests/pubsub/check_pubsub_publish_uadp.c
@@ -31,7 +31,8 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    connectionConfig.publisherId.numeric = 62541;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 62541;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
     UA_PublishedDataSetConfig publishedDataSetConfig;
@@ -180,7 +181,7 @@ START_TEST(CheckNMandDSMcalculation){
     UA_ByteString buffer = UA_BYTESTRING("");
     UA_NetworkMessage networkMessage;
     receiveAvailableMessages(buffer, connection, &networkMessage);
-    //ck_assert_int_eq(networkMessage.publisherId.publisherIdUInt32 , 62541);
+    //ck_assert_int_eq(networkMessage.publisherId.uint32 , 62541);
     ck_assert_int_eq(networkMessage.payloadHeader.dataSetPayloadHeader.count, 10);
     for(size_t i = 10; i > 0; i--){
         ck_assert_int_eq(*(networkMessage.payloadHeader.dataSetPayloadHeader.dataSetWriterIds+(i-1)), 21-i);
@@ -346,7 +347,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
     UA_ByteString buffer = UA_BYTESTRING("");
     UA_NetworkMessage networkMessage;
     receiveAvailableMessages(buffer, connection, &networkMessage);
-    //ck_assert_int_eq(networkMessage.publisherId.publisherIdUInt32 , 62541);
+    //ck_assert_int_eq(networkMessage.publisherId.uint32 , 62541);
     ck_assert_int_eq(networkMessage.payloadHeader.dataSetPayloadHeader.count, 10);
     for(size_t i = 10; i > 0; i--){
         ck_assert_int_eq(*(networkMessage.payloadHeader.dataSetPayloadHeader.dataSetWriterIds+(i-1)), 21-i);

--- a/tests/pubsub/check_pubsub_publisherid.c
+++ b/tests/pubsub/check_pubsub_publisherid.c
@@ -1,0 +1,2285 @@
+#include <open62541/plugin/pubsub_udp.h>
+#include <open62541/server_config_default.h>
+#include <open62541/server_pubsub.h>
+#include <open62541/plugin/log_stdout.h>
+
+#include "testing_clock.h"
+#include "ua_pubsub.h"
+
+#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+#include "ua_util_internal.h"
+#include "ua_pubsub_config.h"
+#endif /* UA_ENABLE_PUBSUB_FILE_CONFIG */
+
+#include <check.h>
+
+static UA_Server *server = NULL;
+
+/* global variables for test configuration */
+static UA_Boolean UseFastPath = UA_FALSE;
+static UA_Boolean UseRawEncoding = UA_FALSE;
+
+/***************************************************************************************************/
+/***************************************************************************************************/
+static void setup(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nsetup\n\n");
+
+    server = UA_Server_new();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    ck_assert(config != 0);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_ServerConfig_setDefault(config));
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP()));
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_run_startup(server));
+}
+
+/***************************************************************************************************/
+static void teardown(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nteardown\n\n");
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_run_shutdown(server));
+    UA_Server_delete(server);
+}
+/***************************************************************************************************/
+/***************************************************************************************************/
+
+
+/***************************************************************************************************/
+/***************************************************************************************************/
+/* utility functions to setup the PubSub configuration */
+
+/***************************************************************************************************/
+static void AddConnection(
+    char *pName,
+    UA_PublisherIdType publisherIdType,
+    UA_PublisherId publisherId,
+    UA_NodeId *opConnectionId) {
+
+    ck_assert(pName != 0);
+    ck_assert(opConnectionId != 0);
+
+    UA_PubSubConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
+    connectionConfig.name = UA_STRING(pName);
+    connectionConfig.enabled = UA_TRUE;
+    connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
+    UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING("opc.udp://224.0.0.22:4840/")};
+    UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    connectionConfig.publisherIdType = publisherIdType;
+    /* deep copy is not needed (not even for string) because UA_Server_addPubSubConnection performs deep copy */
+    connectionConfig.publisherId = publisherId;
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_addPubSubConnection(server, &connectionConfig, opConnectionId));
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_PubSubConnection_regist(server, opConnectionId));
+}
+
+/***************************************************************************************************/
+static void AddWriterGroup(
+    UA_NodeId *pConnectionId,
+    char *pName,
+    UA_UInt32 WriterGroupId,
+    UA_NodeId *opWriterGroupId) {
+
+    ck_assert(pConnectionId != 0);
+    ck_assert(pName != 0);
+    ck_assert(opWriterGroupId != 0);
+
+    UA_WriterGroupConfig writerGroupConfig;
+    memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
+    writerGroupConfig.name = UA_STRING(pName);
+    writerGroupConfig.publishingInterval = 50.0;
+    writerGroupConfig.enabled = UA_FALSE;
+    writerGroupConfig.writerGroupId = (UA_UInt16) WriterGroupId;
+    writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
+    writerGroupConfig.messageSettings.encoding             = UA_EXTENSIONOBJECT_DECODED;
+    writerGroupConfig.messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE];
+    UA_UadpWriterGroupMessageDataType *writerGroupMessage  = UA_UadpWriterGroupMessageDataType_new();
+    writerGroupMessage->networkMessageContentMask          = (UA_UadpNetworkMessageContentMask)(UA_UADPNETWORKMESSAGECONTENTMASK_PUBLISHERID |
+                                                              (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_GROUPHEADER |
+                                                              (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_WRITERGROUPID |
+                                                              (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_PAYLOADHEADER);
+    writerGroupConfig.messageSettings.content.decoded.data = writerGroupMessage;
+    if (UseFastPath) {
+        writerGroupConfig.rtLevel = UA_PUBSUB_RT_FIXED_SIZE;
+    }
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_addWriterGroup(server, *pConnectionId, &writerGroupConfig, opWriterGroupId));
+    UA_UadpWriterGroupMessageDataType_delete(writerGroupMessage);
+}
+
+/***************************************************************************************************/
+static void AddPublishedDataSet(
+    UA_NodeId *pWriterGroupId,
+    char *pPublishedDataSetName,
+    char *pDataSetWriterName,
+    UA_UInt32 DataSetWriterId,
+    UA_NodeId *opPublishedDataSetId,
+    UA_NodeId *opPublishedVarId,
+    UA_DataValue **oppFastPathPublisherDataValue,
+    UA_NodeId *opDataSetWriterId) {
+
+    ck_assert(pWriterGroupId != 0);
+    ck_assert(pPublishedDataSetName != 0);
+    ck_assert(pDataSetWriterName != 0);
+    ck_assert(opPublishedDataSetId != 0);
+    ck_assert(opPublishedVarId != 0);
+    ck_assert(oppFastPathPublisherDataValue != 0);
+    ck_assert(opDataSetWriterId != 0);
+
+    UA_PublishedDataSetConfig pdsConfig;
+    memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
+    pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
+    pdsConfig.name = UA_STRING(pPublishedDataSetName);
+    UA_AddPublishedDataSetResult result = UA_Server_addPublishedDataSet(server, &pdsConfig, opPublishedDataSetId);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, result.addResult);
+
+    /* Create variable to publish integer data */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.description           = UA_LOCALIZEDTEXT("en-US","Published Int32");
+    attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Int32");
+    attr.dataType              = UA_TYPES[UA_TYPES_INT32].typeId;
+    UA_Int32 publisherData     = 42;
+    UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_addVariableNode(server, UA_NODEID_NULL,
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                        UA_QUALIFIEDNAME(1, "Published Int32"),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                        attr, NULL, opPublishedVarId));
+
+    UA_NodeId dataSetFieldId;
+    UA_DataSetFieldConfig dataSetFieldConfig;
+    memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
+    dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
+    dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Int32 Publish var");
+    dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
+    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = *opPublishedVarId;
+    dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
+    if (UseFastPath) {
+        dataSetFieldConfig.field.variable.rtValueSource.rtInformationModelNode = UA_TRUE;
+        *oppFastPathPublisherDataValue = UA_DataValue_new();
+        ck_assert(*oppFastPathPublisherDataValue != 0);
+        UA_Int32 *pPublisherData  = UA_Int32_new();
+        ck_assert(pPublisherData != 0);
+        *pPublisherData = 42;
+        UA_Variant_setScalar(&((**oppFastPathPublisherDataValue).value), pPublisherData, &UA_TYPES[UA_TYPES_INT32]);
+        /* add external value backend for fast-path */
+        UA_ValueBackend valueBackend;
+        memset(&valueBackend, 0, sizeof(valueBackend));
+        valueBackend.backendType = UA_VALUEBACKENDTYPE_EXTERNAL;
+        valueBackend.backend.external.value = oppFastPathPublisherDataValue;
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setVariableNode_valueBackend(server, *opPublishedVarId, valueBackend));
+    }
+    UA_DataSetFieldResult PdsFieldResult = UA_Server_addDataSetField(server, *opPublishedDataSetId,
+                              &dataSetFieldConfig, &dataSetFieldId);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, PdsFieldResult.result);
+
+    UA_DataSetWriterConfig dataSetWriterConfig;
+    memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
+    dataSetWriterConfig.name = UA_STRING(pDataSetWriterName);
+    dataSetWriterConfig.dataSetWriterId = (UA_UInt16) DataSetWriterId;
+    dataSetWriterConfig.keyFrameCount = 10;
+    if (UseRawEncoding) {
+        dataSetWriterConfig.dataSetFieldContentMask = UA_DATASETFIELDCONTENTMASK_RAWDATA;
+    } else {
+        dataSetWriterConfig.dataSetFieldContentMask = UA_DATASETFIELDCONTENTMASK_NONE;
+    }
+    ck_assert_int_eq(UA_STATUSCODE_GOOD,
+        UA_Server_addDataSetWriter(server, *pWriterGroupId, *opPublishedDataSetId, &dataSetWriterConfig, opDataSetWriterId));
+}
+
+/***************************************************************************************************/
+static void AddReaderGroup(
+    UA_NodeId *pConnectionId,
+    char *pName,
+    UA_NodeId *opReaderGroupId) {
+
+    ck_assert(pConnectionId != 0);
+    ck_assert(pName != 0);
+    ck_assert(opReaderGroupId != 0);
+
+    UA_ReaderGroupConfig readerGroupConfig;
+    memset (&readerGroupConfig, 0, sizeof(UA_ReaderGroupConfig));
+    readerGroupConfig.name = UA_STRING(pName);
+    if (UseFastPath) {
+        readerGroupConfig.rtLevel = UA_PUBSUB_RT_FIXED_SIZE;
+    }
+    ck_assert_int_eq(UA_STATUSCODE_GOOD,
+        UA_Server_addReaderGroup(server, *pConnectionId, &readerGroupConfig, opReaderGroupId));
+}
+
+/***************************************************************************************************/
+static void AddDataSetReader(
+    UA_NodeId *pReaderGroupId,
+    char *pName,
+    UA_PublisherIdType publisherIdType,
+    UA_PublisherId publisherId,
+    UA_UInt32 WriterGroupId,
+    UA_UInt32 DataSetWriterId,
+    UA_NodeId *opSubscriberVarId,
+    UA_DataValue **oppFastPathSubscriberDataValue,
+    UA_NodeId *opDataSetReaderId) {
+
+    ck_assert(pReaderGroupId != 0);
+    ck_assert(pName != 0);
+    ck_assert(opSubscriberVarId != 0);
+    ck_assert(oppFastPathSubscriberDataValue != 0);
+    ck_assert(opDataSetReaderId != 0);
+
+    UA_DataSetReaderConfig readerConfig;
+    memset (&readerConfig, 0, sizeof(UA_DataSetReaderConfig));
+    readerConfig.name = UA_STRING(pName);
+    switch (publisherIdType) {
+        case UA_PUBLISHERIDTYPE_BYTE:
+            UA_Variant_setScalar(&readerConfig.publisherId, &publisherId.byte, &UA_TYPES[UA_TYPES_BYTE]);
+            break;
+        case UA_PUBLISHERIDTYPE_UINT16:
+            UA_Variant_setScalar(&readerConfig.publisherId, &publisherId.uint16, &UA_TYPES[UA_TYPES_UINT16]);
+            break;
+        case UA_PUBLISHERIDTYPE_UINT32:
+            UA_Variant_setScalar(&readerConfig.publisherId, &publisherId.uint32, &UA_TYPES[UA_TYPES_UINT32]);
+            break;
+        case UA_PUBLISHERIDTYPE_UINT64:
+            UA_Variant_setScalar(&readerConfig.publisherId, &publisherId.uint64, &UA_TYPES[UA_TYPES_UINT64]);
+            break;
+        case UA_PUBLISHERIDTYPE_STRING:
+            UA_Variant_setScalar(&readerConfig.publisherId, &publisherId.string, &UA_TYPES[UA_TYPES_STRING]);
+            break;
+        default:
+            ck_assert(UA_FALSE);
+            break;
+    }
+    readerConfig.writerGroupId    = (UA_UInt16) WriterGroupId;
+    readerConfig.dataSetWriterId  = (UA_UInt16) DataSetWriterId;
+    readerConfig.messageReceiveTimeout = 200.0;
+    readerConfig.messageSettings.encoding = UA_EXTENSIONOBJECT_DECODED;
+    readerConfig.messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPDATASETREADERMESSAGEDATATYPE];
+    UA_UadpDataSetReaderMessageDataType *dsReaderMessage = UA_UadpDataSetReaderMessageDataType_new();
+    dsReaderMessage->networkMessageContentMask = (UA_UadpNetworkMessageContentMask)(UA_UADPNETWORKMESSAGECONTENTMASK_PUBLISHERID |
+                                                    (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_GROUPHEADER |
+                                                    (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_WRITERGROUPID |
+                                                    (UA_UadpNetworkMessageContentMask)UA_UADPNETWORKMESSAGECONTENTMASK_PAYLOADHEADER);
+    readerConfig.messageSettings.content.decoded.data = dsReaderMessage;
+    if (UseRawEncoding) {
+        readerConfig.dataSetFieldContentMask = UA_DATASETFIELDCONTENTMASK_RAWDATA;
+        readerConfig.expectedEncoding = UA_PUBSUB_RT_RAW;
+    } else {
+        readerConfig.dataSetFieldContentMask = UA_DATASETFIELDCONTENTMASK_NONE;
+    }
+
+    UA_DataSetMetaDataType_init(&readerConfig.dataSetMetaData);
+    UA_DataSetMetaDataType *pDataSetMetaData = &readerConfig.dataSetMetaData;
+    pDataSetMetaData->name = UA_STRING (pName);
+    pDataSetMetaData->fieldsSize = 1;
+    pDataSetMetaData->fields = (UA_FieldMetaData*) UA_Array_new (pDataSetMetaData->fieldsSize,
+                         &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+
+    UA_FieldMetaData_init (&pDataSetMetaData->fields[0]);
+    UA_NodeId_copy (&UA_TYPES[UA_TYPES_INT32].typeId,
+                    &pDataSetMetaData->fields[0].dataType);
+    pDataSetMetaData->fields[0].builtInType = UA_NS0ID_INT32;
+    pDataSetMetaData->fields[0].name =  UA_STRING ("Int32 Var");
+    pDataSetMetaData->fields[0].valueRank = -1;
+    ck_assert(UA_Server_addDataSetReader(server, *pReaderGroupId, &readerConfig,
+                                         opDataSetReaderId) == UA_STATUSCODE_GOOD);
+    UA_UadpDataSetReaderMessageDataType_delete(dsReaderMessage);
+    dsReaderMessage = 0;
+
+    /* Variable to subscribe data */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
+    attr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
+    attr.dataType    = UA_TYPES[UA_TYPES_INT32].typeId;
+    UA_Int32 subscriberData = 0;
+    UA_Variant_setScalar(&attr.value, &subscriberData, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_addVariableNode(server, UA_NODEID_NULL,
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Int32"),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, opSubscriberVarId));
+
+    if (UseFastPath) {
+        *oppFastPathSubscriberDataValue = UA_DataValue_new();
+        ck_assert(*oppFastPathSubscriberDataValue != 0);
+        UA_Int32 *pSubscriberData  = UA_Int32_new();
+        ck_assert(pSubscriberData != 0);
+        *pSubscriberData = 0;
+        UA_Variant_setScalar(&((**oppFastPathSubscriberDataValue).value), pSubscriberData, &UA_TYPES[UA_TYPES_INT32]);
+        /* add external value backend for fast-path */
+        UA_ValueBackend valueBackend;
+        memset(&valueBackend, 0, sizeof(valueBackend));
+        valueBackend.backendType = UA_VALUEBACKENDTYPE_EXTERNAL;
+        valueBackend.backend.external.value = oppFastPathSubscriberDataValue;
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setVariableNode_valueBackend(server, *opSubscriberVarId, valueBackend));
+    }
+
+    UA_FieldTargetVariable *pTargetVariables =  (UA_FieldTargetVariable *)
+        UA_calloc(readerConfig.dataSetMetaData.fieldsSize, sizeof(UA_FieldTargetVariable));
+    ck_assert(pTargetVariables != 0);
+
+    UA_FieldTargetDataType_init(&pTargetVariables[0].targetVariable);
+
+    pTargetVariables[0].targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
+    pTargetVariables[0].targetVariable.targetNodeId = *opSubscriberVarId;
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetReader_createTargetVariables(server, *opDataSetReaderId,
+        readerConfig.dataSetMetaData.fieldsSize, pTargetVariables));
+
+    UA_FieldTargetDataType_clear(&pTargetVariables[0].targetVariable);
+    UA_free(pTargetVariables);
+    pTargetVariables = 0;
+
+    UA_free(pDataSetMetaData->fields);
+    pDataSetMetaData->fields = 0;
+}
+
+/***************************************************************************************************/
+/***************************************************************************************************/
+
+/***************************************************************************************************/
+/* utility function to trigger server process loop and wait until callbacks are executed */
+static void ServerDoProcess(
+    const char *pMessage,
+    const UA_UInt32 Sleep_ms,             /* use at least publishing interval */
+    const UA_UInt32 NoOfRunIterateCycles)
+{
+    ck_assert(pMessage != 0);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ServerDoProcess() sleep : %s", pMessage);
+    for (UA_UInt32 i = 0; i < NoOfRunIterateCycles; i++) {
+        UA_Server_run_iterate(server, true);
+        UA_fakeSleep(Sleep_ms);
+        UA_Server_run_iterate(server, true);
+    }
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ServerDoProcess() wakeup : %s", pMessage);
+}
+
+/***************************************************************************************************/
+/* utility function to check working pubsub operation */
+static void ValidatePublishSubscribe(
+    const UA_UInt32 NoOfTestVars,
+    UA_NodeId *publisherVarIds,
+    UA_NodeId *subscriberVarIds,
+    UA_DataValue **fastPathPublisherValues,     /* fast-path publisher DataValue */
+    UA_DataValue **fastPathSubscriberValues,    /* fast-path subscriber DataValue */
+    const UA_Int32 TestValue,
+    const UA_UInt32 Sleep_ms, /* use at least publishing interval */
+    const UA_UInt32 NoOfRunIterateCycles)
+{
+    ck_assert(publisherVarIds != 0);
+    ck_assert(subscriberVarIds != 0);
+    ck_assert(fastPathPublisherValues != 0);
+    ck_assert(fastPathSubscriberValues != 0);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe(): set variable to publish");
+
+    /* set variable value to publish */
+    UA_Int32 tmpValue = TestValue;
+    for (UA_UInt32 i = 0; i < NoOfTestVars; i++) {
+        tmpValue = TestValue + (UA_Int32) i;
+        if (UseFastPath) {
+            ck_assert((fastPathPublisherValues != 0) && (fastPathPublisherValues[i] != 0));
+            *((UA_Int32 *) (fastPathPublisherValues[i]->value.data)) = tmpValue;
+        } else {
+            UA_Variant writeValue;
+            UA_Variant_init(&writeValue);
+            UA_Variant_setScalarCopy(&writeValue, &tmpValue, &UA_TYPES[UA_TYPES_INT32]);
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_writeValue(server, publisherVarIds[i], writeValue));
+            UA_Variant_clear(&writeValue);
+        }
+    }
+
+    ServerDoProcess("ValidatePublishSubscribe()", Sleep_ms, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe(): read subscribed variable");
+    for (UA_UInt32 i = 0; i < NoOfTestVars; i++) {
+        tmpValue = TestValue + (UA_Int32) i;
+        if (UseFastPath) {
+            ck_assert(fastPathSubscriberValues[i] != 0);
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe(): expected value: '%i' vs. actual value: '%i'",
+                tmpValue, *(UA_Int32 *) fastPathSubscriberValues[i]->value.data);
+            ck_assert_int_eq(tmpValue, *(UA_Int32 *) fastPathSubscriberValues[i]->value.data);
+        } else {
+            UA_Variant SubscribedNodeData;
+            UA_Variant_init(&SubscribedNodeData);
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_readValue(server, subscriberVarIds[i], &SubscribedNodeData));
+            ck_assert(SubscribedNodeData.data != 0);
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe(): expected value: '%i' vs. actual value: '%i'",
+                tmpValue, *(UA_Int32 *)SubscribedNodeData.data);
+            ck_assert_int_eq(tmpValue, *(UA_Int32 *)SubscribedNodeData.data);
+            UA_Variant_clear(&SubscribedNodeData);
+        }
+    }
+}
+
+/***************************************************************************************************/
+static void DoTest_1_Connection(
+    UA_PublisherIdType publisherIdType,
+    UA_PublisherId publisherId) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_1_Connection() begin");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "fast-path     = %s", (UseFastPath) ? "enabled" : "disabled");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "raw encoding  = %s", (UseRawEncoding) ? "enabled" : "disabled");
+
+#define DOTEST_1_CONNECTION_MAX_VARS 1
+    UA_NodeId publisherVarIds[DOTEST_1_CONNECTION_MAX_VARS];
+    UA_NodeId subscriberVarIds[DOTEST_1_CONNECTION_MAX_VARS];
+
+    /* Attention: Publisher and corresponding Subscriber DataValue must have the same index */
+    UA_DataValue *fastPathPublisherDataValues[DOTEST_1_CONNECTION_MAX_VARS];
+    UA_DataValue *fastPathSubscriberDataValues[DOTEST_1_CONNECTION_MAX_VARS];
+    for (UA_UInt32 i = 0; i < DOTEST_1_CONNECTION_MAX_VARS; i++) {
+        fastPathPublisherDataValues[i] = 0;
+        fastPathSubscriberDataValues[i] = 0;
+    }
+
+    /* setup Connection 1: */
+    UA_NodeId ConnId_1;
+    UA_NodeId_init(&ConnId_1);
+    AddConnection("Conn1", publisherIdType, publisherId, &ConnId_1);
+
+    UA_NodeId WGId_Conn1_WG1;
+    UA_NodeId_init(&WGId_Conn1_WG1);
+    AddWriterGroup(&ConnId_1, "Conn1_WG1", 1, &WGId_Conn1_WG1);
+
+    UA_NodeId DsWId_Conn1_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+    UA_NodeId PDSId_Conn1_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", 1, &PDSId_Conn1_WG1_PDS1,
+        &publisherVarIds[0], &fastPathPublisherDataValues[0], &DsWId_Conn1_WG1_DS1);
+
+    UA_NodeId RGId_Conn1_RG1;
+    UA_NodeId_init(&RGId_Conn1_RG1);
+    AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+    UA_NodeId DSRId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", publisherIdType, publisherId, 1, 1,
+        &subscriberVarIds[0], &fastPathSubscriberDataValues[0], &DSRId_Conn1_RG1_DSR1);
+
+    /* freeze groups if fast-path is enabled */
+    if (UseFastPath) {
+        if (publisherIdType != UA_PUBLISHERIDTYPE_STRING) {
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeWriterGroupConfiguration(server, WGId_Conn1_WG1));
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeReaderGroupConfiguration(server, RGId_Conn1_RG1));
+        } else {
+            /* string PublisherId is not supported with fast-path */
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "test case: STRING publisherId with fast-path");
+            /* TODO: UA_Server_freezeWriterGroupConfiguration() accepts publisherId of type STRING, but
+                UA_Server_freezeReaderGroupConfiguration() returns an error -> what is correct? */
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeWriterGroupConfiguration(server, WGId_Conn1_WG1));
+            ck_assert_int_eq(UA_STATUSCODE_BADINTERNALERROR, UA_Server_freezeReaderGroupConfiguration(server, RGId_Conn1_RG1));
+
+            /* cleanup and continue with other tests */
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeWriterGroupConfiguration(server, WGId_Conn1_WG1));
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeReaderGroupConfiguration(server, RGId_Conn1_RG1));
+
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, PDSId_Conn1_WG1_PDS1));
+            ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePubSubConnection(server, ConnId_1));
+            for (UA_UInt32 i = 0; i < DOTEST_1_CONNECTION_MAX_VARS; i++) {
+                UA_DataValue_clear(fastPathPublisherDataValues[i]);
+                UA_DataValue_delete(fastPathPublisherDataValues[i]);
+                UA_DataValue_clear(fastPathSubscriberDataValues[i]);
+                UA_DataValue_delete(fastPathSubscriberDataValues[i]);
+            }
+            return;
+        }
+    }
+
+    /* set groups operational */
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1));
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1));
+
+    /* check that publish/subscribe works -> set some test values */
+    ValidatePublishSubscribe(DOTEST_1_CONNECTION_MAX_VARS, &publisherVarIds[0], &subscriberVarIds[0],
+        &fastPathPublisherDataValues[0], &fastPathSubscriberDataValues[0], 10, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_1_CONNECTION_MAX_VARS, &publisherVarIds[0], &subscriberVarIds[0],
+        &fastPathPublisherDataValues[0], &fastPathSubscriberDataValues[0], 33, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_1_CONNECTION_MAX_VARS, &publisherVarIds[0], &subscriberVarIds[0],
+        &fastPathPublisherDataValues[0], &fastPathSubscriberDataValues[0], 44, (UA_UInt32) 100, 3);
+
+    /* set groups to disabled */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable groups");
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1));
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupDisabled(server, RGId_Conn1_RG1));
+
+    /* unfreeze groups if fast-path is enabled */
+    if (UseFastPath) {
+        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "unfreeze groups");
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeWriterGroupConfiguration(server, WGId_Conn1_WG1));
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeReaderGroupConfiguration(server, RGId_Conn1_RG1));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove PDS");
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, PDSId_Conn1_WG1_PDS1));
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove Connection");
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePubSubConnection(server, ConnId_1));
+
+    if (UseFastPath) {
+        for (UA_UInt32 i = 0; i < DOTEST_1_CONNECTION_MAX_VARS; i++) {
+            UA_DataValue_clear(fastPathPublisherDataValues[i]);
+            UA_DataValue_delete(fastPathPublisherDataValues[i]);
+            UA_DataValue_clear(fastPathSubscriberDataValues[i]);
+            UA_DataValue_delete(fastPathSubscriberDataValues[i]);
+        }
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_1_Connection() end");
+}
+
+/***************************************************************************************************/
+/* simple test with 1 connection */
+START_TEST(Test_1_connection) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_1_connection");
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nTest PublisherId BYTE with all combinations");
+
+    UA_PublisherIdType publisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+    UA_PublisherId publisherId;
+    publisherId.byte = 2;
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nTest PublisherId UINT16 with all combinations");
+
+    publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    publisherId.uint16 = 3;
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nTest PublisherId UINT32 with all combinations");
+
+    publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    publisherId.uint32 = 5;
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nTest PublisherId UINT64 with all combinations");
+
+    publisherIdType = UA_PUBLISHERIDTYPE_UINT64;
+    publisherId.uint64 = 6;
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nTest PublisherId STRING with all combinations");
+
+    publisherIdType = UA_PUBLISHERIDTYPE_STRING;
+    publisherId.string = UA_STRING("My PublisherId");
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    /* Note: STRING publisherId is not supported with fast-path */
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_1_Connection(publisherIdType, publisherId);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_1_connection\n\n");
+} END_TEST
+
+
+/***************************************************************************************************/
+static void DoTest_multiple_Connections(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_multiple_Connections() begin");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "fast-path     = %s", (UseFastPath) ? "enabled" : "disabled");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "raw encoding  = %s", (UseRawEncoding) ? "enabled" : "disabled");
+
+    /*  Writers                             -> Readers
+        ----------------------------------------------------------------------------------
+        Conn1 BYTE   Id, WG 1, DSW 1        -> Conn2, RG 1, DSR 1
+        Conn2 BYTE   Id, WG 1, DSW 1        -> Conn1, RG 1, DSR 1
+        Conn3 UINT16 Id, WG 1, DSW 1        -> Conn4, RG 1, DSR 1
+        Conn4 UINT32 Id, WG 1, DSW 1        -> Conn3, RG 1, DSR 1
+        Conn5 UINT64 Id, WG 1, DSW 1        -> Conn6, RG 1, DSR 1
+        Conn6 UINT16 Id, WG 1, DSW 1        -> Conn5, RG 1, DSR 1
+    */
+
+    /* note: PublisherId BYTE 1 is different than UINT16 1 */
+
+    /* every connection has exactly 1 Writer- and ReaderGroup, 1 DataSetWriter and -reader, and 1 publish/subscribe variable */
+#define DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS 6
+
+    UA_NodeId ConnectionIds[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+    UA_NodeId WriterGroupIds[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+    UA_NodeId PublishedDataSetIds[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+    UA_NodeId ReaderGroupIds[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+
+    /* Attention: Publisher and corresponding Subscriber NodeId and DataValue must have the same index
+        e.g. publisherVarIds[0] value is set and subscriberVarIds[0] value is checked at ValidatePublishSubscribe() function */
+    UA_NodeId publisherVarIds[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+    UA_NodeId subscriberVarIds[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+
+    UA_DataValue *fastPathPublisherDataValues[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+    UA_DataValue *fastPathSubscriberDataValues[DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS];
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        fastPathPublisherDataValues[i] = 0;
+        fastPathSubscriberDataValues[i] = 0;
+    }
+
+    const UA_UInt32 WG_Id = 1;
+    const UA_UInt32 DSW_Id = 1;
+
+    /* setup all Publishers */
+
+    /* setup Connection 1: */
+    UA_NodeId ConnId_1;
+    UA_NodeId_init(&ConnId_1);
+    UA_PublisherIdType Conn1_PublisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+    UA_PublisherId Conn1_PublisherId;
+    Conn1_PublisherId.byte = 1;
+    AddConnection("Conn1", Conn1_PublisherIdType, Conn1_PublisherId, &ConnId_1);
+    ConnectionIds[0] = ConnId_1;
+
+    UA_NodeId WGId_Conn1_WG1;
+    UA_NodeId_init(&WGId_Conn1_WG1);
+    AddWriterGroup(&ConnId_1, "Conn1_WG1", WG_Id, &WGId_Conn1_WG1);
+    WriterGroupIds[0] = WGId_Conn1_WG1;
+
+    UA_NodeId DsWId_Conn1_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+    UA_NodeId PDSId_Conn1_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSW_Id, &PDSId_Conn1_WG1_PDS1,
+        &publisherVarIds[0], &fastPathPublisherDataValues[0], &DsWId_Conn1_WG1_DS1);
+    PublishedDataSetIds[0] = PDSId_Conn1_WG1_PDS1;
+
+    /* setup Connection 2: */
+    UA_NodeId ConnId_2;
+    UA_NodeId_init(&ConnId_2);
+    UA_PublisherIdType Conn2_PublisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+    UA_PublisherId Conn2_PublisherId;
+    Conn2_PublisherId.byte = 2;
+    AddConnection("Conn2", Conn2_PublisherIdType, Conn2_PublisherId, &ConnId_2);
+    ConnectionIds[1] = ConnId_2;
+
+    UA_NodeId WGId_Conn2_WG1;
+    UA_NodeId_init(&WGId_Conn2_WG1);
+    AddWriterGroup(&ConnId_2, "Conn2_WG1", WG_Id, &WGId_Conn2_WG1);
+    WriterGroupIds[1] = WGId_Conn2_WG1;
+
+    UA_NodeId DsWId_Conn2_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn2_WG1_DS1);
+    UA_NodeId PDSId_Conn2_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn2_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", DSW_Id, &PDSId_Conn2_WG1_PDS1,
+        &publisherVarIds[1], &fastPathPublisherDataValues[1], &DsWId_Conn2_WG1_DS1);
+    PublishedDataSetIds[1] = PDSId_Conn2_WG1_PDS1;
+
+    /* setup Connection 3: */
+    UA_NodeId ConnId_3;
+    UA_NodeId_init(&ConnId_3);
+    UA_PublisherIdType Conn3_PublisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    UA_PublisherId Conn3_PublisherId;
+    Conn3_PublisherId.uint16 = 1;
+    AddConnection("Conn3", Conn3_PublisherIdType, Conn3_PublisherId, &ConnId_3);
+    ConnectionIds[2] = ConnId_3;
+
+    UA_NodeId WGId_Conn3_WG1;
+    UA_NodeId_init(&WGId_Conn3_WG1);
+    AddWriterGroup(&ConnId_3, "Conn3_WG1", WG_Id, &WGId_Conn3_WG1);
+    WriterGroupIds[2] = WGId_Conn3_WG1;
+
+    UA_NodeId DsWId_Conn3_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn3_WG1_DS1);
+    UA_NodeId PDSId_Conn3_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn3_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn3_WG1, "Conn3_WG1_PDS1", "Conn3_WG1_DS1", DSW_Id, &PDSId_Conn3_WG1_PDS1,
+        &publisherVarIds[2], &fastPathPublisherDataValues[2], &DsWId_Conn3_WG1_DS1);
+    PublishedDataSetIds[2] = PDSId_Conn3_WG1_PDS1;
+
+    /* setup Connection 4 */
+    UA_NodeId ConnId_4;
+    UA_NodeId_init(&ConnId_4);
+    UA_PublisherIdType Conn4_PublisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    UA_PublisherId Conn4_PublisherId;
+    Conn4_PublisherId.uint32 = 15;
+    AddConnection("Conn4", Conn4_PublisherIdType, Conn4_PublisherId, &ConnId_4);
+    ConnectionIds[3] = ConnId_4;
+
+    UA_NodeId WGId_Conn4_WG1;
+    UA_NodeId_init(&WGId_Conn4_WG1);
+    AddWriterGroup(&ConnId_4, "Conn4_WG1", WG_Id, &WGId_Conn4_WG1);
+    WriterGroupIds[3] = WGId_Conn4_WG1;
+
+    UA_NodeId DsWId_Conn4_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn4_WG1_DS1);
+    UA_NodeId PDSId_Conn4_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn4_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn4_WG1, "Conn4_WG1_PDS1", "Conn4_WG1_DS1", DSW_Id, &PDSId_Conn4_WG1_PDS1,
+        &publisherVarIds[3], &fastPathPublisherDataValues[3], &DsWId_Conn4_WG1_DS1);
+    PublishedDataSetIds[3] = PDSId_Conn4_WG1_PDS1;
+
+    /* setup Connection 5 */
+    UA_NodeId ConnId_5;
+    UA_NodeId_init(&ConnId_5);
+    UA_PublisherIdType Conn5_PublisherIdType = UA_PUBLISHERIDTYPE_UINT64;
+    UA_PublisherId Conn5_PublisherId;
+    Conn5_PublisherId.uint64 = 33;
+    AddConnection("Conn5", Conn5_PublisherIdType, Conn5_PublisherId, &ConnId_5);
+    ConnectionIds[4] = ConnId_5;
+
+    UA_NodeId WGId_Conn5_WG1;
+    UA_NodeId_init(&WGId_Conn5_WG1);
+    AddWriterGroup(&ConnId_5, "Conn5_WG1", WG_Id, &WGId_Conn5_WG1);
+    WriterGroupIds[4] = WGId_Conn5_WG1;
+
+    UA_NodeId DsWId_Conn5_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn5_WG1_DS1);
+    UA_NodeId PDSId_Conn5_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn5_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn5_WG1, "Conn5_WG1_PDS1", "Conn5_WG1_DS1", DSW_Id, &PDSId_Conn5_WG1_PDS1,
+        &publisherVarIds[4], &fastPathPublisherDataValues[4], &DsWId_Conn5_WG1_DS1);
+    PublishedDataSetIds[4] = PDSId_Conn5_WG1_PDS1;
+
+    /* setup Connection 6: */
+    UA_NodeId ConnId_6;
+    UA_NodeId_init(&ConnId_6);
+    UA_PublisherIdType Conn6_PublisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    UA_PublisherId Conn6_PublisherId;
+    Conn6_PublisherId.uint16 = 2;
+    AddConnection("Conn6", Conn6_PublisherIdType, Conn6_PublisherId, &ConnId_6);
+    ConnectionIds[5] = ConnId_6;
+
+    UA_NodeId WGId_Conn6_WG1;
+    UA_NodeId_init(&WGId_Conn6_WG1);
+    AddWriterGroup(&ConnId_6, "Conn6_WG1", WG_Id, &WGId_Conn6_WG1);
+    WriterGroupIds[5] = WGId_Conn6_WG1;
+
+    UA_NodeId DsWId_Conn6_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn6_WG1_DS1);
+    UA_NodeId PDSId_Conn6_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn6_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn6_WG1, "Conn6_WG1_PDS1", "Conn6_WG1_DS1", DSW_Id, &PDSId_Conn6_WG1_PDS1,
+        &publisherVarIds[5], &fastPathPublisherDataValues[5], &DsWId_Conn6_WG1_DS1);
+    PublishedDataSetIds[5] = PDSId_Conn6_WG1_PDS1;
+
+    /* setup all Subscribers */
+
+    /* setup Connection 1: */
+    UA_NodeId RGId_Conn1_RG1;
+    UA_NodeId_init(&RGId_Conn1_RG1);
+    AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+    UA_NodeId DSRId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", Conn2_PublisherIdType, Conn2_PublisherId, WG_Id, DSW_Id,
+        &subscriberVarIds[1], &fastPathSubscriberDataValues[1], &DSRId_Conn1_RG1_DSR1);
+    ReaderGroupIds[0] = RGId_Conn1_RG1;
+
+    /* setup Connection 2: */
+    UA_NodeId RGId_Conn2_RG1;
+    UA_NodeId_init(&RGId_Conn2_RG1);
+    AddReaderGroup(&ConnId_2, "Conn2_RG1", &RGId_Conn2_RG1);
+    UA_NodeId DSRId_Conn2_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn2_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, WG_Id, DSW_Id,
+        &subscriberVarIds[0], &fastPathSubscriberDataValues[0], &DSRId_Conn2_RG1_DSR1);
+    ReaderGroupIds[1] = RGId_Conn2_RG1;
+
+    /* setup Connection 3: */
+    UA_NodeId RGId_Conn3_RG1;
+    UA_NodeId_init(&RGId_Conn3_RG1);
+    AddReaderGroup(&ConnId_3, "Conn3_RG1", &RGId_Conn3_RG1);
+    UA_NodeId DSRId_Conn3_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn3_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn3_RG1, "Conn3_RG1_DSR1", Conn4_PublisherIdType, Conn4_PublisherId, WG_Id, DSW_Id,
+        &subscriberVarIds[3], &fastPathSubscriberDataValues[3], &DSRId_Conn3_RG1_DSR1);
+    ReaderGroupIds[2] = RGId_Conn3_RG1;
+
+    /* setup Connection 4: */
+    UA_NodeId RGId_Conn4_RG1;
+    UA_NodeId_init(&RGId_Conn4_RG1);
+    AddReaderGroup(&ConnId_4, "Conn4_RG1", &RGId_Conn4_RG1);
+    UA_NodeId DSRId_Conn4_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn4_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn4_RG1, "Conn4_RG1_DSR1", Conn3_PublisherIdType, Conn3_PublisherId, WG_Id, DSW_Id,
+        &subscriberVarIds[2], &fastPathSubscriberDataValues[2], &DSRId_Conn4_RG1_DSR1);
+    ReaderGroupIds[3] = RGId_Conn4_RG1;
+
+    /* setup Connection 5: */
+    UA_NodeId RGId_Conn5_RG1;
+    UA_NodeId_init(&RGId_Conn5_RG1);
+    AddReaderGroup(&ConnId_5, "Conn5_RG1", &RGId_Conn5_RG1);
+    UA_NodeId DSRId_Conn5_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn5_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn5_RG1, "Conn5_RG1_DSR1", Conn6_PublisherIdType, Conn6_PublisherId, WG_Id, DSW_Id,
+        &subscriberVarIds[5], &fastPathSubscriberDataValues[5], &DSRId_Conn5_RG1_DSR1);
+    ReaderGroupIds[4] = RGId_Conn5_RG1;
+
+    /* setup Connection 6: */
+    UA_NodeId RGId_Conn6_RG1;
+    UA_NodeId_init(&RGId_Conn6_RG1);
+    AddReaderGroup(&ConnId_6, "Conn6_RG1", &RGId_Conn6_RG1);
+    UA_NodeId DSRId_Conn6_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn6_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn6_RG1, "Conn6_RG1_DSR1", Conn5_PublisherIdType, Conn5_PublisherId, WG_Id, DSW_Id,
+        &subscriberVarIds[4], &fastPathSubscriberDataValues[4], &DSRId_Conn6_RG1_DSR1);
+    ReaderGroupIds[5] = RGId_Conn6_RG1;
+
+
+    /* freeze all Groups */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+    /* set groups operational */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupOperational(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupOperational(server, ReaderGroupIds[i]));
+    }
+
+    /* check that publish/subscribe works -> set some test values */
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS, publisherVarIds, subscriberVarIds,
+        fastPathPublisherDataValues, fastPathSubscriberDataValues, 10, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 50, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 100, (UA_UInt32) 100, 3);
+
+    /* set groups to disabled */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable groups");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupDisabled(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupDisabled(server, ReaderGroupIds[i]));
+    }
+    /* unfreeze groups */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove PublishedDataSets");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, PublishedDataSetIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove Connection");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePubSubConnection(server, ConnectionIds[i]));
+    }
+
+    if (UseFastPath) {
+        for (size_t i = 0; i < DOTEST_MULTIPLE_CONNECTIONS_MAX_COMPONENTS; i++) {
+            UA_DataValue_clear(fastPathPublisherDataValues[i]);
+            UA_DataValue_delete(fastPathPublisherDataValues[i]);
+
+            UA_DataValue_clear(fastPathSubscriberDataValues[i]);
+            UA_DataValue_delete(fastPathSubscriberDataValues[i]);
+        }
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_multiple_Connections() end");
+}
+
+/***************************************************************************************************/
+/* test with multiple connections */
+START_TEST(Test_multiple_connections) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_multiple_connections");
+
+    /* note: fast-path does not support
+        - multiple groups and/or DataSets yet, therefore we only test multiple connections
+        - STRING publisherIds */
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_multiple_Connections();
+
+    UseFastPath = UA_FALSE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_multiple_Connections();
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_FALSE;
+    DoTest_multiple_Connections();
+
+    UseFastPath = UA_TRUE;
+    UseRawEncoding = UA_TRUE;
+    DoTest_multiple_Connections();
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_multiple_connections\n\n");
+} END_TEST
+
+/***************************************************************************************************/
+static void Test_string_PublisherId_InformationModel(
+    const UA_NodeId connectionId,
+    const UA_String expectedStringIdValue) {
+
+    /* read PublisherId value of PubSub information model -> check that string read works correctly */
+
+    /* get PublisherId node */
+    UA_RelativePathElement rpe;
+    UA_RelativePathElement_init(&rpe);
+    rpe.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HIERARCHICALREFERENCES);;
+    rpe.isInverse = false;
+    rpe.includeSubtypes = true;
+    rpe.targetName = UA_QUALIFIEDNAME(0, "PublisherId");
+
+    UA_BrowsePath bp;
+    UA_BrowsePath_init(&bp);
+    bp.startingNode = connectionId;
+    bp.relativePath.elementsSize = 1;
+    bp.relativePath.elements = &rpe;
+    UA_BrowsePathResult bpr;
+    UA_BrowsePathResult_init(&bpr);
+    bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, bpr.statusCode);
+    ck_assert_int_eq(1, bpr.targetsSize);
+    UA_NodeId PublisherIdNode = bpr.targets[0].targetId.nodeId;
+
+    /* read value */
+    UA_Variant PublisherIdValue;
+    UA_Variant_init(&PublisherIdValue);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_readValue(server, PublisherIdNode, &PublisherIdValue));
+    ck_assert(true == UA_Variant_hasScalarType(&PublisherIdValue, &UA_TYPES[UA_TYPES_STRING]));
+    ck_assert(true == UA_String_equal(&expectedStringIdValue, (UA_String*) PublisherIdValue.data));
+    UA_Variant_clear(&PublisherIdValue);
+
+    UA_BrowsePathResult_clear(&bpr);
+}
+
+/***************************************************************************************************/
+static void DoTest_string_PublisherId(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_string_PublisherId() begin");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "fast-path     = %s", (UseFastPath) ? "enabled" : "disabled");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "raw encoding  = %s", (UseRawEncoding) ? "enabled" : "disabled");
+
+    /*  Writers                                     -> Readers
+        ----------------------------------------------------------------------------------
+        Conn1 STRING Id "H"       WG 1 DSW 1        -> Conn2, RG 1, DSR 1
+        Conn2 STRING Id "h"       WG 1 DSW 1        -> Conn1, RG 1, DSR 1
+        Conn3 STRING Id "hallo"   WG 1 DSW 1        -> Conn5, RG 1, DSR 1
+        Conn4 STRING Id "hallo1"  WG 1 DSW 1        -> Conn3, RG 1, DSR 1
+        Conn5 STRING Id "Hallo"   WG 1 DSW 1        -> Conn4, RG 1, DSR 1
+    */
+
+    /* every connection has exactly 1 Writer- and ReaderGroup, 1 DataSetWriter and -reader, and 1 publish/subscribe variable */
+#define DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS 5
+    UA_NodeId ConnectionIds[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+    UA_NodeId WriterGroupIds[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+    UA_NodeId PublishedDataSetIds[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+    UA_NodeId ReaderGroupIds[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+
+    /* Attention: Publisher and corresponding Subscriber NodeId and DataValue must have the same index
+        e.g. publisherVarIds[0] value is set and subscriberVarIds[0] value is checked at ValidatePublishSubscribe() function */
+    UA_NodeId publisherVarIds[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+    UA_NodeId subscriberVarIds[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+
+    UA_DataValue *fastPathPublisherDataValues[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+    UA_DataValue *fastPathSubscriberDataValues[DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS];
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        fastPathPublisherDataValues[i] = 0;
+        fastPathSubscriberDataValues[i] = 0;
+    }
+
+    const UA_UInt32 WG_Id = 1;
+    const UA_UInt32 DSW_Id = 1;
+
+    /* setup all Publishers */
+
+{   /* create a local scope and allocate string PublisherIds on stack to check that
+        there are no memory issues with strings (deep copy of strings is done etc.) */
+
+        /* setup Connection 1: */
+        UA_NodeId ConnId_1;
+        UA_NodeId_init(&ConnId_1);
+        UA_PublisherIdType Conn1_PublisherIdType = UA_PUBLISHERIDTYPE_STRING;
+        UA_PublisherId Conn1_PublisherId;
+        Conn1_PublisherId.string = UA_STRING("H");  // allocate string on stack
+        AddConnection("Conn1", Conn1_PublisherIdType, Conn1_PublisherId, &ConnId_1);
+        ConnectionIds[0] = ConnId_1;
+
+        UA_NodeId WGId_Conn1_WG1;
+        UA_NodeId_init(&WGId_Conn1_WG1);
+        AddWriterGroup(&ConnId_1, "Conn1_WG1", WG_Id, &WGId_Conn1_WG1);
+        WriterGroupIds[0] = WGId_Conn1_WG1;
+
+        UA_NodeId DsWId_Conn1_WG1_DS1;
+        UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+        UA_NodeId PDSId_Conn1_WG1_PDS1;
+        UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+        AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSW_Id, &PDSId_Conn1_WG1_PDS1,
+            &publisherVarIds[0], &fastPathPublisherDataValues[0], &DsWId_Conn1_WG1_DS1);
+        PublishedDataSetIds[0] = PDSId_Conn1_WG1_PDS1;
+
+        /* setup Connection 2: */
+        UA_NodeId ConnId_2;
+        UA_NodeId_init(&ConnId_2);
+        UA_PublisherIdType Conn2_PublisherIdType = UA_PUBLISHERIDTYPE_STRING;
+        UA_PublisherId Conn2_PublisherId;
+        Conn2_PublisherId.string = UA_STRING("h");
+        AddConnection("Conn2", Conn2_PublisherIdType, Conn2_PublisherId, &ConnId_2);
+        ConnectionIds[1] = ConnId_2;
+
+        UA_NodeId WGId_Conn2_WG1;
+        UA_NodeId_init(&WGId_Conn2_WG1);
+        AddWriterGroup(&ConnId_2, "Conn2_WG1", WG_Id, &WGId_Conn2_WG1);
+        WriterGroupIds[1] = WGId_Conn2_WG1;
+
+        UA_NodeId DsWId_Conn2_WG1_DS1;
+        UA_NodeId_init(&DsWId_Conn2_WG1_DS1);
+        UA_NodeId PDSId_Conn2_WG1_PDS1;
+        UA_NodeId_init(&PDSId_Conn2_WG1_PDS1);
+        AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", DSW_Id, &PDSId_Conn2_WG1_PDS1,
+            &publisherVarIds[1], &fastPathPublisherDataValues[1], &DsWId_Conn2_WG1_DS1);
+        PublishedDataSetIds[1] = PDSId_Conn2_WG1_PDS1;
+
+        /* setup Connection 3: */
+        UA_NodeId ConnId_3;
+        UA_NodeId_init(&ConnId_3);
+        UA_PublisherIdType Conn3_PublisherIdType = UA_PUBLISHERIDTYPE_STRING;
+        UA_PublisherId Conn3_PublisherId;
+        Conn3_PublisherId.string = UA_STRING("hallo");
+        AddConnection("Conn3", Conn3_PublisherIdType, Conn3_PublisherId, &ConnId_3);
+        ConnectionIds[2] = ConnId_3;
+
+        UA_NodeId WGId_Conn3_WG1;
+        UA_NodeId_init(&WGId_Conn3_WG1);
+        AddWriterGroup(&ConnId_3, "Conn3_WG1", WG_Id, &WGId_Conn3_WG1);
+        WriterGroupIds[2] = WGId_Conn3_WG1;
+
+        UA_NodeId DsWId_Conn3_WG1_DS1;
+        UA_NodeId_init(&DsWId_Conn3_WG1_DS1);
+        UA_NodeId PDSId_Conn3_WG1_PDS1;
+        UA_NodeId_init(&PDSId_Conn3_WG1_PDS1);
+        AddPublishedDataSet(&WGId_Conn3_WG1, "Conn3_WG1_PDS1", "Conn3_WG1_DS1", DSW_Id, &PDSId_Conn3_WG1_PDS1,
+            &publisherVarIds[2], &fastPathPublisherDataValues[2], &DsWId_Conn3_WG1_DS1);
+        PublishedDataSetIds[2] = PDSId_Conn3_WG1_PDS1;
+
+        /* setup Connection 4 */
+        UA_NodeId ConnId_4;
+        UA_NodeId_init(&ConnId_4);
+        UA_PublisherIdType Conn4_PublisherIdType = UA_PUBLISHERIDTYPE_STRING;
+        UA_PublisherId Conn4_PublisherId;
+        Conn4_PublisherId.string = UA_STRING("hallo1");
+        AddConnection("Conn4", Conn4_PublisherIdType, Conn4_PublisherId, &ConnId_4);
+        ConnectionIds[3] = ConnId_4;
+
+        UA_NodeId WGId_Conn4_WG1;
+        UA_NodeId_init(&WGId_Conn4_WG1);
+        AddWriterGroup(&ConnId_4, "Conn4_WG1", WG_Id, &WGId_Conn4_WG1);
+        WriterGroupIds[3] = WGId_Conn4_WG1;
+
+        UA_NodeId DsWId_Conn4_WG1_DS1;
+        UA_NodeId_init(&DsWId_Conn4_WG1_DS1);
+        UA_NodeId PDSId_Conn4_WG1_PDS1;
+        UA_NodeId_init(&PDSId_Conn4_WG1_PDS1);
+        AddPublishedDataSet(&WGId_Conn4_WG1, "Conn4_WG1_PDS1", "Conn4_WG1_DS1", DSW_Id, &PDSId_Conn4_WG1_PDS1,
+            &publisherVarIds[3], &fastPathPublisherDataValues[3], &DsWId_Conn4_WG1_DS1);
+        PublishedDataSetIds[3] = PDSId_Conn4_WG1_PDS1;
+
+        /* setup Connection 5 */
+        UA_NodeId ConnId_5;
+        UA_NodeId_init(&ConnId_5);
+        UA_PublisherIdType Conn5_PublisherIdType = UA_PUBLISHERIDTYPE_STRING;
+        UA_PublisherId Conn5_PublisherId;
+        Conn5_PublisherId.string = UA_STRING("Hallo");
+        AddConnection("Conn5", Conn5_PublisherIdType, Conn5_PublisherId, &ConnId_5);
+        ConnectionIds[4] = ConnId_5;
+
+        UA_NodeId WGId_Conn5_WG1;
+        UA_NodeId_init(&WGId_Conn5_WG1);
+        AddWriterGroup(&ConnId_5, "Conn5_WG1", WG_Id, &WGId_Conn5_WG1);
+        WriterGroupIds[4] = WGId_Conn5_WG1;
+
+        UA_NodeId DsWId_Conn5_WG1_DS1;
+        UA_NodeId_init(&DsWId_Conn5_WG1_DS1);
+        UA_NodeId PDSId_Conn5_WG1_PDS1;
+        UA_NodeId_init(&PDSId_Conn5_WG1_PDS1);
+        AddPublishedDataSet(&WGId_Conn5_WG1, "Conn5_WG1_PDS1", "Conn5_WG1_DS1", DSW_Id, &PDSId_Conn5_WG1_PDS1,
+            &publisherVarIds[4], &fastPathPublisherDataValues[4], &DsWId_Conn5_WG1_DS1);
+        PublishedDataSetIds[4] = PDSId_Conn5_WG1_PDS1;
+
+        /* setup all Subscribers */
+
+        /* setup Connection 1: */
+        UA_NodeId RGId_Conn1_RG1;
+        UA_NodeId_init(&RGId_Conn1_RG1);
+        AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+        UA_NodeId DSRId_Conn1_RG1_DSR1;
+        UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+        AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", Conn2_PublisherIdType, Conn2_PublisherId, WG_Id, DSW_Id,
+            &subscriberVarIds[1], &fastPathSubscriberDataValues[1], &DSRId_Conn1_RG1_DSR1);
+        ReaderGroupIds[0] = RGId_Conn1_RG1;
+
+        /* setup Connection 2: */
+        UA_NodeId RGId_Conn2_RG1;
+        UA_NodeId_init(&RGId_Conn2_RG1);
+        AddReaderGroup(&ConnId_2, "Conn2_RG1", &RGId_Conn2_RG1);
+        UA_NodeId DSRId_Conn2_RG1_DSR1;
+        UA_NodeId_init(&DSRId_Conn2_RG1_DSR1);
+        AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, WG_Id, DSW_Id,
+            &subscriberVarIds[0], &fastPathSubscriberDataValues[0], &DSRId_Conn2_RG1_DSR1);
+        ReaderGroupIds[1] = RGId_Conn2_RG1;
+
+        /* setup Connection 3: */
+        UA_NodeId RGId_Conn3_RG1;
+        UA_NodeId_init(&RGId_Conn3_RG1);
+        AddReaderGroup(&ConnId_3, "Conn3_RG1", &RGId_Conn3_RG1);
+        UA_NodeId DSRId_Conn3_RG1_DSR1;
+        UA_NodeId_init(&DSRId_Conn3_RG1_DSR1);
+        AddDataSetReader(&RGId_Conn3_RG1, "Conn3_RG1_DSR1", Conn5_PublisherIdType, Conn5_PublisherId, WG_Id, DSW_Id,
+            &subscriberVarIds[4], &fastPathSubscriberDataValues[4], &DSRId_Conn3_RG1_DSR1);
+        ReaderGroupIds[2] = RGId_Conn3_RG1;
+
+        /* setup Connection 4: */
+        UA_NodeId RGId_Conn4_RG1;
+        UA_NodeId_init(&RGId_Conn4_RG1);
+        AddReaderGroup(&ConnId_4, "Conn4_RG1", &RGId_Conn4_RG1);
+        UA_NodeId DSRId_Conn4_RG1_DSR1;
+        UA_NodeId_init(&DSRId_Conn4_RG1_DSR1);
+        AddDataSetReader(&RGId_Conn4_RG1, "Conn4_RG1_DSR1", Conn3_PublisherIdType, Conn3_PublisherId, WG_Id, DSW_Id,
+            &subscriberVarIds[2], &fastPathSubscriberDataValues[2], &DSRId_Conn4_RG1_DSR1);
+        ReaderGroupIds[3] = RGId_Conn4_RG1;
+
+        /* setup Connection 5: */
+        UA_NodeId RGId_Conn5_RG1;
+        UA_NodeId_init(&RGId_Conn5_RG1);
+        AddReaderGroup(&ConnId_5, "Conn5_RG1", &RGId_Conn5_RG1);
+        UA_NodeId DSRId_Conn5_RG1_DSR1;
+        UA_NodeId_init(&DSRId_Conn5_RG1_DSR1);
+        AddDataSetReader(&RGId_Conn5_RG1, "Conn5_RG1_DSR1", Conn4_PublisherIdType, Conn4_PublisherId, WG_Id, DSW_Id,
+            &subscriberVarIds[3], &fastPathSubscriberDataValues[3], &DSRId_Conn5_RG1_DSR1);
+        ReaderGroupIds[4] = RGId_Conn5_RG1;
+
+    }   /* end of configuration scope -> string PublisherIds are deallocated from stack
+            deep copy of string PublisherId is done by UA_Server_addPubSubConnection() */
+
+    /* freeze all Groups */
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+    /* set groups operational */
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupOperational(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupOperational(server, ReaderGroupIds[i]));
+    }
+
+    /* check that publish/subscribe works -> set some test values */
+    ValidatePublishSubscribe(DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS, publisherVarIds, subscriberVarIds,
+        fastPathPublisherDataValues, fastPathSubscriberDataValues, 10, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 50, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 100, (UA_UInt32) 100, 3);
+
+    /* check PubSub information model - string Ids */
+    char *expectedPublisherIds[] = {
+        "H",
+        "h",
+        "hallo",
+        "hallo1",
+        "Hallo"
+    };
+
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        Test_string_PublisherId_InformationModel(ConnectionIds[i], UA_STRING(expectedPublisherIds[i]));
+    }
+
+    /* set groups to disabled */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable groups");
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupDisabled(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupDisabled(server, ReaderGroupIds[i]));
+    }
+    /* unfreeze groups */
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove PublishedDataSets");
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, PublishedDataSetIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove Connection");
+    for (UA_UInt32 i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePubSubConnection(server, ConnectionIds[i]));
+    }
+
+    if (UseFastPath) {
+        for (size_t i = 0; i < DOTEST_STRING_PUBLISHERID_MAX_COMPONENTS; i++) {
+            UA_DataValue_clear(fastPathPublisherDataValues[i]);
+            UA_DataValue_delete(fastPathPublisherDataValues[i]);
+
+            UA_DataValue_clear(fastPathSubscriberDataValues[i]);
+            UA_DataValue_delete(fastPathSubscriberDataValues[i]);
+        }
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_string_PublisherId() end");
+}
+
+
+/***************************************************************************************************/
+/* test string PublisherId */
+START_TEST(Test_string_publisherId) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_string_publisherId");
+
+    /* note: fast-path does not support STRING publisherIds */
+    UseFastPath = UA_FALSE;
+
+    UseRawEncoding = UA_FALSE;
+    DoTest_string_PublisherId();
+
+    UseRawEncoding = UA_TRUE;
+    DoTest_string_PublisherId();
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_string_publisherId\n\n");
+} END_TEST
+
+#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+
+/***************************************************************************************************/
+START_TEST(Test_string_publisherId_file_config) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_string_publisherId_file_config");
+
+    UseRawEncoding = UA_FALSE;
+    UseFastPath = UA_FALSE;
+
+#define STRING_PUBLISHERID_FILE_MAX_COMPONENTS 1
+    /* Attention: Publisher and corresponding Subscriber NodeId and DataValue must have the same index
+        e.g. publisherVarIds[0] value is set and subscriberVarIds[0] value is checked at ValidatePublishSubscribe() function */
+    UA_NodeId publisherVarIds[STRING_PUBLISHERID_FILE_MAX_COMPONENTS];
+    UA_NodeId subscriberVarIds[STRING_PUBLISHERID_FILE_MAX_COMPONENTS];
+
+    UA_DataValue *fastPathPublisherDataValues[STRING_PUBLISHERID_FILE_MAX_COMPONENTS];
+    UA_DataValue *fastPathSubscriberDataValues[STRING_PUBLISHERID_FILE_MAX_COMPONENTS];
+    for (UA_UInt32 i = 0; i < STRING_PUBLISHERID_FILE_MAX_COMPONENTS; i++) {
+        fastPathPublisherDataValues[i] = 0;
+        fastPathSubscriberDataValues[i] = 0;
+    }
+
+    /* we do not use a file, but setup PubSubConfigurationDataType structure and encode it to a bytestring
+        to simulate file read */
+    UA_ByteString encodedConfigDataBuffer;
+    UA_ByteString_init(&encodedConfigDataBuffer);
+
+    /* constants for configuration */
+#define DS_MESSAGECONTENT_MASK (UA_UADPDATASETMESSAGECONTENTMASK_STATUS | \
+                                UA_UADPDATASETMESSAGECONTENTMASK_TIMESTAMP)
+#define MAX_NETWORKMESSAGE_SIZE 1400
+#define UADP_NETWORKMESSAGE_CONTENT_MASK \
+    (UA_UADPNETWORKMESSAGECONTENTMASK_PUBLISHERID | UA_UADPNETWORKMESSAGECONTENTMASK_GROUPHEADER | \
+    UA_UADPNETWORKMESSAGECONTENTMASK_WRITERGROUPID | UA_UADPNETWORKMESSAGECONTENTMASK_PAYLOADHEADER)
+
+{   /* we use a local scope to make sure that string PublisherId configuration works correctly
+        -> e.g. deep copy of Id */
+    UA_PubSubConfigurationDataType config;
+    UA_PubSubConfigurationDataType_init(&config);
+
+    config.enabled = UA_TRUE;
+
+    /* PublishedDataSet config */
+    config.publishedDataSetsSize = 1;
+    config.publishedDataSets = UA_PublishedDataSetDataType_new();
+    ck_assert(config.publishedDataSets != 0);
+    UA_PublishedDataSetDataType *pds = config.publishedDataSets;
+    UA_PublishedDataSetDataType_init(pds);
+    pds->name = UA_STRING_ALLOC("PublishedDataSet 1");
+    UA_DataSetMetaDataType dataSetMetaData;
+    UA_DataSetMetaDataType_init(&dataSetMetaData);
+    dataSetMetaData.name = UA_STRING_ALLOC("PublishedDataSet 1");
+    dataSetMetaData.fieldsSize = 1;
+    dataSetMetaData.fields = UA_FieldMetaData_new();
+    ck_assert(dataSetMetaData.fields != 0);
+    UA_FieldMetaData_init(dataSetMetaData.fields);
+    dataSetMetaData.fields->name = UA_STRING_ALLOC("Field 0");
+    dataSetMetaData.fields->fieldFlags = UA_DATASETFIELDFLAGS_NONE;
+    dataSetMetaData.fields->builtInType = UA_TYPES_INT32;
+    dataSetMetaData.fields->dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_INT32);
+    dataSetMetaData.fields->valueRank = UA_VALUERANK_SCALAR;
+    pds->dataSetMetaData = dataSetMetaData;
+    UA_PublishedDataItemsDataType *pdsDataItems = UA_PublishedDataItemsDataType_new();
+    ck_assert(pdsDataItems != 0);
+    UA_PublishedDataItemsDataType_init(pdsDataItems);
+    pdsDataItems->publishedDataSize = 1;
+    pdsDataItems->publishedData = UA_PublishedVariableDataType_new();
+    ck_assert(pdsDataItems->publishedData != 0);
+    UA_PublishedVariableDataType_init(pdsDataItems->publishedData);
+    pdsDataItems->publishedData->attributeId = UA_ATTRIBUTEID_VALUE;
+    /* Create variable to publish integer data */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.description           = UA_LOCALIZEDTEXT("en-US","Published Int32");
+    attr.displayName           = UA_LOCALIZEDTEXT("en-US","Published Int32");
+    attr.dataType              = UA_TYPES[UA_TYPES_INT32].typeId;
+    UA_Int32 publisherData     = 42;
+    UA_Variant_setScalar(&attr.value, &publisherData, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_addVariableNode(server, UA_NODEID_NULL,
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                        UA_QUALIFIEDNAME(1, "Published Int32"),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                        attr, NULL, &(publisherVarIds[0])));
+    UA_NodeId_copy(&(publisherVarIds[0]), &(pdsDataItems->publishedData->publishedVariable));
+    pds->dataSetSource.encoding = UA_EXTENSIONOBJECT_DECODED;
+    pds->dataSetSource.content.decoded.type = &UA_TYPES[UA_TYPES_PUBLISHEDDATAITEMSDATATYPE];
+    pds->dataSetSource.content.decoded.data = pdsDataItems;
+
+    /* connection config */
+    config.connectionsSize = 1;
+    config.connections = UA_PubSubConnectionDataType_new();
+    ck_assert(config.connections != 0);
+    UA_PubSubConnectionDataType *connection = config.connections;
+    UA_PubSubConnectionDataType_init(connection);
+    connection->name = UA_STRING_ALLOC("My Connection");
+    connection->enabled = true;
+    UA_String publisherIdString = UA_STRING("Publisher 1");
+    UA_Variant_setScalarCopy(&connection->publisherId, &publisherIdString, &UA_TYPES[UA_TYPES_STRING]); // TODO?
+    connection->transportProfileUri = UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
+    UA_NetworkAddressUrlDataType *addr = UA_NetworkAddressUrlDataType_new();
+    ck_assert(addr != 0);
+    UA_NetworkAddressUrlDataType_init(addr);
+    addr->url = UA_STRING_ALLOC("opc.udp://224.0.0.22:4840/");
+    connection->address.encoding = UA_EXTENSIONOBJECT_DECODED;
+    connection->address.content.decoded.type = &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE];
+    connection->address.content.decoded.data = addr;
+
+    /* WriterGroup config */
+    connection->writerGroupsSize = 1;
+    connection->writerGroups = UA_WriterGroupDataType_new();
+    ck_assert(connection->writerGroups != 0);
+    UA_WriterGroupDataType *wg = connection->writerGroups;
+    UA_WriterGroupDataType_init(wg);
+    wg->enabled = true;
+    wg->name = UA_STRING_ALLOC("WriterGroup 1");
+    wg->maxNetworkMessageSize = MAX_NETWORKMESSAGE_SIZE;
+    wg->writerGroupId = 1;
+    wg->publishingInterval = 50;
+    wg->keepAliveTime = 1000.00;
+    UA_UadpWriterGroupMessageDataType *wgMessageSettings = UA_UadpWriterGroupMessageDataType_new();
+    ck_assert(wgMessageSettings != 0);
+    UA_UadpWriterGroupMessageDataType_init(wgMessageSettings);
+    wgMessageSettings->networkMessageContentMask = UADP_NETWORKMESSAGE_CONTENT_MASK;
+    wg->messageSettings.encoding = UA_EXTENSIONOBJECT_DECODED;
+    wg->messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE];
+    wg->messageSettings.content.decoded.data = wgMessageSettings;
+
+    /* DataSetWriter config */
+    wg->dataSetWritersSize = 1;
+    wg->dataSetWriters = UA_DataSetWriterDataType_new();
+    ck_assert(wg->dataSetWriters != 0);
+    UA_DataSetWriterDataType *dsw = &wg->dataSetWriters[0];
+    dsw->enabled = UA_TRUE;
+    dsw->name = UA_STRING_ALLOC("DataSetWriter 1");
+    dsw->dataSetWriterId = 1;
+    dsw->dataSetFieldContentMask = UA_DATASETFIELDCONTENTMASK_NONE;
+    dsw->keyFrameCount = 1;
+    dsw->dataSetName = UA_STRING_ALLOC("PublishedDataSet 1");
+    UA_UadpDataSetWriterMessageDataType *dswMessageSettings = UA_UadpDataSetWriterMessageDataType_new();
+    ck_assert(dswMessageSettings != 0);
+    UA_UadpDataSetWriterMessageDataType_init(dswMessageSettings);
+    dswMessageSettings->dataSetMessageContentMask = DS_MESSAGECONTENT_MASK;
+    dsw->messageSettings.encoding = UA_EXTENSIONOBJECT_DECODED;
+    dsw->messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPDATASETWRITERMESSAGEDATATYPE];
+    dsw->messageSettings.content.decoded.data = dswMessageSettings;
+
+    // ReaderGroup
+    connection->readerGroupsSize = 1;
+    connection->readerGroups = UA_ReaderGroupDataType_new();
+    ck_assert(connection->readerGroups != 0);
+    UA_ReaderGroupDataType *rg = &connection->readerGroups[0];
+    UA_ReaderGroupDataType_init(rg);
+    rg->enabled = UA_TRUE;
+    rg->name = UA_STRING_ALLOC("ReaderGroup 1");
+    rg->maxNetworkMessageSize = MAX_NETWORKMESSAGE_SIZE;
+
+    // DataSetReader
+    rg->dataSetReadersSize = 1;
+    rg->dataSetReaders = UA_DataSetReaderDataType_new();
+    ck_assert(rg->dataSetReaders != 0);
+    UA_DataSetReaderDataType *dsr = &rg->dataSetReaders[0];
+    UA_DataSetReaderDataType_init(dsr);
+    dsr->name = UA_STRING_ALLOC("DataSetReader 1");
+    dsr->enabled = true;
+    UA_Variant_setScalarCopy(&dsr->publisherId, &publisherIdString, &UA_TYPES[UA_TYPES_STRING]);
+    dsr->writerGroupId = 1;
+    dsr->dataSetWriterId = 1;
+
+    UA_DataSetMetaDataType dsrDataSetMetaData;
+    UA_DataSetMetaDataType_init(&dsrDataSetMetaData);
+    dsrDataSetMetaData.name = UA_STRING_ALLOC("PublishedDataSet 1");
+    dsrDataSetMetaData.fieldsSize = 1;
+    dsrDataSetMetaData.fields = UA_FieldMetaData_new();
+    ck_assert(dsrDataSetMetaData.fields != 0);
+    dsrDataSetMetaData.fields->name = UA_STRING_ALLOC("Field_0");
+    dsrDataSetMetaData.fields->builtInType = UA_TYPES_INT32;
+    dsrDataSetMetaData.fields->dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_INT32);
+    dsrDataSetMetaData.fields->valueRank = UA_VALUERANK_SCALAR;
+    dsr->dataSetMetaData = dsrDataSetMetaData;
+
+    UA_TargetVariablesDataType *targetVars = UA_TargetVariablesDataType_new();
+    ck_assert(targetVars != 0);
+    UA_TargetVariablesDataType_init(targetVars);
+    targetVars->targetVariablesSize = 1;
+    targetVars->targetVariables = UA_FieldTargetDataType_new();
+    ck_assert(targetVars->targetVariables != 0);
+    targetVars->targetVariables->attributeId = UA_ATTRIBUTEID_VALUE;
+    /* Variable to subscribe data */
+    attr = UA_VariableAttributes_default;
+    attr.description = UA_LOCALIZEDTEXT("en-US", "Subscribed Int32");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "Subscribed Int32");
+    attr.dataType    = UA_TYPES[UA_TYPES_INT32].typeId;
+    UA_Int32 subscriberData = 0;
+    UA_Variant_setScalar(&attr.value, &subscriberData, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_addVariableNode(server, UA_NODEID_NULL,
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Int32"),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, &(subscriberVarIds[0])));
+    UA_NodeId_copy(&(subscriberVarIds[0]), &(targetVars->targetVariables->targetNodeId));
+    dsr->subscribedDataSet.encoding = UA_EXTENSIONOBJECT_DECODED;
+    dsr->subscribedDataSet.content.decoded.type = &UA_TYPES[UA_TYPES_TARGETVARIABLESDATATYPE];
+    dsr->subscribedDataSet.content.decoded.data = targetVars;
+    dsr->dataSetFieldContentMask = UA_DATASETFIELDCONTENTMASK_NONE;
+    dsr->messageReceiveTimeout = 400.0;
+    dsr->keyFrameCount = 1;
+    UA_UadpDataSetReaderMessageDataType *dsrMessageSettings = UA_UadpDataSetReaderMessageDataType_new();
+    ck_assert(dsrMessageSettings != 0);
+    UA_UadpDataSetReaderMessageDataType_init(dsrMessageSettings);
+    dsrMessageSettings->dataSetMessageContentMask = DS_MESSAGECONTENT_MASK;
+    dsrMessageSettings->networkMessageContentMask = UADP_NETWORKMESSAGE_CONTENT_MASK;
+    dsrMessageSettings->publishingInterval = 50;
+    dsr->messageSettings.encoding = UA_EXTENSIONOBJECT_DECODED;
+    dsr->messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPDATASETREADERMESSAGEDATATYPE];
+    dsr->messageSettings.content.decoded.data = dsrMessageSettings;
+
+    /* encode to bytestring to simulate PubSub file config read */
+    UA_UABinaryFileDataType BinaryFileData;
+    UA_UABinaryFileDataType_init(&BinaryFileData);
+    UA_Variant_setScalar(&BinaryFileData.body, (void*) &config, &UA_TYPES[UA_TYPES_PUBSUBCONFIGURATIONDATATYPE]);
+    UA_ExtensionObject extObj;
+    UA_ExtensionObject_init(&extObj);
+    extObj.encoding = UA_EXTENSIONOBJECT_DECODED;
+    extObj.content.decoded.type = &UA_TYPES[UA_TYPES_UABINARYFILEDATATYPE];
+    extObj.content.decoded.data = &BinaryFileData;
+    size_t fileSize = UA_ExtensionObject_calcSizeBinary(&extObj);
+    encodedConfigDataBuffer.data = (UA_Byte*)UA_calloc(fileSize, sizeof(UA_Byte));
+    ck_assert(encodedConfigDataBuffer.data != 0);
+    encodedConfigDataBuffer.length = fileSize;
+    UA_Byte *bufferPos = encodedConfigDataBuffer.data;
+    ck_assert_int_eq(UA_STATUSCODE_GOOD,
+        UA_ExtensionObject_encodeBinary(&extObj, &bufferPos, bufferPos + fileSize));
+    UA_PubSubConfigurationDataType_clear(&config);
+}
+    /* load and apply config from ByteString buffer */
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_PubSubManager_loadPubSubConfigFromByteString(server, encodedConfigDataBuffer));
+
+    /* groups are already operational */
+    /* check that publish/subscribe works -> set some test values */
+    ValidatePublishSubscribe(STRING_PUBLISHERID_FILE_MAX_COMPONENTS, &publisherVarIds[0], &subscriberVarIds[0],
+        &fastPathPublisherDataValues[0], &fastPathSubscriberDataValues[0], 10, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(STRING_PUBLISHERID_FILE_MAX_COMPONENTS, &publisherVarIds[0], &subscriberVarIds[0],
+        &fastPathPublisherDataValues[0], &fastPathSubscriberDataValues[0], 33, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(STRING_PUBLISHERID_FILE_MAX_COMPONENTS, &publisherVarIds[0], &subscriberVarIds[0],
+        &fastPathPublisherDataValues[0], &fastPathSubscriberDataValues[0], 44, (UA_UInt32) 100, 3);
+
+    UA_ByteString_clear(&encodedConfigDataBuffer);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_string_publisherId_file_config\n\n");
+} END_TEST
+
+#endif /* UA_ENABLE_PUBSUB_FILE_CONFIG */
+
+/***************************************************************************************************/
+static void DoTest_multiple_Groups(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_multiple_Groups() begin");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "fast-path     = %s", (UseFastPath) ? "enabled" : "disabled");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "raw encoding  = %s", (UseRawEncoding) ? "enabled" : "disabled");
+
+    /*  Writers                             -> Readers              -> Var Index
+        ----------------------------------------------------------------------------------
+        Conn1 BYTE   Id  WG 1, DSW 1        -> Conn2, RG 2, DSR 1      0
+                         WG 2, DSW 1        -> Conn2, RG 1, DSR 1      1
+                         WG 3, DSW 1        -> Conn3, RG 1, DSR 1      2
+                         WG 4, DSW 1        -> Conn1, RG 1, DSR 1      3
+        Conn2 BYTE   Id  WG 1, DSW 1        -> Conn1, RG 3, DSR 1      4
+                         WG 2, DSW 1        -> Conn3, RG 2, DSR 1      5
+        Conn3 UINT16 Id  WG 1, DSW 1        -> Conn1, RG 2, DSR 1      6
+                         WG 2, DSW 1        -> Conn1, RG 4, DSR 1      7
+    */
+
+#define DOTEST_MULTIPLE_GROUPS_MAX_CONNECTIONS 3
+    UA_NodeId ConnectionIds[DOTEST_MULTIPLE_GROUPS_MAX_CONNECTIONS];
+
+#define DOTEST_MULTIPLE_GROUPS_MAX_WRITERGROUPS 8
+    UA_NodeId WriterGroupIds[DOTEST_MULTIPLE_GROUPS_MAX_WRITERGROUPS];
+
+#define DOTEST_MULTIPLE_GROUPS_MAX_PDS 8
+    UA_NodeId PublishedDataSetIds[DOTEST_MULTIPLE_GROUPS_MAX_PDS];
+
+#define DOTEST_MULTIPLE_GROUPS_MAX_READERGROUPS 8
+    UA_NodeId ReaderGroupIds[DOTEST_MULTIPLE_GROUPS_MAX_READERGROUPS];
+
+    /* Attention: Publisher and corresponding Subscriber NodeId and DataValue must have the same index
+       e.g. publisherVarIds[0] value is set and subscriberVarIds[0] value is checked at ValidatePublishSubscribe() function
+       see table "Var Index" entry above */
+#define DOTEST_MULTIPLE_GROUPS_MAX_VARS 8
+    UA_NodeId publisherVarIds[DOTEST_MULTIPLE_GROUPS_MAX_VARS];
+    UA_NodeId subscriberVarIds[DOTEST_MULTIPLE_GROUPS_MAX_VARS];
+
+    UA_DataValue *fastPathPublisherDataValues[DOTEST_MULTIPLE_GROUPS_MAX_VARS];
+    UA_DataValue *fastPathSubscriberDataValues[DOTEST_MULTIPLE_GROUPS_MAX_VARS];
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_VARS; i++) {
+        fastPathPublisherDataValues[i] = 0;
+        fastPathSubscriberDataValues[i] = 0;
+    }
+
+    const UA_UInt32 DSW_Id = 1;
+
+    /* setup all Publishers */
+
+    /* setup Connection 1: */
+    UA_NodeId ConnId_1;
+    UA_NodeId_init(&ConnId_1);
+    UA_PublisherIdType Conn1_PublisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+    UA_PublisherId Conn1_PublisherId;
+    Conn1_PublisherId.byte = 1;
+    AddConnection("Conn1", Conn1_PublisherIdType, Conn1_PublisherId, &ConnId_1);
+    ConnectionIds[0] = ConnId_1;
+
+    /* WriterGroup 1 */
+    UA_NodeId WGId_Conn1_WG1;
+    UA_NodeId_init(&WGId_Conn1_WG1);
+    const UA_UInt32 Conn1_WG1_Id = 1;
+    AddWriterGroup(&ConnId_1, "Conn1_WG1", Conn1_WG1_Id, &WGId_Conn1_WG1);
+    WriterGroupIds[0] = WGId_Conn1_WG1;
+
+    UA_NodeId DsWId_Conn1_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+    UA_NodeId PDSId_Conn1_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSW_Id, &PDSId_Conn1_WG1_PDS1,
+        &publisherVarIds[0], &fastPathPublisherDataValues[0], &DsWId_Conn1_WG1_DS1);
+    PublishedDataSetIds[0] = PDSId_Conn1_WG1_PDS1;
+
+    /* WriterGroup 2 */
+    UA_NodeId WGId_Conn1_WG2;
+    UA_NodeId_init(&WGId_Conn1_WG2);
+    const UA_UInt32 Conn1_WG2_Id = 2;
+    AddWriterGroup(&ConnId_1, "Conn1_WG2", Conn1_WG2_Id, &WGId_Conn1_WG2);
+    WriterGroupIds[1] = WGId_Conn1_WG2;
+
+    UA_NodeId DsWId_Conn1_WG2_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG2_DS1);
+    UA_NodeId PDSId_Conn1_WG2_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG2_PDS1);
+    AddPublishedDataSet(&WGId_Conn1_WG2, "Conn1_WG2_PDS1", "Conn1_WG2_DS1", DSW_Id, &PDSId_Conn1_WG2_PDS1,
+        &publisherVarIds[1], &fastPathPublisherDataValues[1], &DsWId_Conn1_WG2_DS1);
+    PublishedDataSetIds[1] = PDSId_Conn1_WG2_PDS1;
+
+    /* WriterGroup 3 */
+    UA_NodeId WGId_Conn1_WG3;
+    UA_NodeId_init(&WGId_Conn1_WG3);
+    const UA_UInt32 Conn1_WG3_Id = 3;
+    AddWriterGroup(&ConnId_1, "Conn1_WG3", Conn1_WG3_Id, &WGId_Conn1_WG3);
+    WriterGroupIds[2] = WGId_Conn1_WG3;
+
+    UA_NodeId DsWId_Conn1_WG3_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG3_DS1);
+    UA_NodeId PDSId_Conn1_WG3_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG3_PDS1);
+    AddPublishedDataSet(&WGId_Conn1_WG3, "Conn1_WG3_PDS1", "Conn1_WG3_DS1", DSW_Id, &PDSId_Conn1_WG3_PDS1,
+        &publisherVarIds[2], &fastPathPublisherDataValues[2], &DsWId_Conn1_WG3_DS1);
+    PublishedDataSetIds[2] = PDSId_Conn1_WG3_PDS1;
+
+    /* WriterGroup 4 */
+    UA_NodeId WGId_Conn1_WG4;
+    UA_NodeId_init(&WGId_Conn1_WG4);
+    const UA_UInt32 Conn1_WG4_Id = 4;
+    AddWriterGroup(&ConnId_1, "Conn1_WG4", Conn1_WG4_Id, &WGId_Conn1_WG4);
+    WriterGroupIds[3] = WGId_Conn1_WG4;
+
+    UA_NodeId DsWId_Conn1_WG4_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG4_DS1);
+    UA_NodeId PDSId_Conn1_WG4_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG4_PDS1);
+    AddPublishedDataSet(&WGId_Conn1_WG4, "Conn1_WG4_PDS1", "Conn1_WG4_DS1", DSW_Id, &PDSId_Conn1_WG4_PDS1,
+        &publisherVarIds[3], &fastPathPublisherDataValues[3], &DsWId_Conn1_WG4_DS1);
+    PublishedDataSetIds[3] = PDSId_Conn1_WG4_PDS1;
+
+    /* setup Connection 2: */
+    UA_NodeId ConnId_2;
+    UA_NodeId_init(&ConnId_2);
+    UA_PublisherIdType Conn2_PublisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+    UA_PublisherId Conn2_PublisherId;
+    Conn2_PublisherId.byte = 2;
+    AddConnection("Conn2", Conn2_PublisherIdType, Conn2_PublisherId, &ConnId_2);
+    ConnectionIds[1] = ConnId_2;
+
+    /* WriterGroup 1 */
+    UA_NodeId WGId_Conn2_WG1;
+    UA_NodeId_init(&WGId_Conn2_WG1);
+    const UA_UInt32 Conn2_WG1_Id = 1;
+    AddWriterGroup(&ConnId_2, "Conn2_WG1", Conn2_WG1_Id, &WGId_Conn2_WG1);
+    WriterGroupIds[4] = WGId_Conn2_WG1;
+
+    UA_NodeId DsWId_Conn2_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn2_WG1_DS1);
+    UA_NodeId PDSId_Conn2_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn2_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", DSW_Id, &PDSId_Conn2_WG1_PDS1,
+        &publisherVarIds[4], &fastPathPublisherDataValues[4], &DsWId_Conn2_WG1_DS1);
+    PublishedDataSetIds[4] = PDSId_Conn2_WG1_PDS1;
+
+    /* WriterGroup 2 */
+    UA_NodeId WGId_Conn2_WG2;
+    UA_NodeId_init(&WGId_Conn2_WG2);
+    const UA_UInt32 Conn2_WG2_Id = 2;
+    AddWriterGroup(&ConnId_2, "Conn2_WG2", Conn2_WG2_Id, &WGId_Conn2_WG2);
+    WriterGroupIds[5] = WGId_Conn2_WG2;
+
+    UA_NodeId DsWId_Conn2_WG2_DS1;
+    UA_NodeId_init(&DsWId_Conn2_WG2_DS1);
+    UA_NodeId PDSId_Conn2_WG2_PDS1;
+    UA_NodeId_init(&PDSId_Conn2_WG2_PDS1);
+    AddPublishedDataSet(&WGId_Conn2_WG2, "Conn2_WG2_PDS1", "Conn2_WG2_DS1", DSW_Id, &PDSId_Conn2_WG2_PDS1,
+        &publisherVarIds[5], &fastPathPublisherDataValues[5], &DsWId_Conn2_WG2_DS1);
+    PublishedDataSetIds[5] = PDSId_Conn2_WG2_PDS1;
+
+    /* setup Connection 3: */
+    UA_NodeId ConnId_3;
+    UA_NodeId_init(&ConnId_3);
+    UA_PublisherIdType Conn3_PublisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    UA_PublisherId Conn3_PublisherId;
+    Conn3_PublisherId.uint16 = 1;
+    AddConnection("Conn3", Conn3_PublisherIdType, Conn3_PublisherId, &ConnId_3);
+    ConnectionIds[2] = ConnId_3;
+
+    /* WriterGroup 1 */
+    UA_NodeId WGId_Conn3_WG1;
+    UA_NodeId_init(&WGId_Conn3_WG1);
+    const UA_UInt32 Conn3_WG1_Id = 1;
+    AddWriterGroup(&ConnId_3, "Conn3_WG1", Conn3_WG1_Id, &WGId_Conn3_WG1);
+    WriterGroupIds[6] = WGId_Conn3_WG1;
+
+    UA_NodeId DsWId_Conn3_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn3_WG1_DS1);
+    UA_NodeId PDSId_Conn3_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn3_WG1_PDS1);
+    AddPublishedDataSet(&WGId_Conn3_WG1, "Conn3_WG1_PDS1", "Conn3_WG1_DS1", DSW_Id, &PDSId_Conn3_WG1_PDS1,
+        &publisherVarIds[6], &fastPathPublisherDataValues[6], &DsWId_Conn3_WG1_DS1);
+    PublishedDataSetIds[6] = PDSId_Conn3_WG1_PDS1;
+
+    /* WriterGroup 2 */
+    UA_NodeId WGId_Conn3_WG2;
+    UA_NodeId_init(&WGId_Conn3_WG2);
+    const UA_UInt32 Conn3_WG2_Id = 2;
+    AddWriterGroup(&ConnId_3, "Conn3_WG2", Conn3_WG2_Id, &WGId_Conn3_WG2);
+    WriterGroupIds[7] = WGId_Conn3_WG2;
+
+    UA_NodeId DsWId_Conn3_WG2_DS1;
+    UA_NodeId_init(&DsWId_Conn3_WG2_DS1);
+    UA_NodeId PDSId_Conn3_WG2_PDS1;
+    UA_NodeId_init(&PDSId_Conn3_WG2_PDS1);
+    AddPublishedDataSet(&WGId_Conn3_WG2, "Conn3_WG2_PDS1", "Conn3_WG2_DS1", DSW_Id, &PDSId_Conn3_WG2_PDS1,
+        &publisherVarIds[7], &fastPathPublisherDataValues[7], &DsWId_Conn3_WG2_DS1);
+    PublishedDataSetIds[7] = PDSId_Conn3_WG2_PDS1;
+
+    /* setup all Subscribers */
+
+    /* setup Connection 1: */
+
+    /* ReaderGroup 1 */
+    UA_NodeId RGId_Conn1_RG1;
+    UA_NodeId_init(&RGId_Conn1_RG1);
+    AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+    UA_NodeId DSRId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, Conn1_WG4_Id, DSW_Id,
+        &subscriberVarIds[3], &fastPathSubscriberDataValues[3], &DSRId_Conn1_RG1_DSR1);
+    ReaderGroupIds[0] = RGId_Conn1_RG1;
+
+    /* ReaderGroup 2 */
+    UA_NodeId RGId_Conn1_RG2;
+    UA_NodeId_init(&RGId_Conn1_RG2);
+    AddReaderGroup(&ConnId_1, "Conn1_RG2", &RGId_Conn1_RG2);
+    UA_NodeId DSRId_Conn1_RG2_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG2_DSR1);
+    AddDataSetReader(&RGId_Conn1_RG2, "Conn1_RG2_DSR1", Conn3_PublisherIdType, Conn3_PublisherId, Conn3_WG1_Id, DSW_Id,
+        &subscriberVarIds[6], &fastPathSubscriberDataValues[6], &DSRId_Conn1_RG2_DSR1);
+    ReaderGroupIds[1] = RGId_Conn1_RG2;
+
+    /* ReaderGroup 3 */
+    UA_NodeId RGId_Conn1_RG3;
+    UA_NodeId_init(&RGId_Conn1_RG3);
+    AddReaderGroup(&ConnId_1, "Conn1_RG3", &RGId_Conn1_RG3);
+    UA_NodeId DSRId_Conn1_RG3_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG3_DSR1);
+    AddDataSetReader(&RGId_Conn1_RG3, "Conn1_RG3_DSR1", Conn2_PublisherIdType, Conn2_PublisherId, Conn2_WG1_Id, DSW_Id,
+        &subscriberVarIds[4], &fastPathSubscriberDataValues[4], &DSRId_Conn1_RG3_DSR1);
+    ReaderGroupIds[2] = RGId_Conn1_RG3;
+
+    /* ReaderGroup 4 */
+    UA_NodeId RGId_Conn1_RG4;
+    UA_NodeId_init(&RGId_Conn1_RG4);
+    AddReaderGroup(&ConnId_1, "Conn1_RG4", &RGId_Conn1_RG4);
+    UA_NodeId DSRId_Conn1_RG4_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG4_DSR1);
+    AddDataSetReader(&RGId_Conn1_RG4, "Conn1_RG4_DSR1", Conn3_PublisherIdType, Conn3_PublisherId, Conn3_WG2_Id, DSW_Id,
+        &subscriberVarIds[7], &fastPathSubscriberDataValues[7], &DSRId_Conn1_RG4_DSR1);
+    ReaderGroupIds[3] = RGId_Conn1_RG4;
+
+    /* setup Connection 2: */
+
+    /* ReaderGroup 1 */
+    UA_NodeId RGId_Conn2_RG1;
+    UA_NodeId_init(&RGId_Conn2_RG1);
+    AddReaderGroup(&ConnId_2, "Conn2_RG1", &RGId_Conn2_RG1);
+    UA_NodeId DSRId_Conn2_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn2_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, Conn1_WG2_Id, DSW_Id,
+        &subscriberVarIds[1], &fastPathSubscriberDataValues[1], &DSRId_Conn2_RG1_DSR1);
+    ReaderGroupIds[4] = RGId_Conn2_RG1;
+
+    /* ReaderGroup 2 */
+    UA_NodeId RGId_Conn2_RG2;
+    UA_NodeId_init(&RGId_Conn2_RG2);
+    AddReaderGroup(&ConnId_2, "Conn2_RG2", &RGId_Conn2_RG2);
+    UA_NodeId DSRId_Conn2_RG2_DSR1;
+    UA_NodeId_init(&DSRId_Conn2_RG2_DSR1);
+    AddDataSetReader(&RGId_Conn2_RG2, "Conn2_RG2_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, Conn1_WG1_Id, DSW_Id,
+        &subscriberVarIds[0], &fastPathSubscriberDataValues[0], &DSRId_Conn2_RG2_DSR1);
+    ReaderGroupIds[5] = RGId_Conn2_RG2;
+
+    /* setup Connection 3: */
+
+    /* ReaderGroup 1 */
+    UA_NodeId RGId_Conn3_RG1;
+    UA_NodeId_init(&RGId_Conn3_RG1);
+    AddReaderGroup(&ConnId_3, "Conn3_RG1", &RGId_Conn3_RG1);
+    UA_NodeId DSRId_Conn3_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn3_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn3_RG1, "Conn3_RG1_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, Conn1_WG3_Id, DSW_Id,
+        &subscriberVarIds[2], &fastPathSubscriberDataValues[2], &DSRId_Conn3_RG1_DSR1);
+    ReaderGroupIds[6] = RGId_Conn3_RG1;
+
+    /* ReaderGroup 2 */
+    UA_NodeId RGId_Conn3_RG2;
+    UA_NodeId_init(&RGId_Conn3_RG2);
+    AddReaderGroup(&ConnId_3, "Conn3_RG2", &RGId_Conn3_RG2);
+    UA_NodeId DSRId_Conn3_RG2_DSR1;
+    UA_NodeId_init(&DSRId_Conn3_RG2_DSR1);
+    AddDataSetReader(&RGId_Conn3_RG2, "Conn3_RG2_DSR1", Conn2_PublisherIdType, Conn2_PublisherId, Conn2_WG2_Id, DSW_Id,
+        &subscriberVarIds[5], &fastPathSubscriberDataValues[5], &DSRId_Conn3_RG2_DSR1);
+    ReaderGroupIds[7] = RGId_Conn3_RG2;
+
+    /* freeze all Groups */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+    /* set groups operational */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupOperational(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupOperational(server, ReaderGroupIds[i]));
+    }
+
+    /* check that publish/subscribe works -> set some test values */
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_GROUPS_MAX_VARS, publisherVarIds, subscriberVarIds,
+        fastPathPublisherDataValues, fastPathSubscriberDataValues, 10, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_GROUPS_MAX_VARS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 50, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_GROUPS_MAX_VARS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 100, (UA_UInt32) 100, 3);
+
+    /* set groups to disabled */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable groups");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupDisabled(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupDisabled(server, ReaderGroupIds[i]));
+    }
+    /* unfreeze groups */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove PublishedDataSets");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_PDS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, PublishedDataSetIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove Connections");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_CONNECTIONS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePubSubConnection(server, ConnectionIds[i]));
+    }
+
+    if (UseFastPath) {
+        for (size_t i = 0; i < DOTEST_MULTIPLE_GROUPS_MAX_VARS; i++) {
+            UA_DataValue_clear(fastPathPublisherDataValues[i]);
+            UA_DataValue_delete(fastPathPublisherDataValues[i]);
+
+            UA_DataValue_clear(fastPathSubscriberDataValues[i]);
+            UA_DataValue_delete(fastPathSubscriberDataValues[i]);
+        }
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_multiple_Groups() end");
+}
+
+/***************************************************************************************************/
+START_TEST(Test_multiple_groups) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_multiple_groups");
+
+    /* note: fast-path does not multiple groups/datasets/string publisher Ids
+        therefore fast-path is not enabled at this test */
+    UseFastPath = UA_FALSE;
+
+    UseRawEncoding = UA_FALSE;
+    DoTest_multiple_Groups();
+
+    UseRawEncoding = UA_TRUE;
+    DoTest_multiple_Groups();
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_multiple_groups\n\n");
+} END_TEST
+
+
+/***************************************************************************************************/
+static void DoTest_multiple_DataSets(void) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_multiple_DataSets() begin");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "fast-path     = %s", (UseFastPath) ? "enabled" : "disabled");
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "raw encoding  = %s", (UseRawEncoding) ? "enabled" : "disabled");
+
+    /*  Writers                             -> Readers              -> Var Index
+        ----------------------------------------------------------------------------------
+        Conn1 BYTE   Id  WG 1, DSW 1        -> Conn2, RG 1, DSR 1      0
+                         WG 1, DSW 2        -> Conn2, RG 1, DSR 3      1
+                         WG 1, DSW 3        -> Conn2, RG 1, DSR 2      2
+                         WG 1, DSW 4        -> Conn1, RG 1, DSR 1      3
+        Conn2 UINT16 Id  WG 1, DSW 1        -> Conn1, RG 1, DSR 2      4
+                         WG 1, DSW 2        -> Conn2, RG 1, DSR 4      5
+    */
+
+#define DOTEST_MULTIPLE_DATASETS_MAX_CONNECTIONS 2
+    UA_NodeId ConnectionIds[DOTEST_MULTIPLE_DATASETS_MAX_CONNECTIONS];
+
+#define DOTEST_MULTIPLE_DATASETS_MAX_WRITERGROUPS 2
+    UA_NodeId WriterGroupIds[DOTEST_MULTIPLE_DATASETS_MAX_WRITERGROUPS];
+
+#define DOTEST_MULTIPLE_DATASETS_MAX_PDS 6
+    UA_NodeId PublishedDataSetIds[DOTEST_MULTIPLE_DATASETS_MAX_PDS];
+
+#define DOTEST_MULTIPLE_DATASETS_MAX_READERGROUPS 2
+    UA_NodeId ReaderGroupIds[DOTEST_MULTIPLE_DATASETS_MAX_READERGROUPS];
+
+    /* Attention: Publisher and corresponding Subscriber NodeId and DataValue must have the same index
+       e.g. publisherVarIds[0] value is set and subscriberVarIds[0] value is checked at ValidatePublishSubscribe() function
+       see table "Var Index" entry above */
+#define DOTEST_MULTIPLE_DATASETS_MAX_VARS 6
+    UA_NodeId publisherVarIds[DOTEST_MULTIPLE_DATASETS_MAX_VARS];
+    UA_NodeId subscriberVarIds[DOTEST_MULTIPLE_DATASETS_MAX_VARS];
+
+    UA_DataValue *fastPathPublisherDataValues[DOTEST_MULTIPLE_DATASETS_MAX_VARS];
+    UA_DataValue *fastPathSubscriberDataValues[DOTEST_MULTIPLE_DATASETS_MAX_VARS];
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_VARS; i++) {
+        fastPathPublisherDataValues[i] = 0;
+        fastPathSubscriberDataValues[i] = 0;
+    }
+
+    const UA_UInt32 WG_Id = 1;
+
+    /* setup all Publishers */
+
+    /* setup Connection 1: */
+    UA_NodeId ConnId_1;
+    UA_NodeId_init(&ConnId_1);
+    UA_PublisherIdType Conn1_PublisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+    UA_PublisherId Conn1_PublisherId;
+    Conn1_PublisherId.byte = 1;
+    AddConnection("Conn1", Conn1_PublisherIdType, Conn1_PublisherId, &ConnId_1);
+    ConnectionIds[0] = ConnId_1;
+
+    /* WriterGroup 1 */
+    UA_NodeId WGId_Conn1_WG1;
+    UA_NodeId_init(&WGId_Conn1_WG1);
+    AddWriterGroup(&ConnId_1, "Conn1_WG1", WG_Id, &WGId_Conn1_WG1);
+    WriterGroupIds[0] = WGId_Conn1_WG1;
+
+    /* DataSetWriter 1 */
+    UA_NodeId DsWId_Conn1_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+    UA_NodeId PDSId_Conn1_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+    const UA_UInt32 Conn1_WG1_DSW1_Id = 1;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", Conn1_WG1_DSW1_Id, &PDSId_Conn1_WG1_PDS1,
+        &publisherVarIds[0], &fastPathPublisherDataValues[0], &DsWId_Conn1_WG1_DS1);
+    PublishedDataSetIds[0] = PDSId_Conn1_WG1_PDS1;
+
+    /* DataSetWriter 2 */
+    UA_NodeId DsWId_Conn1_WG1_DS2;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS2);
+    UA_NodeId PDSId_Conn1_WG1_PDS2;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS2);
+    const UA_UInt32 Conn1_WG1_DSW2_Id = 2;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG2_PDS1", "Conn1_WG2_DS1", Conn1_WG1_DSW2_Id, &PDSId_Conn1_WG1_PDS2,
+        &publisherVarIds[1], &fastPathPublisherDataValues[1], &DsWId_Conn1_WG1_DS2);
+    PublishedDataSetIds[1] = PDSId_Conn1_WG1_PDS2;
+
+    /* DataSetWriter 3 */
+    UA_NodeId DsWId_Conn1_WG1_DS3;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS3);
+    UA_NodeId PDSId_Conn1_WG1_PDS3;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS3);
+    const UA_UInt32 Conn1_WG1_DSW3_Id = 3;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG2_PDS3", "Conn1_WG2_DS3", Conn1_WG1_DSW3_Id, &PDSId_Conn1_WG1_PDS3,
+        &publisherVarIds[2], &fastPathPublisherDataValues[2], &DsWId_Conn1_WG1_DS3);
+    PublishedDataSetIds[2] = PDSId_Conn1_WG1_PDS3;
+
+    /* DataSetWriter 4 */
+    UA_NodeId DsWId_Conn1_WG1_DS4;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS4);
+    UA_NodeId PDSId_Conn1_WG1_PDS4;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS4);
+    const UA_UInt32 Conn1_WG1_DSW4_Id = 4;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG2_PDS4", "Conn1_WG2_DS4", Conn1_WG1_DSW4_Id, &PDSId_Conn1_WG1_PDS4,
+        &publisherVarIds[3], &fastPathPublisherDataValues[3], &DsWId_Conn1_WG1_DS4);
+    PublishedDataSetIds[3] = PDSId_Conn1_WG1_PDS4;
+
+    /* setup Connection 2: */
+    UA_NodeId ConnId_2;
+    UA_NodeId_init(&ConnId_2);
+    UA_PublisherIdType Conn2_PublisherIdType = UA_PUBLISHERIDTYPE_BYTE;
+    UA_PublisherId Conn2_PublisherId;
+    Conn2_PublisherId.byte = 2;
+    AddConnection("Conn2", Conn2_PublisherIdType, Conn2_PublisherId, &ConnId_2);
+    ConnectionIds[1] = ConnId_2;
+
+    /* WriterGroup 1 */
+    UA_NodeId WGId_Conn2_WG1;
+    UA_NodeId_init(&WGId_Conn2_WG1);
+    AddWriterGroup(&ConnId_2, "Conn2_WG1", WG_Id, &WGId_Conn2_WG1);
+    WriterGroupIds[1] = WGId_Conn2_WG1;
+
+    /* DataSetWriter 1 */
+    UA_NodeId DsWId_Conn2_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn2_WG1_DS1);
+    UA_NodeId PDSId_Conn2_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn2_WG1_PDS1);
+    const UA_UInt32 Conn2_WG1_DSW1_Id = 1;
+    AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", Conn2_WG1_DSW1_Id, &PDSId_Conn2_WG1_PDS1,
+        &publisherVarIds[4], &fastPathPublisherDataValues[4], &DsWId_Conn2_WG1_DS1);
+    PublishedDataSetIds[4] = PDSId_Conn2_WG1_PDS1;
+
+    /* DataSetWriter 2 */
+    UA_NodeId DsWId_Conn2_WG1_DS2;
+    UA_NodeId_init(&DsWId_Conn2_WG1_DS2);
+    UA_NodeId PDSId_Conn2_WG1_PDS2;
+    UA_NodeId_init(&PDSId_Conn2_WG1_PDS2);
+    const UA_UInt32 Conn2_WG1_DSW2_Id = 2;
+    AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS2", "Conn2_WG1_DS2", Conn2_WG1_DSW2_Id, &PDSId_Conn2_WG1_PDS2,
+        &publisherVarIds[5], &fastPathPublisherDataValues[5], &DsWId_Conn2_WG1_DS2);
+    PublishedDataSetIds[5] = PDSId_Conn2_WG1_PDS2;
+
+
+    /* setup all Subscribers */
+
+    /* setup Connection 1: */
+
+    /* ReaderGroup 1 */
+    UA_NodeId RGId_Conn1_RG1;
+    UA_NodeId_init(&RGId_Conn1_RG1);
+    AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+    ReaderGroupIds[0] = RGId_Conn1_RG1;
+
+    /* DataSetReader 1 */
+    UA_NodeId DSRId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, WG_Id, Conn1_WG1_DSW4_Id,
+        &subscriberVarIds[3], &fastPathSubscriberDataValues[3], &DSRId_Conn1_RG1_DSR1);
+
+    /* DataSetReader 2 */
+    UA_NodeId DSRId_Conn1_RG1_DSR2;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR2);
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR2", Conn2_PublisherIdType, Conn2_PublisherId, WG_Id, Conn1_WG1_DSW1_Id,
+        &subscriberVarIds[4], &fastPathSubscriberDataValues[4], &DSRId_Conn1_RG1_DSR2);
+
+    /* setup Connection 2: */
+
+    /* ReaderGroup 1 */
+    UA_NodeId RGId_Conn2_RG1;
+    UA_NodeId_init(&RGId_Conn2_RG1);
+    AddReaderGroup(&ConnId_2, "Conn2_RG1", &RGId_Conn2_RG1);
+    ReaderGroupIds[1] = RGId_Conn2_RG1;
+
+    /* DataSetReader 1 */
+    UA_NodeId DSRId_Conn2_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn2_RG1_DSR1);
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", Conn1_PublisherIdType, Conn1_PublisherId, WG_Id, Conn1_WG1_DSW1_Id,
+        &subscriberVarIds[0], &fastPathSubscriberDataValues[0], &DSRId_Conn2_RG1_DSR1);
+
+    /* DataSetReader 2 */
+    UA_NodeId DSRId_Conn2_RG1_DSR2;
+    UA_NodeId_init(&DSRId_Conn2_RG1_DSR2);
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR2", Conn1_PublisherIdType, Conn1_PublisherId, WG_Id, Conn1_WG1_DSW3_Id,
+        &subscriberVarIds[2], &fastPathSubscriberDataValues[2], &DSRId_Conn2_RG1_DSR2);
+
+    /* DataSetReader 3 */
+    UA_NodeId DSRId_Conn2_RG1_DSR3;
+    UA_NodeId_init(&DSRId_Conn2_RG1_DSR3);
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR3", Conn1_PublisherIdType, Conn1_PublisherId, WG_Id, Conn1_WG1_DSW2_Id,
+        &subscriberVarIds[1], &fastPathSubscriberDataValues[1], &DSRId_Conn2_RG1_DSR3);
+
+    /* DataSetReader 4 */
+    UA_NodeId DSRId_Conn2_RG1_DSR4;
+    UA_NodeId_init(&DSRId_Conn2_RG1_DSR4);
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR4", Conn2_PublisherIdType, Conn2_PublisherId, WG_Id, Conn1_WG1_DSW2_Id,
+        &subscriberVarIds[5], &fastPathSubscriberDataValues[5], &DSRId_Conn2_RG1_DSR4);
+
+    /* freeze all Groups */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_freezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+    /* set groups operational */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupOperational(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupOperational(server, ReaderGroupIds[i]));
+    }
+
+    /* check that publish/subscribe works -> set some test values */
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_DATASETS_MAX_VARS, publisherVarIds, subscriberVarIds,
+        fastPathPublisherDataValues, fastPathSubscriberDataValues, 10, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_DATASETS_MAX_VARS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 50, (UA_UInt32) 100, 3);
+
+    ValidatePublishSubscribe(DOTEST_MULTIPLE_DATASETS_MAX_VARS, publisherVarIds, subscriberVarIds, fastPathPublisherDataValues,
+        fastPathSubscriberDataValues, 100, (UA_UInt32) 100, 3);
+
+    /* set groups to disabled */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable groups");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setWriterGroupDisabled(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_setReaderGroupDisabled(server, ReaderGroupIds[i]));
+    }
+    /* unfreeze groups */
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_WRITERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeWriterGroupConfiguration(server, WriterGroupIds[i]));
+    }
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_READERGROUPS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeReaderGroupConfiguration(server, ReaderGroupIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove PublishedDataSets");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_PDS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, PublishedDataSetIds[i]));
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "remove Connections");
+    for (UA_UInt32 i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_CONNECTIONS; i++) {
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePubSubConnection(server, ConnectionIds[i]));
+    }
+
+    if (UseFastPath) {
+        for (size_t i = 0; i < DOTEST_MULTIPLE_DATASETS_MAX_VARS; i++) {
+            UA_DataValue_clear(fastPathPublisherDataValues[i]);
+            UA_DataValue_delete(fastPathPublisherDataValues[i]);
+
+            UA_DataValue_clear(fastPathSubscriberDataValues[i]);
+            UA_DataValue_delete(fastPathSubscriberDataValues[i]);
+        }
+    }
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "DoTest_multiple_DataSets() end");
+}
+
+/***************************************************************************************************/
+START_TEST(Test_multiple_datasets) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_multiple_datasets");
+
+    /* note: fast-path does not multiple groups/datasets/string publisher Ids
+        therefore fast-path is not enabled at this test */
+    UseFastPath = UA_FALSE;
+
+    UseRawEncoding = UA_FALSE;
+    DoTest_multiple_DataSets();
+
+    UseRawEncoding = UA_TRUE;
+    DoTest_multiple_DataSets();
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_multiple_datasets\n\n");
+} END_TEST
+
+
+/***************************************************************************************************/
+int main(void) {
+
+    TCase *tc_basic = tcase_create("PublisherId");
+    tcase_add_checked_fixture(tc_basic, setup, teardown);
+
+    /* test case description:
+        - test 1 connection with 1 WriterGroup, 1 DatasetWriter, 1 ReaderGroup and 1 DataSetReader
+        - test all possible publisherId types
+        - test with all combinations of fast-path and raw-encoding
+    */
+    tcase_add_test(tc_basic, Test_1_connection);
+
+    /* test case description:
+        - setup a PubSub configuration with multiple Connections
+        - all WriterGroup Ids and DataSetWriter Ids are equal, because we want to test the publisherId check
+        - use the same publishing interval for all groups to ensure that the Readers receive multiple messages at the same time
+        - set different publishing values to ensure that PublisherId check works and every DataSetReader receives the correct message
+        - test all different publisherId types
+        - test with all combinations of fast-path and raw-encoding
+        - TODO: fast-path does not support multiple groups and datasets, therefore we only test multiple connections with fast-path here
+        - TODO: fast-path does not support STRING publisherIds
+    */
+    tcase_add_test(tc_basic, Test_multiple_connections);
+
+    /* test case description:
+        - setup a PubSub configuration with multiple Connections
+        - all connections have a STRING PublisherId
+        - all WriterGroup Ids and DataSetWriter Ids are equal, because we want to test the publisherId check
+        - use the same publishing interval for all groups to ensure that the Readers receive multiple messages at the same time
+        - set different publishing values to ensure that PublisherId check works and every DataSetReader receives the correct message
+        - test with and without raw-encoding
+        - TODO: fast-path does not support string PublisherIds at the moment
+    */
+    tcase_add_test(tc_basic, Test_string_publisherId);
+
+#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+    /* test case description:
+        - test pubsub file config with string PublisherId
+    */
+    tcase_add_test(tc_basic, Test_string_publisherId_file_config);
+#endif /* UA_ENABLE_PUBSUB_FILE_CONFIG */
+
+    /* test case description:
+        - setup a PubSub configuration with multiple Groups
+        - use the same publishing interval for all groups to ensure that the Readers receive multiple messages at the same time
+        - set different publishing values to ensure that PublisherId check works and every DataSetReader receives the correct message
+        - test with with and without raw-encoding
+    */
+    tcase_add_test(tc_basic, Test_multiple_groups);
+
+    /* test case description:
+        - setup a PubSub configuration with multiple DataSets
+        - use the same publishing interval for all groups to ensure that the Readers receive multiple messages at the same time
+        - set different publishing values to ensure that PublisherId check works and every DataSetReader receives the correct message
+        - test with with and without raw-encoding
+    */
+    tcase_add_test(tc_basic, Test_multiple_datasets);
+
+    Suite *s = suite_create("PubSub publisherId tests");
+    suite_add_tcase(s, tc_basic);
+
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -107,7 +107,8 @@ static void setup(void) {
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = PUBLISHER_ID;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
 }
 
@@ -1337,7 +1338,7 @@ START_TEST(MultiPublishSubscribeInt32) {
     UA_NodeId dataSetWriter;
     UA_NodeId readerIdentifier;
     UA_NodeId writerGroup;
-    
+
     /* Published DataSet */
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;

--- a/tests/pubsub/check_pubsub_subscribe_encrypted.c
+++ b/tests/pubsub/check_pubsub_subscribe_encrypted.c
@@ -70,7 +70,8 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    connectionConfig.publisherId.numeric = PUBLISHER_ID;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = PUBLISHER_ID;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
 }
 

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -73,7 +73,7 @@ static void teardown(void) {
 
 /***************************************************************************************************/
 static void AddConnection(
-    char *pName, 
+    char *pName,
     UA_UInt32 PublisherId,
     UA_NodeId *opConnectionId) {
 
@@ -89,8 +89,8 @@ static void AddConnection(
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
 
-    connectionConfig.publisherIdType = UA_PUBSUB_PUBLISHERID_NUMERIC;
-    connectionConfig.publisherId.numeric = PublisherId;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = PublisherId;
 
     ck_assert(UA_Server_addPubSubConnection(server, &connectionConfig, opConnectionId) == UA_STATUSCODE_GOOD);
     ck_assert(UA_PubSubConnection_regist(server, opConnectionId) == UA_STATUSCODE_GOOD);
@@ -99,7 +99,7 @@ static void AddConnection(
 /***************************************************************************************************/
 static void AddWriterGroup(
     UA_NodeId *pConnectionId,
-    char *pName, 
+    char *pName,
     UA_UInt32 WriterGroupId,
     UA_Duration PublishingInterval,
     UA_NodeId *opWriterGroupId) {
@@ -133,10 +133,10 @@ static void AddWriterGroup(
 /***************************************************************************************************/
 static void AddPublishedDataSet(
     UA_NodeId *pWriterGroupId,
-    char *pPublishedDataSetName, 
+    char *pPublishedDataSetName,
     char *pDataSetWriterName,
     UA_UInt32 DataSetWriterId,
-    UA_NodeId *opPublishedDataSetId, 
+    UA_NodeId *opPublishedDataSetId,
     UA_NodeId *opPublishedVarId,
     UA_NodeId *opDataSetWriterId) {
 
@@ -206,7 +206,7 @@ static void AddPublishedDataSet(
 /***************************************************************************************************/
 static void AddReaderGroup(
     UA_NodeId *pConnectionId,
-    char *pName, 
+    char *pName,
     UA_NodeId *opReaderGroupId) {
 
     ck_assert(pConnectionId != 0);
@@ -226,7 +226,7 @@ static void AddReaderGroup(
 /***************************************************************************************************/
 static void AddDataSetReader(
     UA_NodeId *pReaderGroupId,
-    char *pName, 
+    char *pName,
     UA_UInt32 PublisherId,
     UA_UInt32 WriterGroupId,
     UA_UInt32 DataSetWriterId,
@@ -242,7 +242,7 @@ static void AddDataSetReader(
     UA_DataSetReaderConfig readerConfig;
     memset (&readerConfig, 0, sizeof(UA_DataSetReaderConfig));
     readerConfig.name = UA_STRING(pName);
-    UA_Variant_setScalar(&readerConfig.publisherId, (UA_UInt16*) &PublisherId, &UA_TYPES[UA_TYPES_UINT16]);
+    UA_Variant_setScalar(&readerConfig.publisherId, (UA_UInt32*) &PublisherId, &UA_TYPES[UA_TYPES_UINT32]);
     readerConfig.writerGroupId    = (UA_UInt16) WriterGroupId;
     readerConfig.dataSetWriterId  = (UA_UInt16) DataSetWriterId;
     readerConfig.messageReceiveTimeout = MessageReceiveTimeout;
@@ -303,7 +303,7 @@ static void AddDataSetReader(
     UA_FieldTargetVariable *pTargetVariables =  (UA_FieldTargetVariable *)
         UA_calloc(readerConfig.dataSetMetaData.fieldsSize, sizeof(UA_FieldTargetVariable));
     ck_assert(pTargetVariables != 0);
-    
+
     UA_FieldTargetDataType_init(&pTargetVariables[0].targetVariable);
 
     pTargetVariables[0].targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
@@ -311,7 +311,7 @@ static void AddDataSetReader(
 
     ck_assert(UA_Server_DataSetReader_createTargetVariables(server, *opDataSetReaderId,
         readerConfig.dataSetMetaData.fieldsSize, pTargetVariables) == UA_STATUSCODE_GOOD);
-    
+
     UA_FieldTargetDataType_clear(&pTargetVariables[0].targetVariable);
     UA_free(pTargetVariables);
     pTargetVariables = 0;
@@ -328,7 +328,7 @@ static void AddDataSetReader(
 static void ServerDoProcess(
     const char *pMessage,
     const UA_UInt32 Sleep_ms,             /* use at least publishing interval */
-    const UA_UInt32 NoOfRunIterateCycles) 
+    const UA_UInt32 NoOfRunIterateCycles)
 {
     ck_assert(pMessage != 0);
 
@@ -349,7 +349,7 @@ static void ValidatePublishSubscribe(
     UA_NodeId SubscribedVarId,
     UA_Int32 TestValue,
     UA_UInt32 Sleep_ms, /* use at least publishing interval */
-    UA_UInt32 NoOfRunIterateCycles) 
+    UA_UInt32 NoOfRunIterateCycles)
 {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe(): set variable to publish");
 
@@ -367,7 +367,7 @@ static void ValidatePublishSubscribe(
     retVal = UA_Server_readValue(server, SubscribedVarId, &SubscribedNodeData);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     ck_assert(SubscribedNodeData.data != 0);
-    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe(): check value: %i vs. %i", 
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe(): check value: %i vs. %i",
         TestValue, *(UA_Int32 *)SubscribedNodeData.data);
     ck_assert_int_eq(TestValue, *(UA_Int32 *)SubscribedNodeData.data);
     UA_Variant_clear(&SubscribedNodeData);
@@ -379,7 +379,7 @@ static void ValidatePublishSubscribe(
 static void ValidatePublishSubscribe_fast_path(
     UA_Int32 TestValue,
     UA_UInt32 Sleep_ms, /* use at least publishing interval */
-    UA_UInt32 NoOfRunIterateCycles) 
+    UA_UInt32 NoOfRunIterateCycles)
 {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ValidatePublishSubscribe_fast_path(): set variable to publish");
 
@@ -447,7 +447,7 @@ START_TEST(Test_basic) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
 
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", 1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", 1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1, &DsWId_Conn1_WG1_DS1);
 
     /* setup Connection 2: corresponding readergroup and reader for Connection 1 */
@@ -538,7 +538,7 @@ START_TEST(Test_basic) {
 
     /* check that PubSubStateChange callback has been called for the specific DataSetReader */
     ck_assert_int_eq(1, CallbackCnt);
-    
+
     /* enable the publisher WriterGroup again */
     /* DataSetReader state shall be back to operational after receiving a new message */
     ExpectedCallbackStatus = UA_STATUSCODE_GOOD;
@@ -657,14 +657,14 @@ static void PubSubStateChangeCallback_different_timeouts (
 
 /* TODO: test does not work if we add the same reader on the same connection ...
     maybe only 1 reader per connection receives the data ... ??
-    or the second reader overwrites the first? 
+    or the second reader overwrites the first?
     issue: https://github.com/open62541/open62541/issues/3901 */
 
 START_TEST(Test_different_timeouts) {
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_different_timeouts");
 
-    /* 
+    /*
         Connection 1: WG1 : DSW1 (pub interval = 20)    --> Connection 1: RG1 : DSR1 (msgrcvtimeout = 100)
                                                         --> Connection 1: RG1 : DSR2 (msgrcvtimeout = 200)
                                                         --> Connection 2: RG1 : DSR1 (msgrcvtimeout = 300)
@@ -695,7 +695,7 @@ START_TEST(Test_different_timeouts) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
     UA_UInt32 DSWNo_Conn1_WG1 = 1;
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
 
     UA_NodeId RGId_Conn1_RG1;
@@ -707,7 +707,7 @@ START_TEST(Test_different_timeouts) {
     UA_NodeId VarId_Conn1_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 100.0;
-    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1, 
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1,
         MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
 
     UA_String strId;
@@ -722,7 +722,7 @@ START_TEST(Test_different_timeouts) {
     // UA_NodeId VarId_Conn1_RG1_DSR2;
     // UA_NodeId_init(&VarId_Conn1_RG1_DSR2);
     // UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR2 = 200.0;
-    // AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR2", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1, 
+    // AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR2", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1,
     //     MessageReceiveTimeout_Conn1_RG1_DSR2, &VarId_Conn1_RG1_DSR2, &DSRId_Conn1_RG1_DSR2);
     // UA_String_init(&strId);
     // UA_NodeId_print(&DSRId_Conn1_RG1_DSR2, &strId);
@@ -744,7 +744,7 @@ START_TEST(Test_different_timeouts) {
     UA_NodeId VarId_Conn2_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn2_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn2_RG1_DSR1 = 300.0;
-    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1, MessageReceiveTimeout_Conn2_RG1_DSR1, 
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1, MessageReceiveTimeout_Conn2_RG1_DSR1,
         &VarId_Conn2_RG1_DSR1, &DSRId_Conn2_RG1_DSR1);
     UA_String_init(&strId);
     UA_NodeId_print(&DSRId_Conn2_RG1_DSR1, &strId);
@@ -762,9 +762,9 @@ START_TEST(Test_different_timeouts) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check normal pubsub operation");
 
     /* set all writer- and readergroups to operational (this triggers the publish and subscribe callback)
-        enable the readers first, because otherwise we receive something immediately and start the 
+        enable the readers first, because otherwise we receive something immediately and start the
         message receive timeout.
-        If we do some other checks before triggering the server_run_iterate function, this could 
+        If we do some other checks before triggering the server_run_iterate function, this could
         cause a timeout. */
     ck_assert(UA_STATUSCODE_GOOD == UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1));
     ck_assert(UA_STATUSCODE_GOOD == UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG1));
@@ -780,7 +780,7 @@ START_TEST(Test_different_timeouts) {
     // ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR2, &state) == UA_STATUSCODE_GOOD);
     // ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL); 
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
 
     /* check that publish/subscribe works (for all readers) -> set some test values */
     ValidatePublishSubscribe(VarId_Conn1_WG1_DS1, VarId_Conn1_RG1_DSR1, 10, (UA_UInt32) (PublishingInterval_Conn1_WG1), 20);
@@ -829,10 +829,10 @@ static void PubSubStateChangeCallback_wrong_timeout (
         "Component Id = %.*s, state = %i, status = 0x%08x %s", (UA_Int32) strId.length, strId.data, state, status, UA_StatusCode_name(status));
     UA_String_clear(&strId);
 
-    if ((UA_NodeId_equal(pubsubComponentId, &ExpectedCallbackComponentNodeId) == UA_TRUE) && 
+    if ((UA_NodeId_equal(pubsubComponentId, &ExpectedCallbackComponentNodeId) == UA_TRUE) &&
         (state == UA_PUBSUBSTATE_ERROR) &&
         (status == UA_STATUSCODE_BADTIMEOUT)) {
-        
+
         CallbackCnt++;
     }
 }
@@ -842,7 +842,7 @@ START_TEST(Test_wrong_timeout) {
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_wrong_timeout");
 
-    /* 
+    /*
         Connection 1: WG1 : DSW1    --> Connection 1: RG1 : DSR1
     */
 
@@ -871,7 +871,7 @@ START_TEST(Test_wrong_timeout) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
     UA_UInt32 DSWNo_Conn1_WG1 = 1;
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
 
     UA_NodeId RGId_Conn1_RG1;
@@ -883,7 +883,7 @@ START_TEST(Test_wrong_timeout) {
     UA_NodeId VarId_Conn1_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 200.0;
-    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1, 
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1,
         MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
 
     /* expected order of pubsub component timeouts: */
@@ -960,7 +960,7 @@ static void PubSubStateChangeCallback_many_components (
     if (ExpectedCallbackStateChange == UA_PUBSUBSTATE_ERROR) {
         /*  On error we want to verify the order of DataSetReader timeouts */
         ck_assert(UA_NodeId_equal(pubsubComponentId, &pExpectedComponentCallbackIds[CallbackCnt]) == UA_TRUE);
-    } /* when the state is set back to operational we cannot verify the order of StateChanges, because we 
+    } /* when the state is set back to operational we cannot verify the order of StateChanges, because we
             cannot know which DataSetReader will be operational first */
     CallbackCnt++;
 }
@@ -1003,7 +1003,7 @@ START_TEST(Test_many_components) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
     UA_UInt32 DSWNo_Conn1_WG1_DS1 = 1;
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
 
     UA_NodeId DsWId_Conn1_WG1_DS2;
@@ -1013,7 +1013,7 @@ START_TEST(Test_many_components) {
     UA_NodeId PDSId_Conn1_WG1_PDS2;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS2);
     UA_UInt32 DSWNo_Conn1_WG1_DS2 = 2;
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS2", "Conn1_WG1_DS2", DSWNo_Conn1_WG1_DS2, &PDSId_Conn1_WG1_PDS2, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS2", "Conn1_WG1_DS2", DSWNo_Conn1_WG1_DS2, &PDSId_Conn1_WG1_PDS2,
         &VarId_Conn1_WG1_DS2, &DsWId_Conn1_WG1_DS2);
 
 
@@ -1036,7 +1036,7 @@ START_TEST(Test_many_components) {
     UA_NodeId PDSId_Conn2_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn2_WG1_PDS1);
     UA_UInt32 DSWNo_Conn2_WG1_DS1 = 1;
-    AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", DSWNo_Conn2_WG1_DS1, &PDSId_Conn2_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", DSWNo_Conn2_WG1_DS1, &PDSId_Conn2_WG1_PDS1,
         &VarId_Conn2_WG1_DS1, &DsWId_Conn2_WG1_DS1);
 
 
@@ -1053,7 +1053,7 @@ START_TEST(Test_many_components) {
     UA_NodeId PDSId_Conn2_WG2_PDS1;
     UA_NodeId_init(&PDSId_Conn2_WG2_PDS1);
     UA_UInt32 DSWNo_Conn2_WG2_DS1 = 1;
-    AddPublishedDataSet(&WGId_Conn2_WG2, "Conn2_WG2_PDS1", "Conn2_WG2_DS1", DSWNo_Conn2_WG2_DS1, &PDSId_Conn2_WG2_PDS1, 
+    AddPublishedDataSet(&WGId_Conn2_WG2, "Conn2_WG2_PDS1", "Conn2_WG2_DS1", DSWNo_Conn2_WG2_DS1, &PDSId_Conn2_WG2_PDS1,
         &VarId_Conn2_WG2_DS1, &DsWId_Conn2_WG2_DS1);
 
     /* setup Connection 1: readers */
@@ -1066,7 +1066,7 @@ START_TEST(Test_many_components) {
     UA_NodeId VarId_Conn1_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 25.0;
-    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG1, DSWNo_Conn2_WG1_DS1, 
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG1, DSWNo_Conn2_WG1_DS1,
         MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
     UA_String strId;
     UA_String_init(&strId);
@@ -1084,7 +1084,7 @@ START_TEST(Test_many_components) {
     UA_NodeId VarId_Conn2_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn2_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn2_RG1_DSR1 = 40.0;
-    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1, 
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1,
         MessageReceiveTimeout_Conn2_RG1_DSR1, &VarId_Conn2_RG1_DSR1, &DSRId_Conn2_RG1_DSR1);
     UA_String_init(&strId);
     UA_NodeId_print(&DSRId_Conn2_RG1_DSR1, &strId);
@@ -1100,7 +1100,7 @@ START_TEST(Test_many_components) {
     UA_NodeId VarId_Conn2_RG2_DSR1;
     UA_NodeId_init(&VarId_Conn2_RG2_DSR1);
     UA_Duration MessageReceiveTimeout_Conn2_RG2_DSR1 = 45.0;
-    AddDataSetReader(&RGId_Conn2_RG2, "Conn2_RG2_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS2, 
+    AddDataSetReader(&RGId_Conn2_RG2, "Conn2_RG2_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS2,
         MessageReceiveTimeout_Conn2_RG2_DSR1, &VarId_Conn2_RG2_DSR1, &DSRId_Conn2_RG2_DSR1);
     UA_String_init(&strId);
     UA_NodeId_print(&DSRId_Conn2_RG2_DSR1, &strId);
@@ -1122,7 +1122,7 @@ START_TEST(Test_many_components) {
     UA_NodeId VarId_Conn3_RG1_DSR1;
     UA_NodeId_init(&VarId_Conn3_RG1_DSR1);
     UA_Duration MessageReceiveTimeout_Conn3_RG1_DSR1 = 25.0;
-    AddDataSetReader(&RGId_Conn3_RG1, "Conn3_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG2, DSWNo_Conn2_WG2_DS1, 
+    AddDataSetReader(&RGId_Conn3_RG1, "Conn3_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG2, DSWNo_Conn2_WG2_DS1,
         MessageReceiveTimeout_Conn3_RG1_DSR1, &VarId_Conn3_RG1_DSR1, &DSRId_Conn3_RG1_DSR1);
     UA_String_init(&strId);
     UA_NodeId_print(&DSRId_Conn3_RG1_DSR1, &strId);
@@ -1149,7 +1149,7 @@ START_TEST(Test_many_components) {
 
     /* check that publish/subscribe works -> set some test values */
 
-    /* use a low enough sleep value to ensure that publishing intervals and message receive timeouts 
+    /* use a low enough sleep value to ensure that publishing intervals and message receive timeouts
         are handled */
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn2_RG1_DSR1");
     ValidatePublishSubscribe(VarId_Conn1_WG1_DS1, VarId_Conn2_RG1_DSR1, 10, SleepTime, NoOfRunIterateCycles);
@@ -1213,7 +1213,7 @@ START_TEST(Test_many_components) {
 
     /* check number of timeouts */
     ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
-    
+
     /* enable the publisher WriterGroup again */
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "enable writergroup Conn 1 - WG 1");
     CallbackCnt = 0;
@@ -1264,10 +1264,10 @@ START_TEST(Test_many_components) {
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn3_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
     ValidatePublishSubscribe(VarId_Conn2_WG2_DS1, VarId_Conn3_RG1_DSR1, 119, SleepTime, NoOfRunIterateCycles);
-    
+
     /* check number of timeouts */
     ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
-    
+
     /* enable the publisher WriterGroup again */
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "enable writergroup");
     CallbackCnt = 0;
@@ -1317,7 +1317,7 @@ START_TEST(Test_many_components) {
     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
-    
+
     ServerDoProcess("C 1", SleepTime, NoOfRunIterateCycles);
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable all writers");
@@ -1407,7 +1407,7 @@ START_TEST(Test_update_config) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
 
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", 1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", 1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1, &DsWId_Conn1_WG1_DS1);
 
     /* setup corresponding readergroup and reader for Connection 1 */
@@ -1441,7 +1441,7 @@ START_TEST(Test_update_config) {
     /* check that publish/subscribe works -> set some test values */
     ValidatePublishSubscribe(VarId_Conn1_WG1, VarId_Conn1_RG1_DSR1, 10, SleepTime, NoOfRunIterateCycles);
     ValidatePublishSubscribe(VarId_Conn1_WG1, VarId_Conn1_RG1_DSR1, 33, SleepTime, NoOfRunIterateCycles);
-    
+
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
 
@@ -1577,7 +1577,7 @@ START_TEST(Test_fast_path) {
     UA_NodeId PDSId_Conn1_WG1_PDS1;
     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
 
-    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", 1, &PDSId_Conn1_WG1_PDS1, 
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", 1, &PDSId_Conn1_WG1_PDS1,
         &VarId_Conn1_WG1, &DsWId_Conn1_WG1_DS1);
 
     /* setup Connection 2: corresponding readergroup and reader for Connection 1 */
@@ -1670,7 +1670,7 @@ START_TEST(Test_fast_path) {
 
     /* check that PubSubStateChange callback has been called for the specific DataSetReader */
     ck_assert_int_eq(1, CallbackCnt);
-    
+
     /* enable the publisher WriterGroup again */
     /* DataSetReader state shall be back to operational after receiving a new message */
     ExpectedCallbackStatus = UA_STATUSCODE_GOOD;
@@ -1732,7 +1732,7 @@ int main(void) {
     TCase *tc_basic = tcase_create("Message Receive Timeout");
     tcase_add_checked_fixture(tc_basic, setup, teardown);
 
-    /* test case description: 
+    /* test case description:
         - check normal pubsub operation (2 connections)
         - 1 Connection with 1 DataSetWriter, 1 Connection with counterpart DataSetReader
         - enable/disable writer- and readergroup multiple times
@@ -1740,14 +1740,14 @@ int main(void) {
     */
     tcase_add_test(tc_basic, Test_basic);
 
-    /* test case description: 
+    /* test case description:
         - 1 DataSetWriter
         - multiple DataSetReaders with different timeout settings
         - check order and no of message receive timeouts for the different DataSetReaders
     */
     tcase_add_test(tc_basic, Test_different_timeouts);
 
-    /* test case description: 
+    /* test case description:
         - 1 Connection, 1 DataSetWriter, 1 DataSetReader
         - reader with wrong timeout setting (timeout is smaller than publishing interval)
     */
@@ -1755,7 +1755,7 @@ int main(void) {
 
     /* test case description:
         - configure multiple connections with multiple readers and writers
-        - disable/enable and check for correct timeouts 
+        - disable/enable and check for correct timeouts
     */
     tcase_add_test(tc_basic, Test_many_components);
 

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -48,7 +48,8 @@ addMinimalPubSubConfiguration(void){
     connectionConfig.enabled = UA_TRUE;
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL , UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = 2234;
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
+    connectionConfig.publisherId.uint16 = 2234;
     retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdentifier);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -144,6 +144,7 @@ function unit_tests {
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -227,6 +228,7 @@ function unit_tests_encryption_mbedtls_pubsub {
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
+          -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           ..
     make ${MAKEOPTS}
     make test ARGS="-V"
@@ -252,6 +254,7 @@ function unit_tests_with_coverage {
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           -DUA_ENABLE_ENCRYPTION=MBEDTLS \
           ..
     make ${MAKEOPTS}
@@ -279,6 +282,7 @@ function unit_tests_valgrind {
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
           ..
     make ${MAKEOPTS}
@@ -303,6 +307,7 @@ function build_clang_analyzer {
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           ..
     scan-build-11 --status-bugs make ${MAKEOPTS}
 }


### PR DESCRIPTION
According to OpcUa part 14 specification the PublisherId can be of data type unsigned integer or string.

In the connection configuration data type the publisher Id is defined like this:
https://github.com/open62541/open62541/blob/0daf3b6fb1345feb1207332a1b781e6a95e0e96d/include/open62541/server_pubsub.h#L155-L167

UINT32 data type is used to represent publisherId.


In the network message struct the PublisherId is defined like this:
https://github.com/open62541/open62541/blob/0daf3b6fb1345feb1207332a1b781e6a95e0e96d/src/pubsub/ua_pubsub_networkmessage.h#L92-L98

https://github.com/open62541/open62541/blob/0daf3b6fb1345feb1207332a1b781e6a95e0e96d/src/pubsub/ua_pubsub_networkmessage.h#L137-L159

The union contains a GUID as well, that's not defined in the enum and it seems that it's not used anywhere.

The Publisher always sets the Publisher type to UINT16 at generateNetworkMessage function.
https://github.com/open62541/open62541/blob/0daf3b6fb1345feb1207332a1b781e6a95e0e96d/src/pubsub/ua_pubsub_writer.c#L1973-L1975

The reader on the other hand checks for all types at getReaderFromIdentifier function when it processes the received network messages.
https://github.com/open62541/open62541/blob/0daf3b6fb1345feb1207332a1b781e6a95e0e96d/src/pubsub/ua_pubsub_reader.c#L764-L816

The DataSetReaderConfiguration struct uses a Variant to represent the Publisher Id

https://github.com/open62541/open62541/blob/0daf3b6fb1345feb1207332a1b781e6a95e0e96d/include/open62541/server_pubsub.h#L647-L662

If we set the PublisherId type at DataSetReader configuration to anything else then UINT16 (for numeric publisher IDs) then the reader won't identify the received network message correctly, because the network message publisher Id type is always UINT16, and it's not obvious that that's the case.

I am not sure if it's ok to use a variant at UA_PubSubConnectionConfig? like at DataSetReader config ...

Not finished with tests and refactoring ...