### PR TITLE
fix(sec) Remove use of mbedtls internal headers

### DIFF
--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
@@ -9,7 +9,6 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
@@ -34,7 +34,11 @@ UA_StatusCode
 mbedtls_generateKey(mbedtls_md_context_t *context,
                     const UA_ByteString *secret, const UA_ByteString *seed,
                     UA_ByteString *out) {
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     size_t hashLen = (size_t)mbedtls_md_get_size(context->md_info);
+#else
+    size_t hashLen = (size_t)mbedtls_md_get_size(context->private_md_info);
+#endif
 
     UA_ByteString A_and_seed;
     UA_ByteString_allocBuffer(&A_and_seed, hashLen + seed->length);
@@ -106,7 +110,7 @@ mbedtls_verifySig_sha1(mbedtls_x509_crt *certificate, const UA_ByteString *messa
                        const UA_ByteString *signature) {
     /* Compute the sha1 hash */
     unsigned char hash[UA_SHA1_LENGTH];
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     mbedtls_sha1_ret(message->data, message->length, hash);
 #else
     mbedtls_sha1(message->data, message->length, hash);
@@ -116,7 +120,7 @@ mbedtls_verifySig_sha1(mbedtls_x509_crt *certificate, const UA_ByteString *messa
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(certificate->pk);
     if(!rsaContext)
         return UA_STATUSCODE_BADINTERNALERROR;
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, 0);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
 
     /* Verify */
     int mbedErr = mbedtls_pk_verify(&certificate->pk,
@@ -133,18 +137,22 @@ mbedtls_sign_sha1(mbedtls_pk_context *localPrivateKey,
                   const UA_ByteString *message,
                   UA_ByteString *signature) {
     unsigned char hash[UA_SHA1_LENGTH];
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     mbedtls_sha1_ret(message->data, message->length, hash);
 #else
     mbedtls_sha1(message->data, message->length, hash);
 #endif
 
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*localPrivateKey);
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, 0);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
 
     size_t sigLen = 0;
     int mbedErr = mbedtls_pk_sign(localPrivateKey, MBEDTLS_MD_SHA1, hash,
-                                  UA_SHA1_LENGTH, signature->data, &sigLen,
+                                  UA_SHA1_LENGTH, signature->data,
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+                                  signature->length,
+#endif
+                                  &sigLen,
                                   mbedtls_ctr_drbg_random, drbgContext);
     if(mbedErr)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -161,7 +169,7 @@ mbedtls_thumbprint_sha1(const UA_ByteString *certificate,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* The certificate thumbprint is always a 20 bit sha1 hash, see Part 4 of the Specification. */
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     mbedtls_sha1_ret(certificate->data, certificate->length, thumbprint->data);
 #else
     mbedtls_sha1(certificate->data, certificate->length, thumbprint->data);
@@ -177,9 +185,10 @@ mbedtls_encrypt_rsaOaep(mbedtls_rsa_context *context,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     size_t max_blocks = data->length / plainTextBlockSize;
+    size_t keylen = mbedtls_rsa_get_len(context);
 
     UA_ByteString encrypted;
-    UA_StatusCode retval = UA_ByteString_allocBuffer(&encrypted, max_blocks * context->len);
+    UA_StatusCode retval = UA_ByteString_allocBuffer(&encrypted, max_blocks * keylen);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
@@ -188,17 +197,24 @@ mbedtls_encrypt_rsaOaep(mbedtls_rsa_context *context,
     size_t offset = 0;
     const unsigned char *label = NULL;
     while(lenDataToEncrypt >= plainTextBlockSize) {
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
         int mbedErr = mbedtls_rsa_rsaes_oaep_encrypt(context, mbedtls_ctr_drbg_random,
                                                      drbgContext, MBEDTLS_RSA_PUBLIC,
                                                      label, 0, plainTextBlockSize,
                                                      data->data + inOffset, encrypted.data + offset);
+#else
+        int mbedErr = mbedtls_rsa_rsaes_oaep_encrypt(context, mbedtls_ctr_drbg_random,
+                                                     drbgContext, label, 0, plainTextBlockSize,
+                                                     data->data + inOffset, encrypted.data + offset);
+#endif
+
         if(mbedErr) {
             UA_ByteString_clear(&encrypted);
             return UA_STATUSCODE_BADINTERNALERROR;
         }
 
         inOffset += plainTextBlockSize;
-        offset += context->len;
+        offset += keylen;
         lenDataToEncrypt -= plainTextBlockSize;
     }
 
@@ -213,8 +229,9 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
                         UA_ByteString *data) {
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*localPrivateKey);
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
+    size_t keylen = mbedtls_rsa_get_len(rsaContext);
 
-    if(data->length % rsaContext->len != 0)
+    if(data->length % keylen != 0)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     size_t inOffset = 0;
@@ -223,16 +240,25 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
     unsigned char buf[512];
 
     while(inOffset < data->length) {
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
         int mbedErr = mbedtls_rsa_rsaes_oaep_decrypt(rsaContext, mbedtls_ctr_drbg_random,
                                                      drbgContext, MBEDTLS_RSA_PRIVATE,
                                                      NULL, 0, &outLength,
                                                      data->data + inOffset,
                                                      buf, 512);
+#else
+        int mbedErr = mbedtls_rsa_rsaes_oaep_decrypt(rsaContext, mbedtls_ctr_drbg_random,
+                                                     drbgContext,
+                                                     NULL, 0, &outLength,
+                                                     data->data + inOffset,
+                                                     buf, 512);
+#endif
+
         if(mbedErr)
             return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
         memcpy(data->data + outOffset, buf, outLength);
-        inOffset += rsaContext->len;
+        inOffset += keylen;
         outOffset += outLength;
     }
 
@@ -240,17 +266,21 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
     return UA_STATUSCODE_GOOD;
 }
 
-int UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target)
-{
+int
+UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, void *p_rng) {
     UA_ByteString data = UA_mbedTLS_CopyDataFormatAware(key);
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     int mbedErr = mbedtls_pk_parse_key(target, data.data, data.length, NULL, 0);
+#else
+    int mbedErr = mbedtls_pk_parse_key(target, data.data, data.length, NULL, 0, mbedtls_entropy_func, p_rng);
+#endif
     UA_ByteString_clear(&data);
-
     return mbedErr;
 }
 
-UA_StatusCode UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData, UA_ByteString *target)
-{
+UA_StatusCode
+UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData,
+                                UA_ByteString *target) {
     UA_ByteString data = UA_mbedTLS_CopyDataFormatAware(certData);
 
     mbedtls_x509_crt cert;
@@ -277,8 +307,8 @@ UA_StatusCode UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData, UA_
 
 // mbedTLS expects PEM data to be null terminated
 // The data length parameter must include the null terminator
-UA_ByteString UA_mbedTLS_CopyDataFormatAware(const UA_ByteString *data)
-{
+UA_ByteString
+UA_mbedTLS_CopyDataFormatAware(const UA_ByteString *data) {
     UA_ByteString result;
     UA_ByteString_init(&result);
 

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
@@ -15,12 +15,7 @@
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ctr_drbg.h>
 
-#if !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
-#define MBEDTLS_ENTROPY_POLL_METHOD mbedtls_platform_entropy_poll
-#else
 // MBEDTLS_ENTROPY_HARDWARE_ALT should be defined if your hardware does not supportd platform entropy
-#define MBEDTLS_ENTROPY_POLL_METHOD mbedtls_hardware_poll
-#endif
 
 #define UA_SHA1_LENGTH 20
 

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
@@ -59,7 +59,7 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
                         mbedtls_ctr_drbg_context *drbgContext,
                         UA_ByteString *data);
 
-int UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target);
+int UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, void *p_rng);
 
 UA_StatusCode UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData, UA_ByteString *target);
 

