### PR TITLE
fix(core): do not encode false booleans as nulls

### DIFF
--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -233,7 +233,7 @@ writeJsonKey(CtxJson *ctx, const char* key) {
 
 static bool
 isNull(const void *p, const UA_DataType *type) {
-    if(UA_DataType_isNumeric(type))
+    if(UA_DataType_isNumeric(type) || type->typeKind == UA_DATATYPEKIND_BOOLEAN)
         return false;
     UA_STACKARRAY(char, buf, type->memSize);
     memset(buf, 0, type->memSize);


### PR DESCRIPTION
broken by c8fd22e37b8360eb6502bc1f5f12b0d3745acab4

Booleans in arrays of value "false" were incorrectly encoded as "null"
Previously: [true,null,true]
Currently: [true,false,true]