### PR TITLE
PubSub multicast configuration (encryption): process all network messages

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -1845,11 +1845,10 @@ decodeNetworkMessage(UA_Server *server,
 loops_exit:
 
     // TODO check if warning is correct here and error code carries correct info
-    if (processed == false) {
-        UA_CHECK_WARN(true, return UA_STATUSCODE_BADNOTFOUND, logger, UA_LOGCATEGORY_SERVER,
-                "Subscribe failed. no readergroup found to decrypt/verify the network message");
-    }
-    #endif // UA_ENABLE_PUBSUB_ENCRYPTION
+    UA_CHECK_WARN(processed, return UA_STATUSCODE_BADNOTFOUND, logger, UA_LOGCATEGORY_SERVER,
+            "Subscribe failed. no readergroup found to decrypt/verify the network message");
+
+    #endif
 
     rv = UA_NetworkMessage_decodePayload(buffer, currentPosition, currentNetworkMessage);
     UA_CHECK_STATUS(rv, return rv);


### PR DESCRIPTION
If there are multiple connections within a multicast group all connections receive all network messages, even if not all of networkmessages are meant for a specific connection.

Therefore it's not always an error if a DataSetReader could not be found.
We may not return an error or clear the received buffer in this case. But have to continue decoding the received data.

In the last commit 7c1b2b428314153a71d0027dcfc738828953ced7 I have searched for the cause and pushed a wrong fix, because I forgot to set the PR back to WIP.
Therefore the commit is reverted now and a new commit has been added.

In general the decodeNetworkMessage function (with encryption enabled) shall behave like UA_Server_processNetworkMessage, which only logs an information that the DataSetReader could not be found, but continues with decoding.