### PR TITLE
WIP Event-Filter implicit numeric cast

### DIFF
--- a/src/server/ua_subscription_events_filter.c
+++ b/src/server/ua_subscription_events_filter.c
@@ -316,6 +316,50 @@ implicitNumericVariantTransformation(UA_Variant *variant, void *data){
     return UA_STATUSCODE_GOOD;
 }
 
+static UA_StatusCode
+implicitNumericVariantTransformationUnsingedToSigned(UA_Variant *variant, void *data){
+    if(variant->type == &UA_TYPES[UA_TYPES_UINT64]){
+        if(*(UA_UInt64 *)variant->data > INT64_MAX)
+            return UA_STATUSCODE_BADTYPEMISMATCH;
+        *(UA_Int64 *)data = *(UA_Int64 *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_INT64]);
+    } else if(variant->type == &UA_TYPES[UA_TYPES_UINT32]){
+        *(UA_Int64 *)data = *(UA_Int32 *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_INT64]);
+    } else if(variant->type == &UA_TYPES[UA_TYPES_UINT16]){
+        *(UA_Int64 *)data = *(UA_Int16 *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_INT64]);
+    } else if(variant->type == &UA_TYPES[UA_TYPES_BYTE]){
+        *(UA_Int64 *)data = *(UA_Byte *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_INT64]);
+    } else {
+        return UA_STATUSCODE_BADTYPEMISMATCH;
+    }
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+implicitNumericVariantTransformationSignedToUnSigned(UA_Variant *variant, void *data){
+    if(*(UA_Int64 *)variant->data < 0)
+        return UA_STATUSCODE_BADTYPEMISMATCH;
+    if(variant->type == &UA_TYPES[UA_TYPES_INT64]){
+        *(UA_UInt64 *)data = *(UA_UInt64 *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_UINT64]);
+    } else if(variant->type == &UA_TYPES[UA_TYPES_INT32]){
+        *(UA_UInt64 *)data = *(UA_UInt32 *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_UINT64]);
+    } else if(variant->type == &UA_TYPES[UA_TYPES_INT16]){
+        *(UA_UInt64 *)data = *(UA_UInt16 *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_UINT64]);
+    } else if(variant->type == &UA_TYPES[UA_TYPES_SBYTE]){
+        *(UA_UInt64 *)data = *(UA_Byte *)variant->data;
+        UA_Variant_setScalar(variant, data, &UA_TYPES[UA_TYPES_UINT64]);
+    } else {
+        return UA_STATUSCODE_BADTYPEMISMATCH;
+    }
+    return UA_STATUSCODE_GOOD;
+}
+
 /* 0 -> Same Type, 1 -> Implicit Cast, 2 -> Only explicit Cast, -1 -> cast invalid */
 static UA_SByte convertLookup[21][21] = {
     { 0, 1,-1,-1, 1,-1, 1,-1, 1, 1, 1,-1, 1,-1, 2,-1,-1, 1, 1, 1,-1},
@@ -416,7 +460,9 @@ compareOperation(UA_Variant *firstOperand, UA_Variant *secondOperand, UA_FilterO
         UA_TYPES_DIFFERENT_NUMERIC_FLOATING_POINT,
         UA_TYPES_DIFFERENT_TEXT,
         UA_TYPES_DIFFERENT_COMPARE_FORBIDDEN,
-        UA_TYPES_DIFFERENT_COMPARE_EXPLIC
+        UA_TYPES_DIFFERENT_COMPARE_EXPLIC,
+        UA_TYPES_DIFFERENT_NUMERIC_SIGN_O1_SIGNED,
+        UA_TYPES_DIFFERENT_NUMERIC_SIGN_O2_SIGNED
     } compareHandlingRuleEnum;
 
     if(castRule == 0 &&
@@ -445,6 +491,14 @@ compareOperation(UA_Variant *firstOperand, UA_Variant *secondOperand, UA_FilterO
               isStringType(firstOperand->type->typeKind)&&
               isStringType(secondOperand->type->typeKind)){
         compareHandlingRuleEnum = UA_TYPES_DIFFERENT_TEXT;
+    } else if(castRule == 1 &&
+              isNumericSigned(firstOperand->type->typeKind) &&
+              isNumericUnsigned(secondOperand->type->typeKind)){
+        compareHandlingRuleEnum = UA_TYPES_DIFFERENT_NUMERIC_SIGN_O1_SIGNED;
+    } else if(castRule == 1 &&
+              isNumericSigned(secondOperand->type->typeKind) &&
+              isNumericUnsigned(firstOperand->type->typeKind)){
+        compareHandlingRuleEnum = UA_TYPES_DIFFERENT_NUMERIC_SIGN_O2_SIGNED;
     } else if(castRule == -1 || castRule == 2){
         compareHandlingRuleEnum = UA_TYPES_DIFFERENT_COMPARE_EXPLIC;
     } else {
@@ -467,6 +521,12 @@ compareOperation(UA_Variant *firstOperand, UA_Variant *secondOperand, UA_FilterO
            compareHandlingRuleEnum == UA_TYPES_DIFFERENT_NUMERIC_FLOATING_POINT) {
             implicitNumericVariantTransformation(firstCompareOperand, variantContent);
             implicitNumericVariantTransformation(secondCompareOperand, &variantContent[8]);
+        } else if(compareHandlingRuleEnum == UA_TYPES_DIFFERENT_NUMERIC_SIGN_O1_SIGNED) {
+            implicitNumericVariantTransformation(firstCompareOperand, variantContent);
+            implicitNumericVariantTransformationUnsingedToSigned(secondCompareOperand, &variantContent[8]);
+        } else if(compareHandlingRuleEnum == UA_TYPES_DIFFERENT_NUMERIC_SIGN_O2_SIGNED) {
+            implicitNumericVariantTransformation(firstCompareOperand, variantContent);
+            implicitNumericVariantTransformationSignedToUnSigned(secondCompareOperand, &variantContent[8]);
         } else if(compareHandlingRuleEnum == UA_TYPES_DIFFERENT_TEXT) {
             firstCompareOperand->type = &UA_TYPES[UA_TYPES_STRING];
             secondCompareOperand->type = &UA_TYPES[UA_TYPES_STRING];
@@ -485,6 +545,12 @@ compareOperation(UA_Variant *firstOperand, UA_Variant *secondOperand, UA_FilterO
             memset(&variantContent, 0, sizeof(UA_Byte) * 16);
             implicitNumericVariantTransformation(firstCompareOperand, variantContent);
             implicitNumericVariantTransformation(secondCompareOperand, &variantContent[8]);
+        } else if(compareHandlingRuleEnum == UA_TYPES_DIFFERENT_NUMERIC_SIGN_O1_SIGNED) {
+            implicitNumericVariantTransformation(firstCompareOperand, variantContent);
+            implicitNumericVariantTransformationUnsingedToSigned(secondCompareOperand, &variantContent[8]);
+        } else if(compareHandlingRuleEnum == UA_TYPES_DIFFERENT_NUMERIC_SIGN_O2_SIGNED) {
+            implicitNumericVariantTransformation(firstCompareOperand, variantContent);
+            implicitNumericVariantTransformationSignedToUnSigned(secondCompareOperand, &variantContent[8]);
         } else if(compareHandlingRuleEnum == UA_TYPES_DIFFERENT_TEXT) {
             firstCompareOperand->type = &UA_TYPES[UA_TYPES_STRING];
             secondCompareOperand->type = &UA_TYPES[UA_TYPES_STRING];


### PR DESCRIPTION
This PR extends the implicit numeric cast options within the event-filter mechanism. 
- Allow casting between signed and unsigned integers