### PR TITLE
fix(pubsub): process all network messages

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -522,6 +522,11 @@ UA_EXPANDEDNODEID_BYTESTRING_ALLOC(UA_UInt16 nsIndex, const char *chars) {
     id.serverIndex = 0; id.namespaceUri = UA_STRING_NULL; return id;
 }
 
+static UA_INLINE UA_ExpandedNodeId
+UA_EXPANDEDNODEID_NODEID(UA_NodeId nodeId) {
+    UA_ExpandedNodeId id = {0}; id.nodeId = nodeId; return id;
+}
+
 /* Does the ExpandedNodeId point to a local node? That is, are namespaceUri and
  * serverIndex empty? */
 UA_Boolean UA_EXPORT

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -92,7 +92,7 @@ UA_PubSubConnection_regist(UA_Server *server, UA_NodeId *connectionIdentifier);
 
 /* Process Network Message for a ReaderGroup. But we the ReaderGroup needs to be identified first. */
 UA_StatusCode
-UA_ReaderGroup_processNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
+UA_Server_processNetworkMessage(UA_Server *server, UA_PubSubConnection *connection,
                                      UA_NetworkMessage* msg);
 
 /**********************************************/
@@ -324,10 +324,11 @@ verifyAndDecryptNetworkMessage(const UA_Logger *logger,
 #endif
 
 UA_StatusCode
-decodeNetworkMessage(const UA_Logger *logger,
-                   UA_ByteString *buffer, size_t *currentPosition,
-                   UA_NetworkMessage *currentNetworkMessage,
-                   UA_ReaderGroup *readerGroup);
+decodeNetworkMessage(UA_Server *server,
+                     const UA_Logger *logger,
+                     UA_ByteString *buffer, size_t *currentPosition,
+                     UA_NetworkMessage *currentNetworkMessage,
+                     UA_PubSubConnection *connection);
 
 UA_StatusCode
 receiveBufferedNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -177,8 +177,8 @@ typedef struct UA_DataSetField{
     //internal fields
     TAILQ_ENTRY(UA_DataSetField) listEntry;
     UA_NodeId identifier;
-    UA_NodeId publishedDataSet;             //ref to parent pds
-    UA_FieldMetaData fieldMetaData;
+    UA_NodeId publishedDataSet;     /* parent pds */
+    UA_FieldMetaData fieldMetaData; /* contains the dataSetFieldId */
     UA_UInt64 sampleCallbackId;
     UA_Boolean sampleCallbackIsRegistered;
     /* This flag is 'read only' and is set internally based on the PubSub state. */

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -243,6 +243,10 @@ UA_StatusCode
 UA_DataSetReader_setPubSubState(UA_Server *server, UA_PubSubState state, UA_DataSetReader *dataSetReader);
 
 #ifdef UA_ENABLE_PUBSUB_MONITORING
+/* Check if DataSetReader has a message receive timeout */
+void
+UA_DataSetReader_checkMessageReceiveTimeout(UA_Server *server, UA_DataSetReader *dataSetReader);
+
 /* DataSetReader MessageReceiveTimeout callback for generic PubSub component timeout handling */
 void
 UA_DataSetReader_handleMessageReceiveTimeout(UA_Server *server, void *dataSetReader);

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -6,14 +6,12 @@
  * Copyright (c) 2018 Fraunhofer IOSB (Author: Julius Pfrommer)
  */
 
-#include "server/ua_server_internal.h"
-#include "ua_pubsub_ns0.h"
+#include <open62541/server_pubsub.h>
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 
-#ifdef UA_ENABLE_PUBSUB_MONITORING
-#include <open62541/server_pubsub.h>
-#endif /* UA_ENABLE_PUBSUB_MONITORING */
+#include "server/ua_server_internal.h"
+#include "ua_pubsub_ns0.h"
 
 #define UA_DATETIMESTAMP_2000 125911584000000000
 
@@ -87,14 +85,18 @@ UA_Server_addPubSubConnection(UA_Server *server,
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
-    UA_PubSubManager_generateUniqueNodeId(server, &newConnectionsField->identifier);
+#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+    /* Internally createa a unique id */
+    addPubSubConnectionRepresentation(server, newConnectionsField);
+#else
+    /* Create a unique NodeId that does not correspond to a Node */
+    UA_PubSubManager_generateUniqueNodeId(&server->pubSubManager,
+                                          &newConnectionsField->identifier);
+#endif
 
     if(connectionIdentifier)
         UA_NodeId_copy(&newConnectionsField->identifier, connectionIdentifier);
 
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
-    addPubSubConnectionRepresentation(server, newConnectionsField);
-#endif
     return UA_STATUSCODE_GOOD;
 }
 
@@ -138,7 +140,8 @@ UA_PubSubConnection_regist(UA_Server *server, UA_NodeId *connectionIdentifier) {
 }
 
 UA_AddPublishedDataSetResult
-UA_Server_addPublishedDataSet(UA_Server *server, const UA_PublishedDataSetConfig *publishedDataSetConfig,
+UA_Server_addPublishedDataSet(UA_Server *server,
+                              const UA_PublishedDataSetConfig *publishedDataSetConfig,
                               UA_NodeId *pdsIdentifier) {
     UA_AddPublishedDataSetResult result = {UA_STATUSCODE_BADINVALIDARGUMENT, 0, NULL, {0, 0}};
     if(!publishedDataSetConfig){
@@ -146,97 +149,96 @@ UA_Server_addPublishedDataSet(UA_Server *server, const UA_PublishedDataSetConfig
                      "PublishedDataSet creation failed. No config passed in.");
         return result;
     }
+
     if(publishedDataSetConfig->publishedDataSetType != UA_PUBSUB_DATASET_PUBLISHEDITEMS){
         UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "PublishedDataSet creation failed. Unsupported PublishedDataSet type.");
         return result;
     }
-    //deep copy the given connection config
-    UA_PublishedDataSetConfig tmpPublishedDataSetConfig;
-    memset(&tmpPublishedDataSetConfig, 0, sizeof(UA_PublishedDataSetConfig));
-    if(UA_PublishedDataSetConfig_copy(publishedDataSetConfig, &tmpPublishedDataSetConfig) != UA_STATUSCODE_GOOD){
-        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                     "PublishedDataSet creation failed. Configuration copy failed.");
-        result.addResult = UA_STATUSCODE_BADINTERNALERROR;
-        return result;
-    }
-    //create new PDS and add to UA_PubSubManager
-    UA_PublishedDataSet *newPubSubDataSetField = (UA_PublishedDataSet *)
-            UA_calloc(1, sizeof(UA_PublishedDataSet));
-    if(!newPubSubDataSetField) {
-        UA_PublishedDataSetConfig_clear(&tmpPublishedDataSetConfig);
+
+    /* Create new PDS and add to UA_PubSubManager */
+    UA_PublishedDataSet *newPDS = (UA_PublishedDataSet *)
+        UA_calloc(1, sizeof(UA_PublishedDataSet));
+    if(!newPDS) {
         UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "PublishedDataSet creation failed. Out of Memory.");
         result.addResult = UA_STATUSCODE_BADOUTOFMEMORY;
         return result;
     }
-    memset(newPubSubDataSetField, 0, sizeof(UA_PublishedDataSet));
-    TAILQ_INIT(&newPubSubDataSetField->fields);
-    newPubSubDataSetField->config = tmpPublishedDataSetConfig;
+    TAILQ_INIT(&newPDS->fields);
 
-    if (server->pubSubManager.publishedDataSetsSize != 0)
-        TAILQ_INSERT_TAIL(&server->pubSubManager.publishedDataSets, newPubSubDataSetField, listEntry);
-    else {
-        TAILQ_INIT(&server->pubSubManager.publishedDataSets);
-        TAILQ_INSERT_HEAD(&server->pubSubManager.publishedDataSets, newPubSubDataSetField, listEntry);
-    }
-    if(tmpPublishedDataSetConfig.publishedDataSetType == UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE){
-        //parse template config and add fields (later PubSub batch)
-    }
-    //generate unique nodeId
-    UA_PubSubManager_generateUniqueNodeId(server, &newPubSubDataSetField->identifier);
-    if(pdsIdentifier != NULL){
-        UA_NodeId_copy(&newPubSubDataSetField->identifier, pdsIdentifier);
+    UA_PublishedDataSetConfig *newConfig = &newPDS->config;
+
+    /* Deep copy the given connection config */
+    UA_StatusCode res = UA_PublishedDataSetConfig_copy(publishedDataSetConfig, newConfig);
+    if(res != UA_STATUSCODE_GOOD){
+        UA_free(newPDS);
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "PublishedDataSet creation failed. Configuration copy failed.");
+        result.addResult = UA_STATUSCODE_BADINTERNALERROR;
+        return result;
     }
 
-    result.addResult = UA_STATUSCODE_GOOD;
-    result.fieldAddResults = NULL;
-    result.fieldAddResultsSize = 0;
-
-    //fill the DataSetMetaData
-    switch(tmpPublishedDataSetConfig.publishedDataSetType){
-        case UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE:
-            if(UA_DataSetMetaDataType_copy(&tmpPublishedDataSetConfig.config.itemsTemplate.metaData,
-                    &newPubSubDataSetField->dataSetMetaData) != UA_STATUSCODE_GOOD){
-                UA_Server_removeDataSetField(server, newPubSubDataSetField->identifier);
-                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
-            }
-            break;
-        case UA_PUBSUB_DATASET_PUBLISHEDEVENTS_TEMPLATE:
-            if(UA_DataSetMetaDataType_copy(&tmpPublishedDataSetConfig.config.eventTemplate.metaData,
-                    &newPubSubDataSetField->dataSetMetaData) != UA_STATUSCODE_GOOD){
-                UA_Server_removeDataSetField(server, newPubSubDataSetField->identifier);
-                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
-            }
-            break;
-        case UA_PUBSUB_DATASET_PUBLISHEDEVENTS:
-            newPubSubDataSetField->dataSetMetaData.configurationVersion.majorVersion = UA_PubSubConfigurationVersionTimeDifference();
-            newPubSubDataSetField->dataSetMetaData.configurationVersion.minorVersion = UA_PubSubConfigurationVersionTimeDifference();
-            newPubSubDataSetField->dataSetMetaData.dataSetClassId = UA_GUID_NULL;
-            if(UA_String_copy(&tmpPublishedDataSetConfig.name, &newPubSubDataSetField->dataSetMetaData.name) != UA_STATUSCODE_GOOD){
-                UA_Server_removeDataSetField(server, newPubSubDataSetField->identifier);
-                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
-            }
-            newPubSubDataSetField->dataSetMetaData.description = UA_LOCALIZEDTEXT_ALLOC("", "");
-            break;
-        case UA_PUBSUB_DATASET_PUBLISHEDITEMS:
-            newPubSubDataSetField->dataSetMetaData.configurationVersion.majorVersion = UA_PubSubConfigurationVersionTimeDifference();
-            newPubSubDataSetField->dataSetMetaData.configurationVersion.minorVersion = UA_PubSubConfigurationVersionTimeDifference();
-            if(UA_String_copy(&tmpPublishedDataSetConfig.name, &newPubSubDataSetField->dataSetMetaData.name) != UA_STATUSCODE_GOOD){
-                UA_Server_removeDataSetField(server, newPubSubDataSetField->identifier);
-                result.addResult = UA_STATUSCODE_BADINTERNALERROR;
-            }
-            newPubSubDataSetField->dataSetMetaData.description = UA_LOCALIZEDTEXT_ALLOC("", "");
-            newPubSubDataSetField->dataSetMetaData.dataSetClassId = UA_GUID_NULL;
-            break;
+    /* TODO: Parse template config and add fields (later PubSub batch) */
+    if(newConfig->publishedDataSetType == UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE) {
     }
 
-    server->pubSubManager.publishedDataSetsSize++;
+    /* Fill the DataSetMetaData */
     result.configurationVersion.majorVersion = UA_PubSubConfigurationVersionTimeDifference();
     result.configurationVersion.minorVersion = UA_PubSubConfigurationVersionTimeDifference();
+    switch(newConfig->publishedDataSetType) {
+    case UA_PUBSUB_DATASET_PUBLISHEDEVENTS_TEMPLATE:
+        res = UA_STATUSCODE_BADNOTSUPPORTED;
+        break;
+    case UA_PUBSUB_DATASET_PUBLISHEDEVENTS:
+        res = UA_STATUSCODE_BADNOTSUPPORTED;
+        break;
+    case UA_PUBSUB_DATASET_PUBLISHEDITEMS:
+        newPDS->dataSetMetaData.configurationVersion.majorVersion =
+            UA_PubSubConfigurationVersionTimeDifference();
+        newPDS->dataSetMetaData.configurationVersion.minorVersion =
+            UA_PubSubConfigurationVersionTimeDifference();
+        newPDS->dataSetMetaData.description = UA_LOCALIZEDTEXT_ALLOC("", "");
+        newPDS->dataSetMetaData.dataSetClassId = UA_GUID_NULL;
+        res = UA_String_copy(&newConfig->name, &newPDS->dataSetMetaData.name);
+        break;
+    case UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE:
+        res = UA_DataSetMetaDataType_copy(&newConfig->config.itemsTemplate.metaData,
+                                          &newPDS->dataSetMetaData);
+        break;
+    default:
+        res = UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    /* Abort? */
+    result.addResult = res;
+    if(result.addResult != UA_STATUSCODE_GOOD) {
+        UA_PublishedDataSetConfig_clear(newConfig);
+        UA_free(newPDS);
+        return result;
+    }
+
+    /* Insert into the queue of the manager */
+    if(server->pubSubManager.publishedDataSetsSize != 0) {
+        TAILQ_INSERT_TAIL(&server->pubSubManager.publishedDataSets,
+                          newPDS, listEntry);
+    } else {
+        TAILQ_INIT(&server->pubSubManager.publishedDataSets);
+        TAILQ_INSERT_HEAD(&server->pubSubManager.publishedDataSets,
+                          newPDS, listEntry);
+    }
+    server->pubSubManager.publishedDataSetsSize++;
+
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
-    addPublishedDataItemsRepresentation(server, newPubSubDataSetField);
+    /* Create representation and unique id */
+    addPublishedDataItemsRepresentation(server, newPDS);
+#else
+    /* Generate unique nodeId */
+    UA_PubSubManager_generateUniqueNodeId(&server->pubSubManager, &newPDS->identifier);
 #endif
+    if(pdsIdentifier)
+        UA_NodeId_copy(&newPDS->identifier, pdsIdentifier);
+
     return result;
 }
 
@@ -287,13 +289,22 @@ UA_PubSubConfigurationVersionTimeDifference() {
 
 /* Generate a new unique NodeId. This NodeId will be used for the information
  * model representation of PubSub entities. */
+#ifndef UA_ENABLE_PUBSUB_INFORMATIONMODEL
 void
-UA_PubSubManager_generateUniqueNodeId(UA_Server *server, UA_NodeId *nodeId) {
-    UA_NodeId newNodeId = UA_NODEID_NUMERIC(0, 0);
-    UA_Node *newNode = UA_NODESTORE_NEW(server, UA_NODECLASS_OBJECT);
-    UA_NODESTORE_INSERT(server, newNode, &newNodeId);
-    newNodeId.namespaceIndex = 1;
-    UA_NodeId_copy(&newNodeId, nodeId);
+UA_PubSubManager_generateUniqueNodeId(UA_PubSubManager *psm, UA_NodeId *nodeId) {
+    *nodeId = UA_NODEID_NUMERIC(1, ++psm->uniqueIdCount);
+}
+#endif
+
+UA_Guid
+UA_PubSubManager_generateUniqueGuid(UA_Server *server) {
+    while(true) {
+        UA_NodeId testId = UA_NODEID_GUID(1, UA_Guid_random());
+        const UA_Node *testNode = UA_NODESTORE_GET(server, &testId);
+        if(!testNode)
+            return testId.identifier.guid;
+        UA_NODESTORE_RELEASE(server, testNode);
+    }
 }
 
 /* Delete the current PubSub configuration including all nested members. This

--- a/src/pubsub/ua_pubsub_manager.h
+++ b/src/pubsub/ua_pubsub_manager.h
@@ -16,19 +16,30 @@ _UA_BEGIN_DECLS
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 
-typedef struct UA_PubSubManager{
-    //Connections and PublishedDataSets can exist alone (own lifecycle) -> top level components
+typedef struct UA_PubSubManager {
+    /* Connections and PublishedDataSets can exist alone (own lifecycle) -> top
+     * level components */
     size_t connectionsSize;
     TAILQ_HEAD(UA_ListOfPubSubConnection, UA_PubSubConnection) connections;
+
     size_t publishedDataSetsSize;
     TAILQ_HEAD(UA_ListOfPublishedDataSet, UA_PublishedDataSet) publishedDataSets;
+
+#ifndef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+    UA_UInt32 uniqueIdCount;
+#endif
 } UA_PubSubManager;
 
 void
 UA_PubSubManager_delete(UA_Server *server, UA_PubSubManager *pubSubManager);
 
+#ifndef UA_ENABLE_PUBSUB_INFORMATIONMODEL
 void
-UA_PubSubManager_generateUniqueNodeId(UA_Server *server, UA_NodeId *nodeId);
+UA_PubSubManager_generateUniqueNodeId(UA_PubSubManager *psm, UA_NodeId *nodeId);
+#endif
+
+UA_Guid
+UA_PubSubManager_generateUniqueGuid(UA_Server *server);
 
 UA_UInt32
 UA_PubSubConfigurationVersionTimeDifference(void);

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -543,7 +543,7 @@ addPubSubConnectionRepresentation(UA_Server *server, UA_PubSubConnection *connec
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     if(connection->config->name.length > 512)
         return UA_STATUSCODE_BADOUTOFMEMORY;
-    UA_STACKARRAY(char, connectionName, sizeof(char) * connection->config->name.length +1);
+    char connectionName[513];
     memcpy(connectionName, connection->config->name.data, connection->config->name.length);
     connectionName[connection->config->name.length] = '\0';
     //This code block must use a lock

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -685,21 +685,9 @@ addPubSubConnectionAction(UA_Server *server,
 #endif
 
 UA_StatusCode
-removePubSubConnectionRepresentation(UA_Server *server, UA_PubSubConnection *connection) {
-    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-    retVal |= UA_Server_deleteReference(server, connection->identifier, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE_ADDWRITERGROUP),
-                                        false);
-    retVal |= UA_Server_deleteReference(server, connection->identifier, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE_ADDREADERGROUP),
-                                        false);
-    retVal |= UA_Server_deleteReference(server, connection->identifier, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE_REMOVEGROUP),
-                                        false);
-#endif
-    retVal |= UA_Server_deleteNode(server, connection->identifier, true);
-    return retVal;
+removePubSubConnectionRepresentation(UA_Server *server,
+                                     UA_PubSubConnection *connection) {
+    return UA_Server_deleteNode(server, connection->identifier, true);
 }
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
@@ -814,8 +802,9 @@ addDataSetReaderAction(UA_Server *server,
 #endif
 
 UA_StatusCode
-removeDataSetReaderRepresentation(UA_Server *server, UA_DataSetReader* dataSetReader){
-    return UA_Server_deleteNode(server, dataSetReader->identifier, false);
+removeDataSetReaderRepresentation(UA_Server *server,
+                                  UA_DataSetReader* dataSetReader) {
+    return UA_Server_deleteNode(server, dataSetReader->identifier, true);
 }
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
@@ -880,25 +869,9 @@ removeDataSetFolderAction(UA_Server *server,
                           const UA_NodeId *methodId, void *methodContext,
                           const UA_NodeId *objectId, void *objectContext,
                           size_t inputSize, const UA_Variant *input,
-                          size_t outputSize, UA_Variant *output){
-    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+                          size_t outputSize, UA_Variant *output) {
     UA_NodeId nodeToRemove = *((UA_NodeId *) input[0].data);
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-    retVal |= UA_Server_deleteReference(server, nodeToRemove, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_ADDPUBLISHEDDATAITEMS),
-                                        false);
-    retVal |= UA_Server_deleteReference(server, nodeToRemove, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_REMOVEPUBLISHEDDATASET),
-                                        false);
-    retVal |= UA_Server_deleteReference(server, nodeToRemove, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_ADDDATASETFOLDER),
-                                        false);
-    retVal |= UA_Server_deleteReference(server, nodeToRemove, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_REMOVEDATASETFOLDER),
-                                        false);
-#endif
-    retVal |= UA_Server_deleteNode(server, nodeToRemove, false);
-    return retVal;
+    return UA_Server_deleteNode(server, nodeToRemove, true);
 }
 #endif
 
@@ -1073,8 +1046,9 @@ removeVariablesAction(UA_Server *server,
 
 
 UA_StatusCode
-removePublishedDataSetRepresentation(UA_Server *server, UA_PublishedDataSet *publishedDataSet){
-    return UA_Server_deleteNode(server, publishedDataSet->identifier, false);
+removePublishedDataSetRepresentation(UA_Server *server,
+                                     UA_PublishedDataSet *publishedDataSet) {
+    return UA_Server_deleteNode(server, publishedDataSet->identifier, true);
 }
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
@@ -1270,36 +1244,12 @@ addWriterGroupAction(UA_Server *server,
 
 UA_StatusCode
 removeGroupRepresentation(UA_Server *server, UA_WriterGroup *writerGroup) {
-    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-    retVal |= UA_Server_deleteReference(server, writerGroup->identifier,
-                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_WRITERGROUPTYPE_ADDDATASETWRITER),
-                                        false);
-    retVal |= UA_Server_deleteReference(server, writerGroup->identifier,
-                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_WRITERGROUPTYPE_REMOVEDATASETWRITER),
-                                        false);
-#endif
-    retVal |= UA_Server_deleteNode(server, writerGroup->identifier, false);
-    return retVal;
+    return UA_Server_deleteNode(server, writerGroup->identifier, true);
 }
 
 UA_StatusCode
 removeReaderGroupRepresentation(UA_Server *server, UA_ReaderGroup *readerGroup) {
-    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-    retVal |= UA_Server_deleteReference(server, readerGroup->identifier,
-                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_READERGROUPTYPE_ADDDATASETREADER),
-                                        false);
-    retVal |= UA_Server_deleteReference(server, readerGroup->identifier,
-                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
-                                        UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_READERGROUPTYPE_REMOVEDATASETREADER),
-                                        false);
-#endif
-    retVal |= UA_Server_deleteNode(server, readerGroup->identifier, false);
-    return retVal;
+    return UA_Server_deleteNode(server, readerGroup->identifier, true);
 }
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
@@ -1489,8 +1439,9 @@ addDataSetWriterAction(UA_Server *server,
 
 
 UA_StatusCode
-removeDataSetWriterRepresentation(UA_Server *server, UA_DataSetWriter *dataSetWriter) {
-    return UA_Server_deleteNode(server, dataSetWriter->identifier, false);
+removeDataSetWriterRepresentation(UA_Server *server,
+                                  UA_DataSetWriter *dataSetWriter) {
+    return UA_Server_deleteNode(server, dataSetWriter->identifier, true);
 }
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
@@ -1779,13 +1730,17 @@ UA_Server_initPubSubNS0(UA_Server *server) {
 #endif
 
 #else
-    retVal |= UA_Server_deleteReference(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE), UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
+    /* Remove methods */
+    retVal |= UA_Server_deleteReference(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
                                         UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_ADDCONNECTION),
                                         false);
-    retVal |= UA_Server_deleteReference(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE), UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
+    retVal |= UA_Server_deleteReference(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE),
+                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), true,
                                         UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_REMOVECONNECTION),
                                         false);
 #endif
