### PR TITLE
Nodeset resolver Tool (for generating custom tailored namespace-zero nodesets)

### DIFF
--- a/tools/nodeset_compiler/README.md
+++ b/tools/nodeset_compiler/README.md
@@ -43,10 +43,10 @@ Due to memory constraints, you are using the default reduced OPC UA Namespace-Ze
 ````
 nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
   -x .../deps/ua-nodeset/PADIM/Opc.Ua.IRDI.NodeSet2.xml \
-  -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml -u
 ````
 
-The output shows a list of missing NodeIds, that can not be resolved from the supplied XML files. Ignoring ``ns=0``, the other missing nodeIds can be supplied by including the OPC UA DI model.
+The output shows a list of missing NodeIds, that can not be resolved from the supplied XML files. Ignoring ``nsu=http://opcfoundation.org/UA/``, the other missing nodeIds can be supplied by including the OPC UA DI model (``nsu=http://opcfoundation.org/UA/DI/``).
 ````
 nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
   -x .../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml \
@@ -54,7 +54,7 @@ nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
   -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml
 ````
 
-This time, only NodeIds with ``ns=0`` are listed as unresolvable, because they are missing from the default reduced namespace-zero nodeset.
+This time, only NodeIds of namespace-zero are listed as unresolvable, because they are missing from the default reduced namespace-zero nodeset.
 We can now include the full OPC UA namespace-zero nodeset as a reference file to resolve all missing dependencies.
 
 ````

--- a/tools/nodeset_compiler/README.md
+++ b/tools/nodeset_compiler/README.md
@@ -35,7 +35,7 @@ optional arguments:
 
 ## Showing missing dependencies
 Suppose you want to implement a OPC UA PA-DIM nodeset on an embedded platform.
-Due to memory constraints, you are using the default reduced OPC UA Namespace-Zero nodeset.
+Due to memory constraints, you are using the default reduced OPC UA Namespace-Zero nodeset. However you quickly find yourself in a position, where a lot of additional dependencies need to be satisfied.
 
 ````
 nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
@@ -43,7 +43,7 @@ nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
   -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml
 ````
 
-The output shows a list of missing NodeIds, that can not be resolved from the supplied XML files. Ignoring ``ns=0``, the missing NodeIds can be solved by including the OPC UA DI model.
+The output shows a list of missing NodeIds, that can not be resolved from the supplied XML files. Ignoring ``ns=0``, the other missing nodeIds can be supplied by including the OPC UA DI model.
 ````
 nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
   -x .../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml \
@@ -51,7 +51,7 @@ nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
   -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml
 ````
 
-This time, only NodeIds with ``ns=0`` are list as unresolvable, because they are missing from the default reduced namespace-zero nodeset.
+This time, only NodeIds with ``ns=0`` are listed as unresolvable, because they are missing from the default reduced namespace-zero nodeset.
 We can now include the full OPC UA namespace-zero nodeset as a reference file to resolve all missing dependencies.
 
 ````
@@ -63,10 +63,11 @@ nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
 ````
 
 The output now shows all resolved NodeIds, that are required for namespace zero.
+Now the next step includes generating a new namespace-zero that includes the missing nodes.
 
-## Generating Custom NodeSets
-You can now automatically generate an XML file with these resolved NodeIds by pulling in their definition from the reference XML file.
-Additionally, you can automatically merge the resolved node definitions with the existing XML nodeset given with the ``-e`` parameter.
+## Generating a Custom nodeset
+You can now automatically generate an XML file with the resolved nodes by specifying that their definition should be pulled-in from the reference XML file by specifying ``-p``.
+Additionally, you can automatically merge the resolved node definitions with the existing XML nodeset (given with the ``-e`` parameter) by specifying ``-m``.
 
 Using this feature, you can create a custom tailored namespace-zero XML file using the default reduced nodeset as a basis.
 
@@ -79,7 +80,17 @@ nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
   -p -m > Opc.Ua.NodeSet2.Custom.xml
 ````
 
