### PR TITLE
fix: compiler warning UA_clean_errno() invalid conversion error

### DIFF
--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -127,7 +127,7 @@ void UA_sleep_ms(unsigned long ms);
 #define UA_snprintf snprintf
 #define UA_strncasecmp strncasecmp
 
-#define UA_clean_errno(STR_FUN) (errno == 0 ? "None" : (STR_FUN)(errno))
+#define UA_clean_errno(STR_FUN) (errno == 0 ? (char*) "None" : (STR_FUN)(errno))
 
 #define UA_LOG_SOCKET_ERRNO_WRAP(LOG) { \
     char *errno_str = UA_clean_errno(strerror); \


### PR DESCRIPTION
If errno is 0 then the function returns "None" string, which
is of type 'const char*'. But the return variable expects 'char*'.
Function strerror returns 'char*' which is ok.