### PR TITLE
fix(nc) Allow EnumString with empty text field

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_datatypes.py
+++ b/tools/nodeset_compiler/backend_open62541_datatypes.py
@@ -74,6 +74,8 @@ def generateByteStringCode(value, valueName, global_var_code, isPointer):
                                                         accessor='->' if isPointer else '.')
 
 def generateLocalizedTextCode(value, alloc=False):
+    if value.text is None:
+        value.text = ""
     vt = makeCLiteral(value.text)
     return u"UA_LOCALIZEDTEXT{}(\"{}\", {})".format("_ALLOC" if alloc else "", '' if value.locale is None else value.locale,
                                                    splitStringLiterals(vt))


### PR DESCRIPTION
Currently it's not possible to compile the IO-Link companion specification with our nodeset compiler. The problem exists because the IO-Link spec uses EnumStrings (Array of LocalizedText) and define values with a "null" text value. Our latest Nodeset-Compiler expect a value for the text attribute and crashes therefore.

<img width="715" alt="nscp_iolink" src="https://user-images.githubusercontent.com/5704498/132212576-960f6a15-6c45-48a6-92ab-404da9a2a68d.PNG">

Nodeset-XML example:
https://github.com/OPCFoundation/UA-Nodeset/blob/f0cd86388c7bb1fce87ef3c6b554e7a927f8613d/IOLink/Opc.Ua.IOLink.NodeSet2.xml#L4861-L5646

The problem is solved by setting an empty string within the nodeset compiler.
