### PR TITLE
[Review] Use Pointer within the DataTypeMember structure

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -172,8 +172,13 @@ if(UA_ENABLE_ENCRYPTION)
     target_include_directories(client_encryption PRIVATE "${PROJECT_SOURCE_DIR}/examples")
 endif()
 
-add_example(custom_datatype_client custom_datatype/client_types_custom.c)
-add_example(custom_datatype_server custom_datatype/server_types_custom.c)
+if (NOT (BUILD_SHARED_LIBS AND WIN32))
+    add_example(custom_datatype_client custom_datatype/client_types_custom.c)
+    add_example(custom_datatype_server custom_datatype/server_types_custom.c)
+else()
+    MESSAGE(WARNING "Can't build custom datatype examples on WIN32 when BUILD_SHARED_LIBS enabled. Skipping
+custom_datatype_client and custom_datatype_server!")
+endif()
 
 if(UA_ENABLE_NODEMANAGEMENT)
     add_example(access_control_server access_control/server_access_control.c)

--- a/examples/custom_datatype/custom_datatype.h
+++ b/examples/custom_datatype/custom_datatype.h
@@ -21,48 +21,43 @@ typedef struct {
 static UA_DataTypeMember Point_members[3] = {
     /* x */
     {
-        UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
-        0,               /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        false,           /* .isArray */
-        false            /* .isOptional */
-        UA_TYPENAME("x") /* .memberName */
+        UA_TYPENAME("x")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        0,                         /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional */
     },
-
     /* y */
     {
-        UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
-        Point_padding_y, /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        false,           /* .isArray */
-        false            /* .isOptional */
-        UA_TYPENAME("y") /* .memberName */
+        UA_TYPENAME("y")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        Point_padding_y,           /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional */
     },
     /* z */
     {
-        UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
-        Point_padding_z, /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        false,           /* .isArray */
-        false            /* .isOptional */
-        UA_TYPENAME("z") /* .memberName */
+        UA_TYPENAME("z")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        Point_padding_z,           /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional */
     }
 };
 
 static const UA_DataType PointType = {
+        UA_TYPENAME("Point")                /* .tyspeName */
         {1, UA_NODEIDTYPE_NUMERIC, {4242}}, /* .typeId */
         {1, UA_NODEIDTYPE_NUMERIC, {Point_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                             identifier used on the wire (the
                                             namespaceindex is from .typeId) */
         sizeof(Point),                      /* .memSize */
-        0,                                  /* .typeIndex, in the array of custom types */
         UA_DATATYPEKIND_STRUCTURE,          /* .typeKind */
         true,                               /* .pointerFree */
         false,                              /* .overlayable (depends on endianness and
                                             the absence of padding) */
         3,                                  /* .membersSize */
         Point_members
-        UA_TYPENAME("Point")                /* .tyspeName */
 };
 
 /* The datatype description for the Measurement-Series datatype (Array Example)*/
@@ -74,39 +69,34 @@ typedef struct {
 
 static UA_DataTypeMember Measurements_members[2] = {
     {
-        UA_TYPES_STRING,                       /* .memberTypeIndex, points into UA_TYPES
-                                                   since namespaceZero is true */
+        UA_TYPENAME("Measurement description") /* .memberName */
+        &UA_TYPES[UA_TYPES_STRING],            /* .memberType */
         0,                                     /* .padding */
-        true,                                  /* .namespaceZero, see .memberTypeIndex */
         false,                                 /* .isArray */
         false                                  /* .isOptional */
-        UA_TYPENAME("Measurement description") /* .memberName */
     },
     {
-        UA_TYPES_FLOAT,                        /* .memberTypeIndex, points into UA_TYPES
-                                                   since namespaceZero is true */
+        UA_TYPENAME("Measurements")            /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT],             /* .memberType */
         0,                                     /* .padding */
-        true,                                  /* .namespaceZero, see .memberTypeIndex */
         true,                                  /* .isArray */
         false                                  /* .isOptional */
-        UA_TYPENAME("Measurements")            /* .memberName */
     }
 };
 
 static const UA_DataType MeasurementType = {
+    UA_TYPENAME("Measurement")              /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4443}},     /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {Measurement_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                             identifier used on the wire (the
                                             namespaceindex is from .typeId) */
     sizeof(Measurements),                   /* .memSize */
-    1,                                      /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_STRUCTURE,              /* .typeKind */
     false,                                  /* .pointerFree */
     false,                                  /* .overlayable (depends on endianness and
                                                 the absence of padding) */
     2,                                      /* .membersSize */
     Measurements_members
-    UA_TYPENAME("Measurement")              /* .tyspeName */
 };
 
 
@@ -120,56 +110,43 @@ typedef struct {
 static UA_DataTypeMember Opt_members[3] = {
     /* a */
     {
-        UA_TYPES_INT16,                                       /* .memberTypeIndex, points
-                                                              into UA_TYPES since
-                                                              namespaceZero is true */
+        UA_TYPENAME("a")                                      /* .memberName */
+        &UA_TYPES[UA_TYPES_INT16],                            /* .memberType */
         0,                                                    /* .padding */
-        true,                                                 /* .namespaceZero, see
-                                                              .memberTypeIndex */
         false,                                                /* .isArray */
         false                                                 /* .isOptional */
-        UA_TYPENAME("a")                                      /* .memberName */
     },
     /* b */
     {
-        UA_TYPES_FLOAT,                                       /* .memberTypeIndex, points
-                                                              into UA_TYPES since
-                                                              namespaceZero is true */
+        UA_TYPENAME("b")                                      /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT],                            /* .memberType */
         offsetof(Opt,b) - offsetof(Opt,a) - sizeof(UA_Int16), /* .padding */
-        true,                                                 /* .namespaceZero, see
-                                                               .memberTypeIndex */
         false,                                                /* .isArray */
         true                                                  /* .isOptional */
-        UA_TYPENAME("b")                                      /* .memberName */
     },
     /* c */
     {
-        UA_TYPES_FLOAT,                                       /* .memberTypeIndex, points
-                                                                  into UA_TYPES since
-                                                                  namespaceZero is true */
+        UA_TYPENAME("c")                                      /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT],                            /* .memberType */
         offsetof(Opt,c) - offsetof(Opt,b) - sizeof(void *),   /* .padding */
-        true,                                                 /* .namespaceZero, see
-                                                                  .memberTypeIndex */
         false,                                                /* .isArray */
         true                                                  /* .isOptional */
-        UA_TYPENAME("c")                                      /* .memberName */
     }
 };
 
 static const UA_DataType OptType = {
+    UA_TYPENAME("Opt")                  /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4644}}, /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {Opt_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                         identifier used on the wire (the
                                         namespaceindex is from .typeId) */
     sizeof(Opt),                        /* .memSize */
-    2,                                  /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_OPTSTRUCT,          /* .typeKind */
     false,                              /* .pointerFree */
     false,                              /* .overlayable (depends on endianness and
                                             the absence of padding) */
     3,                                  /* .membersSize */
     Opt_members
-    UA_TYPENAME("Opt")                  /* .typeName */
 };
 
 /* The datatype description for the Uni datatype (Union example) */
@@ -185,37 +162,32 @@ typedef struct {
 
 static UA_DataTypeMember Uni_members[2] = {
     {
-        UA_TYPES_DOUBLE,            /* .memberTypeIndex, points into UA_TYPES since
-                                    namespaceZero is true */
+        UA_TYPENAME("optionA")         /* .memberName */
+        &UA_TYPES[UA_TYPES_DOUBLE],    /* .memberType */
         offsetof(Uni, fields.optionA), /* .padding */
-        true,                       /* .namespaceZero, see .memberTypeIndex */
-        false,                      /* .isArray */
-        false                       /* .isOptional */
-        UA_TYPENAME("optionA")      /* .memberName */
+        false,                         /* .isArray */
+        false                          /* .isOptional */
     },
     {
-        UA_TYPES_STRING,            /* .memberTypeIndex, points into UA_TYPES since
-                                    namespaceZero is true */
+        UA_TYPENAME("optionB")         /* .memberName */
+        &UA_TYPES[UA_TYPES_STRING],    /* .memberType */
         offsetof(Uni, fields.optionB), /* .padding */
-        true,                       /* .namespaceZero, see .memberTypeIndex */
-        false,                      /* .isArray */
-        false                       /* .isOptional */
-        UA_TYPENAME("optionB")      /* .memberName */
+        false,                         /* .isArray */
+        false                          /* .isOptional */
     }
 };
 
 static const UA_DataType UniType = {
+    UA_TYPENAME("Uni")                      /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4845}},     /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {Uni_binary_encoding_id}}, /* .binaryEncodingId, the numeric
                                             identifier used on the wire (the
                                             namespaceindex is from .typeId) */
     sizeof(Uni),                            /* .memSize */
