### PR TITLE
fix(plugin): correct typo for macro parameter

### DIFF
--- a/plugins/crypto/openssl/ua_openssl_version_abstraction.h
+++ b/plugins/crypto/openssl/ua_openssl_version_abstraction.h
@@ -22,7 +22,7 @@
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER)
-#define X509_STORE_CTX_get_check_issued(STORE_CTX) storeCtx->check_issued
+#define X509_STORE_CTX_get_check_issued(STORE_CTX) STORE_CTX->check_issued
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(LIBRESSL_VERSION_NUMBER)


### PR DESCRIPTION
The macro is only used in places where the variable is already (coincidentally) named correctly.