### PR TITLE
Fix docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
-FROM alpine:3.10
-RUN apk add --no-cache cmake gcc git g++ musl-dev mbedtls-dev python py-pip make && rm -rf /var/cache/apk/*
+FROM ubuntu:20.04
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update -qq && apt-get install -y -qq cmake gcc git g++ musl-dev libmbedtls-dev python3 python3-pip make
 ADD . /opt/open62541
 
 # Get all the git tags to make sure we detect the correct version with git describe
@@ -26,10 +28,10 @@ RUN make install
 WORKDIR /opt/open62541
 
 # Generate certificates
-RUN apk add --no-cache python-dev linux-headers openssl && rm -rf /var/cache/apk/*
+RUN apt-get install -y python3-dev openssl
 RUN pip install netifaces==0.10.9
 RUN mkdir -p /opt/open62541/pki/created
-RUN python /opt/open62541/tools/certs/create_self-signed.py /opt/open62541/pki/created
+RUN python3 /opt/open62541/tools/certs/create_self-signed.py /opt/open62541/pki/created
 
 
 EXPOSE 4840

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
-FROM ubuntu:20.04
-ENV TZ=UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt-get update -qq && apt-get install -y -qq cmake gcc git g++ musl-dev libmbedtls-dev python3 python3-pip make
+FROM alpine:3.10
+RUN apk add --no-cache cmake gcc git g++ musl-dev mbedtls-dev python3 py3-pip make && rm -rf /var/cache/apk/*
 ADD . /opt/open62541
 
 # Get all the git tags to make sure we detect the correct version with git describe
@@ -28,8 +26,8 @@ RUN make install
 WORKDIR /opt/open62541
 
 # Generate certificates
-RUN apt-get install -y python3-dev openssl
-RUN pip install netifaces==0.10.9
+RUN apk add --no-cache python3-dev linux-headers openssl && rm -rf /var/cache/apk/*
+RUN pip3 install netifaces==0.10.9
 RUN mkdir -p /opt/open62541/pki/created
 RUN python3 /opt/open62541/tools/certs/create_self-signed.py /opt/open62541/pki/created
 


### PR DESCRIPTION
Docker build fails with :
```
 ---> Running in 78ec21179ee5
-- The C compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find Python3 (missing: Python3_EXECUTABLE Interpreter)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindPython/Support.cmake:1177 (find_package_handle_standard_args)
  /usr/share/cmake/Modules/FindPython3.cmake:181 (include)
  CMakeLists.txt:15 (find_package)
```

I fixed this issue with replace `python` to `python3`. 


Fixed docker image available at `markandreev/open62541:latest`