### PR TITLE
Export malloc singleton function pointers

### DIFF
--- a/arch/posix/ua_architecture_functions.c
+++ b/arch/posix/ua_architecture_functions.c
@@ -10,10 +10,10 @@
 
 /* Global malloc singletons */
 #ifdef UA_ENABLE_MALLOC_SINGLETON
-UA_THREAD_LOCAL void * (*UA_mallocSingleton)(size_t size) = malloc;
-UA_THREAD_LOCAL void (*UA_freeSingleton)(void *ptr) = free;
-UA_THREAD_LOCAL void * (*UA_callocSingleton)(size_t nelem, size_t elsize) = calloc;
-UA_THREAD_LOCAL void * (*UA_reallocSingleton)(void *ptr, size_t size) = realloc;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_mallocSingleton)(size_t size) = malloc;
+UA_EXPORT UA_THREAD_LOCAL void (*UA_freeSingleton)(void *ptr) = free;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_callocSingleton)(size_t nelem, size_t elsize) = calloc;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_reallocSingleton)(void *ptr, size_t size) = realloc;
 #endif
 
 unsigned int UA_socket_set_blocking(UA_SOCKET sockfd){

--- a/arch/vxworks/ua_architecture_functions.c
+++ b/arch/vxworks/ua_architecture_functions.c
@@ -11,10 +11,10 @@
 
 /* Global malloc singletons */
 #ifdef UA_ENABLE_MALLOC_SINGLETON
-UA_THREAD_LOCAL void * (*UA_mallocSingleton)(size_t size) = malloc;
-UA_THREAD_LOCAL void (*UA_freeSingleton)(void *ptr) = free;
-UA_THREAD_LOCAL void * (*UA_callocSingleton)(size_t nelem, size_t elsize) = calloc;
-UA_THREAD_LOCAL void * (*UA_reallocSingleton)(void *ptr, size_t size) = realloc;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_mallocSingleton)(size_t size) = malloc;
+UA_EXPORT UA_THREAD_LOCAL void (*UA_freeSingleton)(void *ptr) = free;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_callocSingleton)(size_t nelem, size_t elsize) = calloc;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_reallocSingleton)(void *ptr, size_t size) = realloc;
 #endif
 
 unsigned int UA_socket_set_blocking(UA_SOCKET sockfd){

--- a/arch/win32/ua_architecture_functions.c
+++ b/arch/win32/ua_architecture_functions.c
@@ -10,10 +10,10 @@
 
 /* Global malloc singletons */
 #ifdef UA_ENABLE_MALLOC_SINGLETON
-UA_THREAD_LOCAL void * (*UA_mallocSingleton)(size_t size) = malloc;
-UA_THREAD_LOCAL void (*UA_freeSingleton)(void *ptr) = free;
-UA_THREAD_LOCAL void * (*UA_callocSingleton)(size_t nelem, size_t elsize) = calloc;
-UA_THREAD_LOCAL void * (*UA_reallocSingleton)(void *ptr, size_t size) = realloc;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_mallocSingleton)(size_t size) = malloc;
+UA_EXPORT UA_THREAD_LOCAL void (*UA_freeSingleton)(void *ptr) = free;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_callocSingleton)(size_t nelem, size_t elsize) = calloc;
+UA_EXPORT UA_THREAD_LOCAL void * (*UA_reallocSingleton)(void *ptr, size_t size) = realloc;
 #endif
 
 unsigned int UA_socket_set_blocking(UA_SOCKET sockfd){


### PR DESCRIPTION
Export malloc singleton function pointers, otherwise there are not
visible if we use shared object library build.