### PR TITLE
WIP: fix(nc): add empty Extention Object if datatype is not in namespace

### DIFF
--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -242,6 +242,10 @@ class Value(object):
 
                 extobj.value = []
                 members = enc.members
+                if enc is None:
+                    logger.warning("DataType is not found in nodeset")
+                    return ExtensionObject()
+                for e in enc.members:
 
                 # The EncodingMask must be skipped.
                 if ebodypart.localName == "EncodingMask":
@@ -258,8 +262,6 @@ class Value(object):
                         members = []
                         members.append(enc.members[data-1])
                         ebodypart = getNextElementNode(ebodypart)
-
-
                 for e in members:
                     # ebodypart can be None if the field is not set, although the field is not optional.
                     if ebodypart is None:

--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -241,11 +241,10 @@ class Value(object):
                     return extobj
 
                 extobj.value = []
-                members = enc.members
                 if enc is None:
                     logger.warning("DataType is not found in nodeset")
                     return ExtensionObject()
-                for e in enc.members:
+                members = enc.members
 
                 # The EncodingMask must be skipped.
                 if ebodypart.localName == "EncodingMask":


### PR DESCRIPTION
Hi,

I implement an adaption of the  Release Candidate of the OPC 40001-101 - UA CS for Machinery Part 101 - Result Transfer.
My modification makes the nodeset v1.04 compatible (UriString -> String, Change Required Nodeset). The nodesets can be found [here](https://github.com/umati/Sample-Server/tree/dev_gms/model/GMS)

My second nodeset use the Result Transfer and crashed because nodeset generation process. I could fix this by returning an empty Extension Object if the enc is None. This solves the problem for me.