--- a/plugins/crypto/mbedtls/securitypolicy_pubsub_aes128ctr.c
+++ b/plugins/crypto/mbedtls/securitypolicy_pubsub_aes128ctr.c
@@ -14,7 +14,6 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>
@@ -299,9 +298,8 @@ policyContext_newContext_sp_pubsub_aes128ctr(UA_PubSubSecurityPolicy *securityPo
         goto error;
     }
 
-    /* Add the system entropy source */
-    mbedErr = mbedtls_entropy_add_source(&pc->entropyContext, mbedtls_platform_entropy_poll,
-                                         NULL, 0, MBEDTLS_ENTROPY_SOURCE_STRONG);
+    mbedErr = mbedtls_entropy_self_test(0);
+
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;

--- a/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
+++ b/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
@@ -14,7 +14,6 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>
@@ -303,9 +302,8 @@ policyContext_newContext_sp_pubsub_aes256ctr(UA_PubSubSecurityPolicy *securityPo
         goto error;
     }
 
-    /* Add the system entropy source */
-    mbedErr = mbedtls_entropy_add_source(&pc->entropyContext, mbedtls_platform_entropy_poll,
-                                         NULL, 0, MBEDTLS_ENTROPY_SOURCE_STRONG);
+    mbedErr = mbedtls_entropy_self_test(0);
+
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;

