### PR TITLE
[REVIEW] Feature: Eventloop server integration

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -25,6 +25,142 @@
 #define MSG_NOSIGNAL 0
 #endif
 
+typedef struct ConnectionEntry {
+    UA_Connection connection;
+    LIST_ENTRY(ConnectionEntry) pointers;
+} ConnectionEntry;
+
+typedef struct {
+    const UA_Logger *logger;
+    UA_UInt16 port;
+    UA_UInt16 maxConnections;
+    UA_SOCKET serverSockets[FD_SETSIZE];
+    UA_UInt16 serverSocketsSize;
+    LIST_HEAD(, ConnectionEntry) connections;
+    UA_UInt16 connectionsSize;
+} ServerNetworkLayerTCP;
+
+/***************************/
+/* Server NetworkLayer TCP */
+/***************************/
+
+#define MAXBACKLOG     100
+#define NOHELLOTIMEOUT 120000 /* timeout in ms before close the connection
+                               * if server does not receive Hello Message */
+
+static UA_StatusCode
+ServerNetworkLayerTCP_start(UA_ServerNetworkLayer *nl, const UA_Logger *logger,
+                            const UA_String *customHostname) {
+    UA_initialize_architecture_network();
+
+    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP *)nl->handle;
+    layer->logger = logger;
+
+    /* Get addrinfo of the server and create server sockets */
+    char hostname[512];
+    if(customHostname->length) {
+        if(customHostname->length >= sizeof(hostname))
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        memcpy(hostname, customHostname->data, customHostname->length);
+        hostname[customHostname->length] = '\0';
+    }
+    char portno[6];
+    UA_snprintf(portno, 6, "%d", layer->port);
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof hints);
+
+    /* Get the discovery url from the hostname */
+    UA_String du = UA_STRING_NULL;
+    char discoveryUrlBuffer[256];
+    if(customHostname->length) {
+        du.length = (size_t)UA_snprintf(discoveryUrlBuffer, 255, "opc.tcp://%.*s:%d/",
+                                        (int)customHostname->length, customHostname->data,
+                                        layer->port);
+        du.data = (UA_Byte*)discoveryUrlBuffer;
+    } else {
+        char hostnameBuffer[256];
+        if(UA_gethostname(hostnameBuffer, 255) == 0) {
+            du.length = (size_t)UA_snprintf(discoveryUrlBuffer, 255, "opc.tcp://%s:%d/",
+                                            hostnameBuffer, layer->port);
+            du.data = (UA_Byte*)discoveryUrlBuffer;
+        } else {
+            UA_LOG_ERROR(layer->logger, UA_LOGCATEGORY_NETWORK, "Could not get the hostname");
+            return UA_STATUSCODE_BADINTERNALERROR;
+        }
+    }
+    UA_String_copy(&du, &nl->discoveryUrl);
+
+    UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
+                "TCP network layer listening on %.*s",
+                (int)nl->discoveryUrl.length, nl->discoveryUrl.data);
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+ServerNetworkLayerTCP_listen(UA_ServerNetworkLayer *nl, UA_Server *server,
+                             UA_UInt16 timeout) {
+    return UA_STATUSCODE_GOOD;
+}
+
+static void
+ServerNetworkLayerTCP_stop(UA_ServerNetworkLayer *nl, UA_Server *server) {
+    UA_deinitialize_architecture_network();
+}
+
+/* run only when the server is stopped */
+static void
+ServerNetworkLayerTCP_clear(UA_ServerNetworkLayer *nl) {
+    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP *)nl->handle;
+    UA_String_clear(&nl->discoveryUrl);
+
+    /* Hard-close and remove remaining connections. The server is no longer
+     * running. So this is safe. */
+    ConnectionEntry *e, *e_tmp;
+    LIST_FOREACH_SAFE(e, &layer->connections, pointers, e_tmp) {
+        LIST_REMOVE(e, pointers);
+        layer->connectionsSize--;
+        UA_free(e);
+        if(nl->statistics) {
+            nl->statistics->currentConnectionCount--;
+        }
+    }
+
+    /* Free the layer */
+    UA_free(layer);
+}
+
+UA_ServerNetworkLayer
+UA_ServerNetworkLayerTCP(UA_ConnectionConfig config, UA_UInt16 port,
+                         UA_UInt16 maxConnections) {
+    UA_ServerNetworkLayer nl;
+    memset(&nl, 0, sizeof(UA_ServerNetworkLayer));
+    nl.clear = ServerNetworkLayerTCP_clear;
+    nl.localConnectionConfig = config;
+    nl.start = ServerNetworkLayerTCP_start;
+    nl.listen = ServerNetworkLayerTCP_listen;
+    nl.stop = ServerNetworkLayerTCP_stop;
+    nl.handle = NULL;
+
+    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP*)
+        UA_calloc(1,sizeof(ServerNetworkLayerTCP));
+    if(!layer)
+        return nl;
+    nl.handle = layer;
+
+    layer->port = port;
+    layer->maxConnections = maxConnections;
+
+    return nl;
+}
+
+typedef struct TCPClientConnection {
+    struct addrinfo hints, *server;
+    UA_DateTime connStart;
+    UA_String endpointUrl;
+    UA_UInt32 timeout;
+} TCPClientConnection;
+
+
 /****************************/
 /* Generic Socket Functions */
 /****************************/
