### PR TITLE
[Review] fix(pubsub): Memory fixes

### DIFF
--- a/examples/pubsub/tutorial_pubsub_mqtt_publish.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt_publish.c
@@ -44,8 +44,6 @@
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
 
-#include "ua_pubsub.h"
-
 #include <signal.h>
 
 #include <open62541/plugin/pubsub_mqtt.h>
@@ -471,14 +469,6 @@ int main(int argc, char **argv) {
         return EXIT_FAILURE;
     }
     addDataSetWriter(server, topic);
-    UA_PubSubConnection *connection = UA_PubSubConnection_findConnectionbyId(server, connectionIdent);
-
-    if(!connection) {
-        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
-                       "Could not create a PubSubConnection");
-        UA_Server_delete(server);
-        return -1;
-    }
 
     UA_Server_run(server, &running);
     UA_Server_delete(server);

--- a/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_publisher.c
+++ b/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_publisher.c
@@ -295,7 +295,7 @@ addPublishedDataSet(UA_Server *server) {
 /* This example only uses two addDataSetField which uses the custom nodes of the XML file
  * (pubDataModel.xml) */
 static void
-addDataSetField(UA_Server *server) {
+_addDataSetField(UA_Server *server) {
     UA_NodeId dataSetFieldIdent;
     UA_DataSetFieldConfig dsfConfig;
     memset(&dsfConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -683,7 +683,7 @@ int main(int argc, char **argv) {
 
     addPubSubConnection(server, &networkAddressUrlPub);
     addPublishedDataSet(server);
-    addDataSetField(server);
+    _addDataSetField(server);
     addWriterGroup(server);
     addDataSetWriter(server);
     UA_Server_freezeWriterGroupConfiguration(server, writerGroupIdent);

--- a/examples/pubsub_realtime/pubsub_TSN_loopback.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback.c
@@ -766,7 +766,7 @@ addPublishedDataSet(UA_Server *server) {
 
 /* DataSetField handling */
 static void
-addDataSetField(UA_Server *server) {
+_addDataSetField(UA_Server *server) {
     /* Add a field to the previous created PublishedDataSet */
     UA_NodeId dataSetFieldIdent1;
     UA_DataSetFieldConfig dataSetFieldConfig;
@@ -1682,7 +1682,7 @@ if(enableCsvLog)
 #if defined(PUBLISHER)
     addPubSubConnection(server, &networkAddressUrlPub);
     addPublishedDataSet(server);
-    addDataSetField(server);
+    _addDataSetField(server);
     addWriterGroup(server);
     addDataSetWriter(server);
     UA_Server_freezeWriterGroupConfiguration(server, writerGroupIdent);

--- a/examples/pubsub_realtime/pubsub_TSN_loopback_single_thread.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback_single_thread.c
@@ -620,7 +620,7 @@ addPublishedDataSet(UA_Server *server) {
 
 /* DataSetField handling */
 static void
-addDataSetField(UA_Server *server) {
+_addDataSetField(UA_Server *server) {
     /* Add a field to the previous created PublishedDataSet */
     UA_NodeId dataSetFieldIdent1;
     UA_DataSetFieldConfig dataSetFieldConfig;
@@ -1327,7 +1327,7 @@ int main(int argc, char **argv) {
 #ifdef TWO_WAY_COMMUNICATION
     addPubSubConnection(server, &transportProfile, &networkAddressUrlPub);
     addPublishedDataSet(server);
-    addDataSetField(server);
+    _addDataSetField(server);
     addWriterGroup(server);
     addDataSetWriter(server);
     UA_Server_freezeWriterGroupConfiguration(server, writerGroupIdent);

--- a/examples/pubsub_realtime/pubsub_TSN_publisher.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher.c
@@ -758,7 +758,7 @@ addPublishedDataSet(UA_Server *server) {
 
 /* DataSetField handling */
 static void
-addDataSetField(UA_Server *server) {
+_addDataSetField(UA_Server *server) {
     /* Add a field to the previous created PublishedDataSet */
     UA_NodeId dataSetFieldIdentRepeated;
     UA_DataSetFieldConfig dataSetFieldConfig;
@@ -1751,7 +1751,7 @@ int main(int argc, char **argv) {
 #if defined(PUBLISHER)
     addPubSubConnection(server, &networkAddressUrlPub);
     addPublishedDataSet(server);
-    addDataSetField(server);
+    _addDataSetField(server);
     addWriterGroup(server);
     addDataSetWriter(server);
     UA_Server_freezeWriterGroupConfiguration(server, writerGroupIdent);

--- a/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
@@ -630,7 +630,7 @@ addPublishedDataSet(UA_Server *server) {
 
 /* DataSetField handling */
 static void
-addDataSetField(UA_Server *server) {
+_addDataSetField(UA_Server *server) {
     /* Add a field to the previous created PublishedDataSet */
     UA_NodeId dataSetFieldIdent1;
     UA_DataSetFieldConfig dataSetFieldConfig;
@@ -1416,7 +1416,7 @@ int main(int argc, char **argv) {
 
     addPubSubConnection(server, &transportProfile, &networkAddressUrlPub);
     addPublishedDataSet(server);
-    addDataSetField(server);
+    _addDataSetField(server);
     addWriterGroup(server);
     addDataSetWriter(server);
     UA_Server_freezeWriterGroupConfiguration(server, writerGroupIdent);

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -384,7 +384,7 @@ typedef struct {
     UA_ConfigurationVersionDataType configurationVersion;
 } UA_DataSetFieldResult;
 
-UA_DataSetFieldResult UA_EXPORT
+UA_DataSetFieldResult UA_EXPORT UA_THREADSAFE
 UA_Server_addDataSetField(UA_Server *server,
                           const UA_NodeId publishedDataSet,
                           const UA_DataSetFieldConfig *fieldConfig,
@@ -395,7 +395,7 @@ UA_StatusCode UA_EXPORT
 UA_Server_getDataSetFieldConfig(UA_Server *server, const UA_NodeId dsf,
                                 UA_DataSetFieldConfig *config);
 
-UA_DataSetFieldResult UA_EXPORT
+UA_DataSetFieldResult UA_EXPORT UA_THREADSAFE
 UA_Server_removeDataSetField(UA_Server *server, const UA_NodeId dsf);
 
 /**

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -219,6 +219,14 @@ UA_DataSetFieldConfig_copy(const UA_DataSetFieldConfig *src,
 UA_DataSetField *
 UA_DataSetField_findDSFbyId(UA_Server *server, UA_NodeId identifier);
 
+UA_DataSetFieldResult
+addDataSetField(UA_Server *server, const UA_NodeId publishedDataSet,
+                const UA_DataSetFieldConfig *fieldConfig,
+                UA_NodeId *fieldIdentifier);
+
+UA_DataSetFieldResult
+removeDataSetField(UA_Server *server, const UA_NodeId dsf);
+
 /**********************************************/
 /*               DataSetReader                */
 /**********************************************/
@@ -250,6 +258,9 @@ UA_DataSetReader_process(UA_Server *server,
                          UA_ReaderGroup *readerGroup,
                          UA_DataSetReader *dataSetReader,
                          UA_DataSetMessage *dataSetMsg);
+
+UA_StatusCode
+removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier);
 
 /* Copy the configuration of DataSetReader */
 UA_StatusCode UA_DataSetReaderConfig_copy(const UA_DataSetReaderConfig *src,

--- a/src/pubsub/ua_pubsub_config.c
+++ b/src/pubsub/ua_pubsub_config.c
@@ -745,14 +745,15 @@ addDataSetFieldVariables(UA_Server *server, const UA_NodeId *pdsIdent,
         UA_DataSetFieldConfig fc;
         memset(&fc, 0, sizeof(UA_DataSetFieldConfig));
         fc.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
-        fc.field.variable.configurationVersion = pdsParams->dataSetMetaData.configurationVersion;
+        fc.field.variable.configurationVersion =
+            pdsParams->dataSetMetaData.configurationVersion;
         fc.field.variable.fieldNameAlias = pdsParams->dataSetMetaData.fields[i].name;
         fc.field.variable.promotedField = pdsParams->dataSetMetaData.
             fields[i].fieldFlags & 0x0001;
         fc.field.variable.publishParameters = pdItems->publishedData[i];
 
         UA_NodeId fieldIdent;
-        UA_StatusCode res = UA_Server_addDataSetField(server, *pdsIdent, &fc, &fieldIdent).result;
+        UA_StatusCode res = addDataSetField(server, *pdsIdent, &fc, &fieldIdent).result;
         if(res != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                          "[UA_PubSubManager_addDataSetFieldVariables] "

--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -1142,10 +1142,6 @@ UA_NetworkMessage_clear(UA_NetworkMessage* p) {
     memset(p, 0, sizeof(UA_NetworkMessage));
 }
 
-void UA_NetworkMessage_delete(UA_NetworkMessage* p) {
-    UA_NetworkMessage_clear(p);
-}
-
 UA_Boolean
 UA_NetworkMessage_ExtendedFlags1Enabled(const UA_NetworkMessage* src) {
     UA_Boolean retval = false;

--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -932,7 +932,8 @@ increaseOffsetArray(UA_NetworkMessageOffsetBuffer *offsetBuffer) {
 }
 
 size_t
-UA_NetworkMessage_calcSizeBinary(UA_NetworkMessage *p, UA_NetworkMessageOffsetBuffer *offsetBuffer) {
+UA_NetworkMessage_calcSizeBinary(UA_NetworkMessage *p,
+                                 UA_NetworkMessageOffsetBuffer *offsetBuffer) {
     size_t retval = 0;
     UA_Byte byte = 0;
     size_t size = UA_Byte_calcSizeBinary(&byte); // UADPVersion + UADPFlags

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -15,6 +15,8 @@
 
 _UA_BEGIN_DECLS
 
+#define UA_NETWORKMESSAGE_MAX_NONCE_LENGTH 16
+
 /* DataSet Payload Header */
 typedef struct {
     UA_Byte count;
@@ -128,7 +130,8 @@ typedef struct {
     UA_Boolean securityFooterEnabled;
     UA_Boolean forceKeyReset;
     UA_UInt32 securityTokenId;      // spec: IntegerId
-    UA_ByteString messageNonce;
+    UA_Byte messageNonce[UA_NETWORKMESSAGE_MAX_NONCE_LENGTH];
+    UA_UInt16 messageNonceSize;
     UA_UInt16 securityFooterSize;
 } UA_NetworkMessageSecurityHeader;
 

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -333,10 +333,6 @@ UA_NetworkMessage_signEncrypt(UA_NetworkMessage *nm, UA_MessageSecurityMode secu
 void
 UA_NetworkMessage_clear(UA_NetworkMessage* p);
 
-void
-UA_NetworkMessage_delete(UA_NetworkMessage* p);
-
-
 #ifdef UA_ENABLE_JSON_ENCODING
 UA_StatusCode
 UA_NetworkMessage_encodeJson(const UA_NetworkMessage *src,

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -218,14 +218,19 @@ typedef struct {
     UA_ByteString buffer; /* The precomputed message buffer */
     UA_NetworkMessageOffset *offsets; /* Offsets for changes in the message buffer */
     size_t offsetsSize;
-    UA_Boolean RTsubscriberEnabled; /* Addtional offsets computation like publisherId, WGId if this bool enabled */
+    UA_Boolean RTsubscriberEnabled; /* Addtional offsets computation like
+                                     * publisherId, WGId if this bool enabled */
     UA_NetworkMessage *nm; /* The precomputed NetworkMessage for subscriber */
     size_t rawMessageLength;
 #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
-    UA_ByteString encryptBuffer; /* The precomputed message buffer is copied into the encrypt buffer for encryption and signing*/
+    UA_ByteString encryptBuffer; /* The precomputed message buffer is copied
+                                  * into the encrypt buffer for encryption and
+                                  * signing*/
     UA_Byte *payloadPosition; /* Payload Position of the message to encrypt*/
 #endif
 } UA_NetworkMessageOffsetBuffer;
+
+void UA_NetworkMessageOffsetBuffer_clear(UA_NetworkMessageOffsetBuffer *nmob);
 
 /**
  * DataSetMessage

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -259,7 +259,7 @@ size_t
 UA_DataSetMessage_calcSizeBinary(UA_DataSetMessage *p, UA_NetworkMessageOffsetBuffer *offsetBuffer,
                                  size_t currentOffset);
 
-void UA_DataSetMessage_clear(const UA_DataSetMessage* p);
+void UA_DataSetMessage_clear(UA_DataSetMessage* p);
 
 /**
  * NetworkMessage

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -259,7 +259,8 @@ UA_DataSetMessage_decodeBinary(const UA_ByteString *src, size_t *offset,
                                UA_DataSetMessage* dst, UA_UInt16 dsmSize);
 
 size_t
-UA_DataSetMessage_calcSizeBinary(UA_DataSetMessage *p, UA_NetworkMessageOffsetBuffer *offsetBuffer,
+UA_DataSetMessage_calcSizeBinary(UA_DataSetMessage *p,
+                                 UA_NetworkMessageOffsetBuffer *offsetBuffer,
                                  size_t currentOffset);
 
 void UA_DataSetMessage_clear(UA_DataSetMessage* p);
@@ -304,13 +305,16 @@ UA_NetworkMessage_encodeFooters(const UA_NetworkMessage* src,
  * ^^^^^^^^^^^^^^^^^^^^^^^ */
 
 UA_StatusCode
-UA_NetworkMessage_decodeHeaders(const UA_ByteString *src, size_t *offset, UA_NetworkMessage *dst);
+UA_NetworkMessage_decodeHeaders(const UA_ByteString *src, size_t *offset,
+                                UA_NetworkMessage *dst);
 
 UA_StatusCode
-UA_NetworkMessage_decodePayload(const UA_ByteString *src, size_t *offset, UA_NetworkMessage *dst);
+UA_NetworkMessage_decodePayload(const UA_ByteString *src, size_t *offset,
+                                UA_NetworkMessage *dst);
 
 UA_StatusCode
-UA_NetworkMessage_decodeFooters(const UA_ByteString *src, size_t *offset, UA_NetworkMessage *dst);
+UA_NetworkMessage_decodeFooters(const UA_ByteString *src, size_t *offset,
+                                UA_NetworkMessage *dst);
 
 UA_StatusCode
 UA_NetworkMessage_decodeBinary(const UA_ByteString *src, size_t *offset,
@@ -318,8 +322,10 @@ UA_NetworkMessage_decodeBinary(const UA_ByteString *src, size_t *offset,
 
 
 UA_StatusCode
-UA_NetworkMessageHeader_decodeBinary(const UA_ByteString *src, size_t *offset, UA_NetworkMessage *dst);
+UA_NetworkMessageHeader_decodeBinary(const UA_ByteString *src, size_t *offset,
+                                     UA_NetworkMessage *dst);
 
+/* Also stores the offset if offsetBuffer != NULL */
 size_t
 UA_NetworkMessage_calcSizeBinary(UA_NetworkMessage *p,
                                  UA_NetworkMessageOffsetBuffer *offsetBuffer);

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -212,13 +212,16 @@ UA_DataSetReader_generateDataSetMessage(UA_Server *server,
     }
 
     /* Not supported for Delta frames atm */
-    return UA_PubSubDataSetReader_generateKeyFrameMessage(server, dataSetMessage, dataSetReader);
+    return UA_PubSubDataSetReader_generateKeyFrameMessage(server, dataSetMessage,
+                                                          dataSetReader);
 }
 
 UA_StatusCode
-UA_DataSetReader_generateNetworkMessage(UA_PubSubConnection *pubSubConnection, UA_ReaderGroup *readerGroup,
-                                        UA_DataSetReader *dataSetReader, UA_DataSetMessage *dsm, UA_UInt16 *writerId, UA_Byte dsmCount,
-                                        UA_NetworkMessage *nm) {
+UA_DataSetReader_generateNetworkMessage(UA_PubSubConnection *pubSubConnection,
+                                        UA_ReaderGroup *readerGroup,
+                                        UA_DataSetReader *dataSetReader,
+                                        UA_DataSetMessage *dsm, UA_UInt16 *writerId,
+                                        UA_Byte dsmCount, UA_NetworkMessage *nm) {
     UA_ExtensionObject *settings = &dataSetReader->config.messageSettings;
     if(settings->content.decoded.type != &UA_TYPES[UA_TYPES_UADPDATASETREADERMESSAGEDATATYPE])
         return UA_STATUSCODE_BADNOTSUPPORTED;

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -471,7 +471,7 @@ UA_Server_addDataSetReader(UA_Server *server, UA_NodeId readerGroupIdentifier,
 }
 
 UA_StatusCode
-UA_Server_removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier) {
+removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier) {
     /* Remove datasetreader given by the identifier */
     UA_DataSetReader *dsr = UA_ReaderGroup_findDSRbyId(server, readerIdentifier);
     if(!dsr)
@@ -515,6 +515,14 @@ UA_Server_removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier) {
 #endif /* UA_ENABLE_PUBSUB_MONITORING */
 
     UA_DataSetReader_clear(server, dsr);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier) {
+    UA_LOCK(&server->serviceMutex);
+    UA_StatusCode res = removeDataSetReader(server, readerIdentifier);
+    UA_UNLOCK(&server->serviceMutex);
     return res;
 }
 

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -537,7 +537,8 @@ UA_Server_freezeReaderGroupConfiguration(UA_Server *server,
         }
     }
 
-    UA_DataSetMessage *dsm = (UA_DataSetMessage *) UA_calloc(1, sizeof(UA_DataSetMessage));
+    UA_DataSetMessage *dsm = (UA_DataSetMessage*)
+        UA_calloc(1, sizeof(UA_DataSetMessage));
     if(!dsm) {
         UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
                      "PubSub RT Offset calculation: DSM creation failed");
@@ -565,7 +566,8 @@ UA_Server_freezeReaderGroupConfiguration(UA_Server *server,
     }
     *dsWriterIds = dataSetReader->config.dataSetWriterId;
 
-    UA_NetworkMessage *networkMessage = (UA_NetworkMessage *)UA_calloc(1, sizeof(UA_NetworkMessage));
+    UA_NetworkMessage *networkMessage = (UA_NetworkMessage *)
+        UA_calloc(1, sizeof(UA_NetworkMessage));
     if(!networkMessage) {
         UA_free(dsWriterIds);
         UA_DataSetMessage_clear(dsm);
@@ -575,6 +577,7 @@ UA_Server_freezeReaderGroupConfiguration(UA_Server *server,
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 
+    /* Move the dsm into the NetworkMessage */
     res = UA_DataSetReader_generateNetworkMessage(pubSubConnection, rg, dataSetReader, dsm,
                                                   dsWriterIds, 1, networkMessage);
     if(res != UA_STATUSCODE_GOOD) {

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -618,32 +618,7 @@ UA_Server_unfreezeReaderGroupConfiguration(UA_Server *server,
     UA_DataSetReader *dataSetReader;
     LIST_FOREACH(dataSetReader, &rg->readers, listEntry) {
         dataSetReader->configurationFrozen = UA_FALSE;
-    }
-
-    if(rg->config.rtLevel != UA_PUBSUB_RT_FIXED_SIZE)
-        return UA_STATUSCODE_GOOD;
-
-    dataSetReader = LIST_FIRST(&rg->readers);
-    if(dataSetReader->bufferedMessage.offsetsSize > 0) {
-        for(size_t i = 0; i < dataSetReader->bufferedMessage.offsetsSize; i++) {
-            UA_NetworkMessageOffset *offset = &dataSetReader->bufferedMessage.offsets[i];
-            if((offset->contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_VARIANT) ||
-                (offset->contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_RAW) ||
-                (offset->contentType == UA_PUBSUB_OFFSETTYPE_DATASETMESSAGE_SEQUENCENUMBER) ||
-                (offset->contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_SEQUENCENUMBER)) {
-                UA_DataValue_delete(offset->offsetData.value.value);
-            } else if(offset->contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_FIELDENCDODING) {
-                offset->offsetData.value.value->value.data = NULL;
-                UA_DataValue_delete(offset->offsetData.value.value);
-            }
-        }
-        UA_free(dataSetReader->bufferedMessage.offsets);
-    }
-
-    if(dataSetReader->bufferedMessage.RTsubscriberEnabled &&
-       dataSetReader->bufferedMessage.nm) {
-        UA_NetworkMessage_delete(dataSetReader->bufferedMessage.nm);
-        UA_free(dataSetReader->bufferedMessage.nm);
+        UA_NetworkMessageOffsetBuffer_clear(&dataSetReader->bufferedMessage);
     }
 
     return UA_STATUSCODE_GOOD;

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -627,7 +627,9 @@ UA_Server_unfreezeReaderGroupConfiguration(UA_Server *server,
         for(size_t i = 0; i < dataSetReader->bufferedMessage.offsetsSize; i++) {
             UA_NetworkMessageOffset *offset = &dataSetReader->bufferedMessage.offsets[i];
             if((offset->contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_VARIANT) ||
-                (offset->contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_RAW)) {
+                (offset->contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_RAW) ||
+                (offset->contentType == UA_PUBSUB_OFFSETTYPE_DATASETMESSAGE_SEQUENCENUMBER) ||
+                (offset->contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_SEQUENCENUMBER)) {
                 UA_DataValue_delete(offset->offsetData.value.value);
             } else if(offset->contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_FIELDENCDODING) {
                 offset->offsetData.value.value->value.data = NULL;

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -129,6 +129,7 @@ UA_Server_addReaderGroup(UA_Server *server, UA_NodeId connectionIdentifier,
     if(!newGroup)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
+    memset(newGroup, 0, sizeof(UA_ReaderGroup));
     newGroup->componentType = UA_PUBSUB_COMPONENT_READERGROUP;
     /* Generate nodeid for the readergroup identifier */
     newGroup->linkedConnection = currentConnectionContext->identifier;

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -456,6 +456,9 @@ UA_Server_freezeReaderGroupConfiguration(UA_Server *server,
     if(!rg)
         return UA_STATUSCODE_BADNOTFOUND;
 
+    if(rg->configurationFrozen)
+        return UA_STATUSCODE_GOOD;
+
     /* PubSubConnection freezeCounter++ */
     UA_NodeId pubSubConnectionId =  rg->linkedConnection;
     UA_PubSubConnection *pubSubConnection =

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -591,10 +591,12 @@ UA_Server_freezeReaderGroupConfiguration(UA_Server *server,
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
+    /* The offset buffer is already clear if the ReaderGroup was unfrozen
+     * UA_NetworkMessageOffsetBuffer_clear(&dataSetReader->bufferedMessage); */
     memset(&dataSetReader->bufferedMessage, 0, sizeof(UA_NetworkMessageOffsetBuffer));
     dataSetReader->bufferedMessage.RTsubscriberEnabled = true;
 
-    /* Fix the offsets necessary to decode */
+    /* Compute and store the offsets necessary to decode */
     UA_NetworkMessage_calcSizeBinary(networkMessage, &dataSetReader->bufferedMessage);
     dataSetReader->bufferedMessage.nm = networkMessage;
 

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -240,7 +240,7 @@ UA_Server_ReaderGroup_clear(UA_Server* server, UA_ReaderGroup *readerGroup) {
     UA_DataSetReader *dataSetReader;
     UA_DataSetReader *tmpDataSetReader;
     LIST_FOREACH_SAFE(dataSetReader, &readerGroup->readers, listEntry, tmpDataSetReader) {
-        UA_Server_removeDataSetReader(server, dataSetReader->identifier);
+        removeDataSetReader(server, dataSetReader->identifier);
     }
     UA_PubSubConnection* pConn =
         UA_PubSubConnection_findConnectionbyId(server, readerGroup->linkedConnection);

--- a/src/pubsub/ua_pubsub_security.c
+++ b/src/pubsub/ua_pubsub_security.c
@@ -98,8 +98,11 @@ verifyAndDecrypt(const UA_Logger *logger, UA_ByteString *buffer,
     }
 
     if(doDecrypt) {
-        rv = securityPolicy->setMessageNonce(channelContext,
-                                             &nm->securityHeader.messageNonce);
+        const UA_ByteString nonce = {
+            (size_t)nm->securityHeader.messageNonceSize,
+            (UA_Byte*)(uintptr_t)nm->securityHeader.messageNonce
+        };
+        rv = securityPolicy->setMessageNonce(channelContext, &nonce);
         UA_CHECK_STATUS_WARN(rv, return rv, logger, UA_LOGCATEGORY_SECURITYPOLICY,
                              "PubSub receive. Faulty Nonce set");
 

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -110,7 +110,7 @@ UA_PubSubConnection_clear(UA_Server *server, UA_PubSubConnection *connection) {
     /* Remove ReaderGroups */
     UA_ReaderGroup *readerGroups, *tmpReaderGroup;
     LIST_FOREACH_SAFE(readerGroups, &connection->readerGroups, listEntry, tmpReaderGroup)
-        UA_Server_removeReaderGroup(server, readerGroups->identifier);
+        removeReaderGroup(server, readerGroups->identifier);
 
     UA_NodeId_clear(&connection->identifier);
     if(connection->channel)
@@ -235,7 +235,7 @@ void
 UA_PublishedDataSet_clear(UA_Server *server, UA_PublishedDataSet *publishedDataSet) {
     UA_DataSetField *field, *tmpField;
     TAILQ_FOREACH_SAFE(field, &publishedDataSet->fields, listEntry, tmpField) {
-        UA_Server_removeDataSetField(server, field->identifier);
+        removeDataSetField(server, field->identifier);
     }
     UA_PublishedDataSetConfig_clear(&publishedDataSet->config);
     UA_DataSetMetaDataType_clear(&publishedDataSet->dataSetMetaData);
@@ -289,7 +289,8 @@ generateFieldMetaData(UA_Server *server, UA_DataSetField *field,
     const UA_PublishedVariableDataType *pp = &var->publishParameters;
     UA_Variant value;
     UA_Variant_init(&value);
-    res = UA_Server_readArrayDimensions(server, pp->publishedVariable, &value);
+    res = readWithReadValue(server, &pp->publishedVariable,
+                            UA_ATTRIBUTEID_ARRAYDIMENSIONS, &value);
     UA_CHECK_STATUS_LOG(res, return res,
                         WARNING, &server->config.logger, UA_LOGCATEGORY_SERVER,
                         "PubSub meta data generation. Reading the array dimensions failed.");
@@ -305,8 +306,8 @@ generateFieldMetaData(UA_Server *server, UA_DataSetField *field,
     fieldMetaData->arrayDimensionsSize = value.arrayDimensionsSize;
 
     /* Set the DataType */
-    res = UA_Server_readDataType(server, pp->publishedVariable,
-                                 &fieldMetaData->dataType);
+    res = readWithReadValue(server, &pp->publishedVariable,
+                            UA_ATTRIBUTEID_DATATYPE, &fieldMetaData->dataType);
     UA_CHECK_STATUS_LOG(res, return res,
                         WARNING, &server->config.logger, UA_LOGCATEGORY_SERVER,
                         "PubSub meta data generation. Reading the datatype failed.");
@@ -330,7 +331,8 @@ generateFieldMetaData(UA_Server *server, UA_DataSetField *field,
 
     /* Set the ValueRank */
     UA_Int32 valueRank;
-    res = UA_Server_readValueRank(server, pp->publishedVariable, &valueRank);
+    res = readWithReadValue(server, &pp->publishedVariable,
+                            UA_ATTRIBUTEID_VALUERANK, &valueRank);
     UA_CHECK_STATUS_LOG(res, return res,
                         WARNING, &server->config.logger, UA_LOGCATEGORY_SERVER,
                         "PubSub meta data generation. Reading the value rank failed.");
@@ -354,9 +356,9 @@ generateFieldMetaData(UA_Server *server, UA_DataSetField *field,
 }
 
 UA_DataSetFieldResult
-UA_Server_addDataSetField(UA_Server *server, const UA_NodeId publishedDataSet,
-                          const UA_DataSetFieldConfig *fieldConfig,
-                          UA_NodeId *fieldIdentifier) {
+addDataSetField(UA_Server *server, const UA_NodeId publishedDataSet,
+                const UA_DataSetFieldConfig *fieldConfig,
+                UA_NodeId *fieldIdentifier) {
     UA_DataSetFieldResult result = {0};
     if(!fieldConfig) {
         result.result = UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -453,7 +455,18 @@ UA_Server_addDataSetField(UA_Server *server, const UA_NodeId publishedDataSet,
 }
 
 UA_DataSetFieldResult
-UA_Server_removeDataSetField(UA_Server *server, const UA_NodeId dsf) {
+UA_Server_addDataSetField(UA_Server *server, const UA_NodeId publishedDataSet,
+                          const UA_DataSetFieldConfig *fieldConfig,
+                          UA_NodeId *fieldIdentifier) {
+    UA_LOCK(&server->serviceMutex);
+    UA_DataSetFieldResult res =
+        addDataSetField(server, publishedDataSet, fieldConfig, fieldIdentifier);
+    UA_UNLOCK(&server->serviceMutex);
+    return res;
+}
+
+UA_DataSetFieldResult
+removeDataSetField(UA_Server *server, const UA_NodeId dsf) {
     UA_DataSetFieldResult result = {0};
 
     UA_DataSetField *currentField = UA_DataSetField_findDSFbyId(server, dsf);
@@ -540,6 +553,14 @@ UA_Server_removeDataSetField(UA_Server *server, const UA_NodeId dsf) {
     result.configurationVersion.minorVersion =
         pds->dataSetMetaData.configurationVersion.minorVersion;
     return result;
+}
+
+UA_DataSetFieldResult
+UA_Server_removeDataSetField(UA_Server *server, const UA_NodeId dsf) {
+    UA_LOCK(&server->serviceMutex);
+    UA_DataSetFieldResult res = removeDataSetField(server, dsf);
+    UA_UNLOCK(&server->serviceMutex);
+    return res;
 }
 
 /**********************************************/
@@ -1019,7 +1040,7 @@ UA_PubSubDataSetField_sampleValue(UA_Server *server, UA_DataSetField *field,
         rvid.nodeId = params->publishedVariable;
         rvid.attributeId = params->attributeId;
         rvid.indexRange = params->indexRange;
-        *value = UA_Server_read(server, &rvid, UA_TIMESTAMPSTORETURN_BOTH);
+        *value = readAttribute(server, &rvid, UA_TIMESTAMPSTORETURN_BOTH);
     } else {
         *value = **field->config.field.variable.rtValueSource.staticValueSource;
         value->value.storageType = UA_VARIANT_DATA_NODELETE;

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -413,18 +413,8 @@ UA_Server_unfreezeWriterGroupConfiguration(UA_Server *server,
             dataSetWriter->configurationFrozen = UA_FALSE;
         }
     }
-    if(wg->config.rtLevel == UA_PUBSUB_RT_FIXED_SIZE) {
-        UA_ByteString_clear(&wg->bufferedMessage.buffer);
-#ifdef UA_ENABLE_PUBSUB_ENCRYPTION
-        if (wg->config.securityMode > UA_MESSAGESECURITYMODE_NONE) {
-            if (wg->bufferedMessage.nm != NULL) {
-                UA_ByteString_clear(&wg->bufferedMessage.nm->securityHeader.messageNonce);
-                UA_free(wg->bufferedMessage.nm);
-            }
-            UA_ByteString_clear(&wg->bufferedMessage.encryptBuffer);
-        }
-#endif
-    }
+
+    UA_NetworkMessageOffsetBuffer_clear(&wg->bufferedMessage);
 
     wg->configurationFrozen = false;
 
@@ -597,7 +587,7 @@ UA_Server_setWriterGroupEncryptionKeys(UA_Server *server, const UA_NodeId writer
 #endif
 
 void
-UA_WriterGroupConfig_clear(UA_WriterGroupConfig *writerGroupConfig){
+UA_WriterGroupConfig_clear(UA_WriterGroupConfig *writerGroupConfig) {
     UA_String_clear(&writerGroupConfig->name);
     UA_ExtensionObject_clear(&writerGroupConfig->transportSettings);
     UA_ExtensionObject_clear(&writerGroupConfig->messageSettings);
@@ -618,28 +608,14 @@ UA_WriterGroup_clear(UA_Server *server, UA_WriterGroup *writerGroup) {
         UA_Server_removeDataSetWriter(server, dataSetWriter->identifier);
     }
 
-    if(writerGroup->bufferedMessage.offsetsSize > 0){
-        for(size_t i = 0; i < writerGroup->bufferedMessage.offsetsSize; i++) {
-            if((writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_VARIANT) ||
-                (writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_RAW) ||
-                (writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_DATASETMESSAGE_SEQUENCENUMBER) ||
-                (writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_SEQUENCENUMBER)) {
-                UA_DataValue_delete(writerGroup->bufferedMessage.offsets[i].offsetData.value.value);
-            } else if(writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_FIELDENCDODING) {
-                writerGroup->bufferedMessage.offsets[i].offsetData.value.value->value.data = NULL;
-                UA_DataValue_delete(writerGroup->bufferedMessage.offsets[i].offsetData.value.value);
-            }
-        }
-        UA_ByteString_clear(&writerGroup->bufferedMessage.buffer);
-        UA_free(writerGroup->bufferedMessage.offsets);
-    }
-
 #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
     if(writerGroup->config.securityPolicy && writerGroup->securityPolicyContext) {
         writerGroup->config.securityPolicy->deleteContext(writerGroup->securityPolicyContext);
         writerGroup->securityPolicyContext = NULL;
     }
 #endif
+
+    UA_NetworkMessageOffsetBuffer_clear(&writerGroup->bufferedMessage);
 }
 
 UA_StatusCode

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -342,19 +342,22 @@ UA_Server_freezeWriterGroupConfiguration(UA_Server *server,
     bufEnd = &wg->bufferedMessage.buffer.data[wg->bufferedMessage.buffer.length];
     bufPos = wg->bufferedMessage.buffer.data;
 #ifdef UA_ENABLE_PUBSUB_ENCRYPTION
-    if (wg->config.securityMode > UA_MESSAGESECURITYMODE_NONE){
+    if(wg->config.securityMode > UA_MESSAGESECURITYMODE_NONE) {
         UA_Byte *payloadPosition;
         UA_NetworkMessage_encodeBinary(&networkMessage, &bufPos, bufEnd, &payloadPosition);
         wg->bufferedMessage.payloadPosition = payloadPosition;
-        wg->bufferedMessage.nm = (UA_NetworkMessage *)UA_malloc(sizeof(networkMessage));
-        wg->bufferedMessage.nm->securityHeader.networkMessageEncrypted = networkMessage.securityHeader.networkMessageEncrypted;
-        wg->bufferedMessage.nm->securityHeader.networkMessageSigned = networkMessage.securityHeader.networkMessageSigned;
-        UA_ByteString_copy(&networkMessage.securityHeader.messageNonce, &wg->bufferedMessage.nm->securityHeader.messageNonce);
+        wg->bufferedMessage.nm = (UA_NetworkMessage *)UA_calloc(1,sizeof(UA_NetworkMessage));
+        wg->bufferedMessage.nm->securityHeader.networkMessageEncrypted =
+            networkMessage.securityHeader.networkMessageEncrypted;
+        wg->bufferedMessage.nm->securityHeader.networkMessageSigned =
+            networkMessage.securityHeader.networkMessageSigned;
+        UA_ByteString_copy(&networkMessage.securityHeader.messageNonce,
+                           &wg->bufferedMessage.nm->securityHeader.messageNonce);
         UA_ByteString_allocBuffer(&wg->bufferedMessage.encryptBuffer, msgSize);
         UA_ByteString_clear(&networkMessage.securityHeader.messageNonce);
     }
 #endif
-    if (wg->config.securityMode <= UA_MESSAGESECURITYMODE_NONE)
+    if(wg->config.securityMode <= UA_MESSAGESECURITYMODE_NONE)
         UA_NetworkMessage_encodeBinary(&networkMessage, &bufPos, bufEnd, NULL);
 
  cleanup:

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -377,19 +377,24 @@ UA_Server_unfreezeWriterGroupConfiguration(UA_Server *server,
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     if(!wg)
         return UA_STATUSCODE_BADNOTFOUND;
+
+    /* Already unfrozen */
+    if(!wg->configurationFrozen)
+        return UA_STATUSCODE_GOOD;
+    
     //if(wg->config.rtLevel == UA_PUBSUB_RT_NONE){
     //    UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER,
     //                   "PubSub configuration freeze without RT configuration has no effect.");
     //    return UA_STATUSCODE_BADCONFIGURATIONERROR;
     //}
     //PubSubConnection freezeCounter--
+
     UA_PubSubConnection *pubSubConnection =  wg->linkedConnection;
     pubSubConnection->configurationFreezeCounter--;
     if(pubSubConnection->configurationFreezeCounter == 0){
         pubSubConnection->configurationFrozen = UA_FALSE;
     }
-    //WriterGroup unfreeze
-    wg->configurationFrozen = UA_FALSE;
+
     //DataSetWriter unfreeze
     UA_DataSetWriter *dataSetWriter;
     LIST_FOREACH(dataSetWriter, &wg->writers, listEntry) {
@@ -420,6 +425,8 @@ UA_Server_unfreezeWriterGroupConfiguration(UA_Server *server,
         }
 #endif
     }
+
+    wg->configurationFrozen = false;
 
     return UA_STATUSCODE_GOOD;
 }

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -182,6 +182,9 @@ UA_Server_freezeWriterGroupConfiguration(UA_Server *server,
     if(!wg)
         return UA_STATUSCODE_BADNOTFOUND;
 
+    if(wg->configurationFrozen)
+        return UA_STATUSCODE_GOOD;
+
     /* PubSubConnection freezeCounter++ */
     UA_PubSubConnection *pubSubConnection =  wg->linkedConnection;
     pubSubConnection->configurationFreezeCounter++;

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -613,7 +613,9 @@ UA_WriterGroup_clear(UA_Server *server, UA_WriterGroup *writerGroup) {
     if(writerGroup->bufferedMessage.offsetsSize > 0){
         for(size_t i = 0; i < writerGroup->bufferedMessage.offsetsSize; i++) {
             if((writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_VARIANT) ||
-                (writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_RAW)) {
+                (writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_PAYLOAD_RAW) ||
+                (writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_DATASETMESSAGE_SEQUENCENUMBER) ||
+                (writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_SEQUENCENUMBER)) {
                 UA_DataValue_delete(writerGroup->bufferedMessage.offsets[i].offsetData.value.value);
             } else if(writerGroup->bufferedMessage.offsets[i].contentType == UA_PUBSUB_OFFSETTYPE_NETWORKMESSAGE_FIELDENCDODING) {
                 writerGroup->bufferedMessage.offsets[i].offsetData.value.value->value.data = NULL;

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -82,6 +82,7 @@ UA_Server_addWriterGroup(UA_Server *server, const UA_NodeId connection,
     if(!newWriterGroup)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
+    memset(newWriterGroup, 0, sizeof(UA_WriterGroup));
     newWriterGroup->componentType = UA_PUBSUB_COMPONENT_WRITERGROUP;
     newWriterGroup->linkedConnection = currentConnectionContext;
 


### PR DESCRIPTION
fix(pubsub): Free memory for sequence number

Memory for sequence number variables has been allocated in
ua_pubsub_networkmessage.c with UA_Variant_setScalarCopy, but not
freed.

fix(pubsub): Symmetric free of WG bufferedMessage

bufferedMessage is initialized in
UA_Server_freezeWriterGroupConfiguration, so it shall be cleared in
UA_Server_unfreezeWriterGroupConfiguration instead of
UA_WriterGroup_clear.

fix(pubsub): Free memory for dataSetPayloadHeader

dataSetWriterIds and dataSetPayload.sizes in payload header are set
irrespective of the variable payloadHeaderEnabled, thus the buffer
also has to be freed independently of this variable.