### PR TITLE
fix(nc): fix the determinism of the generated sources of the nodeset compiler

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -137,7 +137,7 @@ def generateOpen62541Code(nodeset, outfilename, internal_headers=False, typesArr
 
     additionalHeaders = ""
     if len(typesArray) > 0:
-        for arr in set(typesArray):
+        for arr in typesArray:
             if arr == "UA_TYPES":
                 continue
             # remove ua_ prefix if exists
@@ -221,7 +221,7 @@ _UA_END_DECLS
     functionNumber = 0
 
     printed_ids = set()
-    reftypes_functionNumbers = set()
+    reftypes_functionNumbers = list()
     for node in sorted_nodes:
         printed_ids.add(node.id)
 
@@ -280,13 +280,13 @@ _UA_END_DECLS
         # of other nodes might depend on the subtyping information of the
         # referencetype to be complete.
         if isinstance(node, ReferenceTypeNode):
-            reftypes_functionNumbers.add(functionNumber)
+            reftypes_functionNumbers.append(functionNumber)
 
         functionNumber = functionNumber + 1
 
 
     # Load generated types
-    for arr in set(typesArray):
+    for arr in typesArray:
         if arr == "UA_TYPES":
             continue
         writec("\nstatic UA_DataTypeArray custom" + arr + " = {")
@@ -307,7 +307,7 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
 
     # Add generated types to the server
     writec("\n/* Load custom datatype definitions into the server */")
-    for arr in set(typesArray):
+    for arr in typesArray:
         if arr == "UA_TYPES":
             continue
         writec("if(" + arr + "_COUNT > 0) {")

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -69,7 +69,7 @@ class Node(object):
         self.symbolicName = None
         self.writeMask = None
         self.userWriteMask = None
-        self.references = set()
+        self.references = list()
         self.hidden = False
         self.modelUri = None
         self.parent = None
@@ -137,7 +137,7 @@ class Node(object):
                     reftype = RefOrAlias(av)
                 elif at == "IsForward":
                     forward = not "false" in av.lower()
-            self.references.add(Reference(source, reftype, target, forward))
+            self.references.append(Reference(source, reftype, target, forward))
 
     def getParentReference(self, parentreftypes):
         # HasSubtype has precedence
@@ -162,7 +162,6 @@ class Node(object):
         if isinstance(self, VariableNode) or isinstance(self, VariableTypeNode):
             if str(self.dataType) in aliases:
                 self.dataType = NodeId(aliases[self.dataType])
-        new_refs = set()
         for ref in self.references:
             if str(ref.source) in aliases:
                 ref.source = NodeId(aliases[ref.source])
@@ -170,21 +169,16 @@ class Node(object):
                 ref.target = NodeId(aliases[ref.target])
             if str(ref.referenceType) in aliases:
                 ref.referenceType = NodeId(aliases[ref.referenceType])
-            new_refs.add(ref)
-        self.references = new_refs
 
     def replaceNamespaces(self, nsMapping):
         self.id.ns = nsMapping[self.id.ns]
         self.browseName.ns = nsMapping[self.browseName.ns]
         if hasattr(self, 'dataType') and isinstance(self.dataType, NodeId):
             self.dataType.ns = nsMapping[self.dataType.ns]
-        new_refs = set()
         for ref in self.references:
             ref.source.ns = nsMapping[ref.source.ns]
             ref.target.ns = nsMapping[ref.target.ns]
             ref.referenceType.ns = nsMapping[ref.referenceType.ns]
-            new_refs.add(ref)
-        self.references = new_refs
         self.namespaceMapping = nsMapping
 
 class ReferenceTypeNode(Node):

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -69,7 +69,7 @@ class Node(object):
         self.symbolicName = None
         self.writeMask = None
         self.userWriteMask = None
-        self.references = dict()
+        self.references = dict() # using dict because it retains insertion order
         self.hidden = False
         self.modelUri = None
         self.parent = None

--- a/tools/nodeset_compiler/nodes.py
+++ b/tools/nodeset_compiler/nodes.py
@@ -69,7 +69,7 @@ class Node(object):
         self.symbolicName = None
         self.writeMask = None
         self.userWriteMask = None
-        self.references = list()
+        self.references = dict()
         self.hidden = False
         self.modelUri = None
         self.parent = None
@@ -137,7 +137,7 @@ class Node(object):
                     reftype = RefOrAlias(av)
                 elif at == "IsForward":
                     forward = not "false" in av.lower()
-            self.references.append(Reference(source, reftype, target, forward))
+            self.references[Reference(source, reftype, target, forward)] = None
 
     def getParentReference(self, parentreftypes):
         # HasSubtype has precedence
@@ -152,7 +152,7 @@ class Node(object):
     def popTypeDef(self):
         for ref in self.references:
             if ref.referenceType.i == 40 and ref.isForward:
-                self.references.remove(ref)
+                del self.references[ref]
                 return ref
         return Reference(NodeId(), NodeId(), NodeId(), False)
 
@@ -162,6 +162,7 @@ class Node(object):
         if isinstance(self, VariableNode) or isinstance(self, VariableTypeNode):
             if str(self.dataType) in aliases:
                 self.dataType = NodeId(aliases[self.dataType])
+        new_refs = dict()
         for ref in self.references:
             if str(ref.source) in aliases:
                 ref.source = NodeId(aliases[ref.source])
@@ -169,16 +170,21 @@ class Node(object):
                 ref.target = NodeId(aliases[ref.target])
             if str(ref.referenceType) in aliases:
                 ref.referenceType = NodeId(aliases[ref.referenceType])
+            new_refs[ref] = None
+        self.references = new_refs
 
     def replaceNamespaces(self, nsMapping):
         self.id.ns = nsMapping[self.id.ns]
         self.browseName.ns = nsMapping[self.browseName.ns]
         if hasattr(self, 'dataType') and isinstance(self.dataType, NodeId):
             self.dataType.ns = nsMapping[self.dataType.ns]
+        new_refs = dict()
         for ref in self.references:
             ref.source.ns = nsMapping[ref.source.ns]
             ref.target.ns = nsMapping[ref.target.ns]
             ref.referenceType.ns = nsMapping[ref.referenceType.ns]
+            new_refs[ref] = None
+        self.references = new_refs
         self.namespaceMapping = nsMapping
 
 class ReferenceTypeNode(Node):

--- a/tools/nodeset_compiler/nodeset.py
+++ b/tools/nodeset_compiler/nodeset.py
@@ -228,14 +228,14 @@ class NodeSet(object):
                 if r.source not in self.nodes:
                     continue
                 self.nodes[r.source].references = dict(filter(
-                    lambda rt: filterRef(r, rt[0]),
+                    lambda rt: filterRef(r, rt[0]), # filter only on key of each dict item
                     self.nodes[r.source].references.items()
                 ))
             elif r.source == node.id:
                 if r.target not in self.nodes:
                     continue
                 self.nodes[r.target].references = dict(filter(
-                    lambda rt: filterRef(r, rt[0]),
+                    lambda rt: filterRef(r, rt[0]), # filter only on key of each dict item
                     self.nodes[r.target].references.items()
                 ))
         del self.nodes[node.id]

--- a/tools/nodeset_compiler/nodeset.py
+++ b/tools/nodeset_compiler/nodeset.py
@@ -227,14 +227,14 @@ class NodeSet(object):
             if r.target == node.id:
                 if r.source not in self.nodes:
                     continue
-                self.nodes[r.source].references = set(filter(
+                self.nodes[r.source].references = list(filter(
                     lambda rt: filterRef(r, rt),
                     self.nodes[r.source].references
                 ))
             elif r.source == node.id:
                 if r.target not in self.nodes:
                     continue
-                self.nodes[r.target].references = set(filter(
+                self.nodes[r.target].references = list(filter(
                     lambda rt: filterRef(r, rt),
                     self.nodes[r.target].references
                 ))
@@ -382,7 +382,8 @@ class NodeSet(object):
         for u in self.nodes.values():
             for ref in u.references.copy():
                 back = Reference(ref.target, ref.referenceType, ref.source, not ref.isForward)
-                self.nodes[ref.target].references.add(back) # ref set does not make a duplicate entry
+                if back not in self.nodes[ref.target].references:  # prevent making a duplicated entry
+                    self.nodes[ref.target].references.append(back)
 
     def setNodeParent(self):
         parentreftypes = getSubTypesOf(self, self.getNodeByBrowseName("HierarchicalReferences"))

--- a/tools/nodeset_compiler/nodeset.py
+++ b/tools/nodeset_compiler/nodeset.py
@@ -227,16 +227,16 @@ class NodeSet(object):
             if r.target == node.id:
                 if r.source not in self.nodes:
                     continue
-                self.nodes[r.source].references = list(filter(
-                    lambda rt: filterRef(r, rt),
-                    self.nodes[r.source].references
+                self.nodes[r.source].references = dict(filter(
+                    lambda rt: filterRef(r, rt[0]),
+                    self.nodes[r.source].references.items()
                 ))
             elif r.source == node.id:
                 if r.target not in self.nodes:
                     continue
-                self.nodes[r.target].references = list(filter(
-                    lambda rt: filterRef(r, rt),
-                    self.nodes[r.target].references
+                self.nodes[r.target].references = dict(filter(
+                    lambda rt: filterRef(r, rt[0]),
+                    self.nodes[r.target].references.items()
                 ))
         del self.nodes[node.id]
 
@@ -382,8 +382,7 @@ class NodeSet(object):
         for u in self.nodes.values():
             for ref in u.references.copy():
                 back = Reference(ref.target, ref.referenceType, ref.source, not ref.isForward)
-                if back not in self.nodes[ref.target].references:  # prevent making a duplicated entry
-                    self.nodes[ref.target].references.append(back)
+                self.nodes[ref.target].references[back] = None # dict key does not make a duplicate entry
 
     def setNodeParent(self):
         parentreftypes = getSubTypesOf(self, self.getNodeByBrowseName("HierarchicalReferences"))


### PR DESCRIPTION
Currently, the nodeset compiler creates source file including the nodes of the information models
in a different order every time a rebuild is done. This is due to the use of sets which change the
order of there elements every time an element gets added. With this change the nodeset compiler
uses lists where order is relevant.