-_Note_: In this scenario, the nodesets given with the ``-x`` parameter will later be used with the ``nodeset_compiler`` to produce the compiled code for implementing the OPC UA PA-DIM nodeset.
+## Using the custom nodeset
+The custom generatead ``Opc.Ua.NodeSet2.Custom.xml`` can now be included as the namespace-zero file during compilation. For example:
+
+````
+cmake -DUA_ARCHITECTURE=freertosLWIP \
+      -DUA_ENABLE_AMALGAMATION=ON \
+      -DUA_NAMESPACE_ZERO=FULL \
+      -DUA_FILE_NS0='path/to/generated/Opc.Ua.NodeSet2.Custom.xml' ../
+````
+
+_Note_: In this scenario, the nodesets given with the ``-x`` parameter will later be used with the ``nodeset_compiler`` to produce the compiled code for implementing the OPC UA PA-DIM nodeset. For example:
 
 ````
 nodeset_compiler.py -e path/to/generated/Opc.Ua.NodeSet2.Custom.xml \

--- a/tools/nodeset_compiler/README.md
+++ b/tools/nodeset_compiler/README.md
@@ -4,9 +4,9 @@ The nodeset compiler is a collection of Python scripts that can parse OPC UA XML
 
 The initial implementation has been contributed by a research project of the chair for Process Control Systems Engineering of the TU Dresden. It was not strictly speaking created as a C generator, but could be easily modified to fulfill this role for open62541. Later on it was extended and improved by the core developers of open62541.
 
-# open62541 nodeset resolver
+# open62541 nodeset Resolver
 
-The nodeset resolver can be used to identify dependencies between nodesets. The main purpose of this tool is to generate custom stripped-down namespace-zero nodesets.
+The nodeset resolver can be used to identify dependencies between nodesets. The main purpose of this tool is to generate custom tailored, stripped-down namespace-zero nodesets.
 
 ## Usage
 Use ``nodeset_resolver.py --help`` for a help output:
@@ -20,7 +20,8 @@ optional arguments:
                         NodeSet XML files with nodes that are already present
                         on the server.
   -x <nodeSetXML>, --xml <nodeSetXML>
-                        NodeSet XML files with nodes that shall be generated.
+                        NodeSet XML files with nodes that dependencies shall
+                        be resolved for.
   -r <referenceNodeSetXML>, --ref <referenceNodeSetXML>
                         NodeSet XML file where missing dependencies are
                         resolved from.
@@ -29,6 +30,7 @@ optional arguments:
                         (first) existing-NodeSet
   -v, --verbose         Make the script more verbose. Can be applied up to 4
                         times
+
 ````
 
 ## Showing missing dependencies

--- a/tools/nodeset_compiler/README.md
+++ b/tools/nodeset_compiler/README.md
@@ -4,6 +4,89 @@ The nodeset compiler is a collection of Python scripts that can parse OPC UA XML
 
 The initial implementation has been contributed by a research project of the chair for Process Control Systems Engineering of the TU Dresden. It was not strictly speaking created as a C generator, but could be easily modified to fulfill this role for open62541. Later on it was extended and improved by the core developers of open62541.
 
