### PR TITLE
[REVIEW] fix(server): fix no match for TranslateBrowsePathsToNodeIds

### DIFF
--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -1201,7 +1201,7 @@ Operation_TranslateBrowsePathToNodeIds(UA_Server *server, UA_Session *session,
     tmpResults = (UA_BrowsePathTarget*)
         UA_realloc(result->targets, sizeof(UA_BrowsePathTarget) *
                    (result->targetsSize + next->size));
-    if(!tmpResults) {
+    if(!tmpResults && next->size > 0) {
         result->statusCode = UA_STATUSCODE_BADOUTOFMEMORY;
         goto cleanup;
     }

--- a/tests/server/check_services_view.c
+++ b/tests/server/check_services_view.c
@@ -124,7 +124,7 @@ START_TEST(Service_Browse_WithMaxResults) {
             browseWithMaxResults(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), i);
         ck_assert_uint_eq(total, sum_total);
     }
-    
+
     UA_Server_delete(server);
 }
 END_TEST
@@ -396,6 +396,28 @@ START_TEST(Service_TranslateBrowsePathsWithHashCollision) {
 }
 END_TEST
 
+START_TEST(Service_TranslateBrowsePathsNoMatches) {
+    UA_BrowsePath browsePath;
+    UA_BrowsePath_init(&browsePath);
+    UA_RelativePathElement rpe;
+    UA_RelativePathElement_init(&rpe);
+    browsePath.startingNode = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    browsePath.relativePath.elements = &rpe;
+    browsePath.relativePath.elementsSize = 1;
+
+    rpe.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    rpe.targetName = UA_QUALIFIEDNAME_ALLOC(0, "NoMatchToBeFound");
+
+    UA_BrowsePathResult bpr =
+        UA_Server_translateBrowsePathToNodeIds(server_translate_browse, &browsePath);
+
+    ck_assert_int_eq(bpr.statusCode, UA_STATUSCODE_BADNOMATCH);
+    ck_assert_uint_eq(bpr.targetsSize, 0);
+
+    UA_BrowsePathResult_clear(&bpr);
+}
+END_TEST
+
 START_TEST(BrowseSimplifiedBrowsePath) {
     UA_QualifiedName objectsName = UA_QUALIFIEDNAME(0, "Objects");
     UA_BrowsePathResult bpr =
@@ -424,6 +446,7 @@ static Suite *testSuite_Service_TranslateBrowsePathsToNodeIds(void) {
     tcase_add_unchecked_fixture(tc_translate, setup_server, teardown_server);
     tcase_add_test(tc_translate, Service_TranslateBrowsePathsToNodeIds);
     tcase_add_test(tc_translate, Service_TranslateBrowsePathsWithHashCollision);
+    tcase_add_test(tc_translate, Service_TranslateBrowsePathsNoMatches);
     tcase_add_test(tc_translate, BrowseSimplifiedBrowsePath);
 
     suite_add_tcase(s, tc_translate);

--- a/tests/server/check_services_view.c
+++ b/tests/server/check_services_view.c
@@ -406,7 +406,7 @@ START_TEST(Service_TranslateBrowsePathsNoMatches) {
     browsePath.relativePath.elementsSize = 1;
 
     rpe.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
-    rpe.targetName = UA_QUALIFIEDNAME_ALLOC(0, "NoMatchToBeFound");
+    rpe.targetName = UA_QUALIFIEDNAME(0, "NoMatchToBeFound");
 
     UA_BrowsePathResult bpr =
         UA_Server_translateBrowsePathToNodeIds(server_translate_browse, &browsePath);


### PR DESCRIPTION
If no matches are found a size of 0 is passed to UA_realloc(). The
behavior of realloc if the size is 0 is implementation defined and will
either return NULL or a valid pointer. Fix so bad out of memory is not
returned in case a NULL pointer shall be accepted.