### PR TITLE
build: remove testing source from build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -990,7 +990,6 @@ endif()
 
 if(UA_DEBUG_DUMP_PKGS)
     list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/plugins/ua_debug_dump_pkgs.c)
-    list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/tests/testing-plugins/testing_networklayers.c)
 endif()
 
 if(UA_ENABLE_DISCOVERY_MULTICAST)


### PR DESCRIPTION
Testing source-file testing_networklayers.c breaks
build when UA_DEBUG_DUMP_PKGS is enabled because
of missing dependencies (e.g. testing_clock) which are
only build for the testing-build.