### PR TITLE
fix(core): SendServiceFault incorrectly sends empty response.

### DIFF
--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -185,8 +185,7 @@ UA_Server_configSecureChannel(void *application, UA_SecureChannel *channel,
                               const UA_AsymmetricAlgorithmSecurityHeader *asymHeader);
 
 UA_StatusCode
-sendServiceFault(UA_SecureChannel *channel, UA_UInt32 requestId, UA_UInt32 requestHandle,
-                 const UA_DataType *responseType, UA_StatusCode statusCode);
+sendServiceFault(UA_SecureChannel *channel, UA_UInt32 requestId, UA_UInt32 requestHandle, UA_StatusCode statusCode);
 
 void
 UA_Server_closeSecureChannel(UA_Server *server, UA_SecureChannel *channel,

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -209,7 +209,6 @@ Service_Publish(UA_Server *server, UA_Session *session,
     if(TAILQ_EMPTY(&session->subscriptions)) {
         sendServiceFault(session->header.channel, requestId,
                          request->requestHeader.requestHandle,
-                         &UA_TYPES[UA_TYPES_PUBLISHRESPONSE],
                          UA_STATUSCODE_BADNOSUBSCRIPTION);
         return;
     }
@@ -222,7 +221,6 @@ Service_Publish(UA_Server *server, UA_Session *session,
         if(!UA_Session_reachedPublishReqLimit(server, session)) {
             sendServiceFault(session->header.channel, requestId,
                              request->requestHeader.requestHandle,
-                             &UA_TYPES[UA_TYPES_PUBLISHRESPONSE],
                              UA_STATUSCODE_BADINTERNALERROR);
             return;
         }
@@ -234,7 +232,6 @@ Service_Publish(UA_Server *server, UA_Session *session,
     if(!entry) {
         sendServiceFault(session->header.channel, requestId,
                          request->requestHeader.requestHandle,
-                         &UA_TYPES[UA_TYPES_PUBLISHRESPONSE],
                          UA_STATUSCODE_BADOUTOFMEMORY);
         return;
     }
@@ -254,7 +251,6 @@ Service_Publish(UA_Server *server, UA_Session *session,
             UA_free(entry);
             sendServiceFault(session->header.channel, requestId,
                              request->requestHeader.requestHandle,
-                             &UA_TYPES[UA_TYPES_PUBLISHRESPONSE],
                              UA_STATUSCODE_BADOUTOFMEMORY);
             return;
         }

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -385,7 +385,7 @@ sendStatusChangeDelete(UA_Server *server, UA_Subscription *sub,
 void
 UA_Subscription_publish(UA_Server *server, UA_Subscription *sub) {
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
-    UA_LOG_DEBUG_SUBSCRIPTION(&server->config.logger, sub, "Publish Callback");
+    UA_LOG_TRACE_SUBSCRIPTION(&server->config.logger, sub, "Publish Callback");
     UA_assert(sub);
 
     /* Dequeue a response */

--- a/src/ua_util_internal.h
+++ b/src/ua_util_internal.h
@@ -270,6 +270,7 @@ typedef union {
 
 typedef union {
     UA_ResponseHeader responseHeader;
+    UA_ServiceFault serviceFault;
     UA_FindServersResponse findServersResponse;
     UA_GetEndpointsResponse getEndpointsResponse;
 #ifdef UA_ENABLE_DISCOVERY


### PR DESCRIPTION
Expected behavior would be that the server sends the dedicated ServiceFault Service Message.
This is now correctly done, and encoding errors during sending of a response are now also caught and sent as serviceFault instead of falling through resulting in the channel being closed.