### PR TITLE
fix(pubsub): checkReaderIdentifier msg content check

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -775,8 +775,8 @@ UA_Server_setReaderGroupDisabled(UA_Server *server, const UA_NodeId readerGroupI
 
 static UA_StatusCode
 checkReaderIdentifier(UA_Server *server, UA_NetworkMessage *pMsg, UA_DataSetReader *reader) {
-    if(!pMsg->groupHeaderEnabled &&
-       !pMsg->groupHeader.writerGroupIdEnabled &&
+    if(!pMsg->groupHeaderEnabled ||
+       !pMsg->groupHeader.writerGroupIdEnabled ||
        !pMsg->payloadHeaderEnabled) {
         UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                     "Cannot process DataSetReader without WriterGroup"


### PR DESCRIPTION
The function checkReaderIdentifier needs the
GroupHeader, WriterGroupId and DataSetWriterId in the received message
to find the correct reader.

The check at the beginning shall verify that all of these are available.
But the check was wrong.
There a segfault can happen if for example the payload header is
disabled.

Now the check should be correct and return BADNOTIMPLEMENTED
if one of the mandatory parameters is not available in the received
message.