### PR TITLE
fix(nc): skipping nodeset issues wrong counter for TypesArray

### DIFF
--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -123,6 +123,7 @@ def getTypesArray(nsIdx):
 for xmlfile in args.existing:
     if xmlfile.name in loadedFiles:
         logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))
+        nsCount +=1
         continue
     loadedFiles.append(xmlfile.name)
     logger.info("Preprocessing (existing) " + str(xmlfile.name))
@@ -131,6 +132,7 @@ for xmlfile in args.existing:
 for xmlfile in args.infiles:
     if xmlfile.name in loadedFiles:
         logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))
+        nsCount +=1
         continue
     loadedFiles.append(xmlfile.name)
     logger.info("Preprocessing " + str(xmlfile.name))


### PR DESCRIPTION
Hi,

I had a bug in the nodeset compiler importing different  Companion Specification nodeset and my new nodeset. The typesArray of the DataType was wrong, and the code was broken. 

The problem is in my opinion that the nodeset compiler skip existing nodeset but do not count them in the array index. So, the wrong types-array was used. I increased the index as well for skipped nodeset and that works fine. 

Here is the example input argument of the python script:
`
--bsd=D:/codelab/gms_sample_server/Sample-Server/model/GMS/opc.ua.gms.nodeset2.bsd --types-array=UA_TYPES --types-array=UA_TYPES_DI --types-array=UA_TYPES --types-array=UA_TYPES_DI --types-array=UA_TYPES_IA --types-array=UA_TYPES --types-array=UA_TYPES_DI --types-array=UA_TYPES_MACHINERY --types-array=UA_TYPES --types-array=UA_TYPES_MACHINERY_RESULT --types-array=UA_TYPES --types-array=UA_TYPES_DI --types-array=UA_TYPES --types-array=UA_TYPES_DI --types-array=UA_TYPES_MACHINERY --types-array=UA_TYPES --types-array=UA_TYPES_DI --types-array=UA_TYPES_IA --types-array=UA_TYPES_MACHINETOOL --types-array=UA_TYPES_GMS --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/IA/Opc.Ua.IA.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Machinery/Opc.Ua.Machinery.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/model/GMS/opc.ua.machinery.result.nodeset2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Machinery/Opc.Ua.Machinery.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/Schema/Opc.Ua.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/IA/Opc.Ua.IA.NodeSet2.xml --existing=D:/codelab/gms_sample_server/Sample-Server/install/share/open62541/tools/ua-nodeset/MachineTool/Opc.Ua.MachineTool.NodeSet2.xml --xml=D:/codelab/gms_sample_server/Sample-Server/model/GMS/opc.ua.gms.nodeset2.xml D:/codelab/gms_sample_server/Sample-Server/src_generated/namespace_GMS_generated`



<footer>