### PR TITLE
[REVIEW] fix(server): Continuation point for browse refs breaks too early 

### DIFF
--- a/src/server/ua_services_view.c
+++ b/src/server/ua_services_view.c
@@ -543,7 +543,8 @@ browseReferences(UA_Server *server, const UA_NodeHead *head,
              * target to send out. */
             if(head->references[i].referenceTypeIndex == cp->nextRefKindIndex) {
                 ref = UA_NodeReferenceKind_findTarget(rk, &cp->nextTarget);
-                break;
+                if(ref)
+                    break;
             }
         }
 


### PR DESCRIPTION
The foor loop looking for a reference kind match breaks
after the expected reference type index is found. But there
may be one more reference list of that type index but with a
different direction.

Found when running CTT.