### PR TITLE
fix(core): check if output connection is ready before write

### DIFF
--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -20,6 +20,7 @@
 #include <sys/select.h>
 #include <sys/types.h>
 #include <net/if.h>
+#include <poll.h>
 #ifdef UA_sleep_ms
 void UA_sleep_ms(unsigned long ms);
 #else
@@ -70,10 +71,14 @@ void UA_sleep_ms(unsigned long ms);
 #define UA_WOULDBLOCK EWOULDBLOCK
 #define UA_ERR_CONNECTION_PROGRESS EINPROGRESS
 
+#define UA_POLLIN POLLIN
+#define UA_POLLOUT POLLOUT
+
 #define UA_ENABLE_LOG_COLORS
 
 #define UA_getnameinfo(sa, salen, host, hostlen, serv, servlen, flags) \
     getnameinfo(sa, salen, host, hostlen, serv, servlen, flags)
+#define UA_poll poll
 #define UA_send send
 #define UA_recv recv
 #define UA_sendto sendto

--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -42,6 +42,7 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
+#include <winsock2.h>
 
 #if defined (_MSC_VER) || defined(__clang__)
 # ifndef UNDER_CE
@@ -83,6 +84,9 @@ void UA_sleep_ms(unsigned long ms);
 #define UA_WOULDBLOCK WSAEWOULDBLOCK
 #define UA_ERR_CONNECTION_PROGRESS WSAEWOULDBLOCK
 
+#define UA_POLLIN POLLRDNORM
+#define UA_POLLOUT POLLWRNORM
+
 #define UA_fd_set(fd, fds) FD_SET((UA_SOCKET)fd, fds)
 #define UA_fd_isset(fd, fds) FD_ISSET((UA_SOCKET)fd, fds)
 
@@ -92,6 +96,7 @@ void UA_sleep_ms(unsigned long ms);
 
 #define UA_getnameinfo(sa, salen, host, hostlen, serv, servlen, flags) \
     getnameinfo(sa, (socklen_t)salen, host, (DWORD)hostlen, serv, (DWORD)servlen, flags)
+#define UA_poll(fds,nfds,timeout) WSAPoll((LPWSAPOLLFD)fds, nfds, timeout)
 #define UA_send(sockfd, buf, len, flags) send(sockfd, buf, (int)(len), flags)
 #define UA_recv(sockfd, buf, len, flags) recv(sockfd, buf, (int)(len), flags)
 #define UA_sendto(sockfd, buf, len, flags, dest_addr, addrlen) sendto(sockfd, (const char*)(buf), (int)(len), flags, dest_addr, (int) (addrlen))


### PR DESCRIPTION
Hi,

If an output connection is not ready (buffer filled), it will return immediately
with EAGAIN, and connection_write retries to send data without checking if the
condition has changed. It results of an unwanted high CPU use. Polling with
POLLOUT event fixes this issue.

Only a posix implementation for now.

Please let me know if this work is worthwhile for open62541.