### PR TITLE
[REVIEW] fix(pubsub): mutiple readers same network message

### DIFF
--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -92,7 +92,7 @@ UA_PubSubConnection_regist(UA_Server *server, UA_NodeId *connectionIdentifier);
 
 /* Process Network Message for a ReaderGroup. But we the ReaderGroup needs to be identified first. */
 UA_StatusCode
-UA_ReaderGroup_processNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
+UA_Server_processNetworkMessage(UA_Server *server, UA_PubSubConnection *connection,
                                      UA_NetworkMessage* msg);
 
 /**********************************************/
@@ -324,10 +324,11 @@ verifyAndDecryptNetworkMessage(const UA_Logger *logger,
 #endif
 
 UA_StatusCode
-decodeNetworkMessage(const UA_Logger *logger,
-                   UA_ByteString *buffer, size_t *currentPosition,
-                   UA_NetworkMessage *currentNetworkMessage,
-                   UA_ReaderGroup *readerGroup);
+decodeNetworkMessage(UA_Server *server,
+                     const UA_Logger *logger,
+                     UA_ByteString *buffer, size_t *currentPosition,
+                     UA_NetworkMessage *currentNetworkMessage,
+                     UA_PubSubConnection *connection);
 
 UA_StatusCode
 receiveBufferedNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -1806,10 +1806,12 @@ decodeNetworkMessage(UA_Server *server,
                 #ifdef UA_DEBUG_DUMP_PKGS
                 UA_dump_hex_pkg(buffer->data, buffer->length);
                 #endif
-                break;
+                /* break out of all loops when first verify & decrypt was successful */
+                goto loops_exit;
             }
         }
     }
