### PR TITLE
fix mem leak at freezeWriterGroup with UA_ENABLE_JSON_ENCODING enabled

### DIFF
--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -365,7 +365,8 @@ UA_Server_freezeWriterGroupConfiguration(UA_Server *server, const UA_NodeId writ
         for(size_t i = 0; i < dsmCount; i++){
             UA_free(dsmStore[i].data.keyFrameData.dataSetFields);
 #ifdef UA_ENABLE_JSON_ENCODING
-            UA_free(dsmStore[i].data.keyFrameData.fieldNames);
+            UA_Array_delete(dsmStore[i].data.keyFrameData.fieldNames, 
+                dsmStore[i].data.keyFrameData.fieldCount, &UA_TYPES[UA_TYPES_STRING]);
 #endif
         }
     }

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -163,6 +163,7 @@ START_TEST(SubscribeSingleFieldWithFixedOffsets) {
     *intValue = 1000;
     UA_DataValue *dataValue = UA_DataValue_new();
     UA_Variant_setScalar(&dataValue->value, intValue, &UA_TYPES[UA_TYPES_UINT32]);
+    dsfConfig.field.variable.fieldNameAlias = UA_STRING("Published Int32");
     dsfConfig.field.variable.rtValueSource.rtFieldSourceEnabled = UA_TRUE;
     dsfConfig.field.variable.rtValueSource.staticValueSource = &dataValue;
     dsfConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;


### PR DESCRIPTION
Enabling the build option UA_ENABLE_JSON_ENCODING causes a memory leak at UA_PubSubDataSetWriter_generateKeyFrameMessage() if the fieldNameAlias parameter of a PublishedDataSetfield config
has been set.

`valgrind --tool=memcheck --track-origins=yes --leak-check=full --leak-resolution=high --num-callers=40 ./bin/tests/check_pubsub_subscribe_rt_levels `

`
100%: Checks: 2, Failures: 0, Errors: 0
==21995== 
==21995== HEAP SUMMARY:
==21995==     in use at exit: 15 bytes in 1 blocks
==21995==   total heap usage: 7,807 allocs, 7,806 frees, 4,836,763 bytes allocated
==21995== 
==21995== 15 bytes in 1 blocks are definitely lost in loss record 1 of 1
==21995==    at 0x4C2DBC5: calloc (vg_replace_malloc.c:711)
==21995==    by 0x11B71C: UA_Array_copy (ua_types.c:1362)
==21995==    by 0x1184CD: String_copy (ua_types.c:151)
==21995==    by 0x11B216: UA_copy (ua_types.c:1220)
==21995==    by 0x13ABDF: UA_String_copy (types_generated_handling.h:373)
==21995==    by 0x13FEBB: UA_PubSubDataSetWriter_generateKeyFrameMessage (ua_pubsub_writer.c:1591)
==21995==    by 0x140A1A: UA_DataSetWriter_generateDataSetMessage (ua_pubsub_writer.c:1896)
==21995==    by 0x13C3D8: UA_Server_freezeWriterGroupConfiguration (ua_pubsub_writer.c:324)
==21995==    by 0x1167DE: SubscribeSingleFieldWithFixedOffsets (check_pubsub_subscribe_rt_levels.c:277)
==21995==    by 0x1B868A: tcase_run_tfun_nofork.isra.9 (in /workspaces/open62541_FEM_3/build/bin/tests/check_pubsub_subscribe_rt_levels)
==21995==    by 0x1B8A4B: srunner_run (in /workspaces/open62541_FEM_3/build/bin/tests/check_pubsub_subscribe_rt_levels)
==21995==    by 0x117FB2: main (check_pubsub_subscribe_rt_levels.c:466)
`

