### PR TITLE
fix(arch): Use AF_INET in the socket hints if IPV6 is disabled

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -408,7 +408,11 @@ ServerNetworkLayerTCP_start(UA_ServerNetworkLayer *nl, const UA_Logger *logger,
     UA_snprintf(portno, 6, "%d", layer->port);
     struct addrinfo hints, *res;
     memset(&hints, 0, sizeof hints);
-    hints.ai_family = AF_UNSPEC;
+#if UA_IPV6
+    hints.ai_family = AF_UNSPEC; /* allow IPv4 and IPv6 */
+#else
+    hints.ai_family = AF_INET;   /* enforce IPv4 only */
+#endif
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = AI_PASSIVE;
     hints.ai_protocol = IPPROTO_TCP;


### PR DESCRIPTION
The issue was reported and fixed by @tboeckel in #4770