### PR TITLE
test(core): fix compiler errors

### DIFF
--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -364,7 +364,7 @@ START_TEST(Securechannel_sendAsymmetricOPNMessage_extraPaddingPresentWhenKeyLarg
     if(extraPadding) {
         extraPaddingByte = paddingByte;
         paddingByte = sentData.data[sentData.length - keySizes.asym_lcl_sig_size - 2];
-        paddingSize = (extraPaddingByte << 8u) + paddingByte;
+        paddingSize = ((size_t)extraPaddingByte << 8u) + paddingByte;
         paddingSize += 1;
     }
 

--- a/tests/check_types_builtin.c
+++ b/tests/check_types_builtin.c
@@ -195,7 +195,7 @@ END_TEST
 START_TEST(UA_Int64_decodeShallRespectSign) {
     // given
     UA_ByteString rawMessage;
-    UA_UInt64 expectedVal = ((UA_UInt64)0xFF) << 56;
+    UA_Int64 expectedVal = ((UA_Int64)0xFF) << 56;
     UA_Byte  mem[8]      = { 00, 00, 00, 00, 0x00, 0x00, 0x00, 0xFF };
     rawMessage.data   = mem;
     rawMessage.length = 8;

--- a/tests/encryption/check_encryption_aes128sha256rsaoaep.c
+++ b/tests/encryption/check_encryption_aes128sha256rsaoaep.c
@@ -106,12 +106,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -187,12 +187,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/encryption/check_encryption_basic128rsa15.c
+++ b/tests/encryption/check_encryption_basic128rsa15.c
@@ -103,12 +103,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -184,12 +184,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/encryption/check_encryption_basic256.c
+++ b/tests/encryption/check_encryption_basic256.c
@@ -106,12 +106,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -187,12 +187,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/encryption/check_encryption_basic256sha256.c
+++ b/tests/encryption/check_encryption_basic256sha256.c
@@ -106,12 +106,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -187,12 +187,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/server/check_services_attributes.c
+++ b/tests/server/check_services_attributes.c
@@ -199,7 +199,7 @@ START_TEST(ReadSingleServerAttribute) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_BOTH);
 
     ck_assert_int_eq(resp.status, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert_int_eq(resp.serverTimestamp, UA_DateTime_now());
     ck_assert_int_eq(resp.sourceTimestamp, UA_DateTime_now());
     UA_DataValue_clear(&resp);
@@ -825,7 +825,7 @@ START_TEST(WriteSingleAttributeValueWithServerTimestamp) {
     ck_assert(resp.hasValue);
     ck_assert_int_eq(20, *(UA_Int32*)resp.value.data);
     ck_assert(resp.hasServerTimestamp);
-    ck_assert_uint_eq(resp.serverTimestamp, UA_DateTime_now());
+    ck_assert_int_eq(resp.serverTimestamp, UA_DateTime_now());
     UA_DataValue_clear(&resp);
 } END_TEST
 

--- a/tests/server/check_services_nodemanagement.c
+++ b/tests/server/check_services_nodemanagement.c
@@ -618,7 +618,7 @@ START_TEST(ObjectWithDynamicVariableChild) {
 
     UA_BrowsePathResult bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
 
-    ck_assert_int_eq(bpr.targetsSize, 1);
+    ck_assert_uint_eq(bpr.targetsSize, 1);
 
     UA_WriteValue wv;
     UA_WriteValue_init(&wv);


### PR DESCRIPTION
OpenBSD clang version 13.0.0 complains about -Wsign-conversion
errors.  Use correct types to avoid sign conversion and bad comparison.