### PR TITLE
Fix: compilation bug due to missing void parameter

### DIFF
--- a/.idea/open625412.iml
+++ b/.idea/open625412.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -45,7 +45,7 @@ static UA_StatusCode
 setDefaultConfig(UA_ServerConfig *conf);
 
 UA_Server *
-UA_Server_new() {
+UA_Server_new(void) {
     UA_ServerConfig config;
     memset(&config, 0, sizeof(UA_ServerConfig));
 
@@ -757,7 +757,7 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
 /* Default Client Settings */
 /***************************/
 
-UA_Client * UA_Client_new() {
+UA_Client * UA_Client_new(void) {
     UA_ClientConfig config;
     memset(&config, 0, sizeof(UA_ClientConfig));
     config.logger.log = UA_Log_Stdout_log;

--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -1321,7 +1321,7 @@ TransportLayerEthernet_addChannel(UA_PubSubConnectionConfig *connectionConfig) {
 }
 
 UA_PubSubTransportLayer
-UA_PubSubTransportLayerEthernet() {
+UA_PubSubTransportLayerEthernet(void) {
     UA_PubSubTransportLayer pubSubTransportLayer;
     pubSubTransportLayer.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-eth-uadp");

--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -848,7 +848,7 @@ TransportLayerUDPMC_addChannel(UA_PubSubConnectionConfig *connectionConfig) {
 
 //UDPMC channel factory
 UA_PubSubTransportLayer
-UA_PubSubTransportLayerUDPMP() {
+UA_PubSubTransportLayerUDPMP(void) {
     UA_PubSubTransportLayer pubSubTransportLayer;
     pubSubTransportLayer.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -300,7 +300,7 @@ UA_Server_removePublishedDataSet(UA_Server *server, const UA_NodeId pds) {
 /* Calculate the time difference between current time and UTC (00:00) on January
  * 1, 2000. */
 UA_UInt32
-UA_PubSubConfigurationVersionTimeDifference() {
+UA_PubSubConfigurationVersionTimeDifference(void) {
     UA_UInt32 timeDiffSince2000 = (UA_UInt32) (UA_DateTime_now() - UA_DATETIMESTAMP_2000);
     return timeDiffSince2000;
 }

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -25,7 +25,7 @@
 #define UA_MAX_RETRANSMISSIONQUEUESIZE 256
 
 UA_Subscription *
-UA_Subscription_new() {
+UA_Subscription_new(void) {
     /* Allocate the memory */
     UA_Subscription *newSub = (UA_Subscription*)UA_calloc(1, sizeof(UA_Subscription));
     if(!newSub)


### PR DESCRIPTION
Fix compilation for clang-15 which requires function signatures to match exactly. myfun() != myfun(void)