### PR TITLE
[WIP] feat(server): Forward UA_Arguments of OutputArguments Node in method callback

### DIFF
--- a/examples/events/server_random_events.c
+++ b/examples/events/server_random_events.c
@@ -162,7 +162,8 @@ addGenerateSampleEventsMethodCallback(UA_Server *server,
                              const UA_NodeId *methodId, void *methodContext,
                              const UA_NodeId *objectId, void *objectContext,
                              size_t inputSize, const UA_Variant *input,
-                             size_t outputSize, UA_Variant *output) {
+                             size_t outputSize, UA_Variant *output,
+                             UA_Argument *outputArguments) {
     UA_StatusCode retval;
     UA_NodeId* eventNodeId;
     eventNodeId = (UA_NodeId*)
@@ -193,7 +194,8 @@ generateRandomEventMethodCallback(UA_Server *server,
                                   const UA_NodeId *methodId, void *methodContext,
                                   const UA_NodeId *objectId, void *objectContext,
                                   size_t inputSize, const UA_Variant *input,
-                                  size_t outputSize, UA_Variant *output) {
+                                  size_t outputSize, UA_Variant *output,
+                                  UA_Argument *outputArguments) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Creating event");
     UA_UInt32 random = (UA_UInt32) UA_UInt32_random() % SAMPLE_EVENT_TYPES_COUNT;
     /* set up event */

--- a/examples/server_ctt.c
+++ b/examples/server_ctt.c
@@ -303,7 +303,8 @@ helloWorld(UA_Server *server,
            const UA_NodeId *methodId, void *methodContext,
            const UA_NodeId *objectId, void *objectContext,
            size_t inputSize, const UA_Variant *input,
-           size_t outputSize, UA_Variant *output) {
+           size_t outputSize, UA_Variant *output,
+           UA_Argument *outputArguments) {
     /* input is a scalar string (checked by the server) */
     UA_String *name = (UA_String *)input[0].data;
     UA_String hello = UA_STRING("Hello ");
@@ -323,7 +324,8 @@ noargMethod(UA_Server *server,
             const UA_NodeId *methodId, void *methodContext,
             const UA_NodeId *objectId, void *objectContext,
             size_t inputSize, const UA_Variant *input,
-            size_t outputSize, UA_Variant *output) {
+            size_t outputSize, UA_Variant *output,
+            UA_Argument *outputArguments) {
     return UA_STATUSCODE_GOOD;
 }
 
@@ -333,7 +335,8 @@ outargMethod(UA_Server *server,
              const UA_NodeId *methodId, void *methodContext,
              const UA_NodeId *objectId, void *objectContext,
              size_t inputSize, const UA_Variant *input,
-             size_t outputSize, UA_Variant *output) {
+             size_t outputSize, UA_Variant *output,
+             UA_Argument *outputArguments) {
     UA_Int32 out = 42;
     UA_Variant_setScalarCopy(output, &out, &UA_TYPES[UA_TYPES_INT32]);
     return UA_STATUSCODE_GOOD;

--- a/examples/tutorial_server_events.c
+++ b/examples/tutorial_server_events.c
@@ -91,7 +91,8 @@ generateEventMethodCallback(UA_Server *server,
                          const UA_NodeId *methodId, void *methodContext,
                          const UA_NodeId *objectId, void *objectContext,
                          size_t inputSize, const UA_Variant *input,
-                         size_t outputSize, UA_Variant *output) {
+                         size_t outputSize, UA_Variant *output,
+                         UA_Argument *outputArguments) {
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Creating event");
 

--- a/examples/tutorial_server_method.c
+++ b/examples/tutorial_server_method.c
@@ -44,7 +44,8 @@ helloWorldMethodCallback(UA_Server *server,
                          const UA_NodeId *methodId, void *methodContext,
                          const UA_NodeId *objectId, void *objectContext,
                          size_t inputSize, const UA_Variant *input,
-                         size_t outputSize, UA_Variant *output) {
+                         size_t outputSize, UA_Variant *output,
+                         UA_Argument *outputArguments) {
     UA_String *inputStr = (UA_String*)input->data;
     UA_String tmp = UA_STRING_ALLOC("Hello ");
     if(inputStr->length > 0) {
@@ -99,7 +100,8 @@ IncInt32ArrayMethodCallback(UA_Server *server,
                             const UA_NodeId *methodId, void *methodContext,
                             const UA_NodeId *objectId, void *objectContext,
                             size_t inputSize, const UA_Variant *input,
-                            size_t outputSize, UA_Variant *output) {
+                            size_t outputSize, UA_Variant *output,
+                            UA_Argument *outputArguments) {
     UA_Int32 *inputArray = (UA_Int32*)input[0].data;
     UA_Int32 delta = *(UA_Int32*)input[1].data;
 

--- a/examples/tutorial_server_method_async.c
+++ b/examples/tutorial_server_method_async.c
@@ -66,7 +66,8 @@ helloWorldMethodCallback1(UA_Server *server,
                          const UA_NodeId *methodId, void *methodContext,
                          const UA_NodeId *objectId, void *objectContext,
                          size_t inputSize, const UA_Variant *input,
-                         size_t outputSize, UA_Variant *output) {
+                         size_t outputSize, UA_Variant *output,
+                         UA_Argument *outputArguments) {
     UA_String *inputStr = (UA_String*)input->data;
     UA_String tmp = UA_STRING_ALLOC("Hello ");
     if(inputStr->length > 0) {
@@ -123,7 +124,8 @@ helloWorldMethodCallback2(UA_Server *server,
 	const UA_NodeId *methodId, void *methodContext,
 	const UA_NodeId *objectId, void *objectContext,
 	size_t inputSize, const UA_Variant *input,
-	size_t outputSize, UA_Variant *output) {
+	size_t outputSize, UA_Variant *output,
+   UA_Argument *outputArguments) {
 	UA_String *inputStr = (UA_String*)input->data;
 	UA_String tmp = UA_STRING_ALLOC("Hello ");
 	if (inputStr->length > 0) {

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -717,7 +717,7 @@ typedef UA_StatusCode
                      void *methodContext, const UA_NodeId *objectId,
                      void *objectContext, size_t inputSize,
                      const UA_Variant *input, size_t outputSize,
-                     UA_Variant *output);
+                     UA_Variant *output, UA_Argument *outputArgs);
 
 typedef struct {
     UA_NodeHead head;

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -614,7 +614,8 @@ addPubSubConnectionAction(UA_Server *server,
                           const UA_NodeId *methodId, void *methodContext,
                           const UA_NodeId *objectId, void *objectContext,
                           size_t inputSize, const UA_Variant *input,
-                          size_t outputSize, UA_Variant *output){
+                          size_t outputSize, UA_Variant *output,
+                          UA_Argument *outputArgs){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_PubSubConnectionDataType pubSubConnectionDataType = *((UA_PubSubConnectionDataType *) input[0].data);
 
@@ -697,7 +698,8 @@ removeConnectionAction(UA_Server *server,
                        const UA_NodeId *methodId, void *methodContext,
                        const UA_NodeId *objectId, void *objectContext,
                        size_t inputSize, const UA_Variant *input,
-                       size_t outputSize, UA_Variant *output){
+                       size_t outputSize, UA_Variant *output,
+                       UA_Argument *outputArgs){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_NodeId nodeToRemove = *((UA_NodeId *) input[0].data);
     retVal |= UA_Server_removePubSubConnection(server, nodeToRemove);
@@ -779,7 +781,8 @@ addDataSetReaderAction(UA_Server *server,
                        const UA_NodeId *methodId, void *methodContext,
                        const UA_NodeId *objectId, void *objectContext,
                        size_t inputSize, const UA_Variant *input,
-                       size_t outputSize, UA_Variant *output){
+                       size_t outputSize, UA_Variant *output,
+                       UA_Argument *outputArgs){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, *objectId);
     if(rg->configurationFrozen) {
@@ -814,7 +817,8 @@ removeDataSetReaderAction(UA_Server *server,
                           const UA_NodeId *methodId, void *methodContext,
                           const UA_NodeId *objectId, void *objectContext,
                           size_t inputSize, const UA_Variant *input,
-                          size_t outputSize, UA_Variant *output){
+                          size_t outputSize, UA_Variant *output,
+                          UA_Argument *outputArgs){
     UA_NodeId nodeToRemove = *((UA_NodeId *)input[0].data);
     return UA_Server_removeDataSetReader(server, nodeToRemove);
 }
@@ -830,7 +834,8 @@ addDataSetFolderAction(UA_Server *server,
                        const UA_NodeId *methodId, void *methodContext,
                        const UA_NodeId *objectId, void *objectContext,
                        size_t inputSize, const UA_Variant *input,
-                       size_t outputSize, UA_Variant *output){
+                       size_t outputSize, UA_Variant *output,
+                       UA_Argument *outputArgs){
     /* defined in R 1.04 9.1.4.5.7 */
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_String newFolderName = *((UA_String *) input[0].data);
@@ -869,7 +874,8 @@ removeDataSetFolderAction(UA_Server *server,
                           const UA_NodeId *methodId, void *methodContext,
                           const UA_NodeId *objectId, void *objectContext,
                           size_t inputSize, const UA_Variant *input,
-                          size_t outputSize, UA_Variant *output) {
+                          size_t outputSize, UA_Variant *output,
+                          UA_Argument *outputArgs) {
     UA_NodeId nodeToRemove = *((UA_NodeId *) input[0].data);
     return UA_Server_deleteNode(server, nodeToRemove, true);
 }
@@ -963,7 +969,8 @@ addPublishedDataItemsAction(UA_Server *server,
                             const UA_NodeId *methodId, void *methodContext,
                             const UA_NodeId *objectId, void *objectContext,
                             size_t inputSize, const UA_Variant *input,
-                            size_t outputSize, UA_Variant *output){
+                            size_t outputSize, UA_Variant *output,
+                            UA_Argument *outputArgs){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     size_t fieldNameAliasesSize = input[1].arrayLength;
     UA_String * fieldNameAliases = (UA_String *) input[1].data;
@@ -1029,7 +1036,8 @@ addVariablesAction(UA_Server *server,
                    const UA_NodeId *methodId, void *methodContext,
                    const UA_NodeId *objectId, void *objectContext,
                    size_t inputSize, const UA_Variant *input,
-                   size_t outputSize, UA_Variant *output){
+                   size_t outputSize, UA_Variant *output,
+                   UA_Argument *outputArgs){
     return UA_STATUSCODE_GOOD;
 }
 
@@ -1039,7 +1047,8 @@ removeVariablesAction(UA_Server *server,
                       const UA_NodeId *methodId, void *methodContext,
                       const UA_NodeId *objectId, void *objectContext,
                       size_t inputSize, const UA_Variant *input,
-                      size_t outputSize, UA_Variant *output){
+                      size_t outputSize, UA_Variant *output,
+                      UA_Argument *outputArgs){
     return UA_STATUSCODE_GOOD;
 }
 #endif
@@ -1058,7 +1067,8 @@ removePublishedDataSetAction(UA_Server *server,
                              const UA_NodeId *methodId, void *methodContext,
                              const UA_NodeId *objectId, void *objectContext,
                              size_t inputSize, const UA_Variant *input,
-                             size_t outputSize, UA_Variant *output){
+                             size_t outputSize, UA_Variant *output,
+                             UA_Argument *outputArgs){
     UA_NodeId nodeToRemove = *((UA_NodeId *) input[0].data);
     return UA_Server_removePublishedDataSet(server, nodeToRemove);
 }
@@ -1226,7 +1236,8 @@ addWriterGroupAction(UA_Server *server,
                              const UA_NodeId *methodId, void *methodContext,
                              const UA_NodeId *objectId, void *objectContext,
                              size_t inputSize, const UA_Variant *input,
-                             size_t outputSize, UA_Variant *output){
+                             size_t outputSize, UA_Variant *output,
+                             UA_Argument *outputArgs){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_WriterGroupDataType *writerGroupDataType = ((UA_WriterGroupDataType *) input[0].data);
     UA_NodeId writerGroupId;
@@ -1259,7 +1270,8 @@ removeGroupAction(UA_Server *server,
                   const UA_NodeId *methodId, void *methodContext,
                   const UA_NodeId *objectId, void *objectContext,
                   size_t inputSize, const UA_Variant *input,
-                  size_t outputSize, UA_Variant *output){
+                  size_t outputSize, UA_Variant *output,
+                  UA_Argument *outputArgs){
     UA_NodeId nodeToRemove = *((UA_NodeId *)input->data);
     if(UA_WriterGroup_findWGbyId(server, nodeToRemove)) {
         UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, nodeToRemove);
@@ -1313,7 +1325,8 @@ addReaderGroupAction(UA_Server *server,
                      const UA_NodeId *methodId, void *methodContext,
                      const UA_NodeId *objectId, void *objectContext,
                      size_t inputSize, const UA_Variant *input,
-                     size_t outputSize, UA_Variant *output){
+                     size_t outputSize, UA_Variant *output,
+                     UA_Argument *outputArgs){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ReaderGroupDataType *readerGroupDataType = ((UA_ReaderGroupDataType *) input->data);
     UA_NodeId readerGroupId;
@@ -1409,7 +1422,8 @@ addDataSetWriterAction(UA_Server *server,
                        const UA_NodeId *methodId, void *methodContext,
                        const UA_NodeId *objectId, void *objectContext,
                        size_t inputSize, const UA_Variant *input,
-                       size_t outputSize, UA_Variant *output){
+                       size_t outputSize, UA_Variant *output,
+                       UA_Argument *outputArgs){
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, *objectId);
     if(!wg) {
@@ -1451,7 +1465,8 @@ removeDataSetWriterAction(UA_Server *server,
                           const UA_NodeId *methodId, void *methodContext,
                           const UA_NodeId *objectId, void *objectContext,
                           size_t inputSize, const UA_Variant *input,
-                          size_t outputSize, UA_Variant *output){
+                          size_t outputSize, UA_Variant *output,
+                          UA_Argument *outputArgs){
     UA_NodeId nodeToRemove = *((UA_NodeId *) input[0].data);
     return UA_Server_removeDataSetWriter(server, nodeToRemove);
 }
@@ -1578,7 +1593,8 @@ UA_loadPubSubConfigMethodCallback(UA_Server *server,
                                   const UA_NodeId *methodId, void *methodContext,
                                   const UA_NodeId *objectId, void *objectContext,
                                   size_t inputSize, const UA_Variant *input,
-                                  size_t outputSize, UA_Variant *output) {
+                                  size_t outputSize, UA_Variant *output,
+                                  UA_Argument *outputArguments) {
     if(inputSize == 1) {
         UA_ByteString *inputStr = (UA_ByteString*)input->data;
         return UA_PubSubManager_loadPubSubConfigFromByteString(server, *inputStr);
@@ -1621,7 +1637,8 @@ UA_deletePubSubConfigMethodCallback(UA_Server *server,
                                     const UA_NodeId *methodId, void *methodContext,
                                     const UA_NodeId *objectId, void *objectContext,
                                     size_t inputSize, const UA_Variant *input,
-                                    size_t outputSize, UA_Variant *output) {
+                                    size_t outputSize, UA_Variant *output,
+                                    UA_Argument *outputArguments) {
     UA_PubSubManager_delete(server, &(server->pubSubManager));
     return UA_STATUSCODE_GOOD;
 }

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -564,7 +564,7 @@ static UA_StatusCode
 readMonitoredItems(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                    const UA_NodeId *methodId, void *methodContext, const UA_NodeId *objectId,
                    void *objectContext, size_t inputSize, const UA_Variant *input,
-                   size_t outputSize, UA_Variant *output) {
+                   size_t outputSize, UA_Variant *output, UA_Argument *outputArgs) {
     /* Return two empty arrays by default */
     UA_Variant_setArray(&output[0], UA_Array_new(0, &UA_TYPES[UA_TYPES_UINT32]),
                         0, &UA_TYPES[UA_TYPES_UINT32]);

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -1197,7 +1197,8 @@ disableMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                       void *sessionContext, const UA_NodeId *methodId,
                       void *methodContext, const UA_NodeId *objectId,
                       void *objectContext, size_t inputSize,
-                      const UA_Variant *input, size_t outputSize, UA_Variant *output) {
+                      const UA_Variant *input, size_t outputSize, UA_Variant *output,
+                      UA_Argument *outputArgs) {
     UA_NodeId conditionTypeNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_CONDITIONTYPE);
     if(UA_NodeId_equal(objectId, &conditionTypeNodeId)) {
         UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_USERLAND,
@@ -1227,7 +1228,7 @@ enableMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                      void *methodContext, const UA_NodeId *objectId,
                      void *objectContext, size_t inputSize,
                      const UA_Variant *input, size_t outputSize,
-                     UA_Variant *output) {
+                     UA_Variant *output, UA_Argument *outputArgs) {
     UA_NodeId conditionTypeNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_CONDITIONTYPE);
     if(UA_NodeId_equal(objectId, &conditionTypeNodeId)) {
         UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_USERLAND,
@@ -1258,7 +1259,7 @@ addCommentMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                          void *methodContext, const UA_NodeId *objectId,
                          void *objectContext, size_t inputSize,
                          const UA_Variant *input, size_t outputSize,
-                         UA_Variant *output) {
+                         UA_Variant *output, UA_Argument *outputArgs) {
     UA_QualifiedName fieldComment = UA_QUALIFIEDNAME(0, CONDITION_FIELD_COMMENT);
     UA_QualifiedName fieldSourceTimeStamp =
         UA_QUALIFIEDNAME(0, CONDITION_FIELD_CONDITIONVARIABLE_SOURCETIMESTAMP);
@@ -1342,7 +1343,7 @@ acknowledgeMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                           void *methodContext, const UA_NodeId *objectId,
                           void *objectContext, size_t inputSize,
                           const UA_Variant *input, size_t outputSize,
-                          UA_Variant *output) {
+                          UA_Variant *output, UA_Argument *outputArgs) {
     UA_QualifiedName fieldComment = UA_QUALIFIEDNAME(0, CONDITION_FIELD_COMMENT);
     UA_Variant value;
 
@@ -1418,7 +1419,7 @@ confirmMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                       void *methodContext, const UA_NodeId *objectId,
                       void *objectContext, size_t inputSize,
                       const UA_Variant *input, size_t outputSize,
-                      UA_Variant *output) {
+                      UA_Variant *output, UA_Argument *outputArgs) {
     UA_QualifiedName fieldComment = UA_QUALIFIEDNAME(0, CONDITION_FIELD_COMMENT);
     UA_Variant value;
 
@@ -1644,7 +1645,7 @@ refresh2MethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                       void *methodContext, const UA_NodeId *objectId,
                       void *objectContext, size_t inputSize,
                       const UA_Variant *input, size_t outputSize,
-                      UA_Variant *output) {
+                      UA_Variant *output, UA_Argument *outputArgs) {
     //TODO implement logic for subscription array
     /* Check if valid subscriptionId */
     UA_Session *session = UA_Server_getSessionById(server, sessionId);
@@ -1679,7 +1680,7 @@ refreshMethodCallback(UA_Server *server, const UA_NodeId *sessionId,
                       void *methodContext, const UA_NodeId *objectId,
                       void *objectContext, size_t inputSize,
                       const UA_Variant *input, size_t outputSize,
-                      UA_Variant *output) {
+                      UA_Variant *output, UA_Argument *outputArgs) {
     //TODO implement logic for subscription array
     /* Check if valid subscriptionId */
     UA_Session *session = UA_Server_getSessionById(server, sessionId);

--- a/tests/server/check_server_asyncop.c
+++ b/tests/server/check_server_asyncop.c
@@ -26,7 +26,8 @@ methodCallback(UA_Server *serverArg,
          const UA_NodeId *methodId, void *methodContext,
          const UA_NodeId *objectId, void *objectContext,
          size_t inputSize, const UA_Variant *input,
-         size_t outputSize, UA_Variant *output) {
+         size_t outputSize, UA_Variant *output,
+         UA_Argument *outputArguments) {
     return UA_STATUSCODE_GOOD;
 }
 

--- a/tests/server/check_services_call.c
+++ b/tests/server/check_services_call.c
@@ -26,7 +26,7 @@ methodCallback(UA_Server *serverArg,
          const UA_NodeId *methodId, void *methodContext,
          const UA_NodeId *objectId, void *objectContext,
          size_t inputSize, const UA_Variant *input,
-         size_t outputSize, UA_Variant *output)
+         size_t outputSize, UA_Variant *output, UA_Argument *outputArgs)
 {
     return UA_STATUSCODE_GOOD;
 }


### PR DESCRIPTION
When using a generic method callback for all methods in a nodestore
it is useful to have access to the UA_Arguments of the
OutputArguments node in the callback when writing the output
variants. In our case we do a translation of method calls to a
subsystem and need to know the OPC UA types when translating the
subsystem output arguments to OPC UA output arguments.

The callback function can find the OutputArguments node itself by
browsing the method NodeId but as the stack has already done
this work just before calling the method callback we see it as a
possibility to forward this information as an argument.