### PR TITLE
feat(ci) Optimizations for faster AppVeyor builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,32 @@
+name: "Coverage Test"
+on:
+  push:
+    branches: [ main, master ]
+    tags:
+      - v1.*
+  pull_request:
+    branches: [ main, master ]
+    tags:
+      - v1.*
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -qq python3-sphinx graphviz check libmbedtls-dev
+      - name: Fetch
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Execute Tests
+        run: source tools/ci.sh && unit_tests_with_coverage
+        env:
+          ETHERNET_INTERFACE: eth0
+      - name: Debug print
+        run: |
+          tree .
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,8 +289,9 @@ if((UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS) AND (NOT (UA_ENABLE_SUBSCRIPTIONS
 endif()
 
 if(UA_ENABLE_COVERAGE)
-  set(CMAKE_BUILD_TYPE DEBUG)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
+  # We are using the scripts provided at for coverage testing: https://github.com/RWTH-HPC/CMake-codecov
+  set(ENABLE_COVERAGE ON)
+  find_package(codecov REQUIRED)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -lgcov")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
@@ -1360,7 +1361,9 @@ else()
                       open62541-generator-statuscode
                       open62541-generator-namespace
                       )
-
+    if(UA_ENABLE_COVERAGE)
+        add_coverage(open62541-object)
+    endif()
     target_include_directories(open62541-object PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
     add_library(open62541-plugins OBJECT ${default_plugin_sources} ${ua_architecture_sources} ${exported_headers})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ clone_folder: c:\projects\open62541
 skip_branch_with_pr: true
 
 # Fast finish (stop other builds if one fails) to speed up appveyor builds
-# matrix:
-#  fast_finish: true
+matrix:
+  fast_finish: true
 
 environment:
     global:
@@ -30,7 +30,6 @@ cache:
   - C:\ProgramData\chocolatey\bin -> tools/appveyor/install.ps1
   - C:\ProgramData\chocolatey\lib -> tools/appveyor/install.ps1
   - C:\tools\vcpkg\installed -> tools/appveyor/install.ps1
-  #- 'c:\miktex'
 
 init:
   - git config --global core.autocrlf input # Attempt to ensure we don't try to convert line endings to Win32 CRLF as this will cause build to fail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,6 +156,9 @@ endif()
 add_library(open62541-testplugins OBJECT ${test_plugin_sources} ${PROJECT_SOURCE_DIR}/arch/${UA_ARCHITECTURE}/ua_architecture_functions.c)
 add_dependencies(open62541-testplugins open62541)
 target_compile_definitions(open62541-testplugins PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
+if(UA_ENABLE_COVERAGE)
+    add_coverage(open62541-testplugins)
+endif()
 
 # Workaround some clang warnings in the uni tests
 if((NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD") AND (CMAKE_COMPILER_IS_GNUCC OR "x${CMAKE_C_COMPILER_ID}" STREQUAL "xClang"))

--- a/tools/appveyor/build.ps1
+++ b/tools/appveyor/build.ps1
@@ -28,24 +28,7 @@ try {
     Copy-Item README.md pack
 
     Write-Host -ForegroundColor Green "`n###################################################################"
-    Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with amalgamation #####`n"
-    New-Item -ItemType directory -Path "build"
-    cd build
-    & cmake $cmake_cnf `
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
-            -DUA_BUILD_EXAMPLES:BOOL=OFF  `
-            -DUA_ENABLE_AMALGAMATION:BOOL=ON `
-            -DUA_ENABLE_ENCRYPTION:STRING=$build_encryption ..
-    & cmake --build . --config RelWithDebInfo
-    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-        Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
-        exit $LASTEXITCODE
-    }
-    cd ..
-    Remove-Item -Path build -Recurse -Force
-
-    Write-Host -ForegroundColor Green "`n###################################################################"
-    Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with full NS0 #####`n"
+    Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with PubSub #####`n"
     New-Item -ItemType directory -Path "build"
     cd build
     & cmake $cmake_cnf `
@@ -59,7 +42,7 @@ try {
             -DUA_ENABLE_SUBSCRIPTIONS_EVENTS:BOOL=ON `
             -DUA_ENABLE_PUBSUB_MQTT:BOOL=ON `
 	        -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS:BOOL=ON `
-            -DUA_NAMESPACE_ZERO:STRING=FULL ..
+            -DUA_NAMESPACE_ZERO:STRING=REDUCED ..
     & cmake --build . --config RelWithDebInfo
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -211,6 +211,34 @@ function unit_tests_encryption_mbedtls_pubsub {
 }
 
 ##########################################
+# Build and Run Unit Tests with Coverage #
+##########################################
+
+function unit_tests_with_coverage {
+    mkdir -p build; cd build; rm -rf *
+    cmake -DCMAKE_BUILD_TYPE=Debug \
+          -DUA_BUILD_EXAMPLES=ON \
+          -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_COVERAGE=ON \
+          -DUA_ENABLE_DISCOVERY=ON \
+          -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
+          -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+          -DUA_ENABLE_HISTORIZING=ON \
+          -DUA_ENABLE_JSON_ENCODING=ON \
+          -DUA_ENABLE_PUBSUB=ON \
+          -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
+          -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
+          -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_ENABLE_ENCRYPTION=MBEDTLS \
+          ..
+    make ${MAKEOPTS}
+    set_capabilities
+    make test ARGS="-V"
+    make gcov
+}
+
+##########################################
 # Build and Run Unit Tests with Valgrind #
 ##########################################
 

--- a/tools/cmake/FindGcov.cmake
+++ b/tools/cmake/FindGcov.cmake
@@ -1,0 +1,162 @@
+# This file is part of CMake-codecov.
+#
+# Copyright (c)
+#   2015-2020 RWTH Aachen University, Federal Republic of Germany
+#
+# See the LICENSE file in the package base directory for details
+#
+# Written by Alexander Haase, alexander.haase@rwth-aachen.de
+#
+
+
+# include required Modules
+include(FindPackageHandleStandardArgs)
+
+
+# Search for gcov binary.
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
+
+get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+foreach (LANG ${ENABLED_LANGUAGES})
+	# Gcov evaluation is dependent on the used compiler. Check gcov support for
+	# each compiler that is used. If gcov binary was already found for this
+	# compiler, do not try to find it again.
+	if (NOT GCOV_${CMAKE_${LANG}_COMPILER_ID}_BIN)
+		get_filename_component(COMPILER_PATH "${CMAKE_${LANG}_COMPILER}" PATH)
+
+		if ("${CMAKE_${LANG}_COMPILER_ID}" STREQUAL "GNU")
+			# Some distributions like OSX (homebrew) ship gcov with the compiler
+			# version appended as gcov-x. To find this binary we'll build the
+			# suggested binary name with the compiler version.
+			string(REGEX MATCH "^[0-9]+" GCC_VERSION
+				"${CMAKE_${LANG}_COMPILER_VERSION}")
+
+			find_program(GCOV_BIN NAMES gcov-${GCC_VERSION} gcov
+				HINTS ${COMPILER_PATH})
+
+		elseif ("${CMAKE_${LANG}_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
+			# Some distributions like Debian ship llvm-cov with the compiler
+			# version appended as llvm-cov-x.y. To find this binary we'll build
+			# the suggested binary name with the compiler version.
+			string(REGEX MATCH "^[0-9]+.[0-9]+" LLVM_VERSION
+				"${CMAKE_${LANG}_COMPILER_VERSION}")
+
+			# llvm-cov prior version 3.5 seems to be not working with coverage
+			# evaluation tools, but these versions are compatible with the gcc
+			# gcov tool.
+			if(LLVM_VERSION VERSION_GREATER 3.4)
+				find_program(LLVM_COV_BIN NAMES "llvm-cov-${LLVM_VERSION}"
+					"llvm-cov" HINTS ${COMPILER_PATH})
+				mark_as_advanced(LLVM_COV_BIN)
+
+				if (LLVM_COV_BIN)
+					find_program(LLVM_COV_WRAPPER "llvm-cov-wrapper" PATHS
+						${CMAKE_MODULE_PATH})
+					if (LLVM_COV_WRAPPER)
+						set(GCOV_BIN "${LLVM_COV_WRAPPER}" CACHE FILEPATH "")
+
+						# set additional parameters
+						set(GCOV_${CMAKE_${LANG}_COMPILER_ID}_ENV
+							"LLVM_COV_BIN=${LLVM_COV_BIN}" CACHE STRING
+							"Environment variables for llvm-cov-wrapper.")
+						mark_as_advanced(GCOV_${CMAKE_${LANG}_COMPILER_ID}_ENV)
+					endif ()
+				endif ()
+			endif ()
+
+			if (NOT GCOV_BIN)
+				# Fall back to gcov binary if llvm-cov was not found or is
+				# incompatible. This is the default on OSX, but may crash on
+				# recent Linux versions.
+				find_program(GCOV_BIN gcov HINTS ${COMPILER_PATH})
+			endif ()
+		endif ()
+
+
+		if (GCOV_BIN)
+			set(GCOV_${CMAKE_${LANG}_COMPILER_ID}_BIN "${GCOV_BIN}" CACHE STRING
+				"${LANG} gcov binary.")
+
+			if (NOT CMAKE_REQUIRED_QUIET)
+				message("-- Found gcov evaluation for "
+				"${CMAKE_${LANG}_COMPILER_ID}: ${GCOV_BIN}")
+			endif()
+
+			unset(GCOV_BIN CACHE)
+		endif ()
+	endif ()
+endforeach ()
+
+
+
+
+# Add a new global target for all gcov targets. This target could be used to
+# generate the gcov files for the whole project instead of calling <TARGET>-gcov
+# for each target.
+if (NOT TARGET gcov)
+	add_custom_target(gcov)
+endif (NOT TARGET gcov)
+
+
+
+# This function will add gcov evaluation for target <TNAME>. Only sources of
+# this target will be evaluated and no dependencies will be added. It will call
+# Gcov on any source file of <TNAME> once and store the gcov file in the same
+# directory.
+function (add_gcov_target TNAME)
+	get_target_property(TBIN_DIR ${TNAME} BINARY_DIR)
+	set(TDIR ${TBIN_DIR}/CMakeFiles/${TNAME}.dir)
+
+	# We don't have to check, if the target has support for coverage, thus this
+	# will be checked by add_coverage_target in Findcoverage.cmake. Instead we
+	# have to determine which gcov binary to use.
+	get_target_property(TSOURCES ${TNAME} SOURCES)
+	set(SOURCES "")
+	set(TCOMPILER "")
+	foreach (FILE ${TSOURCES})
+		codecov_path_of_source(${FILE} FILE)
+		if (NOT "${FILE}" STREQUAL "")
+			codecov_lang_of_source(${FILE} LANG)
+			if (NOT "${LANG}" STREQUAL "")
+				list(APPEND SOURCES "${FILE}")
+				set(TCOMPILER ${CMAKE_${LANG}_COMPILER_ID})
+			endif ()
+		endif ()
+	endforeach ()
+
+	# If no gcov binary was found, coverage data can't be evaluated.
+	if (NOT GCOV_${TCOMPILER}_BIN)
+		message(WARNING "No coverage evaluation binary found for ${TCOMPILER}.")
+		return()
+	endif ()
+
+	set(GCOV_BIN "${GCOV_${TCOMPILER}_BIN}")
+	set(GCOV_ENV "${GCOV_${TCOMPILER}_ENV}")
+
+
+	set(BUFFER "")
+	set(NULL_DEVICE "/dev/null")
+	if(WIN32)
+		set(NULL_DEVICE "NUL")
+	endif()
+	foreach(FILE ${SOURCES})
+		get_filename_component(FILE_PATH "${TDIR}/${FILE}" PATH)
+
+		# call gcov
+		add_custom_command(OUTPUT ${TDIR}/${FILE}.gcov
+			COMMAND ${GCOV_ENV} ${GCOV_BIN} -p ${TDIR}/${FILE}.gcno > ${NULL_DEVICE}
+			DEPENDS ${TNAME} ${TDIR}/${FILE}.gcno
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		)
+
+		list(APPEND BUFFER ${TDIR}/${FILE}.gcov)
+	endforeach()
+
+
+	# add target for gcov evaluation of <TNAME>
+	add_custom_target(${TNAME}-gcov DEPENDS ${BUFFER})
+
+	# add evaluation target to the global gcov target.
+	add_dependencies(gcov ${TNAME}-gcov)
+endfunction (add_gcov_target)

--- a/tools/cmake/Findcodecov.cmake
+++ b/tools/cmake/Findcodecov.cmake
@@ -1,0 +1,265 @@
+# This file is part of CMake-codecov.
+#
+# Copyright (c)
+#   2015-2020 RWTH Aachen University, Federal Republic of Germany
+#
+# See the LICENSE file in the package base directory for details
+#
+# Written by Alexander Haase, alexander.haase@rwth-aachen.de
+#
+
+set(COVERAGE_FLAG_CANDIDATES
+	# gcc and clang
+	"-O0 -g -fprofile-arcs -ftest-coverage"
+
+	# gcc and clang fallback
+	"-O0 -g --coverage"
+)
+
+
+# Add coverage support for target ${TNAME} and register target for coverage
+# evaluation. If coverage is disabled or not supported, this function will
+# simply do nothing.
+#
+# Note: This function is only a wrapper to define this function always, even if
+#   coverage is not supported by the compiler or disabled. This function must
+#   be defined here, because the module will be exited, if there is no coverage
+#   support by the compiler or it is disabled by the user.
+function (add_coverage TNAME)
+	# only add coverage for target, if coverage is support and enabled.
+	if (ENABLE_COVERAGE)
+		foreach (TNAME ${ARGV})
+			add_coverage_target(${TNAME})
+		endforeach ()
+	endif ()
+endfunction (add_coverage)
+
+
+# Add global target to gather coverage information after all targets have been
+# added. Other evaluation functions could be added here, after checks for the
+# specific module have been passed.
+#
+# Note: This function is only a wrapper to define this function always, even if
+#   coverage is not supported by the compiler or disabled. This function must
+#   be defined here, because the module will be exited, if there is no coverage
+#   support by the compiler or it is disabled by the user.
+function (coverage_evaluate)
+	# add lcov evaluation
+	if (LCOV_FOUND)
+		lcov_capture_initial()
+		lcov_capture()
+	endif (LCOV_FOUND)
+endfunction ()
+
+
+# Exit this module, if coverage is disabled. add_coverage is defined before this
+# return, so this module can be exited now safely without breaking any build-
+# scripts.
+if (NOT ENABLE_COVERAGE)
+	return()
+endif ()
+
+
+
+
+# Find the required flags foreach language.
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
+
+get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+foreach (LANG ${ENABLED_LANGUAGES})
+	if (NOT ${LANG} MATCHES "^(C|CXX|Fortran)$")
+		message(STATUS "Skipping coverage for unsupported language: ${LANG}")
+		continue()
+	endif ()
+
+	# Coverage flags are not dependent on language, but the used compiler. So
+	# instead of searching flags foreach language, search flags foreach compiler
+	# used.
+	set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+	if (NOT COVERAGE_${COMPILER}_FLAGS)
+		foreach (FLAG ${COVERAGE_FLAG_CANDIDATES})
+			if(NOT CMAKE_REQUIRED_QUIET)
+				message(STATUS "Try ${COMPILER} code coverage flag = [${FLAG}]")
+			endif()
+
+			set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+			unset(COVERAGE_FLAG_DETECTED CACHE)
+
+			if (${LANG} STREQUAL "C")
+				include(CheckCCompilerFlag)
+				check_c_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+
+			elseif (${LANG} STREQUAL "CXX")
+				include(CheckCXXCompilerFlag)
+				check_cxx_compiler_flag("${FLAG}" COVERAGE_FLAG_DETECTED)
+
+			elseif (${LANG} STREQUAL "Fortran")
+				# CheckFortranCompilerFlag was introduced in CMake 3.x. To be
+				# compatible with older Cmake versions, we will check if this
+				# module is present before we use it. Otherwise we will define
+				# Fortran coverage support as not available.
+				include(CheckFortranCompilerFlag OPTIONAL
+					RESULT_VARIABLE INCLUDED)
+				if (INCLUDED)
+					check_fortran_compiler_flag("${FLAG}"
+						COVERAGE_FLAG_DETECTED)
+				elseif (NOT CMAKE_REQUIRED_QUIET)
+					message("-- Performing Test COVERAGE_FLAG_DETECTED")
+					message("-- Performing Test COVERAGE_FLAG_DETECTED - Failed"
+						" (Check not supported)")
+				endif ()
+			endif()
+
+			if (COVERAGE_FLAG_DETECTED)
+				set(COVERAGE_${COMPILER}_FLAGS "${FLAG}"
+					CACHE STRING "${COMPILER} flags for code coverage.")
+				mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
+				break()
+			else ()
+				message(WARNING "Code coverage is not available for ${COMPILER}"
+				        " compiler. Targets using this compiler will be "
+				        "compiled without it.")
+			endif ()
+		endforeach ()
+	endif ()
+endforeach ()
+
+set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
+
+
+
+
+# Helper function to get the language of a source file.
+function (codecov_lang_of_source FILE RETURN_VAR)
+	# Usually, only the last extension of the file should be checked, to avoid
+	# template files (i.e. *.t.cpp) are checked with the full file extension.
+	# However, this feature requires CMake 3.14 or later.
+	set(EXT_COMP "LAST_EXT")
+	if(${CMAKE_VERSION} VERSION_LESS "3.14.0")
+		set(EXT_COMP "EXT")
+	endif()
+
+	get_filename_component(FILE_EXT "${FILE}" ${EXT_COMP})
+	string(TOLOWER "${FILE_EXT}" FILE_EXT)
+	string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
+
+	get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+	foreach (LANG ${ENABLED_LANGUAGES})
+		list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
+		if (NOT ${TEMP} EQUAL -1)
+			set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
+			return()
+		endif ()
+	endforeach()
+
+	set(${RETURN_VAR} "" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to get the relative path of the source file destination path.
+# This path is needed by FindGcov and FindLcov cmake files to locate the
+# captured data.
+function (codecov_path_of_source FILE RETURN_VAR)
+	string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _source ${FILE})
+
+	# If expression was found, SOURCEFILE is a generator-expression for an
+	# object library. Currently we found no way to call this function automatic
+	# for the referenced target, so it must be called in the directoryso of the
+	# object library definition.
+	if (NOT "${_source}" STREQUAL "")
+		set(${RETURN_VAR} "" PARENT_SCOPE)
+		return()
+	endif ()
+
+
+	string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/" "" FILE "${FILE}")
+	if(IS_ABSOLUTE ${FILE})
+		file(RELATIVE_PATH FILE ${CMAKE_CURRENT_SOURCE_DIR} ${FILE})
+	endif()
+
+	# get the right path for file
+	string(REPLACE ".." "__" PATH "${FILE}")
+
+	set(${RETURN_VAR} "${PATH}" PARENT_SCOPE)
+endfunction()
+
+
+
+
+# Add coverage support for target ${TNAME} and register target for coverage
+# evaluation.
+function(add_coverage_target TNAME)
+	# Check if all sources for target use the same compiler. If a target uses
+	# e.g. C and Fortran mixed and uses different compilers (e.g. clang and
+	# gfortran) this can trigger huge problems, because different compilers may
+	# use different implementations for code coverage.
+	get_target_property(TSOURCES ${TNAME} SOURCES)
+	set(TARGET_COMPILER "")
+	set(ADDITIONAL_FILES "")
+	foreach (FILE ${TSOURCES})
+		# If expression was found, FILE is a generator-expression for an object
+		# library. Object libraries will be ignored.
+		string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
+		if ("${_file}" STREQUAL "")
+			codecov_lang_of_source(${FILE} LANG)
+			if (LANG)
+				list(APPEND TARGET_COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+
+				list(APPEND ADDITIONAL_FILES "${FILE}.gcno")
+				list(APPEND ADDITIONAL_FILES "${FILE}.gcda")
+			endif ()
+		endif ()
+	endforeach ()
+
+	list(REMOVE_DUPLICATES TARGET_COMPILER)
+	list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+
+	if (NUM_COMPILERS GREATER 1)
+		message(WARNING "Can't use code coverage for target ${TNAME}, because "
+		        "it will be compiled by incompatible compilers. Target will be "
+		        "compiled without code coverage.")
+		return()
+
+	elseif (NUM_COMPILERS EQUAL 0)
+		message(WARNING "Can't use code coverage for target ${TNAME}, because "
+		        "it uses an unknown compiler. Target will be compiled without "
+		        "code coverage.")
+		return()
+
+	elseif (NOT DEFINED "COVERAGE_${TARGET_COMPILER}_FLAGS")
+		# A warning has been printed before, so just return if flags for this
+		# compiler aren't available.
+		return()
+	endif()
+
+
+	# enable coverage for target
+	set_property(TARGET ${TNAME} APPEND_STRING
+		PROPERTY COMPILE_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
+	set_property(TARGET ${TNAME} APPEND_STRING
+		PROPERTY LINK_FLAGS " ${COVERAGE_${TARGET_COMPILER}_FLAGS}")
+
+
+	# Add gcov files generated by compiler to clean target.
+	set(CLEAN_FILES "")
+	foreach (FILE ${ADDITIONAL_FILES})
+		codecov_path_of_source(${FILE} FILE)
+		list(APPEND CLEAN_FILES "CMakeFiles/${TNAME}.dir/${FILE}")
+	endforeach()
+
+	if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
+		set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
+			"${CLEAN_FILES}")
+	else()
+		set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES
+			"${CLEAN_FILES}")
+	endif()
+
+
+	add_gcov_target(${TNAME})
+endfunction(add_coverage_target)
+
+# Include modules for parsing the collected data and output it in a readable
+# format (like gcov and lcov).
+find_package(Gcov)


### PR DESCRIPTION
Since AppVeyor builds currently need ~1:45h this PR reduces the number of tested features and enables the "fast_finish" strategy, which stops the build after the first failed run. E.g. if vs2008 fails than vs2013 is not executed.