### PR TITLE
[Review] core(deps): Bumps LibreSSL to 3.4.2

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -35,9 +35,9 @@ jobs:
           - build_name: "Encryption (LibreSSL) Build & Unit Tests (gcc)"
             cmd_deps: |
                 sudo apt-get install -y -qq curl
-                curl https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.4.1.tar.gz --output libressl.tar.gz
+                curl https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.4.2.tar.gz --output libressl.tar.gz
                 tar -xvz -f libressl.tar.gz
-                cd libressl-3.4.1
+                cd libressl-3.4.2
                 ./configure
                 sudo make install
             cmd_action: unit_tests_encryption LIBRESSL


### PR DESCRIPTION
* fixes [CB-K21-1240](https://www.cert-bund.de/advisoryshort/CB-K21-1240)