### PR TITLE
[REVIEW] fix(server/client): Updated log message format strings to solve type missmatch build warnings

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -216,7 +216,7 @@ sendSymmetricServiceRequest(UA_Client *client, const void *request,
                          (unsigned)rqId, requestType->typeName);
 #else
     UA_LOG_DEBUG_CHANNEL(&client->config.logger, &client->channel,
-                         "Sending request with RequestId %u of type %" PRIi16,
+                         "Sending request with RequestId %u of type %" PRIu32,
                          (unsigned)rqId, requestType->binaryEncodingId.identifier.numeric);
 #endif
 

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -429,7 +429,7 @@ sendResponse(UA_Server *server, UA_Session *session, UA_SecureChannel *channel,
                              (unsigned)requestId, responseType->typeName);
 #else
         UA_LOG_DEBUG_SESSION(&server->config.logger, session,
-                             "Sending reponse for RequestId %u of type %" PRIi16,
+                             "Sending reponse for RequestId %u of type %" PRIu32,
                              (unsigned)requestId, responseType->binaryEncodingId.identifier.numeric);
 #endif
     } else {
@@ -439,7 +439,7 @@ sendResponse(UA_Server *server, UA_Session *session, UA_SecureChannel *channel,
                              (unsigned)requestId, responseType->typeName);
 #else
         UA_LOG_DEBUG_CHANNEL(&server->config.logger, channel,
-                             "Sending reponse for RequestId %u of type %" PRIi16,
+                             "Sending reponse for RequestId %u of type %" PRIu32,
                              (unsigned)requestId, responseType->binaryEncodingId.identifier.numeric);
 #endif
     }
@@ -561,7 +561,7 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
                                    requestType->typeName);
 #else
             UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
-                                   "Service %" PRIi16 " refused without a valid session",
+                                   "Service %" PRIu32 " refused without a valid session",
                                    requestType->binaryEncodingId.identifier.numeric);
 #endif
             return sendServiceFault(channel, requestId, requestHeader->requestHandle,
@@ -584,7 +584,7 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
                                requestType->typeName);
 #else
         UA_LOG_WARNING_SESSION(&server->config.logger, session,
-                               "Service %" PRIi16 " refused on a non-activated session",
+                               "Service %" PRIu32 " refused on a non-activated session",
                                requestType->binaryEncodingId.identifier.numeric);
 #endif
         if(session != &anonymousSession) {


### PR DESCRIPTION
The binaryEncodingId variable of the UA_DataType structure has
over time changed from an 16 bit integer to an UA_NodeId type. This
has caused type missmatches between the format string and the
binaryEncodingId variable when it is used in in log messages.