### PR TITLE
feat(ci) Optimizations for faster AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ clone_folder: c:\projects\open62541
 skip_branch_with_pr: true
 
 # Fast finish (stop other builds if one fails) to speed up appveyor builds
-# matrix:
-#  fast_finish: true
+matrix:
+  fast_finish: true
 
 environment:
     global:
@@ -30,7 +30,6 @@ cache:
   - C:\ProgramData\chocolatey\bin -> tools/appveyor/install.ps1
   - C:\ProgramData\chocolatey\lib -> tools/appveyor/install.ps1
   - C:\tools\vcpkg\installed -> tools/appveyor/install.ps1
-  #- 'c:\miktex'
 
 init:
   - git config --global core.autocrlf input # Attempt to ensure we don't try to convert line endings to Win32 CRLF as this will cause build to fail

--- a/tools/appveyor/build.ps1
+++ b/tools/appveyor/build.ps1
@@ -28,24 +28,7 @@ try {
     Copy-Item README.md pack
 
     Write-Host -ForegroundColor Green "`n###################################################################"
-    Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with amalgamation #####`n"
-    New-Item -ItemType directory -Path "build"
-    cd build
-    & cmake $cmake_cnf `
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
-            -DUA_BUILD_EXAMPLES:BOOL=OFF  `
-            -DUA_ENABLE_AMALGAMATION:BOOL=ON `
-            -DUA_ENABLE_ENCRYPTION:STRING=$build_encryption ..
-    & cmake --build . --config RelWithDebInfo
-    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-        Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
-        exit $LASTEXITCODE
-    }
-    cd ..
-    Remove-Item -Path build -Recurse -Force
-
-    Write-Host -ForegroundColor Green "`n###################################################################"
-    Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with full NS0 #####`n"
+    Write-Host -ForegroundColor Green "`n##### Testing $env:CC_NAME with PubSub #####`n"
     New-Item -ItemType directory -Path "build"
     cd build
     & cmake $cmake_cnf `
@@ -58,8 +41,7 @@ try {
             -DUA_ENABLE_PUBSUB_INFORMATIONMODEL:BOOL=ON `
             -DUA_ENABLE_SUBSCRIPTIONS_EVENTS:BOOL=ON `
             -DUA_ENABLE_PUBSUB_MQTT:BOOL=ON `
-	        -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS:BOOL=ON `
-            -DUA_NAMESPACE_ZERO:STRING=FULL ..
+            -DUA_NAMESPACE_ZERO:STRING=REDUCED ..
     & cmake --build . --config RelWithDebInfo
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"


### PR DESCRIPTION
Since AppVeyor builds currently need ~1:45h this PR reduces the number of tested features and enables the "fast_finish" strategy, which stops the build after the first failed run. E.g. if vs2008 fails than vs2013 is not executed.