### PR TITLE
build(pkgconfig): do not assume relative paths in open62541.pc

### DIFF
--- a/tools/open62541.pc.in
+++ b/tools/open62541.pc.in
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 sharedlibdir=${libdir}
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: open62541
 Description: open62541 is an open source C (C99) implementation of OPC UA


### PR DESCRIPTION
Paths in the pkg-config file are composed of `CMAKE_INSTALL_<dir>`
variables. However, it is allowed to specify them as absolute paths, see

https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#result-variables

> It should typically be a path relative to the installation prefix so
> that it can be converted to an absolute path in a relocatable way (see
> `CMAKE_INSTALL_FULL_<dir>`). However, an absolute path is also
> allowed.

If they are absolute, compositions like
`@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@` yield a wrong path.
Use the `CMAKE_INSTALL_FULL_<dir>` variables instead, as the CMake
documentation suggests.