--- a/plugins/crypto/mbedtls/ua_pki_mbedtls.c
+++ b/plugins/crypto/mbedtls/ua_pki_mbedtls.c
@@ -15,6 +15,7 @@
 #include <mbedtls/x509.h>
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/error.h>
+#include <mbedtls/version.h>
 
 #define REMOTECERTIFICATETRUSTED 1
 #define ISSUERKNOWN              2
@@ -438,10 +439,18 @@ certificateVerification_verify(void *verificationContext,
      * shall be condidered as CA Certificate and cannot be used to establish a
      * connection. Refer the test case CTT/Security/Security Certificate Validation/029.js
      * for more details */
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     if((remoteCertificate.key_usage & MBEDTLS_X509_KU_KEY_CERT_SIGN) &&
        (remoteCertificate.key_usage & MBEDTLS_X509_KU_CRL_SIGN)) {
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
     }
+#else
+    if((remoteCertificate.private_key_usage & MBEDTLS_X509_KU_KEY_CERT_SIGN) &&
+       (remoteCertificate.private_key_usage & MBEDTLS_X509_KU_CRL_SIGN)) {
+        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
+    }
+#endif
+
 
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(mbedErr) {

--- a/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
@@ -18,7 +18,6 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>
@@ -638,10 +637,8 @@ policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolic
         goto error;
     }
 
-    /* Add the system entropy source */
-    mbedErr = mbedtls_entropy_add_source(&pc->entropyContext,
-                                         MBEDTLS_ENTROPY_POLL_METHOD, NULL, 0,
-                                         MBEDTLS_ENTROPY_SOURCE_STRONG);
+    mbedErr = mbedtls_entropy_self_test(0);
+
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic128rsa15.c
@@ -20,7 +20,6 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>
@@ -642,10 +641,8 @@ policyContext_newContext_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
         goto error;
     }
 
-    /* Add the system entropy source */
-    mbedErr = mbedtls_entropy_add_source(&pc->entropyContext,
-                                         MBEDTLS_ENTROPY_POLL_METHOD, NULL, 0,
-                                         MBEDTLS_ENTROPY_SOURCE_STRONG);
+    mbedErr = mbedtls_entropy_self_test(0);
+
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic128rsa15.c
@@ -93,16 +93,14 @@ static size_t
 asym_getLocalSignatureSize_sp_basic128rsa15(const Basic128Rsa15_ChannelContext *cc) {
     if(cc == NULL)
         return 0;
-
-    return mbedtls_pk_rsa(cc->policyContext->localPrivateKey)->len;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->policyContext->localPrivateKey));
 }
 
 static size_t
 asym_getRemoteSignatureSize_sp_basic128rsa15(const Basic128Rsa15_ChannelContext *cc) {
     if(cc == NULL)
         return 0;
-
-    return mbedtls_pk_rsa(cc->remoteCertificate.pk)->len;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
 }
 
 static UA_StatusCode
@@ -112,15 +110,17 @@ asym_encrypt_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *remoteRsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    mbedtls_rsa_set_padding(remoteRsaContext, MBEDTLS_RSA_PKCS_V15, 0);
+    mbedtls_rsa_set_padding(remoteRsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
+    size_t keylen = mbedtls_rsa_get_len(remoteRsaContext);
 
-    size_t plainTextBlockSize = remoteRsaContext->len - UA_SECURITYPOLICY_BASIC128RSA15_RSAPADDING_LEN;
+    size_t plainTextBlockSize = mbedtls_rsa_get_len(remoteRsaContext) -
+        UA_SECURITYPOLICY_BASIC128RSA15_RSAPADDING_LEN;
     if(data->length % plainTextBlockSize != 0)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     size_t blocks = data->length / plainTextBlockSize;
     UA_ByteString encrypted;
-    UA_StatusCode retval = UA_ByteString_allocBuffer(&encrypted, blocks * remoteRsaContext->len);
+    UA_StatusCode retval = UA_ByteString_allocBuffer(&encrypted, blocks * keylen);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
@@ -159,9 +159,10 @@ asym_decrypt_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->policyContext->localPrivateKey);
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, 0);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
+    size_t keylen = mbedtls_rsa_get_len(rsaContext);
 
