### PR TITLE
fix(nc): Inherit the values rank even if the parents have < -1

### DIFF
--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -109,9 +109,7 @@ START_TEST(readValueRank) {
     UA_Variant dims;
     // scalar
     UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10002), &rank);
-    ck_assert_int_eq(rank, -1);
-    UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10002), &rank);
-    ck_assert_int_eq(rank, -1);
+    ck_assert_int_eq(rank, -2);
     UA_Variant_init(&dims);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10002), &dims);
     ck_assert_int_eq(dims.arrayLength, 0);

--- a/tools/nodeset_compiler/backend_open62541_nodes.py
+++ b/tools/nodeset_compiler/backend_open62541_nodes.py
@@ -148,11 +148,10 @@ def setNodeValueRankRecursive(node, nodeset):
 
         setNodeValueRankRecursive(typeDefNode, nodeset)
 
-        if typeDefNode.valueRank is not None and typeDefNode.valueRank > -1:
+        if typeDefNode.valueRank is not None:
             node.valueRank = typeDefNode.valueRank
         else:
-            # Default value
-            node.valueRank = -1
+            raise RuntimeError("Node {}: the ValueRank of the parent node is None.".format(str(node.id)))
     else:
         if node.parent is None:
             raise RuntimeError("Node {}: does not have a parent. Probably the parent node was blacklisted?".format(str(node.id)))
@@ -161,11 +160,10 @@ def setNodeValueRankRecursive(node, nodeset):
         setNodeValueRankRecursive(node.parent, nodeset)
 
 
-        if node.parent.valueRank is not None and node.parent.valueRank > -1:
+        if node.parent.valueRank is not None:
             node.valueRank = node.parent.valueRank
         else:
-            # Default value
-            node.valueRank = -1
+            raise RuntimeError("Node {}: the ValueRank of the parent node is None.".format(str(node.id)))
 
 
 def generateCommonVariableCode(node, nodeset):


### PR DESCRIPTION
Currently, the Powerlink nodeset example does not run. The problem is that the Value Rank does not match the ValueRank of the VariableType #3082. 

The PowerlinkVariableType is assigned a ValueRank of -1 (default). However, in the XML the node has a subtype BaseDataVariableType (ns=0;i=63), which has a ValueRank of -2.