-    3,                                      /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_UNION,                  /* .typeKind */
     false,                                  /* .pointerFree */
     false,                                  /* .overlayable (depends on endianness and
                                             the absence of padding) */
     2,                                      /* .membersSize */
     Uni_members
-    UA_TYPENAME("Uni")                      /* .typeName */
 };

--- a/examples/pubsub/tutorial_pubsub_publish_raw.c
+++ b/examples/pubsub/tutorial_pubsub_publish_raw.c
@@ -16,16 +16,68 @@
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
 
-#include "ua_pubsub_networkmessage.h"
-
 #include <signal.h>
-
-#include <custom_datatype/custom_datatype.h>
 
 const UA_NodeId pointVariableTypeId = {
     1, UA_NODEIDTYPE_NUMERIC, {4243}};
 
 UA_NodeId connectionIdent, publishedDataSetIdent, writerGroupIdent, pointVariableNode;
+
+/* The binary encoding id's for the datatypes */
+#define Point_binary_encoding_id        1
+
+typedef struct {
+    UA_Float x;
+    UA_Float y;
+    UA_Float z;
+} Point;
+
+/* The datatype description for the Point datatype */
+#define Point_padding_y offsetof(Point,y) - offsetof(Point,x) - sizeof(UA_Float)
+#define Point_padding_z offsetof(Point,z) - offsetof(Point,y) - sizeof(UA_Float)
+
+static UA_DataTypeMember Point_members[3] = {
+    /* x */
+    {
+        UA_TYPENAME("x")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        0,                         /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional */
+    },
+
+    /* y */
+    {
+        UA_TYPENAME("y")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        Point_padding_y,           /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional */
+    },
+    /* z */
+    {
+        UA_TYPENAME("z")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        Point_padding_z,           /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional */
+    }
+};
+
+static UA_DataType PointType = {
+    UA_TYPENAME("Point")                /* .typeName */
+    {1, UA_NODEIDTYPE_NUMERIC, {4242}}, /* .typeId */
+    {1, UA_NODEIDTYPE_NUMERIC, {Point_binary_encoding_id}}, /* .binaryEncodingId, the numeric
+                                            identifier used on the wire (the
+                                            namespaceindex is from .typeId) */
+    sizeof(Point),                      /* .memSize */
+    UA_DATATYPEKIND_STRUCTURE,          /* .typeKind */
+    true,                               /* .pointerFree */
+    false,                              /* .overlayable (depends on endianness and
+                                            the absence of padding) */
+    3,                                  /* .membersSize */
+    Point_members
+};
 
 /* non raw encoding specific */
 static void

