### PR TITLE
(Review) Count diagnostics value rejectedSession for BadTooManySessions

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -301,6 +301,7 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
                                "Processing CreateSessionRequest failed");
+        UA_atomic_addSize(&server->serverStats.ss.rejectedSessionCount, 1);
         return;
     }
 


### PR DESCRIPTION
If the maximum supported sessions are reached, the BadTooManySessions statuscode shall be trigger a count for the diagnostic value rejectedSessionCount.