### PR TITLE
fix(arch): add missing defines for poll on arch freertosLWIP

### DIFF
--- a/arch/common/ua_lwip.h
+++ b/arch/common/ua_lwip.h
@@ -37,6 +37,10 @@
 #define UA_WOULDBLOCK EWOULDBLOCK
 #define UA_ERR_CONNECTION_PROGRESS EINPROGRESS
 
+#define UA_POLLIN POLLIN
+#define UA_POLLOUT POLLOUT
+
+#define UA_poll lwip_poll
 #define UA_send lwip_send
 #define UA_recv lwip_recv
 #define UA_sendto lwip_sendto


### PR DESCRIPTION
Commit #4704 add polling to check if output connection is ready before write. This commit add missing defines for arch freertosLWIP and fix corresponding compiler errors.