--- a/examples/server_ctt.c
+++ b/examples/server_ctt.c
@@ -613,51 +613,51 @@ setInformationModel(UA_Server *server) {
         attr.writeMask = UA_WRITEMASK_DISPLAYNAME | UA_WRITEMASK_DESCRIPTION;
         attr.userWriteMask = UA_WRITEMASK_DISPLAYNAME | UA_WRITEMASK_DESCRIPTION;
         attr.valueRank = UA_VALUERANK_SCALAR;
-        switch(UA_TYPES[type].typeIndex) {
-            case UA_TYPES_BOOLEAN: {
+        switch(UA_TYPES[type].typeKind) {
+            case UA_DATATYPEKIND_BOOLEAN: {
                 scaleTestDataSource.read = readRandomBoolData;
                 break;
             }
-            case UA_TYPES_INT16: {
+            case UA_DATATYPEKIND_INT16: {
                 scaleTestDataSource.read = readRandomInt16Data;
                 break;
             }
-            case UA_TYPES_UINT16: {
+            case UA_DATATYPEKIND_UINT16: {
                 scaleTestDataSource.read = readRandomUInt16Data;
                 break;
             }
-            case UA_TYPES_INT32: {
+            case UA_DATATYPEKIND_INT32: {
                 scaleTestDataSource.read = readRandomInt32Data;
                 break;
             }
-            case UA_TYPES_UINT32: {
+            case UA_DATATYPEKIND_UINT32: {
                 scaleTestDataSource.read = readRandomUInt32Data;
                 break;
             }
-            case UA_TYPES_INT64: {
+            case UA_DATATYPEKIND_INT64: {
                 scaleTestDataSource.read = readRandomInt64Data;
                 break;
             }
-            case UA_TYPES_UINT64: {
+            case UA_DATATYPEKIND_UINT64: {
                 scaleTestDataSource.read = readRandomUInt64Data;
                 break;
             }
-            case UA_TYPES_STRING: {
+            case UA_DATATYPEKIND_STRING: {
                 scaleTestDataSource.read = readRandomStringData;
                 break;
             }
-            case UA_TYPES_FLOAT: {
+            case UA_DATATYPEKIND_FLOAT: {
                 scaleTestDataSource.read = readRandomFloatData;
                 break;
             }
-            case UA_TYPES_DOUBLE: {
+            case UA_DATATYPEKIND_DOUBLE: {
                 scaleTestDataSource.read = readRandomDoubleData;
                 break;
             }
-            case UA_TYPES_DATETIME:
+            case UA_DATATYPEKIND_DATETIME:
                 scaleTestDataSource.read = readTimeData;
                 break;
-            case UA_TYPES_BYTESTRING:
+            case UA_DATATYPEKIND_BYTESTRING:
                 scaleTestDataSource.read = readByteString;
                 break;
             default:

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -947,9 +947,11 @@ typedef struct UA_DiagnosticInfo {
  * type operations as static inline functions. */
 
 typedef struct {
-    UA_UInt16 memberTypeIndex;    /* Index of the member in the array of data
-                                     types */
-    UA_Byte   padding;            /* How much padding is there before this
+#ifdef UA_ENABLE_TYPEDESCRIPTION
+    const char *memberName;       /* Human-readable member name */
+#endif
+    const UA_DataType *memberType;/* The member data type description */
+    UA_Byte padding    : 6;       /* How much padding is there before this
                                      member element? For arrays this is the
                                      padding before the size_t length member.
                                      (No padding between size_t and the
@@ -957,16 +959,8 @@ typedef struct {
                                      includes the size of the switchfield (the
                                      offset from the start of the union
                                      type). */
-    UA_Boolean namespaceZero : 1; /* The type of the member is defined in
-                                     namespace zero. In this implementation,
-                                     types from custom namespace may contain
-                                     members from the same namespace or
-                                     namespace zero only.*/
-    UA_Boolean isArray       : 1; /* The member is an array */
-    UA_Boolean isOptional    : 1; /* The member is an optional field */
-#ifdef UA_ENABLE_TYPEDESCRIPTION
-    const char *memberName;       /* Human-readable member name */
-#endif
+    UA_Byte isArray    : 1;       /* The member is an array */
+    UA_Byte isOptional : 1;       /* The member is an optional field */
 } UA_DataTypeMember;
 
 /* The DataType "kind" is an internal type classification. It is used to
@@ -1007,24 +1001,20 @@ typedef enum {
 } UA_DataTypeKind;
 
 struct UA_DataType {
-    UA_NodeId typeId;                /* The nodeid of the type */
-    UA_NodeId binaryEncodingId;      /* NodeId of datatype when encoded as binary */
-    //UA_NodeId xmlEncodingId;       /* NodeId of datatype when encoded as XML */
-    UA_UInt16 memSize;               /* Size of the struct in memory */
-    UA_UInt16 typeIndex;             /* Index of the type in the datatypetable */
-    UA_UInt32 typeKind         : 6;  /* Dispatch index for the handling routines */
-    UA_UInt32 pointerFree      : 1;  /* The type (and its members) contains no
-                                      * pointers that need to be freed */
-    UA_UInt32 overlayable      : 1;  /* The type has the identical memory layout
-                                      * in memory and on the binary stream. */
-    UA_UInt32 membersSize      : 8;  /* How many members does the type have? */
-    UA_DataTypeMember *members;
-
-    /* The typename is only for debugging. Move last so the members pointers
-     * stays within the cacheline. */
 #ifdef UA_ENABLE_TYPEDESCRIPTION
     const char *typeName;
 #endif
+    UA_NodeId typeId;           /* The nodeid of the type */
+    UA_NodeId binaryEncodingId; /* NodeId of datatype when encoded as binary */
+    //UA_NodeId xmlEncodingId;  /* NodeId of datatype when encoded as XML */
+    UA_UInt32 memSize     : 16; /* Size of the struct in memory */
+    UA_UInt32 typeKind    : 6;  /* Dispatch index for the handling routines */
+    UA_UInt32 pointerFree : 1;  /* The type (and its members) contains no
+                                 * pointers that need to be freed */
+    UA_UInt32 overlayable : 1;  /* The type has the identical memory layout
+                                 * in memory and on the binary stream. */
+    UA_UInt32 membersSize : 8;  /* How many members does the type have? */
+    UA_DataTypeMember *members;
 };
 
 /* Test if the data type is a numeric builtin data type. This includes Boolean,
@@ -1162,16 +1152,13 @@ UA_Guid UA_EXPORT UA_Guid_random(void);     /* no cryptographic entropy */
 /* The following is used to exclude type names in the definition of UA_DataType
  * structures if the feature is disabled. */
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-# define UA_TYPENAME(name) , name
+# define UA_TYPENAME(name) name,
 #else
 # define UA_TYPENAME(name)
 #endif
 
 /* Datatype arrays with custom type definitions can be added in a linked list to
- * the client or server configuration. Datatype members can point to types in
- * the same array via the ``memberTypeIndex``. If ``namespaceZero`` is set to
- * true, the member datatype is looked up in the array of builtin datatypes
- * instead. */
+ * the client or server configuration. */
 typedef struct UA_DataTypeArray {
     const struct UA_DataTypeArray *next;
     const size_t typesSize;

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -157,13 +157,13 @@ UA_Server_addWriterGroup(UA_Server *server, const UA_NodeId connection,
     if (writerGroupConfig->messageSettings.content.decoded.type) {
         if (writerGroupConfig->encodingMimeType == UA_PUBSUB_ENCODING_JSON &&
                 (writerGroupConfig->messageSettings.encoding != UA_EXTENSIONOBJECT_DECODED
-                || writerGroupConfig->messageSettings.content.decoded.type->typeIndex != UA_TYPES_JSONWRITERGROUPMESSAGEDATATYPE) ) {
+                || writerGroupConfig->messageSettings.content.decoded.type != &UA_TYPES[UA_TYPES_JSONWRITERGROUPMESSAGEDATATYPE]) ) {
             return UA_STATUSCODE_BADTYPEMISMATCH;
         }
 
         if (writerGroupConfig->encodingMimeType == UA_PUBSUB_ENCODING_UADP &&
                 (writerGroupConfig->messageSettings.encoding != UA_EXTENSIONOBJECT_DECODED
-                        || writerGroupConfig->messageSettings.content.decoded.type->typeIndex != UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE) ) {
+                        || writerGroupConfig->messageSettings.content.decoded.type != &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE]) ) {
             return UA_STATUSCODE_BADTYPEMISMATCH;
         }
     }
@@ -623,8 +623,8 @@ generateFieldMetaData(UA_Server *server, UA_DataSetField *field,
                 UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                                "MetaData creation. Found DataType %s.", currentDataType->typeName);
                 //check if the datatype is a builtInType, if yes set the builtinType
-                if(currentDataType->typeIndex <= 135)
-                    fieldMetaData->builtInType = (UA_Byte)currentDataType->typeIndex;
+                if(currentDataType->typeKind <= UA_DATATYPEKIND_ENUM)
+                    fieldMetaData->builtInType = (UA_Byte)currentDataType->typeKind;
             } else {
                 UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER,
                                "PubSub meta data generation. DataType Node is UA_NODEID_NULL.");

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -317,7 +317,6 @@ getStructureDefinition(const UA_DataType *type, UA_StructureDefinition *def) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 
-    const UA_DataType *typelists[2] = {UA_TYPES, &type[-type->typeIndex]};
     for(size_t cnt = 0; cnt < def->fieldsSize; cnt++) {
         const UA_DataTypeMember *m = &type->members[cnt];
         def->fields[cnt].valueRank = UA_TRUE == m->isArray ? 1 : -1;
@@ -326,7 +325,7 @@ getStructureDefinition(const UA_DataType *type, UA_StructureDefinition *def) {
         def->fields[cnt].name = UA_STRING((char *)(uintptr_t)m->memberName);
         def->fields[cnt].description.locale = UA_STRING_NULL;
         def->fields[cnt].description.text = UA_STRING_NULL;
-        def->fields[cnt].dataType = typelists[!m->namespaceZero][m->memberTypeIndex].typeId;
+        def->fields[cnt].dataType = m->memberType->typeId;
         def->fields[cnt].maxStringLength = 0;
         def->fields[cnt].isOptional = m->isOptional;
     }

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1091,10 +1091,9 @@ copyStructure(const void *src, void *dst, const UA_DataType *type) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     uintptr_t ptrs = (uintptr_t)src;
     uintptr_t ptrd = (uintptr_t)dst;
-    const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     for(size_t i = 0; i < type->membersSize; ++i) {
         const UA_DataTypeMember *m = &type->members[i];
-        const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
+        const UA_DataType *mt = m->memberType;
         ptrs += m->padding;
         ptrd += m->padding;
         if(!m->isOptional) {
@@ -1150,9 +1149,8 @@ copyUnion(const void *src, void *dst, const UA_DataType *type) {
     UA_copy((const UA_UInt32 *) ptrs, (UA_UInt32 *) ptrd, &UA_TYPES[UA_TYPES_UINT32]);
     if(selection == 0)
         return UA_STATUSCODE_GOOD;
-    const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     const UA_DataTypeMember *m = &type->members[selection-1];
-    const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
+    const UA_DataType *mt = m->memberType;
     ptrs += m->padding;
     ptrd += m->padding;
 
@@ -1226,10 +1224,9 @@ UA_copy(const void *src, void *dst, const UA_DataType *type) {
 static void
 clearStructure(void *p, const UA_DataType *type) {
     uintptr_t ptr = (uintptr_t)p;
-    const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     for(size_t i = 0; i < type->membersSize; ++i) {
         const UA_DataTypeMember *m = &type->members[i];
-        const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
+        const UA_DataType *mt = m->memberType;
         ptr += m->padding;
         if(!m->isOptional) {
             if(!m->isArray) {
@@ -1269,9 +1266,8 @@ clearUnion(void *p, const UA_DataType *type) {
     UA_UInt32 selection = *(UA_UInt32 *)ptr;
     if(selection == 0)
         return;
-    const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     const UA_DataTypeMember *m = &type->members[selection-1];
-    const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
+    const UA_DataType *mt = m->memberType;
     ptr += m->padding;
     if (m->isArray) {
         size_t length = *(size_t *)ptr;

--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -1385,10 +1385,9 @@ encodeJsonStructure(const void *src, const UA_DataType *type, CtxJson *ctx) {
 
     uintptr_t ptr = (uintptr_t) src;
     u8 membersSize = type->membersSize;
-    const UA_DataType * typelists[2] = {UA_TYPES, &type[-type->typeIndex]};
     for(size_t i = 0; i < membersSize && ret == UA_STATUSCODE_GOOD; ++i) {
         const UA_DataTypeMember *m = &type->members[i];
-        const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
+        const UA_DataType *mt = m->memberType;
 
         if(m->memberName != NULL && *m->memberName != 0)
             ret |= writeJsonKey(ctx, m->memberName);
@@ -3127,13 +3126,12 @@ decodeJsonStructure(void *dst, const UA_DataType *type, CtxJson *ctx,
     uintptr_t ptr = (uintptr_t)dst;
     status ret = UA_STATUSCODE_GOOD;
     u8 membersSize = type->membersSize;
-    const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     
     UA_STACKARRAY(DecodeEntry, entries, membersSize);
 
     for(size_t i = 0; i < membersSize && ret == UA_STATUSCODE_GOOD; ++i) {
         const UA_DataTypeMember *m = &type->members[i];
-        const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
+        const UA_DataType *mt = m->memberType;
 
         entries[i].type = mt;
         if(!m->isArray) {

--- a/src/ua_types_print.c
+++ b/src/ua_types_print.c
@@ -700,13 +700,12 @@ static UA_StatusCode
 printStructure(UA_PrintContext *ctx, const void *p, const UA_DataType *type) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     uintptr_t ptrs = (uintptr_t)p;
-    const UA_DataType *typelists[2] = { UA_TYPES, &type[-type->typeIndex] };
     retval |= UA_PrintContext_addString(ctx, "{");
     ctx->depth++;
     for(size_t i = 0; i < type->membersSize; ++i) {
         UA_PrintContext_addNewlineTabs(ctx, ctx->depth);
         const UA_DataTypeMember *m = &type->members[i];
-        const UA_DataType *mt = &typelists[!m->namespaceZero][m->memberTypeIndex];
+        const UA_DataType *mt = m->memberType;
         ptrs += m->padding;
         retval |= UA_PrintContext_addName(ctx, m->memberName);
         if(!m->isArray) {

--- a/tests/check_types_builtin_json.c
+++ b/tests/check_types_builtin_json.c
@@ -3508,7 +3508,7 @@ START_TEST(UA_Byte_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_BYTE);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTE);
     ck_assert_uint_eq(*((UA_Byte*)out.data), 0);
     
     UA_Variant_clear(&out);
@@ -3524,7 +3524,7 @@ START_TEST(UA_Byte_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_BYTE);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTE);
     ck_assert_uint_eq(*((UA_Byte*)out.data), 255);
     
     UA_Variant_clear(&out);
@@ -3542,7 +3542,7 @@ START_TEST(UA_UInt16_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_UINT16);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT16);
     ck_assert_uint_eq(*((UA_UInt16*)out.data), 0);
     
     UA_Variant_clear(&out);
@@ -3558,7 +3558,7 @@ START_TEST(UA_UInt16_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_UINT16);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT16);
     ck_assert_uint_eq(*((UA_UInt16*)out.data), 65535);
     
     UA_Variant_clear(&out);
@@ -3575,7 +3575,7 @@ START_TEST(UA_UInt32_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_UINT32);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT32);
     ck_assert_uint_eq(*((UA_UInt32*)out.data), 0);
     
     UA_Variant_clear(&out);
@@ -3591,7 +3591,7 @@ START_TEST(UA_UInt32_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_UINT32);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT32);
     ck_assert_uint_eq(*((UA_UInt32*)out.data), 4294967295);
     
     UA_Variant_clear(&out);
@@ -3608,7 +3608,7 @@ START_TEST(UA_UInt64_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_UINT64);    
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT64);    
     ck_assert_int_eq(((u8*)(out.data))[0], 0x00);
     ck_assert_int_eq(((u8*)(out.data))[1], 0x00);
     ck_assert_int_eq(((u8*)(out.data))[2], 0x00);
@@ -3631,7 +3631,7 @@ START_TEST(UA_UInt64_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_UINT64);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT64);
     ck_assert_int_eq(((u8*)(out.data))[0], 0xFF);
     ck_assert_int_eq(((u8*)(out.data))[1], 0xFF);
     ck_assert_int_eq(((u8*)(out.data))[2], 0xFF);
@@ -3668,7 +3668,7 @@ START_TEST(UA_SByte_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_SBYTE);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_SBYTE);
     ck_assert_int_eq(*((UA_SByte*)out.data), -128);
     
     UA_Variant_clear(&out);
@@ -3684,7 +3684,7 @@ START_TEST(UA_SByte_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_SBYTE);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_SBYTE);
     ck_assert_int_eq(*((UA_SByte*)out.data), 127);
     
     UA_Variant_clear(&out);
@@ -3701,7 +3701,7 @@ START_TEST(UA_Int16_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_INT16);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT16);
     ck_assert_int_eq(*((UA_Int16*)out.data), -32768);
     
     UA_Variant_clear(&out);
@@ -3717,7 +3717,7 @@ START_TEST(UA_Int16_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_INT16);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT16);
     ck_assert_int_eq(*((UA_Int16*)out.data), 32767);
     
     UA_Variant_clear(&out);
@@ -3734,7 +3734,7 @@ START_TEST(UA_Int32_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_INT32);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT32);
     ck_assert(*(UA_Int32*)out.data == -2147483648);
     
     UA_Variant_clear(&out);
@@ -3750,7 +3750,7 @@ START_TEST(UA_Int32_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_INT32);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT32);
     ck_assert_int_eq(*((UA_Int32*)out.data), 2147483647);
     
     UA_Variant_clear(&out);
@@ -3767,7 +3767,7 @@ START_TEST(UA_Int64_Min_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_INT64);    
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT64);    
     ck_assert_int_eq(((u8*)(out.data))[0], 0x00);
     ck_assert_int_eq(((u8*)(out.data))[1], 0x00);
     ck_assert_int_eq(((u8*)(out.data))[2], 0x00);
@@ -3791,7 +3791,7 @@ START_TEST(UA_Int64_Max_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_INT64);    
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT64);    
     ck_assert_int_eq(((u8*)(out.data))[0], 0xFF);
     ck_assert_int_eq(((u8*)(out.data))[1], 0xFF);
     ck_assert_int_eq(((u8*)(out.data))[2], 0xFF);
@@ -4184,7 +4184,7 @@ START_TEST(UA_String_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     ck_assert_int_eq(  ((UA_String*)out.data)->length, 6);
     ck_assert_int_eq( ((UA_String*)out.data)->data[0], 'a');
     ck_assert_int_eq(((UA_String*)out.data)->data[1], 'b');
@@ -4206,7 +4206,7 @@ START_TEST(UA_String_empty_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     ck_assert_int_eq(  ((UA_String*)out.data)->length, 0);
     ck_assert_ptr_eq(  ((UA_String*)out.data)->data, UA_EMPTY_ARRAY_SENTINEL);
 
@@ -4223,7 +4223,7 @@ START_TEST(UA_String_unescapeBS_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     ck_assert_int_eq(  ((UA_String*)out.data)->length, 7);
     ck_assert_int_eq( ((UA_String*)out.data)->data[0], 'a');
     ck_assert_int_eq(((UA_String*)out.data)->data[1], 'b');
@@ -4246,7 +4246,7 @@ START_TEST(UA_String_escape_unicode_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     ck_assert_int_eq(  ((UA_String*)out.data)->length, 1);
     ck_assert_int_eq( ((UA_String*)out.data)->data[0], ',');
     
@@ -4264,7 +4264,7 @@ START_TEST(UA_String_escape2_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     ck_assert_int_eq(  ((UA_String*)out.data)->length, 12);//  \b\th\"e\fl\nl\\o\r
     ck_assert_int_eq( ((UA_String*)out.data)->data[0], '\b');
     ck_assert_int_eq( ((UA_String*)out.data)->data[1], '\t');
@@ -4293,7 +4293,7 @@ START_TEST(UA_String_surrogatePair_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     ck_assert_int_eq(  ((UA_String*)out.data)->length, 4);//U+10000  => 0xF0 0x90 0x80 0x80
     ck_assert_uint_eq( ((UA_String*)out.data)->data[0], 0xF0);
     ck_assert_uint_eq( ((UA_String*)out.data)->data[1], 0x90);
@@ -4314,7 +4314,7 @@ START_TEST(UA_ByteString_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_BYTESTRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTESTRING);
     ck_assert_int_eq(((UA_ByteString*)out.data)->length, 8);
     ck_assert_int_eq(((UA_ByteString*)out.data)->data[0], 'a');
     ck_assert_int_eq(((UA_ByteString*)out.data)->data[1], 's');
@@ -4350,7 +4350,7 @@ START_TEST(UA_ByteString_null_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":15,\"Body\":null}");
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_BYTESTRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTESTRING);
     UA_ByteString *outData = (UA_ByteString*)out.data;
     ck_assert_ptr_ne(outData, NULL);
     ck_assert_ptr_eq(outData->data, NULL);
@@ -4369,7 +4369,7 @@ START_TEST(UA_Guid_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_GUID);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_GUID);
     ck_assert_int_eq(((UA_Guid*)out.data)->data1, 1);
     ck_assert_int_eq(((UA_Guid*)out.data)->data2, 2);
     ck_assert_int_eq(((UA_Guid*)out.data)->data3, 3);
@@ -4395,7 +4395,7 @@ START_TEST(UA_Guid_lower_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_GUID);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_GUID);
     ck_assert_int_eq(((UA_Guid*)out.data)->data1, 1);
     ck_assert_int_eq(((UA_Guid*)out.data)->data2, 2);
     ck_assert_int_eq(((UA_Guid*)out.data)->data3, 3);
@@ -4465,7 +4465,7 @@ START_TEST(UA_StatusCode_2_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STATUSCODE);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STATUSCODE);
     ck_assert_uint_eq(*((UA_StatusCode*)out.data), 2);
     
     UA_Variant_clear(&out);
@@ -4496,7 +4496,7 @@ START_TEST(UA_StatusCode_0_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STATUSCODE);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STATUSCODE);
     ck_assert_uint_eq(*((UA_StatusCode*)out.data), 0);
     UA_Variant_clear(&out);
 }
@@ -4581,7 +4581,7 @@ START_TEST(UA_QualifiedName_null_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":20,\"Body\":null}");
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_QUALIFIEDNAME);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_QUALIFIEDNAME);
     ck_assert_ptr_ne(out.data, NULL);
     UA_Variant_clear(&out);
 }
@@ -4632,7 +4632,7 @@ START_TEST(UA_LocalizedText_null_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":21,\"Body\":null}");
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_LOCALIZEDTEXT);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_LOCALIZEDTEXT);
     ck_assert_ptr_ne(out.data, NULL);
     UA_Variant_clear(&out);
 }
@@ -4977,7 +4977,7 @@ START_TEST(UA_DiagnosticInfo_null_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":25,\"Body\":null}");
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_DIAGNOSTICINFO);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_DIAGNOSTICINFO);
     ck_assert_uint_eq(((UA_DiagnosticInfo*)out.data)->hasAdditionalInfo, 0);
     ck_assert_uint_eq(((UA_DiagnosticInfo*)out.data)->hasInnerDiagnosticInfo, 0);
     ck_assert_uint_eq(((UA_DiagnosticInfo*)out.data)->hasInnerStatusCode, 0);
@@ -5012,7 +5012,7 @@ START_TEST(UA_DataValue_json_decode) {
     ck_assert_int_eq(out.hasSourceTimestamp, 1);
     ck_assert_int_eq(out.hasValue, 1);
     ck_assert_int_eq(out.status, 2153250816);
-    ck_assert_int_eq(out.value.type->typeIndex, 0);
+    ck_assert_int_eq(out.value.type->typeKind, UA_DATATYPEKIND_BOOLEAN);
     ck_assert_int_eq((*((UA_Boolean*)out.value.data)), 1);
     UA_DataValue_clear(&out);
 }
@@ -5069,7 +5069,7 @@ START_TEST(UA_ExtensionObject_json_decode) {
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.encoding, UA_EXTENSIONOBJECT_DECODED);
     ck_assert_int_eq(*((UA_Boolean*)out.content.decoded.data), UA_TRUE);
-    ck_assert_int_eq(out.content.decoded.type->typeIndex, UA_TYPES_BOOLEAN);
+    ck_assert_int_eq(out.content.decoded.type->typeKind, UA_DATATYPEKIND_BOOLEAN);
     UA_ExtensionObject_clear(&out);
 }
 END_TEST
@@ -5164,7 +5164,7 @@ START_TEST(UA_VariantBool_json_decode) {
     UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, 0);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BOOLEAN);
     ck_assert_uint_eq(*((UA_Boolean*)out.data), 0);
     UA_Variant_clear(&out);
 }
@@ -5221,7 +5221,7 @@ START_TEST(UA_VariantStringArray_json_decode) {
     ck_assert_int_eq(out->arrayDimensions[0], 2);
     ck_assert_int_eq(out->arrayDimensions[1], 4);
     ck_assert_int_eq(out->arrayLength, 8);
-    ck_assert_int_eq(out->type->typeIndex, 11);
+    ck_assert_int_eq(out->type->typeKind, UA_DATATYPEKIND_STRING);
     UA_Variant_delete(out);
 }
 END_TEST
@@ -5254,7 +5254,7 @@ START_TEST(UA_VariantStringArrayNull_json_decode) {
     ck_assert_int_eq(out.arrayDimensions[0], 2);
     ck_assert_int_eq(out.arrayDimensions[1], 4);
     ck_assert_int_eq(out.arrayLength, 8);
-    ck_assert_int_eq(out.type->typeIndex, 11);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     UA_Variant_clear(&out);
 }
 END_TEST
@@ -5288,7 +5288,7 @@ START_TEST(UA_VariantLocalizedTextArrayNull_json_decode) {
     ck_assert_int_eq(out.arrayDimensions[0], 2);
     ck_assert_int_eq(out.arrayDimensions[1], 4);
     ck_assert_int_eq(out.arrayLength, 8);
-    ck_assert_int_eq(out.type->typeIndex, 20);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_LOCALIZEDTEXT);
     UA_Variant_clear(&out);
 }
 END_TEST
@@ -5315,7 +5315,7 @@ START_TEST(UA_VariantVariantArrayNull_json_decode) {
     ck_assert_int_eq(out.arrayDimensions[0], 2);
     ck_assert_int_eq(out.arrayDimensions[1], 4);
     ck_assert_int_eq(out.arrayLength, 8);
-    ck_assert_int_eq(out.type->typeIndex, 21);
+    ck_assert_int_eq(out.type->typeKind, 21);
     UA_Variant_clear(&out);
 }
 END_TEST
@@ -5364,7 +5364,7 @@ START_TEST(UA_VariantStringArray_WithoutDimension_json_decode) {
     ck_assert_int_eq((char)testArray[7].data[0], '8');
     ck_assert_int_eq(out.arrayDimensionsSize, 0);
     ck_assert_int_eq(out.arrayLength, 8);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_STRING);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
     UA_Variant_clear(&out);
 }
 END_TEST