+# open62541 nodeset resolver
+
+The nodeset resolver can be used to identify dependencies between nodesets. The main purpose of this tool is to generate custom stripped-down namespace-zero nodesets.
+
+## Usage
+Use ``nodeset_resolver.py --help`` for a help output:
+````
+usage: nodeset_resolver.py [-h] [-e <existingNodeSetXML>] [-x <nodeSetXML>]
+                           [-r <referenceNodeSetXML>] [-p] [-m] [-v]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -e <existingNodeSetXML>, --existing <existingNodeSetXML>
+                        NodeSet XML files with nodes that are already present
+                        on the server.
+  -x <nodeSetXML>, --xml <nodeSetXML>
+                        NodeSet XML files with nodes that shall be generated.
+  -r <referenceNodeSetXML>, --ref <referenceNodeSetXML>
+                        NodeSet XML file where missing dependencies are
+                        resolved from.
+  -p, --pull            Pull in and output missing Nodes from reference XML
+  -m, --merge           Merge missing Nodes from reference NodeSet into
+                        (first) existing-NodeSet
+  -v, --verbose         Make the script more verbose. Can be applied up to 4
+                        times
+````
+
+## Showing missing dependencies
+Suppose you want to implement a OPC UA PA-DIM nodeset on an embedded platform.
+Due to memory constraints, you are using the default reduced OPC UA Namespace-Zero nodeset.
+
+````
+nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.IRDI.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml
+````
+
+The output shows a list of missing NodeIds, that can not be resolved from the supplied XML files. Ignoring ``ns=0``, the missing NodeIds can be solved by including the OPC UA DI model.
+````
+nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
+  -x .../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.IRDI.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml
+````
+
+This time, only NodeIds with ``ns=0`` are list as unresolvable, because they are missing from the default reduced namespace-zero nodeset.
+We can now include the full OPC UA namespace-zero nodeset as a reference file to resolve all missing dependencies.
+
+````
+nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
+  -x .../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.IRDI.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml \
+  -r .../deps/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml
+````
+
+The output now shows all resolved NodeIds, that are required for namespace zero.
+
+## Generating Custom NodeSets
+You can now automatically generate an XML file with these resolved NodeIds by pulling in their definition from the reference XML file.
+Additionally, you can automatically merge the resolved node definitions with the existing XML nodeset given with the ``-e`` parameter.
+
+Using this feature, you can create a custom tailored namespace-zero XML file using the default reduced nodeset as a basis.
+
+````
+nodeset_resolver.py -e ../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml \
+  -x .../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.IRDI.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml \
+  -r .../deps/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml \
+  -p -m > Opc.Ua.NodeSet2.Custom.xml
+````
+
+_Note_: In this scenario, the nodesets given with the ``-x`` parameter will later be used with the ``nodeset_compiler`` to produce the compiled code for implementing the OPC UA PA-DIM nodeset.
+
+````
+nodeset_compiler.py -e path/to/generated/Opc.Ua.NodeSet2.Custom.xml \
+  -x .../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.IRDI.NodeSet2.xml \
+  -x .../deps/ua-nodeset/PADIM/Opc.Ua.PADIM.NodeSet2.xml \
+  PADIM_NodeSet
+````
+
 ## Documentation
 
-Usage documentation and How-Tos can be found on the webpage: <https://open62541.org/doc/current/nodeset_compiler.html> 
+Usage documentation and How-Tos can be found on the webpage: <https://open62541.org/doc/current/nodeset_compiler.html>

--- a/tools/nodeset_compiler/README.md
+++ b/tools/nodeset_compiler/README.md
@@ -8,6 +8,8 @@ The initial implementation has been contributed by a research project of the cha
 
 The nodeset resolver can be used to identify dependencies between nodesets. The main purpose of this tool is to generate custom tailored, stripped-down namespace-zero nodesets.
 
+The initial implementation has been contributed by 2pi-Labs GmbH specifically for space-constrained embedded platforms (e.g. sensors).
+
 ## Usage
 Use ``nodeset_resolver.py --help`` for a help output:
 ````

--- a/tools/nodeset_compiler/README.md
+++ b/tools/nodeset_compiler/README.md
@@ -25,15 +25,15 @@ optional arguments:
                         NodeSet XML files with nodes that dependencies shall
                         be resolved for.
   -r <referenceNodeSetXML>, --ref <referenceNodeSetXML>
-                        NodeSet XML file where missing dependencies are
+                        NodeSet XML files where missing dependencies are
                         resolved from.
   -u, --expanded        Output expanded node ids with a namespace uri
-  -p, --pull            Pull in and output missing Nodes from reference XML
+  -p, --pull            Pull in and output missing Nodes from (first)
+                        reference XML
   -m, --merge           Merge missing Nodes from reference NodeSet into
-                        (first) existing-NodeSet
+                        (first) existing XML
   -v, --verbose         Make the script more verbose. Can be applied up to 4
                         times
-
 ````
 
 ## Showing missing dependencies

--- a/tools/nodeset_compiler/README.md
+++ b/tools/nodeset_compiler/README.md
@@ -14,7 +14,7 @@ The initial implementation has been contributed by 2pi-Labs GmbH specifically fo
 Use ``nodeset_resolver.py --help`` for a help output:
 ````
 usage: nodeset_resolver.py [-h] [-e <existingNodeSetXML>] [-x <nodeSetXML>]
