### PR TITLE
Fixed wrong calculation of UA_DateTime_localTimeUtcOffset when UA_ARC…

### DIFF
--- a/arch/freertosLWIP/ua_clock.c
+++ b/arch/freertosLWIP/ua_clock.c
@@ -4,6 +4,7 @@
  *    Copyright 2016-2017 (c) Julius Pfrommer, Fraunhofer IOSB
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Thomas Stalder
+ *    Copyright 2021 (c) Simon Kueppers, 2pi-Labs GmbH
  */
 
 #ifdef UA_ARCHITECTURE_FREERTOSLWIP
@@ -19,6 +20,18 @@ UA_DateTime UA_DateTime_now(void) {
     return (tv.tv_sec * UA_DATETIME_SEC) + (tv.tv_usec * UA_DATETIME_USEC) + UA_DATETIME_UNIX_EPOCH;
 }
 
+/* Credit to https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
+UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
+    time_t gmt, rawtime = time(NULL);
+    struct tm *ptm;
+    struct tm gbuf;
+    ptm = gmtime_r(&rawtime, &gbuf);
+    // Request that mktime() looksup dst in timezone database
+    ptm->tm_isdst = -1;
+    gmt = mktime(ptm);
+    return (UA_Int64) (difftime(rawtime, gmt) * UA_DATETIME_SEC);
+}
+
 #else /* UA_ARCHITECTURE_FREERTOSLWIP_POSIX_CLOCK */
 
 /* The current time in UTC time */
@@ -27,12 +40,12 @@ UA_DateTime UA_DateTime_now(void) {
   return ((microSeconds / 1000000) * UA_DATETIME_SEC) + ((microSeconds % 1000000) * UA_DATETIME_USEC) + UA_DATETIME_UNIX_EPOCH;
 }
 
-#endif /* UA_ARCHITECTURE_FREERTOSLWIP_POSIX_CLOCK */
-
 /* Offset between local time and UTC time */
 UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
   return 0; //TODO: this is set to zero since UA_DateTime_now() is just the local time, and not UTC.
 }
+
+#endif /* UA_ARCHITECTURE_FREERTOSLWIP_POSIX_CLOCK */
 
 /* CPU clock invariant to system time changes. Use only to measure durations,
  * not absolute time. */


### PR DESCRIPTION
Local time offset in function ``UA_DateTime_localTimeUtcOffset`` is returned as 0, on a FreeRTOS+LWIP architecture, when enabling POSIX compatible time functions (``UA_ARCHITECTURE_FREERTOSLWIP_POSIX_CLOCK``).

I copied the ``UA_DateTime_localTimeUtcOffset`` function from ``arch/posix/ua_clock.c`` to retrieve the actual timezone/UTC offset information.