+loops_exit:
 
     // TODO check if warning is correct here and error code carries correct info
     UA_CHECK_WARN(processed, return UA_STATUSCODE_BADNOTFOUND, logger, UA_LOGCATEGORY_SERVER,

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -602,7 +602,7 @@ UA_Server_freezeReaderGroupConfiguration(UA_Server *server, const UA_NodeId read
     UA_DataSetReader *dataSetReader;
     UA_UInt16 dsrCount = 0;
     LIST_FOREACH(dataSetReader, &rg->readers, listEntry){
-    	dataSetReader->configurationFrozen = UA_TRUE;
+        dataSetReader->configurationFrozen = UA_TRUE;
         dsrCount++;
         /* TODO: Configuration frozen for subscribedDataSet once
          * UA_Server_DataSetReader_addTargetVariables API modified to support
@@ -1663,9 +1663,9 @@ processMessageWithReader(UA_Server *server, UA_ReaderGroup *readerGroup,
 }
 
 UA_StatusCode
-UA_ReaderGroup_processNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
+UA_Server_processNetworkMessage(UA_Server *server, UA_PubSubConnection *connection,
                                      UA_NetworkMessage* msg) {
-    if(!msg || !readerGroup)
+    if(!msg || !connection)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
     /* To Do The condition pMsg->dataSetClassIdEnabled
@@ -1678,13 +1678,17 @@ UA_ReaderGroup_processNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGr
     }
 
     UA_Boolean processed = false;
+    UA_ReaderGroup *readerGroup;
     UA_DataSetReader *reader;
+
     /* There can be several readers listening for the same network message */
-    LIST_FOREACH(reader, &readerGroup->readers, listEntry) {
-        UA_StatusCode retval = checkReaderIdentifier(server, msg, reader);
-        if(retval == UA_STATUSCODE_GOOD) {
-            processed = true;
-            processMessageWithReader(server, readerGroup, reader, msg);
+    LIST_FOREACH(readerGroup, &connection->readerGroups, listEntry) {
+        LIST_FOREACH(reader, &readerGroup->readers, listEntry) {
+            UA_StatusCode retval = checkReaderIdentifier(server, msg, reader);
+            if(retval == UA_STATUSCODE_GOOD) {
+                processed = true;
+                processMessageWithReader(server, readerGroup, reader, msg);
+            }
         }
     }
 
@@ -1763,10 +1767,11 @@ static void UA_DataSetMessage_freeDecodedPayload(UA_DataSetMessage *dsm) {
 }
 
 UA_StatusCode
-decodeNetworkMessage(const UA_Logger *logger,
+decodeNetworkMessage(UA_Server *server,
+                     const UA_Logger *logger,
                      UA_ByteString *buffer, size_t *currentPosition,
                      UA_NetworkMessage *currentNetworkMessage,
-                     UA_ReaderGroup *readerGroup) {
+                     UA_PubSubConnection *connection) {
 
 #ifdef UA_DEBUG_DUMP_PKGS
     UA_dump_hex_pkg(buffer->data, buffer->length);
@@ -1777,20 +1782,40 @@ decodeNetworkMessage(const UA_Logger *logger,
     UA_CHECK_STATUS_ERROR(rv, return rv, logger, UA_LOGCATEGORY_SERVER,
                           "PubSub receive. decoding headers failed");
 
-#ifdef UA_ENABLE_PUBSUB_ENCRYPTION
-    rv = verifyAndDecryptNetworkMessage(logger,
-                                        buffer,
-                                        currentPosition,
-                                        currentNetworkMessage,
-                                        readerGroup);
-    UA_CHECK_STATUS_WARN(rv, return rv, logger, UA_LOGCATEGORY_SERVER,
-                         "Subscribe failed. verify and decrypt network message failed.");
 
-    #ifdef UA_DEBUG_DUMP_PKGS
-    UA_dump_hex_pkg(buffer->data, buffer->length);
+    #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
+    UA_Boolean processed = false;
+    UA_ReaderGroup *readerGroup;
+    UA_DataSetReader *reader;
+
+    /* choose a correct readergroup for decrypt/verify this message
+     * (there could be multiple) */
+    LIST_FOREACH(readerGroup, &connection->readerGroups, listEntry) {
+        LIST_FOREACH(reader, &readerGroup->readers, listEntry) {
+            UA_StatusCode retval = checkReaderIdentifier(server, currentNetworkMessage, reader);
+            if(retval == UA_STATUSCODE_GOOD) {
+                processed = true;
+                rv = verifyAndDecryptNetworkMessage(logger,
+                                                    buffer,
+                                                    currentPosition,
+                                                    currentNetworkMessage,
+                                                    readerGroup);
+                UA_CHECK_STATUS_WARN(rv, return rv, logger, UA_LOGCATEGORY_SERVER,
+                                     "Subscribe failed. verify and decrypt network message failed.");
+
+                #ifdef UA_DEBUG_DUMP_PKGS
+                UA_dump_hex_pkg(buffer->data, buffer->length);
+                #endif
+                break;
+            }
+        }
+    }
+
+    // TODO check if warning is correct here and error code carries correct info
+    UA_CHECK_WARN(processed, return UA_STATUSCODE_BADNOTFOUND, logger, UA_LOGCATEGORY_SERVER,
+            "Subscribe failed. no readergroup found to decrypt/verify the network message")
+
     #endif
-
-#endif
 
     rv = UA_NetworkMessage_decodePayload(buffer, currentPosition, currentNetworkMessage);
     UA_CHECK_STATUS(rv, return rv);
@@ -1811,12 +1836,12 @@ decodeAndProcessNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
     memset(&currentNetworkMessage, 0, sizeof(UA_NetworkMessage));
 
     UA_StatusCode rv = UA_STATUSCODE_GOOD;
-    rv = decodeNetworkMessage(&server->config.logger, buffer, currentPosition,
-                              &currentNetworkMessage, readerGroup);
+    rv = decodeNetworkMessage(server, &server->config.logger, buffer, currentPosition,
+                              &currentNetworkMessage, connection);
     UA_CHECK_STATUS_WARN(rv, goto cleanup, &server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Subscribe failed. verify, decrypt and decode network message failed.");
 
-    rv = UA_ReaderGroup_processNetworkMessage(server, readerGroup, &currentNetworkMessage);
+    rv = UA_Server_processNetworkMessage(server, connection, &currentNetworkMessage);
     // TODO: check what action to perform on error (nothing?)
     UA_CHECK_STATUS_WARN(rv, (void)0, &server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Subscribe failed. process network message failed.");

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -28,6 +28,18 @@
 #include <mbedtls/version.h>
 #include <mbedtls/x509_crt.h>
 
+#define UA_SUBSCRIBER_PORT       4801    /* Port for Subscriber*/
+#define PUBLISH_INTERVAL         5       /* Publish interval*/
+#define PUBLISHER_ID             2234    /* Publisher Id*/
+#define DATASET_WRITER_ID        62541   /* DataSet Writer Id*/
+#define WRITER_GROUP_ID          100     /* Writer group Id  */
+#define PUBLISHER_DATA           42      /* Published data */
+#define PUBLISHVARIABLE_NODEID   1000    /* Published data nodeId */
+#define SUBSCRIBEOBJECT_NODEID   1001    /* Object nodeId */
+#define SUBSCRIBEVARIABLE_NODEID 1002    /* Subscribed data nodeId */
+#define READERGROUP_COUNT        2       /* Value to add readergroup to connection */
+#define CHECK_READERGROUP_COUNT  3       /* Value to check readergroup count */
+
 #define UA_AES128CTR_SIGNING_KEY_LENGTH 16
 #define UA_AES128CTR_KEY_LENGTH 16
 #define UA_AES128CTR_KEYNONCE_LENGTH 4
@@ -36,7 +48,7 @@ UA_Byte signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = {0};
 UA_Byte encryptingKey[UA_AES128CTR_KEY_LENGTH] = {0};
 UA_Byte keyNonce[UA_AES128CTR_KEYNONCE_LENGTH] = {0};
 UA_Server *server = NULL;
-UA_NodeId readerGroupId, connectionId;
+UA_NodeId writerGroupId, readerGroupId, connectionId;
 
 UA_Logger *logger = NULL;
 
@@ -54,7 +66,7 @@ setup(void) {
                                       &config->logger);
 
     UA_Server_run_startup(server);
-    // add 2 connections
+    // add connection
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("UADP Connection");
@@ -64,6 +76,7 @@ setup(void) {
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
+    connectionConfig.publisherId.numeric = 2234;
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
 
     logger = &server->config.logger;
@@ -130,31 +143,31 @@ hexstr_to_char(const char *hexstr) {
 #define MSG_SIG "6e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
 #define MSG_SIG_INVALID "5e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
 
-static void
-UA_Server_ReaderGroup_clear(UA_Server *uaServer, UA_ReaderGroup *readerGroup) {
-    UA_ReaderGroupConfig_clear(&readerGroup->config);
-    UA_DataSetReader *dataSetReader;
-    UA_DataSetReader *tmpDataSetReader;
-    LIST_FOREACH_SAFE(dataSetReader, &readerGroup->readers, listEntry, tmpDataSetReader) {
-        UA_Server_removeDataSetReader(uaServer, dataSetReader->identifier);
-    }
-    UA_PubSubConnection* pConn =
-        UA_PubSubConnection_findConnectionbyId(uaServer, readerGroup->linkedConnection);
-    if(pConn != NULL)
-        pConn->readerGroupsSize--;
-
-    /* Delete ReaderGroup and its members */
-    UA_String_clear(&readerGroup->config.name);
-    UA_NodeId_clear(&readerGroup->linkedConnection);
-    UA_NodeId_clear(&readerGroup->identifier);
-
-#ifdef UA_ENABLE_PUBSUB_ENCRYPTION
-    if(readerGroup->config.securityPolicy && readerGroup->securityPolicyContext) {
-        readerGroup->config.securityPolicy->deleteContext(readerGroup->securityPolicyContext);
-        readerGroup->securityPolicyContext = NULL;
-    }
-#endif
-}
+// static void
+// UA_Server_ReaderGroup_clear(UA_Server *uaServer, UA_ReaderGroup *readerGroup) {
+//     UA_ReaderGroupConfig_clear(&readerGroup->config);
+//     UA_DataSetReader *dataSetReader;
+//     UA_DataSetReader *tmpDataSetReader;
+//     LIST_FOREACH_SAFE(dataSetReader, &readerGroup->readers, listEntry, tmpDataSetReader) {
+//         UA_Server_removeDataSetReader(uaServer, dataSetReader->identifier);
+//     }
+//     UA_PubSubConnection* pConn =
+//         UA_PubSubConnection_findConnectionbyId(uaServer, readerGroup->linkedConnection);
+//     if(pConn != NULL)
+//         pConn->readerGroupsSize--;
+//
+//     /* Delete ReaderGroup and its members */
+//     UA_String_clear(&readerGroup->config.name);
+//     UA_NodeId_clear(&readerGroup->linkedConnection);
+//     UA_NodeId_clear(&readerGroup->identifier);
+//
+// #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
+//     if(readerGroup->config.securityPolicy && readerGroup->securityPolicyContext) {
+//         readerGroup->config.securityPolicy->deleteContext(readerGroup->securityPolicyContext);
+//         readerGroup->securityPolicyContext = NULL;
+//     }
+// #endif
+// }
 
 /*
 static UA_ReaderGroup*
@@ -173,30 +186,91 @@ newReaderGroupWithoutSecurity(void) {
     return rgWithoutSecurity;
 } */
 
-static UA_ReaderGroup*
+static void
 newReaderGroupWithSecurity(UA_MessageSecurityMode mode) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
-    UA_ReaderGroupConfig readerGroupConfig;
-    memset(&readerGroupConfig, 0, sizeof(readerGroupConfig));
-    readerGroupConfig.name = UA_STRING("ReaderGroup");
-
-    readerGroupConfig.securityMode = mode;
-    readerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
-
+    /* Common encryption key informaton */
     UA_ByteString sk = {UA_AES128CTR_SIGNING_KEY_LENGTH, signingKey};
     UA_ByteString ek = {UA_AES128CTR_KEY_LENGTH, encryptingKey};
     UA_ByteString kn = {UA_AES128CTR_KEYNONCE_LENGTH, keyNonce};
 
-    UA_ReaderGroup *rgWithSecurity = (UA_ReaderGroup *)UA_calloc(1, sizeof(UA_ReaderGroup));
-    UA_ReaderGroupConfig_copy(&readerGroupConfig, &rgWithSecurity->config);
-    rgWithSecurity->config.securityPolicy->
-        newContext(rgWithSecurity->config.securityPolicy->policyContext,
-                   &sk, &ek, &kn,
-                   &rgWithSecurity->securityPolicyContext);
+    /* To check status after running both publisher and subscriber */
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+    UA_NodeId dataSetWriter;
+    UA_NodeId readerIdentifier;
+    UA_NodeId writerGroup;
+    UA_DataSetReaderConfig readerConfig;
 
-    return rgWithSecurity;
+    /* Reader Group */
+    UA_ReaderGroupConfig readerGroupConfig;
+    memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
+    readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
+
+    /* Reader Group Encryption settings */
+    readerGroupConfig.securityMode = mode;
+    readerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
+
+    retVal |=  UA_Server_addReaderGroup(server, connectionId, &readerGroupConfig, &readerGroupId);
+
+    /* Add the encryption key informaton for readergroup */
+    // TODO security token not necessary for readergroup (extracted from security-header)
+    UA_Server_setReaderGroupEncryptionKeys(server, readerGroupId, 1, sk, ek, kn);
+
+    /* Data Set Reader */
+    /* Parameters to filter received NetworkMessage */
+    memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
+    readerConfig.name             = UA_STRING ("DataSetReader Test");
+    UA_UInt16 publisherIdentifier = PUBLISHER_ID;
+    readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
+    readerConfig.publisherId.data = &publisherIdentifier;
+    readerConfig.writerGroupId    = WRITER_GROUP_ID;
+    readerConfig.dataSetWriterId  = DATASET_WRITER_ID;
+    /* Setting up Meta data configuration in DataSetReader */
+    UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
+    /* FilltestMetadata function in subscriber implementation */
+    UA_DataSetMetaDataType_init (pMetaData);
+    pMetaData->name       = UA_STRING ("DataSet Test");
+    /* Static definition of number of fields size to 1 to create one
+       targetVariable */
+    pMetaData->fieldsSize = 1;
+    pMetaData->fields     = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
+                                                             &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+    /* Unsigned Integer DataType */
+    UA_FieldMetaData_init (&pMetaData->fields[0]);
+    UA_NodeId_copy (&UA_TYPES[UA_TYPES_INT32].typeId,
+                    &pMetaData->fields[0].dataType);
+    pMetaData->fields[0].builtInType = UA_NS0ID_INT32;
+    pMetaData->fields[0].valueRank   = -1; /* scalar */
+    retVal |= UA_Server_addDataSetReader(server, readerGroupId, &readerConfig,
+                                         &readerIdentifier);
+
 }
+
+// static UA_ReaderGroup*
+// newReaderGroupWithSecurity1(UA_MessageSecurityMode mode) {
+//     UA_ServerConfig *config = UA_Server_getConfig(server);
+//
+//     UA_ReaderGroupConfig readerGroupConfig;
+//     memset(&readerGroupConfig, 0, sizeof(readerGroupConfig));
+//     readerGroupConfig.name = UA_STRING("ReaderGroup");
+//
+//     readerGroupConfig.securityMode = mode;
+//     readerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
+//
+//     UA_ByteString sk = {UA_AES128CTR_SIGNING_KEY_LENGTH, signingKey};
+//     UA_ByteString ek = {UA_AES128CTR_KEY_LENGTH, encryptingKey};
+//     UA_ByteString kn = {UA_AES128CTR_KEYNONCE_LENGTH, keyNonce};
+//
+//     UA_ReaderGroup *rgWithSecurity =
+//         (UA_ReaderGroup *)UA_calloc(1, sizeof(UA_ReaderGroup));
+//     UA_ReaderGroupConfig_copy(&readerGroupConfig, &rgWithSecurity->config);
+//     rgWithSecurity->config.securityPolicy->newContext(
+//         rgWithSecurity->config.securityPolicy->policyContext, &sk, &ek, &kn,
+//         &rgWithSecurity->securityPolicyContext);
+//
+//     return rgWithSecurity;
+// }
 
 // hexstr_to_char("f111ba08016400014df4030100000008b02d012e01000000da434ce02ee19922c"
 //                "6e916c8154123baa25f67288e3378d613f32039096e08a9ff14b83ea2247792ee"
@@ -259,9 +333,13 @@ START_TEST(EncodeDecodeNetworkMessage) {
 END_TEST
 */
 START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
-
-    UA_ReaderGroup *rgWithSecurity = newReaderGroupWithSecurity(
+    newReaderGroupWithSecurity(
         UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+    UA_PubSubConnection *connection =
+        UA_PubSubConnection_findConnectionbyId(server, connectionId);
+    if(!connection) {
+        ck_assert(false);
+    }
 
     const char * msg_enc = MSG_HEADER MSG_PAYLOAD_ENC MSG_SIG;
 
@@ -274,8 +352,8 @@ START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
     memset(&msg, 0, sizeof(UA_NetworkMessage));
 
     size_t currentPosition = 0;
-    UA_StatusCode rv = decodeNetworkMessage(
-        logger, &buffer, &currentPosition, &msg, rgWithSecurity);
+    UA_StatusCode rv = decodeNetworkMessage(server,
+        logger, &buffer, &currentPosition, &msg, connection);
     ck_assert(rv == UA_STATUSCODE_GOOD);
 
     const char * msg_dec_exp = MSG_HEADER MSG_PAYLOAD_DEC;
@@ -287,14 +365,20 @@ START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
 
     free(expectedData);
     free(buffer.data);
-    UA_Server_ReaderGroup_clear(server, rgWithSecurity);
-    free(rgWithSecurity);
+    // UA_Server_ReaderGroup_clear(server, rgWithSecurity);
+    // free(rgWithSecurity);
 }
 END_TEST
 
 START_TEST(InvalidSignature) {
-    UA_ReaderGroup *rgWithSecurity = newReaderGroupWithSecurity(
+    newReaderGroupWithSecurity(
         UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+    UA_PubSubConnection *connection =
+        UA_PubSubConnection_findConnectionbyId(server, connectionId);
+    if(!connection) {
+        ck_assert(false);
+    }
+
     const char * msg_enc = MSG_HEADER MSG_PAYLOAD_ENC MSG_SIG_INVALID;
 
     UA_ByteString buffer;
@@ -306,20 +390,26 @@ START_TEST(InvalidSignature) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(logger, &buffer, &currentPosition, &msg, rgWithSecurity);
+    UA_StatusCode rv = decodeNetworkMessage(server, logger, &buffer, &currentPosition, &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYCHECKSFAILED);
 
     UA_NetworkMessage_clear(&msg);
 
     free(buffer.data);
-    UA_Server_ReaderGroup_clear(server, rgWithSecurity);
-    free(rgWithSecurity);
+    // UA_Server_ReaderGroup_clear(server, rgWithSecurity);
+    // free(rgWithSecurity);
 }
 END_TEST
 
 START_TEST(InvalidSecurityModeInsufficientSig) {
-        UA_ReaderGroup *rgWithoutSecurity = newReaderGroupWithSecurity(
+        newReaderGroupWithSecurity(
             UA_MESSAGESECURITYMODE_NONE);
+        UA_PubSubConnection *connection =
+            UA_PubSubConnection_findConnectionbyId(server, connectionId);
+        if(!connection) {
+            ck_assert(false);
+        }
+
         const char * msg_enc = MSG_HEADER MSG_PAYLOAD_ENC MSG_SIG;
 
         UA_ByteString buffer;
@@ -331,20 +421,25 @@ START_TEST(InvalidSecurityModeInsufficientSig) {
 
         size_t currentPosition = 0;
 
-        UA_StatusCode rv = decodeNetworkMessage(logger, &buffer, &currentPosition, &msg, rgWithoutSecurity);
+        UA_StatusCode rv = decodeNetworkMessage(server, logger, &buffer, &currentPosition, &msg, connection);
         ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT);
 
         UA_NetworkMessage_clear(&msg);
 
         free(buffer.data);
-        UA_Server_ReaderGroup_clear(server, rgWithoutSecurity);
-        free(rgWithoutSecurity);
+        // UA_Server_ReaderGroup_clear(server, rgWithoutSecurity);
+        // free(rgWithoutSecurity);
     }
 END_TEST
 
 START_TEST(InvalidSecurityModeRejectedSig) {
-    UA_ReaderGroup *rgWithSecurity = newReaderGroupWithSecurity(
-        UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+        newReaderGroupWithSecurity(
+            UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+        UA_PubSubConnection *connection =
+            UA_PubSubConnection_findConnectionbyId(server, connectionId);
+        if(!connection) {
+            ck_assert(false);
+        }
     const char * msg_unenc = MSG_HEADER_NO_SEC MSG_PAYLOAD_DEC;
 
     UA_ByteString buffer;
@@ -356,14 +451,14 @@ START_TEST(InvalidSecurityModeRejectedSig) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(logger, &buffer, &currentPosition, &msg, rgWithSecurity);
+    UA_StatusCode rv = decodeNetworkMessage(server, logger, &buffer, &currentPosition, &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEREJECTED);
 
     UA_NetworkMessage_clear(&msg);
 
     free(buffer.data);
-    UA_Server_ReaderGroup_clear(server, rgWithSecurity);
-    free(rgWithSecurity);
+    // UA_Server_ReaderGroup_clear(server, rgWithSecurity);
+    // free(rgWithSecurity);
 }
 END_TEST
 


### PR DESCRIPTION
This is a (maybe temporary) minimally invasive fix for multiple network messages from different writergroups that arrive at the same time. For this to work the fix enables iteration over all configured readergroups and their dataset readers for decoding (verify and decrypt) and processing each network message in a current buffer.