### PR TITLE
Node references as an array when only few references

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -14,6 +14,9 @@ jobs:
           - name: Debug Build & Unit Tests with multithreading (gcc)
             cmd_deps: ""
             cmd_action: unit_tests_mt
+          - name: Debug Build & Unit Tests with Alarms&Conditions (gcc)
+            cmd_deps: ""
+            cmd_action: unit_tests_alarms
           - name: Debug Build & Unit Tests (clang)
             cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11
             cmd_action: CC=clang-11 CXX=clang++-11 unit_tests

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- *    Copyright 2017 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
+ *    Copyright 2017, 2021 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2017 (c) Julian Grothoff
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  */
@@ -257,22 +257,52 @@ UA_ReferenceTypeSet_contains(const UA_ReferenceTypeSet *set, UA_Byte index) {
  * not known or not important. The ``nodeClass`` attribute is used to ensure the
  * correctness of casting from ``UA_Node`` to a specific node type. */
 
-/* Ordered tree structure for fast member check */
 typedef struct {
-    struct aa_entry idTreeEntry; /* Binary-Tree for fast lookup */
-    struct aa_entry nameTreeEntry;
-    UA_UInt32 targetIdHash;      /* Hash of the target's NodeId */
-    UA_UInt32 targetNameHash;    /* Hash of the target's BrowseName */
-    UA_ExpandedNodeId targetId;
+    UA_ExpandedNodeId targetId;  /* Has to be the first entry */
+    UA_UInt32 targetNameHash;    /* Hash of the target's BrowseName. Set to zero
+                                  * if the target is remote. */
 } UA_ReferenceTarget;
 
-/* List of reference targets with the same reference type and direction */
 typedef struct {
-    struct aa_entry *idTreeRoot;   /* Fast lookup based on the target id */
-    struct aa_entry *nameTreeRoot; /* Fast lookup based on the target browseName*/
+    UA_ReferenceTarget target;   /* Has to be the first entry */
+    UA_UInt32 targetIdHash;      /* Hash of the targetId */
+    struct aa_entry idTreeEntry; /* Binary-Tree for fast lookup */
+    struct aa_entry nameTreeEntry;
+} UA_ReferenceTargetTreeElem;
+
+/* List of reference targets with the same reference type and direction. Uses
+ * either an array or a tree structure. The SDK will not change the type of
+ * reference target structure internally. The nodestore implementations may
+ * switch internally when a node is updated.
+ *
+ * The recommendation is to switch to a tree once the number of refs > 8. */
+typedef struct {
+    union {
+        /* Organize the references in an array. Uses less memory, but incurs
+         * lookups in linear time. Recommended if the number of references is
+         * known to be small. */
+        UA_ReferenceTarget *array;
+
+        /* Organize the references in a tree for fast lookup */
+        struct {
+            struct aa_entry *idTreeRoot;   /* Fast lookup based on the target id */
+            struct aa_entry *nameTreeRoot; /* Fast lookup based on the target browseName*/
+        } tree;
+    } targets;
+    size_t targetsSize;
+    UA_Boolean hasRefTree; /* RefTree or RefArray? */
     UA_Byte referenceTypeIndex;
     UA_Boolean isInverse;
 } UA_NodeReferenceKind;
+
+/* Iterate over the references. Assumes that "prev" points to a
+ * NodeReferenceKind. If prev == NULL, the first element is returned. At the end
+ * of the iteration, NULL is returned.
+ *
+ * Do not continue the iteration after the rk was modified. */
+UA_EXPORT const UA_ReferenceTarget *
+UA_NodeReferenceKind_iterate(const UA_NodeReferenceKind *rk,
+                             const UA_ReferenceTarget *prev);
 
 /* Every Node starts with these attributes */
 typedef struct {

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -304,6 +304,11 @@ UA_EXPORT const UA_ReferenceTarget *
 UA_NodeReferenceKind_iterate(const UA_NodeReferenceKind *rk,
                              const UA_ReferenceTarget *prev);
 
+/* Switch between array and tree representation. Does nothing upon error (e.g.
+ * out-of-memory). */
+UA_EXPORT UA_StatusCode
+UA_NodeReferenceKind_switch(UA_NodeReferenceKind *rk);
+
 /* Every Node starts with these attributes */
 typedef struct {
     UA_NodeId nodeId;

--- a/plugins/ua_nodestore_hashmap.c
+++ b/plugins/ua_nodestore_hashmap.c
@@ -194,8 +194,17 @@ deleteNodeMapEntry(UA_NodeMapEntry *entry) {
 
 static void
 cleanupNodeMapEntry(UA_NodeMapEntry *entry) {
-    if(entry->deleted && entry->refCount == 0)
+    if(entry->refCount > 0)
+        return;
+    if(entry->deleted) {
         deleteNodeMapEntry(entry);
+        return;
+    }
+    for(size_t i = 0; i < entry->node.head.referencesSize; i++) {
+        UA_NodeReferenceKind *rk = &entry->node.head.references[i];
+        if(rk->targetsSize > 16 && !rk->hasRefTree)
+            UA_NodeReferenceKind_switch(rk);
+    }
 }
 
 static UA_NodeMapSlot *

--- a/plugins/ua_nodestore_ziptree.c
+++ b/plugins/ua_nodestore_ziptree.c
@@ -106,8 +106,18 @@ deleteEntry(NodeEntry *entry) {
 
 static void
 cleanupEntry(NodeEntry *entry) {
-    if(entry->deleted && entry->refCount == 0)
+    if(entry->refCount > 0)
+        return;
+    if(entry->deleted) {
         deleteEntry(entry);
+        return;
+    }
+    UA_NodeHead *head = (UA_NodeHead*)&entry->nodeId;
+    for(size_t i = 0; i < head->referencesSize; i++) {
+        UA_NodeReferenceKind *rk = &head->references[i];
+        if(rk->targetsSize > 16 && !rk->hasRefTree)
+            UA_NodeReferenceKind_switch(rk);
+    }
 }
 
 /***********************/

--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- *    Copyright 2015-2018 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
+ *    Copyright 2015-2018, 2021 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2015-2016 (c) Sten Grüner
  *    Copyright 2015 (c) Chris Iatrou
  *    Copyright 2015, 2017 (c) Florian Palm
@@ -15,15 +15,20 @@
 #include "ua_types_encoding_binary.h"
 #include "aa_tree.h"
 
+static UA_StatusCode
+addReferenceTarget(UA_NodeReferenceKind *refs, const UA_ExpandedNodeId *target,
+                   UA_UInt32 targetNameHash);
+
 static enum aa_cmp
 cmpRefTargetId(const void *a, const void *b) {
-    const UA_ReferenceTarget *aa = (const UA_ReferenceTarget*)a;
-    const UA_ReferenceTarget *bb = (const UA_ReferenceTarget*)b;
+    const UA_ReferenceTargetTreeElem *aa = (const UA_ReferenceTargetTreeElem*)a;
+    const UA_ReferenceTargetTreeElem *bb = (const UA_ReferenceTargetTreeElem*)b;
     if(aa->targetIdHash < bb->targetIdHash)
         return AA_CMP_LESS;
     if(aa->targetIdHash > bb->targetIdHash)
         return AA_CMP_MORE;
-    return (enum aa_cmp)UA_ExpandedNodeId_order(&aa->targetId, &bb->targetId);
+    return (enum aa_cmp)UA_ExpandedNodeId_order(&aa->target.targetId,
+                                                &bb->target.targetId);
 }
 
 static enum aa_cmp
@@ -39,38 +44,50 @@ cmpRefTargetName(const void *a, const void *b) {
 
 /* Reusable binary search tree "heads". Just switch out the root pointer. */
 static const struct aa_head refIdTree =
-    { NULL, cmpRefTargetId, offsetof(UA_ReferenceTarget, idTreeEntry), 0 };
+    { NULL, cmpRefTargetId, offsetof(UA_ReferenceTargetTreeElem, idTreeEntry), 0 };
 const struct aa_head refNameTree =
-    { NULL, cmpRefTargetName, offsetof(UA_ReferenceTarget, nameTreeEntry),
+    { NULL, cmpRefTargetName, offsetof(UA_ReferenceTargetTreeElem, nameTreeEntry),
       offsetof(UA_ReferenceTarget, targetNameHash) };
 
-UA_ReferenceTarget *
-UA_NodeReferenceKind_firstTarget(const UA_NodeReferenceKind *kind) {
-    struct aa_head _refIdTree =
-        { kind->idTreeRoot, cmpRefTargetId,
-          offsetof(UA_ReferenceTarget, idTreeEntry), 0 };
-    return (UA_ReferenceTarget*)aa_min(&_refIdTree);
+const UA_ReferenceTarget *
+UA_NodeReferenceKind_iterate(const UA_NodeReferenceKind *rk,
+                             const UA_ReferenceTarget *prev) {
+    /* Return from the tree */
+    if(rk->hasRefTree) {
+        const struct aa_head _refIdTree =
+            { rk->targets.tree.idTreeRoot, cmpRefTargetId,
+              offsetof(UA_ReferenceTargetTreeElem, idTreeEntry), 0 };
+        if(prev == NULL)
+            return (const UA_ReferenceTarget*)aa_min(&_refIdTree);
+        return (const UA_ReferenceTarget*)aa_next(&_refIdTree, prev);
+    }
+    if(prev == NULL) /* Return start of the array */
+        return rk->targets.array;
+    if(prev + 1 >= &rk->targets.array[rk->targetsSize])
+        return NULL; /* End of the array */
+    return prev + 1; /* Next element in the array */
 }
 
-UA_ReferenceTarget *
-UA_NodeReferenceKind_nextTarget(const UA_NodeReferenceKind *kind,
-                                const UA_ReferenceTarget *current) {
-    struct aa_head _refIdTree =
-        { kind->idTreeRoot, cmpRefTargetId,
-          offsetof(UA_ReferenceTarget, idTreeEntry), 0 };
-    return (UA_ReferenceTarget*)aa_next(&_refIdTree, current);
-}
-
-UA_ReferenceTarget *
-UA_NodeReferenceKind_findTarget(const UA_NodeReferenceKind *kind,
+const UA_ReferenceTarget *
+UA_NodeReferenceKind_findTarget(const UA_NodeReferenceKind *rk,
                                 const UA_ExpandedNodeId *targetId) {
-    UA_ReferenceTarget tmpTarget;
-    tmpTarget.targetId = *targetId;
-    tmpTarget.targetIdHash = UA_ExpandedNodeId_hash(targetId);
-    struct aa_head _refIdTree =
-        { kind->idTreeRoot, cmpRefTargetId,
-          offsetof(UA_ReferenceTarget, idTreeEntry), 0 };
-    return (UA_ReferenceTarget*)aa_find(&_refIdTree, &tmpTarget);
+    /* Return from the tree */
+    if(rk->hasRefTree) {
+        UA_ReferenceTargetTreeElem tmpTarget;
+        tmpTarget.target.targetId = *targetId;
+        tmpTarget.targetIdHash = UA_ExpandedNodeId_hash(targetId);
+        const struct aa_head _refIdTree =
+            { rk->targets.tree.idTreeRoot, cmpRefTargetId,
+              offsetof(UA_ReferenceTargetTreeElem, idTreeEntry), 0 };
+        return (const UA_ReferenceTarget*)aa_find(&_refIdTree, &tmpTarget);
+    }
+
+    /* Return from the array */
+    for(size_t i = 0; i < rk->targetsSize; i++) {
+        if(UA_ExpandedNodeId_equal(&rk->targets.array[i].targetId, targetId))
+            return &rk->targets.array[i];
+    }
+    return NULL;
 }
 
 const UA_Node *
@@ -210,10 +227,6 @@ UA_ViewNode_copy(const UA_ViewNode *src, UA_ViewNode *dst) {
     return UA_STATUSCODE_GOOD;
 }
 
-static UA_StatusCode
-addReferenceTarget(UA_NodeReferenceKind *refs, const UA_ExpandedNodeId *target,
-                   UA_UInt32 targetNameHash);
-
 UA_StatusCode
 UA_Node_copy(const UA_Node *src, UA_Node *dst) {
     const UA_NodeHead *srchead = &src->head;
@@ -250,24 +263,17 @@ UA_Node_copy(const UA_Node *src, UA_Node *dst) {
             UA_NodeReferenceKind *drefs = &dsthead->references[i];
             drefs->referenceTypeIndex = srefs->referenceTypeIndex;
             drefs->isInverse = srefs->isInverse;
-            drefs->idTreeRoot = NULL;
-            drefs->nameTreeRoot = NULL;
+            drefs->hasRefTree = srefs->hasRefTree; /* initially empty */
 
             /* Copy all the targets */
-            for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(srefs);
-                t; t = UA_NodeReferenceKind_nextTarget(srefs, t)) {
+            const UA_ReferenceTarget *t = NULL;
+            while((t = UA_NodeReferenceKind_iterate(srefs, t))) {
                 retval = addReferenceTarget(drefs, &t->targetId, t->targetNameHash);
-                if(retval != UA_STATUSCODE_GOOD)
-                    break;
+                if(retval != UA_STATUSCODE_GOOD) {
+                    UA_Node_clear(dst);
+                    return retval;
+                }
             }
-
-            if(retval != UA_STATUSCODE_GOOD)
-                break;
-        }
-
-        if(retval != UA_STATUSCODE_GOOD) {
-            UA_Node_clear(dst);
-            return retval;
         }
     }
 
@@ -523,34 +529,64 @@ UA_Node_setAttributes(UA_Node *node, const void *attributes, const UA_DataType *
 /*********************/
 
 static UA_StatusCode
-addReferenceTarget(UA_NodeReferenceKind *refs, const UA_ExpandedNodeId *target,
+addReferenceTarget(UA_NodeReferenceKind *rk, const UA_ExpandedNodeId *targetId,
                    UA_UInt32 targetNameHash) {
-    UA_ReferenceTarget *entry = (UA_ReferenceTarget*)
-        UA_malloc(sizeof(UA_ReferenceTarget));
+    /* Insert into array */
+    if(!rk->hasRefTree) {
+        UA_ReferenceTarget *newRefs = (UA_ReferenceTarget*)
+            UA_realloc(rk->targets.array,
+                       sizeof(UA_ReferenceTarget) * (rk->targetsSize + 1));
+        if(!newRefs)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        rk->targets.array = newRefs;
+
+        UA_StatusCode retval =
+            UA_ExpandedNodeId_copy(targetId,
+                                   &rk->targets.array[rk->targetsSize].targetId);
+        rk->targets.array[rk->targetsSize].targetNameHash = targetNameHash;
+        if(retval != UA_STATUSCODE_GOOD) {
+            if(rk->targetsSize == 0) {
+                UA_free(rk->targets.array);
+                rk->targets.array = NULL;
+            }
+            return retval;
+        }
+        rk->targetsSize++;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    /* Insert into tree */
+    UA_ReferenceTargetTreeElem *entry = (UA_ReferenceTargetTreeElem*)
+        UA_malloc(sizeof(UA_ReferenceTargetTreeElem));
     if(!entry)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    UA_StatusCode retval = UA_ExpandedNodeId_copy(target, &entry->targetId);
+    UA_StatusCode retval =
+        UA_ExpandedNodeId_copy(targetId, &entry->target.targetId);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_free(entry);
         return retval;
     }
 
-    entry->targetIdHash = UA_ExpandedNodeId_hash(target);
-    entry->targetNameHash = targetNameHash;
+    /* <-- The point of no return --> */
+
+    entry->targetIdHash = UA_ExpandedNodeId_hash(targetId);
+    entry->target.targetNameHash = targetNameHash;
 
     /* Insert to the id lookup binary search tree. Only the root is kept in refs
      * to save space. */
     struct aa_head _refIdTree = refIdTree;
-    _refIdTree.root = refs->idTreeRoot;
+    _refIdTree.root = rk->targets.tree.idTreeRoot;
     aa_insert(&_refIdTree, entry);
-    refs->idTreeRoot = _refIdTree.root;
+    rk->targets.tree.idTreeRoot = _refIdTree.root;
 
     /* Insert to the name lookup binary search tree */
     struct aa_head _refNameTree = refNameTree;
-    _refNameTree.root = refs->nameTreeRoot;
+    _refNameTree.root = rk->targets.tree.nameTreeRoot;
     aa_insert(&_refNameTree, entry);
-    refs->nameTreeRoot = _refNameTree.root;
+    rk->targets.tree.nameTreeRoot = _refNameTree.root;
+
+    rk->targetsSize++;
 
     return UA_STATUSCODE_GOOD;
 }
@@ -559,16 +595,16 @@ static UA_StatusCode
 addReferenceKind(UA_NodeHead *head, UA_Byte refTypeIndex, UA_Boolean isForward,
                  const UA_ExpandedNodeId *targetNodeId, UA_UInt32 targetBrowseNameHash) {
     UA_NodeReferenceKind *refs = (UA_NodeReferenceKind*)
-        UA_realloc(head->references, sizeof(UA_NodeReferenceKind) * (head->referencesSize+1));
+        UA_realloc(head->references,
+                   sizeof(UA_NodeReferenceKind) * (head->referencesSize+1));
     if(!refs)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     head->references = refs;
 
     UA_NodeReferenceKind *newRef = &refs[head->referencesSize];
+    memset(newRef, 0, sizeof(UA_NodeReferenceKind));
     newRef->referenceTypeIndex = refTypeIndex;
     newRef->isInverse = !isForward;
-    newRef->idTreeRoot = NULL;
-    newRef->nameTreeRoot = NULL;
     UA_StatusCode retval =
         addReferenceTarget(newRef, targetNodeId, targetBrowseNameHash);
     if(retval != UA_STATUSCODE_GOOD) {
@@ -600,7 +636,7 @@ UA_Node_addReference(UA_Node *node, UA_Byte refTypeIndex, UA_Boolean isForward,
             continue;
 
         /* Does an identical reference already exist? */
-        UA_ReferenceTarget *found =
+        const UA_ReferenceTarget *found =
             UA_NodeReferenceKind_findTarget(refs, targetNodeId);
         if(found)
             return UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED;
@@ -622,40 +658,64 @@ UA_Node_deleteReference(UA_Node *node, UA_Byte refTypeIndex, UA_Boolean isForwar
     struct aa_head _refNameTree = refNameTree;
 
     UA_NodeHead *head = &node->head;
-    for(size_t i = head->referencesSize; i > 0; --i) {
-        UA_NodeReferenceKind *refs = &head->references[i-1];
+    for(size_t i = 0; i < head->referencesSize; i++) {
+        UA_NodeReferenceKind *refs = &head->references[i];
         if(isForward == refs->isInverse)
             continue;
         if(refTypeIndex != refs->referenceTypeIndex)
             continue;
 
-        _refIdTree.root = refs->idTreeRoot;
-        _refNameTree.root = refs->nameTreeRoot;
-
-        UA_ReferenceTarget *target =
+        /* Cast out the const qualifier (hack!) */
+        UA_ReferenceTarget *target = (UA_ReferenceTarget*)(uintptr_t)
             UA_NodeReferenceKind_findTarget(refs, targetNodeId);
         if(!target)
             continue;
 
-        /* Ok, delete the reference */
-        aa_remove(&_refIdTree, target);
-        aa_remove(&_refNameTree, target);
-        UA_ExpandedNodeId_clear(&target->targetId);
-        UA_free(target);
+        /* Ok, delete the reference. Cannot fail */
+        refs->targetsSize--;
 
-        refs->idTreeRoot = _refIdTree.root;
-        refs->nameTreeRoot = _refNameTree.root;
+        if(!refs->hasRefTree) {
+            /* Remove from array */
+            UA_ExpandedNodeId_clear(&target->targetId);
 
-        if(refs->idTreeRoot)
-            return UA_STATUSCODE_GOOD; /* At least one target remains for the refkind */
+            /* Elements remaining. Realloc. */
+            if(refs->targetsSize > 0) {
+                if(target != &refs->targets.array[refs->targetsSize])
+                    *target = refs->targets.array[refs->targetsSize];
+                UA_ReferenceTarget *newRefs = (UA_ReferenceTarget*)
+                    UA_realloc(refs->targets.array,
+                               sizeof(UA_ReferenceTarget) * refs->targetsSize);
+                if(newRefs)
+                    refs->targets.array = newRefs;
+                return UA_STATUSCODE_GOOD; /* Realloc allowed to fail */
+            }
 
+            /* Remove the last target. Remove the ReferenceKind below */
+            UA_free(refs->targets.array);
+        } else {
+            /* Remove from the tree */
+            _refIdTree.root = refs->targets.tree.idTreeRoot;
+            aa_remove(&_refIdTree, target);
+            refs->targets.tree.idTreeRoot = _refIdTree.root;
+
+            _refNameTree.root = refs->targets.tree.nameTreeRoot;
+            aa_remove(&_refNameTree, target);
+            refs->targets.tree.nameTreeRoot = _refNameTree.root;
+
+            /* TaretId is the first member */
+            UA_ExpandedNodeId_delete(&target->targetId);
+            if(refs->targets.tree.idTreeRoot)
+                return UA_STATUSCODE_GOOD; /* At least one target remains */
+        }
+
+        /* No targets remaining. Remove the ReferenceKind. */
         head->referencesSize--;
         if(head->referencesSize > 0) {
             /* No target for the ReferenceType remaining. Remove and shrink down
              * allocated buffer. Ignore errors in case memory buffer could not
              * be shrinked down. */
-            if(i-1 != head->referencesSize)
-                head->references[i-1] = head->references[node->head.referencesSize];
+            if(i != head->referencesSize)
+                head->references[i] = head->references[node->head.referencesSize];
             UA_NodeReferenceKind *newRefs = (UA_NodeReferenceKind*)
                 UA_realloc(head->references,
                            sizeof(UA_NodeReferenceKind) * head->referencesSize);
@@ -675,32 +735,41 @@ void
 UA_Node_deleteReferencesSubset(UA_Node *node, const UA_ReferenceTypeSet *keepSet) {
     UA_NodeHead *head = &node->head;
     struct aa_head _refIdTree = refIdTree;
-    for(size_t i = head->referencesSize; i > 0; --i) {
+    for(size_t i = 0; i < head->referencesSize; i++) {
         /* Keep the references of this type? */
-        UA_NodeReferenceKind *refs = &head->references[i-1];
+        UA_NodeReferenceKind *refs = &head->references[i];
         if(UA_ReferenceTypeSet_contains(keepSet, refs->referenceTypeIndex))
             continue;
 
         /* Remove all target entries. Don't remove entries from browseName tree.
          * The entire ReferenceKind will be removed anyway. */
-        _refIdTree.root = refs->idTreeRoot;
-        UA_ReferenceTarget *target;
-        while((target = (UA_ReferenceTarget*)_refIdTree.root)) {
-            aa_remove(&_refIdTree, target);
-            UA_ExpandedNodeId_clear(&target->targetId);
-            UA_free(target);
+        if(!refs->hasRefTree) {
+            for(size_t j = 0; j < refs->targetsSize; j++)
+                UA_ExpandedNodeId_clear(&refs->targets.array[j].targetId);
+            UA_free(refs->targets.array);
+        } else {
+            _refIdTree.root = refs->targets.tree.idTreeRoot;
+            UA_ExpandedNodeId *target;
+            while((target = (UA_ExpandedNodeId*)_refIdTree.root)) {
+                aa_remove(&_refIdTree, target);
+                UA_ExpandedNodeId_delete(target);
+            }
         }
-        head->referencesSize--;
 
-        /* Move last references-kind entry to this position */
-        if(i-1 != head->referencesSize) /* Don't memcpy over the same position */
-            head->references[i-1] = head->references[head->referencesSize];
+        /* Move last references-kind entry to this position. Don't memcpy over
+         * the same position. Decrease i to repeat at this location. */
+        head->referencesSize--;
+        if(i != head->referencesSize) {
+            head->references[i] = head->references[head->referencesSize];
+            i--;
+        }
     }
 
     if(head->referencesSize > 0) {
         /* Realloc to save memory. Ignore if realloc fails. */
         UA_NodeReferenceKind *refs = (UA_NodeReferenceKind*)
-            UA_realloc(head->references, sizeof(UA_NodeReferenceKind) * head->referencesSize);
+            UA_realloc(head->references,
+                       sizeof(UA_NodeReferenceKind) * head->referencesSize);
         if(refs)
             head->references = refs;
     } else {

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -162,15 +162,8 @@ struct UA_Server {
 
 extern const struct aa_head refNameTree;
 
-UA_ReferenceTarget *
-UA_NodeReferenceKind_firstTarget(const UA_NodeReferenceKind *kind);
-
-UA_ReferenceTarget *
-UA_NodeReferenceKind_nextTarget(const UA_NodeReferenceKind *kind,
-                                const UA_ReferenceTarget *current);
-
-UA_ReferenceTarget *
-UA_NodeReferenceKind_findTarget(const UA_NodeReferenceKind *kind,
+const UA_ReferenceTarget *
+UA_NodeReferenceKind_findTarget(const UA_NodeReferenceKind *rk,
                                 const UA_ExpandedNodeId *targetId);
 
 /**************************/

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -27,8 +27,8 @@ getArgumentsVariableNode(UA_Server *server, const UA_NodeHead *head,
             continue;
         if(rk->referenceTypeIndex != UA_REFERENCETYPEINDEX_HASPROPERTY)
             continue;
-        for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(rk);
-            t; t = UA_NodeReferenceKind_nextTarget(rk, t)) {
+        const UA_ReferenceTarget *t = NULL;
+        while((t = UA_NodeReferenceKind_iterate(rk, t))) {
             const UA_Node *refTarget = UA_NODESTORE_GETFROMREF(server, t);
             if(!refTarget)
                 continue;
@@ -161,8 +161,8 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
             continue;
         if(!UA_ReferenceTypeSet_contains(&hasComponentRefs, rk->referenceTypeIndex))
             continue;
-        for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(rk);
-            t; t = UA_NodeReferenceKind_nextTarget(rk, t)) {
+        const UA_ReferenceTarget *t = NULL;
+        while((t = UA_NodeReferenceKind_iterate(rk, t))) {
             if(UA_ExpandedNodeId_isLocal(&t->targetId) &&
                UA_NodeId_equal(&t->targetId.nodeId, &request->methodId)) {
                 found = true;
@@ -209,8 +209,8 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
             
             /* Verify that the HasTypeDefinition is equal to FunctionGroupType
              * (or sub-type) from the DI model */
-            for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(rk);
-                t && !found; t = UA_NodeReferenceKind_nextTarget(rk, t)) {
+            const UA_ReferenceTarget *t = NULL;
+            while((t = UA_NodeReferenceKind_iterate(rk, t))) {
                 if(!UA_ExpandedNodeId_isLocal(&t->targetId))
                     continue;
                 
@@ -231,8 +231,8 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
                                                UA_REFERENCETYPEINDEX_HASSUBTYPE))
                         continue;
                     
-                    for(UA_ReferenceTarget *t2 = UA_NodeReferenceKind_firstTarget(rkInner);
-                        t2; t2 = UA_NodeReferenceKind_nextTarget(rkInner, t2)) {
+                    const UA_ReferenceTarget *t2 = NULL;
+                    while((t2 = UA_NodeReferenceKind_iterate(rkInner, t2))) {
                         if(!UA_ExpandedNodeId_isLocal(&t2->targetId))
                             continue;
                         if(UA_NodeId_equal(&t2->targetId.nodeId, &request->methodId)) {

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -521,8 +521,8 @@ isMandatoryChild(UA_Server *server, UA_Session *session,
         if(rk->isInverse)
             continue;
 
-        for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(rk);
-            t; t = UA_NodeReferenceKind_nextTarget(rk, t)) {
+        const UA_ReferenceTarget *t = NULL;
+        while((t = UA_NodeReferenceKind_iterate(rk, t))) {
             if(UA_ExpandedNodeId_isLocal(&t->targetId) &&
                UA_NodeId_equal(&mandatoryId, &t->targetId.nodeId)) {
                 UA_NODESTORE_RELEASE(server, child);
@@ -1659,8 +1659,8 @@ removeIncomingReferences(UA_Server *server, UA_Session *session, const UA_NodeHe
         item.isForward = rk->isInverse;
         item.referenceTypeId =
             *UA_NODESTORE_GETREFERENCETYPEID(server, rk->referenceTypeIndex);
-        for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(rk);
-            t; t = UA_NodeReferenceKind_nextTarget(rk, t)) {
+        const UA_ReferenceTarget *t = NULL;
+        while((t = UA_NodeReferenceKind_iterate(rk, t))) {
             if(!UA_ExpandedNodeId_isLocal(&t->targetId))
                 continue;
             item.sourceNodeId = t->targetId.nodeId;
@@ -1679,8 +1679,8 @@ hasParentRef(const UA_NodeHead *head, const UA_ReferenceTypeSet *refSet,
             continue;
         if(!UA_ReferenceTypeSet_contains(refSet, rk->referenceTypeIndex))
             continue;
-        for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(rk);
-            t; t = UA_NodeReferenceKind_nextTarget(rk, t)) {
+        const UA_ReferenceTarget *t = NULL;
+        while((t = UA_NodeReferenceKind_iterate(rk, t))) {
             if(!UA_ExpandedNodeId_isLocal(&t->targetId))
                 continue;
             if(!RefTree_containsNodeId(refTree, &t->targetId.nodeId))
@@ -1765,14 +1765,10 @@ autoDeleteChildren(UA_Server *server, UA_Session *session, RefTree *refTree,
             continue;
 
         /* Loop over the references */
-        for(UA_ReferenceTarget *t = UA_NodeReferenceKind_firstTarget(refs);
-            t; t = UA_NodeReferenceKind_nextTarget(refs, t)) {
-            /* References an external server? */
-            if(!UA_ExpandedNodeId_isLocal(&t->targetId))
-               continue;
-
+        const UA_ReferenceTarget *t = NULL;
+        while((t = UA_NodeReferenceKind_iterate(refs, t))) {
             /* Get the child */
-            const UA_Node *child = UA_NODESTORE_GET(server, &t->targetId.nodeId);
+            const UA_Node *child = UA_NODESTORE_GETFROMREF(server, t);
             if(!child)
                 continue;
 

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -262,8 +262,8 @@ getFieldParentNodeId(UA_Server *server, const UA_NodeId *field, UA_NodeId *paren
         if(!rk->isInverse)
             continue;
         /* Take the first hierarchical inverse reference */
-        for(UA_ReferenceTarget *target = UA_NodeReferenceKind_firstTarget(rk);
-            target; target = UA_NodeReferenceKind_nextTarget(rk, target)) {
+        const UA_ReferenceTarget *target = NULL;
+        while((target = UA_NodeReferenceKind_iterate(rk, target))) {
             if(!UA_ExpandedNodeId_isLocal(&target->targetId))
                 continue;
             retval = UA_NodeId_copy(&target->targetId.nodeId, parent);

--- a/tests/check_types_memory.c
+++ b/tests/check_types_memory.c
@@ -162,37 +162,6 @@ START_TEST(encodeShallYieldDecode) {
 END_TEST
 
 START_TEST(decodeShallFailWithTruncatedBufferButSurvive) {
-    //Skip test for void*
-    if (
-#ifdef UA_ENABLE_DISCOVERY
-        _i == UA_TYPES_DISCOVERYCONFIGURATION ||
-#endif
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-        _i == UA_TYPES_FILTEROPERAND ||
-        _i == UA_TYPES_UNION ||
-#endif
-#ifdef UA_TYPES_FRAME
-        _i == UA_TYPES_FRAME ||
-        _i == UA_TYPES_ORIENTATION ||
-        _i == UA_TYPES_VECTOR ||
-        _i == UA_TYPES_CARTESIANCOORDINATES ||
-#endif
-        _i == UA_TYPES_HISTORYREADDETAILS ||
-        _i == UA_TYPES_NOTIFICATIONDATA ||
-        _i == UA_TYPES_MONITORINGFILTER ||
-        _i == UA_TYPES_MONITORINGFILTERRESULT ||
-        _i == UA_TYPES_DATASETREADERMESSAGEDATATYPE ||
-        _i == UA_TYPES_WRITERGROUPTRANSPORTDATATYPE ||
-        _i == UA_TYPES_CONNECTIONTRANSPORTDATATYPE ||
-        _i == UA_TYPES_WRITERGROUPMESSAGEDATATYPE ||
-        _i == UA_TYPES_READERGROUPTRANSPORTDATATYPE ||
-        _i == UA_TYPES_PUBLISHEDDATASETSOURCEDATATYPE ||
-        _i == UA_TYPES_DATASETREADERTRANSPORTDATATYPE ||
-        _i == UA_TYPES_DATASETWRITERTRANSPORTDATATYPE ||
-        _i == UA_TYPES_SUBSCRIBEDDATASETDATATYPE ||
-        _i == UA_TYPES_READERGROUPMESSAGEDATATYPE ||
-        _i == UA_TYPES_DATASETWRITERMESSAGEDATATYPE)
-        return;
     // given
     UA_ByteString msg1;
     void *obj1 = UA_new(&UA_TYPES[_i]);
@@ -200,11 +169,8 @@ START_TEST(decodeShallFailWithTruncatedBufferButSurvive) {
     UA_Byte *pos = msg1.data;
     const UA_Byte *end = &msg1.data[msg1.length];
     retval |= UA_encodeBinary(obj1, &UA_TYPES[_i], &pos, &end, NULL, NULL);
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     UA_delete(obj1, &UA_TYPES[_i]);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_ByteString_clear(&msg1);
-        return; // e.g. variants cannot be encoded after an init without failing (no datatype set)
-    }
 
     size_t half = (uintptr_t)(pos - msg1.data) / 2;
     msg1.length = half;
@@ -215,6 +181,7 @@ START_TEST(decodeShallFailWithTruncatedBufferButSurvive) {
     retval = UA_decodeBinary(&msg1, &offset, obj2, &UA_TYPES[_i], NULL);
     ck_assert_int_ne(retval, UA_STATUSCODE_GOOD);
     UA_delete(obj2, &UA_TYPES[_i]);
+    msg1.length = 65000;
     UA_ByteString_clear(&msg1);
 }
 END_TEST
@@ -291,40 +258,6 @@ START_TEST(decodeComplexTypeFromRandomBufferShallSurvive) {
 END_TEST
 
 START_TEST(calcSizeBinaryShallBeCorrect) {
-    /* Empty variants (with no type defined) cannot be encoded. This is
-     * intentional. Discovery configuration is just a base class and void * */
-    if(_i == UA_TYPES_VARIANT ||
-       _i == UA_TYPES_VARIABLEATTRIBUTES ||
-       _i == UA_TYPES_VARIABLETYPEATTRIBUTES ||
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-       _i == UA_TYPES_FILTEROPERAND ||
-#endif
-#ifdef UA_ENABLE_DISCOVERY
-       _i == UA_TYPES_DISCOVERYCONFIGURATION ||
-#endif
-       _i == UA_TYPES_UNION ||
-#ifdef UA_TYPES_FRAME
-       _i == UA_TYPES_FRAME ||
-       _i == UA_TYPES_ORIENTATION ||
-       _i == UA_TYPES_VECTOR ||
-       _i == UA_TYPES_CARTESIANCOORDINATES ||
-#endif
-       _i == UA_TYPES_HISTORYREADDETAILS ||
-       _i == UA_TYPES_NOTIFICATIONDATA ||
-       _i == UA_TYPES_MONITORINGFILTER ||
-        _i == UA_TYPES_MONITORINGFILTERRESULT ||
-        _i == UA_TYPES_DATASETREADERMESSAGEDATATYPE ||
-        _i == UA_TYPES_WRITERGROUPTRANSPORTDATATYPE ||
-        _i == UA_TYPES_CONNECTIONTRANSPORTDATATYPE ||
-        _i == UA_TYPES_WRITERGROUPMESSAGEDATATYPE ||
-        _i == UA_TYPES_READERGROUPTRANSPORTDATATYPE ||
-        _i == UA_TYPES_PUBLISHEDDATASETSOURCEDATATYPE ||
-        _i == UA_TYPES_DATASETREADERTRANSPORTDATATYPE ||
-        _i == UA_TYPES_DATASETWRITERTRANSPORTDATATYPE ||
-        _i == UA_TYPES_SUBSCRIBEDDATASETDATATYPE ||
-        _i == UA_TYPES_READERGROUPMESSAGEDATATYPE ||
-        _i == UA_TYPES_DATASETWRITERMESSAGEDATATYPE)
-        return;
     void *obj = UA_new(&UA_TYPES[_i]);
     size_t predicted_size = UA_calcSizeBinary(obj, &UA_TYPES[_i]);
     ck_assert_uint_ne(predicted_size, 0);

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -111,6 +111,20 @@ function unit_tests_mt {
     make test ARGS="-V"
 }
 
+function unit_tests_alarms {
+    mkdir -p build; cd build; rm -rf *
+    cmake -DCMAKE_BUILD_TYPE=Debug \
+          -DUA_BUILD_EXAMPLES=ON \
+          -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_DA=ON \
+          -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+	      -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON \
+          -DUA_NAMESPACE_ZERO=FULL \
+          ..
+    make ${MAKEOPTS}
+    make test ARGS="-V"
+}
+
 function unit_tests_encryption {
     mkdir -p build; cd build; rm -rf *
     cmake -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
This saves about 20% of RAM because we don't need the tree pointer overhead.