### PR TITLE
fix(pub/sub): the socket option SO_PRIORITY should only for Linux

### DIFF
--- a/plugins/ua_pubsub_ethernet.c
+++ b/plugins/ua_pubsub_ethernet.c
@@ -824,6 +824,7 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
         return NULL;
     }
 
+#ifdef __linux__
     /* Setting the socket priority to the socket */
     if(sockOptions.socketPriority) {
         if (UA_setsockopt(sockFd, SOL_SOCKET, SO_PRIORITY, sockOptions.socketPriority, sizeof(int))) {
@@ -837,6 +838,7 @@ UA_PubSubChannelEthernet_open(const UA_PubSubConnectionConfig *connectionConfig)
             return NULL;
         }
     }
+#endif
 
 #if defined(KERNEL_VERSION)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,0))


### PR DESCRIPTION
The socket option, SO_PRIORITY is not mentioned in the posix standard.
It is a specifical implementation of Linux.