### PR TITLE
fix(nc): Remove additional backslash in line breaks inside string values

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -26,7 +26,7 @@ def makeCIdentifier(value):
 
 # Escape C strings:
 def makeCLiteral(value):
-    return re.sub(r'(?<!\\)"', r'\\"', value.replace('\\', r'\\').replace('"', r'\"').replace('\n', r'\\n').replace('\r', r''))
+    return re.sub(r'(?<!\\)"', r'\\"', value.replace('\\', r'\\').replace('"', r'\"').replace('\n', r'\n').replace('\r', r''))
 
 def splitStringLiterals(value, splitLength=500):
     """


### PR DESCRIPTION
Line breaks in value fields of type string are encoded with two backslashes.
This leads to the string "\n" being transmitted as actual value if the value is not overwritten by callbacks.

I assume this behaviour is not intentional, because a similar fix was already introduced for quotes and slashes in 2033d6a41326d472ddbfca7b0b93767d5cff41c9

See also the python reference https://docs.python.org/3/reference/lexical_analysis.html

> Both string and bytes literals may optionally be prefixed with a letter 'r' or 'R'; such strings are called raw strings and treat backslashes as literal characters. 


Example XML:

    <UAVariable NodeId="ns=1;i=2013" BrowseName="1:TestNode" ParentNodeId="ns=1;i=1001" DataType="String">
      <DisplayName>TestNode</DisplayName>
      <Description>TestNode</Description>
      <References>
        <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
        <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
      </References>
      <Value>
        <uax:String>My string
    with line breaks</uax:String>
      </Value>
    </UAVariable>

Current output:

    *variablenode_ns_1_i_2013_variant_DataContents = UA_STRING_ALLOC("My string\\nwith line breaks");

Expected output:

    *variablenode_ns_1_i_2013_variant_DataContents = UA_STRING_ALLOC("My string\nwith line breaks");