### PR TITLE
[Review] fix(arch): UA_fd_isset() evaluates to non-zero value

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -844,7 +844,7 @@ UA_ClientConnectionTCP_poll(UA_Connection *connection, UA_UInt32 timeout,
 
     /* The connection is fully opened. Otherwise, select has timed out. But we
      * can retry. */
-    if(resultsize == 1)
+    if(resultsize > 0)
         connection->state = UA_CONNECTIONSTATE_ESTABLISHED;
 
     return UA_STATUSCODE_GOOD;


### PR DESCRIPTION
fix(arch): UA_fd_isset() evaluates to non-zero value

UA_fd_isset() evaluates to a non-zero value if the descriptor is part of the set.

See https://pubs.opengroup.org/onlinepubs/9699919799.2016edition/functions/select.html