-                           [-r <referenceNodeSetXML>] [-p] [-m] [-v]
+                           [-r <referenceNodeSetXML>] [-u] [-p] [-m] [-v]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -27,6 +27,7 @@ optional arguments:
   -r <referenceNodeSetXML>, --ref <referenceNodeSetXML>
                         NodeSet XML file where missing dependencies are
                         resolved from.
+  -u, --expanded        Output expanded node ids with a namespace uri
   -p, --pull            Pull in and output missing Nodes from reference XML
   -m, --merge           Merge missing Nodes from reference NodeSet into
                         (first) existing-NodeSet

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -218,7 +218,7 @@ if len(args.refs) > 0:
         logger.info("Preprocessing (reference) " + str(xmlfile.name))
         referenceNodeSet.addNodeSet(xmlfile, True, typesArray="UA_TYPES")
 
-    logger.info("Resolving all dependencies from {}...".format(xmlfile.name))
+    logger.info("Resolving all dependencies from references...")
 
     # Walk entire tree to find all dependencies
     dependentNodes = walkNodes(referenceNodeSet, missingNodes)

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -1,7 +1,6 @@
 import logging
 import argparse
 import sys
-import os
 from datatypes import NodeId
 from lxml import etree
 from nodeset import NodeSet
@@ -114,17 +113,13 @@ def walkNodes(nodeSet, nodeIds, nodeList=[]):
             # DataType contains other DataType fields. __definition__ is list of (Name, DataTypeNode) tuples
             for definition in n.__definition__:
                 candidateNodes.append(definition[1].id)
-                #if definition[1].id not in nodeList: nodeList.append(definition[1].id)
 
         if type(n) == nodes.VariableNode or type(n) == nodes.VariableTypeNode:
             if n.dataType is not None:
                 candidateNodes.append(n.dataType)
-                #if n.dataType not in nodeList: nodeList.append(n.dataType)
 
         for ref in n.references:
             if not ref.source == n.id: raise Exception("Reference " + str(ref) + " has an invalid source")
-            #if ref.referenceType not in nodeList: nodeList.append(ref.referenceType)
-            #if ref.target not in nodeList: nodeList.append(ref.target)
             candidateNodes.append(ref.referenceType)
             candidateNodes.append(ref.target)
 
@@ -132,7 +127,7 @@ def walkNodes(nodeSet, nodeIds, nodeList=[]):
         candidateNodes = list(set(candidateNodes) - set(nodeList))
 
         # Add remaining candidateNodes to nodeList
-        nodeList += candidateNodes
+        nodeList.extend(candidateNodes)
 
         # Inquire candidateNodes recursively if there are candidates left
         if len(candidateNodes) > 0:

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -240,6 +240,6 @@ if len(args.refs) > 0:
         # (first) existing XML file (if merge is specified)
         printXML(requiredNodes, args.refs, args.existing[0] if args.merge and len(args.existing) > 0 else None)
     else:
-        printNodeIds(requiredNodes, ns.namespaces if args.expanded else None)
+        printNodeIds(requiredNodes, referenceNodeSet.namespaces if args.expanded else None)
 else:
-    printNodeIds(missingNodes, ns.namespaces if args.expanded else None)
+    printNodeIds(missingNodes, referenceNodeSet.namespaces if args.expanded else None)

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -42,6 +42,12 @@ parser.add_argument('-r', '--ref',
                     default=None,
                     help='NodeSet XML file where missing dependencies are resolved from.')
 
