### PR TITLE
Print the selected endpoint number

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -703,8 +703,8 @@ responseGetEndpoints(UA_Client *client, void *userdata, UA_UInt32 requestId,
 
             /* Log the selected endpoint */
             UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
-                        "Selected Endpoint %.*s with SecurityMode %s and SecurityPolicy %.*s",
-                        (int)endpoint->endpointUrl.length, endpoint->endpointUrl.data,
+                        "Selected endpoint %lu in URL %.*s with SecurityMode %s and SecurityPolicy %.*s",
+                        (long unsigned)i, (int)endpoint->endpointUrl.length, endpoint->endpointUrl.data,
                         securityModeNames[endpoint->securityMode - 1],
                         (int)endpoint->securityPolicyUri.length,
                         endpoint->securityPolicyUri.data);


### PR DESCRIPTION
Make the print more user friendly by explicitly mentioning the selected endpoint number