### PR TITLE
Event-Filter Batch 2 (Using EventFilterResult, Content-Filter Skeleton)

### DIFF
--- a/examples/events/client_eventfilter.c
+++ b/examples/events/client_eventfilter.c
@@ -163,7 +163,7 @@ setupWhereClauses(UA_ContentFilter *contentFilter, UA_UInt16 whereClauseSize, UA
             /* first Element (OR) */
             setupOrFilter(&contentFilter->elements[0]);
             /* second Element (OfType) */
-            setupOfTypeFilter(&contentFilter->elements[1], UA_NS0ID_AUDITEVENTTYPE);
+            setupOfTypeFilter(&contentFilter->elements[1], 60443);
             /* third Element (OfType) */
             setupOfTypeFilter(&contentFilter->elements[2], UA_NS0ID_EVENTQUEUEOVERFLOWEVENTTYPE);
             break;
@@ -171,7 +171,7 @@ setupWhereClauses(UA_ContentFilter *contentFilter, UA_UInt16 whereClauseSize, UA
             UA_ContentFilter_clear(contentFilter);
             return UA_STATUSCODE_BADCONFIGURATIONERROR;
     }
-    return result;
+    return UA_STATUSCODE_GOOD;
 }
 
 static void
@@ -240,7 +240,7 @@ int main(int argc, char *argv[]) {
     /* Add a MonitoredItem */
     UA_MonitoredItemCreateRequest item;
     UA_MonitoredItemCreateRequest_init(&item);
-    item.itemToMonitor.nodeId = UA_NODEID_NUMERIC(0, 2253); // Root->Objects->Server
+    item.itemToMonitor.nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER); // Root->Objects->Server
     item.itemToMonitor.attributeId = UA_ATTRIBUTEID_EVENTNOTIFIER;
     item.monitoringMode = UA_MONITORINGMODE_REPORTING;
 

--- a/examples/events/server_random_events.c
+++ b/examples/events/server_random_events.c
@@ -26,11 +26,11 @@ static volatile UA_Boolean running = true;
 static UA_NodeId* eventTypes;
 
 static UA_StatusCode
