### PR TITLE
Fix HasInterface handling

### DIFF
--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -164,10 +164,9 @@ getAllInterfaceChildNodeIds(UA_Server *server, const UA_NodeId *objectNode,
     UA_ReferenceTypeSet reftypes_subtype =
         UA_REFTYPESET(UA_REFERENCETYPEINDEX_HASSUBTYPE);
 
-    /* Don't include the start node */
     UA_StatusCode retval = browseRecursive(server, 1, objectTypeNode, UA_BROWSEDIRECTION_INVERSE,
                                            &reftypes_subtype, UA_NODECLASS_OBJECTTYPE,
-                                           false, &hasInterfaceCandidatesSize,
+                                           true, &hasInterfaceCandidatesSize,
                                            &hasInterfaceCandidates);
 
     if (retval != UA_STATUSCODE_GOOD)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,18 @@ if(UA_ENABLE_PUBSUB)
     endif()
 endif()
 
+if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+    set(NODESET_COMPILER_OUTPUT_DIR "${CMAKE_BINARY_DIR}/src_generated/tests")
+
+    # Generate namespace for interfaces test
+    ua_generate_nodeset_and_datatypes(
+        NAME "tests-interfaces"
+        OUTPUT_DIR "${NODESET_COMPILER_OUTPUT_DIR}"
+        FILE_NS "${CMAKE_CURRENT_SOURCE_DIR}/server/interface-testmodel.xml"
+        INTERNAL
+    )
+endif()
+
 add_library(open62541-testplugins OBJECT ${test_plugin_sources} ${PROJECT_SOURCE_DIR}/arch/${UA_ARCHITECTURE}/ua_architecture_functions.c)
 add_dependencies(open62541-testplugins open62541)
 target_compile_definitions(open62541-testplugins PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
@@ -597,3 +609,11 @@ endif()
 
 # Tests for Nodeset Compiler
 add_subdirectory(nodeset-compiler)
+
+# Tests for interfaces
+if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+    add_executable(check_interfaces server/check_interfaces.c ${NODESET_COMPILER_OUTPUT_DIR}/namespace_tests_interfaces_generated.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+    target_include_directories(check_interfaces PRIVATE ${NODESET_COMPILER_OUTPUT_DIR})
+    target_link_libraries(check_interfaces ${LIBS})
+    add_test_valgrind(check_interfaces ${TESTS_BINARY_DIR}/check_interfaces)
+endif()

--- a/tests/server/check_interfaces.c
+++ b/tests/server/check_interfaces.c
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright 2021 (c) basysKom GmbH <opensource@basyskom.com>
+ */
+
+#include <namespace_tests_interfaces_generated.h>
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/types.h>
+
+#include "server/ua_server_internal.h"
+#include "server/ua_services.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "check.h"
+
+static UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+
+    UA_StatusCode setupResult = namespace_tests_interfaces_generated(server);
+    ck_assert_int_eq(setupResult, UA_STATUSCODE_GOOD);
+
+    UA_ObjectAttributes attr = UA_ObjectAttributes_default;
+    setupResult = UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(1, 1234), UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                          UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, (char *)"TestObject"),
+                                          UA_NODEID_NUMERIC(2, 1006), attr, NULL, NULL);
+
+    ck_assert_int_eq(setupResult, UA_STATUSCODE_GOOD);
+}
+
+static void teardown(void) {
+    UA_Server_delete(server);
+}
+
+START_TEST(check_interface_instantiation) {
+    UA_BrowsePath bp;
+    UA_BrowsePath_init(&bp);
+    bp.startingNode = UA_NODEID_NUMERIC(1, 1234);
+    bp.relativePath.elementsSize = 1;
+
+    UA_RelativePathElement el;
+    UA_RelativePathElement_init(&el);
+    el.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
+    el.targetName = UA_QUALIFIEDNAME(2, (char *)"ObjectWithInterfaces");
+
+    bp.relativePath.elements = &el;
+
+    UA_BrowsePathResult bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
+    ck_assert_int_eq(bpr.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(bpr.targetsSize, 1);
+
+    const UA_NodeId objectWithInterfacesId = bpr.targets->targetId.nodeId;
+    UA_BrowsePathResult_clear(&bpr);
+
+    UA_BrowseDescription bd;
+    UA_BrowseDescription_init(&bd);
+
+    bd.nodeId = objectWithInterfacesId;
+    bd.resultMask = UA_BROWSERESULTMASK_ALL;
+    bd.browseDirection = UA_BROWSEDIRECTION_FORWARD;
+    bd.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_REFERENCES);
+    bd.includeSubtypes = UA_TRUE;
+    bd.nodeClassMask = 0xFFFFFFFF;
+
+    UA_BrowseResult br = UA_Server_browse(server, 1000, &bd);
+    ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_int_gt(br.referencesSize, 0);
+
+    bool found = false;
+    for (size_t i = 0; i < br.referencesSize; ++i) {
+        UA_NodeId expectedRef = UA_NODEID_NUMERIC(0, UA_NS0ID_HASINTERFACE);
+        UA_NodeId expectedId = UA_NODEID_NUMERIC(2, 1002);
+        if (UA_NodeId_equal(&br.references[i].referenceTypeId, &expectedRef) &&
+                UA_NodeId_equal(&br.references[i].nodeId.nodeId, &expectedId))
+        {
+            found = true;
+            break;
+        }
+    }
+    ck_assert(found == true);
+
+    found = false;
+    for (size_t i = 0; i < br.referencesSize; ++i) {
+        UA_NodeId expectedRef = UA_NODEID_NUMERIC(0, UA_NS0ID_HASINTERFACE);
+        UA_NodeId expectedId = UA_NODEID_NUMERIC(2, 1005);
+        if (UA_NodeId_equal(&br.references[i].referenceTypeId, &expectedRef) &&
+                UA_NodeId_equal(&br.references[i].nodeId.nodeId, &expectedId))
+        {
+            found = true;
+            break;
+        }
+    }
+    ck_assert(found == true);
+
+    found = false;
+    for (size_t i = 0; i < br.referencesSize; ++i) {
+        UA_NodeId expectedRef = UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY);
+        UA_QualifiedName expectedName = UA_QUALIFIEDNAME(2, (char *)"Interface1Property");
+        if (UA_NodeId_equal(&br.references[i].referenceTypeId, &expectedRef) &&
+                UA_QualifiedName_equal(&br.references[i].browseName, &expectedName))
+        {
+            found = true;
+            break;
+        }
+    }
+    ck_assert(found == true);
+
+    found = false;
+    for (size_t i = 0; i < br.referencesSize; ++i) {
+        UA_NodeId expectedRef = UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY);
+        UA_QualifiedName expectedName = UA_QUALIFIEDNAME(2, (char *)"MyOtherInterfaceProperty");
+        if (UA_NodeId_equal(&br.references[i].referenceTypeId, &expectedRef) &&
+                UA_QualifiedName_equal(&br.references[i].browseName, &expectedName))
+        {
+            found = true;
+            break;
+        }
+    }
+    ck_assert(found == true);
+
+    found = false;
+    for (size_t i = 0; i < br.referencesSize; ++i) {
+        UA_NodeId expectedRef = UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY);
+        UA_QualifiedName expectedName = UA_QUALIFIEDNAME(2, (char *)"MyTestObjectProperty");
+        if (UA_NodeId_equal(&br.references[i].referenceTypeId, &expectedRef) &&
+                UA_QualifiedName_equal(&br.references[i].browseName, &expectedName))
+        {
+            found = true;
+            break;
+        }
+    }
+    ck_assert(found == true);
+
+    UA_BrowseResult_clear(&br);
+} END_TEST
+
+int main(void) {
+    Suite *s = suite_create("server");
+
+    TCase *tc_call = tcase_create("server - basics");
+    tcase_add_checked_fixture(tc_call, setup, teardown);
+    tcase_add_test(tc_call, check_interface_instantiation);
+    suite_add_tcase(s, tc_call);
+
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/server/interface-testmodel.xml
+++ b/tests/server/interface-testmodel.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:s1="http://yourorganisation.org/interface-testmodel/Types.xsd" xmlns:ua="http://unifiedautomation.com/Configuration/NodeSet.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://yourorganisation.org/interface-testmodel/</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://yourorganisation.org/interface-testmodel/" PublicationDate="2021-06-18T06:51:01Z" Version="1.0.0">
+            <RequiredModel ModelUri="http://opcfoundation.org/UA/" PublicationDate="2020-07-15T00:00:00Z" Version="1.04.7"/>
+        </Model>
+    </Models>
+    <Aliases>
+        <Alias Alias="Boolean">i=1</Alias>
+        <Alias Alias="Double">i=11</Alias>
+        <Alias Alias="String">i=12</Alias>
+        <Alias Alias="DateTime">i=13</Alias>
+        <Alias Alias="HasModellingRule">i=37</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasProperty">i=46</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+        <Alias Alias="IdType">i=256</Alias>
+        <Alias Alias="NumericRange">i=291</Alias>
+        <Alias Alias="HasInterface">i=17603</Alias>
+    </Aliases>
+    <Extensions>
+        <Extension>
+            <ua:ModelInfo Tool="UaModeler" Hash="QC0H4teuLnB95dz5UaKEmw==" Version="1.6.5"/>
+        </Extension>
+    </Extensions>
+    <UAObjectType NodeId="ns=1;i=1005" BrowseName="1:MyOtherInterface">
+        <DisplayName>MyOtherInterface</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=17602</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6010</Reference>
+            <Reference ReferenceType="HasInterface" IsForward="false">ns=1;i=1004</Reference>
+        </References>
+    </UAObjectType>
+    <UAVariable DataType="Double" ParentNodeId="ns=1;i=1005" NodeId="ns=1;i=6010" BrowseName="1:MyOtherInterfaceProperty" AccessLevel="3">
+        <DisplayName>MyOtherInterfaceProperty</DisplayName>
+        <References>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1005</Reference>
+        </References>
+    </UAVariable>
+    <UAObjectType NodeId="ns=1;i=1002" BrowseName="1:MyTestInterface">
+        <DisplayName>MyTestInterface</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty">ns=1;i=6001</Reference>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=17602</Reference>
+            <Reference ReferenceType="HasInterface" IsForward="false">ns=1;i=1003</Reference>
+        </References>
+    </UAObjectType>
+    <UAVariable DataType="Double" ParentNodeId="ns=1;i=1002" NodeId="ns=1;i=6001" BrowseName="1:Interface1Property" AccessLevel="3">
+        <DisplayName>Interface1Property</DisplayName>
+        <References>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1002</Reference>
+        </References>
+    </UAVariable>
+    <UAObjectType IsAbstract="true" NodeId="ns=1;i=1003" BrowseName="1:MyBaseObjectType">
+        <DisplayName>MyBaseObjectType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+            <Reference ReferenceType="HasInterface">ns=1;i=1002</Reference>
+        </References>
+    </UAObjectType>
+    <UAObjectType NodeId="ns=1;i=1004" BrowseName="1:MyTestObjectType">
+        <DisplayName>MyTestObjectType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasInterface">ns=1;i=1005</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6002</Reference>
+            <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=1003</Reference>
+        </References>
+    </UAObjectType>
+    <UAVariable DataType="Double" ParentNodeId="ns=1;i=1004" NodeId="ns=1;i=6002" BrowseName="1:MyTestObjectProperty" AccessLevel="3">
+        <DisplayName>MyTestObjectProperty</DisplayName>
+        <References>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=1004</Reference>
+        </References>
+    </UAVariable>
+    <UAObjectType NodeId="ns=1;i=1006" BrowseName="1:TopLevelObjectType">
+        <DisplayName>TopLevelObjectType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent">ns=1;i=5002</Reference>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+        </References>
+    </UAObjectType>
+    <UAObject ParentNodeId="ns=1;i=1006" NodeId="ns=1;i=5002" BrowseName="1:ObjectWithInterfaces">
+        <DisplayName>ObjectWithInterfaces</DisplayName>
+        <References>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6011</Reference>
+            <Reference ReferenceType="HasTypeDefinition">ns=1;i=1004</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1006</Reference>
+        </References>
+    </UAObject>
+    <UAVariable DataType="Double" ParentNodeId="ns=1;i=5002" NodeId="ns=1;i=6011" BrowseName="1:MyTestObjectProperty" AccessLevel="3">
+        <DisplayName>MyTestObjectProperty</DisplayName>
+        <References>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5002</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAObject SymbolicName="http___yourorganisation_org_interface_testmodel_" NodeId="ns=1;i=5001" BrowseName="1:http://yourorganisation.org/interface-testmodel/">
+        <DisplayName>http://yourorganisation.org/interface-testmodel/</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty">ns=1;i=6003</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=11616</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">i=11715</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6004</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6005</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6006</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6007</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6008</Reference>
+            <Reference ReferenceType="HasProperty">ns=1;i=6009</Reference>
+        </References>
+    </UAObject>
+    <UAVariable DataType="Boolean" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=6003" BrowseName="IsNamespaceSubset">
+        <DisplayName>IsNamespaceSubset</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5001</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:Boolean>false</uax:Boolean>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="DateTime" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=6004" BrowseName="NamespacePublicationDate">
+        <DisplayName>NamespacePublicationDate</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5001</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:DateTime>2021-06-18T06:51:01Z</uax:DateTime>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="String" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=6005" BrowseName="NamespaceUri">
+        <DisplayName>NamespaceUri</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5001</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:String>http://yourorganisation.org/interface-testmodel/</uax:String>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="String" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=6006" BrowseName="NamespaceVersion">
+        <DisplayName>NamespaceVersion</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5001</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:String>1.0.0</uax:String>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="IdType" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=6007" ArrayDimensions="0" BrowseName="StaticNodeIdTypes">
+        <DisplayName>StaticNodeIdTypes</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="NumericRange" ParentNodeId="ns=1;i=5001" ValueRank="1" NodeId="ns=1;i=6008" ArrayDimensions="0" BrowseName="StaticNumericNodeIdRange">
+        <DisplayName>StaticNumericNodeIdRange</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="String" ParentNodeId="ns=1;i=5001" NodeId="ns=1;i=6009" BrowseName="StaticStringNodeIdPattern">
+        <DisplayName>StaticStringNodeIdPattern</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5001</Reference>
+        </References>
+    </UAVariable>
+</UANodeSet>


### PR DESCRIPTION
Sub nodes of ObjectType nodes and instances were missing the HasInterface reference.

With this patch, all necessary information should be there.
For verification purposes, I have used the XML file from https://github.com/open62541/open62541/pull/4479

What I would expect:
- TopLevelObjectType should have a child of type MyTestObjectType named ObjectWithInterfaces
- ObjectWithInterfaces in the ObjectType node should have two HasInterface references
- ObjectWithInterfaces in the ObjectType node should have three properties (one own property, one from each of the two interfaces. I assume this is correct according to https://reference.opcfoundation.org/v104/Core/docs/Amendment7/4.9.2/ Figure 7A)
- An instance of TopLevelObjectType should look the same