### PR TITLE
[Review] move the json encoding functions to public includes

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1134,6 +1134,52 @@ UA_decodeBinary(const UA_ByteString *inBuf,
                 void *p, const UA_DataType *type,
                 const UA_DecodeBinaryOptions *options);
 
+typedef struct {
+    const UA_String *namespaces;
+    size_t namespacesSize;
+    const UA_String *serverUris;
+    size_t serverUrisSize;
+    UA_Boolean useReversible;
+} UA_EncodeJsonOptions;
+
+/* Returns the number of bytes the value src takes in json encoding. Returns
+ * zero if an error occurs. */
+UA_EXPORT size_t
+UA_calcSizeJson(const void *src, const UA_DataType *type,
+                const UA_EncodeJsonOptions *options);
+
+/* Encodes the scalar value described by type to json encoding.
+ *
+ * @param src The value. Must not be NULL.
+ * @param type The value type. Must not be NULL.
+ * @param outBuf Pointer to ByteString containing the result if the encoding was
+ * successful
+ * @return Returns a statuscode whether encoding succeeded. */
+UA_StatusCode UA_EXPORT
+UA_encodeJson(const void *src, const UA_DataType *type, UA_ByteString *outBuf,
+              const UA_EncodeJsonOptions *options);
+
+/* The structure with the decoding options may be extended in the future.
+ * Zero-out the entire structure initially to ensure code-compatibility when
+ * more fields are added in a later release. */
+typedef struct {
+    const UA_DataTypeArray *customTypes; /* Begin of a linked list with custom
+                                          * datatype definitions */
+} UA_DecodeJsonOptions;
+
+/* Decodes a scalar value described by type from json encoding.
+ *
+ * @param src The buffer with the json encoded value. Must not be NULL.
+ * @param dst The target value. Must not be NULL. The target is assumed to have
+ *        size type->memSize. The value is reset to zero before decoding. If
+ *        decoding fails, members are deleted and the value is reset (zeroed)
+ *        again.
+ * @param type The value type. Must not be NULL.
+ * @param options The options struct for decoding, currently unused
+ * @return Returns a statuscode whether decoding succeeded. */
+UA_StatusCode UA_EXPORT
+UA_decodeJson(const UA_ByteString *src, void *dst, const UA_DataType *type,
+              const UA_DecodeJsonOptions *options);
 /**
  * .. _array-handling:
  *

--- a/src/ua_types_encoding_json.h
+++ b/src/ua_types_encoding_json.h
@@ -20,23 +20,48 @@
 _UA_BEGIN_DECLS
 
 #define UA_JSON_MAXTOKENCOUNT 1000
-    
+
+/* Returns the number of bytes the value src takes in json encoding. Returns
+ * zero if an error occurs. */
 size_t
-UA_calcSizeJson(const void *src, const UA_DataType *type,
-                UA_String *namespaces, size_t namespaceSize,
-                UA_String *serverUris, size_t serverUriSize,
-                UA_Boolean useReversible) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+UA_calcSizeJsonInternal(const void *src, const UA_DataType *type,
+                        const UA_String *namespaces, size_t namespaceSize,
+                        const UA_String *serverUris, size_t serverUriSize,
+                        UA_Boolean useReversible) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
+/* Encodes the scalar value described by type to json encoding.
+ *
+ * @param src The value. Must not be NULL.
+ * @param type The value type. Must not be NULL.
+ * @param bufPos Points to a pointer to the current position in the encoding
+ *        buffer. Must not be NULL.
+ * @param bufEnd Points to a pointer to the end of the encoding buffer (encoding
+ *        always stops before *buf_end). Must not be NULL.
+ * @param namespaces An array of namespaces
+ * @param namespaceSize The size of the namespaces array
+ * @param serverUris An array of serverUris
+ * @param serverUriSize The size of the serverUris array
+ * @param useReversible preserve datatypes in json encoding
+ * @return Returns a statuscode whether encoding succeeded. */
 UA_StatusCode
-UA_encodeJson(const void *src, const UA_DataType *type,
-              uint8_t **bufPos, const uint8_t **bufEnd,
-              UA_String *namespaces, size_t namespaceSize,
-              UA_String *serverUris, size_t serverUriSize,
-              UA_Boolean useReversible) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+UA_encodeJsonInternal(const void *src, const UA_DataType *type, uint8_t **bufPos,
+                      const uint8_t **bufEnd, const UA_String *namespaces,
+                      size_t namespaceSize, const UA_String *serverUris,
+                      size_t serverUriSize,
+                      UA_Boolean useReversible) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
+/* Decodes a scalar value described by type from json encoding.
+ *
+ * @param src The buffer with the json encoded value. Must not be NULL.
+ * @param dst The target value. Must not be NULL. The target is assumed to have
+ *        size type->memSize. The value is reset to zero before decoding. If
+ *        decoding fails, members are deleted and the value is reset (zeroed)
+ *        again.
+ * @param type The value type. Must not be NULL.
+ * @return Returns a statuscode whether decoding succeeded. */
 UA_StatusCode
-UA_decodeJson(const UA_ByteString *src, void *dst,
-              const UA_DataType *type) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+UA_decodeJsonInternal(const UA_ByteString *src, void *dst,
+                      const UA_DataType *type) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
 /* Interal Definitions
  *
@@ -53,10 +78,10 @@ typedef struct {
     UA_Boolean calcOnly; /* Only compute the length of the decoding */
 
     size_t namespacesSize;
-    UA_String *namespaces;
+    const UA_String *namespaces;
     
     size_t serverUrisSize;
-    UA_String *serverUris;
+    const UA_String *serverUris;
 } CtxJson;
 
 UA_StatusCode writeJsonObjStart(CtxJson *ctx);

