### PR TITLE
fix(nc): Support for multiple Depends inside a nodeset and improvement of the code generation of arrays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,8 @@ if(UA_ENABLE_TPM2_KEYSTORE)
 endif()
 
 # Namespace Zero
-set(UA_NAMESPACE_ZERO "REDUCED" CACHE STRING "Completeness of the generated namespace zero (minimal/reduced/full)")
-SET_PROPERTY(CACHE UA_NAMESPACE_ZERO PROPERTY STRINGS "MINIMAL" "REDUCED" "FULL")
+set(UA_NAMESPACE_ZERO "REDUCED" CACHE STRING "Completeness of the generated namespace zero (minimal/reduced/full/latest_1_05)")
+SET_PROPERTY(CACHE UA_NAMESPACE_ZERO PROPERTY STRINGS "MINIMAL" "REDUCED" "FULL" "LATEST_1_05")
 if(UA_NAMESPACE_ZERO STREQUAL "MINIMAL")
     set(UA_GENERATED_NAMESPACE_ZERO OFF)
 else()
@@ -268,6 +268,12 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     set(UA_GENERATED_NAMESPACE_ZERO_FULL ON)
 else()
     set(UA_GENERATED_NAMESPACE_ZERO_FULL OFF)
+endif()
+
+if(UA_NAMESPACE_ZERO STREQUAL "LATEST_1_05")
+    set(UA_GENERATED_NAMESPACE_ZERO_LATEST_1_05 ON)
+else()
+    set(UA_GENERATED_NAMESPACE_ZERO_LATEST_1_05 OFF)
 endif()
 
 if(MSVC AND UA_NAMESPACE_ZERO STREQUAL "FULL")
@@ -1169,7 +1175,7 @@ endif()
 # List of nodeset files combined into NS0 generated file
 set(UA_FILE_NODESETS)
 
-if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+if(UA_NAMESPACE_ZERO STREQUAL "FULL" OR UA_NAMESPACE_ZERO STREQUAL "LATEST_1_05")
     if(NOT UA_FILE_NS0)
         set(UA_FILE_NS0 ${open62541_NODESET_DIR}/Schema/Opc.Ua.NodeSet2.xml)
     endif()
@@ -1177,7 +1183,17 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
     if(NOT EXISTS "${UA_FILE_NS0}")
         message(FATAL_ERROR "File ${UA_FILE_NS0} not found. You probably need to initialize the git submodule for deps/ua-nodeset or set open62541_NODESET_DIR.")
+    else()
+        # If the "LATEST_1_05" flag is set, it must be checked whether the nodeset NS0 is on the latest version.
+        if(UA_NAMESPACE_ZERO STREQUAL "LATEST_1_05")
+            file(READ ${UA_FILE_NS0} ver LIMIT 5000)
+            string(REGEX MATCH ".*http:\\/\\/opcfoundation\\.org\\/UA\\/\" Version=\"1\\.05" match ${ver})
+            if(NOT match)
+                message(FATAL_ERROR "File ${UA_FILE_NS0} is set incorrectly. You probably need to checkout the git submodule for deps/ua-nodeset to version 1.05. Therefore execute the following command inside the deps/ua-nodeset directory \ngit checkout v1.05")
+            endif()
+        endif()
     endif()