-    if(data->length % rsaContext->len != 0)
+    if(data->length % keylen != 0)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     size_t inOffset = 0;
@@ -171,13 +172,13 @@ asym_decrypt_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
 
     while(inOffset < data->length) {
         int mbedErr = mbedtls_pk_decrypt(&cc->policyContext->localPrivateKey,
-                                         data->data + inOffset, rsaContext->len,
+                                         data->data + inOffset, keylen,
                                          buf, &outLength, 512, NULL, NULL);
         if(mbedErr)
             return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
         memcpy(data->data + outOffset, buf, outLength);
-        inOffset += rsaContext->len;
+        inOffset += keylen;
         outOffset += outLength;
     }
 
@@ -197,14 +198,17 @@ asym_getRemoteEncryptionKeyLength_sp_basic128rsa15(const Basic128Rsa15_ChannelCo
 
 static size_t
 asym_getRemoteBlockSize_sp_basic128rsa15(const Basic128Rsa15_ChannelContext *cc) {
-    mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    return rsaContext->len;
+    if(cc == NULL)
+        return 0;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
 }
 
 static size_t
 asym_getRemotePlainTextBlockSize_sp_basic128rsa15(const Basic128Rsa15_ChannelContext *cc) {
-    mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    return rsaContext->len - UA_SECURITYPOLICY_BASIC128RSA15_RSAPADDING_LEN;
+    if(cc == NULL)
+        return 0;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk)) -
+        UA_SECURITYPOLICY_BASIC128RSA15_RSAPADDING_LEN;
 }
 
 static UA_StatusCode
@@ -396,9 +400,9 @@ parseRemoteCertificate_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
     /* Check the key length */
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    if(rsaContext->len < UA_SECURITYPOLICY_BASIC128RSA15_MINASYMKEYLENGTH ||
-       rsaContext->len > UA_SECURITYPOLICY_BASIC128RSA15_MAXASYMKEYLENGTH)
+    size_t keylen = mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
+    if(keylen < UA_SECURITYPOLICY_BASIC128RSA15_MINASYMKEYLENGTH ||
+       keylen > UA_SECURITYPOLICY_BASIC128RSA15_MAXASYMKEYLENGTH)
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
 
     return UA_STATUSCODE_GOOD;
@@ -583,7 +587,7 @@ updateCertificateAndPrivateKey_sp_basic128rsa15(UA_SecurityPolicy *securityPolic
     /* Set the new private key */
     mbedtls_pk_free(&pc->localPrivateKey);
     mbedtls_pk_init(&pc->localPrivateKey);
-    int mbedErr = UA_mbedTLS_LoadPrivateKey(&newPrivateKey, &pc->localPrivateKey);
+    int mbedErr = UA_mbedTLS_LoadPrivateKey(&newPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;
@@ -659,7 +663,7 @@ policyContext_newContext_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
     }
 
     /* Set the private key */
-    mbedErr = UA_mbedTLS_LoadPrivateKey(&localPrivateKey, &pc->localPrivateKey);
+    mbedErr = UA_mbedTLS_LoadPrivateKey(&localPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
 
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
@@ -22,7 +22,6 @@
 
 #include <mbedtls/aes.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/sha1.h>
 #include <mbedtls/version.h>
@@ -593,10 +592,8 @@ policyContext_newContext_sp_basic256(UA_SecurityPolicy *securityPolicy,
         goto error;
     }
 
-    /* Add the system entropy source */
-    mbedErr = mbedtls_entropy_add_source(&pc->entropyContext,
-                                         MBEDTLS_ENTROPY_POLL_METHOD, NULL, 0,
-                                         MBEDTLS_ENTROPY_SOURCE_STRONG);
+    mbedErr = mbedtls_entropy_self_test(0);
+
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
@@ -78,7 +78,7 @@ asym_verify_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     unsigned char hash[UA_SHA256_LENGTH];
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     // TODO check return status
     mbedtls_sha256_ret(message->data, message->length, hash, 0);
 #else
@@ -113,7 +113,7 @@ asym_sign_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     unsigned char hash[UA_SHA256_LENGTH];
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     // TODO check return status
     mbedtls_sha256_ret(message->data, message->length, hash, 0);
 #else
@@ -131,6 +131,9 @@ asym_sign_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
     int mbedErr = mbedtls_pk_sign(&pc->localPrivateKey,
                                   MBEDTLS_MD_SHA256, hash,
                                   UA_SHA256_LENGTH, signature->data,
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+                                  signature->length,
+#endif
                                   &sigLen, mbedtls_ctr_drbg_random,
                                   &pc->drbgContext);
     if(mbedErr)
@@ -142,28 +145,29 @@ static size_t
 asym_getLocalSignatureSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
     if(cc == NULL)
         return 0;
-
-    return mbedtls_pk_rsa(cc->policyContext->localPrivateKey)->len;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->policyContext->localPrivateKey));
 }
 
 static size_t
 asym_getRemoteSignatureSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
     if(cc == NULL)
         return 0;
