### PR TITLE
[REVIEW] fix(core): clean errno after using the error code

### DIFF
--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -127,13 +127,17 @@ void UA_sleep_ms(unsigned long ms);
 #define UA_snprintf snprintf
 #define UA_strncasecmp strncasecmp
 
+#define UA_clean_errno(STR_FUN) (errno == 0 ? "None" : (STR_FUN)(errno))
+
 #define UA_LOG_SOCKET_ERRNO_WRAP(LOG) { \
-    char *errno_str = strerror(errno); \
+    char *errno_str = UA_clean_errno(strerror); \
     LOG; \
+    errno = 0; \
 }
 #define UA_LOG_SOCKET_ERRNO_GAI_WRAP(LOG) { \
-    const char *errno_str = gai_strerror(errno); \
+    const char *errno_str = UA_clean_errno(gai_strerror); \
     LOG; \
+    errno = 0; \
 }
 
 #if UA_MULTITHREADING >= 100


### PR DESCRIPTION
When using errno in logging its nice to clean it afterwards (= 0) and also check if errno is set at all (== 0).