--- a/tests/check_types_builtin_json.c
+++ b/tests/check_types_builtin_json.c
@@ -27,7 +27,7 @@ START_TEST(UA_Boolean_true_json_encode) {
     UA_Boolean_init(src);
     *src = UA_TRUE;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_BOOLEAN];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -35,7 +35,7 @@ START_TEST(UA_Boolean_true_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -58,7 +58,7 @@ START_TEST(UA_Boolean_false_json_encode) {
 
     UA_ByteString buf;
 
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     ck_assert_int_eq(size, 5);
     
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -66,7 +66,7 @@ START_TEST(UA_Boolean_false_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
         
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -91,7 +91,7 @@ START_TEST(UA_Boolean_true_bufferTooSmall_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -111,13 +111,13 @@ START_TEST(UA_String_json_encode) {
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
     
     UA_ByteString buf;
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
     // when
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -133,13 +133,13 @@ START_TEST(UA_String_Empty_json_encode) {
     UA_ByteString buf;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
     
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
     // when
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -155,13 +155,13 @@ START_TEST(UA_String_Null_json_encode) {
     UA_ByteString buf;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
  
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
     // when
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -176,13 +176,13 @@ START_TEST(UA_String_escapesimple_json_encode) {
     UA_String src = UA_STRING("\b\th\"e\fl\nl\\o\r");
     UA_ByteString buf;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
     // when
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -198,13 +198,13 @@ START_TEST(UA_String_escapeutf_json_encode) {
     UA_ByteString buf;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
     // when
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -220,13 +220,13 @@ START_TEST(UA_String_special_json_encode) {
     UA_ByteString buf;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
     // when
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -244,13 +244,13 @@ START_TEST(UA_Byte_Max_Number_json_encode) {
     const UA_DataType *type = &UA_TYPES[UA_TYPES_BYTE];
 
     UA_ByteString buf;
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -269,13 +269,13 @@ START_TEST(UA_Byte_Min_Number_json_encode) {
     const UA_DataType *type = &UA_TYPES[UA_TYPES_BYTE];
 
     UA_ByteString buf;
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -299,7 +299,7 @@ START_TEST(UA_Byte_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -315,7 +315,7 @@ START_TEST(UA_SByte_Max_Number_json_encode) {
     UA_SByte *src = UA_SByte_new();
     *src = 127;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_SBYTE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -323,7 +323,7 @@ START_TEST(UA_SByte_Max_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -340,7 +340,7 @@ START_TEST(UA_SByte_Min_Number_json_encode) {
     UA_SByte *src = UA_SByte_new();
     *src = -128;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_SBYTE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -348,7 +348,7 @@ START_TEST(UA_SByte_Min_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -365,7 +365,7 @@ START_TEST(UA_SByte_Zero_Number_json_encode) {
     UA_SByte *src = UA_SByte_new();
     *src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_SBYTE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -373,7 +373,7 @@ START_TEST(UA_SByte_Zero_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -397,7 +397,7 @@ START_TEST(UA_SByte_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -414,7 +414,7 @@ START_TEST(UA_UInt16_Max_Number_json_encode) {
     UA_UInt16 *src = UA_UInt16_new();
     *src = 65535;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT16];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -422,7 +422,7 @@ START_TEST(UA_UInt16_Max_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -439,7 +439,7 @@ START_TEST(UA_UInt16_Min_Number_json_encode) {
     UA_UInt16 *src = UA_UInt16_new();
     *src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT16];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -447,7 +447,7 @@ START_TEST(UA_UInt16_Min_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -471,7 +471,7 @@ START_TEST(UA_UInt16_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -487,7 +487,7 @@ START_TEST(UA_Int16_Max_Number_json_encode) {
     UA_Int16 *src = UA_Int16_new();
     *src = 32767;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT16];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -495,7 +495,7 @@ START_TEST(UA_Int16_Max_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -512,7 +512,7 @@ START_TEST(UA_Int16_Min_Number_json_encode) {
     UA_Int16 *src = UA_Int16_new();
     *src = -32768;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT16];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -520,7 +520,7 @@ START_TEST(UA_Int16_Min_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -537,7 +537,7 @@ START_TEST(UA_Int16_Zero_Number_json_encode) {
     UA_Int16 *src = UA_Int16_new();
     *src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT16];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -545,7 +545,7 @@ START_TEST(UA_Int16_Zero_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -569,7 +569,7 @@ START_TEST(UA_Int16_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -587,7 +587,7 @@ START_TEST(UA_UInt32_Max_Number_json_encode) {
     UA_UInt32 *src = UA_UInt32_new();
     *src = 4294967295;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT32];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -595,7 +595,7 @@ START_TEST(UA_UInt32_Max_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -612,7 +612,7 @@ START_TEST(UA_UInt32_Min_Number_json_encode) {
     UA_UInt32 *src = UA_UInt32_new();
     *src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT32];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -620,7 +620,7 @@ START_TEST(UA_UInt32_Min_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -644,7 +644,7 @@ START_TEST(UA_UInt32_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -662,7 +662,7 @@ START_TEST(UA_Int32_Max_Number_json_encode) {
     UA_Int32 *src = UA_Int32_new();
     *src = 2147483647;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT32];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -670,7 +670,7 @@ START_TEST(UA_Int32_Max_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -685,7 +685,7 @@ END_TEST
 START_TEST(UA_Int32_Min_Number_json_encode) {
     UA_Int32 src = -2147483648;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT32];
-    size_t size = UA_calcSizeJson((void *)&src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *)&src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -693,7 +693,7 @@ START_TEST(UA_Int32_Min_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *)&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *)&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -709,7 +709,7 @@ START_TEST(UA_Int32_Zero_Number_json_encode) {
     UA_Int32 *src = UA_Int32_new();
     *src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT32];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -717,7 +717,7 @@ START_TEST(UA_Int32_Zero_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -742,7 +742,7 @@ START_TEST(UA_Int32_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -768,7 +768,7 @@ START_TEST(UA_UInt64_Max_Number_json_encode) {
     ((u8*)src)[6] = 0xFF;
     ((u8*)src)[7] = 0xFF;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT64];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -776,7 +776,7 @@ START_TEST(UA_UInt64_Max_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -793,7 +793,7 @@ START_TEST(UA_UInt64_Min_Number_json_encode) {
     UA_UInt64 *src = UA_UInt64_new();
     *src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT64];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -801,7 +801,7 @@ START_TEST(UA_UInt64_Min_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -834,7 +834,7 @@ START_TEST(UA_UInt64_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -859,7 +859,7 @@ START_TEST(UA_Int64_Max_Number_json_encode) {
     ((u8*)src)[7] = 0x7F;
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT64];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -867,7 +867,7 @@ START_TEST(UA_Int64_Max_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -897,7 +897,7 @@ START_TEST(UA_Int64_Min_Number_json_encode) {
     
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT64];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -905,7 +905,7 @@ START_TEST(UA_Int64_Min_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -922,7 +922,7 @@ START_TEST(UA_Int64_Zero_Number_json_encode) {
     UA_Int64 *src = UA_Int64_new();
     *src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_INT64];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -930,7 +930,7 @@ START_TEST(UA_Int64_Zero_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -955,7 +955,7 @@ START_TEST(UA_Int64_smallbuf_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -969,7 +969,7 @@ END_TEST
 START_TEST(UA_Double_json_encode) {
     UA_Double src = 1.1234;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -977,7 +977,7 @@ START_TEST(UA_Double_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -992,7 +992,7 @@ END_TEST
 START_TEST(UA_Double_pluszero_json_encode) {
     UA_Double src = 0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1000,7 +1000,7 @@ START_TEST(UA_Double_pluszero_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -1015,7 +1015,7 @@ END_TEST
 START_TEST(UA_Double_minuszero_json_encode) {
     UA_Double src = -0;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1023,7 +1023,7 @@ START_TEST(UA_Double_minuszero_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -1038,7 +1038,7 @@ END_TEST
 START_TEST(UA_Double_plusInf_json_encode) {
     UA_Double src = INFINITY;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1046,7 +1046,7 @@ START_TEST(UA_Double_plusInf_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -1063,7 +1063,7 @@ END_TEST
 START_TEST(UA_Double_minusInf_json_encode) {
     UA_Double src = -INFINITY;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1071,7 +1071,7 @@ START_TEST(UA_Double_minusInf_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -1086,7 +1086,7 @@ END_TEST
 START_TEST(UA_Double_nan_json_encode) {
     UA_Double src = NAN;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1094,7 +1094,7 @@ START_TEST(UA_Double_nan_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -1109,7 +1109,7 @@ END_TEST
 START_TEST(UA_Double_onesmallest_json_encode) {
     UA_Double src = 1.0000000000000002220446049250313080847263336181640625;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1117,7 +1117,7 @@ START_TEST(UA_Double_onesmallest_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -1132,7 +1132,7 @@ END_TEST
 START_TEST(UA_Float_json_encode) {
     UA_Float src = 1.0000000000F;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_FLOAT];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1140,7 +1140,7 @@ START_TEST(UA_Float_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -1162,7 +1162,7 @@ START_TEST(UA_LocText_json_encode) {
     src->locale = UA_STRING_ALLOC("theLocale");
     src->text = UA_STRING_ALLOC("theText");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_LOCALIZEDTEXT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1170,7 +1170,7 @@ START_TEST(UA_LocText_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1190,7 +1190,7 @@ START_TEST(UA_LocText_NonReversible_json_encode) {
     src->locale = UA_STRING_ALLOC("theLocale");
     src->text = UA_STRING_ALLOC("theText");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_LOCALIZEDTEXT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1198,7 +1198,7 @@ START_TEST(UA_LocText_NonReversible_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -1224,7 +1224,7 @@ START_TEST(UA_LocText_smallBuffer_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[4];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
@@ -1237,7 +1237,7 @@ END_TEST
 START_TEST(UA_Guid_json_encode) {
     UA_Guid src = {3, 9, 10, {8, 7, 6, 5, 4, 3, 2, 1}};
     const UA_DataType *type = &UA_TYPES[UA_TYPES_GUID];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1245,7 +1245,7 @@ START_TEST(UA_Guid_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -1266,7 +1266,7 @@ START_TEST(UA_Guid_smallbuf_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
@@ -1282,7 +1282,7 @@ START_TEST(UA_DateTime_json_encode) {
     UA_DateTime *src = UA_DateTime_new();
     *src = UA_DateTime_fromUnixTime(1234567);
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DATETIME];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1290,7 +1290,7 @@ START_TEST(UA_DateTime_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1306,7 +1306,7 @@ START_TEST(UA_DateTime_with_nanoseconds_json_encode) {
     UA_DateTime *src = UA_DateTime_new();
     *src = UA_DateTime_fromUnixTime(1234567) + 8901234;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DATETIME];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1314,7 +1314,7 @@ START_TEST(UA_DateTime_with_nanoseconds_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1331,7 +1331,7 @@ START_TEST(UA_StatusCode_json_encode) {
     UA_StatusCode *src = UA_StatusCode_new();
     *src = UA_STATUSCODE_BADAGGREGATECONFIGURATIONREJECTED;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STATUSCODE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1339,7 +1339,7 @@ START_TEST(UA_StatusCode_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
      *bufPos = 0;
     
@@ -1356,7 +1356,7 @@ START_TEST(UA_StatusCode_nonReversible_json_encode) {
     UA_StatusCode *src = UA_StatusCode_new();
     *src = UA_STATUSCODE_BADAGGREGATECONFIGURATIONREJECTED;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STATUSCODE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1364,7 +1364,7 @@ START_TEST(UA_StatusCode_nonReversible_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
      *bufPos = 0;
     
@@ -1381,7 +1381,7 @@ START_TEST(UA_StatusCode_nonReversible_good_json_encode) {
     UA_StatusCode *src = UA_StatusCode_new();
     *src = UA_STATUSCODE_GOOD;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STATUSCODE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1389,7 +1389,7 @@ START_TEST(UA_StatusCode_nonReversible_good_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
      *bufPos = 0;
     
@@ -1414,7 +1414,7 @@ START_TEST(UA_StatusCode_smallbuf_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
     UA_ByteString_clear(&buf); 
@@ -1430,7 +1430,7 @@ START_TEST(UA_NodeId_Numeric_json_encode) {
     UA_NodeId *src = UA_NodeId_new();
     *src = UA_NODEID_NUMERIC(0, 5555);
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1438,7 +1438,7 @@ START_TEST(UA_NodeId_Numeric_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1454,7 +1454,7 @@ START_TEST(UA_NodeId_Numeric_Namespace_json_encode) {
     UA_NodeId *src = UA_NodeId_new();
     *src = UA_NODEID_NUMERIC(4, 5555);
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1462,7 +1462,7 @@ START_TEST(UA_NodeId_Numeric_Namespace_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1479,7 +1479,7 @@ START_TEST(UA_NodeId_String_json_encode) {
     UA_NodeId *src = UA_NodeId_new();
     *src = UA_NODEID_STRING_ALLOC(0, "foobar");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1487,7 +1487,7 @@ START_TEST(UA_NodeId_String_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1503,7 +1503,7 @@ START_TEST(UA_NodeId_String_Namespace_json_encode) {
     UA_NodeId *src = UA_NodeId_new();
     *src = UA_NODEID_STRING_ALLOC(5, "foobar");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1511,7 +1511,7 @@ START_TEST(UA_NodeId_String_Namespace_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1530,7 +1530,7 @@ START_TEST(UA_NodeId_Guid_json_encode) {
     UA_Guid g = {3, 9, 10, {8, 7, 6, 5, 4, 3, 2, 1}};
     *src = UA_NODEID_GUID(0, g);
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1538,7 +1538,7 @@ START_TEST(UA_NodeId_Guid_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1555,7 +1555,7 @@ START_TEST(UA_NodeId_Guid_Namespace_json_encode) {
     UA_Guid g = {3, 9, 10, {8, 7, 6, 5, 4, 3, 2, 1}};
     *src = UA_NODEID_GUID(5, g);
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     // {"IdType":2,"Id":"00000003-0009-000A-0807-060504030201","Namespace":5}
@@ -1566,7 +1566,7 @@ START_TEST(UA_NodeId_Guid_Namespace_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1583,7 +1583,7 @@ START_TEST(UA_NodeId_ByteString_json_encode) {
     UA_NodeId *src = UA_NodeId_new();
     *src = UA_NODEID_BYTESTRING_ALLOC(0, "asdfasdf");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1594,7 +1594,7 @@ START_TEST(UA_NodeId_ByteString_json_encode) {
     //{"IdType":3,"Id":"YXNkZmFzZGY="}
     ck_assert_int_eq(size, 32);
     
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1610,7 +1610,7 @@ START_TEST(UA_NodeId_ByteString_Namespace_json_encode) {
     UA_NodeId *src = UA_NodeId_new();
     *src = UA_NODEID_BYTESTRING_ALLOC(5, "asdfasdf");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1618,7 +1618,7 @@ START_TEST(UA_NodeId_ByteString_Namespace_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1637,7 +1637,7 @@ START_TEST(UA_NodeId_NonReversible_Numeric_Namespace_json_encode) {
     const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
     
     UA_String namespaces[3] = {UA_STRING("ns0"),UA_STRING("ns1"),UA_STRING("ns2")};
-    size_t size = UA_calcSizeJson((void *) src, type, namespaces, 3, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, namespaces, 3, NULL, 0, UA_FALSE);
     ck_assert_int_ne(size, 0);
     UA_ByteString buf;
 
@@ -1647,7 +1647,7 @@ START_TEST(UA_NodeId_NonReversible_Numeric_Namespace_json_encode) {
     const UA_Byte *bufEnd = &buf.data[size+1];
 
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, namespaces, 3, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, namespaces, 3, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -1681,7 +1681,7 @@ START_TEST(UA_DiagInfo_json_encode) {
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DIAGNOSTICINFO];
 
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1689,7 +1689,7 @@ START_TEST(UA_DiagInfo_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1737,7 +1737,7 @@ START_TEST(UA_DiagInfo_withInner_json_encode) {
 
 
     UA_ByteString buf;
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString_allocBuffer(&buf, size+1);
 
     UA_Byte *bufPos = &buf.data[0];
@@ -1746,7 +1746,7 @@ START_TEST(UA_DiagInfo_withInner_json_encode) {
     //{"SymbolicId":13,"LocalizedText":14,"Locale":12,"AdditionalInfo":"additionalInfo","InnerStatusCode":2155216896,"InnerDiagnosticInfo":{"AdditionalInfo":"INNER ADDITION INFO"}}
     ck_assert_int_eq(size, 174);
     
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1804,7 +1804,7 @@ START_TEST(UA_DiagInfo_withTwoInner_json_encode) {
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DIAGNOSTICINFO];
 
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1812,7 +1812,7 @@ START_TEST(UA_DiagInfo_withTwoInner_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1828,7 +1828,7 @@ START_TEST(UA_DiagInfo_noFields_json_encode) {
     UA_DiagnosticInfo *src = UA_DiagnosticInfo_new();
     UA_DiagnosticInfo_init(src);
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DIAGNOSTICINFO];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1836,7 +1836,7 @@ START_TEST(UA_DiagInfo_noFields_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1876,7 +1876,7 @@ START_TEST(UA_DiagInfo_smallBuffer_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[2];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1892,7 +1892,7 @@ START_TEST(UA_ByteString_json_encode) {
     UA_ByteString_init(src);
     *src = UA_BYTESTRING_ALLOC("asdfasdf");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_BYTESTRING];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1900,7 +1900,7 @@ START_TEST(UA_ByteString_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -1917,7 +1917,7 @@ START_TEST(UA_ByteString2_json_encode) {
     UA_ByteString_init(src);
     *src = UA_BYTESTRING_ALLOC("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_BYTESTRING];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1925,10 +1925,10 @@ START_TEST(UA_ByteString2_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     
-    //s = UA_decodeJson()
+    //s = UA_decodeJsonInternal()
     *bufPos = 0;
     // then
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
@@ -1947,7 +1947,7 @@ START_TEST(UA_ByteString3_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_BYTESTRING]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1955,14 +1955,14 @@ START_TEST(UA_ByteString3_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status retval = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status retval = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     //printf("%s\n\n", (char*)buf.data);
 
     UA_Variant out;
     UA_Variant_init(&out);
-    retval |= UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    retval |= UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_ByteString *srcData = ((UA_ByteString*)src->data);
@@ -1982,7 +1982,7 @@ START_TEST(UA_QualName_json_encode) {
     src->name = UA_STRING_ALLOC("derName");
     src->namespaceIndex = 1;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_QUALIFIEDNAME];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -1990,7 +1990,7 @@ START_TEST(UA_QualName_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2010,7 +2010,7 @@ START_TEST(UA_QualName_NonReversible_json_encode) {
     src->name = UA_STRING_ALLOC("derName");
     src->namespaceIndex = 1;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_QUALIFIEDNAME];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2018,7 +2018,7 @@ START_TEST(UA_QualName_NonReversible_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2037,7 +2037,7 @@ START_TEST(UA_QualName_NonReversible_Namespace_json_encode) {
     src->namespaceIndex = 2;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_QUALIFIEDNAME];
     UA_String namespaces[3] = {UA_STRING("ns0"),UA_STRING("ns1"),UA_STRING("ns2")};
-    size_t size = UA_calcSizeJson((void *) src, type, namespaces, 3, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, namespaces, 3, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2046,7 +2046,7 @@ START_TEST(UA_QualName_NonReversible_Namespace_json_encode) {
     const UA_Byte *bufEnd = &buf.data[size+1];
 
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, namespaces, 3, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, namespaces, 3, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2064,7 +2064,7 @@ START_TEST(UA_QualName_NonReversible_NoNamespaceAsNumber_json_encode) {
     src->name = UA_STRING_ALLOC("derName");
     src->namespaceIndex = 6789;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_QUALIFIEDNAME];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2072,7 +2072,7 @@ START_TEST(UA_QualName_NonReversible_NoNamespaceAsNumber_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2096,7 +2096,7 @@ START_TEST(UA_Variant_Bool_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_BOOLEAN]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2104,7 +2104,7 @@ START_TEST(UA_Variant_Bool_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2124,7 +2124,7 @@ START_TEST(UA_Variant_Number_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_UINT64]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2132,7 +2132,7 @@ START_TEST(UA_Variant_Number_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2158,7 +2158,7 @@ START_TEST(UA_Variant_Double_json_encode) {
         UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_DOUBLE]);
 
         const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-        size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+        size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
         UA_ByteString buf;
 
         UA_ByteString_allocBuffer(&buf, size+1);
@@ -2166,14 +2166,14 @@ START_TEST(UA_Variant_Double_json_encode) {
         UA_Byte *bufPos = &buf.data[0];
         const UA_Byte *bufEnd = &buf.data[size+1];
 
-        status retval = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+        status retval = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
         *bufPos = 0;
         //printf("%s\n\n", (char*)buf.data);
 
         UA_Variant out;
         UA_Variant_init(&out);
-        retval |= UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+        retval |= UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
         ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
         UA_Double srcData = *((UA_Double*)src->data);
@@ -2195,7 +2195,7 @@ START_TEST(UA_Variant_Double2_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_DOUBLE]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2203,7 +2203,7 @@ START_TEST(UA_Variant_Double2_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status retval = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status retval = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
 
@@ -2212,7 +2212,7 @@ START_TEST(UA_Variant_Double2_json_encode) {
 
     UA_Variant out;
     UA_Variant_init(&out);
-    retval |= UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    retval |= UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_Double srcData = *((UA_Double*)src->data);
@@ -2234,7 +2234,7 @@ START_TEST(UA_Variant_Double3_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_DOUBLE]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2242,13 +2242,13 @@ START_TEST(UA_Variant_Double3_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status retval = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status retval = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
 
     UA_Variant out;
     UA_Variant_init(&out);
-    retval |= UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    retval |= UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_Double srcData = *((UA_Double*)src->data);
@@ -2269,7 +2269,7 @@ START_TEST(UA_Variant_DoubleInf_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_DOUBLE]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2277,14 +2277,14 @@ START_TEST(UA_Variant_DoubleInf_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status retval = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status retval = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     //printf("%s\n\n", (char*)buf.data);
 
     UA_Variant out;
     UA_Variant_init(&out);
-    retval |= UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    retval |= UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_Double srcData = *((UA_Double*)src->data);
@@ -2305,7 +2305,7 @@ START_TEST(UA_Variant_DoubleNan_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_DOUBLE]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2313,14 +2313,14 @@ START_TEST(UA_Variant_DoubleNan_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status retval = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status retval = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     //printf("%s\n\n", (char*)buf.data);
 
     UA_Variant out;
     UA_Variant_init(&out);
-    retval |= UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    retval |= UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_Double srcData = *((UA_Double*)src->data);
@@ -2341,7 +2341,7 @@ START_TEST(UA_Variant_Float_json_encode) {
     UA_Variant_setScalar(src, variantContent, &UA_TYPES[UA_TYPES_FLOAT]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2349,13 +2349,13 @@ START_TEST(UA_Variant_Float_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status retval = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status retval = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
 
     UA_Variant out;
     UA_Variant_init(&out);
-    retval |= UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    retval |= UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_Float srcData = *((UA_Float*)src->data);
@@ -2376,7 +2376,7 @@ START_TEST(UA_Variant_NodeId_json_encode) {
     UA_Variant_setScalarCopy(src, &variantContent, &UA_TYPES[UA_TYPES_NODEID]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2384,7 +2384,7 @@ START_TEST(UA_Variant_NodeId_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2405,7 +2405,7 @@ START_TEST(UA_Variant_LocText_json_encode) {
     UA_Variant_setScalarCopy(src, &variantContent, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2413,7 +2413,7 @@ START_TEST(UA_Variant_LocText_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2436,7 +2436,7 @@ START_TEST(UA_Variant_QualName_json_encode) {
     UA_Variant_setScalarCopy(src, &variantContent, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2444,7 +2444,7 @@ START_TEST(UA_Variant_QualName_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -2467,7 +2467,7 @@ START_TEST(UA_Variant_Array_UInt16_json_encode) {
    
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2477,7 +2477,7 @@ START_TEST(UA_Variant_Array_UInt16_json_encode) {
 
     ck_assert_int_eq(size, 25);
     
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2497,7 +2497,7 @@ START_TEST(UA_Variant_Array_Byte_json_encode) {
    
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2505,7 +2505,7 @@ START_TEST(UA_Variant_Array_Byte_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2525,7 +2525,7 @@ START_TEST(UA_Variant_Array_String_json_encode) {
    
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2533,7 +2533,7 @@ START_TEST(UA_Variant_Array_String_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     
@@ -2563,7 +2563,7 @@ START_TEST(UA_Variant_Matrix_UInt16_json_encode) {
     src.arrayDimensions[1] = 3;
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2572,10 +2572,10 @@ START_TEST(UA_Variant_Matrix_UInt16_json_encode) {
     const UA_Byte *bufEnd = &buf.data[size+1];
 
     //{"Type":5,"Body":[1,2,3,4,5,6,7,8,9],"Dimension":[3,3]}
-    size_t sizeOfBytes = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t sizeOfBytes = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     ck_assert_int_eq(sizeOfBytes, 55);
     
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2596,7 +2596,7 @@ START_TEST(UA_Variant_StatusCode_NonReversible_json_encode) {
     UA_Variant_setScalarCopy(src, &variantContent, &UA_TYPES[UA_TYPES_STATUSCODE]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2604,7 +2604,7 @@ START_TEST(UA_Variant_StatusCode_NonReversible_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2631,7 +2631,7 @@ START_TEST(UA_Variant_Array_String_NonReversible_json_encode) {
     src.arrayDimensions[0] = 8;
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2639,7 +2639,7 @@ START_TEST(UA_Variant_Array_String_NonReversible_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2668,7 +2668,7 @@ START_TEST(UA_Variant_Matrix_String_NonReversible_json_encode) {
     src.arrayDimensions[3] = 1;
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2677,10 +2677,10 @@ START_TEST(UA_Variant_Matrix_String_NonReversible_json_encode) {
     const UA_Byte *bufEnd = &buf.data[size+1];
 
     //{"Body":[[[["1"],["2"]],[["3"],["4"]]],[[["5"],["6"]],[["7"],["8"]]]]}
-    size_t sizeOfBytes = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t sizeOfBytes = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
     ck_assert_int_eq(sizeOfBytes, 70);
     
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2706,7 +2706,7 @@ START_TEST(UA_Variant_Matrix_NodeId_NonReversible_json_encode) {
     src.arrayDimensions[3] = 1;
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2714,7 +2714,7 @@ START_TEST(UA_Variant_Matrix_NodeId_NonReversible_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2740,7 +2740,7 @@ START_TEST(UA_Variant_Wrap_json_encode) {
     UA_Variant_setScalarCopy(src, &variantContent, &UA_TYPES[UA_TYPES_VIEWDESCRIPTION]);
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2748,7 +2748,7 @@ START_TEST(UA_Variant_Wrap_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2785,7 +2785,7 @@ START_TEST(UA_Variant_Wrap_Array_json_encode) {
 
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2793,7 +2793,7 @@ START_TEST(UA_Variant_Wrap_Array_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2830,7 +2830,7 @@ START_TEST(UA_Variant_Wrap_Array_NonReversible_json_encode) {
 
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIANT];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2838,7 +2838,7 @@ START_TEST(UA_Variant_Wrap_Array_NonReversible_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal(&src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2861,7 +2861,7 @@ START_TEST(UA_ExtensionObject_json_encode) {
     src->content.decoded.data = &b;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXTENSIONOBJECT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2869,7 +2869,7 @@ START_TEST(UA_ExtensionObject_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2891,7 +2891,7 @@ START_TEST(UA_ExtensionObject_xml_json_encode) {
     src->content.encoded.body = b;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXTENSIONOBJECT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2899,7 +2899,7 @@ START_TEST(UA_ExtensionObject_xml_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2922,7 +2922,7 @@ START_TEST(UA_ExtensionObject_byteString_json_encode) {
     src->content.encoded.body = b;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXTENSIONOBJECT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2930,7 +2930,7 @@ START_TEST(UA_ExtensionObject_byteString_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -2953,7 +2953,7 @@ START_TEST(UA_ExtensionObject_NonReversible_StatusCode_json_encode) {
     src->content.decoded.data = &b;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXTENSIONOBJECT];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2961,7 +2961,7 @@ START_TEST(UA_ExtensionObject_NonReversible_StatusCode_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -2983,7 +2983,7 @@ START_TEST(UA_ExpandedNodeId_json_encode) {
     src->namespaceUri = UA_STRING_ALLOC("asdf");
     src->serverIndex = 1345;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXPANDEDNODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -2991,7 +2991,7 @@ START_TEST(UA_ExpandedNodeId_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3011,7 +3011,7 @@ START_TEST(UA_ExpandedNodeId_MissingNamespaceUri_json_encode) {
     src->namespaceUri = UA_STRING_NULL;
     src->serverIndex = 1345;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXPANDEDNODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3019,7 +3019,7 @@ START_TEST(UA_ExpandedNodeId_MissingNamespaceUri_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3040,7 +3040,7 @@ START_TEST(UA_ExpandedNodeId_NonReversible_Ns1_json_encode) {
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXPANDEDNODEID];
     
     UA_String serverUris[3] = {UA_STRING("uri0"),UA_STRING("uri1"),UA_STRING("uri2")};
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, serverUris, 3, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, serverUris, 3, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3049,7 +3049,7 @@ START_TEST(UA_ExpandedNodeId_NonReversible_Ns1_json_encode) {
     const UA_Byte *bufEnd = &buf.data[size+1];
 
     
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, serverUris, 3, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, serverUris, 3, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -3072,7 +3072,7 @@ START_TEST(UA_ExpandedNodeId_NonReversible_Namespace_json_encode) {
     UA_String namespaces[3] = {UA_STRING("ns0"),UA_STRING("ns1"),UA_STRING("ns2")};
     UA_String serverUris[3] = {UA_STRING("uri0"),UA_STRING("uri1"),UA_STRING("uri2")};
     
-    size_t size = UA_calcSizeJson((void *) src, type, namespaces, 3, serverUris, 3, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, namespaces, 3, serverUris, 3, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3081,7 +3081,7 @@ START_TEST(UA_ExpandedNodeId_NonReversible_Namespace_json_encode) {
     const UA_Byte *bufEnd = &buf.data[size+1];
 
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, namespaces, 3, serverUris, 3, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, namespaces, 3, serverUris, 3, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -3105,7 +3105,7 @@ START_TEST(UA_ExpandedNodeId_NonReversible_NamespaceUriGiven_json_encode) {
     
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_EXPANDEDNODEID];
-    size_t size = UA_calcSizeJson((void *) src, type, namespaces, 3, serverUris, 3, UA_FALSE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, namespaces, 3, serverUris, 3, UA_FALSE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3113,7 +3113,7 @@ START_TEST(UA_ExpandedNodeId_NonReversible_NamespaceUriGiven_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, namespaces, 3, serverUris, 3, UA_FALSE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, namespaces, 3, serverUris, 3, UA_FALSE);
 
     *bufPos = 0;
     // then
@@ -3152,7 +3152,7 @@ START_TEST(UA_DataValue_json_encode) {
 
     src->status = UA_STATUSCODE_BADAPPLICATIONSIGNATUREINVALID;
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DATAVALUE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3160,7 +3160,7 @@ START_TEST(UA_DataValue_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3177,7 +3177,7 @@ START_TEST(UA_DataValue_null_json_encode) {
     UA_DataValue_init(src);
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_DATAVALUE];
-    size_t size = UA_calcSizeJson((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3185,7 +3185,7 @@ START_TEST(UA_DataValue_null_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3281,7 +3281,7 @@ START_TEST(UA_MessageReadResponse_json_encode) {
     src.responseHeader = rh;
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_READRESPONSE];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3289,7 +3289,7 @@ START_TEST(UA_MessageReadResponse_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3310,7 +3310,7 @@ START_TEST(UA_ViewDescription_json_encode) {
     src.viewId = UA_NODEID_NUMERIC(0,99999);
     
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VIEWDESCRIPTION];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3318,7 +3318,7 @@ START_TEST(UA_ViewDescription_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3427,7 +3427,7 @@ START_TEST(UA_WriteRequest_json_encode) {
     src.requestHeader = rh;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_WRITEREQUEST];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3435,7 +3435,7 @@ START_TEST(UA_WriteRequest_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3470,7 +3470,7 @@ START_TEST(UA_VariableAttributes_json_encode) {
     src.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
 
     const UA_DataType *type = &UA_TYPES[UA_TYPES_VARIABLETYPEATTRIBUTES];
-    size_t size = UA_calcSizeJson((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
+    size_t size = UA_calcSizeJsonInternal((void *) &src, type, NULL, 0, NULL, 0, UA_TRUE);
     UA_ByteString buf;
 
     UA_ByteString_allocBuffer(&buf, size+1);
@@ -3478,7 +3478,7 @@ START_TEST(UA_VariableAttributes_json_encode) {
     UA_Byte *bufPos = &buf.data[0];
     const UA_Byte *bufEnd = &buf.data[size+1];
 
-    status s = UA_encodeJson((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
+    status s = UA_encodeJsonInternal((void *) &src, type, &bufPos, &bufEnd, NULL, 0, NULL, 0, UA_TRUE);
 
     *bufPos = 0;
     // then
@@ -3504,7 +3504,7 @@ START_TEST(UA_Byte_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":3,\"Body\":0}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTE);
@@ -3520,7 +3520,7 @@ START_TEST(UA_Byte_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":3,\"Body\":255}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTE);
@@ -3538,7 +3538,7 @@ START_TEST(UA_UInt16_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":5,\"Body\":0}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT16);
@@ -3554,7 +3554,7 @@ START_TEST(UA_UInt16_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":5,\"Body\":65535}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT16);
@@ -3571,7 +3571,7 @@ START_TEST(UA_UInt32_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":7,\"Body\":0}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT32);
@@ -3587,7 +3587,7 @@ START_TEST(UA_UInt32_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":7,\"Body\":4294967295}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT32);
@@ -3604,7 +3604,7 @@ START_TEST(UA_UInt64_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":9,\"Body\":\"0\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT64);    
@@ -3627,7 +3627,7 @@ START_TEST(UA_UInt64_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":9,\"Body\":\"18446744073709551615\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_UINT64);
@@ -3650,7 +3650,7 @@ START_TEST(UA_UInt64_Overflow_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":9,\"Body\":\"18446744073709551616\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -3664,7 +3664,7 @@ START_TEST(UA_SByte_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":2,\"Body\":-128}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_SBYTE);
@@ -3680,7 +3680,7 @@ START_TEST(UA_SByte_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":2,\"Body\":127}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_SBYTE);
@@ -3697,7 +3697,7 @@ START_TEST(UA_Int16_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":4,\"Body\":-32768}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT16);
@@ -3713,7 +3713,7 @@ START_TEST(UA_Int16_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":4,\"Body\":32767}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT16);
@@ -3730,7 +3730,7 @@ START_TEST(UA_Int32_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":6,\"Body\":-2147483648}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT32);
@@ -3746,7 +3746,7 @@ START_TEST(UA_Int32_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":6,\"Body\":2147483647}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT32);
@@ -3763,7 +3763,7 @@ START_TEST(UA_Int64_Min_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":8,\"Body\":\"-9223372036854775808\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT64);    
@@ -3787,7 +3787,7 @@ START_TEST(UA_Int64_Max_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":8,\"Body\":\"9223372036854775807\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_INT64);    
@@ -3811,7 +3811,7 @@ START_TEST(UA_Int64_Overflow_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":8,\"Body\":\"9223372036854775808\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -3825,7 +3825,7 @@ START_TEST(UA_Int64_TooBig_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":8,\"Body\":\"111111111111111111111111111111\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -3839,7 +3839,7 @@ START_TEST(UA_Int64_NoDigit_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":8,\"Body\":\"a\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -3853,7 +3853,7 @@ START_TEST(UA_Float_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":10,\"Body\":3.1415927410}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     //0 10000000 10010010000111111011011 = 40 49 0f db
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -3871,7 +3871,7 @@ START_TEST(UA_Float_json_one_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":10,\"Body\":1}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     //0 01111111 00000000000000000000000 = 3f80 0000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -3891,7 +3891,7 @@ START_TEST(UA_Float_json_inf_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":10,\"Body\":\"Infinity\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
 
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -3911,7 +3911,7 @@ START_TEST(UA_Float_json_neginf_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":10,\"Body\":\"-Infinity\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     //0 01111111 00000000000000000000000 = 3f80 0000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -3930,7 +3930,7 @@ START_TEST(UA_Float_json_nan_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":10,\"Body\":\"NaN\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     //0 01111111 00000000000000000000000 = 3f80 0000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -3951,7 +3951,7 @@ START_TEST(UA_Float_json_negnan_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":10,\"Body\":\"-NaN\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     //0 01111111 00000000000000000000000 = 3f80 0000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -3972,7 +3972,7 @@ START_TEST(UA_Double_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":1.1234}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);   
     ck_assert_int_eq(((u8*)(out.data))[0], 0xef);
@@ -3994,7 +3994,7 @@ START_TEST(UA_Double_corrupt_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":1.12.34}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -4009,7 +4009,7 @@ START_TEST(UA_Double_one_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":1}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     // 0 01111111111 0000000000000000000000000000000000000000000000000000
     // 3FF0000000000000
@@ -4034,7 +4034,7 @@ START_TEST(UA_Double_onepointsmallest_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":1.0000000000000002}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     // 0 01111111111 0000000000000000000000000000000000000000000000000001
     // 3FF0000000000001
@@ -4058,7 +4058,7 @@ START_TEST(UA_Double_nan_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":\"NaN\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     UA_Double val = *((UA_Double*)out.data);
@@ -4072,7 +4072,7 @@ START_TEST(UA_Double_negnan_json_decode) {
     UA_Variant_init(&out);
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":\"-NaN\"}");
     // when
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     UA_Double val = *((UA_Double*)out.data);
@@ -4088,7 +4088,7 @@ START_TEST(UA_Double_inf_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":\"Infinity\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     // 0 111 1111 1111 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);       
@@ -4111,7 +4111,7 @@ START_TEST(UA_Double_neginf_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":\"-Infinity\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     // 1 111 1111 1111 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);       
@@ -4134,7 +4134,7 @@ START_TEST(UA_Double_zero_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":0}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     // 0 000 0000 0000 0000 0000 0000 00000000 00000000 00000000 00000000 00000000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);       
@@ -4157,7 +4157,7 @@ START_TEST(UA_Double_negzero_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":11,\"Body\":-0}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     // 1 000 0000 0000 0000 00000000 00000000 00000000 00000000 00000000 00000000
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);       
@@ -4180,7 +4180,7 @@ START_TEST(UA_String_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":12,\"Body\":\"abcdef\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
@@ -4202,7 +4202,7 @@ START_TEST(UA_String_empty_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":12,\"Body\":\"\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
@@ -4219,7 +4219,7 @@ START_TEST(UA_String_unescapeBS_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":12,\"Body\":\"ab\\tcdef\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
@@ -4242,7 +4242,7 @@ START_TEST(UA_String_escape_unicode_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":12,\"Body\":\"\\u002c\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
@@ -4260,7 +4260,7 @@ START_TEST(UA_String_escape2_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":12,\"Body\":\"\\b\\th\\\"e\\fl\\nl\\\\o\\r\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
@@ -4289,7 +4289,7 @@ START_TEST(UA_String_surrogatePair_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":12,\"Body\":\"\\uD800\\uDC00\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STRING);
@@ -4310,7 +4310,7 @@ START_TEST(UA_ByteString_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":15,\"Body\":\"YXNkZmFzZGY=\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTESTRING);
@@ -4336,7 +4336,7 @@ START_TEST(UA_ByteString_bad_json_decode) {
     UA_ByteString buf = UA_STRING("\"\x90!\xc5 c{\",");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_BYTESTRING]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_BYTESTRING]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     UA_ByteString_clear(&out);
@@ -4347,7 +4347,7 @@ START_TEST(UA_ByteString_null_json_decode) {
     UA_Variant out;
     UA_Variant_init(&out);
     UA_ByteString buf = UA_STRING("{\"Type\":15,\"Body\":null}");
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BYTESTRING);
     UA_ByteString *outData = (UA_ByteString*)out.data;
@@ -4365,7 +4365,7 @@ START_TEST(UA_Guid_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":14,\"Body\":\"00000001-0002-0003-0405-060708090A0B\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_GUID);
@@ -4391,7 +4391,7 @@ START_TEST(UA_Guid_lower_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":14,\"Body\":\"00000001-0002-0003-0405-060708090a0b\"}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_GUID);
@@ -4418,7 +4418,7 @@ START_TEST(UA_Guid_tooShort_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":14,\"Body\":\"00000001-00\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -4432,7 +4432,7 @@ START_TEST(UA_Guid_tooLong_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":14,\"Body\":\"00000001-0002-0003-0405-060708090A0B00000001\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -4446,7 +4446,7 @@ START_TEST(UA_Guid_wrong_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":14,\"Body\":\"00000=01-0002-0003-0405-060708090A0B\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -4461,7 +4461,7 @@ START_TEST(UA_StatusCode_2_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":19,\"Body\":2}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STATUSCODE);
@@ -4478,7 +4478,7 @@ START_TEST(UA_StatusCode_3_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":19,\"Body\":222222222222222222222222222222222222}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -4492,7 +4492,7 @@ START_TEST(UA_StatusCode_0_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":19,\"Body\":0}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_STATUSCODE);
@@ -4510,7 +4510,7 @@ START_TEST(UA_DateTime_json_decode) {
     UA_ByteString buf = UA_STRING("\"1970-01-02T01:02:03.005Z\"");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
@@ -4535,7 +4535,7 @@ START_TEST(UA_DateTime_micro_json_decode) {
     UA_ByteString buf = UA_STRING("\"1970-01-02T01:02:03.042Z\"");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
@@ -4562,7 +4562,7 @@ START_TEST(UA_QualifiedName_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Name\":\"derName\",\"Uri\":1}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.name.length, 7);
@@ -4578,7 +4578,7 @@ START_TEST(UA_QualifiedName_null_json_decode) {
     UA_Variant out;
     UA_Variant_init(&out);
     UA_ByteString buf = UA_STRING("{\"Type\":20,\"Body\":null}");
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_QUALIFIEDNAME);
     ck_assert_ptr_ne(out.data, NULL);
@@ -4593,7 +4593,7 @@ START_TEST(UA_LocalizedText_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Locale\":\"t1\",\"Text\":\"t2\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.locale.data[0], 't');
@@ -4612,7 +4612,7 @@ START_TEST(UA_LocalizedText_missing_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Locale\":\"t1\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.locale.length, 2);
@@ -4629,7 +4629,7 @@ START_TEST(UA_LocalizedText_null_json_decode) {
     UA_Variant out;
     UA_Variant_init(&out);
     UA_ByteString buf = UA_STRING("{\"Type\":21,\"Body\":null}");
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_LOCALIZEDTEXT);
     ck_assert_ptr_ne(out.data, NULL);
@@ -4645,7 +4645,7 @@ START_TEST(UA_ViewDescription_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Timestamp\":\"1970-01-15T06:56:07Z\",\"ViewVersion\":1236,\"ViewId\":{\"Id\":\"00000009-0002-027C-F3BF-BB7BEEFEEFBE\",\"IdType\":2}}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VIEWDESCRIPTION]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VIEWDESCRIPTION]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.viewVersion, 1236);
@@ -4677,7 +4677,7 @@ START_TEST(UA_NodeId_Nummeric_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Id\":42}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.identifier.numeric, 42);
@@ -4695,7 +4695,7 @@ START_TEST(UA_NodeId_Nummeric_Namespace_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Id\":42,\"Namespace\":123}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.identifier.numeric, 42);
@@ -4714,7 +4714,7 @@ START_TEST(UA_NodeId_String_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":1,\"Id\":\"test123\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.identifier.string.length, 7);
@@ -4740,7 +4740,7 @@ START_TEST(UA_NodeId_Guid_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":2,\"Id\":\"00000001-0002-0003-0405-060708090A0B\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -4769,7 +4769,7 @@ START_TEST(UA_NodeId_ByteString_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":3,\"Id\":\"YXNkZmFzZGY=\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_NODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -4798,7 +4798,7 @@ START_TEST(UA_ExpandedNodeId_Nummeric_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Id\":42}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.nodeId.identifier.numeric, 42);
@@ -4818,7 +4818,7 @@ START_TEST(UA_ExpandedNodeId_String_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":1,\"Id\":\"test\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.nodeId.identifier.string.length, 4);
@@ -4839,7 +4839,7 @@ START_TEST(UA_ExpandedNodeId_String_Namespace_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":1,\"Id\":\"test\",\"Namespace\":\"abcdef\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.nodeId.identifier.string.length, 4);
@@ -4868,7 +4868,7 @@ START_TEST(UA_ExpandedNodeId_String_NamespaceAsIndex_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":1,\"Id\":\"test\",\"Namespace\":42}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.nodeId.identifier.string.length, 4);
@@ -4893,7 +4893,7 @@ START_TEST(UA_ExpandedNodeId_String_Namespace_ServerUri_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":1,\"Id\":\"test\",\"Namespace\":\"test\",\"ServerUri\":13}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.nodeId.identifier.string.length, 4);
@@ -4919,7 +4919,7 @@ START_TEST(UA_ExpandedNodeId_ByteString_json_decode) {
     UA_ByteString buf = UA_STRING("{\"IdType\":3,\"Id\":\"YXNkZmFzZGY=\",\"Namespace\":\"test\",\"ServerUri\":13}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.nodeId.identifier.string.length, 8);
@@ -4957,7 +4957,7 @@ START_TEST(UA_DiagnosticInfo_json_decode) {
             "\"InnerDiagnosticInfo\":{\"AdditionalInfo\":\"INNER ADDITION INFO\"}}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.locale, 12);
@@ -4974,7 +4974,7 @@ START_TEST(UA_DiagnosticInfo_null_json_decode) {
     UA_Variant out;
     UA_Variant_init(&out);
     UA_ByteString buf = UA_STRING("{\"Type\":25,\"Body\":null}");
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_DIAGNOSTICINFO);
     ck_assert_uint_eq(((UA_DiagnosticInfo*)out.data)->hasAdditionalInfo, 0);
@@ -4999,7 +4999,7 @@ START_TEST(UA_DataValue_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_DATAVALUE]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_DATAVALUE]);
     //UA_DiagnosticInfo inner = *out.innerDiagnosticInfo;
 
     // then
@@ -5026,7 +5026,7 @@ START_TEST(UA_DataValueMissingFields_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_DATAVALUE]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_DATAVALUE]);
     //UA_DiagnosticInfo inner = *out.innerDiagnosticInfo;
 
     // then
@@ -5045,7 +5045,7 @@ START_TEST(UA_DataValue_null_json_decode) {
     UA_Variant out;
     UA_Variant_init(&out);
     UA_ByteString buf = UA_STRING("{\"Type\":23,\"Body\":null}");
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_ptr_ne(out.data, NULL);
     UA_Variant_clear(&out);
@@ -5063,7 +5063,7 @@ START_TEST(UA_ExtensionObject_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.encoding, UA_EXTENSIONOBJECT_DECODED);
@@ -5082,7 +5082,7 @@ START_TEST(UA_ExtensionObject_EncodedByteString_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.encoding, UA_EXTENSIONOBJECT_ENCODED_BYTESTRING);
@@ -5111,7 +5111,7 @@ START_TEST(UA_ExtensionObject_EncodedXml_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.encoding, UA_EXTENSIONOBJECT_ENCODED_XML);
@@ -5134,7 +5134,7 @@ START_TEST(UA_ExtensionObject_Unkown_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.encoding, UA_EXTENSIONOBJECT_ENCODED_BYTESTRING);
@@ -5160,7 +5160,7 @@ START_TEST(UA_VariantBool_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":1,\"Body\":false}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BOOLEAN);
@@ -5176,7 +5176,7 @@ START_TEST(UA_VariantBoolNull_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":1,\"Body\":null}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
     UA_Variant_clear(&out);
@@ -5187,7 +5187,7 @@ START_TEST(UA_VariantNull_json_decode) {
     UA_Variant out;
     UA_Variant_init(&out);
     UA_ByteString buf = UA_STRING("{\"Type\":0}");
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 }
 END_TEST
@@ -5202,7 +5202,7 @@ START_TEST(UA_VariantStringArray_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     UA_String *testArray;
     testArray = (UA_String*)(out->data);
@@ -5235,7 +5235,7 @@ START_TEST(UA_VariantStringArrayNull_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     UA_String *testArray;
     testArray = (UA_String*)(out.data);
@@ -5269,7 +5269,7 @@ START_TEST(UA_VariantLocalizedTextArrayNull_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     UA_LocalizedText *testArray;
     testArray = (UA_LocalizedText*)(out.data);
@@ -5303,7 +5303,7 @@ START_TEST(UA_VariantVariantArrayNull_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     UA_Variant *testArray;
     testArray = (UA_Variant*)(out.data);
@@ -5331,7 +5331,7 @@ START_TEST(UA_VariantVariantArrayEmpty_json_decode) {
 
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.arrayLength, 0);
@@ -5347,7 +5347,7 @@ START_TEST(UA_VariantStringArray_WithoutDimension_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":12,\"Body\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\"]}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     UA_String *testArray;
     testArray = (UA_String*)(out.data);
@@ -5376,7 +5376,7 @@ START_TEST(UA_Variant_BooleanArray_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":1,\"Body\":[true, false, true]}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     UA_Boolean *testArray;
     testArray = (UA_Boolean*)(out.data);
@@ -5400,7 +5400,7 @@ START_TEST(UA_Variant_bad1_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":1,\"Body\":\"\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     UA_Variant_clear(&out);
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
@@ -5416,7 +5416,7 @@ START_TEST(UA_Variant_ExtensionObjectWrap_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
@@ -5435,7 +5435,7 @@ START_TEST(UA_duplicate_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":1, \"Body\":false, \"Type\":1}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
     UA_Variant_clear(&out);
@@ -5449,7 +5449,7 @@ START_TEST(UA_wrongBoolean_json_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":1, \"Body\":\"asdfaaaaaaaaaaaaaaaaaaaa\"}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
     UA_Variant_clear(&out);
@@ -5470,7 +5470,7 @@ START_TEST(UA_DataTypeAttributes_json_decode) {
             "\"IsAbstract\":false}");
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_DATATYPEATTRIBUTES]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_DATATYPEATTRIBUTES]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert_int_eq(out.isAbstract, 0);
@@ -5496,7 +5496,7 @@ START_TEST(UA_VariantStringArrayBad_shouldFreeArray_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
@@ -5515,7 +5515,7 @@ START_TEST(UA_VariantFuzzer1_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
@@ -5537,7 +5537,7 @@ START_TEST(UA_VariantFuzzer2_json_decode) {
 
     // when
     
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
 
     // then
     ck_assert(retval == UA_STATUSCODE_GOOD || retval == UA_STATUSCODE_BADDECODINGERROR);
@@ -5551,7 +5551,7 @@ START_TEST(UA_Variant_Bad_Type_decode) {
     UA_ByteString buf = UA_STRING("{\"Type\":1000,\"Body\":0}");
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
 
@@ -5568,7 +5568,7 @@ START_TEST(UA_Variant_Bad_Type2_decode) {
         UA_ByteString buf = UA_STRING(str);
         // when
 
-        UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+        UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
         // then
         ck_assert_int_eq(retval, retval);
         UA_Variant_clear(&out);
@@ -5583,7 +5583,7 @@ START_TEST(UA_Variant_Malformed_decode) {
         char str[80];
         sprintf(str, "{\"Type\":%d, \"Body:\"}", i);
         UA_ByteString buf = UA_STRING(str);
-        UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+        UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
         ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
         UA_Variant_clear(&out);
     }
@@ -5598,7 +5598,7 @@ START_TEST(UA_Variant_Malformed2_decode) {
     UA_ByteString buf = UA_STRING(str);
     // when
 
-    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
+    UA_StatusCode retval = UA_decodeJsonInternal(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT]);
     // then
     ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
     UA_Variant_clear(&out);
@@ -5626,6 +5626,37 @@ START_TEST(UA_JsonHelper) {
 }   
 END_TEST
 
+/* ----------------- Public API ---------------------*/
+START_TEST(UA_VariantBool_public_json_decode) {
+    // given
+    UA_Variant out;
+    UA_Variant_init(&out);
+    UA_ByteString buf = UA_STRING("{\"Type\":1,\"Body\":false}");
+    // when
+
+    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT], NULL);
+    // then
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BOOLEAN);
+    ck_assert_uint_eq(*((UA_Boolean *)out.data), 0);
+    UA_Variant_clear(&out);
+}
+END_TEST
+
+/* Test Boolean */
+START_TEST(UA_Boolean_true_public_json_encode) {
+
+    UA_Boolean src = UA_TRUE;
+    UA_ByteString out = UA_BYTESTRING_NULL;
+    status s = UA_encodeJson(&src, &UA_TYPES[UA_TYPES_BOOLEAN], &out, NULL);
+
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+    UA_ByteString result = UA_BYTESTRING("true");
+    ck_assert(UA_ByteString_equal(&result, &out));
+
+    UA_ByteString_clear(&out);
+}
+END_TEST
 
 static Suite *testSuite_builtin_json(void) {
     Suite *s = suite_create("Built-in Data Types 62541-6 Json");
@@ -5983,6 +6014,10 @@ static Suite *testSuite_builtin_json(void) {
 
     tcase_add_test(tc_json_decode, UA_Variant_Malformed_decode);
     tcase_add_test(tc_json_decode, UA_Variant_Malformed2_decode);
+
+    // public api
+    tcase_add_test(tc_json_decode, UA_VariantBool_public_json_decode);
+    tcase_add_test(tc_json_decode, UA_Boolean_true_public_json_encode);
 
     suite_add_tcase(s, tc_json_decode);
     

--- a/tools/ua-tool/ua.c
+++ b/tools/ua-tool/ua.c
@@ -23,8 +23,6 @@
 #include <open62541/client.h>
 #include <open62541/client_config_default.h>
 
-#include "ua_types_encoding_json.h"
-
 static UA_Client *client = NULL;
 static UA_NodeId nodeidval = {0};
 static char *url = NULL;
@@ -59,11 +57,7 @@ printType(void *p, const UA_DataType *type) {
     if(!json) {
         UA_print(p, type, &out);
     } else {
-        size_t len = UA_calcSizeJson(p, type, NULL, 0, NULL, 0, false);
-        UA_ByteString_allocBuffer(&out, len);
-        UA_Byte *pos = out.data;
-        const UA_Byte *end = &out.data[out.length];
-        UA_StatusCode res = UA_encodeJson(p, type, &pos, &end, NULL, 0, NULL, 0, false);
+        UA_StatusCode res = UA_encodeJson(p, type, &out, NULL);
         (void)res;
     }
 #else

--- a/tools/ua2json/CMakeLists.txt
+++ b/tools/ua2json/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-include_directories(${PROJECT_SOURCE_DIR}/src)
 
 add_executable(ua2json ua2json.c)
 target_link_libraries(ua2json open62541 ${open62541_LIBRARIES})


### PR DESCRIPTION
It would be interesting to use the json decoding/encoding for example to decode a Variant from json description. Related to https://github.com/open62541/open62541/issues/4359