### PR TITLE
Fix error: missing braces around initializer [-Werror=missing-braces]

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -547,7 +547,7 @@ UA_EXPANDEDNODEID_BYTESTRING_ALLOC(UA_UInt16 nsIndex, const char *chars) {
 
 static UA_INLINE UA_ExpandedNodeId
 UA_EXPANDEDNODEID_NODEID(UA_NodeId nodeId) {
-    UA_ExpandedNodeId id = {0}; id.nodeId = nodeId; return id;
+    UA_ExpandedNodeId id; memset(&id, 0, sizeof(UA_ExpandedNodeId)); id.nodeId = nodeId; return id;
 }
 
 /* Does the ExpandedNodeId point to a local node? That is, are namespaceUri and

--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -43,7 +43,7 @@
 # define UA_REFTYPES_ALL_ARRAY UA_REFTYPES_ALL_MASK
 #endif
 
-const UA_ReferenceTypeSet UA_REFERENCETYPESET_NONE = {0};
+const UA_ReferenceTypeSet UA_REFERENCETYPESET_NONE = {{0}};
 const UA_ReferenceTypeSet UA_REFERENCETYPESET_ALL  = {{UA_REFTYPES_ALL_ARRAY}};
 
 /*****************/

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -38,7 +38,7 @@ const UA_String UA_STRING_NULL = {0};
 const UA_ByteString UA_BYTESTRING_NULL = {0};
 const UA_Guid UA_GUID_NULL = {0};
 const UA_NodeId UA_NODEID_NULL = {0};
-const UA_ExpandedNodeId UA_EXPANDEDNODEID_NULL = {0};
+const UA_ExpandedNodeId UA_EXPANDEDNODEID_NULL = { {0}, {0}, 0 };
 
 typedef UA_StatusCode
 (*UA_copySignature)(const void *src, void *dst, const UA_DataType *type);


### PR DESCRIPTION
Using {0} it not portable. 

I got this error in my build chain
```
open62541/src/server/ua_nodes.c:46:1: error: missing braces around initializer [-Werror=missing-braces]
 const UA_ReferenceTypeSet UA_REFERENCETYPESET_NONE = {0};
 ^
open62541/src/server/ua_nodes.c:46:1: error: (near initialization for 'UA_REFERENCETYPESET_NONE.bits') [-Werror=missing-braces]
.cc1: error: unrecognized command line option "-Wno-static-in-inline" [-Werror]
.cc1: all warnings being treated as errors

```
Looks like a deja vu of https://github.com/open62541/open62541/issues/2134

Signed-off-by: Kjeld Flarup <kfa@deif.com>