+parser.add_argument('-u', '--expanded',
+                    action='store_true',
+                    dest='expanded',
+                    default=False,
+                    help='Output expanded node ids with a namespace uri')
+
 parser.add_argument('-p', '--pull',
                     action='store_true',
                     dest='pull',
@@ -169,8 +175,15 @@ def printXML(nodeIds, referenceXml, existingXml=None):
         print(etree.tostring(referenceRoot).decode('utf-8'))
 
 # Function for printg nodeIds (one nodeId per line)
-def printNodeIds(nodeIds):
-    print(os.linesep.join(map(str,nodeIds)))
+def printNodeIds(nodeIds, namespaceMap=None):
+    if namespaceMap is not None:
+        # ExpandedNodeId
+        nodeIdStrings = ['nsu={};i={}'.format(namespaceMap[node.ns], node.i) for node in nodeIds]
+    else:
+        # NodeId
+        nodeIdStrings = ['ns={};i={}'.format(node.ns, node.i) for node in nodeIds]
+
+    print(os.linesep.join(nodeIdStrings))
 
 logger.info("Collecting missing nodes...".format(xmlfile.name))
 usedNodes = walkNodes(ns, ns.nodes)
@@ -212,6 +225,6 @@ if args.ref is not None:
             logger.info("Pulling in required nodes from {}...".format(args.ref.name))
             printXML(requiredNodes, args.ref)
     else:
-        printNodeIds(requiredNodes)
+        printNodeIds(requiredNodes, ns.namespaces if args.expanded else None)
 else:
-    printNodeIds(missingNodes)
+    printNodeIds(missingNodes, ns.namespaces if args.expanded else None)

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -189,7 +189,7 @@ def printNodeIds(nodeIds, namespaceMap=None):
 
     print(os.linesep.join(nodeIdStrings))
 
-logger.info("Collecting missing nodes...".format(xmlfile.name))
+logger.info("Collecting missing nodes...")
 usedNodes = walkNodes(ns, ns.nodes)
 missingNodes = [node for node in usedNodes if node not in ns.nodes]
 logger.info("Collected {} missing nodes out of {} used nodes".format(len(missingNodes), len(usedNodes)))

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -189,7 +189,7 @@ def printXML(nodeIds, referenceXml, existingXml=None):
 logger.info("Collecting missing nodes...".format(xmlfile.name))
 usedNodes = walkNodes(ns, ns.nodes)
 missingNodes = [node for node in usedNodes if node not in ns.nodes]
-logger.info("{} missing nodes out of {} used nodes found".format(len(missingNodes), len(usedNodes)))
+logger.info("Collected {} missing nodes out of {} used nodes".format(len(missingNodes), len(usedNodes)))
 
 # Load reference nodeset if given on command line
 if args.ref is not None:
@@ -212,7 +212,7 @@ if args.ref is not None:
     requiredNodes = [node for node in dependentNodes if node not in ns.nodes]
     unresolvedNodes = [node for node in requiredNodes if node not in referenceNodeSet.nodes]
 
-    logger.info("{} required nodes out of {} dependent nodes found ({} unresolved)"
+    logger.info("Resolved {} required nodes out of {} dependent nodes ({} unresolved)"
         .format(len(requiredNodes), len(dependentNodes), len(unresolvedNodes)))
 
     if args.pull:

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -197,6 +197,10 @@ def printNodeIds(nodeIds, namespaceMap=None):
 
     print(os.linesep.join(nodeIdStrings))
 
+if nsCount == 0:
+    logger.error("No files have been loaded")
+    sys.exit(1)
+
 logger.info("Collecting missing nodes...")
 usedNodes = walkNodes(ns, ns.nodes)
 missingNodes = [node for node in usedNodes if node not in ns.nodes]

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -242,4 +242,4 @@ if len(args.refs) > 0:
     else:
         printNodeIds(requiredNodes, referenceNodeSet.namespaces if args.expanded else None)
 else:
-    printNodeIds(missingNodes, referenceNodeSet.namespaces if args.expanded else None)
+    printNodeIds(missingNodes, ns.namespaces if args.expanded else None)

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -150,12 +150,9 @@ def printXML(nodeids):
 
         for node in existingNodeset.childNodes:
             if node.nodeType == dom.Node.ELEMENT_NODE:
-                nodeId = "ns=0;" + node.getAttribute('NodeId')
+                nodeId = NodeId(node.getAttribute('NodeId'))
 
                 if nodeId not in nodeids:
-                    # if node.nextSibling and node.nextSibling.nodeType == dom.Node.TEXT_NODE and node.nextSibling.data.isspace():
-                        # Remove trailing whitespace (minidom issue)
-                        # node.parentNode.removeChild(node.nextSibling)
                     node.parentNode.removeChild(node)
 
         if args.merge:

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -23,7 +23,7 @@ parser.add_argument('-x', '--xml',
                     action='append',
                     dest="infiles",
                     default=[],
-                    help='NodeSet XML files with nodes that shall be generated.')
+                    help='NodeSet XML files with nodes that dependencies shall be resolved for.')
 
 parser.add_argument('-r', '--ref',
                     metavar="<referenceNodeSetXML>",

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -194,6 +194,10 @@ logger.info("Collected {} missing nodes out of {} used nodes".format(len(missing
 if args.ref is not None:
     referenceNodeSet = NodeSet()
 
+    # Copy namespace mapping from original nodeset to allow direct node
+    # comparison between the two nodesets
+    referenceNodeSet.namespaces = ns.namespaces
+
     for xmlfile in [args.ref]:
         if xmlfile.name in loadedFiles:
             logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+### This Source Code Form is subject to the terms of the Mozilla Public
+### License, v. 2.0. If a copy of the MPL was not distributed with this
+### file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+###    Copyright 2021 (c) Simon Kueppers, 2pi-Labs GmbH
+
+
 import logging
 import argparse
 import sys

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -11,6 +11,7 @@
 import logging
 import argparse
 import sys
+import os
 from datatypes import NodeId
 from lxml import etree
 from nodeset import NodeSet
@@ -167,6 +168,10 @@ def printXML(nodeIds, referenceXml, existingXml=None):
     else:
         print(etree.tostring(referenceRoot).decode('utf-8'))
 
+# Function for printg nodeIds (one nodeId per line)
+def printNodeIds(nodeIds):
+    print(os.linesep.join(map(str,nodeIds)))
+
 logger.info("Collecting missing nodes...".format(xmlfile.name))
 usedNodes = walkNodes(ns, ns.nodes)
 missingNodes = [node for node in usedNodes if node not in ns.nodes]
@@ -207,6 +212,6 @@ if args.ref is not None:
             logger.info("Pulling in required nodes from {}...".format(args.ref.name))
             printXML(requiredNodes, args.ref)
     else:
-        print(requiredNodes)
+        printNodeIds(requiredNodes)
 else:
-    print(missingNodes)
+    printNodeIds(missingNodes)

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -1,0 +1,221 @@
+import logging
+import argparse
+import sys
+from datatypes import NodeId
+from nodeset import *
+import xml.dom.minidom as dom
+import codecs
+import re
+import os
+import nodes
+
+# Parse the arguments
+parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('-e', '--existing',
+                    metavar="<existingNodeSetXML>",
+                    type=argparse.FileType('rb'),
+                    dest="existing",
+                    action='append',
+                    default=[],
+                    help='NodeSet XML files with nodes that are already present on the server.')
+
+parser.add_argument('-x', '--xml',
+                    metavar="<nodeSetXML>",
+                    type=argparse.FileType('rb'),
+                    action='append',
+                    dest="infiles",
+                    default=[],
+                    help='NodeSet XML files with nodes that shall be generated.')
+
+parser.add_argument('-r', '--ref',
+                    metavar="<referenceNodeSetXML>",
+                    type=argparse.FileType('rb'),
+                    dest="ref",
+                    default=None,
+                    help='NodeSet XML file where missing dependencies are resolved from.')
+
+parser.add_argument('-m', '--merge',
+                    action='store_true',
+                    dest='merge',
+                    default=False,
+                    help='Merge missing Nodes from reference NodeSet into (first) existing-NodeSet')
+
+parser.add_argument('-v', '--verbose', action='count',
+                    default=1,
+                    help='Make the script more verbose. Can be applied up to 4 times')
+
+
+
+args = parser.parse_args()
+
+# Set up logging
+# Leave logging output on sys.stderr so that we can output XML data on stdout
+logging.basicConfig(stream=sys.stderr)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+verbosity = 0
+if args.verbose:
+    verbosity = int(args.verbose)
+if verbosity == 1:
+    logging.basicConfig(level=logging.ERROR)
+elif verbosity == 2:
+    logging.basicConfig(level=logging.WARNING)
+elif verbosity == 3:
+    logging.basicConfig(level=logging.INFO)
+elif verbosity >= 4:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.CRITICAL)
+
+# Create a new nodeset. The nodeset name is not significant.
+# Parse the XML files
+ns = NodeSet()
+nsCount = 0
+loadedFiles = list()
+
+for xmlfile in args.existing:
+    if xmlfile.name in loadedFiles:
+        logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))
+        continue
+    loadedFiles.append(xmlfile.name)
+    logger.info("Preprocessing (existing) " + str(xmlfile.name))
+    ns.addNodeSet(xmlfile, True)
+    nsCount +=1
+for xmlfile in args.infiles:
+    if xmlfile.name in loadedFiles:
+        logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))
+        continue
+    loadedFiles.append(xmlfile.name)
+    logger.info("Preprocessing " + str(xmlfile.name))
+    ns.addNodeSet(xmlfile)
+    nsCount +=1
+
+#------------------------
+for n in ns.nodes.values():
+    if n.sanitize() == False:
+        raise Exception("Failed to sanitize node " + str(n))
+
+def walkNodes(nodeSet, nodeIds, nodeList=[]):
+    for nodeId in nodeIds:
+        if nodeId not in nodeSet.nodes:
+            # Can not follow unresolved dependency
+            continue
+
+        n = nodeSet.nodes[nodeId]
+        candidateNodes = []
+
+        if type(n) == nodes.DataTypeNode and n.__isEnum__ == False and n.__isOptionSet__ == False:
+            # DataType contains other DataType fields. __definition__ is list of (Name, DataTypeNode) tuples
+            for definition in n.__definition__:
+                candidateNodes.append(definition[1].id)
+                #if definition[1].id not in nodeList: nodeList.append(definition[1].id)
+
+        if type(n) == nodes.VariableNode or type(n) == nodes.VariableTypeNode:
+            if n.dataType is not None:
+                candidateNodes.append(n.dataType)
+                #if n.dataType not in nodeList: nodeList.append(n.dataType)
+
+        for ref in n.references:
+            if not ref.source == n.id: raise Exception("Reference " + str(ref) + " has an invalid source")
+            #if ref.referenceType not in nodeList: nodeList.append(ref.referenceType)
+            #if ref.target not in nodeList: nodeList.append(ref.target)
+            candidateNodes.append(ref.referenceType)
+            candidateNodes.append(ref.target)
+
+        # Uniquify candidateNodes and exclude nodes already present in nodeList
+        candidateNodes = list(set(candidateNodes) - set(nodeList))
+
+        # Add remaining candidateNodes to nodeList
+        nodeList += candidateNodes
+
+        if len(candidateNodes) > 0:
+            # Inquire candidateNodes recursively if available
+            walkNodes(nodeSet, candidateNodes, nodeList)
+
+    return nodeList
+
+def printXML(nodeids):
+        args.ref.seek(0)
+        fileContent = args.ref.read()
+        #TODO: documentElement
+        # Remove BOM since the dom parser cannot handle it on Python 3 Windows
+        if fileContent.startswith( codecs.BOM_UTF8 ):
+            fileContent = fileContent.lstrip( codecs.BOM_UTF8 )
+        if (sys.version_info >= (3, 0)):
+            fileContent = fileContent.decode("utf-8")
+
+        document = dom.parseString(fileContent)
+        nodeset = document.getElementsByTagName("UANodeSet")[0]
+
+        for node in nodeset.childNodes:
+            if node.nodeType == dom.Node.ELEMENT_NODE:
+                nodeId = "ns=0;" + node.getAttribute('NodeId')
+
+                if nodeId not in nodeids:
+                    # if node.nextSibling and node.nextSibling.nodeType == dom.Node.TEXT_NODE and node.nextSibling.data.isspace():
+                        # Remove trailing whitespace (minidom issue)
+                        # node.parentNode.removeChild(node.nextSibling)
+                    node.parentNode.removeChild(node)
+
+        if args.merge:
+            # TODO: minidom too slow
+            args.existing[0].seek(0)
+            fileContent = args.existing[0].read()
+            # Remove BOM since the dom parser cannot handle it on Python 3 Windows
+            if fileContent.startswith( codecs.BOM_UTF8 ):
+                fileContent = fileContent.lstrip( codecs.BOM_UTF8 )
+            if (sys.version_info >= (3, 0)):
+                fileContent = fileContent.decode("utf-8")
+
+            exDocument = dom.parseString(fileContent)
+            exNodeset = document.getElementsByTagName("UANodeSet")[0]
+            for node in nodeset.childNodes:
+                if node.nodeType == dom.Node.ELEMENT_NODE:
+                    x = exDocument.importNode(node, False)
+                    exNodeset.appendChild(x)
+
+            document = exDocument
+
+
+        # To XML and remove empty lines (minidom quirk)
+        xml = document.toprettyxml(indent="  ")
+        xml = os.linesep.join([s.rstrip() for s in xml.splitlines() if s.strip()])
+        print(xml)
+
+logger.info("Collecting missing nodes...".format(xmlfile.name))
+usedNodes = walkNodes(ns, ns.nodes)
+missingNodes = [node for node in usedNodes if node not in ns.nodes]
+logger.info("{} missing nodes out of {} used nodes found".format(len(missingNodes), len(usedNodes)))
+
+# Load reference nodesets if any
+if args.ref is not None:
+    refNs = NodeSet()
+
+    for xmlfile in [args.ref]:
+        if xmlfile.name in loadedFiles:
+            logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))
+            continue
+        loadedFiles.append(xmlfile.name)
+        logger.info("Preprocessing (reference) " + str(xmlfile.name))
+        refNs.addNodeSet(xmlfile, True, typesArray="UA_TYPES")
+
+    logger.info("Resolving all dependencies from {}...".format(xmlfile.name))
+
+    # Walk entire tree to find all dependencies
+    dependentNodes = walkNodes(refNs, missingNodes)
+
+    # Remove dependencies already satisfied in existing NodeSet
+    requiredNodes = [node for node in dependentNodes if node not in ns.nodes]
+    unresolvedNodes = [node for node in requiredNodes if node not in refNs.nodes]
+
+    logger.info("{} required nodes out of {} dependent nodes found ({} unresolved)"
+        .format(len(requiredNodes), len(dependentNodes), len(unresolvedNodes)))
+
+    if 1:
+        # TODO: Additional switch to control output
+        logger.info("Pulling in required nodes from {}...".format(xmlfile.name))
+        printXML(requiredNodes)
+    else:
+        print(requiredNodes)
+else:
+    print(missingNodes)

