### PR TITLE
[REVIEW]: Segfault with empty method arg

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1010,6 +1010,10 @@ compatibleValue(UA_Server *server, UA_Session *session, const UA_NodeId *targetD
 void
 adjustValueType(UA_Server *server, UA_Variant *value,
                 const UA_NodeId *targetDataTypeId) {
+    /* If the value is empty, there is nothing we can do here */
+    if(!value->type)
+        return;
+
     const UA_DataType *targetDataType = UA_findDataType(targetDataTypeId);
     if(!targetDataType)
         return;

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -77,7 +77,7 @@ typeCheckArguments(UA_Server *server, UA_Session *session,
                             &args[i], NULL))
             continue;
 
-        /* Incompatible try to correct the type if possible */
+        /* Incompatible value. Try to correct the type if possible. */
         adjustValueType(server, &args[i], &argReqs[i].dataType);
 
         /* Recheck */

--- a/tests/server/check_services_call.c
+++ b/tests/server/check_services_call.c
@@ -205,6 +205,31 @@ START_TEST(callMethodWithWronglyTypedArguments) {
 #endif
 } END_TEST
 
+START_TEST(callMethodWithEmptyArgument) {
+/* Minimal nodeset does not add any method nodes we may call here */
+#ifdef UA_GENERATED_NAMESPACE_ZERO
+    UA_Variant inputArgument;
+    UA_Variant_init(&inputArgument);
+
+    UA_CallMethodRequest callMethodRequest;
+    UA_CallMethodRequest_init(&callMethodRequest);
+    callMethodRequest.inputArgumentsSize = 1;
+    callMethodRequest.inputArguments = &inputArgument;
+    callMethodRequest.methodId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_GETMONITOREDITEMS);
+    callMethodRequest.objectId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER);
+
+    UA_CallMethodResult result;
+    UA_CallMethodResult_init(&result);
+    result = UA_Server_call(server, &callMethodRequest);
+
+    ck_assert_uint_gt(result.inputArgumentResultsSize, 0);
+    ck_assert_int_eq(result.inputArgumentResults[0], UA_STATUSCODE_BADTYPEMISMATCH);
+    ck_assert_int_eq(result.statusCode, UA_STATUSCODE_BADINVALIDARGUMENT);
+
+    UA_Array_delete(result.inputArgumentResults, result.inputArgumentResultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
+#endif
+} END_TEST
+
 int main(void) {
     Suite *s = suite_create("services_call");
 
@@ -219,6 +244,7 @@ int main(void) {
     tcase_add_test(tc_call, callMethodWithMissingArguments);
     tcase_add_test(tc_call, callMethodWithTooManyArguments);
     tcase_add_test(tc_call, callMethodWithWronglyTypedArguments);
+    tcase_add_test(tc_call, callMethodWithEmptyArgument);
     suite_add_tcase(s, tc_call);
 
     SRunner *sr = srunner_create(s);


### PR DESCRIPTION
calling a method with empty variant causes a segfault:

```
#0  0x565a3f97 in typeEquivalence (t=0x0) at /workspaces/open62541_FEM/src/server/ua_services_attribute.c:756
#1  0x565a488c in adjustValueType (server=0x56703a40, value=0xffffd040, targetDataTypeId=0x566c15f8) at /workspaces/open62541_FEM/src/server/ua_services_attribute.c:1033
#2  0x5659eb90 in typeCheckArguments (server=0x56703a40, session=0x56703c74, argRequirements=0x566c14a8, argsSize=1, args=0xffffd040, inputArgumentResults=0x566d3a60)
    at /workspaces/open62541_FEM/src/server/ua_services_method.c:81
#3  0x5659ece5 in validMethodArguments (server=0x56703a40, session=0x56703c74, method=0x566c10c8, request=0xffffd074, inputArgumentResults=0x566d3a60)
    at /workspaces/open62541_FEM/src/server/ua_services_method.c:110
#4  0x5659f349 in callWithMethodAndObject (server=0x56703a40, session=0x56703c74, request=0xffffd074, result=0xffffcfa0, method=0x566c10c8, object=0x566d3998)
    at /workspaces/open62541_FEM/src/server/ua_services_method.c:278
#5  0x5659f60f in Operation_CallMethod (server=0x56703a40, session=0x56703c74, context=0x0, request=0xffffd074, result=0xffffcfa0)
    at /workspaces/open62541_FEM/src/server/ua_services_method.c:429
#6  0x5659f7ff in UA_Server_call (server=0x56703a40, request=0xffffd074) at /workspaces/open62541_FEM/src/server/ua_services_method.c:460
#7  0x5655e906 in callMethodWithEmptyArgument (_i=0) at /workspaces/open62541_FEM/tests/server/check_services_call.c:223
#8  0x5663105d in tcase_run_tfun_nofork.isra ()
#9  0x56631440 in srunner_run ()
#10 0x566319b0 in srunner_run_all ()
#11 0x5655edc8 in main () at /workspaces/open62541_FEM/tests/server/check_services_call.c:252
```