### PR TITLE
[REVIEW] LDS-ME IPV6 support in Open62541

### DIFF
--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
     config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample Multicast Server");
 
     //setting custom outbound interface
-    config->mdnsInterfaceIP = UA_String_fromChars("42.42.42.42"); //this line will produce an error and set the interface to 0.0.0.0
+    config->mdnsInterfaceIP = UA_String_fromChars("0.0.0.0"); // "::" to set default ipv6 multicast interface
 
     // See http://www.opcfoundation.org/UA/schemas/1.03/ServerCapabilities.csv
     // For a LDS server, you should only indicate the LDS capability.

--- a/src/server/ua_services_discovery_multicast.c
+++ b/src/server/ua_services_discovery_multicast.c
@@ -268,7 +268,7 @@ setMulticastInterface(UA_Server *server, UA_SOCKET sock,
 static UA_SOCKET
 bindMdnsSocket(UA_SOCKET mdnsSocket, UA_Int32 ipVersion) {
     struct sockaddr_storage mdnsBindAddr;
-    memset(&mdnsBindAddr,0, sizeof(struct sockaddr_storage));
+    memset(&mdnsBindAddr, 0, sizeof(struct sockaddr_storage));
     UA_UInt16 mDNSPort = htons(5353);
     if(ipVersion == AF_INET) {
         struct sockaddr_in *in = (struct sockaddr_in *)&mdnsBindAddr;


### PR DESCRIPTION
This PR adds the support for the creation of mdnsd socket for IPV6/IPV4 socket and adding IPV6 records (QTYPE_AAAA) to publish. The unit tests for selecting ipv4/ipv6 interfaces are also provided in this PR. This PR also adds the functionality for the clients to do mdns lookup on .local domain if the multicast discovery is enabled. This is performed additionally to the dns lookup which will fail on link local or in subnets where no dns server is running.