### PR TITLE
feat(server) automatic copy applicationdescription to the endpoints

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -16,6 +16,7 @@
  *    Copyright 2018 (c) Hilscher Gesellschaft für Systemautomation mbH (Author: Martin Lang)
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
  *    Copyright 2021 (c) Fraunhofer IOSB (Author: Jan Hermes)
+ *    Copyright 2022 (c) Fraunhofer IOSB (Author: Andreas Ebner)
  */
 
 #include "ua_server_internal.h"
@@ -641,6 +642,13 @@ UA_Server_run_startup(UA_Server *server) {
     if(server->config.mdnsEnabled)
         startMulticastDiscoveryServer(server);
 #endif
+
+    /* Update Endpoint description */
+    for(size_t i = 0; i < server->config.endpointsSize; ++i){
+        UA_ApplicationDescription_clear(&server->config.endpoints[i].server);
+        UA_ApplicationDescription_copy(&server->config.applicationDescription,
+                                       &server->config.endpoints[i].server);
+    }
 
     server->state = UA_SERVERLIFECYCLE_FRESH;
 

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -252,6 +252,7 @@ Service_GetEndpoints(UA_Server *server, UA_Session *session,
         for(size_t i = 0; i < clone_times; ++i) {
             retval |= UA_EndpointDescription_copy(&server->config.endpoints[j],
                                                   &response->endpoints[pos]);
+            UA_String_delete(response->endpoints[pos].server.discoveryUrls);
             if(nl_endpointurl)
                 endpointUrl = &server->config.networkLayers[i].discoveryUrl;
             retval |= UA_String_copy(endpointUrl, &response->endpoints[pos].endpointUrl);


### PR DESCRIPTION
The endpoints contain an application description. If the user changes the server application description, the endpoints are currently not updated. This PR changes the default behavior and copy the latest application description to all the endpoints during the server start.