### PR TITLE
fix(nc): fix ordering of types parsed from xml

### DIFF
--- a/tools/nodeset_compiler/type_parser.py
+++ b/tools/nodeset_compiler/type_parser.py
@@ -302,7 +302,7 @@ class TypeParser():
                     return True
             return False
 
-        snippets = {}
+        snippets = OrderedDict()
         xmlDoc = etree.iterparse(
             xmlDescription, events=['start-ns']
         )


### PR DESCRIPTION
Running the generator under windows and linux produced a different types_generated.h (with a different ordering of the types).
Using and OrderedDict for snippets preserves the ordering and gives a more consistent result.