### PR TITLE
feat(client) Expose client socket for use with external eventloops

### DIFF
--- a/include/open62541/client.h
+++ b/include/open62541/client.h
@@ -200,6 +200,19 @@ UA_Client_getContext(UA_Client *client) {
     return UA_Client_getConfig(client)->clientContext; /* Cannot fail */
 }
 
+/* Returns the current socket of the connection. Returns UA_SOCKET_INVALID, if
+ * connection is not opened. The user should monitor the state of the connection
+ * ``UA_Client_getState`` or ``UA_ClientConfig.stateCallback`` to identify when
+ * a socket becomes available or invalid.
+ *
+ * Useful for calling ``UA_Client_run_iterate`` with timeout 0, e.g. when having
+ * multiple UA_Client handles in an application. If the socket activity is
+ * monitored, for example using epoll on linux, UA_Client_run_iterate can be
+ * called immediately when new server responses arrive.
+ */
+UA_EXPORT UA_SOCKET
+UA_Client_getSocket(UA_Client *client);
+
 /* (Disconnect and) delete the client */
 void UA_EXPORT
 UA_Client_delete(UA_Client *client);

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -122,6 +122,12 @@ UA_Client_getState(UA_Client *client, UA_SecureChannelState *channelState,
         *connectStatus = client->connectStatus;
 }
 
+UA_SOCKET
+UA_Client_getSocket(UA_Client *client)
+{
+  return client->connection.sockfd;
+}
+
 UA_ClientConfig *
 UA_Client_getConfig(UA_Client *client) {
     if(!client)


### PR DESCRIPTION
Using an external eventloop (e.g. libevent) it would be useful to be able to monitor if server responses arrive. Then UA_Client_run_iterate(client, 0) can be used which is especially useful if an application uses multiple UA_Clients. I did not expose UA_Connection because there is internal state that should not be visible to the user of the open62541 library.

I would love to see this exposed in version 1.1 too, because i currently use https://conan.io/center/open62541 which currently supports only 1.0.X and 1.1.X packages.