### PR TITLE
feat(core): add attach condition behavior function

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -55,6 +55,7 @@ generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_variabletype.c ${DOC
 generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_datasource.c ${DOC_SRC_DIR}/tutorial_server_datasource.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_events.c ${DOC_SRC_DIR}/tutorial_server_events.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_alarms_conditions.c ${DOC_SRC_DIR}/tutorial_server_alarms_conditions.rst)
+generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_alarms_conditions_custom.c ${DOC_SRC_DIR}/tutorial_server_alarms_conditions_custom.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_monitoreditems.c ${DOC_SRC_DIR}/tutorial_server_monitoreditems.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_object.c ${DOC_SRC_DIR}/tutorial_server_object.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/examples/tutorial_server_method.c ${DOC_SRC_DIR}/tutorial_server_method.rst)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -102,6 +102,7 @@ if(UA_ENABLE_SUBSCRIPTIONS_EVENTS)
   add_example(tutorial_server_events tutorial_server_events.c)
   if(UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS)
     add_example(tutorial_server_alarms_conditions tutorial_server_alarms_conditions.c)
+    add_example(tutorial_server_alarms_conditions_custom tutorial_server_alarms_conditions_custom.c)
   endif()
 endif()
 

--- a/examples/tutorial_server_alarms_conditions_custom.c
+++ b/examples/tutorial_server_alarms_conditions_custom.c
@@ -1,0 +1,538 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+
+#include <signal.h>
+#include <stdlib.h>
+
+/**
+ * Using Custom Alarms and Conditions
+ * ----------------------------------
+ *
+ * Sometimes the application needs to have full control over the nodes, like creating 
+ * all nodes manually to manage the memory and NodeIds. This example will demonstrate
+ * adding alarms and conditions behavior to condition objects, which where created in 
+ * custom manner. For simplicity, UA_Server_addObjectNode will be used to create the
+ * condition object itself and all its children nodes. Condition refresh event objects
+ * must be created manually in this case. Condition properties should be set manually 
+ * as well (not demonstrated in this example).
+ *
+ * Note: The following example will be based on the server events and alarms and conditions 
+ * tutorials. Please make sure to understand the principle of normal events and alarms and 
+ * conditions before proceeding with this example! */
+
+static UA_NodeId conditionSource;
+static UA_NodeId customConditionInstance;
+static UA_NodeId conditionRefreshStart;
+static UA_NodeId conditionRefreshEnd;
+
+/**
+ * Create condition source object */
+static UA_StatusCode
+addConditionSourceObject(UA_Server *server) {
+    UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
+    object_attr.eventNotifier = 1;
+
+    object_attr.displayName = UA_LOCALIZEDTEXT("en", "ConditionSourceObject");
+    UA_StatusCode retval =  UA_Server_addObjectNode(server, UA_NODEID_NULL,
+                                                    UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                                    UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                                    UA_QUALIFIEDNAME(0, "ConditionSourceObject"),
+                                                    UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+                                                    object_attr, NULL, &conditionSource);
+
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Creating Condition Source failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+    }
+
+    /* ConditionSource should be EventNotifier of another Object (usually the
+     * Server Object). If this Reference is not created by user then the A&C
+     * Server will create "HasEventSource" reference to the Server Object
+     * automatically when the condition is created*/
+    retval = UA_Server_addReference(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER),
+                                     UA_NODEID_NUMERIC(0, UA_NS0ID_HASNOTIFIER),
+                                     UA_EXPANDEDNODEID_NUMERIC(conditionSource.namespaceIndex,
+                                                               conditionSource.identifier.numeric),
+                                     UA_TRUE);
+
+    return retval;
+}
+
+/**
+ * Create a custom condition instance (as normal object) from OffNormalAlarmType. The condition source is
+ * the Object created in addConditionSourceObject(). The condition will be
+ * exposed in Address Space through the HasComponent reference to the condition
+ * source. */
+static UA_StatusCode
+addCustomCondition(UA_Server *server) {
+    UA_StatusCode retval = addConditionSourceObject(server);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "creating Condition Source failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+    }
+
+    UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
+    object_attr.displayName = UA_LOCALIZEDTEXT("en", "CustomCondition");
+    retval =  UA_Server_addObjectNode(server, UA_NODEID_NULL,
+                                      conditionSource,
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                      UA_QUALIFIEDNAME(0, "CustomCondition"),
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_OFFNORMALALARMTYPE),
+                                      object_attr, NULL, &customConditionInstance);
+    return retval;
+}
+
+/**
+ * attach condition behavior to a custom condition instance */
+static UA_StatusCode
+attachConditionBehavior(UA_Server *server) {
+    UA_StatusCode retval =
+        UA_Server_attachConditionBehavior(server, customConditionInstance,
+                                          UA_NODEID_NUMERIC(0, UA_NS0ID_OFFNORMALALARMTYPE),
+                                          UA_QUALIFIEDNAME(0, "CustomCondition"),
+                                          conditionSource,
+                                          UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), 
+                                          conditionRefreshStart,
+                                          conditionRefreshEnd);
+
+    return retval;
+}
+
+/**
+ * Create Condition Refresh Event Objects */
+static UA_StatusCode
+addConditionRefreshEvents(UA_Server *server) {
+    UA_StatusCode retval = UA_Server_createEvent(server, 
+                                                 UA_NODEID_NUMERIC(0, UA_NS0ID_REFRESHSTARTEVENTTYPE), 
+                                                 &conditionRefreshStart);
+
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Creating Condition Refresh Start Event failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+    }
+
+    if(retval == UA_STATUSCODE_GOOD) {
+        retval = UA_Server_createEvent(server,
+                                       UA_NODEID_NUMERIC(0, UA_NS0ID_REFRESHENDEVENTTYPE),
+                                       &conditionRefreshEnd);
+
+      if(retval != UA_STATUSCODE_GOOD) {
+          UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                       "Creating Condition Refresh End Event failed. StatusCode %s",
+                       UA_StatusCode_name(retval));
+      }
+    }
+
+    return retval;
+}
+
+static void
+addVariable_1_triggerAlarmOfCondition(UA_Server *server, UA_NodeId* outNodeId) {
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en", "Activate Custom Condition");
+    attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+    UA_Boolean tboolValue = UA_FALSE;
+    UA_Variant_setScalar(&attr.value, &tboolValue, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    UA_QualifiedName CallbackTestVariableName = UA_QUALIFIEDNAME(0, "Activate Custom Condition");
+    UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    UA_NodeId variableTypeNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE);
+    UA_Server_addVariableNode(server, UA_NODEID_NULL, parentNodeId,
+                              parentReferenceNodeId, CallbackTestVariableName,
+                              variableTypeNodeId, attr, NULL, outNodeId);
+}
+
+static void
+addVariable_3_returnCondition_toNormalState(UA_Server *server,
+                                              UA_NodeId* outNodeId) {
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en", "Return to Normal Condition");
+    attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+    UA_Boolean rtn = 0;
+    UA_Variant_setScalar(&attr.value, &rtn, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    UA_QualifiedName CallbackTestVariableName =
+        UA_QUALIFIEDNAME(0, "Return to Normal Condition");
+    UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    UA_NodeId variableTypeNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE);
+    UA_Server_addVariableNode(server, UA_NODEID_NULL, parentNodeId,
+                              parentReferenceNodeId, CallbackTestVariableName,
+                              variableTypeNodeId, attr, NULL, outNodeId);
+}
+
+static void
+afterWriteCallbackVariable_1(UA_Server *server, const UA_NodeId *sessionId,
+                             void *sessionContext, const UA_NodeId *nodeId,
+                             void *nodeContext, const UA_NumericRange *range,
+                             const UA_DataValue *data) {
+    UA_QualifiedName activeStateField = UA_QUALIFIEDNAME(0,"ActiveState");
+    UA_QualifiedName activeStateIdField = UA_QUALIFIEDNAME(0,"Id");
+    UA_Variant value;
+
+    UA_StatusCode retval =
+        UA_Server_writeObjectProperty_scalar(server, customConditionInstance,
+                                             UA_QUALIFIEDNAME(0, "Time"),
+                                             &data->sourceTimestamp,
+                                             &UA_TYPES[UA_TYPES_DATETIME]);
+
+    if(*(UA_Boolean *)(data->value.data) == true) {
+        /* By writing "true" in ActiveState/Id, the A&C server will set the
+         * related fields automatically and then will trigger event
+         * notification. */
+        UA_Boolean activeStateId = true;
+        UA_Variant_setScalar(&value, &activeStateId, &UA_TYPES[UA_TYPES_BOOLEAN]);
+        retval |= UA_Server_setConditionVariableFieldProperty(server, customConditionInstance,
+                                                              &value, activeStateField,
+                                                              activeStateIdField);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                         "Setting ActiveState/Id Field failed. StatusCode %s",
+                         UA_StatusCode_name(retval));
+            return;
+        }
+    } else {
+        /* By writing "false" in ActiveState/Id, the A&C server will set only
+         * the ActiveState field automatically to the value "Inactive". The user
+         * should trigger the event manually by calling
+         * UA_Server_triggerConditionEvent inside the application or call
+         * ConditionRefresh method with client to update the event notification. */
+        UA_Boolean activeStateId = false;
+        UA_Variant_setScalar(&value, &activeStateId, &UA_TYPES[UA_TYPES_BOOLEAN]);
+        retval = UA_Server_setConditionVariableFieldProperty(server, customConditionInstance,
+                                                             &value, activeStateField,
+                                                             activeStateIdField);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                         "Setting ActiveState/Id Field failed. StatusCode %s",
+                         UA_StatusCode_name(retval));
+            return;
+        }
+
+        retval = UA_Server_triggerConditionEvent(server, customConditionInstance,
+                                                 conditionSource, NULL);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                           "Triggering condition event failed. StatusCode %s",
+                           UA_StatusCode_name(retval));
+            return;
+        }
+    }
+}
+
+/**
+ * RTN = return to normal.
+ *
+ * Retain will be set to false, thus no events will be generated for condition 1
+ * (although EnabledState/=true). To set Retain to true again, the disable and
+ * enable methods should be called respectively.
+ */
+static void
+afterWriteCallbackVariable_3(UA_Server *server,
+               const UA_NodeId *sessionId, void *sessionContext,
+               const UA_NodeId *nodeId, void *nodeContext,
+               const UA_NumericRange *range, const UA_DataValue *data) {
+
+    //UA_QualifiedName enabledStateField = UA_QUALIFIEDNAME(0,"EnabledState");
+    UA_QualifiedName ackedStateField = UA_QUALIFIEDNAME(0,"AckedState");
+    UA_QualifiedName confirmedStateField = UA_QUALIFIEDNAME(0,"ConfirmedState");
+    UA_QualifiedName activeStateField = UA_QUALIFIEDNAME(0,"ActiveState");
+    UA_QualifiedName severityField = UA_QUALIFIEDNAME(0,"Severity");
+    UA_QualifiedName messageField = UA_QUALIFIEDNAME(0,"Message");
+    UA_QualifiedName commentField = UA_QUALIFIEDNAME(0,"Comment");
+    UA_QualifiedName retainField = UA_QUALIFIEDNAME(0,"Retain");
+    UA_QualifiedName idField = UA_QUALIFIEDNAME(0,"Id");
+
+    UA_StatusCode retval =
+        UA_Server_writeObjectProperty_scalar(server, customConditionInstance,
+                                             UA_QUALIFIEDNAME(0, "Time"),
+                                             &data->serverTimestamp,
+                                             &UA_TYPES[UA_TYPES_DATETIME]);
+    UA_Variant value;
+    UA_Boolean idValue = false;
+    UA_Variant_setScalar(&value, &idValue, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    retval |= UA_Server_setConditionVariableFieldProperty(server, customConditionInstance,
+                                                          &value, activeStateField,
+                                                          idField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting ActiveState/Id Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return;
+    }
+
+    retval = UA_Server_setConditionVariableFieldProperty(server, customConditionInstance,
+                                                         &value, ackedStateField,
+                                                         idField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting AckedState/Id Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return;
+    }
+
+    retval = UA_Server_setConditionVariableFieldProperty(server, customConditionInstance,
+                                                         &value, confirmedStateField,
+                                                         idField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting ConfirmedState/Id Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return;
+    }
+
+    UA_UInt16 severityValue = 100;
+    UA_Variant_setScalar(&value, &severityValue, &UA_TYPES[UA_TYPES_UINT16]);
+    retval = UA_Server_setConditionField(server, customConditionInstance,
+                                         &value, severityField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting Severity Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return;
+    }
+
+    UA_LocalizedText messageValue =
+        UA_LOCALIZEDTEXT("en", "Condition returned to normal state");
+    UA_Variant_setScalar(&value, &messageValue, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+    retval = UA_Server_setConditionField(server, customConditionInstance,
+                                         &value, messageField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting Message Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return;
+    }
+
+    UA_LocalizedText commentValue = UA_LOCALIZEDTEXT("en", "Normal State");
+    UA_Variant_setScalar(&value, &commentValue, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
+    retval = UA_Server_setConditionField(server, customConditionInstance,
+                                         &value, commentField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting Comment Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return;
+    }
+
+    UA_Boolean retainValue = false;
+    UA_Variant_setScalar(&value, &retainValue, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    retval = UA_Server_setConditionField(server, customConditionInstance,
+                                         &value, retainField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting Retain Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return;
+    }
+
+    retval = UA_Server_triggerConditionEvent(server, customConditionInstance,
+                                             conditionSource, NULL);
+    if (retval != UA_STATUSCODE_GOOD) {
+     UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                    "Triggering condition event failed. StatusCode %s",
+                    UA_StatusCode_name(retval));
+     return;
+    }
+}
+
+static UA_StatusCode
+enteringEnabledStateCallback(UA_Server *server, const UA_NodeId *condition) {
+    UA_Boolean retain = true;
+    return UA_Server_writeObjectProperty_scalar(server, *condition,
+                                                UA_QUALIFIEDNAME(0, "Retain"),
+                                                &retain,
+                                                &UA_TYPES[UA_TYPES_BOOLEAN]);
+}
+
+/**
+ * This is user specific function which will be called upon acknowledging an
+ * alarm notification. In this example we will set the Alarm to Inactive state.
+ * The server is responsible of setting standard fields related to Acknowledge
+ * Method and triggering the alarm notification. */
+static UA_StatusCode
+enteringAckedStateCallback(UA_Server *server, const UA_NodeId *condition) {
+    /* deactivate Alarm when acknowledging*/
+    UA_Boolean activeStateId = false;
+    UA_Variant value;
+    UA_QualifiedName activeStateField = UA_QUALIFIEDNAME(0,"ActiveState");
+    UA_QualifiedName activeStateIdField = UA_QUALIFIEDNAME(0,"Id");
+
+    UA_Variant_setScalar(&value, &activeStateId, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_StatusCode retval =
+        UA_Server_setConditionVariableFieldProperty(server, *condition,
+                                                    &value, activeStateField,
+                                                    activeStateIdField);
+
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting ActiveState/Id Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+    }
+
+    return retval;
+}
+
+static UA_StatusCode
+enteringConfirmedStateCallback(UA_Server *server, const UA_NodeId *condition) {
+	/* Deactivate Alarm and put it out of the interesting state (by writing
+     * false to Retain field) when confirming*/
+    UA_Boolean activeStateId = false;
+    UA_Boolean retain = false;
+    UA_Variant value;
+    UA_QualifiedName activeStateField = UA_QUALIFIEDNAME(0,"ActiveState");
+    UA_QualifiedName activeStateIdField = UA_QUALIFIEDNAME(0,"Id");
+    UA_QualifiedName retainField = UA_QUALIFIEDNAME(0,"Retain");
+
+    UA_Variant_setScalar(&value, &activeStateId, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_StatusCode retval =
+        UA_Server_setConditionVariableFieldProperty(server, *condition,
+                                                    &value, activeStateField,
+                                                    activeStateIdField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting ActiveState/Id Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    UA_Variant_setScalar(&value, &retain, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    retval = UA_Server_setConditionField(server, *condition,
+                                         &value, retainField);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting ActiveState/Id Field failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+    }
+
+    return retval;
+}
+
+static UA_StatusCode
+setUpEnvironment(UA_Server *server) {
+    UA_NodeId variable_1;
+    UA_NodeId variable_3;
+    UA_ValueCallback callback;
+    callback.onRead = NULL;
+
+    /* Create exposed custom condition */
+    UA_StatusCode retval = addCustomCondition(server);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "adding custom condition failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    /* Create condition refresh events */
+    retval = addConditionRefreshEvents(server);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "creating condition refresh events failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    /* Attach condition behavior to cutom condition node */
+    retval = attachConditionBehavior(server);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "attaching condition behavior to custom condition failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    /* Configure condition callbacks */
+    UA_TwoStateVariableChangeCallback userSpecificCallback = enteringEnabledStateCallback;
+    retval = UA_Server_setConditionTwoStateVariableCallback(server, customConditionInstance,
+                                                            conditionSource, false,
+                                                            userSpecificCallback,
+                                                            UA_ENTERING_ENABLEDSTATE);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "adding entering enabled state callback failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    userSpecificCallback = enteringAckedStateCallback;
+    retval = UA_Server_setConditionTwoStateVariableCallback(server, customConditionInstance,
+                                                            conditionSource, false,
+                                                            userSpecificCallback,
+                                                            UA_ENTERING_ACKEDSTATE);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "adding entering acked state callback failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    userSpecificCallback = enteringConfirmedStateCallback;
+    retval = UA_Server_setConditionTwoStateVariableCallback(server, customConditionInstance,
+                                                            conditionSource, false,
+                                                            userSpecificCallback,
+                                                            UA_ENTERING_CONFIRMEDSTATE);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "adding entering confirmed state callback failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    /* Add variables to trigger condition events */
+    addVariable_1_triggerAlarmOfCondition(server, &variable_1);
+
+    callback.onWrite = afterWriteCallbackVariable_1;
+    retval = UA_Server_setVariableNode_valueCallback(server, variable_1, callback);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting variable 1 Callback failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    addVariable_3_returnCondition_toNormalState(server, &variable_3);
+
+    callback.onWrite = afterWriteCallbackVariable_3;
+    retval = UA_Server_setVariableNode_valueCallback(server, variable_3, callback);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Setting variable 3 Callback failed. StatusCode %s",
+                     UA_StatusCode_name(retval));
+    }
+
+    return retval;
+}
+
+/**
+ * It follows the main server code, making use of the above definitions. */
+
+static UA_Boolean running = true;
+static void stopHandler(int sig) {
+    running = false;
+}
+
+int main (void) {
+    /* default server values */
+    signal(SIGINT, stopHandler);
+    signal(SIGTERM, stopHandler);
+
+    UA_Server *server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+
+    UA_StatusCode retval = setUpEnvironment(server);
+
+    if(retval == UA_STATUSCODE_GOOD)
+        retval = UA_Server_run(server, &running);
+
+    UA_Server_delete(server);
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1504,6 +1504,29 @@ UA_Server_createCondition(UA_Server *server,
                           UA_QualifiedName conditionName, const UA_NodeId conditionSource,
                           const UA_NodeId hierarchialReferenceType, UA_NodeId *outConditionId);
 
+/**
+ * attach condition behavior to an already existing condition Node. The function checks first whether the passed conditionType
+ * is a subType of ConditionType. Then checks whether the condition source has HasEventSource
+ * reference to its parent. If not, a HasEventSource reference will be created between condition
+ * source and server object. To expose the condition in address space, a hierarchical ReferenceType
+ * should be passed to create the reference to condition source. Otherwise, UA_NODEID_NULL should be
+ * passed to make the condition not exposed.
+ * @param server The server object
+ * @param conditionId The NodeId of the static Condition Object.
+ * @param conditionType The NodeId of the node representation of the ConditionType
+ * @param conditionName The name of the condition to be created
+ * @param conditionSource The NodeId of the Condition Source (Parent of the Condition)
+ * @param hierarchialReferenceType The NodeId of Hierarchical ReferenceType between Condition and its source
+ * @param refreshStart The NodeId of RefreshStartEvent
+ * @param refreshEnd The NodeId of RefreshEndEvent
+ * @return The StatusCode of the UA_Server_createCondition method */
+UA_StatusCode UA_EXPORT
+UA_Server_attachConditionBehavior(UA_Server *server,
+                                  const UA_NodeId conditionId, const UA_NodeId conditionType,
+                                  UA_QualifiedName conditionName, const UA_NodeId conditionSource,
+                                  const UA_NodeId hierarchialReferenceType,
+                                  const UA_NodeId refreshStart, const UA_NodeId refreshEnd);
+								  
 /* Set the value of condition field.
  *
  * @param server The server object

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -217,7 +217,7 @@ UA_Server_setConditionTwoStateVariableCallback(UA_Server *server, const UA_NodeI
     UA_Condition *c = getCondition(server, &conditionSource, &condition);
     if(!c)
         return UA_STATUSCODE_BADNOTFOUND;
-        
+
     /* Set the callback */
     switch(callbackType) {
     case UA_ENTERING_ENABLEDSTATE:
@@ -653,16 +653,16 @@ enteringDisabledState(UA_Server *server, const UA_NodeId *conditionId,
         UA_StatusCode retval = UA_Server_setConditionField(server, triggeredNode,
                                                            &value, fieldMessageQN);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition Message failed",);
-        
+
         UA_Variant_setScalar(&value, &enableText, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
         retval = UA_Server_setConditionField(server, triggeredNode, &value, fieldEnabledStateQN);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition EnabledState text failed",);
-        
+
         UA_Boolean retain = false;
         UA_Variant_setScalar(&value, &retain, &UA_TYPES[UA_TYPES_BOOLEAN]);
         retval = UA_Server_setConditionField(server, triggeredNode, &value, fieldRetainQN);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition Retain failed",);
-        
+
         /* Trigger event */
         UA_ByteString lastEventId = UA_BYTESTRING_NULL;
         /* Trigger the event for Condition or its Branch */
@@ -671,13 +671,13 @@ enteringDisabledState(UA_Server *server, const UA_NodeId *conditionId,
         retval = UA_Server_triggerEvent(server, triggeredNode, *conditionSource, &lastEventId, false);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Triggering condition event failed",);
         setIsCallerAC(server, &triggeredNode, conditionSource, false);
-        
+
         /* Update list */
         retval = updateConditionLastEventId(server, &triggeredNode, conditionSource, &lastEventId);
         UA_ByteString_clear(&lastEventId);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "updating condition event failed",);
     }
-    
+
     return UA_STATUSCODE_GOOD;
 }
 
@@ -702,7 +702,7 @@ enteringEnabledState(UA_Server *server,
             triggeredNode = cond->conditionId;
         else //enable branches
             triggeredNode = branch->conditionBranchId;
-        
+
         UA_LocalizedText message = UA_LOCALIZEDTEXT(LOCALE, ENABLED_MESSAGE);
         UA_LocalizedText enableText = UA_LOCALIZEDTEXT(LOCALE, ENABLED_TEXT);
         UA_Variant value;
@@ -710,24 +710,24 @@ enteringEnabledState(UA_Server *server,
         UA_StatusCode retval = UA_Server_setConditionField(server, triggeredNode,
                                                            &value, fieldMessageQN);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "set Condition Message failed",);
-        
+
         UA_Variant_setScalar(&value, &enableText, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
         retval = UA_Server_setConditionField(server, triggeredNode, &value, fieldEnabledStateQN);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "set Condition EnabledState text failed",);
-        
+
         /* User callback TODO how should branches be evaluated? see p.19 (5.5.2) */
         UA_Boolean removeBranch = false;//not used
         retval = callConditionTwoStateVariableCallback(server, &triggeredNode,
                                                        conditionSource, &removeBranch,
                                                        UA_ENTERING_ENABLEDSTATE);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "calling condition callback failed",);
-        
+
         /* Trigger event */
         //Condition Nodes should not be deleted after triggering the event
         retval = UA_Server_triggerConditionEvent(server, triggeredNode, *conditionSource, NULL);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "triggering condition event failed",);
     }
-    
+
     return UA_STATUSCODE_GOOD;
 }
 
@@ -837,21 +837,21 @@ afterWriteCallbackAckedStateChange(UA_Server *server,
     retval = UA_Server_setConditionField(server, conditionNode, &value, fieldMessageQN);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set Condition Message failed",
                                  UA_NodeId_clear(&conditionNode););
-    
+
     /* Set AckedState text */
     UA_LocalizedText text = UA_LOCALIZEDTEXT(LOCALE, ACKED_TEXT);
     UA_Variant_setScalar(&value, &text, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     retval = UA_Server_setConditionField(server, conditionNode, &value, fieldAckedStateQN);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set Condition AckedState failed",
                                  UA_NodeId_clear(&conditionNode););
-    
+
     /* Get conditionSource */
     UA_NodeId conditionSource;
     retval = getNodeIdValueOfConditionField(server, &conditionNode, fieldSourceQN,
                                             &conditionSource);
     CONDITION_ASSERT_RETURN_VOID(retval, "ConditionSource not found",
                                  UA_NodeId_clear(&conditionNode););
-    
+
     /* User callback*/
     UA_Boolean removeBranch = false;
     retval = callConditionTwoStateVariableCallback(server, &conditionNode, &conditionSource,
@@ -859,7 +859,7 @@ afterWriteCallbackAckedStateChange(UA_Server *server,
     CONDITION_ASSERT_RETURN_VOID(retval, "Calling condition callback failed",
                                  UA_NodeId_clear(&conditionNode);
                                  UA_NodeId_clear(&conditionSource););
-    
+
     /* Trigger event */
     //Condition Nodes should not be deleted after triggering the event
     retval = UA_Server_triggerConditionEvent(server, conditionNode, conditionSource, NULL);
@@ -895,7 +895,7 @@ afterWriteCallbackConfirmedStateChange(UA_Server *server,
                                                       &UA_TYPES[UA_TYPES_DATETIME]);
         CONDITION_ASSERT_RETURN_VOID(retval, "Set deactivating Time failed",
                                      UA_NodeId_clear(&conditionNode););
-        
+
         /* Set ConfirmedState text to (Unconfirmed)*/
         UA_LocalizedText text = UA_LOCALIZEDTEXT(LOCALE, UNCONFIRMED_TEXT);
         UA_Variant_setScalar(&value, &text, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
@@ -925,27 +925,27 @@ afterWriteCallbackConfirmedStateChange(UA_Server *server,
                                                   &UA_TYPES[UA_TYPES_DATETIME]);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set Confirming Time failed",
                                  UA_NodeId_clear(&conditionNode););
-    
+
     /* Set Message */
     UA_LocalizedText message = UA_LOCALIZEDTEXT(LOCALE, CONFIRMED_MESSAGE);
     UA_Variant_setScalar(&value, &message, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     retval = UA_Server_setConditionField(server, conditionNode, &value, fieldMessageQN);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set Condition Message failed",
                                  UA_NodeId_clear(&conditionNode););
-    
+
     /* Set ConfirmedState text */
     UA_LocalizedText text = UA_LOCALIZEDTEXT(LOCALE, CONFIRMED_TEXT);
     UA_Variant_setScalar(&value, &text, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     retval = UA_Server_setConditionField(server, conditionNode, &value, fieldConfirmedStateQN);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set Condition ConfirmedState failed",
                                  UA_NodeId_clear(&conditionNode););
-    
+
     /* Get conditionSource */
     UA_NodeId conditionSource;
     retval = getNodeIdValueOfConditionField(server, &conditionNode, fieldSourceQN, &conditionSource);
     CONDITION_ASSERT_RETURN_VOID(retval, "ConditionSource not found",
                                  UA_NodeId_clear(&conditionNode););
-    
+
     /* User callback*/
     UA_Boolean removeBranch = false;
     retval = callConditionTwoStateVariableCallback(server, &conditionNode,
@@ -954,7 +954,7 @@ afterWriteCallbackConfirmedStateChange(UA_Server *server,
     CONDITION_ASSERT_RETURN_VOID(retval, "Calling condition callback failed",
                                  UA_NodeId_clear(&conditionNode);
                                  UA_NodeId_clear(&conditionSource););
-    
+
     /* Trigger event */
     //Condition Nodes should not be deleted after triggering the event
     retval = UA_Server_triggerConditionEvent(server, conditionNode, conditionSource, NULL);
@@ -1080,7 +1080,7 @@ afterWriteCallbackActiveStateChange(UA_Server *server,
         CONDITION_ASSERT_RETURN_VOID(retval, "Set Condition ActiveState failed",
                                      UA_NodeId_clear(&conditionNode);
                                      UA_NodeId_clear(&conditionSource););
-        
+
         /* Set deactivating time */
         retval = UA_Server_writeObjectProperty_scalar(server, conditionNode, fieldTimeQN,
                                                       &data->sourceTimestamp,
@@ -1088,7 +1088,7 @@ afterWriteCallbackActiveStateChange(UA_Server *server,
         CONDITION_ASSERT_RETURN_VOID(retval, "Set deactivating Time failed",
                                      UA_NodeId_clear(&conditionNode);
                                      UA_NodeId_clear(&conditionSource););
-        
+
         retval = updateConditionActiveState(server, &conditionSource, &conditionNode,
                                             currentActiveState, UA_INACTIVE, isLimitalarm);
         UA_NodeId_clear(&conditionSource);
@@ -1239,7 +1239,7 @@ enableMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
     /* Check if disabled */
     if(isTwoStateVariableInTrueState(server, objectId, &fieldEnabledStateQN))
         return UA_STATUSCODE_BADCONDITIONALREADYENABLED;
-        
+
     /* Enable by writing true to EnabledStateId--> will cause a callback to
      * trigger the new events */
     UA_Variant value;
@@ -1295,21 +1295,21 @@ addCommentMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                                                          fieldComment, fieldSourceTimeStamp);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition EnabledState text failed",
                                    UA_NodeId_clear(&triggerEvent););
-    
+
     /* Set adding comment time (the same value of SourceTimestamp) */
     retval = UA_Server_writeObjectProperty_scalar(server, triggerEvent, fieldTimeQN,
                                                   &fieldSourceTimeStampValue,
                                                   &UA_TYPES[UA_TYPES_DATETIME]);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Set enabling/disabling Time failed",
                                    UA_NodeId_clear(&triggerEvent););
-    
+
     /* Set Message */
     message = UA_LOCALIZEDTEXT(LOCALE, COMMENT_MESSAGE);
     UA_Variant_setScalar(&value, &message, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     retval = UA_Server_setConditionField(server, triggerEvent, &value, fieldMessageQN);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition Message failed",
                                    UA_NodeId_clear(&triggerEvent););
-    
+
     /* Set Comment. Check whether comment is empty -> leave the last value as is*/
     UA_LocalizedText *inputComment = (UA_LocalizedText *)input[1].data;
     UA_String nullString = UA_STRING_NULL;
@@ -1320,13 +1320,13 @@ addCommentMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition Comment failed",
                                        UA_NodeId_clear(&triggerEvent););
     }
-    
+
     /* Get conditionSource */
     UA_NodeId conditionSource;
     retval = getNodeIdValueOfConditionField(server, &triggerEvent, fieldSourceQN, &conditionSource);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "ConditionSource not found",
                                    UA_NodeId_clear(&triggerEvent););
-    
+
     /* Trigger event */
     //Condition Nodes should not be deleted after triggering the event
     retval = UA_Server_triggerConditionEvent(server, triggerEvent, conditionSource, NULL);
@@ -1375,7 +1375,7 @@ acknowledgeMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                                             &eventType);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "EventType not found",
                                    UA_NodeId_clear(&conditionNode););
-    
+
     /* Check if ConditionType is subType of AcknowledgeableConditionType TODO Over Kill*/
     UA_NodeId AcknowledgeableConditionTypeId =
         UA_NODEID_NUMERIC(0, UA_NS0ID_ACKNOWLEDGEABLECONDITIONTYPE);
@@ -1387,9 +1387,9 @@ acknowledgeMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
         UA_NodeId_clear(&eventType);
         return UA_STATUSCODE_BADNODEIDINVALID;
     }
