### PR TITLE
[REVIEW] Fix Issue 4727 MQTT Build failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1061,14 +1061,18 @@ if(UA_ENABLE_PUBSUB)
         endif()
     endif()
     if(UA_ENABLE_PUBSUB_MQTT)
-      list(APPEND default_plugin_headers ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt_pal.h
-        ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.h
-        ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.h
-        ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.h)
-      list(APPEND default_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_pal.c
-        ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.c
-        ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.c
-        ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.c)
+        if(WIN32)
+            MESSAGE(WARNING "Multithreading is enabled in MQTT plugin. This feature is under development and marked as EXPERIMENTAL")
+        else()
+            list(APPEND default_plugin_headers ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt_pal.h
+                                               ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.h
+                                               ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.h
+                                               ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.h)
+            list(APPEND default_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_pal.c
+                                               ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.c
+                                               ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.c
+                                               ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.c)
+        endif()
     endif()
     if(UA_ENABLE_MALLOC_SINGLETON AND UA_ENABLE_PUBSUB_BUFMALLOC)
         list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_bufmalloc.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ if(UA_BUILD_FUZZING OR UA_BUILD_OSS_FUZZ OR UA_BUILD_FUZZING_CORPUS)
     set(UA_ENABLE_DISCOVERY ON CACHE STRING "" FORCE)
     set(UA_ENABLE_DISCOVERY_MULTICAST ON CACHE STRING "" FORCE)
     set(UA_ENABLE_ENCRYPTION ON CACHE STRING "OFF" FORCE)
-    set(UA_ENABLE_ENCRYPTION_MBEDTLS ON CACHE STRING "" FORCE)    
+    set(UA_ENABLE_ENCRYPTION_MBEDTLS ON CACHE STRING "" FORCE)
     set(UA_ENABLE_HISTORIZING ON CACHE STRING "" FORCE)
     set(UA_ENABLE_JSON_ENCODING ON CACHE STRING "" FORCE)
     set(UA_ENABLE_SUBSCRIPTIONS ON CACHE STRING "" FORCE)
@@ -572,7 +572,7 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_MQTT_TLS_OPENSSL)
     find_package(OpenSSL REQUIRED)
     list(APPEND open62541_LIBRARIES ${OPENSSL_LIBRARIES})
     endif ()
-    
+
 if(UA_ENABLE_ENCRYPTION_LIBRESSL)
     # See https://github.com/libressl-portable/portable/blob/master/FindLibreSSL.cmake
     find_package(LibreSSL REQUIRED)
@@ -940,7 +940,7 @@ set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c
                 ${PROJECT_SOURCE_DIR}/deps/pcg_basic.c
                 ${PROJECT_SOURCE_DIR}/deps/base64.c
                 ${PROJECT_SOURCE_DIR}/deps/aa_tree.c
-                
+
                 ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_config.c)
 
 set(default_plugin_headers ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -1061,18 +1061,14 @@ if(UA_ENABLE_PUBSUB)
         endif()
     endif()
     if(UA_ENABLE_PUBSUB_MQTT)
-        if(WIN32)
-            MESSAGE(WARNING "Multithreading is enabled in MQTT plugin. This feature is under development and marked as EXPERIMENTAL")
-        else()
-            list(APPEND default_plugin_headers ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt_pal.h
-                                               ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.h
-                                               ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.h
-                                               ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.h)
-            list(APPEND default_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_pal.c
-                                               ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.c
-                                               ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.c
-                                               ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.c)
-        endif()
+      list(APPEND default_plugin_headers ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt_pal.h
+        ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.h
+        ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.h
+        ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.h)
+      list(APPEND default_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_pal.c
+        ${PROJECT_SOURCE_DIR}/deps/mqtt-c/mqtt.c
+        ${PROJECT_SOURCE_DIR}/plugins/ua_network_pubsub_mqtt.c
+        ${PROJECT_SOURCE_DIR}/plugins/mqtt/ua_mqtt_adapter.c)
     endif()
     if(UA_ENABLE_MALLOC_SINGLETON AND UA_ENABLE_PUBSUB_BUFMALLOC)
         list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_bufmalloc.c)
@@ -1647,8 +1643,8 @@ set(UA_install_tools_files "tools/generate_datatypes.py"
     "tools/generate_nodeid_header.py"
     "tools/generate_statuscode_descriptions.py")
 
