### PR TITLE
test(core): fix more compiler errors

### DIFF
--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -113,26 +113,26 @@ START_TEST(readValueRank) {
     ck_assert_int_eq(rank, -2);
     UA_Variant_init(&dims);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10002), &dims);
-    ck_assert_int_eq(dims.arrayLength, 0);
+    ck_assert_uint_eq(dims.arrayLength, 0);
     UA_Variant_clear(&dims);
     // 1-dim
     UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10007), &rank);
     ck_assert_int_eq(rank, 1);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10007), &dims);
-    ck_assert_int_eq(dims.arrayLength, 1);
+    ck_assert_uint_eq(dims.arrayLength, 1);
     ck_assert_int_eq(*((UA_UInt32 *)dims.data), 0);
     UA_Variant_clear(&dims);
     UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10004), &rank);
     ck_assert_int_eq(rank, 1);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10004), &dims);
-    ck_assert_int_eq(dims.arrayLength, 1);
+    ck_assert_uint_eq(dims.arrayLength, 1);
     ck_assert_int_eq(*((UA_UInt32 *)dims.data), 4);
     UA_Variant_clear(&dims);
     // 2-dim
     UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10006), &rank);
     ck_assert_int_eq(rank, 2);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10006), &dims);
-    ck_assert_int_eq(dims.arrayLength, 2);
+    ck_assert_uint_eq(dims.arrayLength, 2);
     UA_UInt32 *dimensions = (UA_UInt32 *)dims.data;
     ck_assert_int_eq(dimensions[0], 2);
     ck_assert_int_eq(dimensions[1], 2);

--- a/tests/server/check_interfaces.c
+++ b/tests/server/check_interfaces.c
@@ -56,7 +56,7 @@ START_TEST(check_interface_instantiation) {
 
     UA_BrowsePathResult bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
     ck_assert_int_eq(bpr.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(bpr.targetsSize, 1);
+    ck_assert_uint_eq(bpr.targetsSize, 1);
 
     const UA_NodeId objectWithInterfacesId = bpr.targets->targetId.nodeId;
     UA_BrowsePathResult_clear(&bpr);
@@ -73,7 +73,7 @@ START_TEST(check_interface_instantiation) {
 
     UA_BrowseResult br = UA_Server_browse(server, 1000, &bd);
     ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_gt(br.referencesSize, 0);
+    ck_assert_uint_gt(br.referencesSize, 0);
 
     bool found = false;
     for (size_t i = 0; i < br.referencesSize; ++i) {
@@ -150,7 +150,7 @@ START_TEST(check_interface_instantiation) {
 
     bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
     ck_assert_int_eq(bpr.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(bpr.targetsSize, 1);
+    ck_assert_uint_eq(bpr.targetsSize, 1);
 
     const UA_NodeId baseObjectWithInterfaceId = bpr.targets->targetId.nodeId;
     UA_BrowsePathResult_clear(&bpr);
@@ -164,7 +164,7 @@ START_TEST(check_interface_instantiation) {
 
     br = UA_Server_browse(server, 1000, &bd);
     ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_gt(br.referencesSize, 0);
+    ck_assert_uint_gt(br.referencesSize, 0);
 
     found = false;
     for (size_t i = 0; i < br.referencesSize; ++i) {


### PR DESCRIPTION
When compiling with UA_NAMESPACE_ZERO=FULL more -Wsign-conversion
errors show up.