### PR TITLE
Look for HasInterface references in the type hierarchy

### DIFF
--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -297,8 +297,8 @@ getParentTypeAndInterfaceHierarchy(UA_Server *server, const UA_NodeId *typeNode,
 
 /* Returns the recursive interface hierarchy of the node */
 UA_StatusCode
-getInterfaceHierarchy(UA_Server *server, const UA_NodeId *objectNode,
-                                   UA_NodeId **typeHierarchy, size_t *typeHierarchySize);
+getAllInterfaceChildNodeIds(UA_Server *server, const UA_NodeId *objectNode, const UA_NodeId *objectTypeNode,
+                                   UA_NodeId **interfaceChildNodes, size_t *interfaceChildNodesSize);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
 

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -151,43 +151,117 @@ getParentTypeAndInterfaceHierarchy(UA_Server *server, const UA_NodeId *typeNode,
 }
 
 UA_StatusCode
-getInterfaceHierarchy(UA_Server *server, const UA_NodeId *objectNode,
-                                   UA_NodeId **typeHierarchy, size_t *typeHierarchySize) {
-    UA_ReferenceTypeSet reftypes_interface =
-        UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASINTERFACE);
-    UA_ExpandedNodeId *interfaces = NULL;
-    size_t interfacesSize = 0;
-    UA_StatusCode retval = browseRecursive(server, 1, objectNode, UA_BROWSEDIRECTION_FORWARD,
-                                           &reftypes_interface, UA_NODECLASS_UNSPECIFIED,
-                                           false, &interfacesSize, &interfaces);
-    if(retval != UA_STATUSCODE_GOOD) {
+getAllInterfaceChildNodeIds(UA_Server *server, const UA_NodeId *objectNode,
+                            const UA_NodeId *objectTypeNode,
+                            UA_NodeId **interfaceChildNodes, size_t *interfaceChildNodesSize) {
+    *interfaceChildNodesSize = 0;
+    *interfaceChildNodes = NULL;
+
+    UA_ExpandedNodeId *hasInterfaceCandidates = NULL;
+    size_t hasInterfaceCandidatesSize = 0;
+    UA_ReferenceTypeSet reftypes_subtype =
+        UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASSUBTYPE);
+
+    /* Don't include the start node */
+    UA_StatusCode retval = browseRecursive(server, 1, objectTypeNode, UA_BROWSEDIRECTION_INVERSE,
+                                           &reftypes_subtype, UA_NODECLASS_OBJECTTYPE,
+                                           false, &hasInterfaceCandidatesSize,
+                                           &hasInterfaceCandidates);
+
+    if (retval != UA_STATUSCODE_GOOD)
         return retval;
-    }
 
-    UA_assert(interfacesSize < 1000);
+    /* The interface could also have been added manually before calling UA_Server_addNode_finish
+     * This can be handled by adding the object node as a start node for the HasInterface lookup */
+    UA_ExpandedNodeId *resizedHasInterfaceCandidates =
+            (UA_ExpandedNodeId*)UA_realloc(hasInterfaceCandidates,
+                                           (hasInterfaceCandidatesSize + 1) * sizeof(UA_ExpandedNodeId));
 
-    if (interfacesSize == 0) {
-        *typeHierarchySize = 0;
-        return UA_STATUSCODE_GOOD;
-    }
-
-    UA_NodeId *hierarchy = (UA_NodeId*)
-        UA_malloc(sizeof(UA_NodeId) * (interfacesSize));
-    if(!hierarchy) {
-        UA_Array_delete(interfaces, interfacesSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    if (!resizedHasInterfaceCandidates) {
+        if (hasInterfaceCandidates)
+            UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                            &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 
-    for(size_t i = 0; i < interfacesSize; i++) {
-        hierarchy[i] = interfaces[i].nodeId;
-        UA_NodeId_init(&interfaces[i].nodeId);
+    hasInterfaceCandidates = resizedHasInterfaceCandidates;
+    hasInterfaceCandidatesSize += 1;
+    UA_ExpandedNodeId_init(&hasInterfaceCandidates[hasInterfaceCandidatesSize - 1]);
+
+    UA_ExpandedNodeId_init(&hasInterfaceCandidates[hasInterfaceCandidatesSize - 1]);
+    UA_NodeId_copy(objectNode, &hasInterfaceCandidates[hasInterfaceCandidatesSize - 1].nodeId);
+
+    size_t outputIndex = 0;
+
+    for (size_t i = 0; i < hasInterfaceCandidatesSize; ++i) {
+        UA_ReferenceTypeSet reftypes_interface =
+            UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASINTERFACE);
+        UA_ExpandedNodeId *interfaceChildren = NULL;
+        size_t interfacesChildrenSize = 0;
+        retval = browseRecursive(server, 1, &hasInterfaceCandidates[i].nodeId,
+                                 UA_BROWSEDIRECTION_FORWARD,
+                                 &reftypes_interface, UA_NODECLASS_OBJECTTYPE,
+                                 false, &interfacesChildrenSize, &interfaceChildren);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                            &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+            if (interfaceChildNodesSize) {
+                UA_Array_delete(*interfaceChildNodes, *interfaceChildNodesSize,
+                                &UA_TYPES[UA_TYPES_NODEID]);
+                *interfaceChildNodesSize = 0;
+            }
+            return retval;
+        }
+
+        UA_assert(interfacesChildrenSize < 1000);
+
+        if (interfacesChildrenSize == 0) {
+            continue;
+        }
+
+        if (!*interfaceChildNodes) {
+            *interfaceChildNodes = (UA_NodeId*)
+                UA_calloc(interfacesChildrenSize, sizeof(UA_NodeId));
+            *interfaceChildNodesSize = interfacesChildrenSize;
+
+            if(!*interfaceChildNodes) {
+                UA_Array_delete(interfaceChildren, interfacesChildrenSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                return UA_STATUSCODE_BADOUTOFMEMORY;
+            }
+        } else {
+            UA_NodeId *resizedInterfaceChildNodes =
+                    (UA_NodeId*)UA_realloc(*interfaceChildNodes,
+                                           ((*interfaceChildNodesSize + interfacesChildrenSize) * sizeof(UA_NodeId)));
+
+            if (!resizedInterfaceChildNodes) {
+                UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                UA_Array_delete(interfaceChildren, interfacesChildrenSize,
+                                &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+                return UA_STATUSCODE_BADOUTOFMEMORY;
+            }
+
+            const size_t oldSize = *interfaceChildNodesSize;
+            *interfaceChildNodesSize += interfacesChildrenSize;
+            *interfaceChildNodes = resizedInterfaceChildNodes;
+
+            for (size_t j = oldSize; j < *interfaceChildNodesSize; ++j)
+                UA_NodeId_init(&(*interfaceChildNodes)[j]);
+        }
+
+        for(size_t j = 0; j < interfacesChildrenSize; j++) {
+            (*interfaceChildNodes)[outputIndex++] = interfaceChildren[j].nodeId;
+        }
+
+        UA_assert(*interfaceChildNodesSize < 1000);
+        UA_Array_delete(interfaceChildren, interfacesChildrenSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     }
 
-    *typeHierarchy = hierarchy;
-    *typeHierarchySize = interfacesSize;
+    UA_Array_delete(hasInterfaceCandidates, hasInterfaceCandidatesSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
 
-    UA_assert(*typeHierarchySize < 1000);
-    UA_Array_delete(interfaces, interfacesSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     return UA_STATUSCODE_GOOD;
 }
 

--- a/src/server/ua_services.h
+++ b/src/server/ua_services.h
@@ -184,7 +184,11 @@ void Service_CloseSession(UA_Server *server, UA_SecureChannel *channel,
  *
  * AddNodes Service
  * ^^^^^^^^^^^^^^^^
- * Used to add one or more Nodes into the AddressSpace hierarchy. */
+ * Used to add one or more Nodes into the AddressSpace hierarchy.
+ * If the type or one of the supertypes has any HasInterface references
+ * (see OPC 10001-7 - Amendment 7, 4.9.2), the child nodes of the interfaces
+ * are added to the new object.
+*/
 void Service_AddNodes(UA_Server *server, UA_Session *session,
                       const UA_AddNodesRequest *request,
                       UA_AddNodesResponse *response);
@@ -192,7 +196,7 @@ void Service_AddNodes(UA_Server *server, UA_Session *session,
 /**
  * AddReferences Service
  * ^^^^^^^^^^^^^^^^^^^^^
- * Used to add one or more References to one or more Nodes. */
+ * Used to add one or more References to one or more Nodes.*/
 void Service_AddReferences(UA_Server *server, UA_Session *session,
                            const UA_AddReferencesRequest *request,
                            UA_AddReferencesResponse *response);

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -732,11 +732,11 @@ addTypeChildren(UA_Server *server, UA_Session *session,
 
 static UA_StatusCode
 addInterfaceChildren(UA_Server *server, UA_Session *session,
-                const UA_NodeHead *head) {
+                const UA_NodeHead *head, const UA_Node *type) {
     /* Get the hierarchy of the type and all its supertypes */
     UA_NodeId *hierarchy = NULL;
     size_t hierarchySize = 0;
-    UA_StatusCode retval = getInterfaceHierarchy(server, &head->nodeId,
+    UA_StatusCode retval = getAllInterfaceChildNodeIds(server, &head->nodeId, &type->head.nodeId,
                                                               &hierarchy, &hierarchySize);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
@@ -1221,9 +1221,9 @@ recursiveTypeCheckAddChildren(UA_Server *server, UA_Session *session,
         }
     }
 
-    /* Add (mandatory) child nodes from the direct HasInterface reference */
+    /* Add (mandatory) child nodes from the HasInterface references */
     if(node->head.nodeClass == UA_NODECLASS_OBJECT) {
-        retval = addInterfaceChildren(server, session, &node->head);
+        retval = addInterfaceChildren(server, session, &node->head, type);
         if(retval != UA_STATUSCODE_GOOD) {
             UA_LOG_NODEID_INFO(&node->head.nodeId,
             UA_LOG_INFO_SESSION(&server->config.logger, session,


### PR DESCRIPTION
This commit adds support for interfaces that are not directly
attached to the object type being instantiated.

fix(core): HasInterface reference on base type (#4363)