### PR TITLE
[Review] Fix(plugin): Openssl versions less than 1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,6 +947,7 @@ endif()
 if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_AMALGAMATION)
 list(INSERT default_plugin_sources 0
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/securitypolicy_openssl_common.h
+     ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_version_abstraction.h
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/securitypolicy_openssl_common.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_basic128rsa15.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_basic256.c

--- a/plugins/crypto/openssl/securitypolicy_openssl_common.c
+++ b/plugins/crypto/openssl/securitypolicy_openssl_common.c
@@ -27,12 +27,7 @@ modification history
 #include <openssl/pem.h>
 
 #include "securitypolicy_openssl_common.h"
-
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-#define get_pkey_rsa(evp) EVP_PKEY_get0_RSA(evp)
-#else
-#define get_pkey_rsa(evp) ((evp)->pkey.rsa)
-#endif
+#include "ua_openssl_version_abstraction.h"
 
 #define SHA1_DIGEST_LENGTH 20          /* 160 bits */
 
@@ -892,11 +887,7 @@ UA_OpenSSL_LoadPrivateKey(const UA_ByteString *privateKey) {
                                           &pkData, len);
     } else {
         BIO *bio = NULL;
-#if OPENSSL_VERSION_NUMBER < 0x1000207fL
         bio = BIO_new_mem_buf((void *) privateKey->data, (int) privateKey->length);
-#else
-        bio = BIO_new_mem_buf((const void *) privateKey->data, (int) privateKey->length);
-#endif
         result = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
         BIO_free(bio);
     }
