### PR TITLE
style: Consistently use "cannot"

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -766,7 +766,7 @@ UA_ClientConnectionTCP_poll(UA_Connection *connection, UA_UInt32 timeout,
     UA_UInt32 timeout_usec = timeout * 1000;
 
 #ifdef _OS9000
-    /* OS-9 can't use select for checking write sockets. Therefore, we need to
+    /* OS-9 cannot use select for checking write sockets. Therefore, we need to
      * use connect until success or failed */
     int resultsize = 0;
     do {

--- a/examples/pubsub_realtime/vxworks/pubsub_interrupt_publish_tsn.c
+++ b/examples/pubsub_realtime/vxworks/pubsub_interrupt_publish_tsn.c
@@ -141,7 +141,7 @@ addApplicationCallback(UA_Server *server, UA_NodeId identifier,
     uint32_t interval = (uint32_t)(interval_ms * NS_PER_MS);
     tsnClockId = initTsnTimer(interval);
     if(tsnClockId == 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't allocate a TSN timer");
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot allocate a TSN timer");
         return UA_STATUSCODE_BADINTERNALERROR;
     }
     /* Set the callback -- used as a sentinel to detect an operational publisher */
@@ -150,7 +150,7 @@ addApplicationCallback(UA_Server *server, UA_NodeId identifier,
     pubData = data;
 
     if(tsnClockEnable (tsnClockId, NULL) == ERROR) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't enable a TSN timer");
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot enable a TSN timer");
         (void)tsnTimerRelease(tsnClockId);
         tsnClockId = 0;
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -417,7 +417,7 @@ static void open62541EthTSNTask(void) {
         t = ieee1588TimeGet();
 
         /*
-         * Because we can't get the task end time of one packet before it is
+         * Because we cannot get the task end time of one packet before it is
          * sent, we let one packet take its previous packet's cycleTriggerTime,
          * taskBeginTime and taskEndTime.
          */
@@ -438,7 +438,7 @@ static void open62541EthTSNTask(void) {
 static void open62541ServerTask(void) {
     UA_Server *server = UA_Server_new();
     if(server == NULL) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't allocate a server object");
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot allocate a server object");
         goto serverCleanup;
     }
 
@@ -446,7 +446,7 @@ static void open62541ServerTask(void) {
     UA_ServerConfig_setDefault(config);
     config->pubsubTransportLayers = (UA_PubSubTransportLayer *)UA_malloc(sizeof(UA_PubSubTransportLayer));
     if(config->pubsubTransportLayers == NULL) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't allocate a UA_PubSubTransportLayer");
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot allocate a UA_PubSubTransportLayer");
         goto serverCleanup;
     }
     config->pubsubTransportLayers[0] = UA_PubSubTransportLayerEthernet();
@@ -468,11 +468,11 @@ serverCleanup:
 static bool initTSNStream(char *eName, size_t eNameSize, int unit) {
     streamCfg = tsnConfigFind (eName, eNameSize, unit);
     if(streamCfg == NULL) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't find TSN configuration for %s%d", eName, unit);
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot find TSN configuration for %s%d", eName, unit);
         return false;
     }
     if(streamCfg->streamCount == 0) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't find stream defined for %s%d", eName, unit);
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot find stream defined for %s%d", eName, unit);
         return false;
     }
     else {
@@ -492,7 +492,7 @@ static bool initTSNTask() {
     tsnTask = taskSpawn ((char *)"tTsnPub", TSN_TASK_PRIO, 0, TSN_TASK_STACKSZ, (FUNCPTR)open62541EthTSNTask,
                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     if(tsnTask == TASK_ID_ERROR) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't spawn a TSN task");
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot spawn a TSN task");
         return false;
     }
 
@@ -505,7 +505,7 @@ static bool initTSNTask() {
         CPUSET_ZERO (cpus);
         CPUSET_SET (cpus, stackIndex);
         if(taskCpuAffinitySet (tsnTask, cpus) != OK) {
-            UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't move TSN task to core %d", stackIndex);
+            UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot move TSN task to core %d", stackIndex);
             return false;
         }
     }
@@ -517,7 +517,7 @@ static bool initServerTask() {
     serverTask = taskSpawn((char *)"tPubServer", TSN_TASK_PRIO + 5, 0, TSN_TASK_STACKSZ*2, (FUNCPTR)open62541ServerTask,
                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     if(serverTask == TASK_ID_ERROR) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't spawn a server task");
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot spawn a server task");
         return false;
     }
 
@@ -530,7 +530,7 @@ static bool initServerTask() {
         CPUSET_ZERO(cpus);
         CPUSET_SET(cpus, stackIndex);
         if(taskCpuAffinitySet(serverTask, cpus) != OK) {
-            UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't move TSN task to core %d", stackIndex);
+            UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot move TSN task to core %d", stackIndex);
             return false;
         }
     }
@@ -615,7 +615,7 @@ STATUS open62541PubTSNStart(char *eName, size_t eNameSize, int unit, uint32_t st
     /* Create a binary semaphore which is used by the TSN timer to wake up the sender task */
     msgSendSem = semBCreate(SEM_Q_FIFO, SEM_EMPTY);
     if(msgSendSem == SEM_ID_NULL) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Can't create a semaphore");
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot create a semaphore");
         goto startCleanup;
     }
     running = true;

--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -141,7 +141,7 @@ UA_MonitoredItemCreateRequest_default(UA_NodeId nodeId) {
 }
 
 /**
- * The clientHandle parameter can't be set by the user, any value will be replaced
+ * The clientHandle parameter cannot be set by the user, any value will be replaced
  * by the client before sending the request to the server. */
 
 /* Callback for the deletion of a MonitoredItem */

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -447,7 +447,7 @@ typedef enum {
  * UA_PUBSUB_RT_FIXED_LENGTH (Preview - not implemented)
  * ---> Description: All DataSetFields have a known, non-changing length. The server will pre-generate some
  * buffers and use only memcopy operations to generate requested PubSub packages.
- * ---> Requirements: DataSetFields with variable size can't be used within this mode.
+ * ---> Requirements: DataSetFields with variable size cannot be used within this mode.
  * ---> Restrictions: The configuration must be frozen and changes are not allowed while the WriterGroup is 'Operational'.
  * UA_PUBSUB_RT_DETERMINISTIC (Preview - not implemented)
  * ---> Description: -

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -789,7 +789,7 @@ UA_StatusCode UA_EXPORT
 UA_Variant_copyRange(const UA_Variant *src, UA_Variant * UA_RESTRICT dst,
                      const UA_NumericRange range);
 
-/* Insert a range of data into an existing variant. The data array can't be
+/* Insert a range of data into an existing variant. The data array cannot be
  * reused afterwards if it contains types without a fixed size (e.g. strings)
  * since the members are moved into the variant and take on its lifecycle.
  *

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -631,7 +631,7 @@ static void
 serverExecuteRepeatedCallback(UA_Server *server, UA_ApplicationCallback cb,
                               void *callbackApplication, void *data) {
     /* Service mutex is not set inside the timer that triggers the callback */
-    /* The following check can't be used since another thread can take the
+    /* The following check cannot be used since another thread can take the
      * serviceMutex during a server_iterate_call. */
     //UA_LOCK_ASSERT(&server->serviceMutex, 0);
     cb(callbackApplication, data);

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -444,7 +444,7 @@ UA_Subscription_publish(UA_Server *server, UA_Subscription *sub) {
      * the SecureChannel for the Session is closed. */
     if(!pre || !sub->session || !sub->session->header.channel) {
         UA_LOG_DEBUG_SUBSCRIPTION(&server->config.logger, sub,
-                                  "Want to send a publish response but can't. "
+                                  "Want to send a publish response but cannot. "
                                   "The subscription is late.");
         sub->state = UA_SUBSCRIPTIONSTATE_LATE;
         if(pre)

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -886,8 +886,8 @@ START_TEST(Test_wrong_timeout) {
 //     if (ExpectedCallbackStateChange == UA_PUBSUBSTATE_ERROR) {
 //         /*  On error we want to verify the order of DataSetReader timeouts */
 //         ck_assert(UA_NodeId_equal(pubsubComponentId, &pExpectedComponentCallbackIds[CallbackCnt]) == UA_TRUE);
-//     } /* when the state is set back to operational we can't verify the order of StateChanges, because we 
-//             can't know which DataSetReader will be operational first */
+//     } /* when the state is set back to operational we cannot verify the order of StateChanges, because we 
+//             cannot know which DataSetReader will be operational first */
 //     CallbackCnt++;
 // }
 // 

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -523,7 +523,7 @@ class DataTypeNode(Node):
         # An option set is at the same time also an enum, at least for the encoding below
         isOptionSet = parentType is not None and parentType.id.ns == 0 and parentType.id.i==12755
 
-        # We need to store the definition as ordered data, but can't use orderedDict
+        # We need to store the definition as ordered data, but cannot use orderedDict
         # for backward compatibility with Python 2.6 and 3.4
         enumDict = []
         typeDict = []

--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -144,7 +144,7 @@ for ignoreFile in args.ignoreFiles:
         id = line.replace("\n", "")
         ns.hide_node(NodeId(id))
         #if not ns.hide_node(NodeId(id)):
-        #    logger.info("Can't ignore node, namespace does currently not contain a node with id " + str(id))
+        #    logger.info("Cannot ignore node, namespace does currently not contain a node with id " + str(id))
     ignoreFile.close()
 
 # Remove nodes that are not printable or contain parsing errors, such as
@@ -172,7 +172,7 @@ if args.blacklistFiles:
                 continue
             n = ns.getNodeByIDString(id)
             if n is None:
-                logger.debug("Can't blacklist node, namespace does currently not contain a node with id " + str(id))
+                logger.debug("Cannot blacklist node, namespace does currently not contain a node with id " + str(id))
             else:
                 ns.remove_node(n)
         blacklist.close()


### PR DESCRIPTION
In most places in the repository, "cannot" is used.
This patch replaces the few occurrences of "can't" with "cannot" to provide a consistent user experience.
