### PR TITLE
[REVIEW] Adding macros for checking error codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,13 @@ if(CMAKE_VERSION VERSION_GREATER 3.6)
     SET_PROPERTY(CACHE UA_ENABLE_STATIC_ANALYZER PROPERTY STRINGS "OFF" "MINIMAL" "REDUCED" "FULL")
 endif()
 
+option(UA_DEBUG_FILE_LINE_INFO "Enable file and line information as additional debugging output for error messages" OFF)
+mark_as_advanced(UA_DEBUG_FILE_LINE_INFO)
+
+if(CMAKE_BUILD_TYPE MATCHES DEBUG)
+    set(UA_DEBUG_FILE_LINE_INFO ON)
+endif()
+
 # Build Targets
 option(UA_BUILD_EXAMPLES "Build example servers and clients" OFF)
 option(UA_BUILD_TOOLS "Build OPC UA shell tools" OFF)

--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -75,7 +75,7 @@
 /* Options for Debugging */
 #cmakedefine UA_DEBUG
 #cmakedefine UA_DEBUG_DUMP_PKGS
-
+#cmakedefine UA_DEBUG_FILE_LINE_INFO
 /**
  * Function Export
  * ---------------

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -15,6 +15,7 @@
  *    Copyright 2017 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2018 (c) Hilscher Gesellschaft für Systemautomation mbH (Author: Martin Lang)
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
+ *    Copyright 2021 (c) Fraunhofer IOSB (Author: Jan Hermes)
  */
 
 #include "ua_server_internal.h"