@@ -5389,7 +5389,7 @@ START_TEST(UA_Variant_BooleanArray_json_decode) {
     ck_assert_int_eq(testArray[2], 1);
     ck_assert_int_eq(out.arrayDimensionsSize, 0);
     ck_assert_int_eq(out.arrayLength, 3);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_BOOLEAN);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BOOLEAN);
     UA_Variant_clear(&out);
 }
 END_TEST
@@ -5421,17 +5421,13 @@ START_TEST(UA_Variant_ExtensionObjectWrap_json_decode) {
     // then
     
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(out.type->typeIndex, UA_TYPES_VIEWDESCRIPTION);
+    ck_assert(out.type == &UA_TYPES[UA_TYPES_VIEWDESCRIPTION]);
     UA_ViewDescription *vd = (UA_ViewDescription*)out.data;
     ck_assert_int_eq(vd->viewId.identifier.numeric, 99999);
     ck_assert_int_eq(vd->viewVersion, 1236);
     UA_Variant_clear(&out);
 }
 END_TEST
-
-
-
-
 
 START_TEST(UA_duplicate_json_decode) {
     // given

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -38,42 +38,45 @@ typedef struct {
 static UA_DataTypeMember members[3] = {
     /* x */
     {
-        UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since
-                            .namespaceZero is true */
-        0,               /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        false,           /* .isArray */
-        false            /* .isOptional*/
-        UA_TYPENAME("x") /* .memberName */
+        UA_TYPENAME("x")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        0,                         /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional*/
     },
 
     /* y */
     {
-        UA_TYPES_FLOAT, padding_y, true, false, false
         UA_TYPENAME("y")
+        &UA_TYPES[UA_TYPES_FLOAT],
+        padding_y,
+        false,
+        false
     },
 
     /* z */
     {
-        UA_TYPES_FLOAT, padding_z, true, false, false
         UA_TYPENAME("z")
+        &UA_TYPES[UA_TYPES_FLOAT],
+        padding_z,
+        false,
+        false
     }
 };
 
 static const UA_DataType PointType = {
+    UA_TYPENAME("Point")             /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {1}}, /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {17}}, /* .binaryEncodingId, the numeric
                                          identifier used on the wire (the
                                          namespaceindex is from .typeId) */
     sizeof(Point),                   /* .memSize */
-    0,                               /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_STRUCTURE,       /* .typeKind */
     true,                            /* .pointerFree */
     false,                           /* .overlayable (depends on endianness and
                                          the absence of padding) */
     3,                               /* .membersSize */
     members
-    UA_TYPENAME("Point")             /* .typeName */
 };
 
 const UA_DataTypeArray customDataTypes = {NULL, 1, &PointType};