-install(DIRECTORY ${UA_install_tools_dirs} 
-    DESTINATION ${open62541_install_tools_dir} 
+install(DIRECTORY ${UA_install_tools_dirs}
+    DESTINATION ${open62541_install_tools_dir}
     USE_SOURCE_PERMISSIONS
     FILES_MATCHING
     PATTERN "*"
@@ -1702,7 +1698,7 @@ if(NOT UA_ENABLE_AMALGAMATION)
     endforeach()
 
 else()
-    # Export amalgamated header open62541.h which is generated due to build of 
+    # Export amalgamated header open62541.h which is generated due to build of
     # open62541-object
     install(FILES ${PROJECT_BINARY_DIR}/open62541.h DESTINATION include)
 endif()

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,6 +1,6 @@
 # open62541 Third-Party libraries
 
-Specific optional features are dependent on third-party libraries. 
+Specific optional features are dependent on third-party libraries.
 Any third-party library which may be used is inside this `/deps` folder.
 
 Up to now all these libraries have a less strict License compared to MPL 2.0.
@@ -21,3 +21,4 @@ Here's a list of third party libraries:
 | pcg_basic       | Apache License 2 | Random Number Generation                      |
 | string_escape   | MIT              | utf8 encoding and decoding                    |
 | ziptree         | MPL 2.0          | Reusable zip tree implementation              |
+| mqtt-c          | MIT              | a portable MQTT client, written in C          |

--- a/deps/mqtt-c/mqtt.c
+++ b/deps/mqtt-c/mqtt.c
@@ -24,11 +24,11 @@ SOFTWARE.
 
 #include "mqtt.h"
 
-/** 
- * @file 
+/**
+ * @file
  * @brief Implements the functionality of MQTT-C.
  * @note The only files that are included are mqtt.h and mqtt_pal.h.
- * 
+ *
  * @cond Doxygen_Suppress
  */
 
@@ -44,7 +44,7 @@ enum MQTTErrors mqtt_sync(struct mqtt_client *client) {
     }
 
     /* Call inspector callback if necessary */
-    
+
     if (client->inspector_callback != NULL) {
         MQTT_PAL_MUTEX_LOCK(&client->mutex);
         err = client->inspector_callback(client);
@@ -67,7 +67,7 @@ uint16_t __mqtt_next_pid(struct mqtt_client *client) {
         client->pid_lfsr = 163u;
     }
     /* LFSR taps taken from: https://en.wikipedia.org/wiki/Linear-feedback_shift_register */
-    
+
     do {
         struct mqtt_queued_message *curr;
         unsigned lsb = client->pid_lfsr & 1;
@@ -175,7 +175,7 @@ void mqtt_reinit(struct mqtt_client* client,
     client->recv_buffer.curr_sz = client->recv_buffer.mem_size;
 }
 
-/** 
+/**
  * A macro function that:
  *      1) Checks that the client isn't in an error state.
  *      2) Attempts to pack to client's message queue.
@@ -210,19 +210,21 @@ void mqtt_reinit(struct mqtt_client* client,
 
 
 enum MQTTErrors mqtt_connect(struct mqtt_client *client,
-                     const char* client_id,
-                     const char* will_topic,
-                     const void* will_message,
-                     size_t will_message_size,
-                     const char* user_name,
-                     const char* password,
-                        const char* caFilePath,
-                        const char* caPath,
-                        const char* clientCertPath,
-                        const char* clientKeyPath,
-                        bool useTLS,
-                     uint8_t connect_flags,
-                     uint16_t keep_alive)
+                             const char* client_id,
+                             const char* will_topic,
+                             const void* will_message,
+                             size_t will_message_size,
+                             const char* user_name,
+                             const char* password,
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
+                             const char* caFilePath,
+                             const char* caPath,
+                             const char* clientCertPath,
+                             const char* clientKeyPath,
+                             bool useTLS,
+#endif
+                             uint8_t connect_flags,
+                             uint16_t keep_alive)
 {
     ssize_t rv;
     struct mqtt_queued_message *msg;
@@ -234,18 +236,32 @@ enum MQTTErrors mqtt_connect(struct mqtt_client *client,
     if (client->error == MQTT_ERROR_CONNECT_NOT_CALLED) {
         client->error = MQTT_OK;
     }
-    
+
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
     /* try to pack the message */
-    MQTT_CLIENT_TRY_PACK(rv, msg, client, 
-        mqtt_pack_connection_request(
-            client->mq.curr, client->mq.curr_sz,
-            client_id, will_topic, will_message, 
-            will_message_size,user_name, password,
-                caFilePath, caPath, clientCertPath, clientKeyPath
-            connect_flags, keep_alive
-        ), 
-        1
-    );
+    MQTT_CLIENT_TRY_PACK(rv, msg, client,
+                         mqtt_pack_connection_request(
+                                                      client->mq.curr, client->mq.curr_sz,
+                                                      client_id, will_topic, will_message,
+                                                      will_message_size,user_name, password,
+                                                      caFilePath, caPath, clientCertPath, clientKeyPath
+                                                      connect_flags, keep_alive
+                                                      ),
+                         1
+                         );
+#else
+    /* try to pack the message */
+    MQTT_CLIENT_TRY_PACK(rv, msg, client,
+                         mqtt_pack_connection_request(
+                                                      client->mq.curr, client->mq.curr_sz,
+                                                      client_id, will_topic, will_message,
+                                                      will_message_size,user_name, password,
+                                                      connect_flags, keep_alive
+                                                      ),
+                         1
+                         );
+#endif
+
     /* save the control type of the message */
     msg->control_type = MQTT_CONTROL_CONNECT;
 
@@ -268,7 +284,7 @@ enum MQTTErrors mqtt_publish(struct mqtt_client *client,
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_publish_request(
             client->mq.curr, client->mq.curr_sz,
             topic_name,
@@ -276,7 +292,7 @@ enum MQTTErrors mqtt_publish(struct mqtt_client *client,
             application_message,
             application_message_size,
             publish_flags
-        ), 
+        ),
         1
     );
     /* save the control type and packet id of the message */
@@ -293,7 +309,7 @@ ssize_t __mqtt_puback(struct mqtt_client *client, uint16_t packet_id) {
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_pubxxx_request(
             client->mq.curr, client->mq.curr_sz,
             MQTT_CONTROL_PUBACK,
@@ -314,7 +330,7 @@ ssize_t __mqtt_pubrec(struct mqtt_client *client, uint16_t packet_id) {
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_pubxxx_request(
             client->mq.curr, client->mq.curr_sz,
             MQTT_CONTROL_PUBREC,
@@ -335,7 +351,7 @@ ssize_t __mqtt_pubrel(struct mqtt_client *client, uint16_t packet_id) {
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_pubxxx_request(
             client->mq.curr, client->mq.curr_sz,
             MQTT_CONTROL_PUBREL,
@@ -356,7 +372,7 @@ ssize_t __mqtt_pubcomp(struct mqtt_client *client, uint16_t packet_id) {
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_pubxxx_request(
             client->mq.curr, client->mq.curr_sz,
             MQTT_CONTROL_PUBCOMP,
@@ -383,14 +399,14 @@ enum MQTTErrors mqtt_subscribe(struct mqtt_client *client,
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_subscribe_request(
             client->mq.curr, client->mq.curr_sz,
             packet_id,
             topic_name,
             max_qos_level,
             (const char*)NULL
-        ), 
+        ),
         1
     );
     /* save the control type and packet id of the message */
@@ -411,13 +427,13 @@ enum MQTTErrors mqtt_unsubscribe(struct mqtt_client *client,
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_unsubscribe_request(
             client->mq.curr, client->mq.curr_sz,
             packet_id,
             topic_name,
             (const char*)NULL
-        ), 
+        ),
         1
     );
     /* save the control type and packet id of the message */
@@ -436,14 +452,14 @@ enum MQTTErrors mqtt_ping(struct mqtt_client *client) {
     return rv;
 }
 
-enum MQTTErrors __mqtt_ping(struct mqtt_client *client) 
+enum MQTTErrors __mqtt_ping(struct mqtt_client *client)
 {
     ssize_t rv;
     struct mqtt_queued_message *msg;
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_ping_request(
             client->mq.curr, client->mq.curr_sz
         ),
@@ -452,11 +468,11 @@ enum MQTTErrors __mqtt_ping(struct mqtt_client *client)
     /* save the control type and packet id of the message */
     msg->control_type = MQTT_CONTROL_PINGREQ;
 
-    
+
     return MQTT_OK;
 }
 
-enum MQTTErrors mqtt_disconnect(struct mqtt_client *client) 
+enum MQTTErrors mqtt_disconnect(struct mqtt_client *client)
 {
     ssize_t rv;
     struct mqtt_queued_message *msg;
@@ -464,10 +480,10 @@ enum MQTTErrors mqtt_disconnect(struct mqtt_client *client)
 
     /* try to pack the message */
     MQTT_CLIENT_TRY_PACK(
-        rv, msg, client, 
+        rv, msg, client,
         mqtt_pack_disconnect(
             client->mq.curr, client->mq.curr_sz
-        ), 
+        ),
         1
     );
     /* save the control type and packet id of the message */
@@ -477,15 +493,15 @@ enum MQTTErrors mqtt_disconnect(struct mqtt_client *client)
     return MQTT_OK;
 }
 
-ssize_t __mqtt_send(struct mqtt_client *client) 
+ssize_t __mqtt_send(struct mqtt_client *client)
 {
     uint8_t inspected;
     ssize_t len;
     int inflight_qos2 = 0;
     int i = 0;
-    
+
     MQTT_PAL_MUTEX_LOCK(&client->mutex);
-    
+
     if (client->error < 0 && client->error != MQTT_ERROR_SEND_BUFFER_IS_FULL) {
         MQTT_PAL_MUTEX_UNLOCK(&client->mutex);
         return client->error;
@@ -510,7 +526,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
 
         /* only send QoS 2 message if there are no inflight QoS 2 PUBLISH messages */
         if (msg->control_type == MQTT_CONTROL_PUBLISH
-            && (msg->state == MQTT_QUEUED_UNSENT || msg->state == MQTT_QUEUED_AWAITING_ACK)) 
+            && (msg->state == MQTT_QUEUED_UNSENT || msg->state == MQTT_QUEUED_AWAITING_ACK))
         {
             inspected = 0x03 & ((msg->start[0]) >> 1); /* qos */
             if (inspected == 2) {
@@ -551,7 +567,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
         client->time_of_last_send = MQTT_PAL_TIME();
         msg->time_sent = client->time_of_last_send;
 
-        /* 
+        /*
         Determine the state to put the message in.
         Control Types:
         MQTT_CONTROL_CONNECT     -> awaiting
@@ -581,7 +597,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
                 msg->state = MQTT_QUEUED_COMPLETE;
             } else if (inspected == 1) {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
-                /*set DUP flag for subsequent sends [Spec MQTT-3.3.1-1] */ 
+                /*set DUP flag for subsequent sends [Spec MQTT-3.3.1-1] */
                 msg->start[0] |= MQTT_PUBLISH_DUP;
             } else {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
@@ -956,7 +972,7 @@ static ssize_t mqtt_fixed_header_rule_violation(const struct mqtt_fixed_header *
     if (!mqtt_fixed_header_rules.control_type_is_valid[control_type]) {
         return MQTT_ERROR_CONTROL_FORBIDDEN_TYPE;
     }
-    
+
     /* check that flags are appropriate */
     if(MQTT_BITFIELD_RULE_VIOLOATION(control_flags, required_flags, mask_required_flags)) {
         return MQTT_ERROR_CONTROL_INVALID_FLAGS;
@@ -970,7 +986,7 @@ ssize_t mqtt_unpack_fixed_header(struct mqtt_response *response, const uint8_t *
     const uint8_t *start = buf;
     int lshift;
     ssize_t errcode;
-    
+
     /* check for null pointers or empty buffer */
     if (response == NULL || buf == NULL) {
         return MQTT_ERROR_NULLPTR;
@@ -1002,7 +1018,7 @@ ssize_t mqtt_unpack_fixed_header(struct mqtt_response *response, const uint8_t *
         /* parse next byte*/
         fixed_header->remaining_length += (uint32_t)((*buf & 0x7F) << lshift);
         lshift += 7;
-    } while(*buf & 0x80); /* while continue bit is set */ 
+    } while(*buf & 0x80); /* while continue bit is set */
 
     /* consume last byte */
     --bufsz;
@@ -1027,7 +1043,7 @@ ssize_t mqtt_pack_fixed_header(uint8_t *buf, size_t bufsz, const struct mqtt_fix
     const uint8_t *start = buf;
     ssize_t errcode;
     uint32_t remaining_length;
-    
+
     /* check for null pointers or empty buffer */
     if (fixed_header == NULL || buf == NULL) {
         return MQTT_ERROR_NULLPTR;
@@ -1057,13 +1073,13 @@ ssize_t mqtt_pack_fixed_header(uint8_t *buf, size_t bufsz, const struct mqtt_fix
         --bufsz;
         ++buf;
         if (bufsz == 0) return 0;
-        
+
         /* pack next byte */
         *buf  = remaining_length & 0x7F;
         if(remaining_length > 127) *buf |= 0x80;
         remaining_length = remaining_length >> 7;
     } while(*buf & 0x80);
-    
+
     /* consume last byte */
     --bufsz;
     ++buf;
@@ -1085,20 +1101,23 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
                                      size_t will_message_size,
                                      const char* user_name,
                                      const char* password,
-                                        const char* caFilePath,
-                                        const char* caPath,
-                                        const char* clientCertPath,
-                                        const char* clientKeyPath,
-                                        const bool useTLS,
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
+                                     const char* caFilePath,
+                                     const char* caPath,
+                                     const char* clientCertPath,
+                                     const char* clientKeyPath,
+                                     const bool useTLS,
+#endif
                                      uint8_t connect_flags,
                                      uint16_t keep_alive)
-{ 
+{
     struct mqtt_fixed_header fixed_header;
     size_t remaining_length;
     const uint8_t *const start = buf;
     ssize_t rv;
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
     char strTLS[2];
-    
+#endif
     /* pack the fixed headr */
     fixed_header.control_type = MQTT_CONTROL_CONNECT;
     fixed_header.control_flags = 0x00;
@@ -1122,7 +1141,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
         /* there is a will */
         connect_flags |= MQTT_CONNECT_WILL_FLAG;
         remaining_length += __mqtt_packed_cstrlen(will_topic);
-        
+
         if (will_message == NULL) {
             /* if there's a will there MUST be a will message */
             return MQTT_ERROR_CONNECT_NULL_WILL_MESSAGE;
@@ -1130,7 +1149,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
         remaining_length += 2 + will_message_size; /* size of will_message */
 
         /* assert that the will QOS is valid (i.e. not 3) */
-        temp = connect_flags & 0x18; /* mask to QOS */   
+        temp = connect_flags & 0x18; /* mask to QOS */
         if (temp == 0x18) {
             /* bitwise equality with QoS 3 (invalid)*/
             return MQTT_ERROR_CONNECT_FORBIDDEN_WILL_QOS;
@@ -1157,8 +1176,8 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
     } else {
         connect_flags &= (uint8_t)~MQTT_CONNECT_PASSWORD;
     }
-
-    if (useTLS) {    
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
+    if (useTLS) {
             if (caFilePath != NULL) {
             /* a caFilePath is present */
             connect_flags |= MQTT_CONNECT_CAFILEPATH;
@@ -1198,7 +1217,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
         connect_flags |= MQTT_CONNECT_USETLS;
         remaining_length += (uint32_t)__mqtt_packed_cstrlen(strTLS);
     }
-    
+#endif
     /* fixed header length is now calculated*/
     fixed_header.remaining_length = (uint32_t)remaining_length;
 
@@ -1241,13 +1260,14 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
     if (connect_flags & MQTT_CONNECT_PASSWORD) {
         buf += __mqtt_pack_str(buf, password);
     }
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
     if (connect_flags & MQTT_CONNECT_CAFILEPATH) {
         buf += __mqtt_pack_str(buf, caFilePath);
     }
     if (connect_flags & MQTT_CONNECT_CAPATH) {
         buf += __mqtt_pack_str(buf, caPath);
     }
-    if (useTSL) {    
+    if (useTSL) {
         if (connect_flags & MQTT_CONNECT_CLIENTCERTPATH) {
             buf += __mqtt_pack_str(buf, clientCertPath);
         }
@@ -1258,7 +1278,8 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
         if (connect_flags & MQTT_CONNECT_USETLS) {
             buf += __mqtt_pack_str(buf, strTLS);
         }
-    }        
+    }
+#endif
     /* return the number of bytes that were consumed */
     return buf - start;
 }
@@ -1272,7 +1293,7 @@ ssize_t mqtt_unpack_connack_response(struct mqtt_response *mqtt_response, const 
     if (mqtt_response->fixed_header.remaining_length != 2) {
         return MQTT_ERROR_MALFORMED_RESPONSE;
     }
-    
+
     response = &(mqtt_response->decoded.connack);
     /* unpack */
     if (*buf & 0xFE) {
@@ -1382,11 +1403,11 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
 }
 
 ssize_t mqtt_unpack_publish_response(struct mqtt_response *mqtt_response, const uint8_t *buf)
-{    
+{
     const uint8_t *const start = buf;
     struct mqtt_fixed_header *fixed_header;
     struct mqtt_response_publish *response;
-    
+
     fixed_header = &(mqtt_response->fixed_header);
     response = &(mqtt_response->decoded.publish);
 
@@ -1419,15 +1440,15 @@ ssize_t mqtt_unpack_publish_response(struct mqtt_response *mqtt_response, const 
         response->application_message_size = fixed_header->remaining_length - response->topic_name_size - 4;
     }
     buf += response->application_message_size;
-    
+
     /* return number of bytes consumed */
     return buf - start;
 }
 
 /* PUBXXX */
-ssize_t mqtt_pack_pubxxx_request(uint8_t *buf, size_t bufsz, 
+ssize_t mqtt_pack_pubxxx_request(uint8_t *buf, size_t bufsz,
                                  enum MQTTControlPacketType control_type,
-                                 uint16_t packet_id) 
+                                 uint16_t packet_id)
 {
     const uint8_t *const start = buf;
     struct mqtt_fixed_header fixed_header;
@@ -1454,13 +1475,13 @@ ssize_t mqtt_pack_pubxxx_request(uint8_t *buf, size_t bufsz,
     if (bufsz < fixed_header.remaining_length) {
         return 0;
     }
-    
+
     buf += __mqtt_pack_uint16(buf, packet_id);
 
     return buf - start;
 }
 
-ssize_t mqtt_unpack_pubxxx_response(struct mqtt_response *mqtt_response, const uint8_t *buf) 
+ssize_t mqtt_unpack_pubxxx_response(struct mqtt_response *mqtt_response, const uint8_t *buf)
 {
     const uint8_t *const start = buf;
     uint16_t packet_id;
@@ -1491,7 +1512,7 @@ ssize_t mqtt_unpack_pubxxx_response(struct mqtt_response *mqtt_response, const u
 ssize_t mqtt_unpack_suback_response (struct mqtt_response *mqtt_response, const uint8_t *buf) {
     const uint8_t *const start = buf;
     uint32_t remaining_length = mqtt_response->fixed_header.remaining_length;
-    
+
     /* assert remaining length is at least 3 (for packet id and at least 1 topic) */
     if (remaining_length < 3) {
         return MQTT_ERROR_MALFORMED_RESPONSE;
@@ -1560,8 +1581,8 @@ ssize_t mqtt_pack_subscribe_request(uint8_t *buf, size_t bufsz, unsigned int pac
     if (bufsz < fixed_header.remaining_length) {
         return 0;
     }
-    
-    
+
+
     /* pack variable header */
     buf += __mqtt_pack_uint16(buf, (uint16_t)packet_id);
 
@@ -1576,7 +1597,7 @@ ssize_t mqtt_pack_subscribe_request(uint8_t *buf, size_t bufsz, unsigned int pac
 }
 
 /* UNSUBACK */
-ssize_t mqtt_unpack_unsuback_response(struct mqtt_response *mqtt_response, const uint8_t *buf) 
+ssize_t mqtt_unpack_unsuback_response(struct mqtt_response *mqtt_response, const uint8_t *buf)
 {
     const uint8_t *const start = buf;
 
@@ -1652,7 +1673,7 @@ ssize_t mqtt_pack_unsubscribe_request(uint8_t *buf, size_t bufsz, unsigned int p
 }
 
 /* MESSAGE QUEUE */
-void mqtt_mq_init(struct mqtt_message_queue *mq, void *buf, size_t bufsz) 
+void mqtt_mq_init(struct mqtt_message_queue *mq, void *buf, size_t bufsz)
 {
     mq->mem_start = buf;
     mq->mem_end = (uint8_t *)buf + bufsz;
@@ -1682,7 +1703,7 @@ void mqtt_mq_clean(struct mqtt_message_queue *mq) {
     for(new_head = mqtt_mq_get(mq, 0); new_head >= mq->queue_tail; --new_head) {
         if (new_head->state != MQTT_QUEUED_COMPLETE) break;
     }
-    
+
     /* check if everything can be removed */
     if (new_head < mq->queue_tail) {
         mq->curr = (uint8_t *)mq->mem_start;
@@ -1700,14 +1721,14 @@ void mqtt_mq_clean(struct mqtt_message_queue *mq) {
         size_t removing = (size_t)(new_head->start - (uint8_t*) mq->mem_start);
         memmove(mq->mem_start, new_head->start, n);
         mq->curr = (uint8_t *)((uint8_t *)mq->mem_start + n);
-      
+
 
         /* move queue */
         {
             ssize_t new_tail_idx = new_head - mq->queue_tail;
             memmove(mqtt_mq_get(mq, new_tail_idx), mq->queue_tail, sizeof(struct mqtt_queued_message) * (size_t)((new_tail_idx + 1)));
             mq->queue_tail = mqtt_mq_get(mq, new_tail_idx);
-          
+
             {
                 /* bump back start's */
                 for(ssize_t i = 0; i < new_tail_idx + 1; ++i) {
@@ -1802,7 +1823,7 @@ ssize_t __mqtt_pack_str(uint8_t *buf, const char* str) {
     for(int i = 0; i < length; ++i) {
         *(buf++) = (uint8_t)str[i];
     }
-    
+
     /* return number of bytes consumed */
     return length + 2;
 }

--- a/deps/mqtt-c/mqtt.h
+++ b/deps/mqtt-c/mqtt.h
@@ -33,53 +33,53 @@ SOFTWARE.
 /**
  * @file
  * @brief Declares all the MQTT-C functions and datastructures.
- * 
+ *
  * @note You should <code>\#include <mqtt.h></code>.
- * 
+ *
  * @example simple_publisher.c
- * A simple program to that publishes the current time whenever ENTER is pressed. 
- * 
+ * A simple program to that publishes the current time whenever ENTER is pressed.
+ *
  * Usage:
  * \code{.sh}
  * ./bin/simple_publisher [address [port [topic]]]
- * \endcode     
- * 
- * Where \c address is the address of the MQTT broker, \c port is the port number the 
+ * \endcode
+ *
+ * Where \c address is the address of the MQTT broker, \c port is the port number the
  * MQTT broker is running on, and \c topic is the name of the topic to publish with. Note
  * that all these arguments are optional and the defaults are \c address = \c "test.mosquitto.org",
  * \c port = \c "1883", and \c topic = "datetime".
- * 
+ *
  * @example simple_subscriber.c
  * A simple program that subscribes to a single topic and prints all updates that are received.
- * 
+ *
  * Usage:
  * \code{.sh}
  * ./bin/simple_subscriber [address [port [topic]]]
- * \endcode   
- * 
- * Where \c address is the address of the MQTT broker, \c port is the port number the 
+ * \endcode
+ *
+ * Where \c address is the address of the MQTT broker, \c port is the port number the
  * MQTT broker is running on, and \c topic is the name of the topic subscribe to. Note
  * that all these arguments are optional and the defaults are \c address = \c "test.mosquitto.org",
- * \c port = \c "1883", and \c topic = "datetime".  
- * 
+ * \c port = \c "1883", and \c topic = "datetime".
+ *
  * @example reconnect_subscriber.c
- * Same program as \ref simple_subscriber.c, but using the automatic reconnect functionality. 
- * 
+ * Same program as \ref simple_subscriber.c, but using the automatic reconnect functionality.
+ *
  * @example bio_publisher.c
  * Same program as \ref simple_publisher.c, but uses an unencrypted BIO socket.
  *
  * @example openssl_publisher.c
  * Same program as \ref simple_publisher.c, but over an encrypted connection using OpenSSL.
- * 
+ *
  * Usage:
  * \code{.sh}
  * ./bin/openssl_publisher ca_file [address [port [topic]]]
- * \endcode   
- * 
- * 
+ * \endcode
+ *
+ *
  * @defgroup api API
  * @brief Documentation of everything you need to know to use the MQTT-C client.
- * 
+ *
  * This module contains everything you need to know to use MQTT-C in your application.
  * For usage examples see:
  *     - @ref simple_publisher.c
@@ -87,28 +87,28 @@ SOFTWARE.
  *     - @ref reconnect_subscriber.c
  *     - @ref bio_publisher.c
  *     - @ref openssl_publisher.c
- * 
- * @note MQTT-C can be used in both single-threaded and multi-threaded applications. All 
+ *
+ * @note MQTT-C can be used in both single-threaded and multi-threaded applications. All
  *       the functions in \ref api are thread-safe.
- * 
+ *
  * @defgroup packers Control Packet Serialization
- * @brief Developer documentation of the functions and datastructures used for serializing MQTT 
+ * @brief Developer documentation of the functions and datastructures used for serializing MQTT
  *        control packets.
- * 
+ *
  * @defgroup unpackers Control Packet Deserialization
- * @brief Developer documentation of the functions and datastructures used for deserializing MQTT 
+ * @brief Developer documentation of the functions and datastructures used for deserializing MQTT
  *        control packets.
- * 
+ *
  * @defgroup details Utilities
  * @brief Developer documentation for the utilities used to implement the MQTT-C client.
  *
- * @note To deserialize a packet from a buffer use \ref mqtt_unpack_response (it's the only 
+ * @note To deserialize a packet from a buffer use \ref mqtt_unpack_response (it's the only
  *       function you need).
  */
 
 
  /**
-  * @brief An enumeration of the MQTT control packet types. 
+  * @brief An enumeration of the MQTT control packet types.
   * @ingroup unpackers
   *
   * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718021">
@@ -135,7 +135,7 @@ SOFTWARE.
 /**
  * @brief The fixed header of an MQTT control packet.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718020">
  * MQTT v3.1.1: Fixed Header
  * </a>
@@ -154,15 +154,15 @@ struct mqtt_fixed_header {
 /**
  * @brief The protocol identifier for MQTT v3.1.1.
  * @ingroup packers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718030">
  * MQTT v3.1.1: CONNECT Variable Header.
- * </a>  
+ * </a>
  */
 #define MQTT_PROTOCOL_LEVEL 0x04
 
-/** 
- * @brief A macro used to declare the enum MQTTErrors and associated 
+/**
+ * @brief A macro used to declare the enum MQTTErrors and associated
  *        error messages (the members of the num) at the same time.
  */
 #define __ALL_MQTT_ERRORS(MQTT_ERROR)                    \
@@ -196,25 +196,25 @@ struct mqtt_fixed_header {
 
 /* todo: add more connection refused errors */
 
-/** 
- * @brief A macro used to generate the enum MQTTErrors from 
+/**
+ * @brief A macro used to generate the enum MQTTErrors from
  *        \ref __ALL_MQTT_ERRORS
  * @see __ALL_MQTT_ERRORS
 */
 #define GENERATE_ENUM(ENUM) ENUM,
 
-/** 
- * @brief A macro used to generate the error messages associated with 
+/**
+ * @brief A macro used to generate the error messages associated with
  *        MQTTErrors from \ref __ALL_MQTT_ERRORS
  * @see __ALL_MQTT_ERRORS
 */
 #define GENERATE_STRING(STRING) #STRING,
 
 
-/** 
+/**
  * @brief An enumeration of error codes. Error messages can be retrieved by calling \ref mqtt_error_str.
  * @ingroup api
- * 
+ *
  * @see mqtt_error_str
  */
 enum MQTTErrors {
@@ -223,47 +223,47 @@ enum MQTTErrors {
     MQTT_OK = 1
 };
 
-/** 
+/**
  * @brief Returns an error message for error code, \p error.
  * @ingroup api
- * 
+ *
  * @param[in] error the error code.
- * 
+ *
  * @returns The associated error message.
  */
 const char* mqtt_error_str(enum MQTTErrors error);
 
 /**
  * @brief Pack a MQTT 16 bit integer, given a native 16 bit integer .
- * 
+ *
  * @param[out] buf the buffer that the MQTT integer will be written to.
  * @param[in] integer the native integer to be written to \p buf.
- * 
+ *
  * @warning This function provides no error checking.
- * 
+ *
  * @returns 2
 */
 ssize_t __mqtt_pack_uint16(uint8_t *buf, uint16_t integer);
 
 /**
  * @brief Unpack a MQTT 16 bit integer to a native 16 bit integer.
- * 
+ *
  * @param[in] buf the buffer that the MQTT integer will be read from.
- * 
+ *
  * @warning This function provides no error checking and does not modify \p buf.
- * 
+ *
  * @returns The native integer
 */
 uint16_t __mqtt_unpack_uint16(const uint8_t *buf);
 
 /**
  * @brief Pack a MQTT string, given a c-string \p str.
- * 
+ *
  * @param[out] buf the buffer that the MQTT string will be written to.
  * @param[in] str the c-string to be written to \p buf.
- * 
+ *
  * @warning This function provides no error checking.
- * 
+ *
  * @returns strlen(str) + 2
 */
 ssize_t __mqtt_pack_str(uint8_t *buf, const char* str);
@@ -276,10 +276,10 @@ ssize_t __mqtt_pack_str(uint8_t *buf, const char* str);
 /**
  * @brief An enumeration of the return codes returned in a CONNACK packet.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_3.1_-">
  * MQTT v3.1.1: CONNACK return codes.
- * </a> 
+ * </a>
  */
 enum MQTTConnackReturnCode {
     MQTT_CONNACK_ACCEPTED = 0u,
@@ -293,21 +293,21 @@ enum MQTTConnackReturnCode {
 /**
  * @brief A connection response datastructure.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718033">
  * MQTT v3.1.1: CONNACK - Acknowledgement connection response.
  * </a>
  */
 struct mqtt_response_connack {
-    /** 
+    /**
      * @brief Allows client and broker to check if they have a consistent view about whether there is
      * already a stored session state.
     */
     uint8_t session_present_flag;
 
-    /** 
-     * @brief The return code of the connection request. 
-     * 
+    /**
+     * @brief The return code of the connection request.
+     *
      * @see MQTTConnackReturnCode
      */
     enum MQTTConnackReturnCode return_code;
@@ -316,24 +316,24 @@ struct mqtt_response_connack {
  /**
   * @brief A publish packet received from the broker.
   * @ingroup unpackers
-  * 
-  * A publish packet is received from the broker when a client publishes to a topic that the 
+  *
+  * A publish packet is received from the broker when a client publishes to a topic that the
   * \em {local client} is subscribed to.
   *
-  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718037"> 
+  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718037">
   * MQTT v3.1.1: PUBLISH - Publish Message.
-  * </a> 
+  * </a>
   */
 struct mqtt_response_publish {
-    /** 
+    /**
      * @brief The DUP flag. DUP flag is 0 if its the first attempt to send this publish packet. A DUP flag
      * of 1 means that this might be a re-delivery of the packet.
      */
     uint8_t dup_flag;
 
-    /** 
+    /**
      * @brief The quality of service level.
-     * 
+     *
      * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_3.11_-">
      * MQTT v3.1.1: QoS Definitions
      * </a>
@@ -346,9 +346,9 @@ struct mqtt_response_publish {
     /** @brief Size of the topic name (number of characters). */
     uint16_t topic_name_size;
 
-    /** 
-     * @brief The topic name. 
-     * @note topic_name is not null terminated. Therefore topic_name_size must be used to get the 
+    /**
+     * @brief The topic name.
+     * @note topic_name is not null terminated. Therefore topic_name_size must be used to get the
      *       string length.
      */
     const void* topic_name;
@@ -366,10 +366,10 @@ struct mqtt_response_publish {
 /**
  * @brief A publish acknowledgement for messages that were published with QoS level 1.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718043">
  * MQTT v3.1.1: PUBACK - Publish Acknowledgement.
- * </a> 
+ * </a>
  *
  */
 struct mqtt_response_puback {
@@ -380,10 +380,10 @@ struct mqtt_response_puback {
 /**
  * @brief The response packet to a PUBLISH packet with QoS level 2.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718048">
  * MQTT v3.1.1: PUBREC - Publish Received.
- * </a> 
+ * </a>
  *
  */
 struct mqtt_response_pubrec {
@@ -394,10 +394,10 @@ struct mqtt_response_pubrec {
 /**
  * @brief The response to a PUBREC packet.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718053">
  * MQTT v3.1.1: PUBREL - Publish Release.
- * </a> 
+ * </a>
  *
  */
 struct mqtt_response_pubrel {
@@ -408,10 +408,10 @@ struct mqtt_response_pubrel {
 /**
  * @brief The response to a PUBREL packet.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718058">
  * MQTT v3.1.1: PUBCOMP - Publish Complete.
- * </a> 
+ * </a>
  *
  */
 struct mqtt_response_pubcomp {
@@ -422,10 +422,10 @@ struct mqtt_response_pubcomp {
 /**
  * @brief An enumeration of subscription acknowledgement return codes.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Figure_3.26_-">
  * MQTT v3.1.1: SUBACK Return Codes.
- * </a> 
+ * </a>
  */
 enum MQTTSubackReturnCodes {
     MQTT_SUBACK_SUCCESS_MAX_QOS_0 = 0u,
@@ -437,18 +437,18 @@ enum MQTTSubackReturnCodes {
 /**
  * @brief The response to a subscription request.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718068">
  * MQTT v3.1.1: SUBACK - Subscription Acknowledgement.
- * </a> 
+ * </a>
  */
 struct mqtt_response_suback {
     /** @brief The published messages packet ID. */
     uint16_t packet_id;
 
-    /** 
+    /**
      * Array of return codes corresponding to the requested subscribe topics.
-     * 
+     *
      * @see MQTTSubackReturnCodes
      */
     const uint8_t *return_codes;
@@ -460,10 +460,10 @@ struct mqtt_response_suback {
 /**
  * @brief The brokers response to a UNSUBSCRIBE request.
  * @ingroup unpackers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718077">
  * MQTT v3.1.1: UNSUBACK - Unsubscribe Acknowledgement.
- * </a> 
+ * </a>
  */
 struct mqtt_response_unsuback {
     /** @brief The published messages packet ID. */
@@ -473,12 +473,12 @@ struct mqtt_response_unsuback {
 /**
  * @brief The response to a ping request.
  * @ingroup unpackers
- * 
+ *
  * @note This response contains no members.
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718086">
  * MQTT v3.1.1: PINGRESP - Ping Response.
- * </a> 
+ * </a>
  */
 struct mqtt_response_pingresp {
   int dummy;
@@ -494,10 +494,10 @@ struct mqtt_response {
 
     /**
      * @brief A union of the possible responses from the broker.
-     * 
+     *
      * @note The fixed_header contains the control type. This control type corresponds to the
-     *       member of this union that should be accessed. For example if 
-     *       fixed_header#control_type == \c MQTT_CONTROL_PUBLISH then 
+     *       member of this union that should be accessed. For example if
+     *       fixed_header#control_type == \c MQTT_CONTROL_PUBLISH then
      *       decoded#publish should be accessed.
      */
     union {
@@ -516,15 +516,15 @@ struct mqtt_response {
 /**
  * @brief Deserialize the contents of \p buf into an mqtt_fixed_header object.
  * @ingroup unpackers
- * 
+ *
  * @note This function performs complete error checking and a positive return value
  *       means the entire mqtt_response can be deserialized from \p buf.
- * 
+ *
  * @param[out] response the response who's \ref mqtt_response.fixed_header will be initialized.
  * @param[in] buf the buffer.
  * @param[in] bufsz the total number of bytes in the buffer.
- * 
- * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough 
+ *
+ * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough
  *          bytes to parse the packet, or a negative value if there was a protocol violation.
  */
 ssize_t mqtt_unpack_fixed_header(struct mqtt_response *response, const uint8_t *buf, size_t bufsz);
@@ -532,17 +532,17 @@ ssize_t mqtt_unpack_fixed_header(struct mqtt_response *response, const uint8_t *
 /**
  * @brief Deserialize a CONNACK response from \p buf.
  * @ingroup unpackers
- * 
+ *
  * @pre \ref mqtt_unpack_fixed_header must have returned a positive value and the control packet type
  *      must be \c MQTT_CONTROL_CONNACK.
- * 
+ *
  * @param[out] mqtt_response the mqtt_response that will be initialized.
- * @param[in] buf the buffer that contains the variable header and payload of the packet. The 
+ * @param[in] buf the buffer that contains the variable header and payload of the packet. The
  *                first byte of \p buf should be the first byte of the variable header.
- * 
- * @relates mqtt_response_connack 
- * 
- * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough 
+ *
+ * @relates mqtt_response_connack
+ *
+ * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough
  *          bytes to parse the packet, or a negative value if there was a protocol violation.
  */
 ssize_t mqtt_unpack_connack_response (struct mqtt_response *mqtt_response, const uint8_t *buf);
@@ -550,16 +550,16 @@ ssize_t mqtt_unpack_connack_response (struct mqtt_response *mqtt_response, const
 /**
  * @brief Deserialize a publish response from \p buf.
  * @ingroup unpackers
- * 
+ *
  * @pre \ref mqtt_unpack_fixed_header must have returned a positive value and the mqtt_response must
  *      have a control type of \c MQTT_CONTROL_PUBLISH.
- * 
+ *
  * @param[out] mqtt_response the response that is initialized from the contents of \p buf.
  * @param[in] buf the buffer with the incoming data.
- * 
- * @relates mqtt_response_publish 
- * 
- * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough 
+ *
+ * @relates mqtt_response_publish
+ *
+ * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough
  *          bytes to parse the packet, or a negative value if there was a protocol violation.
  */
 ssize_t mqtt_unpack_publish_response (struct mqtt_response *mqtt_response, const uint8_t *buf);
@@ -567,17 +567,17 @@ ssize_t mqtt_unpack_publish_response (struct mqtt_response *mqtt_response, const
 /**
  * @brief Deserialize a PUBACK/PUBREC/PUBREL/PUBCOMP packet from \p buf.
  * @ingroup unpackers
- * 
+ *
  * @pre \ref mqtt_unpack_fixed_header must have returned a positive value and the mqtt_response must
  *      have a control type of \c MQTT_CONTROL_PUBACK, \c MQTT_CONTROL_PUBREC, \c MQTT_CONTROL_PUBREL
  *      or \c MQTT_CONTROL_PUBCOMP.
- * 
+ *
  * @param[out] mqtt_response the response that is initialized from the contents of \p buf.
  * @param[in] buf the buffer with the incoming data.
  *
  * @relates mqtt_response_puback mqtt_response_pubrec mqtt_response_pubrel mqtt_response_pubcomp
- * 
- * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough 
+ *
+ * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough
  *          bytes to parse the packet, or a negative value if there was a protocol violation.
  */
 ssize_t mqtt_unpack_pubxxx_response(struct mqtt_response *mqtt_response, const uint8_t *buf);
@@ -585,16 +585,16 @@ ssize_t mqtt_unpack_pubxxx_response(struct mqtt_response *mqtt_response, const u
 /**
  * @brief Deserialize a SUBACK packet from \p buf.
  * @ingroup unpacker
- *  
+ *
  * @pre \ref mqtt_unpack_fixed_header must have returned a positive value and the mqtt_response must
  *      have a control type of \c MQTT_CONTROL_SUBACK.
- * 
+ *
  * @param[out] mqtt_response the response that is initialized from the contents of \p buf.
  * @param[in] buf the buffer with the incoming data.
  *
  * @relates mqtt_response_suback
- * 
- * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough 
+ *
+ * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough
  *          bytes to parse the packet, or a negative value if there was a protocol violation.
  */
 ssize_t mqtt_unpack_suback_response(struct mqtt_response *mqtt_response, const uint8_t *buf);
@@ -602,32 +602,32 @@ ssize_t mqtt_unpack_suback_response(struct mqtt_response *mqtt_response, const u
 /**
  * @brief Deserialize an UNSUBACK packet from \p buf.
  * @ingroup unpacker
- *  
+ *
  * @pre \ref mqtt_unpack_fixed_header must have returned a positive value and the mqtt_response must
  *      have a control type of \c MQTT_CONTROL_UNSUBACK.
- * 
+ *
  * @param[out] mqtt_response the response that is initialized from the contents of \p buf.
  * @param[in] buf the buffer with the incoming data.
  *
  * @relates mqtt_response_unsuback
- * 
- * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough 
+ *
+ * @returns The number of bytes that were consumed, or 0 if the buffer does not contain enough
  *          bytes to parse the packet, or a negative value if there was a protocol violation.
- */  
+ */
 ssize_t mqtt_unpack_unsuback_response(struct mqtt_response *mqtt_response, const uint8_t *buf);
 
 /**
  * @brief Deserialize a packet from the broker.
  * @ingroup unpackers
- * 
+ *
  * @param[out] response the mqtt_response that will be initialize from \p buf.
  * @param[in] buf the incoming data buffer.
  * @param[in] bufsz the number of bytes available in the buffer.
- * 
+ *
  * @relates mqtt_response
- * 
+ *
  * @returns The number of bytes consumed on success, zero \p buf does not contain enough bytes
- *          to deserialize the packet, a negative value if a protocol violation was encountered.  
+ *          to deserialize the packet, a negative value if a protocol violation was encountered.
  */
 ssize_t mqtt_unpack_response(struct mqtt_response* response, const uint8_t *buf, size_t bufsz);
 
@@ -636,15 +636,15 @@ ssize_t mqtt_unpack_response(struct mqtt_response* response, const uint8_t *buf,
  /**
  * @brief Serialize an mqtt_fixed_header and write it to \p buf.
  * @ingroup packers
- * 
+ *
  * @note This function performs complete error checking and a positive return value
  *       guarantees the entire packet will fit into the given buffer.
- * 
+ *
  * @param[out] buf the buffer to write to.
  * @param[in] bufsz the maximum number of bytes that can be put in to \p buf.
  * @param[in] fixed_header the fixed header that will be serialized.
- * 
- * @returns The number of bytes written to \p buf, or 0 if \p buf is too small, or a 
+ *
+ * @returns The number of bytes written to \p buf, or 0 if \p buf is too small, or a
  *          negative value if there was a protocol violation.
  */
 ssize_t mqtt_pack_fixed_header(uint8_t *buf, size_t bufsz, const struct mqtt_fixed_header *fixed_header);
@@ -652,10 +652,10 @@ ssize_t mqtt_pack_fixed_header(uint8_t *buf, size_t bufsz, const struct mqtt_fix
 /**
  * @brief An enumeration of CONNECT packet flags.
  * @ingroup packers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718030">
  * MQTT v3.1.1: CONNECT Variable Header.
- * </a> 
+ * </a>
  */
 enum MQTTConnectFlags {
     MQTT_CONNECT_RESERVED = 1u,
@@ -670,9 +670,9 @@ enum MQTTConnectFlags {
 };
 
 /**
- * @brief Serialize a connection request into a buffer. 
+ * @brief Serialize a connection request into a buffer.
  * @ingroup packers
- * 
+ *
  * @param[out] buf the buffer to pack the connection request packet into.
  * @param[in] bufsz the number of bytes left in \p buf.
  * @param[in] client_id the ID that identifies the local client. \p client_id can be NULL or an empty
@@ -681,46 +681,53 @@ enum MQTTConnectFlags {
  *                       Set to \c NULL for no will message. If \p will_topic is not \c NULL a
  *                       \p will_message must also be provided.
  * @param[in] will_message the will message to be published upon an unsuccessful disconnection of
- *                         the local client. Set to \c NULL if \p will_topic is \c NULL. 
- *                         \p will_message must \em not be \c NULL if \p will_topic is not 
+ *                         the local client. Set to \c NULL if \p will_topic is \c NULL.
+ *                         \p will_message must \em not be \c NULL if \p will_topic is not
  *                         \c NULL.
  * @param[in] will_message_size The size of \p will_message in bytes.
- * @param[in] user_name the username to be used to connect to the broker with. Set to \c NULL if 
+ * @param[in] user_name the username to be used to connect to the broker with. Set to \c NULL if
  *                      no username is required.
  * @param[in] password the password to be used to connect to the broker with. Set to \c NULL if
  *                     no password is required.
  * @param[in] connect_flags additional MQTTConnectFlags to be set. The only flags that need to be
  *                          set manually are \c MQTT_CONNECT_CLEAN_SESSION,
- *                          \c MQTT_CONNECT_WILL_QOS_X (for \c X &isin; {0, 1, 2}), and 
- *                          \c MQTT_CONNECT_WILL_RETAIN. Set to 0 if no additional flags are 
+ *                          \c MQTT_CONNECT_WILL_QOS_X (for \c X &isin; {0, 1, 2}), and
+ *                          \c MQTT_CONNECT_WILL_RETAIN. Set to 0 if no additional flags are
  *                          required.
- * @param[in] keep_alive the keep alive time in seconds. It is the responsibility of the clinet 
+ * @param[in] keep_alive the keep alive time in seconds. It is the responsibility of the clinet
  *                       to ensure packets are sent to the server \em {at least} this frequently.
- * 
- * @note If there is a \p will_topic and no additional \p connect_flags are given, then by 
+ *
+ * @note If there is a \p will_topic and no additional \p connect_flags are given, then by
  *       default \p will_message will be published at QoS level 0.
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718028">
  * MQTT v3.1.1: CONNECT - Client Requests a Connection to a Server.
  * </a>
- * 
- * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the CONNECT 
+ *
+ * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the CONNECT
  *          packet, a negative value if there was a protocol violation.
  */
-ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz, 
+ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
                                      const char* client_id,
                                      const char* will_topic,
                                      const void* will_message,
                                      size_t will_message_size,
                                      const char* user_name,
                                      const char* password,
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
+                                     const char* caFilePath,
+                                     const char* caPath,
+                                     const char* clientCertPath,
+                                     const char* clientKeyPath,
+                                     const bool useTLS,
+#endif
                                      uint8_t connect_flags,
                                      uint16_t keep_alive);
 
 /**
  * @brief An enumeration of the PUBLISH flags.
  * @ingroup packers
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718037">
  * MQTT v3.1.1: PUBLISH - Publish Message.
  * </a>
@@ -737,7 +744,7 @@ enum MQTTPublishFlags {
 /**
  * @brief Serialize a PUBLISH request and put it in \p buf.
  * @ingroup packers
- * 
+ *
  * @param[out] buf the buffer to put the PUBLISH packet in.
  * @param[in] bufsz the maximum number of bytes that can be put into \p buf.
  * @param[in] topic_name the topic to publish \p application_message under.
@@ -745,16 +752,16 @@ enum MQTTPublishFlags {
  * @param[in] application_message the application message to be published.
  * @param[in] application_message_size the size of \p application_message in bytes.
  * @param[in] publish_flags The flags to publish \p application_message with. These include
- *                          the \c MQTT_PUBLISH_DUP flag, \c MQTT_PUBLISH_QOS_X (\c X &isin; 
+ *                          the \c MQTT_PUBLISH_DUP flag, \c MQTT_PUBLISH_QOS_X (\c X &isin;
  *                          {0, 1, 2}), and \c MQTT_PUBLISH_RETAIN flag.
- * 
+ *
  * @note The default QoS is level 0.
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718037">
  * MQTT v3.1.1: PUBLISH - Publish Message.
  * </a>
- * 
- * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the PUBLISH 
+ *
+ * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the PUBLISH
  *          packet, a negative value if there was a protocol violation.
  */
 ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
@@ -767,15 +774,15 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
 /**
  * @brief Serialize a PUBACK, PUBREC, PUBREL, or PUBCOMP packet and put it in \p buf.
  * @ingroup packers
- * 
+ *
  * @param[out] buf the buffer to put the PUBXXX packet in.
  * @param[in] bufsz the maximum number of bytes that can be put into \p buf.
- * @param[in] control_type the type of packet. Must be one of: \c MQTT_CONTROL_PUBACK, 
- *                         \c MQTT_CONTROL_PUBREC, \c MQTT_CONTROL_PUBREL, 
+ * @param[in] control_type the type of packet. Must be one of: \c MQTT_CONTROL_PUBACK,
+ *                         \c MQTT_CONTROL_PUBREC, \c MQTT_CONTROL_PUBREL,
  *                         or \c MQTT_CONTROL_PUBCOMP.
  * @param[in] packet_id the packet ID of the packet being acknowledged.
- * 
- * 
+ *
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718043">
  * MQTT v3.1.1: PUBACK - Publish Acknowledgement.
  * </a>
@@ -788,94 +795,94 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718058">
  * MQTT v3.1.1: PUBCOMP - Publish Complete.
  * </a>
- * 
- * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the PUBXXX 
+ *
+ * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the PUBXXX
  *          packet, a negative value if there was a protocol violation.
  */
-ssize_t mqtt_pack_pubxxx_request(uint8_t *buf, size_t bufsz, 
+ssize_t mqtt_pack_pubxxx_request(uint8_t *buf, size_t bufsz,
                                  enum MQTTControlPacketType control_type,
                                  uint16_t packet_id);
 
-/** 
- * @brief The maximum number topics that can be subscribed to in a single call to 
+/**
+ * @brief The maximum number topics that can be subscribed to in a single call to
  *         mqtt_pack_subscribe_request.
  * @ingroup packers
- * 
+ *
  * @see mqtt_pack_subscribe_request
  */
 #define MQTT_SUBSCRIBE_REQUEST_MAX_NUM_TOPICS 8
 
-/** 
+/**
  * @brief Serialize a SUBSCRIBE packet and put it in \p buf.
  * @ingroup packers
- * 
+ *
  * @param[out] buf the buffer to put the SUBSCRIBE packet in.
  * @param[in] bufsz the maximum number of bytes that can be put into \p buf.
  * @param[in] packet_id the packet ID to be used.
  * @param[in] ... \c NULL terminated list of (\c {const char *topic_name}, \c {int max_qos_level})
  *                pairs.
- * 
+ *
  * @note The variadic arguments, \p ..., \em must be followed by a \c NULL. For example:
  * @code
  * ssize_t n = mqtt_pack_subscribe_request(buf, bufsz, 1234, "topic_1", 0, "topic_2", 2, NULL);
  * @endcode
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718063">
  * MQTT v3.1.1: SUBSCRIBE - Subscribe to Topics.
  * </a>
- * 
- * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the SUBSCRIBE 
+ *
+ * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the SUBSCRIBE
  *          packet, a negative value if there was a protocol violation.
  */
-ssize_t mqtt_pack_subscribe_request(uint8_t *buf, size_t bufsz, 
-                                    unsigned int packet_id, 
+ssize_t mqtt_pack_subscribe_request(uint8_t *buf, size_t bufsz,
+                                    unsigned int packet_id,
                                     ...); /* null terminated */
 
-/** 
- * @brief The maximum number topics that can be subscribed to in a single call to 
+/**
+ * @brief The maximum number topics that can be subscribed to in a single call to
  *         mqtt_pack_unsubscribe_request.
  * @ingroup packers
- * 
+ *
  * @see mqtt_pack_unsubscribe_request
  */
 #define MQTT_UNSUBSCRIBE_REQUEST_MAX_NUM_TOPICS 8
 
-/** 
+/**
  * @brief Serialize a UNSUBSCRIBE packet and put it in \p buf.
  * @ingroup packers
- * 
+ *
  * @param[out] buf the buffer to put the UNSUBSCRIBE packet in.
  * @param[in] bufsz the maximum number of bytes that can be put into \p buf.
  * @param[in] packet_id the packet ID to be used.
  * @param[in] ... \c NULL terminated list of \c {const char *topic_name}'s to unsubscribe from.
- * 
+ *
  * @note The variadic arguments, \p ..., \em must be followed by a \c NULL. For example:
  * @code
  * ssize_t n = mqtt_pack_unsubscribe_request(buf, bufsz, 4321, "topic_1", "topic_2", NULL);
  * @endcode
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718072">
  * MQTT v3.1.1: UNSUBSCRIBE - Unsubscribe from Topics.
  * </a>
- * 
- * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the UNSUBSCRIBE 
+ *
+ * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the UNSUBSCRIBE
  *          packet, a negative value if there was a protocol violation.
  */
-ssize_t mqtt_pack_unsubscribe_request(uint8_t *buf, size_t bufsz, 
-                                      unsigned int packet_id, 
+ssize_t mqtt_pack_unsubscribe_request(uint8_t *buf, size_t bufsz,
+                                      unsigned int packet_id,
                                       ...); /* null terminated */
 
 /**
  * @brief Serialize a PINGREQ and put it into \p buf.
  * @ingroup packers
- * 
+ *
  * @param[out] buf the buffer to put the PINGREQ packet in.
  * @param[in] bufsz the maximum number of bytes that can be put into \p buf.
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718081">
  * MQTT v3.1.1: PINGREQ - Ping Request.
  * </a>
- * 
+ *
  * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the PINGREQ
  *          packet, a negative value if there was a protocol violation.
  */
@@ -884,22 +891,22 @@ ssize_t mqtt_pack_ping_request(uint8_t *buf, size_t bufsz);
 /**
  * @brief Serialize a DISCONNECT and put it into \p buf.
  * @ingroup packers
- * 
+ *
  * @param[out] buf the buffer to put the DISCONNECT packet in.
  * @param[in] bufsz the maximum number of bytes that can be put into \p buf.
- * 
+ *
  * @see <a href="http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718090">
  * MQTT v3.1.1: DISCONNECT - Disconnect Notification.
  * </a>
- * 
- * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the DISCONNECT 
+ *
+ * @returns The number of bytes put into \p buf, 0 if \p buf is too small to fit the DISCONNECT
  *          packet, a negative value if there was a protocol violation.
  */
 ssize_t mqtt_pack_disconnect(uint8_t *buf, size_t bufsz);
 
 
 /**
- * @brief An enumeration of queued message states. 
+ * @brief An enumeration of queued message states.
  * @ingroup details
  */
 enum MQTTQueuedMessageState {
@@ -923,9 +930,9 @@ struct mqtt_queued_message {
     /** @brief The state of the message. */
     enum MQTTQueuedMessageState state;
 
-    /** 
+    /**
      * @brief The time at which the message was sent..
-     * 
+     *
      * @note A timeout will only occur if the message is in
      *       the MQTT_QUEUED_AWAITING_ACK \c state.
      */
@@ -936,10 +943,10 @@ struct mqtt_queued_message {
      */
     enum MQTTControlPacketType control_type;
 
-    /** 
+    /**
      * @brief The packet id of the message.
-     * 
-     * @note This field is only used if the associate \c control_type has a 
+     *
+     * @note This field is only used if the associate \c control_type has a
      *       \c packet_id field.
      */
     uint16_t packet_id;
@@ -948,14 +955,14 @@ struct mqtt_queued_message {
 /**
  * @brief A message queue.
  * @ingroup details
- * 
+ *
  * @note This struct is used internally to manage sending messages.
- * @note The only members the user should use are \c curr and \c curr_sz. 
+ * @note The only members the user should use are \c curr and \c curr_sz.
  */
 struct mqtt_message_queue {
-    /** 
-     * @brief The start of the message queue's memory block. 
-     * 
+    /**
+     * @brief The start of the message queue's memory block.
+     *
      * @warning This member should \em not be manually changed.
      */
     void *mem_start;
@@ -965,7 +972,7 @@ struct mqtt_message_queue {
 
     /**
      * @brief A pointer to the position in the buffer you can pack bytes at.
-     * 
+     *
      * @note Immediately after packing bytes at \c curr you \em must call
      *       mqtt_mq_register.
      */
@@ -973,17 +980,17 @@ struct mqtt_message_queue {
 
     /**
      * @brief The number of bytes that can be written to \c curr.
-     * 
-     * @note curr_sz will decrease by more than the number of bytes you write to 
-     *       \c curr. This is because the mqtt_queued_message structs share the 
-     *       same memory (and thus, a mqtt_queued_message must be allocated in 
-     *       the message queue's memory whenever a new message is registered).  
+     *
+     * @note curr_sz will decrease by more than the number of bytes you write to
+     *       \c curr. This is because the mqtt_queued_message structs share the
+     *       same memory (and thus, a mqtt_queued_message must be allocated in
+     *       the message queue's memory whenever a new message is registered).
      */
     size_t curr_sz;
-    
+
     /**
      * @brief The tail of the array of mqtt_queued_messages's.
-     * 
+     *
      * @note This member should not be used manually.
      */
     struct mqtt_queued_message *queue_tail;
@@ -992,11 +999,11 @@ struct mqtt_message_queue {
 /**
  * @brief Initialize a message queue.
  * @ingroup details
- * 
+ *
  * @param[out] mq The message queue to initialize.
  * @param[in] buf The buffer for this message queue.
- * @param[in] bufsz The number of bytes in the buffer. 
- * 
+ * @param[in] bufsz The number of bytes in the buffer.
+ *
  * @relates mqtt_message_queue
  */
 void mqtt_mq_init(struct mqtt_message_queue *mq, void *buf, size_t bufsz);
@@ -1004,11 +1011,11 @@ void mqtt_mq_init(struct mqtt_message_queue *mq, void *buf, size_t bufsz);
 /**
  * @brief Clear as many messages from the front of the queue as possible.
  * @ingroup details
- * 
+ *
  * @note Calls to this function are the \em only way to remove messages from the queue.
- * 
+ *
  * @param mq The message queue.
- * 
+ *
  * @relates mqtt_message_queue
  */
 void mqtt_mq_clean(struct mqtt_message_queue *mq);
@@ -1016,17 +1023,17 @@ void mqtt_mq_clean(struct mqtt_message_queue *mq);
 /**
  * @brief Register a message that was just added to the buffer.
  * @ingroup details
- * 
+ *
  * @note This function should be called immediately following a call to a packer function
  *       that returned a positive value. The positive value (number of bytes packed) should
  *       be passed to this function.
- * 
+ *
  * @param mq The message queue.
  * @param[in] nbytes The number of bytes that were just packed.
- * 
+ *
  * @note This function will step mqtt_message_queue::curr and update mqtt_message_queue::curr_sz.
  * @relates mqtt_message_queue
- * 
+ *
  * @returns The newly added struct mqtt_queued_message.
  */
 struct mqtt_queued_message* mqtt_mq_register(struct mqtt_message_queue *mq, size_t nbytes);
@@ -1034,12 +1041,12 @@ struct mqtt_queued_message* mqtt_mq_register(struct mqtt_message_queue *mq, size
 /**
  * @brief Find a message in the message queue.
  * @ingroup details
- * 
+ *
  * @param mq The message queue.
  * @param[in] control_type The control type of the message you want to find.
- * @param[in] packet_id The packet ID of the message you want to find. Set to \c NULL if you 
+ * @param[in] packet_id The packet ID of the message you want to find. Set to \c NULL if you
  *            don't want to specify a packet ID.
- * 
+ *
  * @relates mqtt_message_queue
  * @returns The found message. \c NULL if the message was not found.
  */
@@ -1048,9 +1055,9 @@ struct mqtt_queued_message* mqtt_mq_find(struct mqtt_message_queue *mq, enum MQT
 /**
  * @brief Returns the mqtt_queued_message at \p index.
  * @ingroup details
- * 
+ *
  * @param mq_ptr A pointer to the message queue.
- * @param index The index of the message. 
+ * @param index The index of the message.
  *
  * @returns The mqtt_queued_message at \p index.
  */
@@ -1071,9 +1078,9 @@ struct mqtt_queued_message* mqtt_mq_find(struct mqtt_message_queue *mq, enum MQT
 /* CLIENT */
 
 /**
- * @brief An MQTT client. 
+ * @brief An MQTT client.
  * @ingroup details
- * 
+ *
  * @note All members can be manipulated via the related functions.
  */
 struct mqtt_client {
@@ -1086,8 +1093,8 @@ struct mqtt_client {
     /** @brief The keep-alive time in seconds. */
     uint16_t keep_alive;
 
-    /** 
-     * @brief A counter counting pings that have been sent to keep the connection alive. 
+    /**
+     * @brief A counter counting pings that have been sent to keep the connection alive.
      * @see keep_alive
      */
     int number_of_keep_alives;
@@ -1099,31 +1106,31 @@ struct mqtt_client {
      */
     size_t send_offset;
 
-    /** 
+    /**
      * @brief The timestamp of the last message sent to the buffer.
-     * 
+     *
      * This is used to detect the need for keep-alive pings.
-     * 
+     *
      * @see keep_alive
     */
     mqtt_pal_time_t time_of_last_send;
 
-    /** 
-     * @brief The error state of the client. 
-     * 
+    /**
+     * @brief The error state of the client.
+     *
      * error should be MQTT_OK for the entirety of the connection.
-     * 
+     *
      * @note The error state will be MQTT_ERROR_CONNECT_NOT_CALLED until
      *       you call mqtt_connect.
      */
     enum MQTTErrors error;
 
-    /** 
+    /**
      * @brief The timeout period in seconds.
-     * 
+     *
      * If the broker doesn't return an ACK within response_timeout seconds a timeout
-     * will occur and the message will be retransmitted. 
-     * 
+     * will occur and the message will be retransmitted.
+     *
      * @note The default value is 30 [seconds] but you can change it at any time.
      */
     int response_timeout;
@@ -1132,30 +1139,30 @@ struct mqtt_client {
     int number_of_timeouts;
 
     /**
-     * @brief Approximately much time it has typically taken to receive responses from the 
+     * @brief Approximately much time it has typically taken to receive responses from the
      *        broker.
-     * 
+     *
      * @note This is tracked using an exponential-averaging.
      */
     double typical_response_time;
 
     /**
      * @brief The callback that is called whenever a publish is received from the broker.
-     * 
-     * Any topics that you have subscribed to will be returned from the broker as 
-     * mqtt_response_publish messages. All the publishes received from the broker will 
+     *
+     * Any topics that you have subscribed to will be returned from the broker as
+     * mqtt_response_publish messages. All the publishes received from the broker will
      * be passed to this function.
-     * 
+     *
      * @note A pointer to publish_response_callback_state is always passed to the callback.
-     *       Use publish_response_callback_state to keep track of any state information you 
+     *       Use publish_response_callback_state to keep track of any state information you
      *       need.
      */
     void (*publish_response_callback)(void** state, struct mqtt_response_publish *publish);
 
     /**
      * @brief A pointer to any publish_response_callback state information you need.
-     * 
-     * @note A pointer to this pointer will always be publish_response_callback upon 
+     *
+     * @note A pointer to this pointer will always be publish_response_callback upon
      *       receiving a publish message from the broker.
      */
     void* publish_response_callback_state;
@@ -1164,30 +1171,30 @@ struct mqtt_client {
      * @brief A user-specified callback, triggered on each \ref mqtt_sync, allowing
      *        the user to perform state inspections (and custom socket error detection)
      *        on the client.
-     * 
+     *
      * This callback is triggered on each call to \ref mqtt_sync. If it returns MQTT_OK
      * then \ref mqtt_sync will continue normally (performing reads and writes). If it
      * returns an error then \ref mqtt_sync will not call reads and writes.
-     * 
+     *
      * This callback can be used to perform custom error detection, namely platform
      * specific socket error detection, and force the client into an error state.
-     * 
-     * This member is always initialized to NULL but it can be manually set at any 
+     *
+     * This member is always initialized to NULL but it can be manually set at any
      * time.
      */
     enum MQTTErrors (*inspector_callback)(struct mqtt_client*);
 
     /**
      * @brief A callback that is called whenever the client is in an error state.
-     * 
+     *
      * This callback is responsible for: application level error handling, closing
-     * previous sockets, and reestabilishing the connection to the broker and 
-     * session configurations (i.e. subscriptions).  
+     * previous sockets, and reestabilishing the connection to the broker and
+     * session configurations (i.e. subscriptions).
      */
     void (*reconnect_callback)(struct mqtt_client*, void**);
 
     /**
-     * @brief A pointer to some state. A pointer to this member is passed to 
+     * @brief A pointer to some state. A pointer to this member is passed to
      *        \ref mqtt_client.reconnect_callback.
      */
     void* reconnect_state;
@@ -1209,9 +1216,9 @@ struct mqtt_client {
         size_t curr_sz;
     } recv_buffer;
 
-    /** 
+    /**
      * @brief A variable passed to support thread-safety.
-     * 
+     *
      * A pointer to this variable is passed to \c MQTT_PAL_MUTEX_LOCK, and
      * \c MQTT_PAL_MUTEX_UNLOCK.
      */
@@ -1224,11 +1231,11 @@ struct mqtt_client {
 /**
  * @brief Generate a new next packet ID.
  * @ingroup details
- * 
+ *
  * Packet ID's are generated using a max-length LFSR.
- * 
+ *
  * @param client The MQTT client.
- * 
+ *
  * @returns The new packet ID that should be used.
  */
 uint16_t __mqtt_next_pid(struct mqtt_client *client);
@@ -1236,82 +1243,82 @@ uint16_t __mqtt_next_pid(struct mqtt_client *client);
 /**
  * @brief Handles egress client traffic.
  * @ingroup details
- * 
+ *
  * @param client The MQTT client.
- * 
- * @returns MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 ssize_t __mqtt_send(struct mqtt_client *client);
 
 /**
  * @brief Handles ingress client traffic.
  * @ingroup details
- * 
+ *
  * @param client The MQTT client.
- * 
- * @returns MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 ssize_t __mqtt_recv(struct mqtt_client *client);
 
 /**
- * @brief Function that does the actual sending and receiving of 
+ * @brief Function that does the actual sending and receiving of
  *        traffic from the network.
  * @ingroup api
- * 
+ *
  * All the other functions in the @ref api simply stage messages for
  * being sent to the broker. This function does the actual sending of
- * those messages. Additionally this function receives traffic (responses and 
+ * those messages. Additionally this function receives traffic (responses and
  * acknowledgements) from the broker and responds to that traffic accordingly.
  * Lastly this function also calls the \c publish_response_callback when
  * any \c MQTT_CONTROL_PUBLISH messages are received.
- * 
+ *
  * @pre mqtt_init must have been called.
- * 
+ *
  * @param[in,out] client The MQTT client.
- * 
- * @attention It is the responsibility of the application programmer to 
+ *
+ * @attention It is the responsibility of the application programmer to
  *            call this function periodically. All functions in the @ref api are
  *            thread-safe so it is perfectly reasonable to have a thread dedicated
  *            to calling this function every 200 ms or so. MQTT-C can be used in single
- *            threaded application though by simply calling this functino periodically 
+ *            threaded application though by simply calling this functino periodically
  *            inside your main thread. See @ref simple_publisher.c and @ref simple_subscriber.c
  *            for examples (specifically the \c client_refresher functions).
- * 
- * @returns MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_sync(struct mqtt_client *client);
 
 /**
  * @brief Initializes an MQTT client.
  * @ingroup api
- * 
+ *
  * This function \em must be called before any other API function calls.
- * 
+ *
  * @pre None.
- * 
+ *
  * @param[out] client The MQTT client.
- * @param[in] sockfd The socket file descriptor (or equivalent socket handle, e.g. BIO pointer 
+ * @param[in] sockfd The socket file descriptor (or equivalent socket handle, e.g. BIO pointer
  *            for OpenSSL sockets) connected to the MQTT broker.
  * @param[in] sendbuf A buffer that will be used for sending messages to the broker.
  * @param[in] sendbufsz The size of \p sendbuf in bytes.
  * @param[in] recvbuf A buffer that will be used for receiving messages from the broker.
  * @param[in] recvbufsz The size of \p recvbuf in bytes.
  * @param[in] publish_response_callback The callback to call whenever application messages
- *            are received from the broker. 
- * 
+ *            are received from the broker.
+ *
  * @post mqtt_connect must be called.
- * 
+ *
  * @note \p sockfd is a non-blocking TCP connection.
  * @note If \p sendbuf fills up completely during runtime a \c MQTT_ERROR_SEND_BUFFER_IS_FULL
  *       error will be set. Similarly if \p recvbuf is ever to small to receive a message from
  *       the broker an MQTT_ERROR_RECV_BUFFER_TOO_SMALL error will be set.
- * @note A pointer to \ref mqtt_client.publish_response_callback_state is always passed as the 
- *       \c state argument to \p publish_response_callback. Note that the second argument is 
+ * @note A pointer to \ref mqtt_client.publish_response_callback_state is always passed as the
+ *       \c state argument to \p publish_response_callback. Note that the second argument is
  *       the mqtt_response_publish that was received from the broker.
- * 
- * @attention Only initialize an MQTT client once (i.e. don't call \ref mqtt_init or 
+ *
+ * @attention Only initialize an MQTT client once (i.e. don't call \ref mqtt_init or
  *            \ref mqtt_init_reconnect more than once per client).
- * 
+ *
  * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_init(struct mqtt_client *client,
@@ -1323,44 +1330,44 @@ enum MQTTErrors mqtt_init(struct mqtt_client *client,
 /**
  * @brief Initializes an MQTT client and enables automatic reconnections.
  * @ingroup api
- * 
- * An alternative to \ref mqtt_init that allows the client to automatically reconnect to the 
+ *
+ * An alternative to \ref mqtt_init that allows the client to automatically reconnect to the
  * broker after an error occurs (e.g. socket error or internal buffer overflows).
- * 
- * This is accomplished by calling the \p reconnect_callback whenever the client enters an error 
- * state. The job of the \p reconnect_callback is to: (1) perform error handling/logging, 
- * (2) clean up the old connection (i.e. close client->socketfd), (3) \ref mqtt_reinit the 
- * client, and (4) reconfigure the MQTT session by calling \ref mqtt_connect followed by other 
+ *
+ * This is accomplished by calling the \p reconnect_callback whenever the client enters an error
+ * state. The job of the \p reconnect_callback is to: (1) perform error handling/logging,
+ * (2) clean up the old connection (i.e. close client->socketfd), (3) \ref mqtt_reinit the
+ * client, and (4) reconfigure the MQTT session by calling \ref mqtt_connect followed by other
  * API calls such as \ref mqtt_subscribe.
- * 
- * The first argument to the \p reconnect_callback is the client (which will be in an error 
+ *
+ * The first argument to the \p reconnect_callback is the client (which will be in an error
  * state) and the second argument is a pointer to a void pointer where you can store some state
- * information. Internally, MQTT-C calls the reconnect callback like so: 
- * 
- * \code 
+ * information. Internally, MQTT-C calls the reconnect callback like so:
+ *
+ * \code
  *     client->reconnect_callback(client, &client->reconnect_state)
  * \endcode
- * 
+ *
  * Note that the \p reconnect_callback is also called to setup the initial session. After
- * calling \ref mqtt_init_reconnect the client will be in the error state 
+ * calling \ref mqtt_init_reconnect the client will be in the error state
  * \c MQTT_ERROR_INITIAL_RECONNECT.
- * 
+ *
  * @pre None.
- * 
+ *
  * @param[in,out] client The MQTT client that will be initialized.
- * @param[in] reconnect_callback The callback that will be called to connect/reconnect the 
- *            client to the broker and perform application level error handling. 
+ * @param[in] reconnect_callback The callback that will be called to connect/reconnect the
+ *            client to the broker and perform application level error handling.
  * @param[in] reconnect_state A pointer to some state data for your \p reconnect_callback.
  *            If your \p reconnect_callback does not require any state information set this
  *            to NULL. A pointer to the memory address where the client stores a copy of this
- *            pointer is passed as the second argumnet to \p reconnect_callback. 
+ *            pointer is passed as the second argumnet to \p reconnect_callback.
  * @param[in] publish_response_callback The callback to call whenever application messages
- *            are received from the broker. 
- * 
- * @post Call \p reconnect_callback yourself, or call \ref mqtt_sync 
+ *            are received from the broker.
+ *
+ * @post Call \p reconnect_callback yourself, or call \ref mqtt_sync
  *       (which will trigger the call to \p reconnect_callback).
- * 
- * @attention Only initialize an MQTT client once (i.e. don't call \ref mqtt_init or 
+ *
+ * @attention Only initialize an MQTT client once (i.e. don't call \ref mqtt_init or
  *            \ref mqtt_init_reconnect more than once per client).
  *
  */
@@ -1372,24 +1379,24 @@ void mqtt_init_reconnect(struct mqtt_client *client,
 /**
  * @brief Safely assign/reassign a socket and buffers to an new/existing client.
  * @ingroup api
- * 
+ *
  * This function also clears the \p client error state. Upon exiting this function
  * \c client->error will be \c MQTT_ERROR_CONNECT_NOT_CALLED (which will be cleared)
  * as soon as \ref mqtt_connect is called.
- * 
- * @pre This function must be called BEFORE \ref mqtt_connect. 
- * 
+ *
+ * @pre This function must be called BEFORE \ref mqtt_connect.
+ *
  * @param[in,out] client The MQTT client.
- * @param[in] socketfd The new socket connected to the broker. 
+ * @param[in] socketfd The new socket connected to the broker.
  * @param[in] sendbuf The buffer that will be used to buffer egress traffic to the broker.
  * @param[in] sendbufsz The size of \p sendbuf in bytes.
  * @param[in] recvbuf The buffer that will be used to buffer ingress traffic from the broker.
  * @param[in] recvbufsz The size of \p recvbuf in bytes.
- * 
+ *
  * @post Call \ref mqtt_connect.
- * 
- * @attention This function should be used in conjunction with clients that have been 
- *            initialzed with \ref mqtt_init_reconnect.  
+ *
+ * @attention This function should be used in conjunction with clients that have been
+ *            initialzed with \ref mqtt_init_reconnect.
  */
 void mqtt_reinit(struct mqtt_client* client,
                  mqtt_pal_socket_handle socketfd,
@@ -1399,27 +1406,27 @@ void mqtt_reinit(struct mqtt_client* client,
 /**
  * @brief Establishes a session with the MQTT broker.
  * @ingroup api
- * 
+ *
  * @pre mqtt_init must have been called.
- * 
+ *
  * @param[in,out] client The MQTT client.
  * @param[in] client_id The unique name identifying the client. (or NULL)
- * @param[in] will_topic The topic name of client's \p will_message. If no will message is 
+ * @param[in] will_topic The topic name of client's \p will_message. If no will message is
  *            desired set to \c NULL.
- * @param[in] will_message The application message (data) to be published in the event the 
+ * @param[in] will_message The application message (data) to be published in the event the
  *            client ungracefully disconnects. Set to \c NULL if \p will_topic is \c NULL.
  * @param[in] will_message_size The size of \p will_message in bytes.
  * @param[in] user_name The username to use when establishing the session with the MQTT broker.
  *            Set to \c NULL if a username is not required.
  * @param[in] password The password to use when establishing the session with the MQTT broker.
  *            Set to \c NULL if a password is not required.
- * @param[in] connect_flags Additional \ref MQTTConnectFlags to use when establishing the connection. 
- *            These flags are for forcing the session to start clean, 
- *            \c MQTT_CONNECT_CLEAN_SESSION, the QOS level to publish the \p will_message with 
- *            (provided \c will_message != \c NULL), MQTT_CONNECT_WILL_QOS_[0,1,2], and whether 
+ * @param[in] connect_flags Additional \ref MQTTConnectFlags to use when establishing the connection.
+ *            These flags are for forcing the session to start clean,
+ *            \c MQTT_CONNECT_CLEAN_SESSION, the QOS level to publish the \p will_message with
+ *            (provided \c will_message != \c NULL), MQTT_CONNECT_WILL_QOS_[0,1,2], and whether
  *            or not the broker should retain the \c will_message, MQTT_CONNECT_WILL_RETAIN.
- * @param[in] keep_alive The keep-alive time in seconds. A reasonable value for this is 400 [seconds]. 
- * 
+ * @param[in] keep_alive The keep-alive time in seconds. A reasonable value for this is 400 [seconds].
+ *
  * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_connect(struct mqtt_client *client,
@@ -1432,26 +1439,26 @@ enum MQTTErrors mqtt_connect(struct mqtt_client *client,
                              uint8_t connect_flags,
                              uint16_t keep_alive);
 
-/* 
+/*
     todo: will_message should be a void*
 */
 
 /**
  * @brief Publish an application message.
  * @ingroup api
- * 
+ *
  * Publishes an application message to the MQTT broker.
- * 
+ *
  * @pre mqtt_connect must have been called.
- * 
+ *
  * @param[in,out] client The MQTT client.
  * @param[in] topic_name The name of the topic.
  * @param[in] application_message The data to be published.
  * @param[in] application_message_size The size of \p application_message in bytes.
- * @param[in] publish_flags \ref MQTTPublishFlags to be used, namely the QOS level to 
- *            publish at (MQTT_PUBLISH_QOS_[0,1,2]) or whether or not the broker should 
+ * @param[in] publish_flags \ref MQTTPublishFlags to be used, namely the QOS level to
+ *            publish at (MQTT_PUBLISH_QOS_[0,1,2]) or whether or not the broker should
  *            retain the publish (MQTT_PUBLISH_RETAIN).
- * 
+ *
  * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_publish(struct mqtt_client *client,
@@ -1466,8 +1473,8 @@ enum MQTTErrors mqtt_publish(struct mqtt_client *client,
  *
  * @param[in,out] client The MQTT client.
  * @param[in] packet_id The packet ID of the ingress publish being acknowledged.
- * 
- * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 ssize_t __mqtt_puback(struct mqtt_client *client, uint16_t packet_id);
 
@@ -1477,8 +1484,8 @@ ssize_t __mqtt_puback(struct mqtt_client *client, uint16_t packet_id);
  *
  * @param[in,out] client The MQTT client.
  * @param[in] packet_id The packet ID of the ingress publish being acknowledged.
- * 
- * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 ssize_t __mqtt_pubrec(struct mqtt_client *client, uint16_t packet_id);
 
@@ -1488,8 +1495,8 @@ ssize_t __mqtt_pubrec(struct mqtt_client *client, uint16_t packet_id);
  *
  * @param[in,out] client The MQTT client.
  * @param[in] packet_id The packet ID of the ingress PUBREC being acknowledged.
- * 
- * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 ssize_t __mqtt_pubrel(struct mqtt_client *client, uint16_t packet_id);
 
@@ -1499,8 +1506,8 @@ ssize_t __mqtt_pubrel(struct mqtt_client *client, uint16_t packet_id);
  *
  * @param[in,out] client The MQTT client.
  * @param[in] packet_id The packet ID of the ingress PUBREL being acknowledged.
- * 
- * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 ssize_t __mqtt_pubcomp(struct mqtt_client *client, uint16_t packet_id);
 
@@ -1508,15 +1515,15 @@ ssize_t __mqtt_pubcomp(struct mqtt_client *client, uint16_t packet_id);
 /**
  * @brief Subscribe to a topic.
  * @ingroup api
- * 
+ *
  * @pre mqtt_connect must have been called.
- * 
+ *
  * @param[in,out] client The MQTT client.
  * @param[in] topic_name The name of the topic to subscribe to.
  * @param[in] max_qos_level The maximum QOS level with which the broker can send application
  *            messages for this topic.
- * 
- * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_subscribe(struct mqtt_client *client,
                                const char* topic_name,
@@ -1525,45 +1532,45 @@ enum MQTTErrors mqtt_subscribe(struct mqtt_client *client,
 /**
  * @brief Unsubscribe from a topic.
  * @ingroup api
- * 
+ *
  * @pre mqtt_connect must have been called.
- * 
+ *
  * @param[in,out] client The MQTT client.
  * @param[in] topic_name The name of the topic to unsubscribe from.
- * 
- * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise. 
+ *
+ * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_unsubscribe(struct mqtt_client *client,
                                  const char* topic_name);
 
 /**
- * @brief Ping the broker. 
+ * @brief Ping the broker.
  * @ingroup api
- * 
+ *
  * @pre mqtt_connect must have been called.
- * 
+ *
  * @param[in,out] client The MQTT client.
- * 
+ *
  * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_ping(struct mqtt_client *client);
 
 /**
- * @brief Ping the broker without locking/unlocking the mutex. 
+ * @brief Ping the broker without locking/unlocking the mutex.
  * @see mqtt_ping
  */
 enum MQTTErrors __mqtt_ping(struct mqtt_client *client);
 
 /**
- * @brief Terminate the session with the MQTT broker. 
+ * @brief Terminate the session with the MQTT broker.
  * @ingroup api
- * 
+ *
  * @pre mqtt_connect must have been called.
- * 
+ *
  * @param[in,out] client The MQTT client.
- * 
+ *
  * @note To re-establish the session, mqtt_connect must be called.
- * 
+ *
  * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_disconnect(struct mqtt_client *client);

--- a/plugins/mqtt/ua_mqtt_adapter.c
+++ b/plugins/mqtt/ua_mqtt_adapter.c
@@ -290,7 +290,7 @@ connectMqtt(UA_PubSubChannelDataMQTT* channelData){
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     client->keep_alive = 400;
-    
+
     /* save reference */
     channelData->mqttClient = client;
 
@@ -451,19 +451,19 @@ connectMqtt(UA_PubSubChannelDataMQTT* channelData){
 #endif
 
     /* Connect mqtt with socket fd of networktcp  */
-#ifdef UA_ENABLE_MQTT_TLS_OPENSSL    
+#ifdef UA_ENABLE_MQTT_TLS_OPENSSL
     mqttErr = mqtt_connect(client, clientId, NULL, NULL, 0, username, password,
                             caFilePath, caPath, clientCertPath, clientKeyPath, useTLS, 0, client->keep_alive);
     UA_free(clientId);
     UA_free(username);
-    UA_free(password);     
+    UA_free(password);
     UA_free(caFilePath);
     UA_free(caPath);
     UA_free(clientCertPath);
     UA_free(clientKeyPath);
 #else
     mqttErr = mqtt_connect(client, clientId, NULL, NULL, 0, username, password,
-                            NULL, NULL, NULL, NULL, UA_FALSE, 0, client->keep_alive);
+                           0, client->keep_alive);
     UA_free(clientId);
     UA_free(username);
     UA_free(password);
@@ -523,9 +523,9 @@ publish_callback(void** channelDataPtr, struct mqtt_response_publish *published)
                 //Setup topic
                 UA_ByteString *topic = UA_ByteString_new();
                 if(!topic) return;
-                UA_ByteString *msg = UA_ByteString_new();  
+                UA_ByteString *msg = UA_ByteString_new();
                 if(!msg) return;
-                
+
                 /* memory for topic */
                 UA_StatusCode ret = UA_ByteString_allocBuffer(topic, published->topic_name_size);
                 if(ret){
@@ -546,7 +546,7 @@ publish_callback(void** channelDataPtr, struct mqtt_response_publish *published)
                 channelData->callback(msg, topic);
             }
         }
-    }  
+    }
 }
 
 UA_StatusCode
@@ -555,7 +555,7 @@ subscribeMqtt(UA_PubSubChannelDataMQTT* channelData, UA_String topic, UA_Byte qo
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
     struct mqtt_client* client = (struct mqtt_client*)channelData->mqttClient;
-    
+
     UA_STACKARRAY(char, topicStr, sizeof(char) * topic.length +1);
     memcpy(topicStr, topic.data, topic.length);
     topicStr[topic.length] = '\0';
@@ -584,14 +584,14 @@ yieldMqtt(UA_PubSubChannelDataMQTT* channelData, UA_UInt16 timeout){
     if(!connection) {
         return UA_STATUSCODE_BADCOMMUNICATIONERROR;
     }
-    
+
     if(connection->state != UA_CONNECTIONSTATE_ESTABLISHED &&
        connection->state != UA_CONNECTIONSTATE_OPENING) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_NETWORK,
                      "PubSub MQTT: yield: Tcp Connection not established!");
         return UA_STATUSCODE_BADCOMMUNICATIONERROR;
     }
-    
+
     struct mqtt_client* client = (struct mqtt_client*)channelData->mqttClient;
     client->socketfd->timeout = timeout;
 
@@ -602,11 +602,11 @@ yieldMqtt(UA_PubSubChannelDataMQTT* channelData, UA_UInt16 timeout){
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_NETWORK, "PubSub MQTT: yield: Communication Error.");
         return UA_STATUSCODE_BADCOMMUNICATIONERROR;
     }
-    
+
     /* map mqtt errors to ua errors */
     const char* errorStr = mqtt_error_str(error);
     UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "PubSub MQTT: yield: error: %s", errorStr);
-    
+
     switch(error){
         case MQTT_ERROR_CONNECTION_CLOSED:
             return UA_STATUSCODE_BADNOTCONNECTED;
@@ -614,7 +614,7 @@ yieldMqtt(UA_PubSubChannelDataMQTT* channelData, UA_UInt16 timeout){
             return UA_STATUSCODE_BADCOMMUNICATIONERROR;
         case MQTT_ERROR_CONNECTION_REFUSED:
             return UA_STATUSCODE_BADCONNECTIONREJECTED;
-            
+
         default:
             return UA_STATUSCODE_BADCOMMUNICATIONERROR;
     }
@@ -629,7 +629,7 @@ publishMqtt(UA_PubSubChannelDataMQTT* channelData, UA_String topic, const UA_Byt
     UA_STACKARRAY(char, topicChar, sizeof(char) * topic.length +1);
     memcpy(topicChar, topic.data, topic.length);
     topicChar[topic.length] = '\0';
-    
+
     struct mqtt_client* client = (struct mqtt_client*)channelData->mqttClient;
     if(client == NULL)
         return UA_STATUSCODE_BADNOTCONNECTED;


### PR DESCRIPTION
Code is mixed with `UA_ENABLE_MQTT_TLS_OPENSSL` and NO TLS_OPENSSL.
This PR uses `#ifdef UA_ENABLE_MQTT_TLS_OPENSSL` to separate them.