### PR TITLE
fix(nodeset_compiler): Adding the various EventNotifier attributes in the code generation

### DIFF
--- a/include/open62541/common.h
+++ b/include/open62541/common.h
@@ -118,6 +118,18 @@ typedef enum {
 #define UA_VALUERANK_THREE_DIMENSIONS          3
 
 /**
+ * EventNotifier
+ * -------------
+ * The following are the available EventNotifier used for Nodes.
+ * The EventNotifier Attribute is used to indicate if the Node can be used
+ * to subscribe to Events or to read / write historic Events.
+ * Part 3: 5.4 Table 10 */
+
+#define UA_EVENTNOTIFIER_SUBSCRIBE_TO_EVENT (0x01u << 0u)
+#define UA_EVENTNOTIFIER_HISTORY_READ       (0x01u << 2u)
+#define UA_EVENTNOTIFIER_HISTORY_WRITE      (0x01u << 3u)
+
+/**
  * Rule Handling
  * -------------
  *

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -70,7 +70,23 @@ def generateObjectNodeCode(node):
     code = []
     code.append("UA_ObjectAttributes attr = UA_ObjectAttributes_default;")
     if node.eventNotifier:
-        code.append("attr.eventNotifier = true;")
+        code_part = "attr.eventNotifier = "
+        is_first = True
+        if node.eventNotifier & 1:
+            code_part += "UA_EVENTNOTIFIER_SUBSCRIBE_TO_EVENT"
+            is_first = False
+        if node.eventNotifier & 4:
+            if not is_first:
+                code_part += " || "
+            code_part += "UA_EVENTNOTIFIER_HISTORY_READ"
+            is_first = False
+        if node.eventNotifier & 8:
+            if not is_first:
+                code_part += " || "
+            code_part += "UA_EVENTNOTIFIER_HISTORY_WRITE"
+            is_first = False
+        code_part += ";"
+        code.append(code_part)
     return code
 
 def setNodeDatatypeRecursive(node, nodeset):


### PR DESCRIPTION
Adding the various EventNotifier attributes in the code generation to indicate if the Node can be used to subscribe to Events or read/write historic Events.