### PR TITLE
fix: use `#!/usr/bin/env python3` instead of `#!/usr/bin/env python`

### DIFF
--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # coding: UTF-8
 # This Source Code Form is subject to the terms of the Mozilla Public

--- a/tools/c2rst.py
+++ b/tools/c2rst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this 

--- a/tools/gdb-prettyprint.py
+++ b/tools/gdb-prettyprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Load into gdb with 'source <path-to>/tools/gdb-prettyprint.py'
 # Make sure to have 'set print pretty on' to get nice structure printouts

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/generate_nodeid_header.py
+++ b/tools/generate_nodeid_header.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this 

--- a/tools/generate_statuscode_descriptions.py
+++ b/tools/generate_statuscode_descriptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this 

--- a/tools/nodeset_compiler/nodeset.py
+++ b/tools/nodeset_compiler/nodeset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ### This Source Code Form is subject to the terms of the Mozilla Public

--- a/tools/nodeset_compiler/nodeset_testing.py
+++ b/tools/nodeset_compiler/nodeset_testing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ### This Source Code Form is subject to the terms of the Mozilla Public
 ### License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/prepare_packaging.py
+++ b/tools/prepare_packaging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/update_copyright_header.py
+++ b/tools/update_copyright_header.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tools/valgrind_check_error.py
+++ b/tools/valgrind_check_error.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # coding: UTF-8
 # This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
The newer Ubuntu since 20.04 do not have the `python` binary.
There one explicitly needs to choose between `python2` or `python3`.

See also:
https://askubuntu.com/q/1296790/141958