@@ -71,14 +72,13 @@ UA_UInt16 addNamespace(UA_Server *server, const UA_String name) {
     /* Make the array bigger */
     UA_String *newNS = (UA_String*)UA_realloc(server->namespaces,
                                               sizeof(UA_String) * (server->namespacesSize + 1));
-    if(!newNS)
-        return 0;
+    UA_CHECK_MEM(newNS, return 0);
+
     server->namespaces = newNS;
 
     /* Copy the namespace string */
     UA_StatusCode retval = UA_String_copy(&name, &server->namespaces[server->namespacesSize]);
-    if(retval != UA_STATUSCODE_GOOD)
-        return 0;
+    UA_CHECK_STATUS(retval, return 0);
 
     /* Announce the change (otherwise, the array appears unchanged) */
     ++server->namespacesSize;
@@ -98,9 +98,8 @@ UA_UInt16 UA_Server_addNamespace(UA_Server *server, const char* name) {
 
 UA_ServerConfig*
 UA_Server_getConfig(UA_Server *server) {
-  if(!server)
-      return NULL;
-  return &server->config;
+    UA_CHECK_MEM(server, return NULL);
+    return &server->config;
 }
 
 UA_StatusCode
@@ -139,20 +138,16 @@ UA_Server_forEachChildNodeCall(UA_Server *server, UA_NodeId parentNodeId,
 
     UA_BrowseResult br = UA_Server_browse(server, 0, &bd);
     UA_StatusCode res = br.statusCode;
-    if(res != UA_STATUSCODE_GOOD) {
-        UA_BrowseResult_clear(&br);
-        return res;
-    }
+    UA_CHECK_STATUS(res, goto cleanup);
 
     for(size_t i = 0; i < br.referencesSize; i++) {
         if(!UA_ExpandedNodeId_isLocal(&br.references[i].nodeId))
             continue;
         res = callback(br.references[i].nodeId.nodeId, !br.references[i].isForward,
                        br.references[i].referenceTypeId, handle);
-        if(res != UA_STATUSCODE_GOOD)
-            break;
+        UA_CHECK_STATUS(res, goto cleanup);
     }
-
+cleanup:
     UA_BrowseResult_clear(&br);
     return res;
 }
@@ -248,15 +243,20 @@ UA_Server_cleanup(UA_Server *server, void *_) {
 /* Server Lifecycle */
 /********************/
 
+static
+UA_INLINE
+UA_Boolean UA_Server_NodestoreIsConfigured(UA_Server *server) {
+    return server->config.nodestore.getNode != NULL;
+}
+
 static UA_Server *
 UA_Server_init(UA_Server *server) {
+
     UA_StatusCode res = UA_STATUSCODE_GOOD;
-    
-    if(!server->config.nodestore.getNode) {
-        UA_LOG_FATAL(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                     "No Nodestore configured in the server");
-        goto cleanup;
-    }
+    UA_CHECK_FATAL(UA_Server_NodestoreIsConfigured(server), goto cleanup,
+                    &server->config.logger, UA_LOGCATEGORY_SERVER,
+                    "No Nodestore configured in the server"
+                   );
 
     /* Init start time to zero, the actual start time will be sampled in
      * UA_Server_run_startup() */
@@ -284,10 +284,8 @@ UA_Server_init(UA_Server *server) {
     /* Create Namespaces 0 and 1
      * Ns1 will be filled later with the uri from the app description */
     server->namespaces = (UA_String *)UA_Array_new(2, &UA_TYPES[UA_TYPES_STRING]);
-    if(!server->namespaces) {
-        UA_Server_delete(server);
-        return NULL;
-    }
+    UA_CHECK_MEM(server->namespaces, goto cleanup);
+
     server->namespaces[0] = UA_STRING_ALLOC("http://opcfoundation.org/UA/");
     server->namespaces[1] = UA_STRING_NULL;
     server->namespacesSize = 2;
@@ -312,8 +310,7 @@ UA_Server_init(UA_Server *server) {
 
     /* Initialize namespace 0*/
     res = UA_Server_initNS0(server);
-    if(res != UA_STATUSCODE_GOOD)
-        goto cleanup;
+    UA_CHECK_STATUS(res, goto cleanup);
 
 #ifdef UA_ENABLE_PUBSUB
     /* Build PubSub information model */
@@ -324,8 +321,7 @@ UA_Server_init(UA_Server *server) {
 #ifdef UA_ENABLE_PUBSUB_MONITORING
     /* setup default PubSub monitoring callbacks */
     res = UA_PubSubManager_setDefaultMonitoringCallbacks(&server->config.pubSubConfig.monitoringInterface);
-    if(res != UA_STATUSCODE_GOOD)
-        goto cleanup;
+    UA_CHECK_STATUS(res, goto cleanup);
 #endif /* UA_ENABLE_PUBSUB_MONITORING */
 #endif /* UA_ENABLE_PUBSUB */
     return server;
@@ -337,16 +333,12 @@ UA_Server_init(UA_Server *server) {
 
 UA_Server *
 UA_Server_newWithConfig(UA_ServerConfig *config) {
-    if(!config)
-        return NULL;
+    UA_CHECK_MEM(config, return NULL);
+
     UA_Server *server = (UA_Server *)UA_calloc(1, sizeof(UA_Server));
-    if(!server) {
-        UA_ServerConfig_clean(config);
-        return NULL;
-    }
+    UA_CHECK_MEM(server, UA_ServerConfig_clean(config); return NULL);
+
     server->config = *config;
-
-
     /* The config might have been "moved" into the server struct. Ensure that
      * the logger pointer is correct. */
     for(size_t i = 0; i < server->config.securityPoliciesSize; i++)
@@ -444,8 +436,8 @@ UA_Server_updateCertificate(UA_Server *server,
                             UA_Boolean closeSessions,
                             UA_Boolean closeSecureChannels) {
 
-    if(!server || !oldCertificate || !newCertificate || !newPrivateKey)
-        return UA_STATUSCODE_BADINTERNALERROR;
+    UA_CHECK(server && oldCertificate && newCertificate && newPrivateKey,
+             return UA_STATUSCODE_BADINTERNALERROR);
 
     if(closeSessions) {
         session_list_entry *current;
@@ -477,8 +469,7 @@ UA_Server_updateCertificate(UA_Server *server,
             UA_String_copy(newCertificate, &ed->serverCertificate);
             UA_SecurityPolicy *sp = getSecurityPolicyByUri(server,
                             &server->config.endpoints[i].securityPolicyUri);
-            if(!sp)
-                return UA_STATUSCODE_BADINTERNALERROR;
+            UA_CHECK_MEM(sp, return UA_STATUSCODE_BADINTERNALERROR);
             sp->updateCertificateAndPrivateKey(sp, *newCertificate, *newPrivateKey);
         }
         i++;
@@ -512,16 +503,14 @@ verifyServerApplicationURI(const UA_Server *server) {
             verifyApplicationURI(server->config.certificateVerification.context,
                                  &sp->localCertificate,
                                  &server->config.applicationDescription.applicationUri);
-        if(retval != UA_STATUSCODE_GOOD) {
-            UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                         "The configured ApplicationURI \"%.*s\"does not match the "
-                         "ApplicationURI specified in the certificate for the "
-                         "SecurityPolicy %.*s",
-                         (int)server->config.applicationDescription.applicationUri.length,
-                         server->config.applicationDescription.applicationUri.data,
-                         (int)sp->policyUri.length, sp->policyUri.data);
-            return retval;
-        }
+
+        UA_CHECK_STATUS_ERROR(retval, return retval, &server->config.logger, UA_LOGCATEGORY_SERVER,
+                       "The configured ApplicationURI \"%.*s\"does not match the "
+                       "ApplicationURI specified in the certificate for the "
+                       "SecurityPolicy %.*s",
+                       (int)server->config.applicationDescription.applicationUri.length,
+                       server->config.applicationDescription.applicationUri.data,
+                       (int)sp->policyUri.length, sp->policyUri.data);
     }
     return UA_STATUSCODE_GOOD;
 }
@@ -565,8 +554,7 @@ UA_Server_run_startup(UA_Server *server) {
         writeNs0VariableArray(server, UA_NS0ID_SERVER_SERVERARRAY,
                               &server->config.applicationDescription.applicationUri,
                               1, &UA_TYPES[UA_TYPES_STRING]);
-    if(retVal != UA_STATUSCODE_GOOD)
-        return retVal;
+    UA_CHECK_STATUS(retVal, return retVal);
 
     if(server->state > UA_SERVERLIFECYCLE_FRESH)
         return UA_STATUSCODE_GOOD;
@@ -585,8 +573,7 @@ UA_Server_run_startup(UA_Server *server) {
     /* Does the ApplicationURI match the local certificates? */
 #ifdef UA_ENABLE_ENCRYPTION
     retVal = verifyServerApplicationURI(server);
-    if(retVal != UA_STATUSCODE_GOOD)
-        return retVal;
+    UA_CHECK_STATUS(retVal, return retVal);
 #endif
 
     /* Sample the start time and set it to the Server object */
@@ -605,8 +592,7 @@ UA_Server_run_startup(UA_Server *server) {
         nl->statistics = &server->serverStats.ns;
         result |= nl->start(nl, &server->config.logger, &server->config.customHostname);
     }
-    if(result != UA_STATUSCODE_GOOD)
-        return result;
+    UA_CHECK_STATUS(result, return result);
 
     /* Update the application description to match the previously added
      * discovery urls. We can only do this after the network layer is started
@@ -619,8 +605,9 @@ UA_Server_run_startup(UA_Server *server) {
     }
     server->config.applicationDescription.discoveryUrls = (UA_String *)
         UA_Array_new(server->config.networkLayersSize, &UA_TYPES[UA_TYPES_STRING]);
-    if(!server->config.applicationDescription.discoveryUrls)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    UA_CHECK_MEM(server->config.applicationDescription.discoveryUrls,
+             return UA_STATUSCODE_BADOUTOFMEMORY);
+
     server->config.applicationDescription.discoveryUrlsSize =
         server->config.networkLayersSize;
     for(size_t i = 0; i < server->config.applicationDescription.discoveryUrlsSize; i++) {
@@ -736,8 +723,8 @@ testShutdownCondition(UA_Server *server) {
 UA_StatusCode
 UA_Server_run(UA_Server *server, const volatile UA_Boolean *running) {
     UA_StatusCode retval = UA_Server_run_startup(server);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
+    UA_CHECK_STATUS(retval, return retval);
+
 #ifdef UA_ENABLE_VALGRIND_INTERACTIVE
     size_t loopCount = 0;
 #endif

--- a/src/ua_util_internal.h
+++ b/src/ua_util_internal.h
@@ -9,6 +9,7 @@
  *    Copyright 2015 (c) Chris Iatrou
  *    Copyright 2015-2016 (c) Oleksiy Vasylyev
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
+ *    Copyright 2021 (c) Fraunhofer IOSB (Author: Jan Hermes)
  */
 
 #ifndef UA_UTIL_H_
@@ -85,6 +86,113 @@ typedef UA_Int32 i32;
 typedef UA_UInt64 u64;
 typedef UA_Int64 i64;
 typedef UA_StatusCode status;
+
+/**
+ * Error checking macros
+ */
+
+static UA_INLINE UA_Boolean
+isGood(UA_StatusCode code) {
+    return code == UA_STATUSCODE_GOOD;
+}
+
+static UA_INLINE UA_Boolean
+isNonNull(const void *ptr) {
+    return ptr != NULL;
+}
+
+static UA_INLINE UA_Boolean
+isTrue(uint8_t expr) {
+    return expr;
+}
+
+#define UA_CHECK(A, EVAL_ON_ERROR)                                                       \
+    if(!isTrue(A)) {                                                         \
+        EVAL_ON_ERROR;                                                                   \
+    }
+
+#define UA_CHECK_STATUS(STATUSCODE, EVAL_ON_ERROR)                                       \
+    UA_CHECK(isGood(STATUSCODE), EVAL_ON_ERROR)
+
+#define UA_CHECK_MEM(STATUSCODE, EVAL_ON_ERROR)                                       \
+    UA_CHECK(isNonNull(STATUSCODE), EVAL_ON_ERROR)
+
+#ifdef UA_DEBUG_FILE_LINE_INFO
+#define UA_CHECK_LOG_INTERNAL(A, STATUSCODE, EVAL, LOG, LOGGER, CAT, MSG, ...)           \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK(A, LOG(LOGGER, CAT, "" MSG "%s (%s:%d: statuscode: %s)", __VA_ARGS__,   \
+                        __FILE__, __LINE__, UA_StatusCode_name(STATUSCODE));             \
+                 EVAL))
+#else
+#define UA_CHECK_LOG_INTERNAL(A, STATUSCODE, EVAL, LOG, LOGGER, CAT, MSG, ...)           \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK(A, LOG(LOGGER, CAT, "" MSG "%s (statuscode: %s)", __VA_ARGS__,   \
+                        UA_StatusCode_name(STATUSCODE));             \
+                 EVAL))
+#endif
+
+#define UA_CHECK_LOG(A, EVAL, LEVEL, LOGGER, CAT, ...)                                   \
+    UA_MACRO_EXPAND(UA_CHECK_LOG_INTERNAL(A, UA_STATUSCODE_BAD, EVAL, UA_LOG_##LEVEL,    \
+                                          LOGGER, CAT, __VA_ARGS__, ""))
+
+#define UA_CHECK_STATUS_LOG(STATUSCODE, EVAL, LEVEL, LOGGER, CAT, ...)                   \
+    UA_MACRO_EXPAND(UA_CHECK_LOG_INTERNAL(isGood(STATUSCODE), STATUSCODE,  \
+                                          EVAL, UA_LOG_##LEVEL, LOGGER, CAT,             \
+                                          __VA_ARGS__, ""))
+
+#define UA_CHECK_MEM_LOG(PTR, EVAL, LEVEL, LOGGER, CAT, ...)                   \
+    UA_MACRO_EXPAND(UA_CHECK_LOG_INTERNAL(isNonNull(PTR), UA_STATUSCODE_BADOUTOFMEMORY,  \
+                                          EVAL, UA_LOG_##LEVEL, LOGGER, CAT,             \
+                                          __VA_ARGS__, ""))
+
+/**
+ * Check Macros
+ * Usage examples:
+ *
+ *    void *data = malloc(...);
+ *    UA_CHECK(data, return error);
+ *
+ *    UA_StatusCode rv = some_func(...);
+ *    UA_CHECK_STATUS(rv, return rv);
+ *
+ *    UA_Logger *logger = &server->config.logger;
+ *    rv = bar_func(...);
+ *    UA_CHECK_STATUS_WARN(rv, return rv, logger, UA_LOGCATEGORY_SERVER, "msg & args %s", "arg");
+ */
+#define UA_CHECK_FATAL(A, EVAL, LOGGER, CAT, ...)                                        \
+    UA_MACRO_EXPAND(UA_CHECK_LOG(A, EVAL, FATAL, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_ERROR(A, EVAL, LOGGER, CAT, ...)                                        \
+    UA_MACRO_EXPAND(UA_CHECK_LOG(A, EVAL, ERROR, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_WARN(A, EVAL, LOGGER, CAT, ...)                                         \
+    UA_MACRO_EXPAND(UA_CHECK_LOG(A, EVAL, WARNING, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_INFO(A, EVAL, LOGGER, CAT, ...)                                         \
+    UA_MACRO_EXPAND(UA_CHECK_LOG(A, EVAL, INFO, LOGGER, CAT, __VA_ARGS__))
+
+#define UA_CHECK_STATUS_FATAL(STATUSCODE, EVAL, LOGGER, CAT, ...)                        \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_STATUS_LOG(STATUSCODE, EVAL, FATAL, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_STATUS_ERROR(STATUSCODE, EVAL, LOGGER, CAT, ...)                        \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_STATUS_LOG(STATUSCODE, EVAL, ERROR, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_STATUS_WARN(STATUSCODE, EVAL, LOGGER, CAT, ...)                         \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_STATUS_LOG(STATUSCODE, EVAL, WARNING, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_STATUS_INFO(STATUSCODE, EVAL, LOGGER, CAT, ...)                         \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_STATUS_LOG(STATUSCODE, EVAL, INFO, LOGGER, CAT, __VA_ARGS__))
+
+#define UA_CHECK_MEM_FATAL(PTR, EVAL, LOGGER, CAT, ...)                        \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_MEM_LOG(PTR, EVAL, FATAL, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_MEM_ERROR(PTR, EVAL, LOGGER, CAT, ...)                        \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_MEM_LOG(PTR, EVAL, ERROR, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_MEM_WARN(PTR, EVAL, LOGGER, CAT, ...)                         \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_MEM_LOG(PTR, EVAL, WARNING, LOGGER, CAT, __VA_ARGS__))
+#define UA_CHECK_MEM_INFO(PTR, EVAL, LOGGER, CAT, ...)                         \
+    UA_MACRO_EXPAND(                                                                     \
+        UA_CHECK_MEM_LOG(PTR, EVAL, INFO, LOGGER, CAT, __VA_ARGS__))
 
 /**
  * Utility Functions


### PR DESCRIPTION
Adding the possibility to use specific macros to check for error codes.

### Examples

#### Check without logging

The following macros do error-code or error-state checks without logging anything and just evaluating an additional parameter.
- `UA_CHECK`
- `UA_CHECK_MEM`

`UA_CHECK_MEM` can be used in cases where an `malloc/calloc/realloc` call return-value is checked.

Here the return code is checked and returns the error code itself if the check encounters an error code.
```c
static UA_StatusCode
foo() {
    UA_StatusCode rv = some_func();
    UA_CHECK(rv, return rv);

    return UA_STATUSCODE_GOOD;
}
```

If there is the need for a cleanup routine one can simply jump to an according label like in this example:

```c
static UA_StatusCode
foo() {
    void *data;

    UA_StatusCode rv = some_func_which_allocates_memory(data);
    // check jumps into cleanup routine
    UA_CHECK(rv, goto error);

    return UA_STATUSCODE_GOOD;
error:
    if (data) {
        UA_free(data);
    }
    return rv;
```


#### Check with logging

A common case is to log a warning, info or error when the error-code implies a faulty state.
There are three macros for this:
- `UA_CHECK_INFO`
- `UA_CHECK_WARN`
- `UA_CHECK_ERROR`
Those macros can be called with a logger, a logging category, a message and variadic arguments.

In this example the return code is checked, while generating a log message with the `WARNING` logger level
and variadic arguments attached.

```c
static
UA_StatusCode
someFunc(UA_Server *server) {

    UA_StatusCode rv = some_func();
    UA_CHECK_WARN(rv, goto error, &server->config.logger, UA_LOGCATEGORY_SERVER, "failed: %s!", "my arg");
    return UA_STATUSCODE_GOOD;
error:
    // do cleanup
    return rv;
}
```

### Output of logging messages

The message of a check-call is generated with additional information and can look like this:

`[1601-01-01 00:02:35.290 (UTC+0000)] warn/server	My log message (/path/to/open62541/src/pubsub/ua_pubsub_reader.c:1207: status-code: GoodNonCriticalTimeout)`

In this case a macro-call such as `UA_CHECK_WARN(..., "My log message")` would suffice. The information of filename, linenumber and status-code string is added by the macro.