### PR TITLE
Fix: Fix memory leaks detected by AddressSanitizer.

### DIFF
--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -253,6 +253,10 @@ UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
     UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_SERVER,
                    "AccessControl: Unconfigured AccessControl. Users have all permissions.");
     UA_AccessControl *ac = &config->accessControl;
+
+    if (ac->clear)
+        clear_default(ac);
+    
     ac->clear = clear_default;
     ac->activateSession = activateSession_default;
     ac->closeSession = closeSession_default;
@@ -344,3 +348,4 @@ UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
     }
     return UA_STATUSCODE_GOOD;
 }
+

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -664,6 +664,10 @@ copyChild(UA_Server *server, UA_Session *session,
          * typechecking is performed here. Assuming that the original is
          * consistent. */
         retval = copyAllChildren(server, session, &rd->nodeId.nodeId, &newNodeId);
+        
+        /* Clean up.  Because it can happen that a string is assigned as ID at 
+         * generateChildNodeId. */
+        UA_NodeId_clear(&newNodeId);
     }
 
     return retval;


### PR DESCRIPTION
AddressSanitizer detected two memory leaks when using open62451.

- The first one occurs when string IDs are used when creating child nodes. If this is the case, the NodeId must be cleaned up.
- The second case occurs when using Encryption, when calling UA_AccessControl_default, new memory is allocated, but before that it is not checked if memory has already been allocated elsewhere for the UA_AccessControl struct. Therefore, it must be ensured that the UA_AccessControl is clean at the beginning.
