### PR TITLE
build(pkgconfig): remove the 'v' prefix from the version string

### DIFF
--- a/tools/open62541.pc.in
+++ b/tools/open62541.pc.in
@@ -10,6 +10,6 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: open62541
 Description: open62541 is an open source C (C99) implementation of OPC UA
-Version: @OPEN62541_VERSION@
+Version: @OPEN62541_VER_MAJOR@.@OPEN62541_VER_MINOR@.@OPEN62541_VER_PATCH@@OPEN62541_VER_LABEL@
 Libs: -L${libdir} -lopen62541
 Cflags: -I${includedir}


### PR DESCRIPTION
This prefix does not play nicely with the tools using pkg-config (like meson
for instance).