### PR TITLE
fix(client): handle timeout when connecting

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -825,6 +825,13 @@ UA_ClientConnectionTCP_poll(UA_Connection *connection, UA_UInt32 timeout,
                        tcpConnection->endpointUrl.data, strerror(UA_ERRNO));
         ClientNetworkLayerTCP_close(connection);
         return UA_STATUSCODE_BADDISCONNECT;
+    } else if (ret == 0) {
+        UA_LOG_WARNING(logger, UA_LOGCATEGORY_NETWORK,
+                       "Connection to %.*s timed out",
+                       (int)tcpConnection->endpointUrl.length,
+                       tcpConnection->endpointUrl.data);
+        ClientNetworkLayerTCP_close(connection);
+        return UA_STATUSCODE_BADTIMEOUT;
     }
 
     int resultsize = UA_fd_isset(connection->sockfd, &writing_fdset);


### PR DESCRIPTION
This change adds code to handle a timeout of UA_select when the client tries to connect.

Previously, the return code for a timeout was unchecked, and instead handled as if successful. This caused issue #3221 .

Merging this change would also make pull request #4976 obsolete.