### PR TITLE
Update ua_services_discovery.c

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -621,7 +621,7 @@ UA_Server_addPeriodicServerRegisterCallback(UA_Server *server,
     }
 
 
-    if (client->connection.state != UA_CONNECTIONSTATE_CLOSED) {
+    if (client->connection.state != UA_CONNECTIONSTATE_ESTABLISHED) {
         UA_UNLOCK(&server->serviceMutex);
         return UA_STATUSCODE_BADINVALIDSTATE;
     }


### PR DESCRIPTION
In this function UA_Server_addPeriodicServerRegisterCallback(), line 624 checks is incorrect:

if (client->connection.state != UA_CONNECTIONSTATE_CLOSED)

It should be : if (client->connection.state != UA_CONNECTIONSTATE_ESTABLISHED)