### PR TITLE
MSVC: Do not redefine _CRT_SECURE_NO_WARNINGS

### DIFF
--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -54,7 +54,7 @@ if is_c:
 #endif
 
 /* Disable security warnings for BSD sockets on MSVC */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 # define _CRT_SECURE_NO_WARNINGS
 #endif
 


### PR DESCRIPTION
Do not try to redefine _CRT_SECURE_NO_WARNINGS if it is already
defined (for instance through the command line / build system).

This prevents warnings like

  open62541.c(25): warning C4005: '_CRT_SECURE_NO_WARNINGS': macro redefinition
  
Alternative: Remove the define altogether, because the same checks already exists in open62541.h which is included in the lines below?