### PR TITLE
fix(nc): check namespace when searching for HasTypeDefinition reference

### DIFF
--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -151,7 +151,7 @@ class Node(object):
 
     def popTypeDef(self):
         for ref in self.references:
-            if ref.referenceType.i == 40 and ref.isForward:
+            if ref.referenceType.ns == 0 and ref.referenceType.i == 40 and ref.isForward:
                 self.references.remove(ref)
                 return ref
         return Reference(NodeId(), NodeId(), NodeId(), False)


### PR DESCRIPTION
References with i=40 can exist in other namespaces, so the namespace index needs to be checked when searching for HasTypeDefinition reference.