### PR TITLE
feat(pubsub): Recognize the PDS name

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -186,6 +186,9 @@ UA_String_fromChars(const char *src) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 UA_Boolean UA_EXPORT
 UA_String_equal(const UA_String *s1, const UA_String *s2);
 
+UA_Boolean UA_EXPORT
+UA_String_isEmpty(const UA_String *s);
+
 UA_EXPORT extern const UA_String UA_STRING_NULL;
 
 /**

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -54,6 +54,9 @@ UA_PublishedDataSetConfig_copy(const UA_PublishedDataSetConfig *src,
 UA_PublishedDataSet *
 UA_PublishedDataSet_findPDSbyId(UA_Server *server, UA_NodeId identifier);
 
+UA_PublishedDataSet *
+UA_PublishedDataSet_findPDSbyName(UA_Server *server, UA_String name);
+
 void
 UA_PublishedDataSet_clear(UA_Server *server,
                           UA_PublishedDataSet *publishedDataSet);

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -160,12 +160,16 @@ UA_Server_addPublishedDataSet(UA_Server *server,
     if(UA_String_isEmpty(&publishedDataSetConfig->name))
     {
         // DataSet has to have a valid name
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "PublishedDataSet creation failed. Invalid name.");
         return result;
     }
 
     if(UA_PublishedDataSet_findPDSbyName(server, publishedDataSetConfig->name))
     {
         // DataSet name has to be unique in the publisher
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "PublishedDataSet creation failed. DataSet with the same name already exists.");
         result.addResult = UA_STATUSCODE_BADBROWSENAMEDUPLICATED;
         return result;
     }

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -157,6 +157,19 @@ UA_Server_addPublishedDataSet(UA_Server *server,
         return result;
     }
 
+    if(UA_String_isEmpty(&publishedDataSetConfig->name))
+    {
+        // DataSet has to have a valid name
+        return result;
+    }
+
+    if(UA_PublishedDataSet_findPDSbyName(server, publishedDataSetConfig->name))
+    {
+        // DataSet name has to be unique in the publisher
+        result.addResult = UA_STATUSCODE_BADBROWSENAMEDUPLICATED;
+        return result;
+    }
+
     /* Create new PDS and add to UA_PubSubManager */
     UA_PublishedDataSet *newPDS = (UA_PublishedDataSet *)
         UA_calloc(1, sizeof(UA_PublishedDataSet));

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -196,6 +196,17 @@ UA_PublishedDataSet_findPDSbyId(UA_Server *server, UA_NodeId identifier) {
     return tmpPDS;
 }
 
+UA_PublishedDataSet *
+UA_PublishedDataSet_findPDSbyName(UA_Server *server, UA_String name) {
+    UA_PublishedDataSet *tmpPDS = NULL;
+    TAILQ_FOREACH(tmpPDS, &server->pubSubManager.publishedDataSets, listEntry) {
+        if(UA_String_equal(&name, &tmpPDS->config.name))
+            break;
+    }
+
+    return tmpPDS;
+}
+
 void
 UA_PublishedDataSetConfig_clear(UA_PublishedDataSetConfig *pdsConfig) {
     //delete pds config

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -134,6 +134,11 @@ UA_String_equal(const UA_String *s1, const UA_String *s2) {
     return (stringOrder(s1, s2, NULL) == UA_ORDER_EQ);
 }
 
+UA_Boolean
+UA_String_isEmpty(const UA_String *s) {
+    return (s->length == 0 || s->data == NULL);
+}
+
 /* Do not expose UA_String_equal_ignorecase to public API as it currently only handles
  * ASCII strings, and not UTF8! */
 UA_Boolean

--- a/tests/pubsub/check_pubsub_pds.c
+++ b/tests/pubsub/check_pubsub_pds.c
@@ -38,6 +38,7 @@ START_TEST(AddPDSWithMinimalValidConfiguration){
     ck_assert_int_eq(server->pubSubManager.publishedDataSetsSize, 1);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_NodeId newPDSNodeID;
+    pdsConfig.name = UA_STRING("TEST PDS 2");
     retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &newPDSNodeID).addResult;
     ck_assert_int_eq(server->pubSubManager.publishedDataSetsSize, 2);
     ck_assert_int_eq(newPDSNodeID.identifierType, UA_NODEIDTYPE_NUMERIC);

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -333,6 +333,8 @@ START_TEST(SubscribeSingleFieldWithFixedOffsets) {
     UA_DataValue_delete(dataValue);
     UA_free(subValue);
     UA_free(subDataValueRT);
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, publishedDataSetIdent));
 } END_TEST
 
 START_TEST(SetupInvalidPubSubConfigReader) {
@@ -475,6 +477,8 @@ START_TEST(SetupInvalidPubSubConfigReader) {
         ck_assert(UA_Server_freezeReaderGroupConfiguration(server, readerGroupIdentifier) == UA_STATUSCODE_BADNOTSUPPORTED); // DateTime not supported
         ck_assert(UA_Server_unfreezeReaderGroupConfiguration(server, readerGroupIdentifier) == UA_STATUSCODE_GOOD);
         ck_assert(UA_Server_unfreezeWriterGroupConfiguration(server, writerGroupIdent) == UA_STATUSCODE_GOOD);
+
+        ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, publishedDataSetIdent));
     } END_TEST
 
 START_TEST(SetupInvalidPubSubConfig) {
@@ -526,6 +530,8 @@ START_TEST(SetupInvalidPubSubConfig) {
     ck_assert(UA_Server_addDataSetWriter(server, writerGroupIdent, publishedDataSetIdent, &dataSetWriterConfig, &dataSetWriterIdent) == UA_STATUSCODE_BADCONFIGURATIONERROR);
 
     UA_Variant_clear(&variant);
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, publishedDataSetIdent));
 } END_TEST
 
 /* additional SubscriberBeforeWriteCallback test data */
@@ -706,6 +712,8 @@ static void PublishSubscribeWithWriteCallback_Helper(
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_unfreezeReaderGroupConfiguration(server, readerGroupIdentifier));
 
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePubSubConnection(server, connectionIdentifier));
+
+    ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_removePublishedDataSet(server, publishedDataSetIdent));
 
     UA_NodeId_clear(&connectionIdentifier);
     UA_NodeId_clear(&publishedDataSetIdent);


### PR DESCRIPTION
Part 14 requires that a PDS has a unique name within the Publisher. Make the corresponding check before creating a new PDS.
![image](https://user-images.githubusercontent.com/70644594/153863057-a39598d9-3d32-42b2-8046-767e8f486744.png)
![image](https://user-images.githubusercontent.com/70644594/153863273-41a0882e-a33f-43df-9cc6-fd51bfa06700.png)


The new function `UA_PublishedDataSet_findPDSbyName` may be also used in future by new applications e.g. OPC UA FX.

By the way, added utility function `UA_String_isEmpty` to the core library. If such an addition is not appropriate, I can replace the check in ua_pubsub_manager.c with:
`UA_String_equal(&publishedDataSetConfig->name, &UA_STRING_NULL)`, or `(publishedDataSetConfig->name.length == 0)` like it's done elsewhere. 