### PR TITLE
fix(core): Decoding Boolean must result in either 0 or 1.

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -13,9 +13,12 @@ else:
 # Some types can be memcpy'd off the binary stream. That's especially important
 # for arrays. But we need to check if they contain padding and whether the
 # endianness is correct. This dict gives the C-statement that must be true for the
-# type to be overlayable. Parsed types are added if they apply.
-builtin_overlayable = {"Boolean": "true",
-                       "SByte": "true", "Byte": "true",
+# type to be overlayable. Parsed types are added to the list if they apply.
+#
+# Boolean is not overlayable 1-byte type. We get "undefined behavior" errors
+# during fuzzing if we don't force the value to either exactly true or false.
+builtin_overlayable = {"SByte": "true",
+                       "Byte": "true",
                        "Int16": "UA_BINARY_OVERLAYABLE_INTEGER",
                        "UInt16": "UA_BINARY_OVERLAYABLE_INTEGER",
                        "Int32": "UA_BINARY_OVERLAYABLE_INTEGER",

--- a/tools/nodeset_compiler/type_parser.py
+++ b/tools/nodeset_compiler/type_parser.py
@@ -21,21 +21,20 @@ builtin_types = ["Boolean", "SByte", "Byte", "Int16", "UInt16", "Int32", "UInt32
                  "QualifiedName", "LocalizedText", "ExtensionObject", "DataValue",
                  "Variant", "DiagnosticInfo"]
 
+builtin_pointerfree = ["Boolean", "SByte", "Byte", "Int16", "UInt16",
+                       "Int32", "UInt32", "Int64", "UInt64", "Float", "Double",
+                       "DateTime", "StatusCode", "Guid"]
+
 # DataTypes that are ignored/not generated
 excluded_types = [
     # NodeId Types
-    "NodeIdType", "TwoByteNodeId", "FourByteNodeId", "NumericNodeId", "StringNodeId", "GuidNodeId", "ByteStringNodeId",
+    "NodeIdType", "TwoByteNodeId", "FourByteNodeId", "NumericNodeId",
+    "StringNodeId", "GuidNodeId", "ByteStringNodeId",
     # Node Types
     "InstanceNode", "TypeNode", "Node", "ObjectNode", "ObjectTypeNode", "VariableNode",
     "VariableTypeNode", "ReferenceTypeNode", "MethodNode", "ViewNode", "DataTypeNode"]
 
 rename_types = {"NumericRange": "OpaqueNumericRange"}
-
-# Boolean is not overlayable 1-byte type. We get "undefined behavior" errors
-# during fuzzing if we don't force the value to either exactly true or false.
-builtin_overlayable = ["SByte", "Byte", "Int16", "UInt16", "Int32", "UInt32",
-                       "Int64", "UInt64", "Float", "Double", "DateTime",
-                       "StatusCode", "Guid"]
 
 # Type aliases
 type_aliases = {"CharArray": "String"}
@@ -92,8 +91,7 @@ class BuiltinType(Type):
     def __init__(self, name):
         Type.__init__(self, "types", None, "http://opcfoundation.org/UA/")
         self.name = name
-        if self.name in builtin_overlayable:
-            self.pointerfree = True
+        self.pointerfree = self.name in builtin_pointerfree
 
 
 class EnumerationType(Type):


### PR DESCRIPTION
Don't allow any 8-bit result as this will give a warning during fuzzing.

Actually fix what was attempted in
e26cf59af81d1924f81eda32b332668600095243.