@@ -929,11 +920,7 @@ UA_OpenSSL_LoadPemCertificate(const UA_ByteString *certificate) {
     X509 * result = NULL;
 
     BIO* bio = NULL;
-#if OPENSSL_VERSION_NUMBER < 0x1000207fL
     bio = BIO_new_mem_buf((void *) certificate->data, (int) certificate->length);
-#else
-    bio = BIO_new_mem_buf((const void *) certificate->data, (int) certificate->length);
-#endif
     result = PEM_read_bio_X509(bio, NULL, NULL, NULL);
     BIO_free(bio);
 

--- a/plugins/crypto/openssl/ua_openssl_version_abstraction.h
+++ b/plugins/crypto/openssl/ua_openssl_version_abstraction.h
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2021 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
+ *
+ */
+
+#ifndef UA_OPENSSL_VERSION_ABSTRACTION_H_
+#define UA_OPENSSL_VERSION_ABSTRACTION_H_
+
+#ifdef UA_ENABLE_ENCRYPTION_OPENSSL
+
+#include <openssl/x509.h>
+
+#if !defined(OPENSSL_VERSION_NUMBER)
+#error "OPENSSL_VERSION_NUMBER is not defined."
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define X509_STORE_CTX_set0_trusted_stack(STORE_CTX, CTX_SKTRUSTED) X509_STORE_CTX_trusted_stack(STORE_CTX, CTX_SKTRUSTED)
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+#define X509_STORE_CTX_get_check_issued(STORE_CTX) storeCtx->check_issued
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+#define get_pkey_rsa(evp) ((evp)->pkey.rsa)
+#else
+#define get_pkey_rsa(evp) EVP_PKEY_get0_RSA(evp)
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+#define X509_get0_subject_key_id(PX509_CERT) (const ASN1_OCTET_STRING *)X509_get_ext_d2i(PX509_CERT, NID_subject_key_identifier, NULL, NULL);
+#endif
+
+#endif /* UA_ENABLE_ENCRYPTION_OPENSSL */
+#endif /* UA_OPENSSL_VERSION_ABSTRACTION_H_ */

--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -18,6 +18,8 @@
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>
 
+#include "ua_openssl_version_abstraction.h"
+
 /* Find binary substring. Taken and adjusted from
  * http://tungchingkai.blogspot.com/2011/07/binary-strstr.html */
 
@@ -175,14 +177,8 @@ UA_skCrls_Cert2X509 (const UA_ByteString *   certificateRevocationList,
             crl = d2i_X509_CRL (NULL, &pData, (long) certificateRevocationList[i].length);
         } else {
             BIO* bio = NULL;
-
-#if OPENSSL_VERSION_NUMBER < 0x1000207fL
             bio = BIO_new_mem_buf((void *) certificateRevocationList[i].data,
                                   (int) certificateRevocationList[i].length);
-#else
-            bio = BIO_new_mem_buf((const void *) certificateRevocationList[i].data,
-                                  (int) certificateRevocationList[i].length);
-#endif
             crl = PEM_read_bio_X509_CRL(bio, NULL, NULL, NULL);
             BIO_free(bio);
         }
@@ -478,11 +474,9 @@ UA_CertificateVerification_Verify (void *                verificationContext,
         ret = UA_STATUSCODE_BADINTERNALERROR;
         goto cleanup;
     }
-#if OPENSSL_API_COMPAT < 0x10100000L
-	(void) X509_STORE_CTX_trusted_stack (storeCtx, ctx->skTrusted);
-#else
-	(void) X509_STORE_CTX_set0_trusted_stack (storeCtx, ctx->skTrusted);
-#endif
+
+    (void) X509_STORE_CTX_set0_trusted_stack (storeCtx, ctx->skTrusted);
+
 
     /* Set crls to ctx */
     if (sk_X509_CRL_num (ctx->skCrls) > 0) {
@@ -492,23 +486,16 @@ UA_CertificateVerification_Verify (void *                verificationContext,
     /* Set flag to check if the certificate has an invalid signature */
     X509_STORE_CTX_set_flags (storeCtx, X509_V_FLAG_CHECK_SS_SIGNATURE);
 
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-    if (X509_STORE_CTX_get_check_issued (storeCtx) (storeCtx,certificateX509, certificateX509) != 1) {
+    if (X509_STORE_CTX_get_check_issued(storeCtx) (storeCtx,certificateX509, certificateX509) != 1) {
         X509_STORE_CTX_set_flags (storeCtx, X509_V_FLAG_CRL_CHECK);
     }
-#else
-    if (storeCtx->check_issued(storeCtx,certificateX509, certificateX509) != 1) {
-        X509_STORE_CTX_set_flags (storeCtx, X509_V_FLAG_CRL_CHECK);
-    }
-#endif
 
     /* This condition will check whether the certificate is a User certificate or a CA certificate.
      * If the KU_KEY_CERT_SIGN and KU_CRL_SIGN of key_usage are set, then the certificate shall be
      * condidered as CA Certificate and cannot be used to establish a connection. Refer the test case
      * CTT/Security/Security Certificate Validation/029.js for more details */
-    uint32_t val = X509_get_key_usage(certificateX509);
-    if((val & KU_KEY_CERT_SIGN) &&
-       (val & KU_CRL_SIGN)) {
+     /** \todo Can the ca-parameter of X509_check_purpose can be used? */
+    if(X509_check_purpose(certificateX509, X509_PURPOSE_CRL_SIGN, 0) && X509_check_ca(certificateX509)) {
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
     }
 
@@ -519,11 +506,7 @@ UA_CertificateVerification_Verify (void *                verificationContext,
         /* Check if the not trusted certificate has a CRL file. If there is no CRL file available for the corresponding
          * parent certificate then return status code UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN. Refer the test
          * case CTT/Security/Security Certificate Validation/002.js */
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
         if (X509_STORE_CTX_get_check_issued (storeCtx) (storeCtx,certificateX509, certificateX509) != 1) {
-#else
-        if (storeCtx->check_issued(storeCtx,certificateX509, certificateX509) != 1) {
-#endif
             /* Free X509_STORE_CTX and reuse it for certification verification */
             if (storeCtx != NULL) {
                X509_STORE_CTX_free(storeCtx);


### PR DESCRIPTION
This cleans up the version specific openssl-Code to a separate file and fixes compatabilit with openssl 1.0 (tested on Ubuntu 16.04 Docker)

I've removes this version distinguish, as the first one works just fine with the new API:
https://github.com/open62541/open62541/blob/b82ad4df1b751e9a301102b32fea518394d00c19/plugins/crypto/openssl/ua_pki_openssl.c#L179-L185

There were some 1.0 bugs, which I tried to fix, but as I do not have CTT available, I was not able to test this.

This code does not work with 1.0, as `X509_get_key_usage` has been introduced in 1.1.
https://github.com/open62541/open62541/blob/b82ad4df1b751e9a301102b32fea518394d00c19/plugins/crypto/openssl/ua_pki_openssl.c#L509-L513

This is my replacement, which should do the same:
https://github.com/open62541/open62541/blob/4cf032d43b3413a82b9db47cd4afffcdfb982c52/plugins/crypto/openssl/ua_pki_openssl.c#L498-L500

This does also not work with 1.0:
https://github.com/open62541/open62541/blob/4cf032d43b3413a82b9db47cd4afffcdfb982c52/plugins/crypto/openssl/ua_pki_openssl.c#L555

This is the fix:
https://github.com/open62541/open62541/blob/4cf032d43b3413a82b9db47cd4afffcdfb982c52/plugins/crypto/openssl/ua_openssl_version_abstraction.h#L27-L29
