### PR TITLE
fix(nc): add conformance to OPC 10000-6

### DIFF
--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -408,6 +408,24 @@ class Int32(Integer):
         if xmlelement:
             self.parseXML(xmlelement)
 
+    def parseXML(self, xmlvalue):
+        Integer.parseXML(self, xmlvalue)
+        # Values of enumerations can be encoded as strings: <symbol>_<value> (see OPC specification part 6)
+        # UaModeler does this for enums that are fields of structs
+        # Extract <value> from string if possible
+        if isinstance(self.value, unicode) and not self.__strIsInt(self.value):
+            split = self.value.split('_')
+            if len(split) == 2 and self.__strIsInt(split[1]):
+                self.value = split[1]
+
+    @staticmethod
+    def __strIsInt(strValue):
+        try:
+            int(strValue)
+            return True
+        except:
+            return False
+
 class UInt32(UInteger):
     def __init__(self, xmlelement=None):
         UInteger.__init__(self)

--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -413,7 +413,7 @@ class Int32(Integer):
         # Values of enumerations can be encoded as strings: <symbol>_<value> (see OPC specification part 6)
         # UaModeler does this for enums that are fields of structs
         # Extract <value> from string if possible
-        if isinstance(self.value, unicode) and not self.__strIsInt(self.value):
+        if isinstance(self.value, string_types) and not self.__strIsInt(self.value):
             split = self.value.split('_')
             if len(split) == 2 and self.__strIsInt(split[1]):
                 self.value = split[1]


### PR DESCRIPTION
According to Section 5.33 of the OPC UA specification 10000-6, enumerations can be encoded as strings in the following format: `<symbol>_<value>`. This format is used by the UaModeler for enumerations that are nested in structures. As of yet, the XML Nodeset Compiler does not correctly interpret this encoding.

This pull request modifies the way the Nodeset Compiler parses Int32 values from XML elements to take into account the string encoding. The extension only concerns Int32 values since it's the datatype used for storing values of enumerations.

The following snippet of a nodeset XML exported by UaModeler serves to illustrate the issue. First, a custom enumeration Enum and structure StructEnum that holds an Enum are defined. Next, an instance of the new structure AStructEnum is created. Thereby, the Enum field of the instance is filled with the string encoding Field2_1 which will later on lead to a compilation error after the Nodeset Compiler assigned Field2_1 to the C-enumeration.
There is also a fully working nodeset attached to the post to reproduce the problem.

```
<UADataType NodeId="ns=1;i=3002" BrowseName="1:StructEnum">
    <DisplayName>StructEnum</DisplayName>
    <References>
        <Reference ReferenceType="HasEncoding">ns=1;i=5001</Reference>
        <Reference ReferenceType="HasEncoding">ns=1;i=5003</Reference>
        <Reference ReferenceType="HasEncoding">ns=1;i=5002</Reference>
        <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
    </References>
    <Definition Name="1:StructEnum">
        <Field DataType="Enum" Name="AnEnum"/>
        <Field DataType="Double" Name="ADouble"/>
    </Definition>
</UADataType>

<UADataType NodeId="ns=1;i=3003" BrowseName="1:Enum">
    <DisplayName>Enum</DisplayName>
    <References>
        <Reference ReferenceType="HasSubtype" IsForward="false">i=29</Reference>
        <Reference ReferenceType="HasProperty">ns=1;i=6008</Reference>
    </References>
    <Definition Name="1:Enum">
        <Field Name="Field1" Value="0"/>
        <Field Name="Field2" Value="1"/>
    </Definition>
</UADataType>

<UAVariable DataType="StructEnum" NodeId="ns=1;i=6007" BrowseName="1:AStructEnum" AccessLevel="3">
    <DisplayName>AStructEnum</DisplayName>
    <References>
        <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5005</Reference>
        <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
    </References>
    <Value>
        <uax:ExtensionObject>
            <uax:TypeId>
                <uax:Identifier>ns=1;i=5002</uax:Identifier>
            </uax:TypeId>
            <uax:Body>
                <StructEnum xmlns="http://yourorganisation.org/Struct_Enum_minimal/Types.xsd">
                    <AnEnum>Field2_1</AnEnum>
                    <ADouble>0.5</ADouble>
                </StructEnum>
            </uax:Body>
        </uax:ExtensionObject>
    </Value>
</UAVariable>
```

[example.zip](https://github.com/open62541/open62541/files/6816330/example.zip)