### PR TITLE
[REVIEW] fix(el): win32 shutdown takes 120 s

### DIFF
--- a/arch/eventloop_posix_tcp.c
+++ b/arch/eventloop_posix_tcp.c
@@ -490,6 +490,69 @@ TCP_registerListenSocketDomainName(UA_ConnectionManager *cm, const char *hostnam
     return UA_STATUSCODE_GOOD;
 }
 
+#ifdef _WIN32
+static UA_RegisteredFD *
+findRegisteredFD(TCPConnectionManager *cm, uintptr_t connectionId) {
+    UA_RegisteredFD *rfd;
+    LIST_FOREACH(rfd, &cm->fds, es_pointers) {
+        if(rfd->fd == connectionId) return rfd;
+    }
+    return NULL;
+}
+
+static UA_DelayedCallback
+*createExplicitlyDelayedShutdownCallback(UA_ConnectionManager *cm, UA_RegisteredFD *rfd, UA_Callback callback) {
+    UA_DelayedCallback *explicitlyDelayedShutdownCallback = (UA_DelayedCallback*) UA_malloc(sizeof(UA_DelayedCallback));
+    if(!explicitlyDelayedShutdownCallback) {
+        return NULL;
+    }
+    explicitlyDelayedShutdownCallback->callback = callback;
+    explicitlyDelayedShutdownCallback->application = cm;
+    explicitlyDelayedShutdownCallback->data = (void*) rfd->fd;
+
+    return explicitlyDelayedShutdownCallback;
+}
+
+static UA_INLINE void
+createAndAddDelayedShutdownCallback(UA_ConnectionManager *cm, UA_RegisteredFD *rfd, UA_Callback callback) {
+    UA_DelayedCallback *explicitlyDelayedShutdownCallback = createExplicitlyDelayedShutdownCallback(cm, rfd, callback);
+    if(!explicitlyDelayedShutdownCallback) {
+        UA_LOG_SOCKET_ERRNO_WRAP(
+            UA_LOG_WARNING(cm->eventSource.eventLoop->logger,
+                           UA_LOGCATEGORY_NETWORK,
+                           "TCP %u\t| Warning: Out of memory for creating delayed shutdown callback (%s)",
+                           (unsigned)rfd->fd, errno_str));
+        return;
+    }
+    UA_EventLoop *el = cm->eventSource.eventLoop;
+    el->addDelayedCallback(el, explicitlyDelayedShutdownCallback);
+}
+
+static void
+delayedShutdownCallback(void* application, void* data) {
+
+    UA_ConnectionManager *cm = (UA_ConnectionManager*) application;
+    TCPConnectionManager *tcm = (TCPConnectionManager*)cm;
+    UA_FD fd = (UA_FD) data;
+
+    UA_RegisteredFD* rfd = findRegisteredFD(tcm, fd);
+    if(rfd == NULL) {
+        return;
+    }
+    UA_ByteString response = tcm->rxBuffer;
+    int ret = UA_recv(fd, (char *)response.data, response.length, MSG_DONTWAIT | MSG_PEEK);
+    if(ret == 0 || ret == -1) {
+        cm->connectionCallback(cm, (uintptr_t)fd, &rfd->context,
+                               UA_STATUSCODE_BADCONNECTIONCLOSED,
+                               0, NULL, UA_BYTESTRING_NULL);
+        TCP_close(tcm, rfd);
+    } else {
+        /* add the delayed shutdown callback again because the peeked data will be processed in the next el cycle */
+        createAndAddDelayedShutdownCallback(cm, rfd, delayedShutdownCallback);
+    }
+}
+#endif
+
 static UA_StatusCode
 TCP_shutdownConnection(UA_ConnectionManager *cm, uintptr_t connectionId) {
     UA_LOG_DEBUG(cm->eventSource.eventLoop->logger,
@@ -500,7 +563,11 @@ TCP_shutdownConnection(UA_ConnectionManager *cm, uintptr_t connectionId) {
 #ifndef _WIN32
     int res = UA_shutdown((UA_FD)connectionId, SHUT_RDWR);
 #else
-    int res = UA_shutdown((UA_FD)connectionId, SD_BOTH);
+    int res = UA_shutdown((UA_FD)connectionId, SD_SEND);
+    TCPConnectionManager *tcm = (TCPConnectionManager*)cm;
+    UA_RegisteredFD* rfd = findRegisteredFD(tcm, (UA_FD) connectionId);
+
+    createAndAddDelayedShutdownCallback(cm, rfd, delayedShutdownCallback);
 #endif
     if(res != 0) {
         UA_LOG_SOCKET_ERRNO_WRAP(


### PR DESCRIPTION
resolves #4964 

This fix resolves 120 sek timeout for win32 shutdown of tcp connections.

### HOW:

1. calls shutdown "SD_SEND" for connections to be shut down
2. adds a delayed callback that closes a tcp connection after a peek to recv showed no data on the socket
3. if there is peeked data on the socket the delayed callback adds itself again and waits another cycle of the eventloop to process the data that arrived on the socket

### WHY:

As mentioned in the according issue by @ccvca, according to win32 documentation this is the correct way of shutting down a socket gracefully:

> 1. Call shutdown with how=SD_SEND.
> 2. Call [recv](https://docs.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-recv) or [WSARecv](https://docs.microsoft.com/en-us/windows/desktop/api/winsock2/nf-winsock2-wsarecv) until the function completes with success and indicates zero bytes were received. If SOCKET_ERROR is returned, then the graceful disconnect is not possible.
> 3. Call [closesocket](https://docs.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-closesocket).

https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown#remarks

### TODO:

- [x] Check if VScode CI executes unit tests
- [x] write test(s) for code coverage pass