### PR TITLE
fix(ex): fix the usage info for example: tutorial_pubsub_mqtt_publish

### DIFF
--- a/examples/pubsub/tutorial_pubsub_mqtt_publish.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt_publish.c
@@ -376,7 +376,7 @@ static void stopHandler(int sign) {
 }
 
 static void usage(void) {
-    printf("Usage: tutorial_pubsub_mqtt [--url <opc.mqtt://hostname:port>] "
+    printf("Usage: tutorial_pubsub_mqtt_publish [--url <opc.mqtt://hostname:port>] "
            "[--topic <mqttTopic>] "
            "[--freq <frequency in ms> "
            "[--json]\n"


### PR DESCRIPTION
Fix the usage info for example: tutorial_pubsub_mqtt_publish

Signed-off-by: Pingfang Liao <winndows@163.com>