### PR TITLE
fix(server): revert removal of Dictionaries object

### DIFF
--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -1011,7 +1011,6 @@ UA_Server_initNS0(UA_Server *server) {
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXBYTESTRINGLENGTH), true);
 
     /* Remove not supported server configurations */
-    UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_DICTIONARIES), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_ESTIMATEDRETURNTIME), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME), true);
     UA_Server_deleteNode(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_REQUESTSERVERSTATECHANGE), true);


### PR DESCRIPTION
The I4AAS companion specification depends on the Dictionaries object of the OPC UA Nodeset2 specification. Commit [bdb233e](https://github.com/open62541/open62541/commit/bdb233e810a7c9f5187c2e53f021c71abdefba80#diff-78df7143ea0c91caf7c6e0969cd003ad1265cbdb359a2fa529228c5263734dfe) removed this node and therefore breaks compatibility to the I4AAS specification.