### PR TITLE
[REVIEW] Fix receiving multiple messages in one pubsub callback

### DIFF
--- a/examples/pubsub/pubsub_subscribe_standalone.c
+++ b/examples/pubsub/pubsub_subscribe_standalone.c
@@ -26,6 +26,8 @@
 #endif
 
 UA_Boolean running = true;
+static UA_StatusCode
+customDecodeAndProcessCallback(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer);
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                 "received ctrl-c");
@@ -42,26 +44,35 @@ subscriberListen(UA_PubSubChannel *psc) {
         return retval;
     }
 
+    // UA_ClosureContext testCtx = {&buffer, 0};
+
+    UA_DecodeAndProcessClosure closure;
+    closure.ctx = NULL;
+    closure.call = customDecodeAndProcessCallback;
+
     /* Receive the message. Blocks for 100ms */
-    retval = psc->receive(psc, &buffer, NULL, 100);
-    if(retval != UA_STATUSCODE_GOOD || buffer.length == 0) {
+    return psc->receive(psc, &closure, NULL, 100);
+}
+static UA_StatusCode
+customDecodeAndProcessCallback(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer) {
+    if((*buffer).length == 0) {
         /* Workaround!! Reset buffer length. Receive can set the length to zero.
          * Then the buffer is not deleted because no memory allocation is
          * assumed.
          * TODO: Return an error code in 'receive' instead of setting the buf
          * length to zero. */
-        buffer.length = 512;
-        UA_ByteString_clear(&buffer);
+        (*buffer).length = 512;
+        UA_ByteString_clear(buffer);
         return UA_STATUSCODE_GOOD;
     }
 
     /* Decode the message */
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
-                "Message length: %lu", (unsigned long) buffer.length);
+                "Message length: %lu", (unsigned long) (*buffer).length);
     UA_NetworkMessage networkMessage;
     memset(&networkMessage, 0, sizeof(UA_NetworkMessage));
     size_t currentPosition = 0;
-    UA_NetworkMessage_decodeBinary(&buffer, &currentPosition, &networkMessage);
+    UA_NetworkMessage_decodeBinary(buffer, &currentPosition, &networkMessage);
 
     /* Is this the correct message type? */
     if(networkMessage.networkMessageType != UA_NETWORKMESSAGE_DATASET)
@@ -113,11 +124,11 @@ subscriberListen(UA_PubSubChannel *psc) {
             }
         }
     }
-    UA_ByteString_clear(&buffer);
+    UA_ByteString_clear(buffer);
 
-    cleanup:
+cleanup:
     UA_NetworkMessage_clear(&networkMessage);
