### PR TITLE
[Review]Revert "fix(nc): skipping nodeset issues wrong counter for TypesArray"

### DIFF
--- a/tools/nodeset_compiler/nodeset_compiler.py
+++ b/tools/nodeset_compiler/nodeset_compiler.py
@@ -129,7 +129,6 @@ def getTypesArray(nsIdx):
 for xmlfile in args.existing:
     if xmlfile.name in loadedFiles:
         logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))
-        nsCount +=1
         continue
     loadedFiles.append(xmlfile.name)
     logger.info("Preprocessing (existing) " + str(xmlfile.name))
@@ -138,7 +137,6 @@ for xmlfile in args.existing:
 for xmlfile in args.infiles:
     if xmlfile.name in loadedFiles:
         logger.info("Skipping Nodeset since it is already loaded: {} ".format(xmlfile.name))
-        nsCount +=1
         continue
     loadedFiles.append(xmlfile.name)
     logger.info("Preprocessing " + str(xmlfile.name))


### PR DESCRIPTION
This reverts commit ca50a8d4fe8563932a761c3b1992d7017778097f.
Obsolete due to functionality introduce with commit a0c28b8bb51e797ab96c4f1af7fc952871a5fdc5
