### PR TITLE
server(deps) update and fix ua-nodeset (5fdc7d4 to f71b3f4)

### DIFF
--- a/examples/nodeset/CMakeLists.txt
+++ b/examples/nodeset/CMakeLists.txt
@@ -91,7 +91,7 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     ua_generate_nodeset_and_datatypes(
         NAME "plc"
         # PLCopen does not define custom types. Only generate the nodeset
-        FILE_NS "${FILE_NS_DIRPREFIX}/PLCopen/Opc.Ua.Plc.NodeSet2.xml"
+        FILE_NS "${FILE_NS_DIRPREFIX}/PLCopen/Opc.Ua.PLCopen.NodeSet2_V1.02.xml"
         # PLCopen depends on the di nodeset, which must be generated before
         DEPENDS "di"
         INTERNAL

--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -45,7 +45,7 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     ua_generate_nodeset_and_datatypes(
         NAME "tests-plc"
         # PLCopen does not define custom types. Only generate the nodeset
-        FILE_NS "${open62541_NODESET_DIR}/PLCopen/Opc.Ua.Plc.NodeSet2.xml"
+        FILE_NS "${open62541_NODESET_DIR}/PLCopen/Opc.Ua.PLCopen.NodeSet2_V1.02.xml"
         # PLCopen depends on the di nodeset, which must be generated before
         OUTPUT_DIR "${GENERATE_OUTPUT_DIR}"
         DEPENDS "tests-di"

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -246,7 +246,7 @@ class CGenerator(object):
             return "typedef enum {\n    " + ",\n    ".join(
                 map(lambda kv: makeCIdentifier("UA_" + enum.name.upper() + "_" + kv[0].upper()) +
                                " = " + kv[1], values)) + \
-                   ",\n    __UA_{0}_FORCE32BIT = 0x7fffffff\n".format(makeCIdentifier(enum.name.upper())) + "} " + \
+                   "{}\n    __UA_{}_FORCE32BIT = 0x7fffffff\n".format("," if len(enum.elements) != 0 else "", makeCIdentifier(enum.name.upper())) + "} " + \
                    "UA_{0};\nUA_STATIC_ASSERT(sizeof(UA_{0}) == sizeof(UA_Int32), enum_must_be_32bit);".format(
                        makeCIdentifier(enum.name))
 

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -559,6 +559,9 @@ class DataTypeNode(Node):
                         isOptional = str(av)
                     elif at == "ArrayDimensions":
                         arrayDimensions = int(av)
+                    elif at == "AllowSubTypes":
+                        # ignore
+                        continue
                     else:
                         logger.warn("Unknown Field Attribute " + str(at))
                 # This can either be an enumeration OR a structure, not both.


### PR DESCRIPTION
Move ua-nodeset to f71b3f4 (Tag Glass=1.0.0-2022-01-01)
Fix nodeset compiler to handle new empty enumartion, contained in types-bsd.