+
 
     set(UA_FILE_NODEIDS ${open62541_NODESET_DIR}/Schema/NodeIds.csv)
     set(UA_FILE_STATUSCODES ${open62541_NODESET_DIR}/Schema/StatusCode.csv)

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -2085,7 +2085,11 @@ Operation_addReference(UA_Server *server, UA_Session *session, void *context,
     if(*retval == UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED) {
         /* Calculate common duplicate reference not allowed result and set bad
          * result if BOTH directions already existed */
-        if(firstExisted) {
+        if(UA_NodeId_equal(&item->sourceNodeId, &item->targetNodeId.nodeId)) {
+            *retval = UA_STATUSCODE_GOOD;
+            UA_LOG_INFO_SESSION(&server->config.logger, session, "The source node and the target node are identical. The check for duplicate references is skipped.");
+        }
+        else if(firstExisted) {
             *retval = UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED;
             return;
         }

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -20,6 +20,7 @@ import re
 import logging
 
 import sys
+
 if sys.version_info[0] >= 3:
     # strings are already parsed to unicode
     def unicode(s):
@@ -305,6 +306,7 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, i
         if subv is None:
             continue
         encField = node.encodingRule[idx].name
+        encRule = node.encodingRule[idx]
         memberName = makeCIdentifier(lowerFirstChar(encField))
 
         # Check if this is an array
@@ -331,16 +333,11 @@ def generateExtensionObjectSubtypeCode(node, parent, nodeset, global_var_code, i
             continue
 
         logger.debug("Encoding of field " + memberName + " is " + str(subv.encodingRule) + "defined by " + str(encField))
-        if subv.valueRank is None or subv.valueRank == 0:
-            if not subv.isNone():
-                # Some values can be optional
-                valueName = instanceName + accessor + memberName
-                code.append(generateNodeValueCode(valueName,
-                            subv, instanceName,valueName, global_var_code, asIndirect=False, nodeset=nodeset))
-        else:
-            memberName = makeCIdentifier(lowerFirstChar(encField))
-            code.append(generateNodeValueCode(instanceName + accessor + memberName + "Size", subv,
-                                              instanceName,valueName, global_var_code, asIndirect=False))
+        if not subv.isNone():
+            # Some values can be optional
+            valueName = instanceName + accessor + memberName
+            code.append(generateNodeValueCode(valueName,
+                        subv, instanceName,valueName, global_var_code, asIndirect=False, nodeset=nodeset, encRule=encRule))
 
     if not isArrayElement:
         code.append("UA_Variant_setScalar(&attr.value, " + instanceName + ", &" + typeArrayString + ");")

--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -274,10 +274,21 @@ class Value(object):
                                 t.parseXML(ebodypart)
                                 extobj.value.append(t)
                         elif isinstance(e.member_type, StructType):
+                            # information is_array!
                             structure = Structure()
                             structure.alias = ebodypart.localName
                             structure.value = []
-                            structure.__parseXMLSingleValue(ebodypart, parentDataTypeNode, parent, parser, alias=None, encodingPart=e.member_type)
+                            if e.is_array:
+                                values = []
+                                for el in ebodypart.childNodes:
+                                    if not el.nodeType == el.ELEMENT_NODE:
+                                        continue
+                                    structure.__parseXMLSingleValue(el, parentDataTypeNode, parent, parser, alias=None, encodingPart=e.member_type)
+                                    values.append(structure.value)
+                                    structure.value = []
+                                structure.value = values
+                            else:
+                                structure.__parseXMLSingleValue(ebodypart, parentDataTypeNode, parent, parser, alias=None, encodingPart=e.member_type)
                             extobj.value.append(structure)
                         elif isinstance(e.member_type, EnumerationType):
                             t = self.getTypeByString("Int32", None)
@@ -348,7 +359,7 @@ class Value(object):
                                         self.value.append(t)
                         elif isinstance(e.member_type, StructType):
                             structure = Structure()
-                            structure.alias = ebodypart.localName
+                            structure.alias = e.name
                             structure.value = []
                             structure.__parseXMLSingleValue(childValue, parentDataTypeNode, parent, parser, alias=None, encodingPart=e.member_type)
                             self.value.append(structure)

--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -114,6 +114,12 @@ ns = NodeSet()
 nsCount = 0
 loadedFiles = list()
 
+# Remove duplicate entries in typesArray, which occur when a nodeset has more than one depend.
+tmp_list = []
+for e in args.typesArray:
+    if e not in tmp_list:
+        tmp_list.append(e)
+args.typesArray = tmp_list
 def getTypesArray(nsIdx):
     if nsIdx < len(args.typesArray):
         return args.typesArray[nsIdx]


### PR DESCRIPTION
- Support of code generation for arrays. Currently, only the generation of "simple" arrays is possible. Arrays in structures or structures which are arrays themselves are not supported.
- Support of nodesets that have multiple Depends
- Fixed a bug with symmetric references when the target node is the same as the source node.