### PR TITLE
fix(pubsub): Fix IPv6 Multicast Support

### DIFF
--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -458,10 +458,11 @@ UA_PubSubChannelUDPMC_unregist(UA_PubSubChannel *channel, UA_ExtensionObject *tr
     }
     UA_PubSubChannelDataUDPMC * connectionConfig = (UA_PubSubChannelDataUDPMC *) channel->handle;
     if(connectionConfig->ai_family == PF_INET){//IPv4 handling
-        struct ip_mreq groupV4;
+        struct ip_mreq groupV4 = { 0 };
+
         memcpy(&groupV4.imr_multiaddr,
                &((const struct sockaddr_in *) &connectionConfig->ai_addr)->sin_addr,
-               sizeof(struct ip_mreq));
+               sizeof(struct in_addr));
         groupV4.imr_interface.s_addr = UA_htonl(INADDR_ANY);
 
         if(UA_setsockopt(channel->sockfd, IPPROTO_IP, IP_DROP_MEMBERSHIP,

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -390,10 +390,15 @@ UA_PubSubChannelUDPMC_regist(UA_PubSubChannel *channel, UA_ExtensionObject *tran
 
     if(connectionConfig->isMulticast){
 #if UA_IPV6
-        struct ipv6_mreq groupV6;
+        struct ipv6_mreq groupV6 = { 0 };
+
+        memcpy(&groupV6.ipv6mr_multiaddr,
+               &((const struct sockaddr_in6 *) &connectionConfig->ai_addr)->sin6_addr,
+               sizeof(struct in6_addr));
+
         if(UA_setsockopt(channel->sockfd,
             connectionConfig->ai_family == PF_INET6 ? IPPROTO_IPV6 : IPPROTO_IP,
-            connectionConfig->ai_family == PF_INET6 ? IPV6_JOIN_GROUP : IP_ADD_MEMBERSHIP,
+            connectionConfig->ai_family == PF_INET6 ? IPV6_ADD_MEMBERSHIP : IP_ADD_MEMBERSHIP,
             connectionConfig->ai_family == PF_INET6 ? (const void *) &groupV6 : &groupV4,
             connectionConfig->ai_family == PF_INET6 ? sizeof(groupV6) : sizeof(groupV4)) < 0)
 #else

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -494,7 +494,6 @@ UA_PubSubChannelUDPMC_receive(UA_PubSubChannel *channel, UA_ByteString *message,
                      "PubSub Connection receive failed. Invalid state.");
         return UA_STATUSCODE_BADINTERNALERROR;
     }
-    UA_PubSubChannelDataUDPMC *channelConfigUDPMC = (UA_PubSubChannelDataUDPMC *) channel->handle;
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     UA_UInt16 rcvCount = 0;
     struct timeval tmptv;
@@ -530,19 +529,13 @@ UA_PubSubChannelUDPMC_receive(UA_PubSubChannel *channel, UA_ByteString *message,
         }
 
         UA_DateTime now = UA_DateTime_nowMonotonic();
-        if(channelConfigUDPMC->ai_family == PF_INET){
-            ssize_t messageLength = UA_recvfrom(channel->sockfd, (message->data + dataLength), remainingMessageLength, 0, NULL, NULL);
-            if(messageLength > 0){
-                dataLength += (size_t)messageLength;
-                remainingMessageLength -= (size_t)dataLength;
-            } else {
-                retval = UA_STATUSCODE_BADINTERNALERROR;
-                break;
-            }
-#if UA_IPV6
+        ssize_t messageLength = UA_recvfrom(channel->sockfd, (message->data + dataLength), remainingMessageLength, 0, NULL, NULL);
+        if(messageLength > 0){
+            dataLength += (size_t)messageLength;
+            remainingMessageLength -= (size_t)dataLength;
         } else {
-        //TODO implement recieve for IPv6
-#endif
+            retval = UA_STATUSCODE_BADINTERNALERROR;
+            break;
         }
 
         rcvCount++;

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -180,11 +180,16 @@ UA_PubSubChannelUDPMC_open(const UA_PubSubConnectionConfig *connectionConfig) {
 
     /* Set loop back data to your host */
 #if UA_IPV6
+    /* The Linux Kernel IPv6 socket code checks for optlen to be at least the
+     * size of an integer. However, channelDataUDPMC->enableLoopback is a
+     * boolean. In order for the code to work for IPv4 and IPv6 propagate it to
+     * an temporary integer here. */
+    UA_Int32 enable = channelDataUDPMC->enableLoopback;
     if(UA_setsockopt(newChannel->sockfd,
                      requestResult->ai_family == PF_INET6 ? IPPROTO_IPV6 : IPPROTO_IP,
                      requestResult->ai_family == PF_INET6 ? IPV6_MULTICAST_LOOP : IP_MULTICAST_LOOP,
-                     (const char *)&channelDataUDPMC->enableLoopback,
-                     sizeof (channelDataUDPMC->enableLoopback)) < 0)
+                     (const char *)&enable,
+                     sizeof (enable)) < 0)
 #else
     if(UA_setsockopt(newChannel->sockfd, IPPROTO_IP, IP_MULTICAST_LOOP,
                      (const char *)&channelDataUDPMC->enableLoopback,

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -60,7 +60,7 @@ START_TEST(EndpointUrl_split) {
     // IPv6
     endPointUrl = UA_STRING("opc.tcp://[2001:0db8:85a3::8a2e:0370:7334]:1234/path");
     ck_assert_uint_eq(UA_parseEndpointUrl(&endPointUrl, &hostname, &port, &path), UA_STATUSCODE_GOOD);
-    expected = UA_STRING("[2001:0db8:85a3::8a2e:0370:7334]");
+    expected = UA_STRING("2001:0db8:85a3::8a2e:0370:7334");
     UA_String expectedPath = UA_STRING("path");
     ck_assert(UA_String_equal(&hostname, &expected));
     ck_assert_uint_eq(port, 1234);


### PR DESCRIPTION
Hi,

currently PubSub over IPv6 Multicast on Linux doesn't work. Enable it.

Tested on Linux v5.10 with the PubSub examples.

Thanks, Kurt