### PR TITLE
ci: dependant issues (allows dependent PRs)

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,42 @@
+name: Dependent Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      # Makes sure we always add status check for PRs. Useful only if
+      # this action is required to pass before merging. Can be removed
+      # otherwise.
+      - synchronize
+
+  # Schedule a daily check. Useful if you reference cross-repository
+  # issues or pull requests. Can be removed otherwise.
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          # (Required) The token to use to make API calls to GitHub.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # (Optional) The label to use to mark dependent issues
+          label: dependent
+
+          # (Optional) Enable checking for dependencies in issues.
+          # Enable by setting the value to "on". Default "off"
+          check_issues: off
+
+          # (Optional) A comma-separated list of keywords. Default
+          # "depends on, blocked by"
+          keywords: depends on, blocked by


### PR DESCRIPTION
Workflow that allows for adding dependencies into a pull request.

An example pullrequest message might look like this:

```
Depends on #4420 

This pull request depends on integrating the pullrequest #4420.
```

The dependent-issues-bot will add a "dependent" label to this pullrequest an block until the dependency is integrated.
This way developers can create multiple separate pullrequests that depend on one another.

An example image of such a pullrequest with the according bot-action:

![image](https://user-images.githubusercontent.com/10834314/118978506-b4c52d80-b977-11eb-992b-9a07e53b6765.png)