### PR TITLE
Fixed compiler warnings (-Wformat) related to printf format specifiers

### DIFF
--- a/include/open62541/util.h
+++ b/include/open62541/util.h
@@ -191,7 +191,8 @@ UA_RelativePath_parse(UA_RelativePath *rp, const UA_String str);
 /**
  * Convenience macros for complex types
  * ------------------------------------ */
-#define UA_PRINTF_GUID_FORMAT "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x"
+#define UA_PRINTF_GUID_FORMAT "%08" PRIx32 "-%04" PRIx16 "-%04" PRIx16 \
+    "-%02" PRIx8 "%02" PRIx8 "-%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8
 #define UA_PRINTF_GUID_DATA(GUID) (GUID).data1, (GUID).data2, (GUID).data3, \
         (GUID).data4[0], (GUID).data4[1], (GUID).data4[2], (GUID).data4[3], \
         (GUID).data4[4], (GUID).data4[5], (GUID).data4[6], (GUID).data4[7]

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -283,7 +283,7 @@ processAsyncResponse(UA_Client *client, UA_UInt32 requestId, const UA_NodeId *re
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
                     "Could not decode the response with id %u due to %s",
-                    requestId, UA_StatusCode_name(retval));
+                    (unsigned)requestId, UA_StatusCode_name(retval));
         response.responseHeader.serviceResult = retval;
     } else if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         /* Decode as a ServiceFault, i.e. only the response header */

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -125,7 +125,7 @@ UA_Session_dequeuePublishReq(UA_Session *session);
                 (SESSION)->header.channel->securityToken.channelId : 0; \
         }                                                               \
         UA_LOG_##LEVEL(LOGGER, UA_LOGCATEGORY_SESSION,                  \
-                       "SecureChannel %i | Session %.*s | " MSG "%.0s", \
+                       "SecureChannel %" PRIu32 " | Session %.*s | " MSG "%.0s", \
                        channelId, (int)idString.length, idString.data, __VA_ARGS__); \
         UA_String_clear(&idString);                                     \
     } while(0)

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -333,7 +333,7 @@ UA_Server_evaluateWhereClauseContentFilter(UA_Server *server,
     if((SUB) && (SUB)->session) {                                       \
         UA_NodeId_print(&(SUB)->session->sessionId, &idString);         \
         UA_LOG_##LEVEL(LOGGER, UA_LOGCATEGORY_SESSION,                  \
-                       "SecureChannel %i | Session %.*s | Subscription %" PRIu32 " | " MSG "%.0s", \
+                       "SecureChannel %" PRIu32 " | Session %.*s | Subscription %" PRIu32 " | " MSG "%.0s", \
                        ((SUB)->session->header.channel ?                \
                         (SUB)->session->header.channel->securityToken.channelId : 0), \
                        (int)idString.length, idString.data, (SUB)->subscriptionId, __VA_ARGS__); \


### PR DESCRIPTION
Wrong format specifiers cause a heap of compiler warnings with -Wformat enabled. I used the correct definitions from ``inttypes.h`` or cast to the correct type (to follow the scheme within the source code file).