### PR TITLE
Update the localhost.cnf

### DIFF
--- a/tools/certs/localhost.cnf
+++ b/tools/certs/localhost.cnf
@@ -6,7 +6,7 @@
 # This definition stops the following lines choking if HOME isn't
 # defined.
 HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
+#RANDFILE		= $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
 #oid_file		= $ENV::HOME/.oid
@@ -58,7 +58,7 @@ crlnumber	= $dir/crlnumber	# the current crl number
 					# must be commented out to leave a V1 CRL
 crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/ca.key 		# The private key
-RANDFILE	= $dir/.rand		# private random number file
+#RANDFILE	= $dir/.rand		# private random number file
 
 x509_extensions	= usr_cert		# The extensions to add to the cert
 


### PR DESCRIPTION
As per discussion in the OpenSSL issues [forum](https://github.com/openssl/openssl/issues/7754), it says that OpenSSL version 1.1.1 does not require RANDFILE configurations anymore.

 - RANDFILE configuration causes error: 'Can't load /root/.rnd into RNG' (as shown below)
![image](https://user-images.githubusercontent.com/37533590/114018525-f6e45500-988a-11eb-8bde-c46806fa39c5.png)

 - After the fix the error get resolved (as shown below)
![image](https://user-images.githubusercontent.com/37533590/114018593-09f72500-988b-11eb-9e73-5ae4e0c40660.png)
