### PR TITLE
fix(build) resolve cmake warning during find check library

### DIFF
--- a/tools/cmake/FindCheck.cmake
+++ b/tools/cmake/FindCheck.cmake
@@ -17,7 +17,7 @@
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
 
-INCLUDE( FindPkgConfig )
+find_package(PkgConfig REQUIRED)
 
 # Take care about check.pc settings
 PKG_SEARCH_MODULE( CHECK check )


### PR DESCRIPTION
This PR adjusts the FindCheck.cmake logic to avoid the current cmake warning (if unit tests are enabled).