-    
+
     UA_NodeId_clear(&eventType);
-    
+
     /* Set Comment. Check whether comment is empty -> leave the last value as is*/
     UA_LocalizedText *inputComment = (UA_LocalizedText *)input[1].data;
     UA_String nullString = UA_STRING_NULL;
@@ -1451,7 +1451,7 @@ confirmMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                                             &eventType);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "EventType not found",
                                    UA_NodeId_clear(&conditionNode););
-    
+
     /* Check if ConditionType is subType of AcknowledgeableConditionType. */
     UA_NodeId AcknowledgeableConditionTypeId =
         UA_NODEID_NUMERIC(0, UA_NS0ID_ACKNOWLEDGEABLECONDITIONTYPE);
@@ -1463,9 +1463,9 @@ confirmMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
         UA_NodeId_clear(&eventType);
         return UA_STATUSCODE_BADNODEIDINVALID;
     }
-    
+
     UA_NodeId_clear(&eventType);
-    
+
     /* Set Comment. Check whether comment is empty -> leave the last value as is*/
     UA_LocalizedText *inputComment = (UA_LocalizedText *)input[1].data;
     UA_String nullString = UA_STRING_NULL;
@@ -1476,7 +1476,7 @@ confirmMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition Comment failed",
                                        UA_NodeId_clear(&conditionNode););
     }
