### PR TITLE
fix: UA_PubSubTransportLayerMQTT symbol not available in shared library

### DIFF
--- a/plugins/ua_network_pubsub_mqtt.h
+++ b/plugins/ua_network_pubsub_mqtt.h
@@ -49,7 +49,7 @@ typedef struct {
  */    
 
 
-UA_PubSubTransportLayer
+UA_PubSubTransportLayer UA_EXPORT
 UA_PubSubTransportLayerMQTT(void);
 
 


### PR DESCRIPTION
close #5087