### PR TITLE
fix(deps): Fix missing conversions and zero-terminate the strTLS value.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,9 @@ if(UA_ENABLE_PUBSUB_MQTT)
     endif()
 endif()
 
+option(UA_ENABLE_MQTT_TLS_OPENSSL "Enable TLS support for publish/subscribe with mqtt (use OpenSSL)" OFF)
+mark_as_advanced(UA_ENABLE_MQTT_TLS_OPENSSL)
+
 option(UA_ENABLE_MQTT_TLS "Enable TLS support for publish/subscribe with mqtt" OFF)
 mark_as_advanced(UA_ENABLE_MQTT_TLS)
 if(UA_ENABLE_MQTT_TLS)
@@ -434,8 +437,6 @@ if(UA_ENABLE_MQTT_TLS)
         set(UA_ENABLE_MQTT_TLS_OPENSSL ON)
 endif()
 
-option(UA_ENABLE_MQTT_TLS_OPENSSL "Enable TLS support for publish/subscribe with mqtt (use OpenSSL)" OFF)
-mark_as_advanced(UA_ENABLE_MQTT_TLS_OPENSSL)
 if(UA_ENABLE_MQTT_TLS_OPENSSL)
     set(UA_ENABLE_MQTT_TLS ON)
 endif()

--- a/deps/mqtt-c/mqtt.c
+++ b/deps/mqtt-c/mqtt.c
@@ -1205,10 +1205,11 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
             connect_flags &= (uint8_t)~MQTT_CONNECT_CLIENTKEYPATH;
         }
 
+        /* Call the strncpy function with a size of two to zero-terminate the strTLS value */
         if (useTLS) /* useTLS = true */
-            memcpy(strTLS, "1", 1);
+            strncpy(strTLS, "1", 2);
         else
-            memcpy(strTLS, "0", 1);
+            strncpy(strTLS, "0", 2);
         connect_flags |= (uint8_t)~MQTT_CONNECT_USETLS;
         remaining_length += (uint32_t)__mqtt_packed_cstrlen(strTLS);
     }

--- a/deps/mqtt-c/mqtt.c
+++ b/deps/mqtt-c/mqtt.c
@@ -1175,7 +1175,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
     if (useTLS) {
         if (caFilePath != NULL) {
             /* a caFilePath is present */
-            connect_flags |= MQTT_CONNECT_CAFILEPATH;
+            connect_flags |= (uint8_t)~MQTT_CONNECT_CAFILEPATH;
             remaining_length += (uint32_t)__mqtt_packed_cstrlen(caFilePath);
         } else {
             connect_flags &= (uint8_t)~MQTT_CONNECT_CAFILEPATH;
@@ -1183,7 +1183,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
 
         if (caPath != NULL) {
             /* a caPath is present */
-            connect_flags |= MQTT_CONNECT_CAPATH;
+            connect_flags |= (uint8_t)~MQTT_CONNECT_CAPATH;
             remaining_length += (uint32_t)__mqtt_packed_cstrlen(caPath);
         } else {
             connect_flags &= (uint8_t)~MQTT_CONNECT_CAPATH;
@@ -1191,7 +1191,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
 
         if (clientCertPath != NULL) {
             /* a clientCertPath is present */
-            connect_flags |= MQTT_CONNECT_CLIENTCERTPATH;
+            connect_flags |= (uint8_t)~MQTT_CONNECT_CLIENTCERTPATH;
             remaining_length += (uint32_t)__mqtt_packed_cstrlen(clientCertPath);
         } else {
             connect_flags &= (uint8_t)~MQTT_CONNECT_CLIENTCERTPATH;
@@ -1199,17 +1199,17 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
 
         if (clientKeyPath != NULL) {
             /* a clientKeyPath is present */
-            connect_flags |= MQTT_CONNECT_CLIENTKEYPATH;
+            connect_flags |= (uint8_t)~MQTT_CONNECT_CLIENTKEYPATH;
             remaining_length += (uint32_t)__mqtt_packed_cstrlen(clientKeyPath);
         } else {
             connect_flags &= (uint8_t)~MQTT_CONNECT_CLIENTKEYPATH;
         }
 
         if (useTLS) /* useTLS = true */
-            strncpy(strTLS, "1", 1);
+            memcpy(strTLS, "1", 1);
         else
-            strncpy(strTLS, "0", 1);
-        connect_flags |= MQTT_CONNECT_USETLS;
+            memcpy(strTLS, "0", 1);
+        connect_flags |= (uint8_t)~MQTT_CONNECT_USETLS;
         remaining_length += (uint32_t)__mqtt_packed_cstrlen(strTLS);
     }
 #endif


### PR DESCRIPTION
Fix the errors that occur in the build process with the following CMake flags ([build.log](https://github.com/open62541/open62541/files/8419291/build.log)):
-DCMAKE_BUILD_TYPE=Debug
-DUA_BUILD_EXAMPLES=ON
-DUA_BUILD_UNIT_TESTS=ON
-DUA_ENABLE_PUBSUB=ON
-DUA_ENABLE_PUBSUB_MQTT=ON
-DUA_ENABLE_MQTT_TLS=ON
-DUA_ENABLE_MQTT_TLS_OPENSSL=ON
-DUA_NAMESPACE_ZERO=FULL

Fix missing conversions and zero-terminate the strTLS value to avoid the warning when the result is not expected to be NUL-terminated.

Fixed a bug in Cmake where the UA_ENABLE_MQTT_TLS_OPENSSL flag is overwritten again after it is set to ON in the UA_ENABLE_MQTT_TLS check.
