### PR TITLE
[REVIEW] Fix the isDynamic flag for nested child variables

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -76,6 +76,10 @@ UA_Server_setNodeContext(UA_Server *server, UA_NodeId nodeId,
     return retval;
 }
 
+static UA_StatusCode
+checkSetIsDynamicVariable(UA_Server *server, UA_Session *session,
+                          const UA_NodeId *nodeId);
+
 /**********************/
 /* Consistency Checks */
 /**********************/
@@ -646,6 +650,15 @@ copyChild(UA_Server *server, UA_Session *session,
         if(retval != UA_STATUSCODE_GOOD) {
             UA_NODESTORE_REMOVE(server, &newNodeId);
             return retval;
+        }
+
+        if (rd->nodeClass == UA_NODECLASS_VARIABLE) {
+            retval = checkSetIsDynamicVariable(server, session, &newNodeId);
+
+            if(retval != UA_STATUSCODE_GOOD) {
+                UA_NODESTORE_REMOVE(server, &newNodeId);
+                return retval;
+            }
         }
 
         /* For the new child, recursively copy the members of the original. No

--- a/tests/server/check_services_nodemanagement.c
+++ b/tests/server/check_services_nodemanagement.c
@@ -603,8 +603,8 @@ START_TEST(ObjectWithDynamicVariableChild) {
     wv.nodeId = bpr.targets->targetId.nodeId;
     wv.attributeId = UA_ATTRIBUTEID_VALUE;
     wv.value.hasValue = UA_TRUE;
-    UA_NamingRuleType rt = UA_NAMINGRULETYPE_MANDATORY;
-    UA_Variant_setScalar(&wv.value.value, &rt, &UA_TYPES[UA_TYPES_NAMINGRULETYPE]);
+    UA_Int32 rt = 1;
+    UA_Variant_setScalar(&wv.value.value, &rt, &UA_TYPES[UA_TYPES_INT32]);
     wv.value.hasSourceTimestamp = UA_TRUE;
     wv.value.sourceTimestamp = 12345;
 


### PR DESCRIPTION
If a node with Variable children is added, the variable children are never marked as dynamic.
This prevents the usage of the server and source timestamps in the DataValue.