-    return retval;
+    return UA_STATUSCODE_GOOD;
 }
 
 int main(int argc, char **argv) {

--- a/include/open62541/plugin/pubsub.h
+++ b/include/open62541/plugin/pubsub.h
@@ -45,6 +45,13 @@ typedef enum {
     UA_PUBSUB_CHANNEL_CLOSED
 } UA_PubSubChannelState;
 
+typedef struct _decodeAndProcessClosure {
+    void *ctx;
+    UA_StatusCode (*call)(struct _decodeAndProcessClosure *closure,
+                          UA_ByteString *buffer);
+} UA_DecodeAndProcessClosure;
+
+
 /* Interface structure between network plugin and internal implementation */
 struct UA_PubSubChannel {
     UA_UInt32 publisherId; /* unique identifier */
@@ -61,14 +68,14 @@ struct UA_PubSubChannel {
                           const UA_ByteString *buf);
 
     /* Register to an specified message source, e.g. multicast group or topic. Callback is used for mqtt. */
-    UA_StatusCode (*regist)(UA_PubSubChannel * channel, UA_ExtensionObject *transportSettings,
+    UA_StatusCode (*regist)(UA_PubSubChannel *channel, UA_ExtensionObject *transportSettings,
         void (*callback)(UA_ByteString *encodedBuffer, UA_ByteString *topic));
 
     /* Remove subscription to an specified message source, e.g. multicast group or topic */
-    UA_StatusCode (*unregist)(UA_PubSubChannel * channel, UA_ExtensionObject *transportSettings);
+    UA_StatusCode (*unregist)(UA_PubSubChannel *channel, UA_ExtensionObject *transportSettings);
 
     /* Receive messages. A regist to the message source is needed before. */
-    UA_StatusCode (*receive)(UA_PubSubChannel * channel, UA_ByteString *,
+    UA_StatusCode (*receive)(UA_PubSubChannel *channel, UA_DecodeAndProcessClosure *closure,
                              UA_ExtensionObject *transportSettings, UA_UInt32 timeout);
 
     /* Closing the connection and implicit free of the channel structures. */

--- a/include/open62541/plugin/pubsub.h
+++ b/include/open62541/plugin/pubsub.h
@@ -45,12 +45,10 @@ typedef enum {
     UA_PUBSUB_CHANNEL_CLOSED
 } UA_PubSubChannelState;
 
-typedef struct _decodeAndProcessClosure {
-    void *ctx;
-    UA_StatusCode (*call)(struct _decodeAndProcessClosure *closure,
-                          UA_ByteString *buffer);
-} UA_DecodeAndProcessClosure;
-
+typedef UA_StatusCode
+(*UA_PubSubReceiveCallback)(UA_PubSubChannel *channel,
+                            void *callbackContext,
+                            const UA_ByteString *buffer);
 
 /* Interface structure between network plugin and internal implementation */
 struct UA_PubSubChannel {
@@ -75,8 +73,11 @@ struct UA_PubSubChannel {
     UA_StatusCode (*unregist)(UA_PubSubChannel *channel, UA_ExtensionObject *transportSettings);
 
     /* Receive messages. A regist to the message source is needed before. */
-    UA_StatusCode (*receive)(UA_PubSubChannel *channel, UA_DecodeAndProcessClosure *closure,
-                             UA_ExtensionObject *transportSettings, UA_UInt32 timeout);
+    UA_StatusCode (*receive)(UA_PubSubChannel *channel,
+                             UA_ExtensionObject *transportSettings,
+                             UA_PubSubReceiveCallback receiveCallback,
+                             void *receiveCallbackContext,
+                             UA_UInt32 timeout);
 
     /* Closing the connection and implicit free of the channel structures. */
     UA_StatusCode (*close)(UA_PubSubChannel *channel);

--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -14,6 +14,9 @@
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pubsub_ethernet.h>
 
+#define RECEIVE_MSG_BUFFER_SIZE   4096
+static UA_THREAD_LOCAL UA_Byte ReceiveMsgBuffer[RECEIVE_MSG_BUFFER_SIZE];
+
 #if !defined(UA_ARCHITECTURE_POSIX) && !defined(UA_ARCHITECTURE_VXWORKS)
 /* For anything else than Linux or VxWorks which are specifically handled below,
  * depend only on headers included by the architecture layer.
@@ -1112,7 +1115,7 @@ UA_PubSubChannelEthernet_send(UA_PubSubChannel *channel,
  * @return
  */
 static UA_StatusCode
-UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *message,
+UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessClosure *closure,
                                  UA_ExtensionObject *transportSettings, UA_UInt32 timeout) {
     UA_PubSubChannelDataEthernet *channelDataEthernet =
         (UA_PubSubChannelDataEthernet *) channel->handle;
@@ -1137,11 +1140,9 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
         tmptv.tv_usec = (long int)(timeout % 1000000);
         int resultsize = UA_select(channel->sockfd+1, &fdset, NULL, NULL, &tmptv);
         if(resultsize == 0) {
-            message->length = 0;
             return UA_STATUSCODE_GOODNONCRITICALTIMEOUT;
         }
         if(resultsize == -1) {
-            message->length = 0;
             return UA_STATUSCODE_BADINTERNALERROR;
         }
     }
@@ -1168,14 +1169,16 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
      * first packet received */
     receiveFlags     = 0;
     size_t messageLength = 0;
-    size_t remainingMessageLength = 0;
-    remainingMessageLength = message->length;
 
     do {
         if(maxTimeValue < currentTimeValue) {
              retval = UA_STATUSCODE_GOODNONCRITICALTIMEOUT;
              break;
         }
+
+        UA_ByteString buffer;
+        buffer.length = RECEIVE_MSG_BUFFER_SIZE;
+        buffer.data = ReceiveMsgBuffer;
 
         struct ether_header eth_hdr;
         struct iovec        iov[2];
@@ -1186,8 +1189,8 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
 
         iov[0].iov_base = &eth_hdr;
         iov[0].iov_len  = sizeof(eth_hdr);
-        iov[1].iov_base = message->data + messageLength;
-        iov[1].iov_len  = remainingMessageLength;
+        iov[1].iov_base = buffer.data;
+        iov[1].iov_len  = RECEIVE_MSG_BUFFER_SIZE;
         msg.msg_iov     = iov;
         msg.msg_iovlen  = 2;
 
@@ -1235,7 +1238,10 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
                                            * so the packet length is less than 60bytes */
 
         messageLength = messageLength + ((size_t)dataLen - sizeof(struct ether_header));
-        remainingMessageLength -= messageLength;
+        buffer.length = messageLength;
+
+        closure->call(closure, &buffer);
+
         rcvCount++;
 #if !defined(UA_ARCHITECTURE_POSIX)
         clock_gettime(CLOCK_REALTIME, &currentTime);
@@ -1247,10 +1253,9 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_ByteString *messa
         /* The recvmsg API with MSG_DONTWAIT flag will not wait for the next packet */
         receiveFlags = MSG_DONTWAIT;
 
-    } while(remainingMessageLength >= 1496); /* 1518 bytes is the maximum size of ethernet packet
+    } while(true); /* 1518 bytes is the maximum size of ethernet packet
                                               * where 18 bytes used for header size, 4 bytes of LLC
                                               * so remaining length is 1496 */
-    message->length = messageLength;
     return retval;
 }
 

--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -1240,7 +1240,12 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessC
         messageLength = messageLength + ((size_t)dataLen - sizeof(struct ether_header));
         buffer.length = messageLength;
 
-        closure->call(closure, &buffer);
+        retval = closure->call(closure, &buffer);
+        if (retval != UA_STATUSCODE_GOOD) {
+            UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_NETWORK,
+                           "PubSub Connection decode and process failed.");
+
+        }
 
         rcvCount++;
 #if !defined(UA_ARCHITECTURE_POSIX)

--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -1115,8 +1115,11 @@ UA_PubSubChannelEthernet_send(UA_PubSubChannel *channel,
  * @return
  */
 static UA_StatusCode
-UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessClosure *closure,
-                                 UA_ExtensionObject *transportSettings, UA_UInt32 timeout) {
+UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel,
+                                 UA_ExtensionObject *transportSettings,
+                                 UA_PubSubReceiveCallback receiveCallback,
+                                 void *receiveCallbackContext,
+                                 UA_UInt32 timeout) {
     UA_PubSubChannelDataEthernet *channelDataEthernet =
         (UA_PubSubChannelDataEthernet *) channel->handle;
 
@@ -1200,8 +1203,7 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessC
                 UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                              "PubSub connection receive failed. Receive message failed.");
                 retval = UA_STATUSCODE_BADINTERNALERROR;
-            }
-            else {
+            } else {
                 retval = UA_STATUSCODE_GOOD;
             }
             break;
@@ -1240,7 +1242,7 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessC
         messageLength = messageLength + ((size_t)dataLen - sizeof(struct ether_header));
         buffer.length = messageLength;
 
-        retval = closure->call(closure, &buffer);
+        retval = receiveCallback(channel, receiveCallbackContext, &buffer);
         if (retval != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_NETWORK,
                            "PubSub Connection decode and process failed.");

--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -15,7 +15,7 @@
 #include <open62541/plugin/pubsub_ethernet.h>
 
 #define RECEIVE_MSG_BUFFER_SIZE   4096
-static UA_THREAD_LOCAL UA_Byte ReceiveMsgBuffer[RECEIVE_MSG_BUFFER_SIZE];
+static UA_THREAD_LOCAL UA_Byte ReceiveMsgBufferETH[RECEIVE_MSG_BUFFER_SIZE];
 
 #if !defined(UA_ARCHITECTURE_POSIX) && !defined(UA_ARCHITECTURE_VXWORKS)
 /* For anything else than Linux or VxWorks which are specifically handled below,
@@ -1181,7 +1181,7 @@ UA_PubSubChannelEthernet_receive(UA_PubSubChannel *channel,
 
         UA_ByteString buffer;
         buffer.length = RECEIVE_MSG_BUFFER_SIZE;
-        buffer.data = ReceiveMsgBuffer;
+        buffer.data = ReceiveMsgBufferETH;
 
         struct ether_header eth_hdr;
         struct iovec        iov[2];

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -16,7 +16,7 @@
 #include <open62541/plugin/pubsub_udp.h>
 
 #define RECEIVE_MSG_BUFFER_SIZE   4096
-static UA_THREAD_LOCAL UA_Byte ReceiveMsgBuffer[RECEIVE_MSG_BUFFER_SIZE];
+static UA_THREAD_LOCAL UA_Byte ReceiveMsgBufferUDP[RECEIVE_MSG_BUFFER_SIZE];
 
 
 /* UDP multicast network layer specific internal data */
@@ -595,7 +595,7 @@ UA_PubSubChannelUDPMC_receive(UA_PubSubChannel *channel,
         }
         UA_ByteString buffer;
         buffer.length = RECEIVE_MSG_BUFFER_SIZE;
-        buffer.data = ReceiveMsgBuffer;
+        buffer.data = ReceiveMsgBufferUDP;
 
         UA_DateTime beforeRecvTime = UA_DateTime_nowMonotonic();
         ssize_t messageLength = UA_recvfrom(channel->sockfd, buffer.data,

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -591,7 +591,14 @@ UA_PubSubChannelUDPMC_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessClos
         ssize_t messageLength = UA_recvfrom(channel->sockfd, buffer.data, RECEIVE_MSG_BUFFER_SIZE, 0, NULL, NULL);
         if(messageLength > 0){
             buffer.length = (size_t) messageLength;
-            closure->call(closure, &buffer);
+            retval = closure->call(closure, &buffer);
+
+            if (retval != UA_STATUSCODE_GOOD) {
+                    UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_NETWORK,
+                                   "PubSub Connection decode and process failed.");
+
+            }
+
         } else {
             UA_LOG_SOCKET_ERRNO_WRAP(
                 UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_NETWORK,

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -554,15 +554,12 @@ UA_PubSubChannelUDPMC_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessClos
     struct timeval tmptv;
     struct timeval receiveTime;
     fd_set fdset;
-    size_t remainingMessageLength = 0;
-    size_t dataLength = 0;
 
     memset(&tmptv, 0, sizeof(tmptv));
     memset(&receiveTime, 0, sizeof(receiveTime));
     FD_ZERO(&fdset);
     tmptv.tv_sec  = (long int)(timeout / 1000000);
     tmptv.tv_usec = (long int)(timeout % 1000000);
-    // remainingMessageLength = message->length;
     do {
         if(timeout > 0) {
             UA_fd_set(channel->sockfd, &fdset);
@@ -593,10 +590,7 @@ UA_PubSubChannelUDPMC_receive(UA_PubSubChannel *channel, UA_DecodeAndProcessClos
         UA_DateTime now = UA_DateTime_nowMonotonic();
         ssize_t messageLength = UA_recvfrom(channel->sockfd, buffer.data, RECEIVE_MSG_BUFFER_SIZE, 0, NULL, NULL);
         if(messageLength > 0){
-            dataLength += (size_t)messageLength;
-            remainingMessageLength -= (size_t)dataLength;
-            buffer.length = dataLength;
-
+            buffer.length = (size_t) messageLength;
             closure->call(closure, &buffer);
         } else {
             UA_LOG_SOCKET_ERRNO_WRAP(

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -370,7 +370,7 @@ verifyAndDecryptNetworkMessage(const UA_Logger *logger, UA_ByteString *buffer,
 /* Takes a value (and not a pointer) to the buffer. The original buffer is
    const. Internally we may adjust the length during decryption. */
 UA_StatusCode
-decodeNetworkMessage(UA_Server *server, UA_ByteString buffer, size_t *pos,
+decodeNetworkMessage(UA_Server *server, UA_ByteString *buffer, size_t *pos,
                      UA_NetworkMessage *nm, UA_PubSubConnection *connection);
 
 UA_StatusCode

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -357,20 +357,20 @@ UA_ReaderGroup_subscribeCallback(UA_Server *server, UA_ReaderGroup *readerGroup)
 #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
 UA_StatusCode
 verifyAndDecrypt(const UA_Logger *logger, UA_ByteString *buffer,
-                 const size_t *currentPosition,
-                 const UA_NetworkMessage *currentNetworkMessage,
+                 const size_t *currentPosition, const UA_NetworkMessage *nm,
                  UA_Boolean doValidate, UA_Boolean doDecrypt,
                  void *channelContext, UA_PubSubSecurityPolicy *securityPolicy);
 
 UA_StatusCode
-verifyAndDecryptNetworkMessage(const UA_Logger *logger,
-                               UA_ByteString *buffer, size_t *currentPosition,
-                               UA_NetworkMessage *currentNetworkMessage,
+verifyAndDecryptNetworkMessage(const UA_Logger *logger, UA_ByteString *buffer,
+                               size_t *currentPosition, UA_NetworkMessage *nm,
                                UA_ReaderGroup *readerGroup);
 #endif
 
+/* Takes a value (and not a pointer) to the buffer. The original buffer is
+   const. Internally we may adjust the length during decryption. */
 UA_StatusCode
-decodeNetworkMessage(UA_Server *server, UA_ByteString *buffer, size_t *pos,
+decodeNetworkMessage(UA_Server *server, UA_ByteString buffer, size_t *pos,
                      UA_NetworkMessage *nm, UA_PubSubConnection *connection);
 
 UA_StatusCode

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -1237,13 +1237,13 @@ static void UA_DataSetMessage_freeDecodedPayload(UA_DataSetMessage *dsm) {
 }
 
 UA_StatusCode
-decodeNetworkMessage(UA_Server *server, UA_ByteString buffer, size_t *pos,
+decodeNetworkMessage(UA_Server *server, UA_ByteString *buffer, size_t *pos,
                      UA_NetworkMessage *nm, UA_PubSubConnection *connection) {
 #ifdef UA_DEBUG_DUMP_PKGS
     UA_dump_hex_pkg(buffer->data, buffer->length);
 #endif
 
-    UA_StatusCode rv = UA_NetworkMessage_decodeHeaders(&buffer, pos, nm);
+    UA_StatusCode rv = UA_NetworkMessage_decodeHeaders(buffer, pos, nm);
     UA_CHECK_STATUS_ERROR(rv, return rv,
                           &server->config.logger, UA_LOGCATEGORY_SERVER,
                           "PubSub receive. decoding headers failed");
@@ -1260,14 +1260,14 @@ decodeNetworkMessage(UA_Server *server, UA_ByteString buffer, size_t *pos,
             UA_StatusCode retval = checkReaderIdentifier(server, nm, reader);
             if(retval == UA_STATUSCODE_GOOD) {
                 processed = true;
-                rv = verifyAndDecryptNetworkMessage(&server->config.logger, &buffer, pos,
+                rv = verifyAndDecryptNetworkMessage(&server->config.logger, buffer, pos,
                                                     nm, readerGroup);
                 UA_CHECK_STATUS_WARN(rv, return rv,
                                      &server->config.logger, UA_LOGCATEGORY_SERVER,
                                      "Subscribe failed. verify and decrypt network message failed.");
 
 #ifdef UA_DEBUG_DUMP_PKGS
-                UA_dump_hex_pkg(buffer.data, buffer.length);
+                UA_dump_hex_pkg(buffer->data, buffer->length);
 #endif
                 /* break out of all loops when first verify & decrypt was successful */
                 goto loops_exit;
@@ -1291,10 +1291,10 @@ loops_exit:
     }
 #endif
 
-    rv = UA_NetworkMessage_decodePayload(&buffer, pos, nm);
+    rv = UA_NetworkMessage_decodePayload(buffer, pos, nm);
     UA_CHECK_STATUS(rv, return rv);
 
-    rv = UA_NetworkMessage_decodeFooters(&buffer, pos, nm);
+    rv = UA_NetworkMessage_decodeFooters(buffer, pos, nm);
     UA_CHECK_STATUS(rv, return rv);
 
     return UA_STATUSCODE_GOOD;
@@ -1304,13 +1304,13 @@ static
 UA_StatusCode
 decodeAndProcessNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
                                UA_PubSubConnection *connection,
-                               const UA_ByteString *buffer) {
+                               UA_ByteString *buffer) {
     UA_NetworkMessage nm;
     memset(&nm, 0, sizeof(UA_NetworkMessage));
     size_t currentPosition = 0;
 
     UA_StatusCode rv = UA_STATUSCODE_GOOD;
-    rv = decodeNetworkMessage(server, *buffer, &currentPosition, &nm, connection);
+    rv = decodeNetworkMessage(server, buffer, &currentPosition, &nm, connection);
     UA_CHECK_STATUS_WARN(rv, goto cleanup, &server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Subscribe failed. verify, decrypt and decode network message failed.");
 
@@ -1328,7 +1328,7 @@ static
 UA_StatusCode
 decodeAndProcessNetworkMessageRT(UA_Server *server, UA_ReaderGroup *readerGroup,
                                  UA_PubSubConnection *connection,
-                                 const UA_ByteString *buffer) {
+                                 UA_ByteString *buffer) {
 #ifdef UA_ENABLE_PUBSUB_BUFMALLOC
     useMembufAlloc();
 #endif
@@ -1380,17 +1380,19 @@ typedef struct {
 static UA_StatusCode
 decodeAndProcessFun(UA_PubSubChannel *channel, void *cbContext,
                     const UA_ByteString *buffer) {
+    UA_ByteString mutableBuffer = {buffer->length, buffer->data};
     UA_RGContext *ctx = (UA_RGContext*) cbContext;
     return decodeAndProcessNetworkMessage(ctx->server, ctx->readerGroup,
-                                          ctx->connection, buffer);
+                                          ctx->connection, &mutableBuffer);
 }
 
 static UA_StatusCode
 decodeAndProcessFunRT(UA_PubSubChannel *channel, void *cbContext,
                       const UA_ByteString *buffer) {
+    UA_ByteString mutableBuffer = {buffer->length, buffer->data};
     UA_RGContext *ctx = (UA_RGContext*) cbContext;
     return decodeAndProcessNetworkMessageRT(ctx->server, ctx->readerGroup,
-                                            ctx->connection, buffer);
+                                            ctx->connection, &mutableBuffer);
 }
 
 UA_StatusCode

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -866,7 +866,7 @@ DataSetReader_processRaw(UA_Server *server, UA_ReaderGroup *rg,
                  "Received RAW Frame");
     msg->data.keyFrameData.fieldCount = (UA_UInt16)
         dsr->config.dataSetMetaData.fieldsSize;
-    
+
     size_t offset = 0;
     for(size_t i = 0; i < dsr->config.dataSetMetaData.fieldsSize; i++) {
         /* TODO The datatype reference should be part of the internal
@@ -885,10 +885,10 @@ DataSetReader_processRaw(UA_Server *server, UA_ReaderGroup *rg,
                         (unsigned)i, UA_StatusCode_name(res));
             return;
         }
-        
+
         UA_FieldTargetVariable *tv =
             &dsr->config.subscribedDataSet.subscribedDataSetTarget.targetVariables[i];
-        
+
         if(rg->config.rtLevel == UA_PUBSUB_RT_FIXED_SIZE) {
             memcpy((**tv->externalDataValue).value.data, value, type->memSize);
             if(tv->targetVariableContext)
@@ -926,12 +926,12 @@ DataSetReader_processFixedSize(UA_Server *server, UA_ReaderGroup *rg,
     for(size_t i = 0; i < fieldCount; i++) {
         if(!msg->data.keyFrameData.dataSetFields[i].hasValue)
             continue;
-        
+
         UA_FieldTargetVariable *tv =
             &dsr->config.subscribedDataSet.subscribedDataSetTarget.targetVariables[i];
         if(tv->targetVariable.attributeId != UA_ATTRIBUTEID_VALUE)
             continue;
-        
+
         memcpy((**tv->externalDataValue).value.data,
                msg->data.keyFrameData.dataSetFields[i].value.data,
                msg->data.keyFrameData.dataSetFields[i].value.type->memSize);
@@ -940,7 +940,7 @@ DataSetReader_processFixedSize(UA_Server *server, UA_ReaderGroup *rg,
             memcpy(tv->targetVariableContext,
                    msg->data.keyFrameData.dataSetFields[i].value.data,
                    msg->data.keyFrameData.dataSetFields[i].value.type->memSize);
-        
+
         if(tv->afterWrite)
             tv->afterWrite(server, &dsr->identifier, &dsr->linkedReaderGroup,
                            &tv->targetVariable.targetNodeId,
@@ -994,10 +994,10 @@ UA_DataSetReader_process(UA_Server *server, UA_ReaderGroup *rg,
     size_t fieldCount = msg->data.keyFrameData.fieldCount;
     if(dsr->config.dataSetMetaData.fieldsSize < fieldCount)
         fieldCount = dsr->config.dataSetMetaData.fieldsSize;
-    
+
     if(dsr->config.subscribedDataSet.subscribedDataSetTarget.targetVariablesSize < fieldCount)
         fieldCount = dsr->config.subscribedDataSet.subscribedDataSetTarget.targetVariablesSize;
-    
+
     /* Process message with fixed size fields (realtime capable) */
     if(rg->config.rtLevel == UA_PUBSUB_RT_FIXED_SIZE) {
         DataSetReader_processFixedSize(server, rg, dsr, msg, fieldCount);
@@ -1006,16 +1006,16 @@ UA_DataSetReader_process(UA_Server *server, UA_ReaderGroup *rg,
 #endif
         return;
     }
-    
+
     /* Write the message fields via the write service (non realtime) */
     UA_StatusCode res = UA_STATUSCODE_GOOD;
     for(size_t i = 0; i < fieldCount; i++) {
         if(!msg->data.keyFrameData.dataSetFields[i].hasValue)
             continue;
-        
+
         UA_FieldTargetVariable *tv =
             &dsr->config.subscribedDataSet.subscribedDataSetTarget.targetVariables[i];
-        
+
         UA_WriteValue writeVal;
         UA_WriteValue_init(&writeVal);
         writeVal.attributeId = tv->targetVariable.attributeId;
@@ -1214,9 +1214,6 @@ UA_Server_processNetworkMessage(UA_Server *server, UA_PubSubConnection *connecti
 
 #define MIN_PAYLOAD_SIZE_ETHERNET 46
 
-#define RECEIVE_MSG_BUFFER_SIZE   4096
-static UA_THREAD_LOCAL UA_Byte ReceiveMsgBuffer[RECEIVE_MSG_BUFFER_SIZE];
-
 /* Delete the payload value of every decoded DataSet field */
 static void UA_DataSetMessage_freeDecodedPayload(UA_DataSetMessage *dsm) {
     if(dsm->header.fieldEncoding == UA_FIELDENCODING_VARIANT) {
@@ -1306,14 +1303,14 @@ loops_exit:
 static
 UA_StatusCode
 decodeAndProcessNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
-                               UA_PubSubConnection *connection, size_t previousPosition,
-                               UA_ByteString *buffer, size_t *currentPosition) {
-    size_t paddingBytes = 0;
+                               UA_PubSubConnection *connection,
+                               UA_ByteString *buffer) {
     UA_NetworkMessage nm;
     memset(&nm, 0, sizeof(UA_NetworkMessage));
+    size_t currentPosition = 0;
 
     UA_StatusCode rv = UA_STATUSCODE_GOOD;
-    rv = decodeNetworkMessage(server, buffer, currentPosition, &nm, connection);
+    rv = decodeNetworkMessage(server, buffer, &currentPosition, &nm, connection);
     UA_CHECK_STATUS_WARN(rv, goto cleanup, &server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Subscribe failed. verify, decrypt and decode network message failed.");
 
@@ -1321,19 +1318,6 @@ decodeAndProcessNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
     // TODO: check what action to perform on error (nothing?)
     UA_CHECK_STATUS_WARN(rv, (void)0, &server->config.logger, UA_LOGCATEGORY_SERVER,
                          "Subscribe failed. process network message failed.");
-
-    /* Minimum ethernet packet size is 64 bytes where the header size is 14
-     * bytes and FCS size is 4 bytes so remaining minimum payload size of
-     * ethernet packet is 46 bytes */
-    /* TODO: Need to handle padding bytes for UDP */
-    if((((*currentPosition) - previousPosition) < MIN_PAYLOAD_SIZE_ETHERNET) &&
-        (strncmp((const char *)connection->config->transportProfileUri.data,
-                 "http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp",
-                 (size_t)(connection->config->transportProfileUri.length)) == 0)) {
-        paddingBytes = (MIN_PAYLOAD_SIZE_ETHERNET - ((*currentPosition) - previousPosition));
-        (*currentPosition) += paddingBytes; /* During multiple receive, move the position to
-                             handle padding bytes */
-    }
 
 cleanup:
     UA_NetworkMessage_clear(&nm);
@@ -1343,22 +1327,22 @@ cleanup:
 static
 UA_StatusCode
 decodeAndProcessNetworkMessageRT(UA_Server *server, UA_ReaderGroup *readerGroup,
-                                 UA_PubSubConnection *connection, size_t previousPosition,
-                                 UA_ByteString *buffer, size_t *currentPosition) {
+                                 UA_PubSubConnection *connection,
+                                 UA_ByteString *buffer) {
 #ifdef UA_ENABLE_PUBSUB_BUFMALLOC
     useMembufAlloc();
 #endif
 
     /* Considering max DSM as 1
-     * TODO: Process with the static value source */
-    size_t paddingBytes = 0;
+    * TODO: Process with the static value source */
+    size_t currentPosition = 0;
     UA_DataSetReader *dataSetReader = LIST_FIRST(&readerGroup->readers);
     UA_NetworkMessage *nm = dataSetReader->bufferedMessage.nm;
 
     /* Decode only the necessary offset and update the networkMessage */
     UA_StatusCode res =
         UA_NetworkMessage_updateBufferedNwMessage(&dataSetReader->bufferedMessage,
-                                                  buffer, currentPosition);
+                                                  buffer, &currentPosition);
     if(res != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO(&server->config.logger, UA_LOGCATEGORY_SERVER,
                     "PubSub receive. Unknown field type.");
@@ -1379,20 +1363,6 @@ decodeAndProcessNetworkMessageRT(UA_Server *server, UA_ReaderGroup *readerGroup,
     UA_DataSetReader_process(server, readerGroup, dataSetReader,
                              nm->payload.dataSetPayload.dataSetMessages);
 
-    /* Minimum ethernet packet size is 64 bytes where the header size is 14
-     * bytes and FCS size is 4 bytes so remaining minimum payload size of
-     * ethernet packet is 46 bytes */
-    /* TODO: Need to handle padding bytes for UDP */
-    if(((*currentPosition - previousPosition) < MIN_PAYLOAD_SIZE_ETHERNET) &&
-       (strncmp((const char *)connection->config->transportProfileUri.data,
-                "http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp",
-                (size_t)(connection->config->transportProfileUri.length)) == 0)) {
-        paddingBytes =
-            (MIN_PAYLOAD_SIZE_ETHERNET - ((*currentPosition) - previousPosition));
-        (*currentPosition) += paddingBytes; /* During multiple receive, move the position
-                                               to handle padding bytes */
-    }
-
  cleanup:
     UA_DataSetMessage_freeDecodedPayload(nm->payload.dataSetPayload.dataSetMessages);
 #ifdef UA_ENABLE_PUBSUB_BUFMALLOC
@@ -1401,15 +1371,42 @@ decodeAndProcessNetworkMessageRT(UA_Server *server, UA_ReaderGroup *readerGroup,
     return res;
 }
 
+typedef struct {
+    UA_Server *server;
+    UA_PubSubConnection *connection;
+    UA_ReaderGroup *readerGroup;
+} UA_ClosureContext;
+
+static
+UA_StatusCode closureDecodeAndProcessFun(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer) {
+
+    UA_ClosureContext *ctx = (UA_ClosureContext*) closure->ctx;
+    return decodeAndProcessNetworkMessage(ctx->server, ctx->readerGroup, ctx->connection, buffer);
+}
+static
+UA_StatusCode closureDecodeAndProcessFunRT(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer) {
+
+    UA_ClosureContext *ctx = (UA_ClosureContext*) closure->ctx;
+    return decodeAndProcessNetworkMessageRT(ctx->server, ctx->readerGroup, ctx->connection, buffer);
+}
+
 UA_StatusCode
 receiveBufferedNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
                               UA_PubSubConnection *connection) {
-    UA_ByteString buffer;
-    buffer.length = RECEIVE_MSG_BUFFER_SIZE;
-    buffer.data = ReceiveMsgBuffer;
+    UA_ClosureContext ctx = {server, connection, readerGroup};
+
+    UA_DecodeAndProcessClosure closure;
+    closure.ctx = &ctx;
+    closure.call = closureDecodeAndProcessFun;
+
+    if(readerGroup->config.rtLevel == UA_PUBSUB_RT_FIXED_SIZE) {
+        closure.call = closureDecodeAndProcessFunRT;
+    } else {
+        closure.call = closureDecodeAndProcessFun;
+    }
 
     UA_StatusCode rv =
-        connection->channel->receive(connection->channel, &buffer, NULL,
+        connection->channel->receive(connection->channel, &closure, NULL,
                                      readerGroup->config.timeout);
 
     // TODO attention: here rv is ok if UA_STATUSCODE_GOOD != rv
@@ -1417,31 +1414,6 @@ receiveBufferedNetworkMessage(UA_Server *server, UA_ReaderGroup *readerGroup,
                   &server->config.logger, UA_LOGCATEGORY_SERVER,
                   "SubscribeCallback(): Connection receive failed!");
 
-    UA_StatusCode (*decodeAndProcessNetworkMessageFun)(UA_Server *server,
-                                                       UA_ReaderGroup *readerGroup,
-                                                       UA_PubSubConnection *connection,
-                                                       size_t previousPosition,
-                                                       UA_ByteString *buffer,
-                                                       size_t *currentPosition) = NULL;
-    if(readerGroup->config.rtLevel == UA_PUBSUB_RT_FIXED_SIZE) {
-        decodeAndProcessNetworkMessageFun = decodeAndProcessNetworkMessageRT;
-    } else {
-        decodeAndProcessNetworkMessageFun = decodeAndProcessNetworkMessage;
-    }
-
-    size_t currentPosition = 0;
-    size_t previousPosition = 0;
-    while(buffer.length > currentPosition) {
-        rv = decodeAndProcessNetworkMessageFun(server, readerGroup, connection,
-                                               previousPosition, &buffer,
-                                               &currentPosition);
-        if(rv != UA_STATUSCODE_BADNOTFOUND || previousPosition == currentPosition) {
-            UA_CHECK_STATUS_WARN(rv, return rv,
-                                 &server->config.logger, UA_LOGCATEGORY_SERVER,
-                                 "SubscribeCallback(): receive message failed");
-        }
-        previousPosition = currentPosition;
-    }
     return UA_STATUSCODE_GOOD;
 }
 

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -139,7 +139,10 @@ hexstr_to_char(const char *hexstr) {
 #define MSG_HEADER "f111ba08016400014df4030100000008b02d012e01000000"
 #define MSG_HEADER_NO_SEC "f101ba08016400014df4"
 #define MSG_PAYLOAD_ENC "da434ce02ee19922c6e916c8154123baa25f67288e3378d613f3203909"
-#define MSG_PAYLOAD_DEC "e1101054c2949f3ad701b4205f69841e5f6901000d7657c2949F3ad701"
+#define MSG_PAYLOAD_DEC "e1101054c2949f3a" \
+                        "d701b4205f69841e" \
+                        "5f6901000d7657c2" \
+                        "949F3ad701"
 #define MSG_SIG "6e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
 #define MSG_SIG_INVALID "5e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
 
@@ -351,7 +354,7 @@ START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
     memset(&msg, 0, sizeof(UA_NetworkMessage));
 
     size_t currentPosition = 0;
-    UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
+    UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
                                             &msg, connection);
     ck_assert(rv == UA_STATUSCODE_GOOD);
 
@@ -390,7 +393,7 @@ START_TEST(InvalidSignature) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
+    UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
                                             &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYCHECKSFAILED);
 
@@ -423,7 +426,7 @@ START_TEST(InvalidSecurityModeInsufficientSig) {
 
         size_t currentPosition = 0;
 
-        UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
+        UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
                                                 &msg, connection);
         ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT);
 
@@ -455,7 +458,7 @@ START_TEST(InvalidSecurityModeRejectedSig) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
+    UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
                                             &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEREJECTED);
 

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -351,7 +351,7 @@ START_TEST(DecodeAndVerifyEncryptedNetworkMessage) {
     memset(&msg, 0, sizeof(UA_NetworkMessage));
 
     size_t currentPosition = 0;
-    UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
+    UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
                                             &msg, connection);
     ck_assert(rv == UA_STATUSCODE_GOOD);
 
@@ -390,7 +390,7 @@ START_TEST(InvalidSignature) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
+    UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
                                             &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYCHECKSFAILED);
 
@@ -423,7 +423,7 @@ START_TEST(InvalidSecurityModeInsufficientSig) {
 
         size_t currentPosition = 0;
 
-        UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
+        UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
                                                 &msg, connection);
         ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT);
 
@@ -455,7 +455,7 @@ START_TEST(InvalidSecurityModeRejectedSig) {
 
     size_t currentPosition = 0;
 
-    UA_StatusCode rv = decodeNetworkMessage(server, &buffer, &currentPosition,
+    UA_StatusCode rv = decodeNetworkMessage(server, buffer, &currentPosition,
                                             &msg, connection);
     ck_assert(rv == UA_STATUSCODE_BADSECURITYMODEREJECTED);
 

--- a/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
@@ -64,17 +64,14 @@ static void teardown(void) {
 typedef struct {
     UA_ByteString *buffer;
     size_t offset;
-} UA_ClosureContext;
+} UA_ReceiveContext;
 
-static
-UA_StatusCode closureTestFun(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer) {
-
-    UA_ClosureContext *ctx = (UA_ClosureContext*) closure->ctx;
-
+static UA_StatusCode
+recvTestFun(UA_PubSubChannel *channel, void *context, const UA_ByteString *buffer) {
+    UA_ReceiveContext *ctx = (UA_ReceiveContext*)context;
     memcpy(ctx->buffer->data + ctx->offset, buffer->data, buffer->length);
     ctx->offset += buffer->length;
     ctx->buffer->length = ctx->offset;
-
     return UA_STATUSCODE_GOOD;
 }
 
@@ -84,13 +81,9 @@ receiveMultipleMessageRT(UA_PubSubConnection *connection, UA_DataSetReader *data
     if (UA_ByteString_allocBuffer(&buffer, 4096) != UA_STATUSCODE_GOOD) {
         ck_abort_msg("Message buffer allocation failed!");
     }
-    UA_ClosureContext testCtx = {&buffer, 0};
 
-    UA_DecodeAndProcessClosure closure;
-    closure.ctx = &testCtx;
-    closure.call = closureTestFun;
-
-    connection->channel->receive(connection->channel, &closure, NULL, 1000000);
+    UA_ReceiveContext testCtx = {&buffer, 0};
+    connection->channel->receive(connection->channel, NULL, recvTestFun, &testCtx, 1000000);
     if(buffer.length > 0) {
         size_t currentPosition = 0;
         UA_UInt16  rcvCount    = 0;
@@ -133,14 +126,10 @@ static void receiveSingleMessage(UA_PubSubConnection *connection) {
         ck_abort_msg("Message buffer allocation failed!");
     }
 
-    UA_ClosureContext testCtx = {&buffer, 0};
-
-    UA_DecodeAndProcessClosure closure;
-    closure.ctx = &testCtx;
-    closure.call = closureTestFun;
-
+    UA_ReceiveContext testCtx = {&buffer, 0};
     UA_StatusCode retval =
-        connection->channel->receive(connection->channel, &closure, NULL, 1000000);
+        connection->channel->receive(connection->channel, NULL, recvTestFun,
+                                     &testCtx, 1000000);
     if(retval != UA_STATUSCODE_GOOD || buffer.length == 0) {
         buffer.length = 4096;
         UA_ByteString_clear(&buffer);

--- a/tests/pubsub/check_pubsub_publish_uadp.c
+++ b/tests/pubsub/check_pubsub_publish_uadp.c
@@ -61,12 +61,11 @@ static void teardown(void) {
 typedef struct {
     size_t counter;
     UA_NetworkMessage *msgs;
-} UA_ClosureContext;
+} UA_ReceiveContext;
 
-static
-UA_StatusCode closureTestFun(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer) {
-
-    UA_ClosureContext *ctx = (UA_ClosureContext*) closure->ctx;
+static UA_StatusCode
+recvTestFun(UA_PubSubChannel *channel, void *context, const UA_ByteString *buffer) {
+    UA_ReceiveContext *ctx = (UA_ReceiveContext*)context;
 
     // memcpy(ctx->buffer->data + ctx->offset, buffer->data, buffer->length);
     // ctx->buffer->length = buffer->length;
@@ -124,14 +123,10 @@ static void receiveAvailableMessages(UA_ByteString buffer, UA_PubSubConnection *
         ck_abort_msg("Message buffer allocation failed!");
     }
 
-    UA_ClosureContext testCtx = {0, networkMessage};
-
-    UA_DecodeAndProcessClosure closure;
-    closure.ctx = &testCtx;
-    closure.call = closureTestFun;
-
+    UA_ReceiveContext testCtx = {0, networkMessage};
     UA_StatusCode retval =
-            connection->channel->receive(connection->channel, &closure, NULL, 80000);
+        connection->channel->receive(connection->channel, NULL, recvTestFun,
+                                     &testCtx, 80000);
     if(retval != UA_STATUSCODE_GOOD || buffer.length == 0) {
         buffer.length = 512;
         UA_ByteString_clear(&buffer);

--- a/tests/pubsub/check_pubsub_publish_uadp.c
+++ b/tests/pubsub/check_pubsub_publish_uadp.c
@@ -58,26 +58,84 @@ static void teardown(void) {
     UA_Server_delete(server);
 }
 
-static void receiveSingleMessage(UA_ByteString buffer, UA_PubSubConnection *connection, UA_NetworkMessage *networkMessage) {
-    if (UA_ByteString_allocBuffer(&buffer, 512) != UA_STATUSCODE_GOOD) {
-        ck_abort_msg("Message buffer allocation failed!");
-    }
-    UA_StatusCode retval =
-            connection->channel->receive(connection->channel, &buffer, NULL, 10000);
-    if(retval != UA_STATUSCODE_GOOD || buffer.length == 0) {
-        buffer.length = 512;
-        UA_ByteString_clear(&buffer);
-        ck_abort_msg("Expected message not received!");
-    }
+typedef struct {
+    size_t counter;
+    UA_NetworkMessage *msgs;
+} UA_ClosureContext;
+
+static
+UA_StatusCode closureTestFun(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer) {
+
+    UA_ClosureContext *ctx = (UA_ClosureContext*) closure->ctx;
+
+    // memcpy(ctx->buffer->data + ctx->offset, buffer->data, buffer->length);
+    // ctx->buffer->length = buffer->length;
+    // ctx->offset += buffer->length;
+
+    UA_NetworkMessage *networkMessage = &ctx->msgs[ctx->counter];
+
     memset(networkMessage, 0, sizeof(UA_NetworkMessage));
     size_t currentPosition = 0;
-    UA_NetworkMessage_decodeBinary(&buffer, &currentPosition, networkMessage);
+    UA_NetworkMessage_decodeBinary(buffer, &currentPosition, networkMessage);
     for(int i = 0; i < networkMessage->payloadHeader.dataSetPayloadHeader.count; ++i) {
         UA_Byte * rawContent = (UA_Byte *) UA_malloc(networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.length);
         memcpy(rawContent,
                networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data,
                networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.length);
         networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data = rawContent;
+    }
+
+    ctx->counter++;
+
+    return UA_STATUSCODE_GOOD;
+}
+// static void receiveSingleMessage(UA_ByteString buffer, UA_PubSubConnection *connection, UA_NetworkMessage *networkMessage) {
+//     if (UA_ByteString_allocBuffer(&buffer, 512) != UA_STATUSCODE_GOOD) {
+//         ck_abort_msg("Message buffer allocation failed!");
+//     }
+//     UA_ClosureContext testCtx = {0, networkMessage};
+//
+//     UA_DecodeAndProcessClosure closure;
+//     closure.ctx = &testCtx;
+//     closure.call = closureTestFun;
+//
+//     UA_StatusCode retval =
+//         connection->channel->receive(connection->channel, &closure, NULL, 10000);
+//     if(retval != UA_STATUSCODE_GOOD || buffer.length == 0) {
+//         buffer.length = 512;
+//         UA_ByteString_clear(&buffer);
+//         ck_abort_msg("Expected message not received!");
+//     }
+//     memset(networkMessage, 0, sizeof(UA_NetworkMessage));
+//     size_t currentPosition = 0;
+//     UA_NetworkMessage_decodeBinary(&buffer, &currentPosition, networkMessage);
+//     for(int i = 0; i < networkMessage->payloadHeader.dataSetPayloadHeader.count; ++i) {
+//         UA_Byte * rawContent = (UA_Byte *) UA_malloc(networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.length);
+//         memcpy(rawContent,
+//                networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data,
+//                networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.length);
+//         networkMessage->payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data = rawContent;
+//     }
+//     UA_ByteString_clear(&buffer);
+// }
+
+static void receiveAvailableMessages(UA_ByteString buffer, UA_PubSubConnection *connection, UA_NetworkMessage *networkMessage) {
+    if (UA_ByteString_allocBuffer(&buffer, 512) != UA_STATUSCODE_GOOD) {
+        ck_abort_msg("Message buffer allocation failed!");
+    }
+
+    UA_ClosureContext testCtx = {0, networkMessage};
+
+    UA_DecodeAndProcessClosure closure;
+    closure.ctx = &testCtx;
+    closure.call = closureTestFun;
+
+    UA_StatusCode retval =
+            connection->channel->receive(connection->channel, &closure, NULL, 80000);
+    if(retval != UA_STATUSCODE_GOOD || buffer.length == 0) {
+        buffer.length = 512;
+        UA_ByteString_clear(&buffer);
+        ck_abort_msg("Expected message not received!");
     }
     UA_ByteString_clear(&buffer);
 }
@@ -127,7 +185,7 @@ START_TEST(CheckNMandDSMcalculation){
 
     UA_ByteString buffer = UA_BYTESTRING("");
     UA_NetworkMessage networkMessage;
-    receiveSingleMessage(buffer, connection, &networkMessage);
+    receiveAvailableMessages(buffer, connection, &networkMessage);
     //ck_assert_int_eq(networkMessage.publisherId.publisherIdUInt32 , 62541);
     ck_assert_int_eq(networkMessage.payloadHeader.dataSetPayloadHeader.count, 10);
     for(size_t i = 10; i > 0; i--){
@@ -143,19 +201,19 @@ START_TEST(CheckNMandDSMcalculation){
     //maximum DSM in one NM = 5
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 5;
     UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
-    UA_NetworkMessage networkMessage1, networkMessage2;
-    receiveSingleMessage(buffer, connection, &networkMessage1);
-    receiveSingleMessage(buffer, connection, &networkMessage2);
-    ck_assert_int_eq(networkMessage1.payloadHeader.dataSetPayloadHeader.count, 5);
-    ck_assert_int_eq(networkMessage1.payloadHeader.dataSetPayloadHeader.count, 5);
-    for(int i = 0; i < networkMessage1.payloadHeader.dataSetPayloadHeader.count; ++i) {
-        UA_Byte_delete(networkMessage1.payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
+    // UA_NetworkMessage networkMessage1, networkMessage2;
+    UA_NetworkMessage networkMessages[2];
+    receiveAvailableMessages(buffer, connection, networkMessages);
+    ck_assert_int_eq(networkMessages[0].payloadHeader.dataSetPayloadHeader.count, 5);
+    ck_assert_int_eq(networkMessages[1].payloadHeader.dataSetPayloadHeader.count, 5);
+    for(int i = 0; i < networkMessages[0].payloadHeader.dataSetPayloadHeader.count; ++i) {
+        UA_Byte_delete(networkMessages[0].payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
     }
-    UA_NetworkMessage_clear(&networkMessage1);
-    for(int i = 0; i < networkMessage2.payloadHeader.dataSetPayloadHeader.count; ++i) {
-        UA_Byte_delete(networkMessage2.payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
+    UA_NetworkMessage_clear(&networkMessages[0]);
+    for(int i = 0; i < networkMessages[1].payloadHeader.dataSetPayloadHeader.count; ++i) {
+        UA_Byte_delete(networkMessages[1].payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
     }
-    UA_NetworkMessage_clear(&networkMessage2);
+    UA_NetworkMessage_clear(&networkMessages[1]);
 
     //change publish interval triggers implicit one publish callback run | alternatively run UA_Server_iterate
     writerGroupConfig.publishingInterval = 300000;
@@ -163,7 +221,7 @@ START_TEST(CheckNMandDSMcalculation){
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 20;
     UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
     UA_NetworkMessage networkMessage3;
-    receiveSingleMessage(buffer, connection, &networkMessage3);
+    receiveAvailableMessages(buffer, connection, &networkMessage3);
     ck_assert_int_eq(networkMessage3.payloadHeader.dataSetPayloadHeader.count, 10);
 
     for(int i = 0; i < networkMessage3.payloadHeader.dataSetPayloadHeader.count; ++i) {
@@ -177,8 +235,8 @@ START_TEST(CheckNMandDSMcalculation){
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 1;
     UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
     UA_NetworkMessage messageArray[10];
+    receiveAvailableMessages(buffer, connection, messageArray);
     for (int j = 0; j < 10; ++j) {
-        receiveSingleMessage(buffer, connection, &(messageArray[j]));
         ck_assert_int_eq(messageArray[j].payloadHeader.dataSetPayloadHeader.count, 1);
         for(int i = 0; i < messageArray[j].payloadHeader.dataSetPayloadHeader.count; ++i) {
             UA_Byte_delete(messageArray[j].payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
@@ -192,8 +250,9 @@ START_TEST(CheckNMandDSMcalculation){
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 0;
     UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
     UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+
+    receiveAvailableMessages(buffer, connection, messageArray);
     for (int j = 0; j < 10; ++j) {
-        receiveSingleMessage(buffer, connection, &(messageArray[j]));
         ck_assert_int_eq(messageArray[j].payloadHeader.dataSetPayloadHeader.count, 1);
         for(int i = 0; i < messageArray[j].payloadHeader.dataSetPayloadHeader.count; ++i) {
             UA_Byte_delete(messageArray[j].payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
@@ -292,7 +351,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
 
     UA_ByteString buffer = UA_BYTESTRING("");
     UA_NetworkMessage networkMessage;
-    receiveSingleMessage(buffer, connection, &networkMessage);
+    receiveAvailableMessages(buffer, connection, &networkMessage);
     //ck_assert_int_eq(networkMessage.publisherId.publisherIdUInt32 , 62541);
     ck_assert_int_eq(networkMessage.payloadHeader.dataSetPayloadHeader.count, 10);
     for(size_t i = 10; i > 0; i--){
@@ -308,46 +367,45 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
     //maximum DSM in one NM = 5
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 5;
     UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
-    UA_NetworkMessage networkMessage1, networkMessage2;
-    receiveSingleMessage(buffer, connection, &networkMessage1);
-    receiveSingleMessage(buffer, connection, &networkMessage2);
-    ck_assert_int_eq(networkMessage1.payloadHeader.dataSetPayloadHeader.count, 5);
-    ck_assert_int_eq(networkMessage1.payloadHeader.dataSetPayloadHeader.count, 5);
-    ck_assert(networkMessage1.payload.dataSetPayload.dataSetMessages->header.fieldEncoding == UA_FIELDENCODING_RAWDATA);
-    ck_assert(networkMessage2.payload.dataSetPayload.dataSetMessages->header.fieldEncoding == UA_FIELDENCODING_RAWDATA);
-    ck_assert(networkMessage1.payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields.data != NULL);
-    ck_assert(networkMessage2.payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields.data != NULL);
+    UA_NetworkMessage networkMessages[2];
+    receiveAvailableMessages(buffer, connection, networkMessages);
+    ck_assert_int_eq(networkMessages[0].payloadHeader.dataSetPayloadHeader.count, 5);
+    ck_assert_int_eq(networkMessages[0].payloadHeader.dataSetPayloadHeader.count, 5);
+    ck_assert(networkMessages[0].payload.dataSetPayload.dataSetMessages->header.fieldEncoding == UA_FIELDENCODING_RAWDATA);
+    ck_assert(networkMessages[1].payload.dataSetPayload.dataSetMessages->header.fieldEncoding == UA_FIELDENCODING_RAWDATA);
+    ck_assert(networkMessages[0].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields.data != NULL);
+    ck_assert(networkMessages[1].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields.data != NULL);
 
     size_t offset  = 0;
     UA_DateTime dateTime;
     dateTime = 0;
-    ck_assert(UA_DateTime_decodeBinary(&networkMessage1.payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields, &offset, &dateTime) ==
+    ck_assert(UA_DateTime_decodeBinary(&networkMessages[0].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields, &offset, &dateTime) ==
               UA_STATUSCODE_GOOD);
         ck_assert_uint_le(UA_DateTime_now() - dateTime, 1000000);
     offset  = 0;
     dateTime = 0;
-    ck_assert(UA_DateTime_decodeBinary(&networkMessage2.payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields, &offset, &dateTime) ==
+    ck_assert(UA_DateTime_decodeBinary(&networkMessages[1].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields, &offset, &dateTime) ==
               UA_STATUSCODE_GOOD);
     //TODO check if the length can be set right using the metadata
     //ck_assert_uint_eq(UA_DateTime_calcSizeBinary(&dateTime),
-    //                  networkMessage2.payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields.length);
+    //                  networkMessages[1].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields.length);
         ck_assert_uint_le(UA_DateTime_now() - dateTime, 1000000);
     //Decode raw message of second DSM included in the NM
     offset  = 0;
     dateTime = 0;
-    ck_assert(UA_DateTime_decodeBinary(&networkMessage2.payload.dataSetPayload.dataSetMessages[1].data.keyFrameData.rawFields, &offset, &dateTime) ==
+    ck_assert(UA_DateTime_decodeBinary(&networkMessages[1].payload.dataSetPayload.dataSetMessages[1].data.keyFrameData.rawFields, &offset, &dateTime) ==
           UA_STATUSCODE_GOOD);
     ck_assert_uint_le(UA_DateTime_now() - dateTime, 1000000);
 
     /* add a second field to the dataset writer */
-    for(int i = 0; i < networkMessage1.payloadHeader.dataSetPayloadHeader.count; ++i) {
-        UA_Byte_delete(networkMessage1.payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
+    for(int i = 0; i < networkMessages[0].payloadHeader.dataSetPayloadHeader.count; ++i) {
+        UA_Byte_delete(networkMessages[0].payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
     }
-    for(int i = 0; i < networkMessage2.payloadHeader.dataSetPayloadHeader.count; ++i) {
-        UA_Byte_delete(networkMessage2.payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
+    for(int i = 0; i < networkMessages[1].payloadHeader.dataSetPayloadHeader.count; ++i) {
+        UA_Byte_delete(networkMessages[1].payload.dataSetPayload.dataSetMessages[i].data.keyFrameData.rawFields.data);
     }
-    UA_NetworkMessage_clear(&networkMessage1);
-    UA_NetworkMessage_clear(&networkMessage2);
+    UA_NetworkMessage_clear(&networkMessages[0]);
+    UA_NetworkMessage_clear(&networkMessages[1]);
 } END_TEST
 
 int main(void) {

--- a/tests/pubsub/check_pubsub_publish_uadp.c
+++ b/tests/pubsub/check_pubsub_publish_uadp.c
@@ -381,7 +381,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
     dateTime = 0;
     ck_assert(UA_DateTime_decodeBinary(&networkMessages[0].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields, &offset, &dateTime) ==
               UA_STATUSCODE_GOOD);
-        ck_assert_uint_le(UA_DateTime_now() - dateTime, 1000000);
+    ck_assert_uint_eq(UA_DateTime_now(), dateTime);
     offset  = 0;
     dateTime = 0;
     ck_assert(UA_DateTime_decodeBinary(&networkMessages[1].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields, &offset, &dateTime) ==
@@ -389,13 +389,13 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
     //TODO check if the length can be set right using the metadata
     //ck_assert_uint_eq(UA_DateTime_calcSizeBinary(&dateTime),
     //                  networkMessages[1].payload.dataSetPayload.dataSetMessages->data.keyFrameData.rawFields.length);
-        ck_assert_uint_le(UA_DateTime_now() - dateTime, 1000000);
+    ck_assert_uint_eq(UA_DateTime_now(), dateTime);
     //Decode raw message of second DSM included in the NM
     offset  = 0;
     dateTime = 0;
     ck_assert(UA_DateTime_decodeBinary(&networkMessages[1].payload.dataSetPayload.dataSetMessages[1].data.keyFrameData.rawFields, &offset, &dateTime) ==
           UA_STATUSCODE_GOOD);
-    ck_assert_uint_le(UA_DateTime_now() - dateTime, 1000000);
+    ck_assert_uint_eq(UA_DateTime_now(), dateTime);
 
     /* add a second field to the dataset writer */
     for(int i = 0; i < networkMessages[0].payloadHeader.dataSetPayloadHeader.count; ++i) {

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -65,21 +65,19 @@ static void teardown(void) {
 typedef struct {
     UA_ByteString *buffer;
     size_t offset;
-} UA_ClosureContext;
+} UA_ReceiveContext;
 
-static
-UA_StatusCode closureTestFun(UA_DecodeAndProcessClosure *closure, UA_ByteString *buffer) {
-
-    UA_ClosureContext *ctx = (UA_ClosureContext*) closure->ctx;
-
+static UA_StatusCode
+recvTestFun(UA_PubSubChannel *channel, void *context, const UA_ByteString *buffer) {
+    UA_ReceiveContext *ctx = (UA_ReceiveContext*)context;
     memcpy(ctx->buffer->data + ctx->offset, buffer->data, buffer->length);
     ctx->offset += buffer->length;
     ctx->buffer->length = ctx->offset;
-
     return UA_STATUSCODE_GOOD;
 }
 
-static void receiveSingleMessageRT(UA_PubSubConnection *connection, UA_DataSetReader *dataSetReader) {
+static void
+receiveSingleMessageRT(UA_PubSubConnection *connection, UA_DataSetReader *dataSetReader) {
     UA_ByteString buffer;
     if (UA_ByteString_allocBuffer(&buffer, 512) != UA_STATUSCODE_GOOD) {
         ck_abort_msg("Message buffer allocation failed!");
@@ -90,13 +88,10 @@ static void receiveSingleMessageRT(UA_PubSubConnection *connection, UA_DataSetRe
         return;
     }
 
-    UA_ClosureContext testCtx = {&buffer, 0};
-
-    UA_DecodeAndProcessClosure closure;
-    closure.ctx = &testCtx;
-    closure.call = closureTestFun;
-
-    UA_StatusCode retval = connection->channel->receive(connection->channel, &closure, NULL, 1000000);
+    UA_ReceiveContext testCtx = {&buffer, 0};
+    UA_StatusCode retval =
+        connection->channel->receive(connection->channel, NULL,
+                                     recvTestFun, &testCtx, 1000000);
     if(retval != UA_STATUSCODE_GOOD || buffer.length == 0) {
         buffer.length = 512;
         UA_ByteString_clear(&buffer);


### PR DESCRIPTION
Depends on #4565 
Depends on #4579 

### Before
Receiving multiple messages in one pubsub callback was previously done like so:

1. create a buffer
2. call a recv wrapper on that buffer:
  - fill the buffer with as much raw messages (opcua NetworkMessages) as it can carry and as are messages on the socket
3. process the buffer (decode and process all NetworkMessages)

This behavior led to the situation that the length of single messages in the buffer is unknown upon decoding. Decryption though needs this information for determining the position of the encrypted payload and signature.

### After
This pull request implements the following behavior:
  
  - call a recv wrapper on a functional closure
  - receive each message separately and decode and process with the given closure

### Other

- make `check_pubsub_publish_uadp` independent of timing issues. (use fake timer?)
  - resolved via fake timer