### PR TITLE
[REVIEW] fix(server): Allow SecurityPolicyNone without an application certificate

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -497,8 +497,11 @@ getSecurityPolicyByUri(const UA_Server *server, const UA_ByteString *securityPol
  * SecurityPolicies */
 static UA_StatusCode
 verifyServerApplicationURI(const UA_Server *server) {
+    const UA_String securityPolicyNoneUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#None");
     for(size_t i = 0; i < server->config.securityPoliciesSize; i++) {
         UA_SecurityPolicy *sp = &server->config.securityPolicies[i];
+        if(UA_String_equal(&sp->policyUri, &securityPolicyNoneUri) && (sp->localCertificate.length == 0))
+            continue;
         UA_StatusCode retval = server->config.certificateVerification.
             verifyApplicationURI(server->config.certificateVerification.context,
                                  &sp->localCertificate,


### PR DESCRIPTION
Currently the UA_Server_run_startup() function fails with the status
code UA_STATUSCODE_BADSECURITYCHECKSFAILED if the stack is built with
UA_ENABLE_ENCRYPTION=ON and the server config contains the
SecurityPolicyNone without an application certificate.

This is a problem if you build a product with encryption support but
supports to it run without any secured SecurityPolicies enabled and
no certificates installed.

This fix makes verifyServerApplicationURI() to not verify the
applicationURI of SecurityPolicyNone instances without an application
certificate.