+
     UA_NodeTypeLifecycle lifeCycle;
     lifeCycle.constructor = NULL;
     lifeCycle.destructor = connectionTypeDestructor;

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -17,7 +17,7 @@
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL /* conditional compilation */
 
-typedef struct{
+typedef struct {
     UA_NodeId parentNodeId;
     UA_UInt32 parentClassifier;
     UA_UInt32 elementClassiefier;
@@ -645,7 +645,7 @@ addPubSubConnectionAction(UA_Server *server,
         }
 
         //TODO: Need to handle the UA_Server_setWriterGroupOperational based on the status variable in information model
-        if (pubSubConnectionDataType.enabled == UA_TRUE) {
+        if(pubSubConnectionDataType.enabled) {
             UA_Server_freezeWriterGroupConfiguration(server, writerGroupId);
             UA_Server_setWriterGroupOperational(server, writerGroupId);
         } else
@@ -671,7 +671,7 @@ addPubSubConnectionAction(UA_Server *server,
             }
         }
         //TODO: Need to handle the UA_Server_setReaderGroupOperational based on the status variable in information model
-        if(pubSubConnectionDataType.enabled == UA_TRUE) {
+        if(pubSubConnectionDataType.enabled) {
             UA_Server_freezeReaderGroupConfiguration(server, readerGroupId);
             UA_Server_setReaderGroupOperational(server, readerGroupId);
         }
@@ -782,7 +782,7 @@ addDataSetReaderAction(UA_Server *server,
                        size_t outputSize, UA_Variant *output){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, *objectId);
-    if(rg->configurationFrozen == UA_TRUE) {
+    if(rg->configurationFrozen) {
         UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "addDataSetReader cannot be done because ReaderGroup config frozen");
         return UA_STATUSCODE_BAD;
@@ -995,7 +995,7 @@ addPublishedDataItemsAction(UA_Server *server,
         dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
         dataSetFieldConfig.field.variable.fieldNameAlias = fieldNameAliases[j];
         if(fieldFlags[j] == UA_DATASETFIELDFLAGS_PROMOTEDFIELD)
-            dataSetFieldConfig.field.variable.promotedField = UA_TRUE;
+            dataSetFieldConfig.field.variable.promotedField = true;
 
         UA_PublishedVariableDataType variablesToAddField;
         UA_PublishedVariableDataType_init(&variablesToAddField);
@@ -1568,12 +1568,10 @@ publishedDataItemsTypeDestructor(UA_Server *server,
 /*         PubSub configurator       */
 /*************************************/
 
-/* UA_loadPubSubConfigMethodCallback() */
-/**
- * @brief   callback function that will be executed when the method "PubSub configurator (replace config)" is called.
- */
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS 
-#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+#if defined(UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS) && defined(UA_ENABLE_PUBSUB_FILE_CONFIG)
+
+/* Callback function that will be executed when the method "PubSub configurator
+ * (replace config)" is called. */
 static UA_StatusCode
 UA_loadPubSubConfigMethodCallback(UA_Server *server,
                                   const UA_NodeId *sessionId, void *sessionHandle,
@@ -1590,21 +1588,9 @@ UA_loadPubSubConfigMethodCallback(UA_Server *server,
         return UA_STATUSCODE_BADARGUMENTSMISSING;
     }
 }
-#endif
-#endif /*UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS*/
 
-
-/* UA_addLoadPubSubConfigMethod() */
-/**
- * @brief       Adds method node to server. This method is used to load binary files for PubSub 
- *              configuration and delete / replace old PubSub configurations.
- * 
- * @param       server      [bi]    UA_Server object that shall contain the method.
- * 
- * @return      UA_STATUSCODE_GOOD on success
- */
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+/* Adds method node to server. This method is used to load binary files for
+ * PubSub configuration and delete / replace old PubSub configurations. */
 static UA_StatusCode 
 UA_addLoadPubSubConfigMethod(UA_Server *server) {
     UA_Argument inputArgument;
@@ -1626,16 +1612,9 @@ UA_addLoadPubSubConfigMethod(UA_Server *server) {
                                    configAttr, &UA_loadPubSubConfigMethodCallback,
                                    1, &inputArgument, 0, NULL, NULL, NULL);
 }
-#endif
-#endif /*UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS*/
 
-
-/* UA_deletePubSubConfigMethodCallback() */
-/**
- * @brief   callback function that will be executed when the method "PubSub configurator (delete config)" is called.
- */
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+/* Callback function that will be executed when the method "PubSub configurator
+ *  (delete config)" is called. */
 static UA_StatusCode
 UA_deletePubSubConfigMethodCallback(UA_Server *server,
                                     const UA_NodeId *sessionId, void *sessionHandle,
@@ -1646,20 +1625,9 @@ UA_deletePubSubConfigMethodCallback(UA_Server *server,
     UA_PubSubManager_delete(server, &(server->pubSubManager));
     return UA_STATUSCODE_GOOD;
 }
-#endif
-#endif /*UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS*/
 
-
-/* UA_addDeletePubSubConfigMethod() */
-/**
- * @brief       Adds method node to server. This method is used to delete the current PubSub configuration.
- * 
- * @param       server      [bi]    UA_Server object that shall contain the method.
- * 
- * @return      UA_STATUSCODE_GOOD on success
- */
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+/* Adds method node to server. This method is used to delete the current PubSub
+ * configuration. */
 static UA_StatusCode 
 UA_addDeletePubSubConfigMethod(UA_Server *server) {
     UA_MethodAttributes configAttr = UA_MethodAttributes_default;
@@ -1674,8 +1642,8 @@ UA_addDeletePubSubConfigMethod(UA_Server *server) {
                                    configAttr, &UA_deletePubSubConfigMethodCallback,
                                    0, NULL, 0, NULL, NULL, NULL);
 }
-#endif
-#endif /*UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS*/
+
+#endif /* defined(UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS) && defined(UA_ENABLE_PUBSUB_FILE_CONFIG) */
 
 UA_StatusCode
 UA_Server_initPubSubNS0(UA_Server *server) {
@@ -1684,14 +1652,10 @@ UA_Server_initPubSubNS0(UA_Server *server) {
     profileArray[0] = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
 
     retVal |= writePubSubNs0VariableArray(server, UA_NS0ID_PUBLISHSUBSCRIBE_SUPPORTEDTRANSPORTPROFILES,
-                                    profileArray,
-                                    1, &UA_TYPES[UA_TYPES_STRING]);
+                                    profileArray, 1, &UA_TYPES[UA_TYPES_STRING]);
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_ADDCONNECTION), addPubSubConnectionAction);
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_REMOVECONNECTION), removeConnectionAction);
+    /* Add missing references */
     retVal |= UA_Server_addReference(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_PUBLISHEDDATASETS),
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                                      UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_ADDDATASETFOLDER), true);
@@ -1704,18 +1668,16 @@ UA_Server_initPubSubNS0(UA_Server *server) {
     retVal |= UA_Server_addReference(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_PUBLISHEDDATASETS),
                                      UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                                      UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_REMOVEDATASETFOLDER), true);
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_ADDDATASETFOLDER), addDataSetFolderAction);
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_REMOVEDATASETFOLDER), removeDataSetFolderAction);
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_ADDPUBLISHEDDATAITEMS), addPublishedDataItemsAction);
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_REMOVEPUBLISHEDDATASET), removePublishedDataSetAction);
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHEDDATAITEMSTYPE_ADDVARIABLES), addVariablesAction);
-    retVal |= UA_Server_setMethodNode_callback(server,
-                                               UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHEDDATAITEMSTYPE_REMOVEVARIABLES), removeVariablesAction);
+
+    /* Set method callbacks */
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_ADDCONNECTION), addPubSubConnectionAction);
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_REMOVECONNECTION), removeConnectionAction);
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_ADDDATASETFOLDER), addDataSetFolderAction);
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_REMOVEDATASETFOLDER), removeDataSetFolderAction);
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_ADDPUBLISHEDDATAITEMS), addPublishedDataItemsAction);
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETFOLDERTYPE_REMOVEPUBLISHEDDATASET), removePublishedDataSetAction);
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHEDDATAITEMSTYPE_ADDVARIABLES), addVariablesAction);
+    retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHEDDATAITEMSTYPE_REMOVEVARIABLES), removeVariablesAction);
     retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE_ADDWRITERGROUP), addWriterGroupAction);
     retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE_ADDREADERGROUP), addReaderGroupAction);
     retVal |= UA_Server_setMethodNode_callback(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE_REMOVEGROUP), removeGroupAction);