@@ -87,47 +90,43 @@ typedef struct {
 static UA_DataTypeMember Opt_members[3] = {
         /* a */
         {
-                UA_TYPES_INT16,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
-                0, /* .padding */
-                true,       /* .namespaceZero, see .memberTypeIndex */
-                false,      /* .isArray */
-                false       /* .isOptional */
-                UA_TYPENAME("a") /* .memberName */
+                UA_TYPENAME("a")           /* .memberName */
+                &UA_TYPES[UA_TYPES_INT16], /* .memberType */
+                0,                         /* .padding */
+                false,                     /* .isArray */
+                false                      /* .isOptional */
         },
         /* b */
         {
-                UA_TYPES_FLOAT,
+                UA_TYPENAME("b")
+                &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
                 offsetof(Opt,b) - offsetof(Opt,a) - sizeof(UA_Int16),
-                true,
                 false,
                 true        /* b is an optional field */
-                UA_TYPENAME("b")
         },
         /* c */
         {
-                UA_TYPES_FLOAT,
+                UA_TYPENAME("c")
+                &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
                 offsetof(Opt,c) - offsetof(Opt,b) - sizeof(void *),
-                true,
                 false,
                 true        /* b is an optional field */
-                UA_TYPENAME("c")
         }
 };
 
 static const UA_DataType OptType = {
+        UA_TYPENAME("Opt")             /* .typeName */
         {1, UA_NODEIDTYPE_NUMERIC, {4242}}, /* .typeId */
         {1, UA_NODEIDTYPE_NUMERIC, {5}}, /* .binaryEncodingId, the numeric
                                          identifier used on the wire (the
                                          namespaceindex is from .typeId) */
-        sizeof(Opt),                   /* .memSize */
-        0,                               /* .typeIndex, in the array of custom types */
+        sizeof(Opt),                     /* .memSize */
         UA_DATATYPEKIND_OPTSTRUCT,       /* .typeKind */
         false,                            /* .pointerFree */
         false,                           /* .overlayable (depends on endianness and
                                          the absence of padding) */
         3,                               /* .membersSize */
         Opt_members
-        UA_TYPENAME("Opt")             /* .typeName */
 };
 
 const UA_DataTypeArray customDataTypesOptStruct = {&customDataTypes, 2, &OptType};
@@ -142,45 +141,41 @@ typedef struct {
 
 static UA_DataTypeMember ArrayOptStruct_members[3] = {
     {
-        UA_TYPES_STRING,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
-        0,               /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        false,            /* .isArray */
-        false
         UA_TYPENAME("Measurement description") /* .memberName */
-    },
-    {
-        UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
-        offsetof(OptArray, bSize) - offsetof(OptArray, description) - sizeof(UA_String),               /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        true,            /* .isArray */
-        true
-        UA_TYPENAME("TestArray1") /* .memberName */
-    },
-    {
-        UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since namespaceZero is true */
-        offsetof(OptArray, cSize) - offsetof(OptArray, b) - sizeof(void *),               /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        true,            /* .isArray */
+        &UA_TYPES[UA_TYPES_STRING],            /* .memberType */
+        0,                                     /* .padding */
+        false,                                 /* .isArray */
         false
-        UA_TYPENAME("TestArray2") /* .memberName */
+    },
+    {
+        UA_TYPENAME("TestArray1") /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        offsetof(OptArray, bSize) - offsetof(OptArray, description) - sizeof(UA_String),               /* .padding */
+        true,                      /* .isArray */
+        true
+    },
+    {
+        UA_TYPENAME("TestArray2")  /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        offsetof(OptArray, cSize) - offsetof(OptArray, b) - sizeof(void *),               /* .padding */
+        true,                      /* .isArray */
+        false
     }
 };
 
 static const UA_DataType ArrayOptType = {
+    UA_TYPENAME("OptArray")             /* .tyspeName */
     {1, UA_NODEIDTYPE_NUMERIC, {4243}},     /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {1337}}, /* .binaryEncodingId, the numeric
                                          identifier used on the wire (the
                                          namespaceindex is from .typeId) */
     sizeof(OptArray),                   /* .memSize */
-    0,                               /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_OPTSTRUCT,       /* .typeKind */
     false,                            /* .pointerFree */
     false,                           /* .overlayable (depends on endianness and
                                          the absence of padding) */
     3,                               /* .membersSize */
     ArrayOptStruct_members
-    UA_TYPENAME("OptArray")             /* .tyspeName */
 };
 
 const UA_DataTypeArray customDataTypesOptArrayStruct = {&customDataTypesOptStruct, 3, &ArrayOptType};
@@ -197,34 +192,31 @@ typedef struct {
 
 static UA_DataTypeMember Uni_members[2] = {
         {
-                UA_TYPES_DOUBLE,
+                UA_TYPENAME("optionA")
+                &UA_TYPES[UA_TYPES_DOUBLE], /* .memberType */
                 offsetof(Uni, fields.optionA),
-                true,
                 false,
                 false
-                UA_TYPENAME("optionA")
         },
         {
-                UA_TYPES_STRING,
+                UA_TYPENAME("optionB")
+                &UA_TYPES[UA_TYPES_STRING], /* .memberType */
                 offsetof(Uni, fields.optionB),
-                true,
                 false,
                 false
-                UA_TYPENAME("optionB")
         }
 };
 
 static const UA_DataType UniType = {
+        UA_TYPENAME("Uni")
         {1, UA_NODEIDTYPE_NUMERIC, {4245}},
         {1, UA_NODEIDTYPE_NUMERIC, {13338}},
         sizeof(Uni),
-        1,
         UA_DATATYPEKIND_UNION,
         false,
         false,
         2,
         Uni_members
-        UA_TYPENAME("Uni")
 };
 
 const UA_DataTypeArray customDataTypesUnion = {&customDataTypesOptArrayStruct, 2, &UniType};
@@ -248,35 +240,34 @@ struct UA_SelfContainingUnion {
     } fields;
 };
 
+extern const UA_DataType selfContainingUnionType;
+
 static UA_DataTypeMember SelfContainingUnion_members[2] = {
 {
-    UA_TYPES_DOUBLE, /* .memberTypeIndex */
+    UA_TYPENAME("_double")                            /* .memberName */
+    &UA_TYPES[UA_TYPES_DOUBLE],                       /* .memberType */
     offsetof(UA_SelfContainingUnion, fields._double), /* .padding */
-    true, /* .namespaceZero */
-    false, /* .isArray */
-    false  /* .isOptional */
-    UA_TYPENAME("_double") /* .memberName */
+    false,                                            /* .isArray */
+    false                                             /* .isOptional */
 },
 {
-    0, /* .memberTypeIndex */
-    offsetof(UA_SelfContainingUnion, fields.array), /* .padding */
-    false, /* .namespaceZero */
-    true, /* .isArray */
-    false  /* .isOptional */
-    UA_TYPENAME("Array") /* .memberName */
+    UA_TYPENAME("Array")                              /* .memberName */
+    &selfContainingUnionType,                         /* .memberType */
+    offsetof(UA_SelfContainingUnion, fields.array),   /* .padding */
+    true,                                             /* .isArray */
+    false                                             /* .isOptional */
 },};
 
-static const UA_DataType selfContainingUnionType = {
+const UA_DataType selfContainingUnionType = {
+    UA_TYPENAME("SelfContainingStruct") /* .typeName */
     {2, UA_NODEIDTYPE_NUMERIC, {4002LU}}, /* .typeId */
     {2, UA_NODEIDTYPE_NUMERIC, {0}}, /* .binaryEncodingId */
     sizeof(UA_SelfContainingUnion), /* .memSize */
-    0, /* .typeIndex */
     UA_DATATYPEKIND_UNION, /* .typeKind */
     false, /* .pointerFree */
     false, /* .overlayable */
     2, /* .membersSize */
     SelfContainingUnion_members  /* .members */
-    UA_TYPENAME("SelfContainingStruct") /* .typeName */
 };
 
 const UA_DataTypeArray customDataTypesSelfContainingUnion = {NULL, 1, &selfContainingUnionType};

--- a/tests/server/check_local_monitored_item.c
+++ b/tests/server/check_local_monitored_item.c
@@ -124,30 +124,27 @@ typedef struct {
 
 static UA_DataTypeMember members[1] = {
     {
-        UA_TYPES_FLOAT,  /* .memberTypeIndex, points into UA_TYPES since
-                            .namespaceZero is true */
-        0,               /* .padding */
-        true,            /* .namespaceZero, see .memberTypeIndex */
-        false,           /* .isArray */
-        false            /* .isOptional*/
-        UA_TYPENAME("p") /* .memberName */
+        UA_TYPENAME("p")           /* .memberName */
+        &UA_TYPES[UA_TYPES_FLOAT], /* .memberType */
+        0,                         /* .padding */
+        false,                     /* .isArray */
+        false                      /* .isOptional*/
     }
 };
 
 static UA_DataType PointType = {
+    UA_TYPENAME("Point")             /* .typeName */
     {1, UA_NODEIDTYPE_NUMERIC, {0}}, /* .typeId */
     {1, UA_NODEIDTYPE_NUMERIC, {0}}, /* .binaryEncodingId, the numeric
                                          identifier used on the wire (the
                                          namespaceindex is from .typeId) */
     sizeof(Point),                   /* .memSize */
-    0,                               /* .typeIndex, in the array of custom types */
     UA_DATATYPEKIND_STRUCTURE,       /* .typeKind */
     true,                            /* .pointerFree */
     false,                           /* .overlayable (depends on endianness and
                                          the absence of padding) */
     1,                               /* .membersSize */
     members
-    UA_TYPENAME("Point")             /* .typeName */
 };
 
 UA_DataTypeArray customDataTypes = {NULL, 1, &PointType};

--- a/tests/server/check_services_attributes.c
+++ b/tests/server/check_services_attributes.c
@@ -623,7 +623,7 @@ START_TEST(ReadSingleAttributeDataTypeDefinitionWithoutTimestamp) {
 
 #ifdef UA_ENABLE_TYPEDESCRIPTION
     ck_assert_int_eq(UA_STATUSCODE_GOOD, resp.status);
-    ck_assert_uint_eq(resp.value.type->typeIndex, UA_TYPES_STRUCTUREDEFINITION);
+    ck_assert(resp.value.type == &UA_TYPES[UA_TYPES_STRUCTUREDEFINITION]);
     UA_StructureDefinition *def = (UA_StructureDefinition*)resp.value.data;
     ck_assert_uint_eq(def->fieldsSize, 5);
 #else


### PR DESCRIPTION
This PR is based on #4408 and the major work is done by @Johnsik. This PR is intended to fix the mentioned problems in the original PR and cleans up the history.

Currently DataTypes con only contain members of a type, which is declared in ns0 or the same ns like the DataType. This restriction is based on the use of an index which refers to the right type entry in the types array. This PR replaces this index and use a pointer which can now also point to other type arrays.