-
-    return mbedtls_pk_rsa(cc->remoteCertificate.pk)->len;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
 }
 
 static size_t
 asym_getRemoteBlockSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
-    mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    return rsaContext->len;
+    if(cc == NULL)
+        return 0;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
 }
 
 static size_t
 asym_getRemotePlainTextBlockSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
-    mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    return rsaContext->len - UA_SECURITYPOLICY_BASIC256SHA256_RSAPADDING_LEN;
+    if(cc == NULL)
+        return 0;
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk)) -
+        UA_SECURITYPOLICY_BASIC256SHA256_RSAPADDING_LEN;
 }
 
 
@@ -391,9 +395,9 @@ parseRemoteCertificate_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
     /* Check the key length */
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    if(rsaContext->len < UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH ||
-       rsaContext->len > UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH)
+    size_t keylen = mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
+    if(keylen < UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH ||
+       keylen > UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH)
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
 
     return UA_STATUSCODE_GOOD;
@@ -582,7 +586,7 @@ updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPoli
     /* Set the new private key */
     mbedtls_pk_free(&pc->localPrivateKey);
     mbedtls_pk_init(&pc->localPrivateKey);
-    int mbedErr = UA_mbedTLS_LoadPrivateKey(&newPrivateKey, &pc->localPrivateKey);
+    int mbedErr = UA_mbedTLS_LoadPrivateKey(&newPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;
@@ -658,7 +662,7 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
     }
 
     /* Set the private key */
-    mbedErr = UA_mbedTLS_LoadPrivateKey(&localPrivateKey, &pc->localPrivateKey);
+    mbedErr = UA_mbedTLS_LoadPrivateKey(&localPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
@@ -19,7 +19,6 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>
@@ -641,10 +640,8 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
         goto error;
     }
 
-    /* Add the system entropy source */
-    mbedErr = mbedtls_entropy_add_source(&pc->entropyContext,
-                                         MBEDTLS_ENTROPY_POLL_METHOD, NULL, 0,
-                                         MBEDTLS_ENTROPY_SOURCE_STRONG);
+    mbedErr = mbedtls_entropy_self_test(0);
+
     if(mbedErr) {
         retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
         goto error;

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -19,7 +19,6 @@
 #include <mbedtls/aes.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
-#include <mbedtls/entropy_poll.h>
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>


### PR DESCRIPTION
Background: The mbedtls version from the pacman installer was updated to mbedtls 3.1.0. We used in our stack definitions from the entropy_poll.h, which is meant to be mbedtls internal only. Therefore, the header is not available anymore, see the mbedtls changelog:

   * Move internal headers.
     Header files that were only meant for the library's internal use and
     were not meant to be used in application code have been moved out of
     the include/ directory. The headers concerned are bn_mul.h, aesni.h,
     padlock.h, entropy_poll.h and *_internal.h.

The entropy sources are now configured within the mbedtls_entropy_init only and custom configurations must be done directly in the mbedtls_config.