@@ -1741,20 +1703,27 @@ UA_Server_initPubSubNS0(UA_Server *server) {
                                         false);
 #endif
 
+    /* Set the object-type destructors */
     UA_NodeTypeLifecycle lifeCycle;
     lifeCycle.constructor = NULL;
+
     lifeCycle.destructor = connectionTypeDestructor;
-    UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE), lifeCycle);
+    retVal |= UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBSUBCONNECTIONTYPE), lifeCycle);
+
     lifeCycle.destructor = writerGroupTypeDestructor;
-    UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_WRITERGROUPTYPE), lifeCycle);
+    retVal |= UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_WRITERGROUPTYPE), lifeCycle);
+
     lifeCycle.destructor = readerGroupTypeDestructor;
-    UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_READERGROUPTYPE), lifeCycle);
+    retVal |= UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_READERGROUPTYPE), lifeCycle);
+
     lifeCycle.destructor = dataSetWriterTypeDestructor;
-    UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETWRITERTYPE), lifeCycle);
+    retVal |= UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETWRITERTYPE), lifeCycle);
+
     lifeCycle.destructor = publishedDataItemsTypeDestructor;
-    UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHEDDATAITEMSTYPE), lifeCycle);
+    retVal |= UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHEDDATAITEMSTYPE), lifeCycle);
+
     lifeCycle.destructor = dataSetReaderTypeDestructor;
-    UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETREADERTYPE), lifeCycle);
+    retVal |= UA_Server_setNodeTypeLifecycle(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DATASETREADERTYPE), lifeCycle);
 
     return retVal;
 }

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -23,29 +23,6 @@ typedef struct{
     UA_UInt32 elementClassiefier;
 } UA_NodePropertyContext;
 
-//Prototypes
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS
-static UA_StatusCode addWriterGroupAction(UA_Server *server,
-                                          const UA_NodeId *sessionId, void *sessionHandle,
-                                          const UA_NodeId *methodId, void *methodContext,
-                                          const UA_NodeId *objectId, void *objectContext,
-                                          size_t inputSize, const UA_Variant *input,
-                                          size_t outputSize, UA_Variant *output);
-static UA_StatusCode removeGroupAction(UA_Server *server,
-                                          const UA_NodeId *sessionId, void *sessionHandle,
-                                          const UA_NodeId *methodId, void *methodContext,
-                                          const UA_NodeId *objectId, void *objectContext,
-                                          size_t inputSize, const UA_Variant *input,
-                                          size_t outputSize, UA_Variant *output);
-static UA_StatusCode addDataSetWriterAction(UA_Server *server,
-                                          const UA_NodeId *sessionId, void *sessionHandle,
-                                          const UA_NodeId *methodId, void *methodContext,
-                                          const UA_NodeId *objectId, void *objectContext,
-                                          size_t inputSize, const UA_Variant *input,
-                                          size_t outputSize, UA_Variant *output);
-
-#endif
-
 static UA_StatusCode
 writePubSubNs0VariableArray(UA_Server *server, UA_UInt32 id, void *v,
                       size_t length, const UA_DataType *type) {

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -1806,10 +1806,12 @@ decodeNetworkMessage(UA_Server *server,
                 #ifdef UA_DEBUG_DUMP_PKGS
                 UA_dump_hex_pkg(buffer->data, buffer->length);
                 #endif
-                break;
+                /* break out of all loops when first verify & decrypt was successful */
+                goto loops_exit;
             }
         }
     }