-    
+
     /* Set ConfirmedStateId */
     UA_Boolean idValue = true;
     UA_Variant_setScalar(&value, &idValue, &UA_TYPES[UA_TYPES_BOOLEAN]);
@@ -1658,7 +1658,7 @@ refresh2MethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                                                   &refreshEvents[REFRESHEVENT_START_IDX],
                                                   &refreshEvents[REFRESHEVENT_END_IDX]);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Create Event RefreshStart or RefreshEnd failed",);
-    
+
     /* Trigger RefreshStartEvent and RefreshEndEvent for the each monitoredItem
      * in the subscription */
     UA_MonitoredItem *monitoredItem =
@@ -1693,7 +1693,7 @@ refreshMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
         setRefreshMethodEvents(server, &refreshEvents[REFRESHEVENT_START_IDX],
                                &refreshEvents[REFRESHEVENT_END_IDX]);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Create Event RefreshStart or RefreshEnd failed",);
-    
+
     /* Trigger RefreshStartEvent and RefreshEndEvent for the each monitoredItem
      * in the subscription */
     //TODO when there are a lot of monitoreditems (not only events)?
@@ -1945,37 +1945,49 @@ setStandardConditionFields(UA_Server *server, const UA_NodeId* condition,
     if(!isNodeInTree_singleRef(server, conditionType, &acknowledgeableConditionTypeId,
                                UA_REFERENCETYPEINDEX_HASSUBTYPE))
         return UA_STATUSCODE_GOOD;
-    
+
     /* Set AckedState (Id = false by default) */
     text = UA_LOCALIZEDTEXT(LOCALE, UNACKED_TEXT);
     UA_Variant_setScalar(&value, &text, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     retval = UA_Server_setConditionField(server, *condition, &value, fieldAckedStateQN);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Set AckedState Field failed",);
-    
+
     UA_Variant_setScalar(&value, &stateId, &UA_TYPES[UA_TYPES_BOOLEAN]);
     retval = UA_Server_setConditionVariableFieldProperty(server, *condition, &value,
                                                          fieldAckedStateQN, twoStateVariableIdQN);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Set AckedState/Id Field failed",);
-    
+
 #ifdef CONDITIONOPTIONALFIELDS_SUPPORT
-    /* add optional field ConfirmedState*/
-    retval = UA_Server_addConditionOptionalField(server, *condition, acknowledgeableConditionTypeId,
-                                                 fieldConfirmedStateQN, NULL);
-    CONDITION_ASSERT_RETURN_RETVAL(retval, "Adding ConfirmedState optional Field failed",);
+    /* add optional field ConfirmedState if not already added statically by user*/
+    UA_BrowsePathResult bpr = UA_Server_browseSimplifiedBrowsePath(server, *condition, 1, &fieldConfirmedStateQN);
+    if(bpr.statusCode == UA_STATUSCODE_BADNOMATCH) {
+      retval = UA_Server_addConditionOptionalField(server, *condition, acknowledgeableConditionTypeId,
+                                                   fieldConfirmedStateQN, NULL);
+      CONDITION_ASSERT_RETURN_RETVAL(retval, "Adding ConfirmedState optional Field failed",);
+
+      /* add reference from Condition to Confirm Method */
+      retval = UA_Server_addReference(server, *condition, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                       UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_ACKNOWLEDGEABLECONDITIONTYPE_CONFIRM), true);
+      CONDITION_ASSERT_RETURN_RETVAL(retval, "Adding HasComponent Reference to Confirm Method failed",);
+    }
+    else if(bpr.statusCode == UA_STATUSCODE_GOOD)
+    {
+      UA_BrowsePathResult_clear(&bpr);
+    }
 
     /* Set ConfirmedState (Id = false by default) */
     text = UA_LOCALIZEDTEXT(LOCALE, UNCONFIRMED_TEXT);
     UA_Variant_setScalar(&value, &text, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
     retval = UA_Server_setConditionField(server, *condition, &value, fieldConfirmedStateQN);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Set ConfirmedState Field failed",);
-    
+
     UA_Variant_setScalar(&value, &stateId, &UA_TYPES[UA_TYPES_BOOLEAN]);
     retval = UA_Server_setConditionVariableFieldProperty(server, *condition, &value,
                                                          fieldConfirmedStateQN,
                                                          twoStateVariableIdQN);
-    CONDITION_ASSERT_RETURN_RETVAL(retval, "Set EnabledState/Id Field failed",);
+    CONDITION_ASSERT_RETURN_RETVAL(retval, "Set ConfirmedState/Id Field failed",);
 #endif//CONDITIONOPTIONALFIELDS_SUPPORT
-    
+
     /* 2. Check if ConditionType is subType of AlarmConditionType */
     UA_NodeId alarmConditionTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ALARMCONDITIONTYPE);
     if(isNodeInTree_singleRef(server, conditionType, &alarmConditionTypeId,
@@ -2032,13 +2044,6 @@ setTwoStateVariableCallbacks(UA_Server *server, const UA_NodeId* condition,
         retval = getConditionFieldPropertyNodeId(server, condition, &fieldConfirmedStateQN,
                                                  &twoStateVariableIdQN, &twoStateVariableIdNodeId);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Id Property of TwoStateVariable not found",);
-
-        /* add reference from Condition to Confirm Method */
-        retval = UA_Server_addReference(server, *condition, UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
-                     UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_ACKNOWLEDGEABLECONDITIONTYPE_CONFIRM), true);
-        CONDITION_ASSERT_RETURN_RETVAL(retval,
-                                       "Adding HasComponent Reference to Confirm Method failed",
-                                       UA_NodeId_clear(&twoStateVariableIdNodeId););
 
         retval = UA_Server_setVariableNode_valueCallback(server, twoStateVariableIdNodeId, callback);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Adding ConfirmedState/Id callback failed",
@@ -2145,7 +2150,7 @@ setStandardConditionCallbacks(UA_Server *server, const UA_NodeId* condition,
     if(LIST_EMPTY(&server->conditionSources)) {
         retval = setConditionMethodCallbacks(server, condition, conditionType);
         CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Method Callback failed",);
-        
+
         // Create RefreshEvents
         if(UA_NodeId_isNull(&refreshEvents[REFRESHEVENT_START_IDX]) &&
            UA_NodeId_isNull(&refreshEvents[REFRESHEVENT_END_IDX])) {
@@ -2154,7 +2159,7 @@ setStandardConditionCallbacks(UA_Server *server, const UA_NodeId* condition,
             CONDITION_ASSERT_RETURN_RETVAL(retval, "Create RefreshEvents failed",);
         }
     }
-    
+
     return retval;
 }
 
@@ -2266,6 +2271,81 @@ UA_Server_createCondition(UA_Server *server,
     return appendConditionEntry(server, &newNodeId, &conditionSource);
 }
 
+/**
+ * attach condition behavior to an already existing condition Node. The function checks first whether the passed conditionType
+ * is a subType of ConditionType. Then checks whether the condition source has HasEventSource
+ * reference to its parent. If not, a HasEventSource reference will be created between condition
+ * source and server object. To expose the condition in address space, a hierarchical ReferenceType
+ * should be passed to create the reference to condition source. Otherwise, UA_NODEID_NULL should be
+ * passed to make the condition not exposed.
+ */
+UA_StatusCode
+UA_Server_attachConditionBehavior(UA_Server *server,
+                                  const UA_NodeId conditionId, const UA_NodeId conditionType,
+                                  UA_QualifiedName conditionName, const UA_NodeId conditionSource,
+                                  const UA_NodeId hierarchialReferenceType,
+                                  const UA_NodeId refreshStart, const UA_NodeId refreshEnd) {
+
+    /*ConditionId and ConditionSource Nodes will be checked implicitly by other function calls*/
+    UA_StatusCode retval;
+
+    /* Make sure the conditionType is a Subtype of ConditionType */
+    UA_NodeId conditionTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_CONDITIONTYPE);
+    if(!isNodeInTree_singleRef(server, &conditionType, &conditionTypeId,
+                               UA_REFERENCETYPEINDEX_HASSUBTYPE)) {
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_USERLAND,
+                     "Condition Type must be a subtype of ConditionType!");
+        return UA_STATUSCODE_BADNOMATCH;
+    }
+
+    /* create HasCondition Reference (HasCondition should be forward from the ConditionSourceNode to the Condition.
+     * else, HasCondition should be forward from the ConditionSourceNode to the ConditionType Node) */
+    UA_ExpandedNodeId hasConditionTarget;
+    if(!UA_NodeId_isNull(&hierarchialReferenceType))
+        hasConditionTarget = UA_EXPANDEDNODEID_NUMERIC(conditionId.namespaceIndex, conditionId.identifier.numeric);
+    else
+        hasConditionTarget = UA_EXPANDEDNODEID_NUMERIC(conditionType.namespaceIndex, conditionType.identifier.numeric);
+
+    UA_NodeId hasConditionId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCONDITION);
+    retval = UA_Server_addReference(server, conditionSource, hasConditionId,
+                                    hasConditionTarget, true);
+    CONDITION_ASSERT_RETURN_RETVAL(retval, "Creating HasCondition Reference failed",);
+
+    /* Set standard fields */
+    retval = setStandardConditionFields(server, &conditionId, &conditionType,
+                                        &conditionSource, &conditionName);
+    CONDITION_ASSERT_RETURN_RETVAL(retval, "Set standard Condition Fields failed",);
+
+    /* Attach RefreshEvents */
+    if(LIST_EMPTY(&server->conditionSources)) {
+      const UA_Node *refreshStartTmp = UA_NODESTORE_GET(server, &refreshStart);
+      if(refreshStartTmp == NULL) {
+        CONDITION_ASSERT_RETURN_RETVAL(UA_STATUSCODE_BADINVALIDARGUMENT, "RefreshStartEvent Node does not exist in server",);
+      }
+
+      retval = UA_NodeId_copy(&refreshStart, &refreshEvents[REFRESHEVENT_START_IDX]);
+      CONDITION_ASSERT_RETURN_RETVAL(retval, "Set RefreshStartEvent failed",);
+
+      const UA_Node *refreshEndTmp = UA_NODESTORE_GET(server, &refreshEnd);
+      if(refreshEndTmp == NULL) {
+        UA_NODESTORE_RELEASE(server, refreshStartTmp);
+        CONDITION_ASSERT_RETURN_RETVAL(UA_STATUSCODE_BADINVALIDARGUMENT, "RefreshEndEvent Node does not exist in server",);
+      }
+
+      retval = UA_NodeId_copy(&refreshEnd, &refreshEvents[REFRESHEVENT_END_IDX]);
+      UA_NODESTORE_RELEASE(server, refreshStartTmp);
+      UA_NODESTORE_RELEASE(server, refreshEndTmp);
+      CONDITION_ASSERT_RETURN_RETVAL(retval, "Set RefreshEndEvent failed",);
+    }
+
+    /* Set Method Callbacks */
+    retval = setStandardConditionCallbacks(server, &conditionId, &conditionType);
+    CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Condition callbacks failed",);
+
+    /* append Condition to list */
+    return appendConditionEntry(server, &conditionId, &conditionSource);
+}
+
 #ifdef CONDITIONOPTIONALFIELDS_SUPPORT
 
 static UA_StatusCode
@@ -2299,7 +2379,7 @@ addOptionalVariableField(UA_Server *server, const UA_NodeId *originCondition,
         referenceToParent = UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY);
     else
         referenceToParent = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
-    
+
     /* Set a random unused NodeId with specified Namespace Index*/
     UA_NodeId optionalVariable = {originCondition->namespaceIndex, UA_NODEIDTYPE_NUMERIC, {0}};
     retval = UA_Server_addVariableNode(server, optionalVariable, *originCondition,
@@ -2337,7 +2417,7 @@ addOptionalObjectField(UA_Server *server, const UA_NodeId *originCondition,
         referenceToParent = UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY);
     else
         referenceToParent = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
-    
+
     UA_NodeId optionalObject = {originCondition->namespaceIndex, UA_NODEIDTYPE_NUMERIC, {0}};
     retval = UA_Server_addObjectNode(server, optionalObject, *originCondition,
                                      referenceToParent, *fieldName, type->head.nodeId,
@@ -2502,9 +2582,9 @@ UA_Server_triggerConditionEvent(UA_Server *server, const UA_NodeId condition,
     //Condition Nodes should not be deleted after triggering the event
     UA_StatusCode retval = UA_Server_triggerEvent(server, condition, conditionSource, &eventId, false);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Triggering condition event failed",);
-    
+
     setIsCallerAC(server, &condition, &conditionSource, false);
-    
+
     /* Update list */
     retval = updateConditionLastEventId(server, &condition, &conditionSource, &eventId);
     if(outEventId)


### PR DESCRIPTION
In case of custom nodes, which are entirely managed by the application, the function "UA_Server_attachConditionBehavior" can be used to have the alarms and conditions behavior attached to a normal object node of ConditionType.
An example for a usecase could be wanting to create all children nodes manually to manage the memory and node ids and still being able to have alarms and conditions functionality.