### PR TITLE
Fix for socket resource leak (out of socket)

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1107,8 +1107,12 @@ connectSync(UA_Client *client) {
         if(client->noSession && client->channel.state == UA_SECURECHANNELSTATE_OPEN)
             break;
         now = UA_DateTime_nowMonotonic();
-        if(maxDate < now)
-            return UA_STATUSCODE_BADTIMEOUT;
+        if(maxDate < now) {
+            /* set maxDate to now so timeout will be detected when calling
+	     * UA_Client_run_iterate
+	     */
+            maxDate = now;
+        }
         retval = UA_Client_run_iterate(client,
                                        (UA_UInt32)((maxDate - now) / UA_DATETIME_MSEC));
     }

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1109,8 +1109,8 @@ connectSync(UA_Client *client) {
         now = UA_DateTime_nowMonotonic();
         if(maxDate < now) {
             /* set maxDate to now so timeout will be detected when calling
-	     * UA_Client_run_iterate
-	     */
+             * UA_Client_run_iterate
+             */
             maxDate = now;
         }
         retval = UA_Client_run_iterate(client,


### PR DESCRIPTION
On our test system we detected a socket resource leak if the following preconditions are met:
1. OPC UA server is behind a gateway.
2. OPC UA server is down.
3. OPC UA client tries to connect to OPC UA server.

Observed behavior:
After each connect operation an additional file descriptor is being added to the list of file descriptors (/proc/self/fd).

The provided patch fixes the problem.
