### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /opt/open62541
 
 # Generate certificates
 RUN apk add --no-cache python3-dev linux-headers openssl && rm -rf /var/cache/apk/*
-RUN pip3 install netifaces==0.10.9
+RUN pip3 install --no-cache-dir netifaces==0.10.9
 RUN mkdir -p /opt/open62541/pki/created
 RUN python3 /opt/open62541/tools/certs/create_self-signed.py /opt/open62541/pki/created
 


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>