### PR TITLE
Some const qualifiers which causes build with older openssl (pre 1.1) to fail.

### DIFF
--- a/plugins/crypto/openssl/ua_openssl_create_certificate.c
+++ b/plugins/crypto/openssl/ua_openssl_create_certificate.c
@@ -67,8 +67,9 @@ UA_String_chr(const UA_String *pUaStr, char needl) {
     return -1;
 }
 
+/* char *value cannot be const due to openssl 1.0 compatibility */
 static UA_StatusCode
-add_x509V3ext(X509 *x509, int nid, const char *value) {
+add_x509V3ext(X509 *x509, int nid, char *value) {
     X509_EXTENSION *ex;
     X509V3_CTX ctx;
     X509V3_set_ctx_nodb(&ctx);
@@ -261,7 +262,7 @@ UA_CreateCertificate(const UA_Logger *logger,
         goto cleanup;
     }
 
-    errRet = add_x509V3ext(x509, NID_subject_alt_name, (const char*) fullAltSubj.data);
+    errRet = add_x509V3ext(x509, NID_subject_alt_name, (char*) fullAltSubj.data);
     if(errRet != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(logger, UA_LOGCATEGORY_SECURECHANNEL,
                      "Create Certificate: Setting 'Subject Alternative Name:' failed.");


### PR DESCRIPTION
While updating to latest master, I encountered passing of some const variables has changed.  
In the older tool chains I use, the functions in openssl does not have a const in the declaration, which causes a violation.

I'm actually in the process of migrating to openssl 1.1.1, so this will be less important for me soon.

Signed-off-by: Kjeld Flarup <kfa@deif.com>