### PR TITLE
feat(server) Add internal API function for Namespace Lookup

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1666,6 +1666,11 @@ UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
                              size_t* foundIndex);
 
+/* Get namespace by id from the server. */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_getNamespaceByIndex(UA_Server *server, const size_t namespaceIndex,
+                              UA_String *foundUri);
+
 /**
 * .. _async-operations:
 *

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -47,7 +47,7 @@
  * Application URI.
  *
  * This is done as soon as the Namespace Array is read or written via node value
- * read / write services, or UA_Server_addNamespace,
+ * read / write services, or UA_Server_addNamespace, or UA_Server_getNamespaceByIndex
  * UA_Server_getNamespaceByName or UA_Server_run_startup is called.
  *
  * Therefore one has to set the custom NS1 URI before one of the previously
@@ -120,10 +120,31 @@ getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
 }
 
 UA_StatusCode
+getNamespaceByIndex(UA_Server *server, const size_t namespaceIndex,
+                   UA_String *foundUri) {
+    /* ensure that the uri for ns1 is set up from the app description */
+    setupNs1Uri(server);
+    UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
+    if(namespaceIndex > server->namespacesSize)
+        return res;
+    res = UA_String_copy(&server->namespaces[namespaceIndex], foundUri);
+    return res;
+}
+
+UA_StatusCode
 UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
                              size_t *foundIndex) {
     UA_LOCK(&server->serviceMutex);
     UA_StatusCode res = getNamespaceByName(server, namespaceUri, foundIndex);
+    UA_UNLOCK(&server->serviceMutex);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_getNamespaceByIndex(UA_Server *server, const size_t namespaceIndex,
+                              UA_String *foundUri) {
+    UA_LOCK(&server->serviceMutex);
+    UA_StatusCode res = getNamespaceByIndex(server, namespaceIndex, foundUri);
     UA_UNLOCK(&server->serviceMutex);
     return res;
 }

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -213,6 +213,10 @@ getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
                    size_t *foundIndex);
 
 UA_StatusCode
+getNamespaceByIndex(UA_Server *server, const size_t namespaceIndex,
+                    UA_String *foundUri);
+
+UA_StatusCode
 getBoundSession(UA_Server *server, const UA_SecureChannel *channel,
                 const UA_NodeId *token, UA_Session **session);
 

--- a/tests/server/check_server.c
+++ b/tests/server/check_server.c
@@ -46,6 +46,18 @@ START_TEST(checkGetNamespaceByName) {
     ck_assert_uint_eq(found, UA_STATUSCODE_GOOD);
 } END_TEST
 
+START_TEST(checkGetNamespaceById) {
+    UA_String searchResultNamespace;
+    UA_StatusCode notFound = UA_Server_getNamespaceByIndex(server, 10, &searchResultNamespace);
+    ck_assert_uint_eq(notFound, UA_STATUSCODE_BADNOTFOUND);
+
+    UA_String compareNamespace = UA_STRING("http://opcfoundation.org/UA/");
+    UA_StatusCode found = UA_Server_getNamespaceByIndex(server, 0, &searchResultNamespace);
+    ck_assert(UA_String_equal(&compareNamespace, &searchResultNamespace));
+    ck_assert_uint_eq(found, UA_STATUSCODE_GOOD);
+    UA_String_clear(&searchResultNamespace);
+} END_TEST
+
 static void timedCallbackHandler(UA_Server *s, void *data) {
     *((UA_Boolean*)data) = false;  // stop the server via a timedCallback
 }
@@ -67,6 +79,7 @@ int main(void) {
     tcase_add_checked_fixture(tc_call, setup, teardown);
     tcase_add_test(tc_call, checkGetConfig);
     tcase_add_test(tc_call, checkGetNamespaceByName);
+    tcase_add_test(tc_call, checkGetNamespaceById);
     tcase_add_test(tc_call, checkServer_run);
     suite_add_tcase(s, tc_call);
 


### PR DESCRIPTION
This PR introduces the counterpart function of the existing "getNamespaceByName" function. The Namespace String can be obtained by the namespace id.