### PR TITLE
[Review] Permit CreateMonitoredItem service for hidden nodes/statuscode BadNodeIdUnknown

### DIFF
--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -105,6 +105,14 @@ struct UA_AccessControl {
     UA_Boolean (*allowTransferSubscription)(UA_Server *server, UA_AccessControl *ac,
                                             const UA_NodeId *oldSessionId, void *oldSessionContext,
                                             const UA_NodeId *newSessionId, void *newSessionContext);
+
+    /* Allow CreateMonitoredItem request for NodeId and certain AttributeId.
+     * true = it is permitted to create a MonitoredItem to this currently not available node.
+     * false = request will rejected with Operation Level Result Code BadNodeIdUnknown.
+     */
+    UA_Boolean (*allowCreateMonitoredItemNodeId)(UA_Server *server, const UA_NodeId *sessionId,
+                                                 void *sessionContext, const UA_NodeId *nodeId,
+                                                 const UA_UInt32 attributeId);
 #endif
 
 #ifdef UA_ENABLE_HISTORIZING

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -127,6 +127,10 @@ struct UA_ServerConfig {
      * empty variant value. The default behaviour is to auto-create a matching
      * zeroed-out value for empty VariableNodes when they are added. */
     UA_RuleHandling allowEmptyVariables;
+    
+    /* A server creates a MonitoredItem even the statuscode 
+     * is bad, e.g. BadUnknownNodeId. */
+    UA_RuleHandling allowCreateMonItemBadStatusCode; 
 
     /**
      * Custom Data Types

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -4,8 +4,8 @@
  *    Copyright 2016-2017 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2019 (c) HMS Industrial Networks AB (Author: Jonas Green)
+ *    Copyright 2021 (c) Hilscher Gesellschaft für Systemautomation mbH (Author: Martin Lang)
  */
-
 #include <open62541/plugin/accesscontrol_default.h>
 
 /* Example access control management. Anonymous and username / password login.
@@ -216,6 +216,14 @@ allowTransferSubscription_default(UA_Server *server, UA_AccessControl *ac,
                                    (UA_ByteString*)newSessionContext);
     return false;
 }
+
+static UA_Boolean
+allowCreateMonitoredItemNodeId_default(UA_Server *server, const UA_NodeId *sessionId,
+                               void *sessionContext, const UA_NodeId *nodeId,
+                               const UA_UInt32 attributeId)
+{
+  return true;
+}
 #endif
 
 #ifdef UA_ENABLE_HISTORIZING
@@ -295,6 +303,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     ac->allowTransferSubscription = allowTransferSubscription_default;
+    ac->allowCreateMonitoredItemNodeId = allowCreateMonitoredItemNodeId_default;
 #endif
 
 #ifdef UA_ENABLE_HISTORIZING

--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2014-2018 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2016-2017 (c) Florian Palm
@@ -95,7 +95,7 @@ Service_SetTriggering(UA_Server *server, UA_Session *session,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
         return;
     }
-    
+
     /* Get the MonitoredItem */
     UA_MonitoredItem *mon = UA_Subscription_getMonitoredItem(sub, request->triggeringItemId);
     if(!mon) {
@@ -215,8 +215,11 @@ checkAdjustMonitoredItemParams(UA_Server *server, UA_Session *session,
                 params->samplingInterval = vn->minimumSamplingInterval;
             UA_NODESTORE_RELEASE(server, node);
         }
+        else{
+          params->samplingInterval = server->config.samplingIntervalLimits.min;
+        }
     }
-        
+
     /* Adjust to sampling interval to lie within the limits */
     if(params->samplingInterval <= 0.0) {
         /* A sampling interval of zero is possible and indicates that the


### PR DESCRIPTION
Part 4, 5.12.2 CreateMonitoredItems: Monitored Nodes can be removed from the AddressSpace after the creation of a MonitoredItem. This does not affect the validity of the MonitoredItem but a Bad_NodeIdUnknown shall be returned in the Publish response. It is possible that the MonitoredItem becomes valid again if the Node is added again to the AddressSpace and the MonitoredItem still exists. 

OPCF Forum:
https://opcfoundation.org/forum/opc-ua-standard/create-monitoreditem-with-node-statuscode-badnodeidunknown/