### PR TITLE
fix(nc): Sort references before adding to list of nodes

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -72,7 +72,7 @@ def sortNodes(nodeset):
         L.append(u)
         del R[u.id]
 
-        for ref in u.references:
+        for ref in sorted(u.references, key=lambda r: str(r.target)):
             if not ref.referenceType in relevant_refs:
                 continue
             if nodeset.nodes[ref.target].hidden:
@@ -90,7 +90,7 @@ def sortNodes(nodeset):
         L.append(u)
         del R[u.id]
 
-        for ref in u.references:
+        for ref in sorted(u.references, key=lambda r: str(r.target)):
             if not ref.referenceType in relevant_refs:
                 continue
             if nodeset.nodes[ref.target].hidden:


### PR DESCRIPTION
`Node.references` is of type `set()` which is an unordered collection.
This results in a different order of elements on every run of nodeset compiler although the input did not change.

This change fixes this behaviour and produces identical (i.e. deterministic) output from the same input.