### PR TITLE
dix(doc) Update documentation push logic

### DIFF
--- a/.github/workflows/doc_upload.yml
+++ b/.github/workflows/doc_upload.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout Website Repository
         uses: actions/checkout@v2
         with:
-          repository: andreasebner/open62541-www-staging
+          repository: open62541/open62541-www
           path: open62541-www
           persist-credentials: false
       - name: Get the current branch name
@@ -52,6 +52,6 @@ jobs:
         with:
           github_token: ${{ secrets.WWW_PUSH_TOKEN }}
           directory: open62541-www
-          repository: open62541/open62541-www-staging
-          branch: master
+          repository: open62541/open62541-www
+          branch: main
           force: true


### PR DESCRIPTION
The new open62541-website is now online and we need to push the autogenerated documentation in the new location.