--- a/tools/nodeset_compiler/nodeset_resolver.py
+++ b/tools/nodeset_compiler/nodeset_resolver.py
@@ -34,6 +34,12 @@ parser.add_argument('-r', '--ref',
                     default=None,
                     help='NodeSet XML file where missing dependencies are resolved from.')
 
+parser.add_argument('-p', '--pull',
+                    action='store_true',
+                    dest='pull',
+                    default=False,
+                    help='Pull in and output missing Nodes from reference XML')
+
 parser.add_argument('-m', '--merge',
                     action='store_true',
                     dest='merge',
@@ -209,8 +215,7 @@ if args.ref is not None:
     logger.info("{} required nodes out of {} dependent nodes found ({} unresolved)"
         .format(len(requiredNodes), len(dependentNodes), len(unresolvedNodes)))
 
-    if 1:
-        # TODO: Additional switch to control output
+    if args.pull:
         logger.info("Pulling in required nodes from {}...".format(xmlfile.name))
         printXML(requiredNodes)
     else:


### PR DESCRIPTION
We are using the open62541 stack in an embedded environment, where RAM is scarce. When implementing a PA-DIM nodeset, I noticed that there are a lot of dependencies, that can thus far only be satisfied by including the full namespace-zero. 
However, because this is a heavy burden on the on-chip memory I was looking for a way to produce a custom tailored namespace-zero that included only the hard dependencies.

I could not find a way to programatically produce such a custom XML file, which is why I created the ``nodeset_resolver`` tool. It heavily reuses the nodeset libraries used by the exquisite ``nodeset_compiler``, which is why I put it into the same folder. Although this is a bit messy, this may be something a folder rename might fix in the future.

It works by loading the given XML files into a nodeset representation and then searches the tree for missing nodeIds. Then, the tool can look up those nodeIds from a reference XML, that is loaded into a separate nodeset representation. All (child-) dependencies are gathered and output. Lastly, it can automagically create an XML nodeset file for the required nodes from the reference XML or even splice it into the existing XML.

What do you think of this idea? It was a bit fiddly to get it working to really get all dependencies from the supplied nodeset files (especially if you don't know a lot about OPC UA yet) but the examples I have written into the README file work very well for our embedded setup. Comments are welcome!

EDIT: Should I include an affiliation in the README (similar to the one for the ``nodeset_compiler``) in case you are interested in this PR?
EDIT2: Also a license should be included in the Python script, right?