+loops_exit:
 
     // TODO check if warning is correct here and error code carries correct info
     UA_CHECK_WARN(processed, return UA_STATUSCODE_BADNOTFOUND, logger, UA_LOGCATEGORY_SERVER,

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -602,7 +602,7 @@ UA_Server_freezeReaderGroupConfiguration(UA_Server *server, const UA_NodeId read
     UA_DataSetReader *dataSetReader;
     UA_UInt16 dsrCount = 0;
     LIST_FOREACH(dataSetReader, &rg->readers, listEntry){
-    	dataSetReader->configurationFrozen = UA_TRUE;
+        dataSetReader->configurationFrozen = UA_TRUE;
         dsrCount++;
         /* TODO: Configuration frozen for subscribedDataSet once
          * UA_Server_DataSetReader_addTargetVariables API modified to support
@@ -1663,9 +1663,9 @@ processMessageWithReader(UA_Server *server, UA_ReaderGroup *readerGroup,
 }
 
 UA_StatusCode
-UA_ReaderGroup_processNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
+UA_Server_processNetworkMessage(UA_Server *server, UA_PubSubConnection *connection,
                                      UA_NetworkMessage* msg) {
-    if(!msg || !readerGroup)
+    if(!msg || !connection)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
     /* To Do The condition pMsg->dataSetClassIdEnabled
@@ -1678,13 +1678,17 @@ UA_ReaderGroup_processNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGr
     }
 
     UA_Boolean processed = false;
+    UA_ReaderGroup *readerGroup;
     UA_DataSetReader *reader;
+
     /* There can be several readers listening for the same network message */
-    LIST_FOREACH(reader, &readerGroup->readers, listEntry) {
-        UA_StatusCode retval = checkReaderIdentifier(server, msg, reader);
-        if(retval == UA_STATUSCODE_GOOD) {
-            processed = true;
-            processMessageWithReader(server, readerGroup, reader, msg);
+    LIST_FOREACH(readerGroup, &connection->readerGroups, listEntry) {
+        LIST_FOREACH(reader, &readerGroup->readers, listEntry) {
+            UA_StatusCode retval = checkReaderIdentifier(server, msg, reader);
+            if(retval == UA_STATUSCODE_GOOD) {
+                processed = true;
+                processMessageWithReader(server, readerGroup, reader, msg);
+            }
         }
     }
 
@@ -1763,10 +1767,11 @@ static void UA_DataSetMessage_freeDecodedPayload(UA_DataSetMessage *dsm) {
 }
 
 UA_StatusCode
-decodeNetworkMessage(const UA_Logger *logger,
+decodeNetworkMessage(UA_Server *server,
+                     const UA_Logger *logger,
                      UA_ByteString *buffer, size_t *currentPosition,
                      UA_NetworkMessage *currentNetworkMessage,
-                     UA_ReaderGroup *readerGroup) {
+                     UA_PubSubConnection *connection) {
 
 #ifdef UA_DEBUG_DUMP_PKGS
     UA_dump_hex_pkg(buffer->data, buffer->length);
@@ -1777,20 +1782,40 @@ decodeNetworkMessage(const UA_Logger *logger,
     UA_CHECK_STATUS_ERROR(rv, return rv, logger, UA_LOGCATEGORY_SERVER,
                           "PubSub receive. decoding headers failed");
 
-#ifdef UA_ENABLE_PUBSUB_ENCRYPTION
-    rv = verifyAndDecryptNetworkMessage(logger,
-                                        buffer,
-                                        currentPosition,
-                                        currentNetworkMessage,
-                                        readerGroup);
-    UA_CHECK_STATUS_WARN(rv, return rv, logger, UA_LOGCATEGORY_SERVER,
-                         "Subscribe failed. verify and decrypt network message failed.");
 
-    #ifdef UA_DEBUG_DUMP_PKGS
-    UA_dump_hex_pkg(buffer->data, buffer->length);
+    #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
+    UA_Boolean processed = false;
+    UA_ReaderGroup *readerGroup;
+    UA_DataSetReader *reader;
+
+    /* choose a correct readergroup for decrypt/verify this message
+     * (there could be multiple) */
+    LIST_FOREACH(readerGroup, &connection->readerGroups, listEntry) {
+        LIST_FOREACH(reader, &readerGroup->readers, listEntry) {
+            UA_StatusCode retval = checkReaderIdentifier(server, currentNetworkMessage, reader);
+            if(retval == UA_STATUSCODE_GOOD) {
+                processed = true;
+                rv = verifyAndDecryptNetworkMessage(logger,
+                                                    buffer,
+                                                    currentPosition,
+                                                    currentNetworkMessage,
+                                                    readerGroup);
+                UA_CHECK_STATUS_WARN(rv, return rv, logger, UA_LOGCATEGORY_SERVER,
+                                     "Subscribe failed. verify and decrypt network message failed.");
+
+                #ifdef UA_DEBUG_DUMP_PKGS
+                UA_dump_hex_pkg(buffer->data, buffer->length);
+                #endif
+                break;
+            }
+        }
+    }
+
+    // TODO check if warning is correct here and error code carries correct info
+    UA_CHECK_WARN(processed, return UA_STATUSCODE_BADNOTFOUND, logger, UA_LOGCATEGORY_SERVER,
+            "Subscribe failed. no readergroup found to decrypt/verify the network message")
+
     #endif
-
-#endif
 
     rv = UA_NetworkMessage_decodePayload(buffer, currentPosition, currentNetworkMessage);
     UA_CHECK_STATUS(rv, return rv);
@@ -1811,12 +1836,12 @@ decodeAndProcessNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
     memset(&currentNetworkMessage, 0, sizeof(UA_NetworkMessage));
 
     UA_StatusCode rv = UA_STATUSCODE_GOOD;
-    rv = decodeNetworkMessage(&server->config.logger, buffer, currentPosition,
-                              &currentNetworkMessage, readerGroup);
+    rv = decodeNetworkMessage(server, &server->config.logger, buffer, currentPosition,
+                              &currentNetworkMessage, connection);
     UA_CHECK_STATUS_WARN(rv, goto cleanup, &server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Subscribe failed. verify, decrypt and decode network message failed.");
 
-    rv = UA_ReaderGroup_processNetworkMessage(server, readerGroup, &currentNetworkMessage);
+    rv = UA_Server_processNetworkMessage(server, connection, &currentNetworkMessage);
     // TODO: check what action to perform on error (nothing?)
     UA_CHECK_STATUS_WARN(rv, (void)0, &server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Subscribe failed. process network message failed.");

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -517,6 +517,11 @@ UA_Boolean
 compatibleDataTypes(UA_Server *server, const UA_NodeId *dataType,
                     const UA_NodeId *constraintDataType);
 
+/* Set to the target type if compatible */
+void
+adjustValueType(UA_Server *server, UA_Variant *value,
+                const UA_NodeId *targetDataTypeId);
+
 /* Is the Value compatible with the DataType? Can perform additional checks
  * compared to compatibleDataTypes. */
 UA_Boolean

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -297,8 +297,8 @@ getParentTypeAndInterfaceHierarchy(UA_Server *server, const UA_NodeId *typeNode,
 
 /* Returns the recursive interface hierarchy of the node */
 UA_StatusCode
-getInterfaceHierarchy(UA_Server *server, const UA_NodeId *objectNode,
-                                   UA_NodeId **typeHierarchy, size_t *typeHierarchySize);
+getAllInterfaceChildNodeIds(UA_Server *server, const UA_NodeId *objectNode, const UA_NodeId *objectTypeNode,
+                                   UA_NodeId **interfaceChildNodes, size_t *interfaceChildNodesSize);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
 

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -151,43 +151,117 @@ getParentTypeAndInterfaceHierarchy(UA_Server *server, const UA_NodeId *typeNode,
 }
 
 UA_StatusCode
-getInterfaceHierarchy(UA_Server *server, const UA_NodeId *objectNode,
-                                   UA_NodeId **typeHierarchy, size_t *typeHierarchySize) {
-    UA_ReferenceTypeSet reftypes_interface =
-        UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASINTERFACE);
-    UA_ExpandedNodeId *interfaces = NULL;
-    size_t interfacesSize = 0;
-    UA_StatusCode retval = browseRecursive(server, 1, objectNode, UA_BROWSEDIRECTION_FORWARD,
-                                           &reftypes_interface, UA_NODECLASS_UNSPECIFIED,
-                                           false, &interfacesSize, &interfaces);
-    if(retval != UA_STATUSCODE_GOOD) {
+getAllInterfaceChildNodeIds(UA_Server *server, const UA_NodeId *objectNode,
+                            const UA_NodeId *objectTypeNode,
+                            UA_NodeId **interfaceChildNodes, size_t *interfaceChildNodesSize) {
+    *interfaceChildNodesSize = 0;
+    *interfaceChildNodes = NULL;
+
+    UA_ExpandedNodeId *hasInterfaceCandidates = NULL;
+    size_t hasInterfaceCandidatesSize = 0;
+    UA_ReferenceTypeSet reftypes_subtype =
+        UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASSUBTYPE);
+
+    /* Don't include the start node */
+    UA_StatusCode retval = browseRecursive(server, 1, objectTypeNode, UA_BROWSEDIRECTION_INVERSE,
+                                           &reftypes_subtype, UA_NODECLASS_OBJECTTYPE,
+                                           false, &hasInterfaceCandidatesSize,
+                                           &hasInterfaceCandidates);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    }
 
-    UA_assert(interfacesSize < 1000);
+    /* The interface could also have been added manually before calling UA_Server_addNode_finish
+     * This can be handled by adding the object node as a start node for the HasInterface lookup */
+    UA_ExpandedNodeId *resizedHasInterfaceCandidates =
+            (UA_ExpandedNodeId*)UA_realloc(hasInterfaceCandidates,
+                                           (hasInterfaceCandidatesSize + 1) * sizeof(UA_ExpandedNodeId));
 
-    if (interfacesSize == 0) {
-        *typeHierarchySize = 0;
-        return UA_STATUSCODE_GOOD;
-    }
-
-    UA_NodeId *hierarchy = (UA_NodeId*)
-        UA_malloc(sizeof(UA_NodeId) * (interfacesSize));
-    if(!hierarchy) {
-        UA_Array_delete(interfaces, interfacesSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    if (!resizedHasInterfaceCandidates) {
+        if (hasInterfaceCandidates)
+            UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                            &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 
-    for(size_t i = 0; i < interfacesSize; i++) {
-        hierarchy[i] = interfaces[i].nodeId;
-        UA_NodeId_init(&interfaces[i].nodeId);
+    hasInterfaceCandidates = resizedHasInterfaceCandidates;
+    hasInterfaceCandidatesSize += 1;
+    UA_ExpandedNodeId_init(&hasInterfaceCandidates[hasInterfaceCandidatesSize - 1]);
+
+    UA_ExpandedNodeId_init(&hasInterfaceCandidates[hasInterfaceCandidatesSize - 1]);
+    UA_NodeId_copy(objectNode, &hasInterfaceCandidates[hasInterfaceCandidatesSize - 1].nodeId);
+
+    size_t outputIndex = 0;
+
+    for (size_t i = 0; i < hasInterfaceCandidatesSize; ++i) {
+        UA_ReferenceTypeSet reftypes_interface =
+            UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASINTERFACE);
+        UA_ExpandedNodeId *interfaceChildren = NULL;
+        size_t interfacesChildrenSize = 0;
+        retval = browseRecursive(server, 1, &hasInterfaceCandidates[i].nodeId,
+                                 UA_BROWSEDIRECTION_FORWARD,
+                                 &reftypes_interface, UA_NODECLASS_OBJECTTYPE,
+                                 false, &interfacesChildrenSize, &interfaceChildren);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                            &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+            if (interfaceChildNodesSize) {
+                UA_Array_delete(*interfaceChildNodes, *interfaceChildNodesSize,
+                                &UA_TYPES[UA_TYPES_NODEID]);
+                *interfaceChildNodesSize = 0;
+            }
+            return retval;
+        }
+
+        UA_assert(interfacesChildrenSize < 1000);
+
+        if (interfacesChildrenSize == 0) {
+            continue;
+        }
+
+        if (!*interfaceChildNodes) {
+            *interfaceChildNodes = (UA_NodeId*)
+                UA_calloc(interfacesChildrenSize, sizeof(UA_NodeId));
+            *interfaceChildNodesSize = interfacesChildrenSize;
+
+            if(!*interfaceChildNodes) {
+                UA_Array_delete(interfaceChildren, interfacesChildrenSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                return UA_STATUSCODE_BADOUTOFMEMORY;
+            }
+        } else {
+            UA_NodeId *resizedInterfaceChildNodes =
+                    (UA_NodeId*)UA_realloc(*interfaceChildNodes,
+                                           ((*interfaceChildNodesSize + interfacesChildrenSize) * sizeof(UA_NodeId)));
+
+            if (!resizedInterfaceChildNodes) {
+                UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                UA_Array_delete(interfaceChildren, interfacesChildrenSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                return UA_STATUSCODE_BADOUTOFMEMORY;
+            }
+
+            const size_t oldSize = *interfaceChildNodesSize;
+            *interfaceChildNodesSize += interfacesChildrenSize;
+            *interfaceChildNodes = resizedInterfaceChildNodes;
+
+            for (size_t j = oldSize; j < *interfaceChildNodesSize; ++j)
+                UA_NodeId_init(&(*interfaceChildNodes)[j]);
+        }
+
+        for(size_t j = 0; j < interfacesChildrenSize; j++) {
+            (*interfaceChildNodes)[outputIndex++] = interfaceChildren[j].nodeId;
+        }
+
+        UA_assert(*interfaceChildNodesSize < 1000);
+        UA_Array_delete(interfaceChildren, interfacesChildrenSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     }
 
-    *typeHierarchy = hierarchy;
-    *typeHierarchySize = interfacesSize;
+    UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
 
-    UA_assert(*typeHierarchySize < 1000);
-    UA_Array_delete(interfaces, interfacesSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     return UA_STATUSCODE_GOOD;
 }
 

--- a/src/server/ua_services.h
+++ b/src/server/ua_services.h
@@ -184,7 +184,11 @@ void Service_CloseSession(UA_Server *server, UA_SecureChannel *channel,
  *
  * AddNodes Service
  * ^^^^^^^^^^^^^^^^
- * Used to add one or more Nodes into the AddressSpace hierarchy. */
+ * Used to add one or more Nodes into the AddressSpace hierarchy.
+ * If the type or one of the supertypes has any HasInterface references
+ * (see OPC 10001-7 - Amendment 7, 4.9.2), the child nodes of the interfaces
+ * are added to the new object.
+*/
 void Service_AddNodes(UA_Server *server, UA_Session *session,
                       const UA_AddNodesRequest *request,
                       UA_AddNodesResponse *response);
@@ -192,7 +196,7 @@ void Service_AddNodes(UA_Server *server, UA_Session *session,
 /**
  * AddReferences Service
  * ^^^^^^^^^^^^^^^^^^^^^
- * Used to add one or more References to one or more Nodes. */
+ * Used to add one or more References to one or more Nodes.*/
 void Service_AddReferences(UA_Server *server, UA_Session *session,
                            const UA_AddReferencesRequest *request,
                            UA_AddReferencesResponse *response);

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1009,9 +1009,9 @@ compatibleValue(UA_Server *server, UA_Session *session, const UA_NodeId *targetD
 /* Write Service */
 /*****************/
 
-static void
-adjustValue(UA_Server *server, UA_Variant *value,
-            const UA_NodeId *targetDataTypeId) {
+void
+adjustValueType(UA_Server *server, UA_Variant *value,
+                const UA_NodeId *targetDataTypeId) {
     const UA_DataType *targetDataType = UA_findDataType(targetDataTypeId);
     if(!targetDataType)
         return;
@@ -1276,7 +1276,7 @@ writeNodeValueAttribute(UA_Server *server, UA_Session *session,
 
     /* Type checking. May change the type of editableValue */
     if(value->hasValue && value->value.type) {
-        adjustValue(server, &adjustedValue.value, &node->dataType);
+        adjustValueType(server, &adjustedValue.value, &node->dataType);
 
         /* The value may be an extension object, especially the nodeset compiler
          * uses extension objects to write variable values. If value is an

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -71,6 +71,15 @@ typeCheckArguments(UA_Server *server, UA_Session *session,
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     UA_Argument *argReqs = (UA_Argument*)argRequirements->value.data.value.value.data;
     for(size_t i = 0; i < argReqsSize; ++i) {
+        if(compatibleValue(server, session, &argReqs[i].dataType, argReqs[i].valueRank,
+                            argReqs[i].arrayDimensionsSize, argReqs[i].arrayDimensions,
+                            &args[i], NULL))
+            continue;
+
+        /* Incompatible try to correct the type if possible */
+        adjustValueType(server, &args[i], &argReqs[i].dataType);
+
+        /* Recheck */
         if(!compatibleValue(server, session, &argReqs[i].dataType, argReqs[i].valueRank,
                             argReqs[i].arrayDimensionsSize, argReqs[i].arrayDimensions,
                             &args[i], NULL)) {

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -732,11 +732,11 @@ addTypeChildren(UA_Server *server, UA_Session *session,
 
 static UA_StatusCode
 addInterfaceChildren(UA_Server *server, UA_Session *session,
-                const UA_NodeHead *head) {
+                const UA_NodeHead *head, const UA_Node *type) {
     /* Get the hierarchy of the type and all its supertypes */
     UA_NodeId *hierarchy = NULL;
     size_t hierarchySize = 0;
-    UA_StatusCode retval = getInterfaceHierarchy(server, &head->nodeId,
+    UA_StatusCode retval = getAllInterfaceChildNodeIds(server, &head->nodeId, &type->head.nodeId,
                                                               &hierarchy, &hierarchySize);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
@@ -1221,9 +1221,9 @@ recursiveTypeCheckAddChildren(UA_Server *server, UA_Session *session,
         }
     }
 
-    /* Add (mandatory) child nodes from the direct HasInterface reference */
+    /* Add (mandatory) child nodes from the HasInterface references */
     if(node->head.nodeClass == UA_NODECLASS_OBJECT) {
-        retval = addInterfaceChildren(server, session, &node->head);
+        retval = addInterfaceChildren(server, session, &node->head, type);
         if(retval != UA_STATUSCODE_GOOD) {
             UA_LOG_NODEID_INFO(&node->head.nodeId,
             UA_LOG_INFO_SESSION(&server->config.logger, session,

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -28,6 +28,18 @@
 #include <mbedtls/version.h>
 #include <mbedtls/x509_crt.h>
 
+#define UA_SUBSCRIBER_PORT       4801    /* Port for Subscriber*/
+#define PUBLISH_INTERVAL         5       /* Publish interval*/
+#define PUBLISHER_ID             2234    /* Publisher Id*/
+#define DATASET_WRITER_ID        62541   /* DataSet Writer Id*/
+#define WRITER_GROUP_ID          100     /* Writer group Id  */
+#define PUBLISHER_DATA           42      /* Published data */
+#define PUBLISHVARIABLE_NODEID   1000    /* Published data nodeId */
+#define SUBSCRIBEOBJECT_NODEID   1001    /* Object nodeId */
+#define SUBSCRIBEVARIABLE_NODEID 1002    /* Subscribed data nodeId */
+#define READERGROUP_COUNT        2       /* Value to add readergroup to connection */
+#define CHECK_READERGROUP_COUNT  3       /* Value to check readergroup count */
+
 #define UA_AES128CTR_SIGNING_KEY_LENGTH 16
 #define UA_AES128CTR_KEY_LENGTH 16
 #define UA_AES128CTR_KEYNONCE_LENGTH 4
@@ -36,7 +48,7 @@ UA_Byte signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = {0};
 UA_Byte encryptingKey[UA_AES128CTR_KEY_LENGTH] = {0};
 UA_Byte keyNonce[UA_AES128CTR_KEYNONCE_LENGTH] = {0};
 UA_Server *server = NULL;
-UA_NodeId readerGroupId, connectionId;
+UA_NodeId writerGroupId, readerGroupId, connectionId;
 
 UA_Logger *logger = NULL;
 
@@ -54,7 +66,7 @@ setup(void) {
                                       &config->logger);
 
     UA_Server_run_startup(server);
-    // add 2 connections
+    // add connection
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("UADP Connection");
@@ -64,6 +76,7 @@ setup(void) {
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
+    connectionConfig.publisherId.numeric = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
 
     logger = &server->config.logger;
@@ -130,31 +143,31 @@ hexstr_to_char(const char *hexstr) {
 #define MSG_SIG "6e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
 #define MSG_SIG_INVALID "5e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
 
-static void
-UA_Server_ReaderGroup_clear(UA_Server *uaServer, UA_ReaderGroup *readerGroup) {
-    UA_ReaderGroupConfig_clear(&readerGroup->config);
-    UA_DataSetReader *dataSetReader;
-    UA_DataSetReader *tmpDataSetReader;
-    LIST_FOREACH_SAFE(dataSetReader, &readerGroup->readers, listEntry, tmpDataSetReader) {
-        UA_Server_removeDataSetReader(uaServer, dataSetReader->identifier);
-    }
-    UA_PubSubConnection* pConn =
-        UA_PubSubConnection_findConnectionbyId(uaServer, readerGroup->linkedConnection);
-    if(pConn != NULL)
-        pConn->readerGroupsSize--;
-
-    /* Delete ReaderGroup and its members */
-    UA_String_clear(&readerGroup->config.name);
-    UA_NodeId_clear(&readerGroup->linkedConnection);
-    UA_NodeId_clear(&readerGroup->identifier);
-
-#ifdef UA_ENABLE_PUBSUB_ENCRYPTION
-    if(readerGroup->config.securityPolicy && readerGroup->securityPolicyContext) {
-        readerGroup->config.securityPolicy->deleteContext(readerGroup->securityPolicyContext);
-        readerGroup->securityPolicyContext = NULL;
-    }
-#endif
-}
+// static void
+// UA_Server_ReaderGroup_clear(UA_Server *uaServer, UA_ReaderGroup *readerGroup) {
+//     UA_ReaderGroupConfig_clear(&readerGroup->config);
+//     UA_DataSetReader *dataSetReader;
+//     UA_DataSetReader *tmpDataSetReader;
+//     LIST_FOREACH_SAFE(dataSetReader, &readerGroup->readers, listEntry, tmpDataSetReader) {
+//         UA_Server_removeDataSetReader(uaServer, dataSetReader->identifier);
+//     }
+//     UA_PubSubConnection* pConn =
+//         UA_PubSubConnection_findConnectionbyId(uaServer, readerGroup->linkedConnection);
+//     if(pConn != NULL)
+//         pConn->readerGroupsSize--;
+//
+//     /* Delete ReaderGroup and its members */
+//     UA_String_clear(&readerGroup->config.name);
+//     UA_NodeId_clear(&readerGroup->linkedConnection);
+//     UA_NodeId_clear(&readerGroup->identifier);
+//
+// #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
+//     if(readerGroup->config.securityPolicy && readerGroup->securityPolicyContext) {
+//         readerGroup->config.securityPolicy->deleteContext(readerGroup->securityPolicyContext);
+//         readerGroup->securityPolicyContext = NULL;
+//     }
+// #endif
+// }
 
 /*
 static UA_ReaderGroup*
@@ -173,30 +186,91 @@ newReaderGroupWithoutSecurity(void) {
     return rgWithoutSecurity;
 } */
 
-static UA_ReaderGroup*
+static void
 newReaderGroupWithSecurity(UA_MessageSecurityMode mode) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
-    UA_ReaderGroupConfig readerGroupConfig;
-    memset(&readerGroupConfig, 0, sizeof(readerGroupConfig));
-    readerGroupConfig.name = UA_STRING("ReaderGroup");
-
-    readerGroupConfig.securityMode = mode;
-    readerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
-
+    /* Common encryption key informaton */
     UA_ByteString sk = {UA_AES128CTR_SIGNING_KEY_LENGTH, signingKey};
     UA_ByteString ek = {UA_AES128CTR_KEY_LENGTH, encryptingKey};
     UA_ByteString kn = {UA_AES128CTR_KEYNONCE_LENGTH, keyNonce};
 
-    UA_ReaderGroup *rgWithSecurity = (UA_ReaderGroup *)UA_calloc(1, sizeof(UA_ReaderGroup));
-    UA_ReaderGroupConfig_copy(&readerGroupConfig, &rgWithSecurity->config);
-    rgWithSecurity->config.securityPolicy->
-        newContext(rgWithSecurity->config.securityPolicy->policyContext,
-                   &sk, &ek, &kn,
-                   &rgWithSecurity->securityPolicyContext);
+    /* To check status after running both publisher and subscriber */
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+    UA_NodeId dataSetWriter;
+    UA_NodeId readerIdentifier;
+    UA_NodeId writerGroup;
+    UA_DataSetReaderConfig readerConfig;
 
-    return rgWithSecurity;
+    /* Reader Group */
+    UA_ReaderGroupConfig readerGroupConfig;
+    memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
+    readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
+
+    /* Reader Group Encryption settings */
+    readerGroupConfig.securityMode = mode;
+    readerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
+
+    retVal |=  UA_Server_addReaderGroup(server, connectionId, &readerGroupConfig, &readerGroupId);
+
+    /* Add the encryption key informaton for readergroup */
+    // TODO security token not necessary for readergroup (extracted from security-header)
+    UA_Server_setReaderGroupEncryptionKeys(server, readerGroupId, 1, sk, ek, kn);
+
+    /* Data Set Reader */
+    /* Parameters to filter received NetworkMessage */
+    memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
+    readerConfig.name             = UA_STRING ("DataSetReader Test");
+    UA_UInt16 publisherIdentifier = PUBLISHER_ID;
+    readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+    readerConfig.publisherId.data = &publisherIdentifier;
+    readerConfig.writerGroupId    = WRITER_GROUP_ID;
+    readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
+    /* Setting up Meta data configuration in DataSetReader */
+    UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
+    /* FilltestMetadata function in subscriber implementation */
+    UA_DataSetMetaDataType_init (pMetaData);
+    pMetaData->name       = UA_STRING ("DataSet Test");
+    /* Static definition of number of fields size to 1 to create one
+       targetVariable */
+    pMetaData->fieldsSize = 1;
+    pMetaData->fields     = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
+                                                             &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+    /* Unsigned Integer DataType */
+    UA_FieldMetaData_init (&pMetaData->fields[0]);
+    UA_NodeId_copy (&UA_TYPES[UA_TYPES_INT32].typeId,
+                    &pMetaData->fields[0].dataType);
+    pMetaData->fields[0].builtInType = UA_NS0ID_INT32;
+    pMetaData->fields[0].valueRank   = -1; /* scalar */
+    retVal |= UA_Server_addDataSetReader(server, readerGroupId, &readerConfig,
+                                         &readerIdentifier);
+
 }
+
+// static UA_ReaderGroup*
+// newReaderGroupWithSecurity1(UA_MessageSecurityMode mode) {
+//     UA_ServerConfig *config = UA_Server_getConfig(server);
+//
+//     UA_ReaderGroupConfig readerGroupConfig;
+//     memset(&readerGroupConfig, 0, sizeof(readerGroupConfig));
+//     readerGroupConfig.name = UA_STRING("ReaderGroup");
+//
+//     readerGroupConfig.securityMode = mode;
+//     readerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
+//
+//     UA_ByteString sk = {UA_AES128CTR_SIGNING_KEY_LENGTH, signingKey};
+//     UA_ByteString ek = {UA_AES128CTR_KEY_LENGTH, encryptingKey};
+//     UA_ByteString kn = {UA_AES128CTR_KEYNONCE_LENGTH, keyNonce};
+//
+//     UA_ReaderGroup *rgWithSecurity =
+//         (UA_ReaderGroup *)UA_calloc(1, sizeof(UA_ReaderGroup));
+//     UA_ReaderGroupConfig_copy(&readerGroupConfig, &rgWithSecurity->config);
+//     rgWithSecurity->config.securityPolicy->newContext(
+//         rgWithSecurity->config.securityPolicy->policyContext, &sk, &ek, &kn,
+//         &rgWithSecurity->securityPolicyContext);
+//
+//     return rgWithSecurity;
+// }
 
 // hexstr_to_char("f111ba08016400014df4030100000008b02d012e01000000da434ce02ee19922c"
 //                "6e916c8154123baa25f67288e3378d613f32039096e08a9ff14b83ea2247792ee"
@@ -259,9 +333,13 @@ START_TEST(EncodeDecodeNetworkMessage) {
 END_TEST
 */
 START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
-
-    UA_ReaderGroup *rgWithSecurity = newReaderGroupWithSecurity(
+    newReaderGroupWithSecurity(
         UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+    UA_PubSubConnection *connection =
+        UA_PubSubConnection_findConnectionbyId(server, connectionId);
+    if(!connection) {
+        ck_assert(false);
+    }
 
     const char * msg_enc = MSG_HEADER MSG_PAYLOAD_ENC MSG_SIG;
 
@@ -274,8 +352,8 @@ START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
     memset(&msg, 0, sizeof(UA_NetworkMessage));
 
     size_t currentPosition = 0;
-    UA_StatusCode rv = decodeNetworkMessage(
-        logger, &buffer, &currentPosition, &msg, rgWithSecurity);
+    UA_StatusCode rv = decodeNetworkMessage(server,
+        logger, &buffer, &currentPosition, &msg, connection);
     ck_assert(rv == UA_STATUSCODE_GOOD);
 
     const char * msg_dec_exp = MSG_HEADER MSG_PAYLOAD_DEC;
@@ -287,14 +365,20 @@ START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
 
     free(expectedData);
     free(buffer.data);
-    UA_Server_ReaderGroup_clear(server, rgWithSecurity);
-    free(rgWithSecurity);
+    // UA_Server_ReaderGroup_clear(server, rgWithSecurity);
+    // free(rgWithSecurity);
 }
 END_TEST
 
 START_TEST(InvalidSignature) {
-    UA_ReaderGroup *rgWithSecurity = newReaderGroupWithSecurity(
+    newReaderGroupWithSecurity(
         UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+    UA_PubSubConnection *connection =
+        UA_PubSubConnection_findConnectionbyId(server, connectionId);
+    if(!connection) {
+        ck_assert(false);
+    }
+
     const char * msg_enc = MSG_HEADER MSG_PAYLOAD_ENC MSG_SIG_INVALID;
 
     UA_ByteString buffer;
@@ -306,20 +390,26 @@ START_TEST(InvalidSignature) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(logger, &buffer, &currentPosition, &msg, rgWithSecurity);
+    UA_StatusCode rv = decodeNetworkMessage(server, logger, &buffer, &currentPosition, &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYCHECKSFAILED);
 
     UA_NetworkMessage_clear(&msg);
 
     free(buffer.data);
-    UA_Server_ReaderGroup_clear(server, rgWithSecurity);
-    free(rgWithSecurity);
+    // UA_Server_ReaderGroup_clear(server, rgWithSecurity);
+    // free(rgWithSecurity);
 }
 END_TEST
 
 START_TEST(InvalidSecurityModeInsufficientSig) {
-        UA_ReaderGroup *rgWithoutSecurity = newReaderGroupWithSecurity(
+        newReaderGroupWithSecurity(
             UA_MESSAGESECURITYMODE_NONE);
+        UA_PubSubConnection *connection =
+            UA_PubSubConnection_findConnectionbyId(server, connectionId);
+        if(!connection) {
+            ck_assert(false);
+        }
+
         const char * msg_enc = MSG_HEADER MSG_PAYLOAD_ENC MSG_SIG;
 
         UA_ByteString buffer;
@@ -331,20 +421,25 @@ START_TEST(InvalidSecurityModeInsufficientSig) {
 
         size_t currentPosition = 0;
 
-        UA_StatusCode rv = decodeNetworkMessage(logger, &buffer, &currentPosition, &msg, rgWithoutSecurity);
+        UA_StatusCode rv = decodeNetworkMessage(server, logger, &buffer, &currentPosition, &msg, connection);
         ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT);
 
         UA_NetworkMessage_clear(&msg);
 
         free(buffer.data);
-        UA_Server_ReaderGroup_clear(server, rgWithoutSecurity);
-        free(rgWithoutSecurity);
+        // UA_Server_ReaderGroup_clear(server, rgWithoutSecurity);
+        // free(rgWithoutSecurity);
     }
 END_TEST
 
 START_TEST(InvalidSecurityModeRejectedSig) {
-    UA_ReaderGroup *rgWithSecurity = newReaderGroupWithSecurity(
-        UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+        newReaderGroupWithSecurity(
+            UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+        UA_PubSubConnection *connection =
+            UA_PubSubConnection_findConnectionbyId(server, connectionId);
+        if(!connection) {
+            ck_assert(false);
+        }
     const char * msg_unenc = MSG_HEADER_NO_SEC MSG_PAYLOAD_DEC;
 
     UA_ByteString buffer;
@@ -356,14 +451,14 @@ START_TEST(InvalidSecurityModeRejectedSig) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(logger, &buffer, &currentPosition, &msg, rgWithSecurity);
+    UA_StatusCode rv = decodeNetworkMessage(server, logger, &buffer, &currentPosition, &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEREJECTED);
 
     UA_NetworkMessage_clear(&msg);
 
     free(buffer.data);
-    UA_Server_ReaderGroup_clear(server, rgWithSecurity);
-    free(rgWithSecurity);
+    // UA_Server_ReaderGroup_clear(server, rgWithSecurity);
+    // free(rgWithSecurity);
 }
 END_TEST
 

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -975,9 +975,9 @@ START_TEST(Test_many_components) {
     /*  Writers            : Interval  -> Readers            : Timeout
         ----------------------------------------------------------------------------------
         Conn 1 WG 1 - DSW1 : 30        -> Conn 2 RG 1 - DSR1 : 40
-        Conn 1 WG 1 - DSW2 : 30        -> Conn 2 RG 2 - DSR2 : 45
+        Conn 1 WG 1 - DSW2 : 30        -> Conn 2 RG 2 - DSR1 : 45
         Conn 2 WG 1 - DSW1 : 20        -> Conn 1 RG 1 - DSR1 : 25
-        Conn 2 WG 2 - DSW2 : 10        -> Conn 3 RG 1 - DSR1 : 25
+        Conn 2 WG 2 - DSW1 : 10        -> Conn 3 RG 1 - DSR1 : 25
     */
 
     UA_ServerConfig *config = UA_Server_getConfig(server);

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -7,7 +7,6 @@
 #include "ua_pubsub.h"
 
 #include <check.h>
-#include <assert.h>
 
 static UA_Server *server = NULL;
 
@@ -44,7 +43,7 @@ static void setup(void) {
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
 
     UA_StatusCode res = UA_Server_run_startup(server);
-    assert(UA_STATUSCODE_GOOD == res);
+    ck_assert(UA_STATUSCODE_GOOD == res);
 
     UseFastPath = UA_FALSE;
 }
@@ -54,7 +53,7 @@ static void teardown(void) {
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nteardown\n\n");
 
-    assert(UA_STATUSCODE_GOOD == UA_Server_run_shutdown(server));
+    ck_assert(UA_STATUSCODE_GOOD == UA_Server_run_shutdown(server));
     UA_Server_delete(server);
 
     UA_NodeId_clear(&ExpectedCallbackComponentNodeId);
@@ -78,8 +77,8 @@ static void AddConnection(
     UA_UInt32 PublisherId,
     UA_NodeId *opConnectionId) {
 
-    assert(pName != 0);
-    assert(opConnectionId != 0);
+    ck_assert(pName != 0);
+    ck_assert(opConnectionId != 0);
 
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
@@ -105,9 +104,9 @@ static void AddWriterGroup(
     UA_Duration PublishingInterval,
     UA_NodeId *opWriterGroupId) {
 
-    assert(pConnectionId != 0);
-    assert(pName != 0);
-    assert(opWriterGroupId != 0);
+    ck_assert(pConnectionId != 0);
+    ck_assert(pName != 0);
+    ck_assert(opWriterGroupId != 0);
 
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
@@ -141,12 +140,12 @@ static void AddPublishedDataSet(
     UA_NodeId *opPublishedVarId,
     UA_NodeId *opDataSetWriterId) {
 
-    assert(pWriterGroupId != 0);
-    assert(pPublishedDataSetName != 0);
-    assert(pDataSetWriterName != 0);
-    assert(opPublishedDataSetId != 0);
-    assert(opPublishedVarId != 0);
-    assert(opDataSetWriterId != 0);
+    ck_assert(pWriterGroupId != 0);
+    ck_assert(pPublishedDataSetName != 0);
+    ck_assert(pDataSetWriterName != 0);
+    ck_assert(opPublishedDataSetId != 0);
+    ck_assert(opPublishedVarId != 0);
+    ck_assert(opDataSetWriterId != 0);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
@@ -210,9 +209,9 @@ static void AddReaderGroup(
     char *pName, 
     UA_NodeId *opReaderGroupId) {
 
-    assert(pConnectionId != 0);
-    assert(pName != 0);
-    assert(opReaderGroupId != 0);
+    ck_assert(pConnectionId != 0);
+    ck_assert(pName != 0);
+    ck_assert(opReaderGroupId != 0);
 
     UA_ReaderGroupConfig readerGroupConfig;
     memset (&readerGroupConfig, 0, sizeof(UA_ReaderGroupConfig));
@@ -235,10 +234,10 @@ static void AddDataSetReader(
     UA_NodeId *opSubscriberVarId,
     UA_NodeId *opDataSetReaderId) {
 
-    assert(pReaderGroupId != 0);
-    assert(pName != 0);
-    assert(opSubscriberVarId != 0);
-    assert(opDataSetReaderId != 0);
+    ck_assert(pReaderGroupId != 0);
+    ck_assert(pName != 0);
+    ck_assert(opSubscriberVarId != 0);
+    ck_assert(opDataSetReaderId != 0);
 
     UA_DataSetReaderConfig readerConfig;
     memset (&readerConfig, 0, sizeof(UA_DataSetReaderConfig));
@@ -303,7 +302,7 @@ static void AddDataSetReader(
 
     UA_FieldTargetVariable *pTargetVariables =  (UA_FieldTargetVariable *)
         UA_calloc(readerConfig.dataSetMetaData.fieldsSize, sizeof(UA_FieldTargetVariable));
-    assert(pTargetVariables != 0);
+    ck_assert(pTargetVariables != 0);
     
     UA_FieldTargetDataType_init(&pTargetVariables[0].targetVariable);
 
@@ -331,7 +330,7 @@ static void ServerDoProcess(
     const UA_UInt32 Sleep_ms,             /* use at least publishing interval */
     const UA_UInt32 NoOfRunIterateCycles) 
 {
-    assert(pMessage != 0);
+    ck_assert(pMessage != 0);
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "ServerDoProcess() sleep : %s", pMessage);
     for (UA_UInt32 i = 0; i < NoOfRunIterateCycles; i++) {
@@ -644,7 +643,7 @@ static void PubSubStateChangeCallback_different_timeouts (
         "Callback Cnt = %u", CallbackCnt);
 
     ck_assert(CallbackCnt < ExpectedCallbackCnt);
-    assert(pExpectedComponentCallbackIds != 0);
+    ck_assert(pExpectedComponentCallbackIds != 0);
     UA_String_init(&strId);
     UA_NodeId_print(&(pExpectedComponentCallbackIds[CallbackCnt]), &strId);
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "PubSubStateChangeCallback(): "
@@ -755,7 +754,7 @@ START_TEST(Test_different_timeouts) {
     /* prepare expected order of pubsub component timeouts: */
     ExpectedCallbackCnt = 2;
     pExpectedComponentCallbackIds = (UA_NodeId*) UA_calloc(ExpectedCallbackCnt, sizeof(UA_NodeId));
-    assert(pExpectedComponentCallbackIds != 0);
+    ck_assert(pExpectedComponentCallbackIds != 0);
     pExpectedComponentCallbackIds[0] = DSRId_Conn1_RG1_DSR1;
     pExpectedComponentCallbackIds[1] = DSRId_Conn2_RG1_DSR1;
     /* TODO: 2nd datasetreader */
@@ -947,7 +946,7 @@ static void PubSubStateChangeCallback_many_components (
         "Component Id = %.*s, state = %i, status = 0x%08x %s", (UA_Int32) strId.length, strId.data, state, status, UA_StatusCode_name(status));
     UA_String_clear(&strId);
 
-    assert(pExpectedComponentCallbackIds != 0);
+    ck_assert(pExpectedComponentCallbackIds != 0);
     ck_assert(CallbackCnt < ExpectedCallbackCnt);
 
     UA_String_init(&strId);
@@ -1172,7 +1171,7 @@ START_TEST(Test_many_components) {
     /* prepare expected pubsub components with message receive timeout */
     ExpectedCallbackCnt = 2;
     pExpectedComponentCallbackIds = (UA_NodeId*) UA_calloc(ExpectedCallbackCnt, sizeof(UA_NodeId));
-    assert(pExpectedComponentCallbackIds != 0);
+    ck_assert(pExpectedComponentCallbackIds != 0);
     pExpectedComponentCallbackIds[0] = DSRId_Conn2_RG1_DSR1;
     pExpectedComponentCallbackIds[1] = DSRId_Conn2_RG2_DSR1;
 
@@ -1292,7 +1291,7 @@ START_TEST(Test_many_components) {
 
     ExpectedCallbackCnt = 4;
     pExpectedComponentCallbackIds = (UA_NodeId*) UA_calloc(ExpectedCallbackCnt, sizeof(UA_NodeId));
-    assert(pExpectedComponentCallbackIds != 0);
+    ck_assert(pExpectedComponentCallbackIds != 0);
     pExpectedComponentCallbackIds[0] = DSRId_Conn3_RG1_DSR1;
     pExpectedComponentCallbackIds[1] = DSRId_Conn1_RG1_DSR1;
     pExpectedComponentCallbackIds[2] = DSRId_Conn2_RG1_DSR1;

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -962,8 +962,7 @@ START_TEST(Test_wrong_timeout) {
 //     if (ExpectedCallbackStateChange == UA_PUBSUBSTATE_ERROR) {
 //         /*  On error we want to verify the order of DataSetReader timeouts */
 //         ck_assert(UA_NodeId_equal(pubsubComponentId, &pExpectedComponentCallbackIds[CallbackCnt]) == UA_TRUE);
-//     } /* when the state is set back to operational we cannot verify the order of StateChanges, because we 
-//             cannot know which DataSetReader will be operational first */
+            cannot know which DataSetReader will be operational first */
 //     CallbackCnt++;
 // }
 // 

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -929,425 +929,425 @@ START_TEST(Test_wrong_timeout) {
 } END_TEST
 
 
-// TODO: fix this test (the publisherids, writergroupIds, datasetwriterIds are not correctly set)
-//
-// /***************************************************************************************************/
-// /***************************************************************************************************/
-// /* Test a bigger configuration */
-// 
-// /***************************************************************************************************/
-// static void PubSubStateChangeCallback_many_components (
-//     UA_NodeId *pubsubComponentId,
-//     UA_PubSubState state,
-//     UA_StatusCode status) {
-// 
-//     UA_String strId;
-//     UA_String_init(&strId);
-//     UA_NodeId_print(pubsubComponentId, &strId);
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "PubSubStateChangeCallback(): "
-//         "Component Id = %.*s, state = %i, status = 0x%08x %s", (UA_Int32) strId.length, strId.data, state, status, UA_StatusCode_name(status));
-//     UA_String_clear(&strId);
-// 
-//     assert(pExpectedComponentCallbackIds != 0);
-//     ck_assert(CallbackCnt < ExpectedCallbackCnt);
-// 
-//     UA_String_init(&strId);
-//     UA_NodeId_print(&(pExpectedComponentCallbackIds[CallbackCnt]), &strId);
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "PubSubStateChangeCallback(): "
-//         "Expected Id (on timeout) = %.*s", (UA_Int32) strId.length, strId.data);
-//     UA_String_clear(&strId);
-// 
-//     ck_assert(state == ExpectedCallbackStateChange);
-//     ck_assert(status == ExpectedCallbackStatus);
-//     if (ExpectedCallbackStateChange == UA_PUBSUBSTATE_ERROR) {
-//         /*  On error we want to verify the order of DataSetReader timeouts */
-//         ck_assert(UA_NodeId_equal(pubsubComponentId, &pExpectedComponentCallbackIds[CallbackCnt]) == UA_TRUE);
+
+/***************************************************************************************************/
+/***************************************************************************************************/
+/* Test a bigger configuration */
+
+/***************************************************************************************************/
+static void PubSubStateChangeCallback_many_components (
+    UA_NodeId *pubsubComponentId,
+    UA_PubSubState state,
+    UA_StatusCode status) {
+
+    UA_String strId;
+    UA_String_init(&strId);
+    UA_NodeId_print(pubsubComponentId, &strId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "PubSubStateChangeCallback(): "
+        "Component Id = %.*s, state = %i, status = 0x%08x %s", (UA_Int32) strId.length, strId.data, state, status, UA_StatusCode_name(status));
+    UA_String_clear(&strId);
+
+    assert(pExpectedComponentCallbackIds != 0);
+    ck_assert(CallbackCnt < ExpectedCallbackCnt);
+
+    UA_String_init(&strId);
+    UA_NodeId_print(&(pExpectedComponentCallbackIds[CallbackCnt]), &strId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "PubSubStateChangeCallback(): "
+        "Expected Id (on timeout) = %.*s", (UA_Int32) strId.length, strId.data);
+    UA_String_clear(&strId);
+
+    ck_assert(state == ExpectedCallbackStateChange);
+    ck_assert(status == ExpectedCallbackStatus);
+    if (ExpectedCallbackStateChange == UA_PUBSUBSTATE_ERROR) {
+        /*  On error we want to verify the order of DataSetReader timeouts */
+        ck_assert(UA_NodeId_equal(pubsubComponentId, &pExpectedComponentCallbackIds[CallbackCnt]) == UA_TRUE);
+    } /* when the state is set back to operational we can't verify the order of StateChanges, because we 
             cannot know which DataSetReader will be operational first */
-//     CallbackCnt++;
-// }
-// 
-// /***************************************************************************************************/
-// START_TEST(Test_many_components) {
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_many_components");
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "prepare configuration");
-// 
-//     /*  Writers            : Interval  -> Readers            : Timeout
-//         ----------------------------------------------------------------------------------
-//         Conn 1 WG 1 - DSW1 : 30        -> Conn 2 RG 1 - DSR1 : 40
-//         Conn 1 WG 1 - DSW2 : 30        -> Conn 2 RG 2 - DSR2 : 45
-//         Conn 2 WG 1 - DSW1 : 20        -> Conn 1 RG 1 - DSR1 : 25
-//         Conn 2 WG 2 - DSW2 : 10        -> Conn 3 RG 1 - DSR1 : 25
-//     */
-// 
-//     UA_ServerConfig *config = UA_Server_getConfig(server);
-//     /* set custom callback triggered for specific PubSub state changes */
-//     config->pubSubConfig.stateChangeCallback = PubSubStateChangeCallback_many_components;
-// 
-//     /* setup Connection 1: writers */
-//     UA_NodeId ConnId_1;
-//     UA_NodeId_init(&ConnId_1);
-//     UA_UInt32 PublisherNo_Conn1 = 1;
-//     AddConnection("Conn1", PublisherNo_Conn1, &ConnId_1);
-// 
-//     UA_NodeId WGId_Conn1_WG1;
-//     UA_NodeId_init(&WGId_Conn1_WG1);
-//     UA_UInt32 WGNo_Conn1_WG1 = 1;
-//     UA_Duration PublishingInterval_Conn1_WG1 = 30.0;
-//     AddWriterGroup(&ConnId_1, "Conn1_WG1", WGNo_Conn1_WG1, PublishingInterval_Conn1_WG1, &WGId_Conn1_WG1);
-// 
-//     UA_NodeId DsWId_Conn1_WG1_DS1;
-//     UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
-//     UA_NodeId VarId_Conn1_WG1_DS1;
-//     UA_NodeId_init(&VarId_Conn1_WG1_DS1);
-//     UA_NodeId PDSId_Conn1_WG1_PDS1;
-//     UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
-//     UA_UInt32 DSWNo_Conn1_WG1_DS1 = 1;
-//     AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1, 
-//         &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
-// 
-//     UA_NodeId DsWId_Conn1_WG1_DS2;
-//     UA_NodeId_init(&DsWId_Conn1_WG1_DS2);
-//     UA_NodeId VarId_Conn1_WG1_DS2;
-//     UA_NodeId_init(&VarId_Conn1_WG1_DS2);
-//     UA_NodeId PDSId_Conn1_WG1_PDS2;
-//     UA_NodeId_init(&PDSId_Conn1_WG1_PDS2);
-//     UA_UInt32 DSWNo_Conn1_WG1_DS2 = 2;
-//     AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS2", "Conn1_WG1_DS2", DSWNo_Conn1_WG1_DS2, &PDSId_Conn1_WG1_PDS2, 
-//         &VarId_Conn1_WG1_DS2, &DsWId_Conn1_WG1_DS2);
-// 
-// 
-//     /* setup Connection 2: writers */
-//     UA_NodeId ConnId_2;
-//     UA_NodeId_init(&ConnId_2);
-//     UA_UInt32 PublisherNo_Conn2 = 2;
-//     AddConnection("Conn2", PublisherNo_Conn2, &ConnId_2);
-// 
-//     UA_NodeId WGId_Conn2_WG1;
-//     UA_NodeId_init(&WGId_Conn2_WG1);
-//     UA_UInt32 WGNo_Conn2_WG1 = 1;
-//     UA_Duration PublishingInterval_Conn2_WG1 = 20.0;
-//     AddWriterGroup(&ConnId_2, "Conn2_WG1", WGNo_Conn2_WG1, PublishingInterval_Conn2_WG1, &WGId_Conn2_WG1);
-// 
-//     UA_NodeId DsWId_Conn2_WG1_DS1;
-//     UA_NodeId_init(&DsWId_Conn2_WG1_DS1);
-//     UA_NodeId VarId_Conn2_WG1_DS1;
-//     UA_NodeId_init(&VarId_Conn2_WG1_DS1);
-//     UA_NodeId PDSId_Conn2_WG1_PDS1;
-//     UA_NodeId_init(&PDSId_Conn2_WG1_PDS1);
-//     UA_UInt32 DSWNo_Conn2_WG1_DS1 = 1;
-//     AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", DSWNo_Conn2_WG1_DS1, &PDSId_Conn2_WG1_PDS1, 
-//         &VarId_Conn2_WG1_DS1, &DsWId_Conn2_WG1_DS1);
-// 
-// 
-//     UA_NodeId WGId_Conn2_WG2;
-//     UA_NodeId_init(&WGId_Conn2_WG2);
-//     UA_UInt32 WGNo_Conn2_WG2 = 2;
-//     UA_Duration PublishingInterval_Conn2_WG2 = 10.0;
-//     AddWriterGroup(&ConnId_2, "Conn2_WG2", WGNo_Conn2_WG2, PublishingInterval_Conn2_WG2, &WGId_Conn2_WG2);
-// 
-//     UA_NodeId DsWId_Conn2_WG2_DS1;
-//     UA_NodeId_init(&DsWId_Conn2_WG2_DS1);
-//     UA_NodeId VarId_Conn2_WG2_DS1;
-//     UA_NodeId_init(&VarId_Conn2_WG2_DS1);
-//     UA_NodeId PDSId_Conn2_WG2_PDS1;
-//     UA_NodeId_init(&PDSId_Conn2_WG2_PDS1);
-//     UA_UInt32 DSWNo_Conn2_WG2_DS1 = 1;
-//     AddPublishedDataSet(&WGId_Conn2_WG2, "Conn2_WG2_PDS1", "Conn2_WG2_DS1", DSWNo_Conn2_WG2_DS1, &PDSId_Conn2_WG2_PDS1, 
-//         &VarId_Conn2_WG2_DS1, &DsWId_Conn2_WG2_DS1);
-// 
-//     /* setup Connection 1: readers */
-//     UA_NodeId RGId_Conn1_RG1;
-//     UA_NodeId_init(&RGId_Conn1_RG1);
-//     AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
-// 
-//     UA_NodeId DSRId_Conn1_RG1_DSR1;
-//     UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
-//     UA_NodeId VarId_Conn1_RG1_DSR1;
-//     UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
-//     UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 25.0;
-//     AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG1, DSWNo_Conn2_WG1_DS1, 
-//         MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
-//     UA_String strId;
-//     UA_String_init(&strId);
-//     UA_NodeId_print(&DSRId_Conn1_RG1_DSR1, &strId);
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn1_RG1_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
-//     UA_String_clear(&strId);
-// 
-//      /* setup Connection 2: readers */
-//     UA_NodeId RGId_Conn2_RG1;
-//     UA_NodeId_init(&RGId_Conn2_RG1);
-//     AddReaderGroup(&ConnId_2, "Conn2_RG1", &RGId_Conn2_RG1);
-// 
-//     UA_NodeId DSRId_Conn2_RG1_DSR1;
-//     UA_NodeId_init(&DSRId_Conn2_RG1_DSR1);
-//     UA_NodeId VarId_Conn2_RG1_DSR1;
-//     UA_NodeId_init(&VarId_Conn2_RG1_DSR1);
-//     UA_Duration MessageReceiveTimeout_Conn2_RG1_DSR1 = 40.0;
-//     AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1, 
-//         MessageReceiveTimeout_Conn2_RG1_DSR1, &VarId_Conn2_RG1_DSR1, &DSRId_Conn2_RG1_DSR1);
-//     UA_String_init(&strId);
-//     UA_NodeId_print(&DSRId_Conn2_RG1_DSR1, &strId);
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn2_RG1_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
-//     UA_String_clear(&strId);
-// 
-//     UA_NodeId RGId_Conn2_RG2;
-//     UA_NodeId_init(&RGId_Conn2_RG2);
-//     AddReaderGroup(&ConnId_2, "Conn2_RG2", &RGId_Conn2_RG2);
-// 
-//     UA_NodeId DSRId_Conn2_RG2_DSR1;
-//     UA_NodeId_init(&DSRId_Conn2_RG2_DSR1);
-//     UA_NodeId VarId_Conn2_RG2_DSR1;
-//     UA_NodeId_init(&VarId_Conn2_RG2_DSR1);
-//     UA_Duration MessageReceiveTimeout_Conn2_RG2_DSR1 = 45.0;
-//     AddDataSetReader(&RGId_Conn2_RG2, "Conn2_RG2_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS2, 
-//         MessageReceiveTimeout_Conn2_RG2_DSR1, &VarId_Conn2_RG2_DSR1, &DSRId_Conn2_RG2_DSR1);
-//     UA_String_init(&strId);
-//     UA_NodeId_print(&DSRId_Conn2_RG2_DSR1, &strId);
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn2_RG2_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
-//     UA_String_clear(&strId);
-// 
-//     /* setup Connection 3: readers */
-//     UA_NodeId ConnId_3;
-//     UA_NodeId_init(&ConnId_3);
-//     UA_UInt32 PublisherNo_Conn3 = 3;
-//     AddConnection("Conn3", PublisherNo_Conn3, &ConnId_3);
-// 
-//     UA_NodeId RGId_Conn3_RG1;
-//     UA_NodeId_init(&RGId_Conn3_RG1);
-//     AddReaderGroup(&ConnId_3, "Conn3_RG1", &RGId_Conn3_RG1);
-// 
-//     UA_NodeId DSRId_Conn3_RG1_DSR1;
-//     UA_NodeId_init(&DSRId_Conn3_RG1_DSR1);
-//     UA_NodeId VarId_Conn3_RG1_DSR1;
-//     UA_NodeId_init(&VarId_Conn3_RG1_DSR1);
-//     UA_Duration MessageReceiveTimeout_Conn3_RG1_DSR1 = 25.0;
-//     AddDataSetReader(&RGId_Conn3_RG1, "Conn3_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG2, DSWNo_Conn2_WG2_DS1, 
-//         MessageReceiveTimeout_Conn3_RG1_DSR1, &VarId_Conn3_RG1_DSR1, &DSRId_Conn3_RG1_DSR1);
-//     UA_String_init(&strId);
-//     UA_NodeId_print(&DSRId_Conn3_RG1_DSR1, &strId);
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn3_RG1_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
-//     UA_String_clear(&strId);
-// 
-//     const UA_UInt32 SleepTime = 5;
-//     const UA_UInt32 NoOfRunIterateCycles = 11;
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "set everything operational");
-// 
-//     /* check normal operation first -> there should not be any timeouts */
-//     pExpectedComponentCallbackIds = 0;
-//     ExpectedCallbackCnt = 0;
-// 
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG2) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn3_RG1) == UA_STATUSCODE_GOOD);
-// 
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
-// 
-//     /* check that publish/subscribe works -> set some test values */
-// 
-//     /* use a low enough sleep value to ensure that publishing intervals and message receive timeouts 
-//         are handled */
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn2_RG1_DSR1");
-//     ValidatePublishSubscribe(VarId_Conn1_WG1_DS1, VarId_Conn2_RG1_DSR1, 10, SleepTime, NoOfRunIterateCycles);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn2_RG2_DSR1");
-//     ValidatePublishSubscribe(VarId_Conn1_WG1_DS2, VarId_Conn2_RG2_DSR1, 99, SleepTime, NoOfRunIterateCycles);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn1_RG1_DSR1");
-//     ValidatePublishSubscribe(VarId_Conn2_WG1_DS1, VarId_Conn1_RG1_DSR1, 40, SleepTime, NoOfRunIterateCycles);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn3_RG1_DSR1");
-//     ValidatePublishSubscribe(VarId_Conn2_WG2_DS1, VarId_Conn3_RG1_DSR1, 123, SleepTime, NoOfRunIterateCycles);
-// 
-//     ck_assert_int_eq(0, CallbackCnt);
-// 
-//     /***************************************************************************************************/
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "TEST A");
-// 
-//     /* prepare expected pubsub components with message receive timeout */
-//     ExpectedCallbackCnt = 2;
-//     pExpectedComponentCallbackIds = (UA_NodeId*) UA_calloc(ExpectedCallbackCnt, sizeof(UA_NodeId));
-//     assert(pExpectedComponentCallbackIds != 0);
-//     pExpectedComponentCallbackIds[0] = DSRId_Conn2_RG1_DSR1;
-//     pExpectedComponentCallbackIds[1] = DSRId_Conn2_RG2_DSR1;
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable writergroup: Conn 1 - WG 1");
-//     ExpectedCallbackStatus = UA_STATUSCODE_BADTIMEOUT;
-//     ExpectedCallbackStateChange = UA_PUBSUBSTATE_ERROR;
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
-// 
-//     UA_PubSubState state = UA_PUBSUBSTATE_OPERATIONAL;
-//     ck_assert(UA_Server_WriterGroup_getState(server, WGId_Conn1_WG1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_DISABLED);
-// 
-//     ServerDoProcess("A 1", SleepTime, NoOfRunIterateCycles);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check state of datasetreaders");
-// 
-//     /* state of Conn 2: ReaderGroup 1 should still be ok */
-//     ck_assert(UA_Server_ReaderGroup_getState(server, RGId_Conn2_RG1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//      /* but DataSetReader state shall be error */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_ERROR);
-// 
-//     /* state of Conn 2: ReaderGroup 2 should still be ok */
-//     ck_assert(UA_Server_ReaderGroup_getState(server, RGId_Conn2_RG1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//      /* but DataSetReader state shall be error */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_ERROR);
-// 
-//     /* Conn 1: RG 1 DatasetReader1 state shall still be operational */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//     ValidatePublishSubscribe(VarId_Conn2_WG1_DS1, VarId_Conn1_RG1_DSR1, 99, SleepTime, NoOfRunIterateCycles);
-//     /* Conn 3: RG 1 DatasetReader1 state shall still be operational */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn3_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//     ValidatePublishSubscribe(VarId_Conn2_WG2_DS1, VarId_Conn3_RG1_DSR1, 118, SleepTime, NoOfRunIterateCycles);
-// 
-//     /* check number of timeouts */
-//     ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
-//     
-//     /* enable the publisher WriterGroup again */
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "enable writergroup Conn 1 - WG 1");
-//     CallbackCnt = 0;
-//     ExpectedCallbackCnt = 2;
-//     ExpectedCallbackStatus = UA_STATUSCODE_GOOD;
-//     ExpectedCallbackStateChange = UA_PUBSUBSTATE_OPERATIONAL;
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
-// 
-//     ServerDoProcess("A 2", SleepTime, NoOfRunIterateCycles);
-// 
-//     /* DataSetReader state shall be back to operational, after receiving a new message */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-// 
-//     /* PubSubStateChange callback must not have been triggered again */
-//     ck_assert(CallbackCnt == 2);
-// 
-//     /***************************************************************************************************/
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "TEST B");
-// 
-//     /* prepare expected pubsub component timeouts */
-//     ExpectedCallbackCnt = 1;
-//     pExpectedComponentCallbackIds[0] = DSRId_Conn1_RG1_DSR1;
-//     CallbackCnt = 0;
-//     ExpectedCallbackStatus = UA_STATUSCODE_BADTIMEOUT;
-//     ExpectedCallbackStateChange = UA_PUBSUBSTATE_ERROR;
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable writergroup: Conn 2 - WG 1");
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
-// 
-//     ServerDoProcess("B 1", (UA_UInt32) SleepTime, NoOfRunIterateCycles);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check state of datasetreaders");
-// 
-//     /* DatasetReader Conn1: RG 1 shall be error */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_ERROR);
-// 
-//     /* other DataSetReaders shall be operational */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//     ValidatePublishSubscribe(VarId_Conn1_WG1_DS1, VarId_Conn2_RG1_DSR1, 47, SleepTime, NoOfRunIterateCycles);
-// 
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn3_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-//     ValidatePublishSubscribe(VarId_Conn2_WG2_DS1, VarId_Conn3_RG1_DSR1, 119, SleepTime, NoOfRunIterateCycles);
-//     
-//     /* check number of timeouts */
-//     ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
-//     
-//     /* enable the publisher WriterGroup again */
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "enable writergroup");
-//     CallbackCnt = 0;
-//     ExpectedCallbackStatus = UA_STATUSCODE_GOOD;
-//     ExpectedCallbackStateChange = UA_PUBSUBSTATE_OPERATIONAL;
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
-// 
-//     ServerDoProcess("B 1", SleepTime, NoOfRunIterateCycles);
-// 
-//     /* DataSetReader state shall be back to operational, after receiving a new message */
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
-// 
-//     ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
-// 
-//     /***************************************************************************************************/
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "TEST C");
-// 
-//     /* prepare expected pubsub component timeouts */
-//     UA_free(pExpectedComponentCallbackIds);
-// 
-//     ExpectedCallbackCnt = 4;
-//     pExpectedComponentCallbackIds = (UA_NodeId*) UA_calloc(ExpectedCallbackCnt, sizeof(UA_NodeId));
-//     assert(pExpectedComponentCallbackIds != 0);
-//     pExpectedComponentCallbackIds[0] = DSRId_Conn3_RG1_DSR1;
-//     pExpectedComponentCallbackIds[1] = DSRId_Conn1_RG1_DSR1;
-//     pExpectedComponentCallbackIds[2] = DSRId_Conn2_RG1_DSR1;
-//     pExpectedComponentCallbackIds[3] = DSRId_Conn2_RG2_DSR1;
-// 
-//     CallbackCnt = 0;
-//     ExpectedCallbackStatus = UA_STATUSCODE_BADTIMEOUT;
-//     ExpectedCallbackStateChange = UA_PUBSUBSTATE_ERROR;
-// 
-//     /* realign all publishers, so we can determine the order of timeouts */
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn2_RG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn2_RG2) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn3_RG1) == UA_STATUSCODE_GOOD);
-// 
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG2) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn3_RG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
-//     ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
-//     
-//     ServerDoProcess("C 1", SleepTime, NoOfRunIterateCycles);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable all writers");
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
-//     ServerDoProcess("C 1", SleepTime, 2);
-// 
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
-//     ServerDoProcess("C 1", SleepTime, 2);
-// 
-//     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
-//     ServerDoProcess("C 2", SleepTime, NoOfRunIterateCycles);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check state of datasetreaders");
-// 
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_ERROR);
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_ERROR);
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_ERROR);
-//     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn3_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-//     ck_assert(state == UA_PUBSUBSTATE_ERROR);
-// 
-//     /* check number of timeouts */
-//     ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
-// 
-//     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_many_components\n\n");
-// 
-// } END_TEST
+    CallbackCnt++;
+}
+
+/***************************************************************************************************/
+START_TEST(Test_many_components) {
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nSTART: Test_many_components");
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "prepare configuration");
+
+    /*  Writers            : Interval  -> Readers            : Timeout
+        ----------------------------------------------------------------------------------
+        Conn 1 WG 1 - DSW1 : 30        -> Conn 2 RG 1 - DSR1 : 40
+        Conn 1 WG 1 - DSW2 : 30        -> Conn 2 RG 2 - DSR2 : 45
+        Conn 2 WG 1 - DSW1 : 20        -> Conn 1 RG 1 - DSR1 : 25
+        Conn 2 WG 2 - DSW2 : 10        -> Conn 3 RG 1 - DSR1 : 25
+    */
+
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    /* set custom callback triggered for specific PubSub state changes */
+    config->pubSubConfig.stateChangeCallback = PubSubStateChangeCallback_many_components;
+
+    /* setup Connection 1: writers */
+    UA_NodeId ConnId_1;
+    UA_NodeId_init(&ConnId_1);
+    UA_UInt32 PublisherNo_Conn1 = 1;
+    AddConnection("Conn1", PublisherNo_Conn1, &ConnId_1);
+
+    UA_NodeId WGId_Conn1_WG1;
+    UA_NodeId_init(&WGId_Conn1_WG1);
+    UA_UInt32 WGNo_Conn1_WG1 = 1;
+    UA_Duration PublishingInterval_Conn1_WG1 = 30.0;
+    AddWriterGroup(&ConnId_1, "Conn1_WG1", WGNo_Conn1_WG1, PublishingInterval_Conn1_WG1, &WGId_Conn1_WG1);
+
+    UA_NodeId DsWId_Conn1_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS1);
+    UA_NodeId VarId_Conn1_WG1_DS1;
+    UA_NodeId_init(&VarId_Conn1_WG1_DS1);
+    UA_NodeId PDSId_Conn1_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS1);
+    UA_UInt32 DSWNo_Conn1_WG1_DS1 = 1;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS1", "Conn1_WG1_DS1", DSWNo_Conn1_WG1_DS1, &PDSId_Conn1_WG1_PDS1, 
+        &VarId_Conn1_WG1_DS1, &DsWId_Conn1_WG1_DS1);
+
+    UA_NodeId DsWId_Conn1_WG1_DS2;
+    UA_NodeId_init(&DsWId_Conn1_WG1_DS2);
+    UA_NodeId VarId_Conn1_WG1_DS2;
+    UA_NodeId_init(&VarId_Conn1_WG1_DS2);
+    UA_NodeId PDSId_Conn1_WG1_PDS2;
+    UA_NodeId_init(&PDSId_Conn1_WG1_PDS2);
+    UA_UInt32 DSWNo_Conn1_WG1_DS2 = 2;
+    AddPublishedDataSet(&WGId_Conn1_WG1, "Conn1_WG1_PDS2", "Conn1_WG1_DS2", DSWNo_Conn1_WG1_DS2, &PDSId_Conn1_WG1_PDS2, 
+        &VarId_Conn1_WG1_DS2, &DsWId_Conn1_WG1_DS2);
+
+
+    /* setup Connection 2: writers */
+    UA_NodeId ConnId_2;
+    UA_NodeId_init(&ConnId_2);
+    UA_UInt32 PublisherNo_Conn2 = 2;
+    AddConnection("Conn2", PublisherNo_Conn2, &ConnId_2);
+
+    UA_NodeId WGId_Conn2_WG1;
+    UA_NodeId_init(&WGId_Conn2_WG1);
+    UA_UInt32 WGNo_Conn2_WG1 = 1;
+    UA_Duration PublishingInterval_Conn2_WG1 = 20.0;
+    AddWriterGroup(&ConnId_2, "Conn2_WG1", WGNo_Conn2_WG1, PublishingInterval_Conn2_WG1, &WGId_Conn2_WG1);
+
+    UA_NodeId DsWId_Conn2_WG1_DS1;
+    UA_NodeId_init(&DsWId_Conn2_WG1_DS1);
+    UA_NodeId VarId_Conn2_WG1_DS1;
+    UA_NodeId_init(&VarId_Conn2_WG1_DS1);
+    UA_NodeId PDSId_Conn2_WG1_PDS1;
+    UA_NodeId_init(&PDSId_Conn2_WG1_PDS1);
+    UA_UInt32 DSWNo_Conn2_WG1_DS1 = 1;
+    AddPublishedDataSet(&WGId_Conn2_WG1, "Conn2_WG1_PDS1", "Conn2_WG1_DS1", DSWNo_Conn2_WG1_DS1, &PDSId_Conn2_WG1_PDS1, 
+        &VarId_Conn2_WG1_DS1, &DsWId_Conn2_WG1_DS1);
+
+
+    UA_NodeId WGId_Conn2_WG2;
+    UA_NodeId_init(&WGId_Conn2_WG2);
+    UA_UInt32 WGNo_Conn2_WG2 = 2;
+    UA_Duration PublishingInterval_Conn2_WG2 = 10.0;
+    AddWriterGroup(&ConnId_2, "Conn2_WG2", WGNo_Conn2_WG2, PublishingInterval_Conn2_WG2, &WGId_Conn2_WG2);
+
+    UA_NodeId DsWId_Conn2_WG2_DS1;
+    UA_NodeId_init(&DsWId_Conn2_WG2_DS1);
+    UA_NodeId VarId_Conn2_WG2_DS1;
+    UA_NodeId_init(&VarId_Conn2_WG2_DS1);
+    UA_NodeId PDSId_Conn2_WG2_PDS1;
+    UA_NodeId_init(&PDSId_Conn2_WG2_PDS1);
+    UA_UInt32 DSWNo_Conn2_WG2_DS1 = 1;
+    AddPublishedDataSet(&WGId_Conn2_WG2, "Conn2_WG2_PDS1", "Conn2_WG2_DS1", DSWNo_Conn2_WG2_DS1, &PDSId_Conn2_WG2_PDS1, 
+        &VarId_Conn2_WG2_DS1, &DsWId_Conn2_WG2_DS1);
+
+    /* setup Connection 1: readers */
+    UA_NodeId RGId_Conn1_RG1;
+    UA_NodeId_init(&RGId_Conn1_RG1);
+    AddReaderGroup(&ConnId_1, "Conn1_RG1", &RGId_Conn1_RG1);
+
+    UA_NodeId DSRId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn1_RG1_DSR1);
+    UA_NodeId VarId_Conn1_RG1_DSR1;
+    UA_NodeId_init(&VarId_Conn1_RG1_DSR1);
+    UA_Duration MessageReceiveTimeout_Conn1_RG1_DSR1 = 25.0;
+    AddDataSetReader(&RGId_Conn1_RG1, "Conn1_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG1, DSWNo_Conn2_WG1_DS1, 
+        MessageReceiveTimeout_Conn1_RG1_DSR1, &VarId_Conn1_RG1_DSR1, &DSRId_Conn1_RG1_DSR1);
+    UA_String strId;
+    UA_String_init(&strId);
+    UA_NodeId_print(&DSRId_Conn1_RG1_DSR1, &strId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn1_RG1_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
+    UA_String_clear(&strId);
+
+     /* setup Connection 2: readers */
+    UA_NodeId RGId_Conn2_RG1;
+    UA_NodeId_init(&RGId_Conn2_RG1);
+    AddReaderGroup(&ConnId_2, "Conn2_RG1", &RGId_Conn2_RG1);
+
+    UA_NodeId DSRId_Conn2_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn2_RG1_DSR1);
+    UA_NodeId VarId_Conn2_RG1_DSR1;
+    UA_NodeId_init(&VarId_Conn2_RG1_DSR1);
+    UA_Duration MessageReceiveTimeout_Conn2_RG1_DSR1 = 40.0;
+    AddDataSetReader(&RGId_Conn2_RG1, "Conn2_RG1_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS1, 
+        MessageReceiveTimeout_Conn2_RG1_DSR1, &VarId_Conn2_RG1_DSR1, &DSRId_Conn2_RG1_DSR1);
+    UA_String_init(&strId);
+    UA_NodeId_print(&DSRId_Conn2_RG1_DSR1, &strId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn2_RG1_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
+    UA_String_clear(&strId);
+
+    UA_NodeId RGId_Conn2_RG2;
+    UA_NodeId_init(&RGId_Conn2_RG2);
+    AddReaderGroup(&ConnId_2, "Conn2_RG2", &RGId_Conn2_RG2);
+
+    UA_NodeId DSRId_Conn2_RG2_DSR1;
+    UA_NodeId_init(&DSRId_Conn2_RG2_DSR1);
+    UA_NodeId VarId_Conn2_RG2_DSR1;
+    UA_NodeId_init(&VarId_Conn2_RG2_DSR1);
+    UA_Duration MessageReceiveTimeout_Conn2_RG2_DSR1 = 45.0;
+    AddDataSetReader(&RGId_Conn2_RG2, "Conn2_RG2_DSR1", PublisherNo_Conn1, WGNo_Conn1_WG1, DSWNo_Conn1_WG1_DS2, 
+        MessageReceiveTimeout_Conn2_RG2_DSR1, &VarId_Conn2_RG2_DSR1, &DSRId_Conn2_RG2_DSR1);
+    UA_String_init(&strId);
+    UA_NodeId_print(&DSRId_Conn2_RG2_DSR1, &strId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn2_RG2_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
+    UA_String_clear(&strId);
+
+    /* setup Connection 3: readers */
+    UA_NodeId ConnId_3;
+    UA_NodeId_init(&ConnId_3);
+    UA_UInt32 PublisherNo_Conn3 = 3;
+    AddConnection("Conn3", PublisherNo_Conn3, &ConnId_3);
+
+    UA_NodeId RGId_Conn3_RG1;
+    UA_NodeId_init(&RGId_Conn3_RG1);
+    AddReaderGroup(&ConnId_3, "Conn3_RG1", &RGId_Conn3_RG1);
+
+    UA_NodeId DSRId_Conn3_RG1_DSR1;
+    UA_NodeId_init(&DSRId_Conn3_RG1_DSR1);
+    UA_NodeId VarId_Conn3_RG1_DSR1;
+    UA_NodeId_init(&VarId_Conn3_RG1_DSR1);
+    UA_Duration MessageReceiveTimeout_Conn3_RG1_DSR1 = 25.0;
+    AddDataSetReader(&RGId_Conn3_RG1, "Conn3_RG1_DSR1", PublisherNo_Conn2, WGNo_Conn2_WG2, DSWNo_Conn2_WG2_DS1, 
+        MessageReceiveTimeout_Conn3_RG1_DSR1, &VarId_Conn3_RG1_DSR1, &DSRId_Conn3_RG1_DSR1);
+    UA_String_init(&strId);
+    UA_NodeId_print(&DSRId_Conn3_RG1_DSR1, &strId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Conn3_RG1_DSR1 Id = %.*s", (UA_Int32) strId.length, strId.data);
+    UA_String_clear(&strId);
+
+    const UA_UInt32 SleepTime = 5;
+    const UA_UInt32 NoOfRunIterateCycles = 11;
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "set everything operational");
+
+    /* check normal operation first -> there should not be any timeouts */
+    pExpectedComponentCallbackIds = 0;
+    ExpectedCallbackCnt = 0;
+
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG2) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn3_RG1) == UA_STATUSCODE_GOOD);
+
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
+
+    /* check that publish/subscribe works -> set some test values */
+
+    /* use a low enough sleep value to ensure that publishing intervals and message receive timeouts 
+        are handled */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn2_RG1_DSR1");
+    ValidatePublishSubscribe(VarId_Conn1_WG1_DS1, VarId_Conn2_RG1_DSR1, 10, SleepTime, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn2_RG2_DSR1");
+    ValidatePublishSubscribe(VarId_Conn1_WG1_DS2, VarId_Conn2_RG2_DSR1, 99, SleepTime, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn1_RG1_DSR1");
+    ValidatePublishSubscribe(VarId_Conn2_WG1_DS1, VarId_Conn1_RG1_DSR1, 40, SleepTime, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check Conn3_RG1_DSR1");
+    ValidatePublishSubscribe(VarId_Conn2_WG2_DS1, VarId_Conn3_RG1_DSR1, 123, SleepTime, NoOfRunIterateCycles);
+
+    ck_assert_int_eq(0, CallbackCnt);
+
+    /***************************************************************************************************/
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "TEST A");
+
+    /* prepare expected pubsub components with message receive timeout */
+    ExpectedCallbackCnt = 2;
+    pExpectedComponentCallbackIds = (UA_NodeId*) UA_calloc(ExpectedCallbackCnt, sizeof(UA_NodeId));
+    assert(pExpectedComponentCallbackIds != 0);
+    pExpectedComponentCallbackIds[0] = DSRId_Conn2_RG1_DSR1;
+    pExpectedComponentCallbackIds[1] = DSRId_Conn2_RG2_DSR1;
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable writergroup: Conn 1 - WG 1");
+    ExpectedCallbackStatus = UA_STATUSCODE_BADTIMEOUT;
+    ExpectedCallbackStateChange = UA_PUBSUBSTATE_ERROR;
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+
+    UA_PubSubState state = UA_PUBSUBSTATE_OPERATIONAL;
+    ck_assert(UA_Server_WriterGroup_getState(server, WGId_Conn1_WG1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_DISABLED);
+
+    ServerDoProcess("A 1", SleepTime, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check state of datasetreaders");
+
+    /* state of Conn 2: ReaderGroup 1 should still be ok */
+    ck_assert(UA_Server_ReaderGroup_getState(server, RGId_Conn2_RG1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+     /* but DataSetReader state shall be error */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+
+    /* state of Conn 2: ReaderGroup 2 should still be ok */
+    ck_assert(UA_Server_ReaderGroup_getState(server, RGId_Conn2_RG1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+     /* but DataSetReader state shall be error */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+
+    /* Conn 1: RG 1 DatasetReader1 state shall still be operational */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+    ValidatePublishSubscribe(VarId_Conn2_WG1_DS1, VarId_Conn1_RG1_DSR1, 99, SleepTime, NoOfRunIterateCycles);
+    /* Conn 3: RG 1 DatasetReader1 state shall still be operational */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn3_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+    ValidatePublishSubscribe(VarId_Conn2_WG2_DS1, VarId_Conn3_RG1_DSR1, 118, SleepTime, NoOfRunIterateCycles);
+
+    /* check number of timeouts */
+    ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
+    
+    /* enable the publisher WriterGroup again */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "enable writergroup Conn 1 - WG 1");
+    CallbackCnt = 0;
+    ExpectedCallbackCnt = 2;
+    ExpectedCallbackStatus = UA_STATUSCODE_GOOD;
+    ExpectedCallbackStateChange = UA_PUBSUBSTATE_OPERATIONAL;
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+
+    ServerDoProcess("A 2", SleepTime, NoOfRunIterateCycles);
+
+    /* DataSetReader state shall be back to operational, after receiving a new message */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+
+    /* PubSubStateChange callback must not have been triggered again */
+    ck_assert(CallbackCnt == 2);
+
+    /***************************************************************************************************/
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "TEST B");
+
+    /* prepare expected pubsub component timeouts */
+    ExpectedCallbackCnt = 1;
+    pExpectedComponentCallbackIds[0] = DSRId_Conn1_RG1_DSR1;
+    CallbackCnt = 0;
+    ExpectedCallbackStatus = UA_STATUSCODE_BADTIMEOUT;
+    ExpectedCallbackStateChange = UA_PUBSUBSTATE_ERROR;
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable writergroup: Conn 2 - WG 1");
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
+
+    ServerDoProcess("B 1", (UA_UInt32) SleepTime, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check state of datasetreaders");
+
+    /* DatasetReader Conn1: RG 1 shall be error */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+
+    /* other DataSetReaders shall be operational */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+    ValidatePublishSubscribe(VarId_Conn1_WG1_DS1, VarId_Conn2_RG1_DSR1, 47, SleepTime, NoOfRunIterateCycles);
+
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn3_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+    ValidatePublishSubscribe(VarId_Conn2_WG2_DS1, VarId_Conn3_RG1_DSR1, 119, SleepTime, NoOfRunIterateCycles);
+    
+    /* check number of timeouts */
+    ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
+    
+    /* enable the publisher WriterGroup again */
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "enable writergroup");
+    CallbackCnt = 0;
+    ExpectedCallbackStatus = UA_STATUSCODE_GOOD;
+    ExpectedCallbackStateChange = UA_PUBSUBSTATE_OPERATIONAL;
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
+
+    ServerDoProcess("B 1", SleepTime, NoOfRunIterateCycles);
+
+    /* DataSetReader state shall be back to operational, after receiving a new message */
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
+
+    ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
+
+    /***************************************************************************************************/
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "TEST C");
+
+    /* prepare expected pubsub component timeouts */
+    UA_free(pExpectedComponentCallbackIds);
+
+    ExpectedCallbackCnt = 4;
+    pExpectedComponentCallbackIds = (UA_NodeId*) UA_calloc(ExpectedCallbackCnt, sizeof(UA_NodeId));
+    assert(pExpectedComponentCallbackIds != 0);
+    pExpectedComponentCallbackIds[0] = DSRId_Conn3_RG1_DSR1;
+    pExpectedComponentCallbackIds[1] = DSRId_Conn1_RG1_DSR1;
+    pExpectedComponentCallbackIds[2] = DSRId_Conn2_RG1_DSR1;
+    pExpectedComponentCallbackIds[3] = DSRId_Conn2_RG2_DSR1;
+
+    CallbackCnt = 0;
+    ExpectedCallbackStatus = UA_STATUSCODE_BADTIMEOUT;
+    ExpectedCallbackStateChange = UA_PUBSUBSTATE_ERROR;
+
+    /* realign all publishers, so we can determine the order of timeouts */
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn2_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn2_RG2) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupDisabled(server, RGId_Conn3_RG1) == UA_STATUSCODE_GOOD);
+
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn1_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn2_RG2) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setReaderGroupOperational(server, RGId_Conn3_RG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
+    ck_assert(UA_Server_setWriterGroupOperational(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
+    
+    ServerDoProcess("C 1", SleepTime, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable all writers");
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG2) == UA_STATUSCODE_GOOD);
+    ServerDoProcess("C 1", SleepTime, 2);
+
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn2_WG1) == UA_STATUSCODE_GOOD);
+    ServerDoProcess("C 1", SleepTime, 2);
+
+    ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
+    ServerDoProcess("C 2", SleepTime, NoOfRunIterateCycles);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "check state of datasetreaders");
+
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG2_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn3_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+
+    /* check number of timeouts */
+    ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
+
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_many_components\n\n");
+
+} END_TEST
 
 
 /***************************************************************************************************/
@@ -1754,13 +1754,11 @@ int main(void) {
     */
     tcase_add_test(tc_basic, Test_wrong_timeout);
 
-    // TODO: fix the test for reenabling it
-    // there are mistakes in the setup of ids (writergroup, datasetwriter, publisherid)
     /* test case description:
         - configure multiple connections with multiple readers and writers
         - disable/enable and check for correct timeouts 
     */
-    // tcase_add_test(tc_basic, Test_many_components);
+    tcase_add_test(tc_basic, Test_many_components);
 
     /* test case description:
         - configure a connection with writer and reader

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -66,7 +66,7 @@ function build_amalgamation {
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
-          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           ..
     make ${MAKEOPTS}
@@ -87,7 +87,7 @@ function unit_tests {
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
-          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           ..
     make ${MAKEOPTS}
@@ -147,7 +147,7 @@ function unit_tests_encryption_mbedtls_pubsub {
           -DUA_ENABLE_ENCRYPTION_MBEDTLS=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
-          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
           ..
@@ -171,7 +171,7 @@ function unit_tests_valgrind {
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
-          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
           -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
@@ -196,7 +196,7 @@ function build_clang_analyzer {
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
-          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           ..
     scan-build-11 --status-bugs make ${MAKEOPTS}

--- a/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
+++ b/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
@@ -1267,13 +1267,12 @@
       <Reference ReferenceType="HasProperty">i=17740</Reference> <!--LocaleIds-->
       <Reference ReferenceType="i=15296">i=17743</Reference> <!--DataSetWriterName-->
       <Reference ReferenceType="HasComponent">i=17969</Reference> <!--AddDataSetWriter-->
-
+      <Reference ReferenceType="HasComponent">i=17992</Reference> <!--RemoveDataSetWriter-->
 
       <!--
             <Reference ReferenceType="HasComponent">i=17741</Reference> TransportSettings
             <Reference ReferenceType="HasComponent">i=17742</Reference> MessageSettings
-            <Reference ReferenceType="HasComponent">i=17812</Reference> Diagnostics
-            <Reference ReferenceType="HasComponent">i=17992</Reference> RemoveDataSetWriter-->
+            <Reference ReferenceType="HasComponent">i=17812</Reference> Diagnostics-->
       <Reference ReferenceType="HasSubtype" IsForward="false">i=14232</Reference>  <!--PubSubGroupType-->
     </References>
   </UAObjectType>
@@ -1336,6 +1335,41 @@
               <ValueRank>-1</ValueRank>
               <ArrayDimensions />
               <Description p5:nil="true" xmlns:p5="http://www.w3.org/2001/XMLSchema-instance" />
+            </Argument>
+          </Body>
+        </ExtensionObject>
+      </ListOfExtensionObject>
+    </Value>
+  </UAVariable>
+  <UAMethod NodeId="i=17992" BrowseName="RemoveDataSetWriter" ParentNodeId="i=17725">
+    <DisplayName>RemoveDataSetWriter</DisplayName>
+    <References>
+      <Reference ReferenceType="HasProperty">i=17993</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=17725</Reference>
+    </References>
+  </UAMethod>
+  <UAVariable NodeId="i=17993" BrowseName="InputArguments" ParentNodeId="i=17992" DataType="i=296" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>InputArguments</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=17992</Reference>
+    </References>
+    <Value>
+      <ListOfExtensionObject xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">
+        <ExtensionObject>
+          <TypeId>
+            <Identifier>i=297</Identifier>
+          </TypeId>
+          <Body>
+            <Argument>
+              <Name>DataSetWriterNodeId</Name>
+              <DataType>
+                <Identifier>i=17</Identifier>
+              </DataType>
+              <ValueRank>-1</ValueRank>
+              <ArrayDimensions />
             </Argument>
           </Body>
         </ExtensionObject>


### PR DESCRIPTION
Hi all!

I wanted to fix the failing PubSub message receive timeout tests, which have been disabled by this commit.
b0fbe615433ce9aa9eb946284900c39fa4b75344

A message receive timeout happened, which was not expected and in this case an assert raised an abort.
A message receive timeout can only happen if something has been received at least once.
Therefore I thought that the PubSub configuration was correct.
In the failing test I setup 3 connections which are all part of the same multicast group.

```
    /*  Writers            : Interval  -> Readers            : Timeout
        ----------------------------------------------------------------------------------
        Conn 1 WG 1 - DSW1 : 30        -> Conn 2 RG 1 - DSR1 : 40
        Conn 1 WG 1 - DSW2 : 30        -> Conn 2 RG 2 - DSR2 : 45
        Conn 2 WG 1 - DSW1 : 20        -> Conn 1 RG 1 - DSR1 : 25
        Conn 2 WG 2 - DSW1 : 10        -> Conn 3 RG 1 - DSR1 : 25
    */
```


I have added some traces and saw that sometimes not all received network messages are processed and therefore the timeout occurred, although the message has been received in time.

I think the problem is the UA_CHECK_STATUS_WARN macro in the receiveBufferedNetworkMessage() function.

If we have multiple connections which are all part of the same multicast group then every connection receives all sent messages, even if they are not meant for them.
In the current implementation the processing of the received buffer is aborted if a message is encountered that's not meant for the currently processed connection.
If this message is always at the beginning of the received frame, then all the other messages which would be interesting for the connection are not processed.


I am not sure if my multicast example is a good real life example or would not be valid.
But if we would have 2 connections (device A and device B) and both are in the same multicast group and both have multiple DataSetReaders and the receiveBufferedNetworkMessage() always checks the wrong DataSetWriterId first, before the expected second one, then I think that the messages would not be processed ....

Not sure about that yet ...