### PR TITLE
[REVIEW] fix(core): Decoding variant with array of structure fails

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,17 @@
 This changelog reports changes visible through the public API. Internal refactorings and bug
 fixes are not reported here.
 
+2023-07-02 Jonas Green <jgr at hms.se>
+
+ * Decoding variant with array of structure
+
+   When decoding an array of structures the extension objects that
+   each structure is wrapped into is now unwrapped if the array 
+   contains only a single type. Previously the decoding API returned
+   an array of extension objects. If the array of extension objects 
+   has more than one type the decoding result will be an array of
+   extension objects.
+
 2022-12-03 Julius Pfrommer <julius.pfrommer at iosb.fraunhofer.de>
 
  * KeyValueMap in PubSub configuration

--- a/tests/check_types_builtin.c
+++ b/tests/check_types_builtin.c
@@ -20,6 +20,71 @@ enum UA_VARIANT_ENCODINGMASKTYPE_enum {
     UA_VARIANT_ENCODINGMASKTYPE_ARRAY       = (0x01 << 7)      // bit 7
 };
 
+static UA_Variant* EncodeDecodeVariant(UA_Variant* sourceVariant) {
+    UA_ByteString encodedVariant;
+    UA_ByteString_init(&encodedVariant);
+    UA_StatusCode encodeResult = UA_encodeBinary(sourceVariant, &UA_TYPES[UA_TYPES_VARIANT], &encodedVariant);
+    UA_Variant* decodedVariant = UA_Variant_new();
+    UA_StatusCode decodeResult = UA_decodeBinary(&encodedVariant, decodedVariant, &UA_TYPES[UA_TYPES_VARIANT], NULL );
+
+    ck_assert_int_eq(encodeResult, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(decodeResult, UA_STATUSCODE_GOOD);
+
+    UA_ByteString_clear(&encodedVariant);
+
+    return decodedVariant;
+}
+
+static void AssertVariantsEqual(UA_Variant* v1, UA_Variant* v2) {
+    ck_assert_ptr_eq(v1->type, v2->type);
+    ck_assert_uint_eq(v1->arrayLength, v2->arrayLength);
+    ck_assert_uint_eq(v1->arrayDimensionsSize, v2->arrayDimensionsSize);
+
+    for(size_t i = 0; i < v1->arrayDimensionsSize; i++) {
+       ck_assert_uint_eq(v1->arrayDimensions[i], v2->arrayDimensions[i]);
+    }
+
+    if(v1->type->pointerFree) {
+       int cmp = memcmp(v1->data, v2->data, v1->type->memSize * v1->arrayLength);
+       ck_assert_int_eq(cmp, 0);
+    }
+}
+
+static void EncodeDecodeArrayOfExtensionObjectTest(UA_ExtensionObject* sourceArray, size_t arraySize) {
+    UA_UInt32 dimensions = (UA_UInt32)arraySize;
+
+    UA_Variant sourceVariant;
+    UA_Variant_setArray(&sourceVariant, sourceArray, arraySize, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
+    sourceVariant.arrayDimensionsSize = 1;
+    sourceVariant.arrayDimensions = &dimensions;
+
+    UA_Variant* decodedVariant = EncodeDecodeVariant(&sourceVariant);
+    AssertVariantsEqual(&sourceVariant, decodedVariant);
+    UA_ExtensionObject* decodedArray = (UA_ExtensionObject*)decodedVariant->data;
+
+    for(size_t i = 0; i < arraySize; i++) {
+        ck_assert_uint_eq(sourceArray[i].encoding,
+                          decodedArray[i].encoding);
+        if(sourceArray[i].encoding < UA_EXTENSIONOBJECT_DECODED ) {
+           ck_assert_uint_eq(UA_NodeId_order(&sourceArray[i].content.encoded.typeId,
+                                             &decodedArray[i].content.encoded.typeId),
+                             UA_ORDER_EQ);
+           ck_assert(UA_String_equal(&sourceArray[i].content.encoded.body,
+                                     &decodedArray[i].content.encoded.body));
+        }
+        else {
+           ck_assert_ptr_eq(sourceArray[i].content.decoded.type,
+                            decodedArray[i].content.decoded.type);
+           int cmp = memcmp(sourceArray[i].content.decoded.data,
+                            decodedArray[i].content.decoded.data,
+                            sourceArray[i].content.decoded.type->memSize);
+           ck_assert_int_eq(cmp, 0);
+        }
+    }
+
+    UA_Variant_delete(decodedVariant);
+}
+
 START_TEST(UA_Byte_decodeShallCopyAndAdvancePosition) {
     // given
     UA_Byte dst;
@@ -1506,6 +1571,130 @@ START_TEST(UA_ExtensionObject_encodeDecodeShallWorkOnExtensionObject) {
 }
 END_TEST
 
+START_TEST(UA_Variant_encodeDecodeShallWorkOnVariantWithStruct) {
+    UA_Range* sourceRange = UA_Range_new();
+    sourceRange->low = 1.0;
+    sourceRange->high = 10.0;
+
+    UA_Variant sourceVariant;
+    UA_Variant_setScalar(&sourceVariant, sourceRange, &UA_TYPES[UA_TYPES_RANGE]);
+
+    UA_Variant* decodedVariant = EncodeDecodeVariant(&sourceVariant);
+    AssertVariantsEqual(&sourceVariant, decodedVariant);
+
+    UA_Variant_delete(decodedVariant);
+    UA_Variant_clear(&sourceVariant);
+}
+END_TEST
+
+START_TEST(UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfStruct) {
+    const size_t arraySize = 2;
+    UA_Range* sourceRangeArray = (UA_Range*)UA_Array_new( arraySize, &UA_TYPES[UA_TYPES_RANGE]);
+
+    for(size_t i = 0; i < arraySize; i++) {
+        UA_Range* rangeElement = &sourceRangeArray[i];
+        UA_Range_init(rangeElement);
+        rangeElement->low = 1.0;
+        rangeElement->high = 10.0;
+    }
+
+    UA_UInt32 *dimensions;
+    dimensions = (UA_UInt32*)UA_malloc(sizeof(UA_UInt32));
+    dimensions[0] = (UA_UInt32)arraySize;
+
+    UA_Variant sourceVariant;
+    UA_Variant_setArray(&sourceVariant, sourceRangeArray, arraySize, &UA_TYPES[UA_TYPES_RANGE]);
+    sourceVariant.arrayDimensionsSize = 1;
+    sourceVariant.arrayDimensions = dimensions;
+
+    UA_Variant* decodedVariant = EncodeDecodeVariant(&sourceVariant);
+    AssertVariantsEqual(&sourceVariant, decodedVariant);
+
+    UA_Variant_delete(decodedVariant);
+    UA_Variant_clear(&sourceVariant);
+}
+END_TEST
+
+START_TEST(UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfDifferentTypes) {
+    const size_t arraySize = 2;
+    UA_ExtensionObject sourceArray[arraySize];
+    UA_Range arrayElement0 = { 1.0, 2.0 };
+    UA_ComplexNumberType arrayElement1 = { 3.0, 4.0 };
+
+    UA_ExtensionObject* arrayElement = &sourceArray[0];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_DECODED;
+    arrayElement->content.decoded.data = &arrayElement0;
+    arrayElement->content.decoded.type = &UA_TYPES[UA_TYPES_RANGE];
+
+    arrayElement = &sourceArray[1];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_DECODED;
+    arrayElement->content.decoded.data = &arrayElement1;
+    arrayElement->content.decoded.type = &UA_TYPES[UA_TYPES_COMPLEXNUMBERTYPE];
+
+    EncodeDecodeArrayOfExtensionObjectTest(sourceArray, arraySize);
+}
+END_TEST
+
+START_TEST(UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfExtensionObjectsWithUnknownType) {
+    const size_t arraySize = 2;
+    UA_ExtensionObject sourceArray[arraySize];
+
+    UA_ExtensionObject* arrayElement = &sourceArray[0];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_ENCODED_BYTESTRING;
+    arrayElement->content.encoded.body = UA_BYTESTRING("DataOfUnknownType");
+    arrayElement->content.encoded.typeId = UA_NODEID_NUMERIC(2, 4);
+
+    arrayElement = &sourceArray[1];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_ENCODED_BYTESTRING;
+    arrayElement->content.encoded.body = UA_BYTESTRING("DataOfUnknownType");
+    arrayElement->content.encoded.typeId = UA_NODEID_NUMERIC(2, 4);
+
+    EncodeDecodeArrayOfExtensionObjectTest(sourceArray, arraySize);
+}
+END_TEST
+
+START_TEST(UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfExtensionObjectsXmlEncoded) {
+    const size_t arraySize = 2;
+    UA_ExtensionObject sourceArray[arraySize];
+
+    UA_ExtensionObject* arrayElement = &sourceArray[0];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_ENCODED_XML;
+    arrayElement->content.encoded.body = UA_STRING("<uax:Boolean>false</uax:Boolean>");
+    arrayElement->content.encoded.typeId = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+
+    arrayElement = &sourceArray[1];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_ENCODED_XML;
+    arrayElement->content.encoded.body = UA_STRING("<uax:Boolean>true</uax:Boolean>");
+    arrayElement->content.encoded.typeId = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+
+    EncodeDecodeArrayOfExtensionObjectTest(sourceArray, arraySize);
+}
+END_TEST
+
+START_TEST(UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfExtensionObjectsNoBody) {
+    const size_t arraySize = 2;
+    UA_ExtensionObject sourceArray[arraySize];
+
+    UA_ExtensionObject* arrayElement = &sourceArray[0];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_ENCODED_NOBODY;
+    arrayElement->content.encoded.typeId = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+
+    arrayElement = &sourceArray[1];
+    UA_ExtensionObject_init(arrayElement);
+    arrayElement->encoding = UA_EXTENSIONOBJECT_ENCODED_NOBODY;
+    arrayElement->content.encoded.typeId = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+
+    EncodeDecodeArrayOfExtensionObjectTest(sourceArray, arraySize);
+}
+END_TEST
+
 START_TEST(UA_StatusCode_utils) {
 
     ck_assert(UA_TRUE == UA_StatusCode_isBad(UA_STATUSCODE_BADINTERNALERROR));
@@ -1571,6 +1760,12 @@ static Suite *testSuite_builtin(void) {
     tcase_add_test(tc_encode, UA_DataValue_encodeShallWorkOnExampleWithoutVariant);
     tcase_add_test(tc_encode, UA_DataValue_encodeShallWorkOnExampleWithVariant);
     tcase_add_test(tc_encode, UA_ExtensionObject_encodeDecodeShallWorkOnExtensionObject);
+    tcase_add_test(tc_encode, UA_Variant_encodeDecodeShallWorkOnVariantWithStruct);
+    tcase_add_test(tc_encode, UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfStruct);
+    tcase_add_test(tc_encode, UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfDifferentTypes);
+    tcase_add_test(tc_encode, UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfExtensionObjectsWithUnknownType);
+    tcase_add_test(tc_encode, UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfExtensionObjectsXmlEncoded);
+    tcase_add_test(tc_encode, UA_Variant_encodeDecodeShallWorkOnVariantWithArrayOfExtensionObjectsNoBody);
     suite_add_tcase(s, tc_encode);
 
     TCase *tc_convert = tcase_create("convert");

--- a/tests/check_types_builtin_json.c
+++ b/tests/check_types_builtin_json.c
@@ -5171,6 +5171,48 @@ START_TEST(UA_Variant_BooleanArray_json_decode) {
 }
 END_TEST
 
+START_TEST(UA_Variant_ExtensionObjectArray_json_decode) {
+    // given
+    UA_Variant out;
+    UA_Variant_init(&out);
+    UA_ByteString buf = UA_STRING("{\"Type\":22,\"Body\":[{\"TypeId\":{\"Id\":1},\"Body\":false}, {\"TypeId\":{\"Id\":1},\"Body\":true}]}");
+    // when
+
+    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT], NULL);
+
+    UA_Boolean *testArray;
+    testArray = (UA_Boolean*)(out.data);
+    // then
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    //decoded as False
+    ck_assert_int_eq(testArray[0], 0);
+    ck_assert_int_eq(testArray[1], 1);
+    ck_assert_uint_eq(out.arrayDimensionsSize, 0);
+    ck_assert_uint_eq(out.arrayLength, 2);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_BOOLEAN);
+    UA_Variant_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Variant_MixedExtensionObjectArray_json_decode) {
+    // given
+    UA_Variant out;
+    UA_Variant_init(&out);
+    UA_ByteString buf = UA_STRING("{\"Type\":22,\"Body\":[{\"TypeId\":{\"Id\":1},\"Body\":false}, {\"TypeId\":{\"Id\":2},\"Body\":1}]}");
+    // when
+
+    UA_StatusCode retval = UA_decodeJson(&buf, &out, &UA_TYPES[UA_TYPES_VARIANT], NULL);
+
+    // then
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    //decoded as False
+    ck_assert_uint_eq(out.arrayDimensionsSize, 0);
+    ck_assert_uint_eq(out.arrayLength, 2);
+    ck_assert_int_eq(out.type->typeKind, UA_DATATYPEKIND_EXTENSIONOBJECT);
+    UA_Variant_clear(&out);
+}
+END_TEST
+
 START_TEST(UA_Variant_bad1_json_decode) {
     // given
     UA_Variant out;
@@ -5771,6 +5813,8 @@ static Suite *testSuite_builtin_json(void) {
     tcase_add_test(tc_json_decode, UA_VariantVariantArrayEmpty_json_decode);
     tcase_add_test(tc_json_decode, UA_VariantStringArray_WithoutDimension_json_decode);
     tcase_add_test(tc_json_decode, UA_Variant_BooleanArray_json_decode);
+    tcase_add_test(tc_json_decode, UA_Variant_ExtensionObjectArray_json_decode);
+    tcase_add_test(tc_json_decode, UA_Variant_MixedExtensionObjectArray_json_decode);
     tcase_add_test(tc_json_decode, UA_Variant_bad1_json_decode);
     tcase_add_test(tc_json_decode, UA_Variant_ExtensionObjectWrap_json_decode);
 

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -390,14 +390,11 @@ START_TEST(parseCustomArray) {
     size_t offset = 0;
     retval = UA_decodeBinaryInternal(&buf, &offset, &var2, &UA_TYPES[UA_TYPES_VARIANT], &customDataTypes);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert(var2.type == &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
+    ck_assert(var2.type == &PointType);
     ck_assert_uint_eq(var2.arrayLength, 10);
 
     for (size_t i = 0; i < 10; i++) {
-        UA_ExtensionObject *eo = &((UA_ExtensionObject*)var2.data)[i];
-        ck_assert_int_eq(eo->encoding, UA_EXTENSIONOBJECT_DECODED);
-        ck_assert(eo->content.decoded.type == &PointType);
-        Point *p2 = (Point*)eo->content.decoded.data;
+        Point *p2 = &((Point*)var2.data)[i];
 
         // we need to cast floats to int to avoid comparison of floats
         // which may result into false results

--- a/tests/pubsub/check_pubsub_encoding_custom.c
+++ b/tests/pubsub/check_pubsub_encoding_custom.c
@@ -645,9 +645,8 @@ START_TEST(UA_PubSub_EnDecode_CustomArrayDeltaFrame){
     ck_assert_int_eq(rv, UA_STATUSCODE_GOOD);
 
     for (size_t i = 0; i < 10; i++) {
-        UA_ExtensionObject *eo = &((UA_ExtensionObject*)m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.value.data)[i];
-        ck_assert(eo->content.decoded.type == &PointType);
-        Point *p2 = (Point*)eo->content.decoded.data;
+        ck_assert(m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.value.type == &PointType);
+        Point *p2 = &((Point*)m2.payload.dataSetPayload.dataSetMessages[0].data.deltaFrameData.deltaFrameFields[0].fieldValue.value.data)[i];
 
         // we need to cast floats to int to avoid comparison of floats
         // which may result into false results
@@ -711,9 +710,8 @@ START_TEST(UA_PubSub_EnDecode_CustomArrayKeyFrame){
     ck_assert_int_eq(rv, UA_STATUSCODE_GOOD);
 
     for (size_t i = 0; i < 10; i++) {
-        UA_ExtensionObject *eo = &((UA_ExtensionObject*)m2.payload.dataSetPayload.dataSetMessages[0].data.keyFrameData.dataSetFields[0].value.data)[i];
-        ck_assert(eo->content.decoded.type == &PointType);
-        Point *p2 = (Point*)eo->content.decoded.data;
+        ck_assert(m2.payload.dataSetPayload.dataSetMessages[0].data.keyFrameData.dataSetFields[0].value.type == &PointType);
+        Point *p2 = &((Point*)m2.payload.dataSetPayload.dataSetMessages[0].data.keyFrameData.dataSetFields[0].value.data)[i];
 
         // we need to cast floats to int to avoid comparison of floats
         // which may result into false results


### PR DESCRIPTION
The decoding does not unwrap the extension objects that the
structures are wrapped into when encoded if the variant contains an
array of structures.

The implemented unit tests of this PR reveals the issue. Also the
test parseCustomArray is updated to what we belive is the correct
behavior.

This change will however break any existing implementation that relies on the extension object is not unwrapped. But the current behavior where a single structure (scalar value) is unwrapped but an array of structures are not must be seen as a bug in the implementation.