### PR TITLE
fix(ex): adjusting the PubSub TransportLayers configuration for example: pubsub_interrupt_publish

### DIFF
--- a/examples/pubsub_realtime/pubsub_interrupt_publish.c
+++ b/examples/pubsub_realtime/pubsub_interrupt_publish.c
@@ -362,10 +362,7 @@ int main(void) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 
-    config->pubsubTransportLayers = (UA_PubSubTransportLayer *)
-        UA_malloc(sizeof(UA_PubSubTransportLayer));
-    config->pubsubTransportLayers[0] = UA_PubSubTransportLayerEthernet();
-    config->pubsubTransportLayersSize++;
+    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerEthernet());
 
     addServerNodes(server);
     addPubSubConfiguration(server);


### PR DESCRIPTION
Adjusting the PubSub TransportLayers configuration for example: pubsub_interrupt_publish