@@ -72,8 +208,8 @@ connection_write(UA_Connection *connection, UA_ByteString *buf) {
         do {
             size_t bytes_to_send = buf->length - nWritten;
             n = UA_send(connection->sockfd,
-                     (const char*)buf->data + nWritten,
-                     bytes_to_send, flags);
+                        (const char*)buf->data + nWritten,
+                        bytes_to_send, flags);
             if(n<0) {
                 if(UA_ERRNO != UA_INTERRUPTED && UA_ERRNO != UA_AGAIN) {
                     connection->close(connection);
@@ -164,513 +300,6 @@ connection_recv(UA_Connection *connection, UA_ByteString *response,
     return UA_STATUSCODE_GOOD;
 }
 
-
-/***************************/
-/* Server NetworkLayer TCP */
-/***************************/
-
-#define MAXBACKLOG     100
-#define NOHELLOTIMEOUT 120000 /* timeout in ms before close the connection
-                               * if server does not receive Hello Message */
-
-typedef struct ConnectionEntry {
-    UA_Connection connection;
-    LIST_ENTRY(ConnectionEntry) pointers;
-} ConnectionEntry;
-
-typedef struct {
-    const UA_Logger *logger;
-    UA_UInt16 port;
-    UA_UInt16 maxConnections;
-    UA_SOCKET serverSockets[FD_SETSIZE];
-    UA_UInt16 serverSocketsSize;
-    LIST_HEAD(, ConnectionEntry) connections;
-    UA_UInt16 connectionsSize;
-} ServerNetworkLayerTCP;
-
-static void
-ServerNetworkLayerTCP_freeConnection(UA_Connection *connection) {
-    UA_free(connection);
-}
-
-/* This performs only 'shutdown'. 'close' is called when the shutdown
- * socket is returned from select. */
-static void
-ServerNetworkLayerTCP_close(UA_Connection *connection) {
-    if(connection->state == UA_CONNECTIONSTATE_CLOSED)
-        return;
-    UA_shutdown((UA_SOCKET)connection->sockfd, 2);
-    connection->state = UA_CONNECTIONSTATE_CLOSED;
-}
-
-static UA_Boolean
-purgeFirstConnectionWithoutChannel(ServerNetworkLayerTCP *layer) {
-    ConnectionEntry *e;
-    LIST_FOREACH(e, &layer->connections, pointers) {
-        if(e->connection.channel == NULL) {
-            LIST_REMOVE(e, pointers);
-            layer->connectionsSize--;
-            UA_close(e->connection.sockfd);
-            e->connection.free(&e->connection);
-            return true;
-        }
-    }
-    return false;
-}
-
-static UA_StatusCode
-ServerNetworkLayerTCP_add(UA_ServerNetworkLayer *nl, ServerNetworkLayerTCP *layer,
-                          UA_Int32 newsockfd, struct sockaddr_storage *remote) {
-   if(layer->maxConnections && layer->connectionsSize >= layer->maxConnections &&
-      !purgeFirstConnectionWithoutChannel(layer)) {
-       return UA_STATUSCODE_BADTCPNOTENOUGHRESOURCES;
-   }
-
-    /* Set nonblocking */
-    UA_socket_set_nonblocking(newsockfd);//TODO: check return value
-
-    /* Do not merge packets on the socket (disable Nagle's algorithm) */
-    int dummy = 1;
-    if(UA_setsockopt(newsockfd, IPPROTO_TCP, TCP_NODELAY,
-               (const char *)&dummy, sizeof(dummy)) < 0) {
-        UA_LOG_SOCKET_ERRNO_WRAP(
-                UA_LOG_ERROR(layer->logger, UA_LOGCATEGORY_NETWORK,
-                             "Cannot set socket option TCP_NODELAY. Error: %s",
-                             errno_str));
-        return UA_STATUSCODE_BADUNEXPECTEDERROR;
-    }
-
-#if defined(UA_getnameinfo)
-    /* Get the peer name for logging */
-    char remote_name[100];
-    int res = UA_getnameinfo((struct sockaddr*)remote,
-                          sizeof(struct sockaddr_storage),
-                          remote_name, sizeof(remote_name),
-                          NULL, 0, NI_NUMERICHOST);
-    if(res == 0) {
-        UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                    "Connection %i | New connection over TCP from %s",
-                    (int)newsockfd, remote_name);
-    } else {
-        UA_LOG_SOCKET_ERRNO_WRAP(UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                                                "Connection %i | New connection over TCP, "
-                                                "getnameinfo failed with error: %s",
-                                                (int)newsockfd, errno_str));
-    }
-#else
-    UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                "Connection %i | New connection over TCP",
-                (int)newsockfd);
-#endif
-    /* Allocate and initialize the connection */
-    ConnectionEntry *e = (ConnectionEntry*)UA_malloc(sizeof(ConnectionEntry));
-    if(!e) {
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-    }
-
-    UA_Connection *c = &e->connection;
-    memset(c, 0, sizeof(UA_Connection));
-    c->sockfd = newsockfd;
-    c->handle = layer;
-    c->send = connection_write;
-    c->close = ServerNetworkLayerTCP_close;
-    c->free = ServerNetworkLayerTCP_freeConnection;
-    c->getSendBuffer = connection_getsendbuffer;
-    c->releaseSendBuffer = connection_releasesendbuffer;
-    c->releaseRecvBuffer = connection_releaserecvbuffer;
-    c->state = UA_CONNECTIONSTATE_OPENING;
-    c->openingDate = UA_DateTime_nowMonotonic();
-
-    layer->connectionsSize++;
-
-    /* Add to the linked list */
-    LIST_INSERT_HEAD(&layer->connections, e, pointers);
-    if(nl->statistics) {
-        nl->statistics->currentConnectionCount++;
-        nl->statistics->cumulatedConnectionCount++;
-    }
-    return UA_STATUSCODE_GOOD;
-}
-
-static UA_StatusCode
-addServerSocket(ServerNetworkLayerTCP *layer, struct addrinfo *ai) {
-    /* Create the server socket */
-    UA_SOCKET newsock = UA_socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-    if(newsock == UA_INVALID_SOCKET)
-    {
-        UA_LOG_SOCKET_ERRNO_WRAP(
-            UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                           "Error opening the server socket: %s", errno_str));
-        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-    }
-
-    /* Some Linux distributions have net.ipv6.bindv6only not activated. So
-     * sockets can double-bind to IPv4 and IPv6. This leads to problems. Use
-     * AF_INET6 sockets only for IPv6. */
-
-    int optval = 1;
-#if UA_IPV6
-    if(ai->ai_family == AF_INET6 &&
-       UA_setsockopt(newsock, IPPROTO_IPV6, IPV6_V6ONLY,
-                  (const char*)&optval, sizeof(optval)) == -1) {
-        UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                       "Could not set an IPv6 socket to IPv6 only");
-        UA_close(newsock);
-        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-
-    }
-#endif
-    if(UA_setsockopt(newsock, SOL_SOCKET, SO_REUSEADDR,
-                  (const char *)&optval, sizeof(optval)) == -1) {
-        UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                       "Could not make the socket reusable");
-        UA_close(newsock);
-        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-    }
-
-
-    if(UA_socket_set_nonblocking(newsock) != UA_STATUSCODE_GOOD) {
-        UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                       "Could not set the server socket to nonblocking");
-        UA_close(newsock);
-        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-    }
-
-    /* Bind socket to address */
-    int ret = UA_bind(newsock, ai->ai_addr, (socklen_t)ai->ai_addrlen);
-    if(ret < 0) {
-        /* If bind to specific address failed, try to bind *-socket */
-        if(ai->ai_family == AF_INET) {
-            struct sockaddr_in *sin = (struct sockaddr_in *)ai->ai_addr;
-            if(sin->sin_addr.s_addr != htonl(INADDR_ANY)) {
-                sin->sin_addr.s_addr = 0;
-                ret = 0;
-            }
-        }
-#if UA_IPV6
-        else if(ai->ai_family == AF_INET6) {
-            struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)ai->ai_addr;
-            if(!IN6_IS_ADDR_UNSPECIFIED(&sin6->sin6_addr)) {
-                memset(&sin6->sin6_addr, 0, sizeof(sin6->sin6_addr));
-                sin6->sin6_scope_id = 0;
-                ret = 0;
-            }
-        }
-#endif // UA_IPV6
-        if(ret == 0) {
-            ret = UA_bind(newsock, ai->ai_addr, (socklen_t)ai->ai_addrlen);
-            if(ret == 0) {
-                /* The second bind fixed the issue, inform the user. */
-                UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                    "Server socket bound to unspecified address");
-            }
-        }
-    }
-    if(ret < 0) {
-        UA_LOG_SOCKET_ERRNO_WRAP(
-            UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                           "Error binding a server socket: %s", errno_str));
-        UA_close(newsock);
-        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-    }
-
-    /* Start listening */
-    if(UA_listen(newsock, MAXBACKLOG) < 0) {
-        UA_LOG_SOCKET_ERRNO_WRAP(
-                UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                       "Error listening on server socket: %s", errno_str));
-        UA_close(newsock);
-        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-    }
-
-    if(layer->port == 0) {
-        /* Port was automatically chosen. Read it from the OS */
-        struct sockaddr_in returned_addr;
-        memset(&returned_addr, 0, sizeof(returned_addr));
-        socklen_t len = sizeof(returned_addr);
-        UA_getsockname(newsock, (struct sockaddr *)&returned_addr, &len);
-        layer->port = ntohs(returned_addr.sin_port);
-    }
-
-    layer->serverSockets[layer->serverSocketsSize] = newsock;
-    layer->serverSocketsSize++;
-    return UA_STATUSCODE_GOOD;
-}
-
-static UA_StatusCode
-ServerNetworkLayerTCP_start(UA_ServerNetworkLayer *nl, const UA_Logger *logger,
-                            const UA_String *customHostname) {
-    UA_initialize_architecture_network();
-
-    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP *)nl->handle;
-    layer->logger = logger;
-
-    /* Get addrinfo of the server and create server sockets */
-    char hostname[512];
-    if(customHostname->length) {
-        if(customHostname->length >= sizeof(hostname))
-            return UA_STATUSCODE_BADOUTOFMEMORY;
-        memcpy(hostname, customHostname->data, customHostname->length);
-        hostname[customHostname->length] = '\0';
-    }
-    char portno[6];
-    UA_snprintf(portno, 6, "%d", layer->port);
-    struct addrinfo hints, *res;
-    memset(&hints, 0, sizeof hints);
-#if UA_IPV6
-    hints.ai_family = AF_UNSPEC; /* allow IPv4 and IPv6 */
-#else
-    hints.ai_family = AF_INET;   /* enforce IPv4 only */
-#endif
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags = AI_PASSIVE;
-#ifdef AI_ADDRCONFIG
-    hints.ai_flags |= AI_ADDRCONFIG;
-#endif
-    hints.ai_protocol = IPPROTO_TCP;
-    int retcode = UA_getaddrinfo(customHostname->length ? hostname : NULL,
-                                 portno, &hints, &res);
-    if(retcode != 0) {
-        UA_LOG_SOCKET_ERRNO_GAI_WRAP(UA_LOG_WARNING(layer->logger, UA_LOGCATEGORY_NETWORK,
-                                                    "getaddrinfo lookup of %s failed with error %d - %s", hostname, retcode, errno_str));
-        return UA_STATUSCODE_BADINTERNALERROR;
-    }
-
-    /* There might be serveral addrinfos (for different network cards,
-     * IPv4/IPv6). Add a server socket for all of them. */
-    struct addrinfo *ai = res;
-    for(layer->serverSocketsSize = 0;
-        layer->serverSocketsSize < FD_SETSIZE && ai != NULL;
-        ai = ai->ai_next) {
-        addServerSocket(layer, ai);
-    }
-    UA_freeaddrinfo(res);
-    
-    if(layer->serverSocketsSize == 0) {
-        return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-    }    
-
-    /* Get the discovery url from the hostname */
-    UA_String du = UA_STRING_NULL;
-    char discoveryUrlBuffer[256];
-    if(customHostname->length) {
-        du.length = (size_t)UA_snprintf(discoveryUrlBuffer, 255, "opc.tcp://%.*s:%d/",
-                                        (int)customHostname->length, customHostname->data,
-                                        layer->port);
-        du.data = (UA_Byte*)discoveryUrlBuffer;
-    } else {
-        char hostnameBuffer[256];
-        if(UA_gethostname(hostnameBuffer, 255) == 0) {
-            du.length = (size_t)UA_snprintf(discoveryUrlBuffer, 255, "opc.tcp://%s:%d/",
-                                            hostnameBuffer, layer->port);
-            du.data = (UA_Byte*)discoveryUrlBuffer;
-        } else {
-            UA_LOG_ERROR(layer->logger, UA_LOGCATEGORY_NETWORK, "Could not get the hostname");
-            return UA_STATUSCODE_BADINTERNALERROR;
-        }
-    }
-    UA_String_copy(&du, &nl->discoveryUrl);
-
-    UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                "TCP network layer listening on %.*s",
-                (int)nl->discoveryUrl.length, nl->discoveryUrl.data);
-    return UA_STATUSCODE_GOOD;
-}
-
-/* After every select, reset the sockets to listen on */
-static UA_Int32
-setFDSet(ServerNetworkLayerTCP *layer, fd_set *fdset) {
-    FD_ZERO(fdset);
-    UA_Int32 highestfd = 0;
-    for(UA_UInt16 i = 0; i < layer->serverSocketsSize; i++) {
-        UA_fd_set(layer->serverSockets[i], fdset);
-        if((UA_Int32)layer->serverSockets[i] > highestfd)
-            highestfd = (UA_Int32)layer->serverSockets[i];
-    }
-
-    ConnectionEntry *e;
-    LIST_FOREACH(e, &layer->connections, pointers) {
-        UA_fd_set(e->connection.sockfd, fdset);
-        if((UA_Int32)e->connection.sockfd > highestfd)
-            highestfd = (UA_Int32)e->connection.sockfd;
-    }
-
-    return highestfd;
-}
-
-static UA_StatusCode
-ServerNetworkLayerTCP_listen(UA_ServerNetworkLayer *nl, UA_Server *server,
-                             UA_UInt16 timeout) {
-    /* Every open socket can generate two jobs */
-    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP *)nl->handle;
-
-    if(layer->serverSocketsSize == 0)
-        return UA_STATUSCODE_GOOD;
-
-    /* Listen on open sockets (including the server) */
-    fd_set fdset, errset;
-    UA_Int32 highestfd = setFDSet(layer, &fdset);
-    setFDSet(layer, &errset);
-    struct timeval tmptv = {0, timeout * 1000};
-    if(UA_select(highestfd+1, &fdset, NULL, &errset, &tmptv) < 0) {
-        UA_LOG_SOCKET_ERRNO_WRAP(
-            UA_LOG_DEBUG(layer->logger, UA_LOGCATEGORY_NETWORK,
-                           "Socket select failed with %s", errno_str));
-        // we will retry, so do not return bad
-        return UA_STATUSCODE_GOOD;
-    }
-
-    /* Accept new connections via the server sockets */
-    for(UA_UInt16 i = 0; i < layer->serverSocketsSize; i++) {
-        if(!UA_fd_isset(layer->serverSockets[i], &fdset))
-            continue;
-
-        struct sockaddr_storage remote;
-        socklen_t remote_size = sizeof(remote);
-        UA_SOCKET newsockfd = UA_accept(layer->serverSockets[i],
-                                  (struct sockaddr*)&remote, &remote_size);
-        if(newsockfd == UA_INVALID_SOCKET)
-            continue;
-
-        UA_LOG_TRACE(layer->logger, UA_LOGCATEGORY_NETWORK,
-                    "Connection %i | New TCP connection on server socket %i",
-                    (int)newsockfd, (int)(layer->serverSockets[i]));
-
-        if(ServerNetworkLayerTCP_add(nl, layer, (UA_Int32)newsockfd, &remote) != UA_STATUSCODE_GOOD) {
-            UA_close(newsockfd);
-        }
-    }
-
-    /* Read from established sockets */
-    ConnectionEntry *e, *e_tmp;
-    UA_DateTime now = UA_DateTime_nowMonotonic();
-    LIST_FOREACH_SAFE(e, &layer->connections, pointers, e_tmp) {
-        if((e->connection.state == UA_CONNECTIONSTATE_OPENING) &&
-            (now > (e->connection.openingDate + (NOHELLOTIMEOUT * UA_DATETIME_MSEC)))) {
-            UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                        "Connection %i | Closed by the server (no Hello Message)",
-                         (int)(e->connection.sockfd));
-            LIST_REMOVE(e, pointers);
-            layer->connectionsSize--;
-            UA_close(e->connection.sockfd);
-            UA_Server_removeConnection(server, &e->connection);
-            if(nl->statistics) {
-                nl->statistics->connectionTimeoutCount--;
-                nl->statistics->currentConnectionCount--;
-            }
-            continue;
-        }
-
-        if(!UA_fd_isset(e->connection.sockfd, &errset) &&
-           !UA_fd_isset(e->connection.sockfd, &fdset))
-          continue;
-
-        UA_LOG_TRACE(layer->logger, UA_LOGCATEGORY_NETWORK,
-                    "Connection %i | Activity on the socket",
-                    (int)(e->connection.sockfd));
-
-        UA_ByteString buf = UA_BYTESTRING_NULL;
-        UA_StatusCode retval = connection_recv(&e->connection, &buf, 0);
-
-        if(retval == UA_STATUSCODE_GOOD) {
-            /* Process packets */
-            UA_Server_processBinaryMessage(server, &e->connection, &buf);
-            connection_releaserecvbuffer(&e->connection, &buf);
-        } else if(retval == UA_STATUSCODE_BADCONNECTIONCLOSED) {
-            /* The socket is shutdown but not closed */
-            UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                        "Connection %i | Closed",
-                        (int)(e->connection.sockfd));
-            LIST_REMOVE(e, pointers);
-            layer->connectionsSize--;
-            UA_close(e->connection.sockfd);
-            UA_Server_removeConnection(server, &e->connection);
-            if(nl->statistics) {
-                nl->statistics->currentConnectionCount--;
-            }
-        }
-    }
-    return UA_STATUSCODE_GOOD;
-}
-
-static void
-ServerNetworkLayerTCP_stop(UA_ServerNetworkLayer *nl, UA_Server *server) {
-    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP *)nl->handle;
-    UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,
-                "Shutting down the TCP network layer");
-
-    /* Close the server sockets */
-    for(UA_UInt16 i = 0; i < layer->serverSocketsSize; i++) {
-        UA_shutdown(layer->serverSockets[i], 2);
-        UA_close(layer->serverSockets[i]);
-    }
-    layer->serverSocketsSize = 0;
-
-    /* Close open connections */
-    ConnectionEntry *e;
-    LIST_FOREACH(e, &layer->connections, pointers)
-        ServerNetworkLayerTCP_close(&e->connection);
-
-    /* Run recv on client sockets. This picks up the closed sockets and frees
-     * the connection. */
-    ServerNetworkLayerTCP_listen(nl, server, 0);
-
-    UA_deinitialize_architecture_network();
-}
-
-/* run only when the server is stopped */
-static void
-ServerNetworkLayerTCP_clear(UA_ServerNetworkLayer *nl) {
-    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP *)nl->handle;
-    UA_String_clear(&nl->discoveryUrl);
-
-    /* Hard-close and remove remaining connections. The server is no longer
-     * running. So this is safe. */
-    ConnectionEntry *e, *e_tmp;
-    LIST_FOREACH_SAFE(e, &layer->connections, pointers, e_tmp) {
-        LIST_REMOVE(e, pointers);
-        layer->connectionsSize--;
-        UA_close(e->connection.sockfd);
-        UA_free(e);
-        if(nl->statistics) {
-            nl->statistics->currentConnectionCount--;
-        }
-    }
-
-    /* Free the layer */
-    UA_free(layer);
-}
-
-UA_ServerNetworkLayer
-UA_ServerNetworkLayerTCP(UA_ConnectionConfig config, UA_UInt16 port,
-                         UA_UInt16 maxConnections) {
-    UA_ServerNetworkLayer nl;
-    memset(&nl, 0, sizeof(UA_ServerNetworkLayer));
-    nl.clear = ServerNetworkLayerTCP_clear;
-    nl.localConnectionConfig = config;
-    nl.start = ServerNetworkLayerTCP_start;
-    nl.listen = ServerNetworkLayerTCP_listen;
-    nl.stop = ServerNetworkLayerTCP_stop;
-    nl.handle = NULL;
-
-    ServerNetworkLayerTCP *layer = (ServerNetworkLayerTCP*)
-        UA_calloc(1,sizeof(ServerNetworkLayerTCP));
-    if(!layer)
-        return nl;
-    nl.handle = layer;
-
-    layer->port = port;
-    layer->maxConnections = maxConnections;
-
-    return nl;
-}
-
-typedef struct TCPClientConnection {
-    struct addrinfo hints, *server;
-    UA_DateTime connStart;
-    UA_String endpointUrl;
-    UA_UInt32 timeout;
-} TCPClientConnection;
 
 /***************************/
 /* Client NetworkLayer TCP */

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -153,9 +153,13 @@ struct UA_ServerConfig {
     UA_EventLoop *eventLoop;
     UA_Boolean externalEventLoop; /* The EventLoop is not deleted with the config */
 
+    size_t connectionManagersSize;
+    UA_ConnectionManager *connectionManagers[10];
+
     /**
      * Networking
      * ^^^^^^^^^^ */
+
     size_t networkLayersSize;
     UA_ServerNetworkLayer *networkLayers;
     UA_String customHostname;

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -141,7 +141,11 @@ setDefaultConfig(UA_ServerConfig *conf) {
         conf->externalEventLoop = false;
     }
 
-    /* --> Start setting the default static config <-- */
+    /* Eventsources */
+    conf->connectionManagersSize = 0;
+    /* conf->connectionManagers; */
+
+   /* --> Start setting the default static config <-- */
 
     conf->shutdownDelay = 0.0;
 
@@ -329,6 +333,18 @@ UA_ServerConfig_addNetworkLayerTCP(UA_ServerConfig *conf, UA_UInt16 portNumber,
     if (!conf->networkLayers[conf->networkLayersSize].handle)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     conf->networkLayersSize++;
+
+    /* TCP Eventsource */
+
+    UA_ConnectionManager *tcpCM = UA_ConnectionManager_new_POSIX_TCP(UA_STRING("tcpCM"));
+    conf->connectionManagers[conf->connectionManagersSize] = tcpCM;
+    UA_UInt16 port = portNumber;
+    UA_Variant portVar;
+    UA_Variant_setScalar(&portVar, &port, &UA_TYPES[UA_TYPES_UINT16]);
+    UA_KeyValueMap_set(&tcpCM->eventSource.params, &tcpCM->eventSource.paramsSize, UA_QUALIFIEDNAME(0, "listen-port"), &portVar);
+    conf->connectionManagersSize++;
+
+    conf->eventLoop->registerEventSource(conf->eventLoop, (UA_EventSource *) tcpCM);
 
     return UA_STATUSCODE_GOOD;
 }

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -28,6 +28,10 @@ UA_ServerConfig_clean(UA_ServerConfig *config) {
 
     /* Custom DataTypes */
     /* nothing to do */
+    for (size_t i = 0; i < config->connectionManagersSize; i++) {
+        UA_ConnectionManager* cm = config->connectionManagers[i];
+        UA_free(cm->initialConnectionContext);
+    }
 
     /* Stop and delete the EventLoop */
     UA_EventLoop *el = config->eventLoop;

--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -34,8 +34,6 @@ removeSecureChannel(UA_Server *server, channel_entry *entry,
 
     /* Detach from the connection and close the connection */
     if(entry->channel.connection) {
-        if(entry->channel.connection->state != UA_CONNECTIONSTATE_CLOSED)
-            entry->channel.connection->close(entry->channel.connection);
         UA_Connection_detachSecureChannel(entry->channel.connection);
     }
 

--- a/src/ua_connection.c
+++ b/src/ua_connection.c
@@ -18,6 +18,8 @@
 #include "ua_types_encoding_binary.h"
 #include "ua_util_internal.h"
 
+#include <open62541/plugin/eventloop.h>
+
 /* Hides some errors before sending them to a client according to the
  * standard. */
 static void
@@ -76,4 +78,83 @@ void
 UA_Connection_attachSecureChannel(UA_Connection *connection, UA_SecureChannel *channel) {
     if(UA_atomic_cmpxchg((void**)&channel->connection, NULL, connection) == NULL)
         UA_atomic_xchg((void**)&connection->channel, (void*)channel);
+}
+
+UA_StatusCode UA_Server_Connection_getSendBuffer(UA_Connection *connection, size_t length,
+                                                        UA_ByteString *buf) {
+    UA_Server_ConnectionContext *ctx = (UA_Server_ConnectionContext *) connection->handle;
+    UA_ConnectionManager *cm = ((UA_Server_BasicConnectionContext *)ctx)->cm;
+    return cm->allocNetworkBuffer(cm, ctx->connectionId, buf, length);
+}
+
+UA_StatusCode UA_Server_Connection_send(UA_Connection *connection, UA_ByteString *buf) {
+    UA_Server_ConnectionContext *ctx = (UA_Server_ConnectionContext *) connection->handle;
+    UA_ConnectionManager *cm = ((UA_Server_BasicConnectionContext *)ctx)->cm;
+
+    return cm->sendWithConnection(cm, ctx->connectionId, 0, NULL, buf);
+}
+
+void UA_Server_Connection_releaseBuffer (UA_Connection *connection, UA_ByteString *buf) {
+    UA_Server_ConnectionContext *ctx = (UA_Server_ConnectionContext *) connection->handle;
+    UA_ConnectionManager *cm = ((UA_Server_BasicConnectionContext *)ctx)->cm;
+    cm->freeNetworkBuffer(cm, ctx->connectionId, buf);
+}
+
+void UA_Server_Connection_close(UA_Connection *connection) {
+    UA_Server_ConnectionContext *ctx = (UA_Server_ConnectionContext *) connection->handle;
+    UA_ConnectionManager *cm = ((UA_Server_BasicConnectionContext *)ctx)->cm;
+    cm->closeConnection(cm, ctx->connectionId);
+}
+
+void
+UA_Server_connectionCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
+                             void **connectionContext, UA_StatusCode stat,
+                             size_t paramsSize, const UA_KeyValuePair *params,
+                             UA_ByteString msg) {
+
+    UA_LOG_DEBUG(cm->eventSource.eventLoop->logger, UA_LOGCATEGORY_SERVER,
+                 "connection callback for id: %lu", (unsigned long) connectionId);
+
+    UA_Server_BasicConnectionContext *ctx = (UA_Server_BasicConnectionContext *) *connectionContext;
+
+    if (stat != UA_STATUSCODE_GOOD) {
+        UA_LOG_INFO(cm->eventSource.eventLoop->logger, UA_LOGCATEGORY_SERVER, "closing connection");
+
+        if (!ctx->isInitial) {
+
+            UA_Server_ConnectionContext *serverctx = (UA_Server_ConnectionContext *) ctx;
+            /* Instead of removing the complete connection just detach the secure channel */
+            /* TODO: check if UA_Server_removeConnection is public api */
+            /* UA_Server_removeConnection(ctx->server, &serverctx->connection); */
+            UA_Connection_detachSecureChannel(&serverctx->connection);
+            free(*connectionContext);
+        }
+        return;
+    }
+
+    if (ctx->isInitial) {
+        UA_Server_ConnectionContext *newCtx = (UA_Server_ConnectionContext*) calloc(1, sizeof(UA_Server_ConnectionContext));
+        newCtx->base.isInitial = false;
+        newCtx->base.cm = ctx->cm;
+        newCtx->base.server = ctx->server;
+        newCtx->connectionId = connectionId;
+        newCtx->connection.close = UA_Server_Connection_close;
+        newCtx->connection.free = NULL;
+        newCtx->connection.getSendBuffer = UA_Server_Connection_getSendBuffer;
+        newCtx->connection.recv = NULL;
+        newCtx->connection.releaseRecvBuffer = UA_Server_Connection_releaseBuffer;
+        newCtx->connection.releaseSendBuffer = UA_Server_Connection_releaseBuffer;
+        newCtx->connection.send = UA_Server_Connection_send;
+        newCtx->connection.state = UA_CONNECTIONSTATE_CLOSED;
+
+        newCtx->connection.handle = newCtx;
+
+        *connectionContext = newCtx;
+    }
+
+    UA_Server_ConnectionContext *conCtx = (UA_Server_ConnectionContext *) *connectionContext;
+
+    if (msg.length > 0) {
+        UA_Server_processBinaryMessage(ctx->server, &conCtx->connection, &msg);
+    }
 }

--- a/src/ua_connection_internal.h
+++ b/src/ua_connection_internal.h
@@ -12,9 +12,12 @@
 #define UA_CONNECTION_INTERNAL_H_
 
 #include <open62541/plugin/network.h>
+#include <open62541/plugin/eventloop.h>
 #include <open62541/transport_generated.h>
 
 _UA_BEGIN_DECLS
+
+
 
 /* When a fatal error occurs the Server shall send an Error Message to the
  * Client and close the socket. When a Client encounters one of these errors, it
@@ -28,6 +31,34 @@ UA_Connection_sendError(UA_Connection *connection,
 void UA_Connection_detachSecureChannel(UA_Connection *connection);
 void UA_Connection_attachSecureChannel(UA_Connection *connection,
                                        UA_SecureChannel *channel);
+
+/********************************/
+/* Server Eventloop integration */
+/********************************/
+
+
+/* In this example, we integrate the server into an external "mainloop". This
+   can be for example the event-loop used in GUI toolkits, such as Qt or GTK. */
+
+typedef struct {
+    UA_Boolean isInitial;
+    UA_ConnectionManager *cm;
+    UA_Server *server;
+} UA_Server_BasicConnectionContext;
+
+typedef struct {
+    UA_Server_BasicConnectionContext base;
+    uintptr_t connectionId;
+    UA_Connection connection;
+} UA_Server_ConnectionContext;
+
+UA_StatusCode UA_Server_Connection_getSendBuffer(UA_Connection *connection, size_t length,
+                                                        UA_ByteString *buf);
+UA_StatusCode UA_Server_Connection_send(UA_Connection *connection, UA_ByteString *buf);
+void UA_Server_Connection_releaseBuffer (UA_Connection *connection, UA_ByteString *buf);
+void UA_Server_Connection_close(UA_Connection *connection);
+void UA_Server_connectionCallback(UA_ConnectionManager *cm, uintptr_t connectionId, void **connectionContext,
+                                  UA_StatusCode stat, size_t paramsSize, const UA_KeyValuePair *params, UA_ByteString msg);
 
 _UA_END_DECLS
 


### PR DESCRIPTION
Integrates the server iteration for the eventloop.

### Summary:
- code for server-networklayer-tcp removed from `arch/network_tcp.c`
- define and initialize connection-managersin server config (`include/open62541/server.h`, `plugins/ua_config_default.c`)
- `UA_Server_setupEventLoop` method which is called in `UA_Server_run_startup` (`server.c`)
- replace server specific code with eventloop-run in `UA_Server_run_iterate` (`server.c`)
- stop event-sources in `UA_Server_run_shutdown` (`server.c`)
- server-connection related logic and structure in `src/ua_connection.c` & `src/ua_connection_internal.h`

### Future Work / Ideas
- networklayers (consistently integrate connection-managers/event-sources in networklayers - key-value-map ? )
- Get rid of complete arch/network_tcp server code and the corresponding logic of the callers?
- Discovery server integration next step