### PR TITLE
feat(pubsub): Extended network message content support

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -338,8 +338,7 @@ static UA_StatusCode
 checkReaderIdentifier(UA_Server *server, UA_NetworkMessage *msg,
                       UA_DataSetReader *reader, UA_ReaderGroupConfig readerGroupConfig) {
 if(readerGroupConfig.encodingMimeType != UA_PUBSUB_ENCODING_JSON){
-    if(!msg->groupHeaderEnabled || !msg->groupHeader.writerGroupIdEnabled ||
-       !msg->payloadHeaderEnabled) {
+    if(!msg->groupHeaderEnabled || !msg->groupHeader.writerGroupIdEnabled) {
         UA_LOG_INFO_READER(&server->config.logger, reader,
                            "Cannot process DataSetReader without WriterGroup"
                            "and DataSetWriter identifiers");
@@ -377,7 +376,8 @@ if(readerGroupConfig.encodingMimeType != UA_PUBSUB_ENCODING_JSON){
     }
 
     if(reader->config.writerGroupId == msg->groupHeader.writerGroupId &&
-       reader->config.dataSetWriterId == *msg->payloadHeader.dataSetPayloadHeader.dataSetWriterIds) {
+       (!msg->payloadHeaderEnabled ||
+        reader->config.dataSetWriterId == *msg->payloadHeader.dataSetPayloadHeader.dataSetWriterIds)) {
         UA_LOG_DEBUG_READER(&server->config.logger, reader,
                             "DataSetReader found, process NetworkMessage");
         return UA_STATUSCODE_GOOD;

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -338,12 +338,6 @@ static UA_StatusCode
 checkReaderIdentifier(UA_Server *server, UA_NetworkMessage *msg,
                       UA_DataSetReader *reader, UA_ReaderGroupConfig readerGroupConfig) {
 if(readerGroupConfig.encodingMimeType != UA_PUBSUB_ENCODING_JSON){
-    if(!msg->groupHeaderEnabled || !msg->groupHeader.writerGroupIdEnabled) {
-        UA_LOG_INFO_READER(&server->config.logger, reader,
-                           "Cannot process DataSetReader without WriterGroup"
-                           "and DataSetWriter identifiers");
-        return UA_STATUSCODE_BADNOTIMPLEMENTED;
-    }
 
     switch(msg->publisherIdType) {
     case UA_PUBLISHERIDTYPE_BYTE:
@@ -375,7 +369,8 @@ if(readerGroupConfig.encodingMimeType != UA_PUBSUB_ENCODING_JSON){
         return UA_STATUSCODE_BADNOTFOUND;
     }
 
-    if(reader->config.writerGroupId == msg->groupHeader.writerGroupId &&
+    if(((!msg->groupHeaderEnabled || !msg->groupHeader.writerGroupIdEnabled) ||
+        (reader->config.writerGroupId == msg->groupHeader.writerGroupId)) &&
        (!msg->payloadHeaderEnabled ||
         reader->config.dataSetWriterId == *msg->payloadHeader.dataSetPayloadHeader.dataSetWriterIds)) {
         UA_LOG_DEBUG_READER(&server->config.logger, reader,


### PR DESCRIPTION
feat(pubsub): Subscriber without payload header

Support subscriber without payload header.
If no payload header is received, only one data set is supported.
It is not possible to check the data set id in this case.

feat(pubsub): Subscriber without group header

Support subscriber without group header.
If no group header or writer group id is received, it is not possible
to check the writer group id in this case. Yet the message should
be received successfully.