### PR TITLE
[Review] MonitoredItem sampling callback handle Bad_StatusCodes improper

### DIFF
--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2017-2020 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
@@ -81,8 +81,18 @@ static UA_StatusCode
 detectValueChangeWithFilter(UA_Server *server, UA_Session *session, UA_MonitoredItem *mon,
                             UA_DataValue *value, UA_ByteString *encoding,
                             UA_Boolean *changed) {
-    if(!value->value.type) {
-        *changed = !(UA_ByteString_equal(encoding, &mon->lastSampledValue));
+    /* Handle status change for instance Bad_NodeIdUnknown */
+    if(value->hasStatus && value->status != mon->lastValue.status) {
+        *changed = true;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    if(!value->value.type &&
+        /* Ensure there is a value. Otherwise:
+         * changed = UA_ByteString_equal(UA_BYTESTRING_NULL, &mon->lastSampledValue)
+         * returns continuously true. */
+        value->hasValue) {
+        *changed = UA_ByteString_equal(encoding, &mon->lastSampledValue);
         return UA_STATUSCODE_GOOD;
     }
 

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -82,7 +82,8 @@ detectValueChangeWithFilter(UA_Server *server, UA_Session *session, UA_Monitored
                             UA_DataValue *value, UA_ByteString *encoding,
                             UA_Boolean *changed) {
     /* Handle status change for instance Bad_NodeIdUnknown */
-    if(value->hasStatus && mon->lastValue.hasStatus && value->status != mon->lastValue.status) {
+    if(value->hasStatus != mon->lastValue.hasStatus ||
+       value->status != mon->lastValue.status) {
         *changed = true;
         return UA_STATUSCODE_GOOD;
     }

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -87,15 +87,6 @@ detectValueChangeWithFilter(UA_Server *server, UA_Session *session, UA_Monitored
         return UA_STATUSCODE_GOOD;
     }
 
-    if(!value->value.type &&
-        /* Ensure there is a value. Otherwise:
-         * changed = UA_ByteString_equal(UA_BYTESTRING_NULL, &mon->lastSampledValue)
-         * returns continuously true. */
-        value->hasValue) {
-        *changed = UA_ByteString_equal(encoding, &mon->lastSampledValue);
-        return UA_STATUSCODE_GOOD;
-    }
-
     /* Test absolute deadband */
     if(UA_DataType_isNumeric(value->value.type) &&
        mon->parameters.filter.content.decoded.type == &UA_TYPES[UA_TYPES_DATACHANGEFILTER]) {

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -82,13 +82,14 @@ detectValueChangeWithFilter(UA_Server *server, UA_Session *session, UA_Monitored
                             UA_DataValue *value, UA_ByteString *encoding,
                             UA_Boolean *changed) {
     /* Handle status change for instance Bad_NodeIdUnknown */
-    if(value->hasStatus && value->status != mon->lastValue.status) {
+    if(value->hasStatus && mon->lastValue.hasStatus && value->status != mon->lastValue.status) {
         *changed = true;
         return UA_STATUSCODE_GOOD;
     }
 
     /* Test absolute deadband */
-    if(UA_DataType_isNumeric(value->value.type) &&
+    if(value->value.type != NULL &&
+       UA_DataType_isNumeric(value->value.type) &&
        mon->parameters.filter.content.decoded.type == &UA_TYPES[UA_TYPES_DATACHANGEFILTER]) {
         UA_DataChangeFilter *filter = (UA_DataChangeFilter*)
             mon->parameters.filter.content.decoded.data;


### PR DESCRIPTION
If the Node are become hidden during runtime the sampling callback did not report Bad_NodeIdKnown. Instead the callback evaluate a data change continuously.

I'm not sure what the line 90 really checks, but I must extend it.
The UA_ByteString_equal signale a datachange if mon->lastSampledValue is a NULL-ByteString all time.
```c
if(!value->value.type) {
    *changed = UA_ByteString_equal(encoding, &mon->lastSampledValue);
    return UA_STATUSCODE_GOOD;
}
```