### PR TITLE
fix(ci) build debian package branch only for standard releases 

### DIFF
--- a/.github/workflows/debian_packing.yml
+++ b/.github/workflows/debian_packing.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main, master ]
     tags:
-      - v1.*
+      - 'v1.*'
+      - 'v1.*.*'
 
 jobs:
   Debian-Package-Branch-Preperation:


### PR DESCRIPTION
Fix github action. Currently we build pack branches also for "-rc" tags.