### PR TITLE
backport #4774 for v1.2

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -652,6 +652,22 @@ copyChild(UA_Server *server, UA_Session *session,
          * typechecking is performed here. Assuming that the original is
          * consistent. */
         retval = copyAllChildren(server, session, &rd->nodeId.nodeId, &newNodeId);
+        if(retval != UA_STATUSCODE_GOOD) {
+            deleteNode(server, newNodeId, true);
+            return retval;
+        }
+
+        /* Check if its a dynamic variable, add all type and/or interface
+         * children and call the constructor */
+        retval = AddNode_finish(server, session, &newNodeId);
+        if(retval != UA_STATUSCODE_GOOD) {
+            deleteNode(server, newNodeId, true);
+            return retval;
+        }
+        
+        /* Clean up.  Because it can happen that a string is assigned as ID at 
+         * generateChildNodeId. */
+        UA_NodeId_clear(&newNodeId);
     }
 
     return retval;

--- a/tests/server/check_node_inheritance.c
+++ b/tests/server/check_node_inheritance.c
@@ -289,20 +289,39 @@ START_TEST(Nodes_checkInheritedValue) {
                 UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
                 UA_QUALIFIEDNAME(1, "State"), &childState);
     ck_assert(!UA_NodeId_isNull(&childState));
+
     UA_NodeId childNumber;
     findChildId(childState, UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY),
                 UA_QUALIFIEDNAME(1, "CustomStateNumber"), &childNumber);
     ck_assert(!UA_NodeId_isNull(&childNumber));
 
-    UA_Variant inheritedValue;
-    UA_Variant_init(&inheritedValue);
-    UA_Server_readValue(server, childNumber, &inheritedValue);
-    ck_assert(inheritedValue.type == &UA_TYPES[UA_TYPES_UINT32]);
-
-    UA_UInt32 *value = (UA_UInt32 *) inheritedValue.data;
-
+    UA_ReadValueId rvi;
+    UA_ReadValueId_init(&rvi);
+    rvi.nodeId = childNumber;
+    rvi.attributeId = UA_ATTRIBUTEID_VALUE;
+    UA_DataValue inheritedValue = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_BOTH);
+    ck_assert(inheritedValue.value.type == &UA_TYPES[UA_TYPES_UINT32]);
+    UA_UInt32 *value = (UA_UInt32 *) inheritedValue.value.data;
     ck_assert_int_eq(*value, valueToBeInherited);
-    UA_Variant_clear(&inheritedValue);
+
+    /* Write a specific timestamp */
+    UA_WriteValue wValue;
+    UA_WriteValue_init(&wValue);
+    wValue.value = inheritedValue;
+    wValue.value.hasSourceTimestamp = true;
+    wValue.value.sourceTimestamp = 1337;
+    wValue.nodeId = childNumber;
+    wValue.attributeId = UA_ATTRIBUTEID_VALUE;
+    UA_StatusCode retval = UA_Server_write(server, &wValue);
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+
+    /* Read the timestamp back out */
+    UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_BOTH);
+    ck_assert(resp.hasSourceTimestamp);
+    ck_assert_int_eq(resp.sourceTimestamp, 1337);
+
+    UA_DataValue_clear(&resp);
+    UA_DataValue_clear(&inheritedValue);
 #endif
 }
 END_TEST

--- a/tests/server/check_services_attributes.c
+++ b/tests/server/check_services_attributes.c
@@ -777,6 +777,8 @@ START_TEST(WriteSingleAttributeValue) {
     UA_Int32 myInteger = 20;
     UA_Variant_setScalar(&wValue.value.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
     wValue.value.hasValue = true;
+    wValue.value.hasSourceTimestamp = true;
+    wValue.value.sourceTimestamp = 1337;
     wValue.nodeId = UA_NODEID_STRING(1, "the.answer");
     wValue.attributeId = UA_ATTRIBUTEID_VALUE;
     UA_StatusCode retval = UA_Server_write(server, &wValue);
@@ -786,10 +788,12 @@ START_TEST(WriteSingleAttributeValue) {
     UA_ReadValueId_init(&rvi);
     rvi.nodeId = UA_NODEID_STRING(1, "the.answer");
     rvi.attributeId = UA_ATTRIBUTEID_VALUE;
-    UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_NEITHER);
+    UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_BOTH);
 
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert(resp.hasValue);
+    ck_assert(resp.hasSourceTimestamp);
+    ck_assert_int_eq(resp.sourceTimestamp, 1337);
     ck_assert_int_eq(20, *(UA_Int32*)resp.value.data);
     UA_DataValue_clear(&resp);
 } END_TEST


### PR DESCRIPTION
This backports #4775 (fix for #4774) for v1.2. There was only a minor conflict.

As we use this branch in productive code for some time, having this official will be great.

CC: @jvoosten