-addEventType(UA_Server *server, char* name, UA_NodeId parentNodeId, UA_NodeId* eventType) {
+addEventType(UA_Server *server, char* name, UA_NodeId parentNodeId, UA_NodeId requestedId, UA_NodeId* eventType) {
     UA_ObjectTypeAttributes attr = UA_ObjectTypeAttributes_default;
     attr.displayName = UA_LOCALIZEDTEXT("en-US", name);
     attr.description = UA_LOCALIZEDTEXT("en-US", "Sample event type");
-    UA_StatusCode retval = UA_Server_addObjectTypeNode(server, UA_NODEID_NULL,
+    UA_StatusCode retval = UA_Server_addObjectTypeNode(server, requestedId,
                                                        parentNodeId,
                                                        UA_NODEID_NUMERIC(0, UA_NS0ID_HASSUBTYPE),
                                                        UA_QUALIFIEDNAME(0, name),
@@ -48,22 +48,27 @@ addSampleEventTypes(UA_Server *server) {
         UA_Array_new(SAMPLE_EVENT_TYPES_COUNT, &UA_TYPES[UA_TYPES_NODEID]);
     UA_StatusCode retval = addEventType(server, "SampleBaseEventType",
                                         UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE),
+                                        UA_NODEID_NULL,
                                         &eventTypes[0]);
     if (retval != UA_STATUSCODE_GOOD) return retval;
     retval = addEventType(server, "SampleDeviceFailureEventType",
                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE),
+                          UA_NODEID_NULL,
                           &eventTypes[1]);
     if (retval != UA_STATUSCODE_GOOD) return retval;
     retval = addEventType(server, "SampleEventQueueOverflowEventType",
                           UA_NODEID_NUMERIC(0, UA_NS0ID_EVENTQUEUEOVERFLOWEVENTTYPE),
+                          UA_NODEID_NULL,
                           &eventTypes[2]);
     if (retval != UA_STATUSCODE_GOOD) return retval;
     retval = addEventType(server, "SampleProgressEventType",
                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE),
+                          UA_NODEID_NULL,
                           &eventTypes[3]);
     if (retval != UA_STATUSCODE_GOOD) return retval;
     retval = addEventType(server, "SampleAuditSecurityEventType",
                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE),
+                          UA_NODEID_NUMERIC(0,60443),
                           &eventTypes[4]);
     if (retval != UA_STATUSCODE_GOOD) return retval;
     return UA_STATUSCODE_GOOD;

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -11,6 +11,7 @@
  *    Copyright 2017 (c) Mattias Bornhager
  *    Copyright 2019 (c) HMS Industrial Networks AB (Author: Jonas Green)
  *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
+ *    Copyright 2021 (c) Fraunhofer IOSB (Author: Andreas Ebner)
  */
 
 #ifndef UA_SUBSCRIPTION_H_
@@ -61,6 +62,7 @@ typedef struct UA_Notification {
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
     UA_Boolean isOverflowEvent; /* Counted manually */
+    UA_EventFilterResult result;
 #endif
 } UA_Notification;
 
@@ -314,9 +316,10 @@ typedef struct UA_ConditionSource UA_ConditionSource;
 /* Evaluate content filter, Only for unit testing */
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
 UA_StatusCode
-UA_Server_evaluateWhereClauseContentFilter(UA_Server *server,
+UA_Server_evaluateWhereClauseContentFilter(UA_Server *server, UA_Session *session,
                                            const UA_NodeId *eventNode,
-                                           const UA_ContentFilter *contentFilter);
+                                           const UA_ContentFilter *contentFilter,
+                                           UA_ContentFilterResult *contentFilterResult);
 #endif
  
 /* Setting an integer value within bounds */

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -164,6 +164,7 @@ UA_Notification_delete(UA_Server *server, UA_Notification *n) {
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
         case UA_ATTRIBUTEID_EVENTNOTIFIER:
             UA_EventFieldList_clear(&n->data.event);
+            UA_EventFilterResult_clear(&n->result);
             break;
 #endif
         default:

--- a/tests/server/check_subscription_events.c
+++ b/tests/server/check_subscription_events.c
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * 
  *    Copyright 2020-2021 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
+ *    Copyright 2021 (c) Fraunhofer IOSB (Author: Andreas Ebner)
  */
 
 #include <open62541/client_config_default.h>
@@ -707,36 +708,122 @@ START_TEST(evaluateWhereClause) {
     UA_NodeId eventNodeId;
     UA_StatusCode retval = eventSetup(&eventNodeId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    //test empty filter
     UA_ContentFilter contentFilter;
     UA_ContentFilter_init(&contentFilter);
-    /* Empty Filter */
+    UA_ContentFilterResult contentFilterResult;
+    UA_ContentFilterResult_init(&contentFilterResult);
+    contentFilterResult.elementResultsSize = contentFilter.elementsSize;
+    contentFilterResult.elementResults = (UA_ContentFilterElementResult *)
+        UA_Array_new(contentFilter.elementsSize,
+                     &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
+    if(!contentFilterResult.elementResults) {
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
+    for(size_t i = 0; i < contentFilterResult.elementResultsSize; ++i) {
+        contentFilterResult.elementResults[i].operandStatusCodesSize =
+            contentFilter.elements->filterOperandsSize;
+        contentFilterResult.elementResults[i].operandStatusCodes =
+            (UA_StatusCode *)UA_Array_new(
+                contentFilter.elements->filterOperandsSize,
+                &UA_TYPES[UA_TYPES_STATUSCODE]);
+        if(!contentFilterResult.elementResults[i].operandStatusCodes) {
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+    }
     UA_LOCK(&server->serviceMutex);
-    retval = UA_Server_evaluateWhereClauseContentFilter(server, &eventNodeId, &contentFilter);
+    retval = UA_Server_evaluateWhereClauseContentFilter(server, &server->adminSession,
+                                                        &eventNodeId, &contentFilter, &contentFilterResult);
     UA_UNLOCK(&server->serviceMutex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_ContentFilterResult_clear(&contentFilterResult);
+
+    /* Illegal filter operators */
     UA_ContentFilterElement contentFilterElement;
     UA_ContentFilterElement_init(&contentFilterElement);
     contentFilter.elements = &contentFilterElement;
     contentFilter.elementsSize = 1;
-
-    /* Illegal filter operators */
+    contentFilter.elements->filterOperandsSize = 6;
     contentFilterElement.filterOperator = UA_FILTEROPERATOR_RELATEDTO;
+
+    UA_ContentFilterResult_init(&contentFilterResult);
+    contentFilterResult.elementResultsSize = contentFilter.elementsSize;
+    contentFilterResult.elementResults = (UA_ContentFilterElementResult *)
+        UA_Array_new(contentFilterResult.elementResultsSize,
+                     &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
+    if(!contentFilterResult.elementResults) {
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
+    for(size_t i = 0; i < contentFilterResult.elementResultsSize; ++i) {
+        ck_assert(contentFilterResult.elementResults != NULL);
+        contentFilterResult.elementResults[i].operandStatusCodesSize =
+            contentFilter.elements[i].filterOperandsSize;
+        contentFilterResult.elementResults[i].operandStatusCodes =
+            (UA_StatusCode *)UA_Array_new(
+                contentFilter.elements->filterOperandsSize,
+                &UA_TYPES[UA_TYPES_STATUSCODE]);
+        if(!contentFilterResult.elementResults[i].operandStatusCodes) {
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+    }
     UA_LOCK(&server->serviceMutex);
-    retval = UA_Server_evaluateWhereClauseContentFilter(server, &eventNodeId, &contentFilter);
+    retval = UA_Server_evaluateWhereClauseContentFilter(server, &server->adminSession, &eventNodeId, &contentFilter, &contentFilterResult);
     UA_UNLOCK(&server->serviceMutex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_BADEVENTFILTERINVALID);
+    UA_ContentFilterResult_clear(&contentFilterResult);
+
     contentFilterElement.filterOperator = UA_FILTEROPERATOR_INVIEW;
+    UA_ContentFilterResult_init(&contentFilterResult);
+    contentFilterResult.elementResultsSize = contentFilter.elementsSize;
+    contentFilterResult.elementResults = (UA_ContentFilterElementResult *)
+        UA_Array_new(contentFilter.elementsSize,
+                     &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
+    if(!contentFilterResult.elementResults) {
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
+    for(size_t i = 0; i < contentFilterResult.elementResultsSize; ++i) {
+        contentFilterResult.elementResults[i].operandStatusCodesSize =
+            contentFilter.elements->filterOperandsSize;
+        contentFilterResult.elementResults[i].operandStatusCodes =
+            (UA_StatusCode *)UA_Array_new(
+                contentFilter.elements->filterOperandsSize,
+                &UA_TYPES[UA_TYPES_STATUSCODE]);
+        if(!contentFilterResult.elementResults[i].operandStatusCodes) {
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+    }
     UA_LOCK(&server->serviceMutex);
-    retval = UA_Server_evaluateWhereClauseContentFilter(server, &eventNodeId, &contentFilter);
+    retval = UA_Server_evaluateWhereClauseContentFilter(server, &server->adminSession, &eventNodeId, &contentFilter, &contentFilterResult);
     UA_UNLOCK(&server->serviceMutex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_BADEVENTFILTERINVALID);
+    UA_ContentFilterResult_clear(&contentFilterResult);
 
     /* No operand provided */
     contentFilterElement.filterOperator = UA_FILTEROPERATOR_OFTYPE;
+    UA_ContentFilterResult_init(&contentFilterResult);
+    contentFilterResult.elementResultsSize = contentFilter.elementsSize;
+    contentFilterResult.elementResults = (UA_ContentFilterElementResult *)
+        UA_Array_new(contentFilter.elementsSize,
+                     &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
+    if(!contentFilterResult.elementResults) {
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
+    for(size_t i = 0; i < contentFilterResult.elementResultsSize; ++i) {
+        contentFilterResult.elementResults[i].operandStatusCodesSize =
+            contentFilter.elements->filterOperandsSize;
+        contentFilterResult.elementResults[i].operandStatusCodes =
+            (UA_StatusCode *)UA_Array_new(
+                contentFilter.elements->filterOperandsSize,
+                &UA_TYPES[UA_TYPES_STATUSCODE]);
+        if(!contentFilterResult.elementResults[i].operandStatusCodes) {
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+    }
     UA_LOCK(&server->serviceMutex);
-    retval = UA_Server_evaluateWhereClauseContentFilter(server, &eventNodeId, &contentFilter);
+    retval = UA_Server_evaluateWhereClauseContentFilter(server, &server->adminSession, &eventNodeId, &contentFilter, &contentFilterResult);
     UA_UNLOCK(&server->serviceMutex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_BADFILTEROPERANDCOUNTMISMATCH);
+    UA_ContentFilterResult_clear(&contentFilterResult);
 
     UA_ExtensionObject filterOperandExObj;
     UA_ExtensionObject_init(&filterOperandExObj);
@@ -749,25 +836,87 @@ START_TEST(evaluateWhereClause) {
 
     /* Same type*/
     UA_Variant_setScalar(&literalOperand.value, &eventType, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_ContentFilterResult_init(&contentFilterResult);
+    contentFilterResult.elementResultsSize = contentFilter.elementsSize;
+    contentFilterResult.elementResults = (UA_ContentFilterElementResult *)
+        UA_Array_new(contentFilter.elementsSize,
+                     &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
+    if(!contentFilterResult.elementResults) {
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
+    for(size_t i = 0; i < contentFilterResult.elementResultsSize; ++i) {
+        contentFilterResult.elementResults[i].operandStatusCodesSize =
+            contentFilter.elements->filterOperandsSize;
+        contentFilterResult.elementResults[i].operandStatusCodes =
+            (UA_StatusCode *)UA_Array_new(
+                contentFilter.elements->filterOperandsSize,
+                &UA_TYPES[UA_TYPES_STATUSCODE]);
+        if(!contentFilterResult.elementResults[i].operandStatusCodes) {
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+    }
     UA_LOCK(&server->serviceMutex);
-    retval = UA_Server_evaluateWhereClauseContentFilter(server, &eventNodeId, &contentFilter);
+    retval = UA_Server_evaluateWhereClauseContentFilter(server, &server->adminSession, &eventNodeId, &contentFilter, &contentFilterResult);
     UA_UNLOCK(&server->serviceMutex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_ContentFilterResult_clear(&contentFilterResult);
 
     /* Base type*/
     UA_NodeId nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
     UA_Variant_setScalar(&literalOperand.value, &nodeId, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_ContentFilterResult_init(&contentFilterResult);
+    contentFilterResult.elementResultsSize = contentFilter.elementsSize;
+    contentFilterResult.elementResults = (UA_ContentFilterElementResult *)
+        UA_Array_new(contentFilter.elementsSize,
+                     &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
+    if(!contentFilterResult.elementResults) {
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
+    for(size_t i = 0; i < contentFilterResult.elementResultsSize; ++i) {
+        ck_assert(contentFilterResult.elementResults != NULL);
+        contentFilterResult.elementResults[i].operandStatusCodesSize =
+            contentFilter.elements->filterOperandsSize;
+        contentFilterResult.elementResults[i].operandStatusCodes =
+            (UA_StatusCode *)UA_Array_new(
+                contentFilter.elements->filterOperandsSize,
+                &UA_TYPES[UA_TYPES_STATUSCODE]);
+        if(!contentFilterResult.elementResults[i].operandStatusCodes) {
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+    }
     UA_LOCK(&server->serviceMutex);
-    retval = UA_Server_evaluateWhereClauseContentFilter(server, &eventNodeId, &contentFilter);
+    retval = UA_Server_evaluateWhereClauseContentFilter(server, &server->adminSession, &eventNodeId, &contentFilter, &contentFilterResult);
     UA_UNLOCK(&server->serviceMutex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_ContentFilterResult_clear(&contentFilterResult);
 
     /* Other type*/
     nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEMODELCHANGEEVENTTYPE);
+    UA_ContentFilterResult_init(&contentFilterResult);
+    contentFilterResult.elementResultsSize = contentFilter.elementsSize;
+    contentFilterResult.elementResults = (UA_ContentFilterElementResult *)
+        UA_Array_new(contentFilter.elementsSize,
+                     &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
+    if(!contentFilterResult.elementResults) {
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    }
+    for(size_t i = 0; i < contentFilterResult.elementResultsSize; ++i) {
+        ck_assert(contentFilterResult.elementResults != NULL);
+        contentFilterResult.elementResults[i].operandStatusCodesSize =
+            contentFilter.elements->filterOperandsSize;
+        contentFilterResult.elementResults[i].operandStatusCodes =
+            (UA_StatusCode *)UA_Array_new(
+                contentFilter.elements->filterOperandsSize,
+                &UA_TYPES[UA_TYPES_STATUSCODE]);
+        if(!contentFilterResult.elementResults[i].operandStatusCodes) {
+            ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        }
+    }
     UA_LOCK(&server->serviceMutex);
-    retval = UA_Server_evaluateWhereClauseContentFilter(server, &eventNodeId, &contentFilter);
+    retval = UA_Server_evaluateWhereClauseContentFilter(server, &server->adminSession, &eventNodeId, &contentFilter, &contentFilterResult);
     UA_UNLOCK(&server->serviceMutex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_BADNOMATCH);
+    UA_ContentFilterResult_clear(&contentFilterResult);
 }
 END_TEST
 


### PR DESCRIPTION
This PR is the second batch of the event filter server logic. The changes are based on batch 1 #4608 

This Batch currently contains:
- Initial Content Filter skeleton (Where Clause evaluation)
- Use of the EventFilterResult structure
- Fix Issue with reduced server and A&C while using UaExpert

The PR is based on the work in #4225 