### PR TITLE
fix/debian): add libmbedtls-dev dependency to open62541-dev

### DIFF
--- a/debian/control-template
+++ b/debian/control-template
@@ -22,7 +22,7 @@ Package: libopen62541-<soname>-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: libopen62541-<soname> (= ${binary:Version}), ${misc:Depends}
+Depends: libopen62541-<soname> (= ${binary:Version}), ${misc:Depends}, libmbedtls-dev
 Description: Open source implementation of OPC UA - development files
  open62541 (http://open62541.org) is an open source and free implementation
  of OPC UA (OPC Unified Architecture) written in the common subset of the


### PR DESCRIPTION
With branch 1.1 there is a dependency on libmbedtls introduced for open62541-dev, but this dependency is missing in the corresponding control file. As result the libmbedtls-dev package won't be automatically installed when installing open62541-dev, as pointed out in #4497. 
This patch adds the related dependency on libmbedtls-dev for open62541-dev and should solve #4497

This patch should be applied to branches 1.1 and master as well.  