### PR TITLE
[WIP] feature: Support for multiple PKI infrastructures

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,7 +3,9 @@
     <Objective-C>
       <option name="KEEP_NESTED_NAMESPACES_IN_ONE_LINE" value="true" />
       <option name="FUNCTION_TOP_AFTER_RETURN_TYPE_WRAP" value="2" />
+      <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
       <option name="LAMBDA_CAPTURE_LIST_ALIGN_MULTILINE" value="true" />
+      <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
       <option name="FUNCTION_CALL_ARGUMENTS_ALIGN_MULTILINE_PARS" value="true" />
       <option name="CLASS_CONSTRUCTOR_INIT_LIST_WRAP" value="0" />
       <option name="CLASS_CONSTRUCTOR_INIT_LIST_NEW_LINE_BEFORE_COLON" value="0" />
@@ -11,12 +13,12 @@
       <option name="SUPERCLASS_LIST_BEFORE_COLON" value="0" />
       <option name="SUPERCLASS_LIST_AFTER_COLON" value="2" />
     </Objective-C>
-    <Objective-C-extensions>
+    <files>
       <extensions>
         <pair source="cpp" header="h" fileNamingConvention="NONE" />
         <pair source="c" header="h" fileNamingConvention="NONE" />
       </extensions>
-    </Objective-C-extensions>
+    </files>
     <codeStyleSettings language="CMake">
       <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
       <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
@@ -35,7 +37,7 @@
       <option name="SPACE_BEFORE_CATCH_PARENTHESES" value="false" />
       <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
       <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-      <option name="SOFT_MARGINS" value="80" />
+      <option name="SOFT_MARGINS" value="120" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
         <option name="LABEL_INDENT_ABSOLUTE" value="true" />

--- a/.idea/csv-plugin.xml
+++ b/.idea/csv-plugin.xml
@@ -3,7 +3,35 @@
   <component name="CsvFileAttributes">
     <option name="attributeMap">
       <map>
+        <entry key="/deps/ua-nodeset/ADI/OpcUaAdiModel.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
         <entry key="/deps/ua-nodeset/CAS/Opc.Ua.CAS.NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/CNC/Opc.Ua.CNC.NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/DEXPI/Opc.Ua.DEXPI.NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/DI/OpcUaDiModel.csv">
           <value>
             <Attribute>
               <option name="separator" value="," />
@@ -17,10 +45,87 @@
             </Attribute>
           </value>
         </entry>
+        <entry key="/deps/ua-nodeset/FDI/OpcUaFdiPart5Model.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/FDI/OpcUaFdiPart7Model.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/GDS/OpcUaGdsModel.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/Glass/Flat/NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/I4AAS/NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/IJT/Tightening/NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
         <entry key="/deps/ua-nodeset/IOLink/EngineeringUnits.csv">
           <value>
             <Attribute>
               <option name="separator" value=";" />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/MDIS/MDIS.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/PNEM/NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/Pumps/Opc.Ua.Pumps.NodeSet2.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/Schema/NodeIds.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/Schema/Opc.Ua.NodeSet2.Services.documentation.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
             </Attribute>
           </value>
         </entry>
@@ -46,6 +151,13 @@
           </value>
         </entry>
         <entry key="/deps/ua-nodeset/Schema/rec20_latest_a2-3.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/deps/ua-nodeset/TMC/Opc.Ua.TMC.NodeIds.csv">
           <value>
             <Attribute>
               <option name="separator" value="," />

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -896,7 +896,8 @@ set(exported_headers ${PROJECT_BINARY_DIR}/src_generated/open62541/config.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/log.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/network.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/accesscontrol.h
-                     ${PROJECT_SOURCE_DIR}/include/open62541/plugin/pki.h
+                     ${PROJECT_SOURCE_DIR}/include/open62541/plugin/certificate_manager.h
+                     ${PROJECT_SOURCE_DIR}/include/open62541/plugin/certstore.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/securitypolicy.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/plugin/pubsub.h
                      ${PROJECT_SOURCE_DIR}/deps/ziptree.h
@@ -906,6 +907,7 @@ set(exported_headers ${PROJECT_BINARY_DIR}/src_generated/open62541/config.h
                      ${historizing_exported_headers}
                      ${PROJECT_SOURCE_DIR}/include/open62541/server_pubsub.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/server.h
+                     ${PROJECT_SOURCE_DIR}/include/open62541/endpoint.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/client.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/client_highlevel.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/client_subscriptions.h
@@ -948,6 +950,7 @@ set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c
                 ${PROJECT_SOURCE_DIR}/src/ua_securechannel_crypto.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_session.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_nodes.c
+    ${PROJECT_SOURCE_DIR}/src/server/endpoint.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_server.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_server_ns0.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_server_ns0_diagnostics.c
@@ -992,6 +995,7 @@ set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c
 
 set(default_plugin_headers ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/accesscontrol_default.h
                            ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/pki_default.h
+                           ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/certstore_default.h
                            ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/log_stdout.h
                            ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/nodestore_default.h
                            ${PROJECT_SOURCE_DIR}/plugins/include/open62541/server_config_default.h
@@ -1005,6 +1009,7 @@ set(default_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_log_stdout.c
                            ${PROJECT_SOURCE_DIR}/plugins/ua_nodestore_hashmap.c
                            ${PROJECT_SOURCE_DIR}/plugins/ua_config_default.c
                            ${PROJECT_SOURCE_DIR}/plugins/crypto/ua_pki_none.c
+                           ${PROJECT_SOURCE_DIR}/plugins/crypto/certstore/ua_certstore_file.c
                            ${PROJECT_SOURCE_DIR}/plugins/crypto/ua_securitypolicy_none.c
 )
 

--- a/arch/eventloop_posix.c
+++ b/arch/eventloop_posix.c
@@ -84,7 +84,7 @@ UA_EventLoopPOSIX_addDelayedCallback(UA_EventLoop *public_el,
 /* Process and then free registered delayed callbacks */
 static void
 processDelayed(UA_EventLoopPOSIX *el) {
-    UA_LOG_DEBUG(el->eventLoop.logger, UA_LOGCATEGORY_EVENTLOOP,
+    UA_LOG_TRACE(el->eventLoop.logger, UA_LOGCATEGORY_EVENTLOOP,
                  "Process delayed callbacks");
 
     UA_LOCK_ASSERT(&el->elMutex, 1);

--- a/examples/access_control/server_access_control.c
+++ b/examples/access_control/server_access_control.c
@@ -62,8 +62,9 @@ int main(void) {
 
     /* Disable anonymous logins, enable two user/password logins */
     config->accessControl.clear(&config->accessControl);
-    UA_StatusCode retval = UA_AccessControl_default(config, false, NULL,
-             &config->securityPolicies[config->securityPoliciesSize-1].policyUri, 2, logins);
+    UA_StatusCode retval = UA_AccessControl_default(config, false, NULL, NULL,
+                                                    &config->securityPolicies[config->securityPoliciesSize - 1]
+                                                        .policyUri, 2, logins);
     if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 

--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -94,6 +94,7 @@ UA_EndpointDescription *getRegisterEndpointFromServer(const char *discoveryServe
                      "Invalid"
         );
         // find the endpoint with highest supported security mode
+        // FIXME: This check will ignore policies other than none and a really weak one. I don't belive this is intended
         if((UA_String_equal(&endpointArray[i].securityPolicyUri, &UA_SECURITY_POLICY_NONE_URI) ||
             UA_String_equal(&endpointArray[i].securityPolicyUri, &UA_SECURITY_POLICY_BASIC128_URI)) && (
             foundEndpoint == NULL || foundEndpoint->securityMode < endpointArray[i].securityMode))

--- a/examples/encryption/server_encryption.c
+++ b/examples/encryption/server_encryption.c
@@ -77,23 +77,11 @@ int main(int argc, char* argv[]) {
     for(size_t i = 0; i < trustListSize; i++)
         trustList[i] = loadFile(argv[i+3]);
 
-    /* Loading of an issuer list, not used in this application */
-    size_t issuerListSize = 0;
-    UA_ByteString *issuerList = NULL;
-
-    /* Loading of a revocation list currently unsupported */
-    UA_ByteString *revocationList = NULL;
-    size_t revocationListSize = 0;
-
     UA_Server *server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
     UA_StatusCode retval =
-        UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840,
-                                                       &certificate, &privateKey,
-                                                       trustList, trustListSize,
-                                                       issuerList, issuerListSize,
-                                                       revocationList, revocationListSize);
+        UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, NULL);
 
     #ifdef UA_ENABLE_WEBSOCKET_SERVER
     UA_ServerConfig_addNetworkLayerWS(UA_Server_getConfig(server), 7681, 0, 0, &certificate, &privateKey);

--- a/examples/server_ctt.c
+++ b/examples/server_ctt.c
@@ -1247,15 +1247,13 @@ int main(int argc, char **argv) {
         goto cleanup;
 #else /* On Linux we can monitor the certs folder and reload when changes are made */
     UA_StatusCode res =
-        UA_ServerConfig_setDefaultWithSecurityPolicies(&config, 4840,
-                                                       &certificate, &privateKey,
-                                                       NULL, 0, NULL, 0, NULL, 0);
+        UA_ServerConfig_setDefaultWithSecurityPolicies(&config, 4840, NULL);
     if(res != UA_STATUSCODE_GOOD)
         goto cleanup;
-    config.certificateVerification.clear(&config.certificateVerification);
-    res = UA_CertificateVerification_CertFolders(&config.certificateVerification,
-                                                 trustlistFolder, issuerlistFolder,
-                                                 revocationlistFolder);
+    config.certificateManager.clear(&config.certificateManager);
+    res = UA_CertificateManager_CertFolders(&config.certificateManager,
+                                            trustlistFolder, issuerlistFolder,
+                                            revocationlistFolder);
     if(res != UA_STATUSCODE_GOOD)
         goto cleanup;
 #endif /* __linux__ */

--- a/include/open62541/client.h
+++ b/include/open62541/client.h
@@ -145,7 +145,7 @@ typedef struct {
     UA_SecurityPolicy *securityPolicies;
 
     /* Certificate Verification Plugin */
-    UA_CertificateVerification certificateVerification;
+    UA_CertificateManager certificateManager;
 
     /* Callbacks for async connection handshakes */
     UA_ConnectClientConnection initConnectionFunc;

--- a/include/open62541/endpoint.h
+++ b/include/open62541/endpoint.h
@@ -1,0 +1,47 @@
+//
+// Created by mark on 11.05.22.
+//
+
+#ifndef OPEN62541_ENDPOINT_H
+#define OPEN62541_ENDPOINT_H
+
+#include <open62541/types_generated.h>
+#include <open62541/plugin/securitypolicy.h>
+#include <open62541/plugin/certstore.h>
+
+typedef struct UA_Endpoint UA_Endpoint;
+
+struct UA_Endpoint {
+    void *context;
+    UA_PKIStore *pkiStore;
+    UA_SecurityPolicy *securityPolicy;
+    UA_Boolean allowNone;
+    UA_Boolean allowSign;
+    UA_Boolean allowSignAndEncrypt;
+    UA_String endpointUrl;
+};
+
+UA_StatusCode
+UA_Endpoint_init(UA_Endpoint *endpoint,
+                 const UA_String *endpointUrl,
+                 UA_PKIStore *pkiStore,
+                 UA_SecurityPolicy *securityPolicy,
+                 UA_Boolean allowNone,
+                 UA_Boolean allowSign,
+                 UA_Boolean allowSignAndEncrypt,
+                 UA_ApplicationDescription applicationDescription,
+                 UA_UserTokenPolicy *userTokenPolicies,
+                 size_t userTokenPoliciesSize);
+
+UA_StatusCode
+UA_Endpoint_updateApplicationDescription(UA_Endpoint *endpoint, const UA_ApplicationDescription *applicationDescription);
+
+UA_StatusCode
+UA_Endpoint_toEndpointDescription(const UA_Endpoint *endpoint,
+                                  UA_EndpointDescription *endpointDescription,
+                                  UA_MessageSecurityMode securityMode);
+
+void
+UA_Endpoint_clear(UA_Endpoint *endpoint);
+
+#endif //OPEN62541_ENDPOINT_H

--- a/include/open62541/plugin/certificate_manager.h
+++ b/include/open62541/plugin/certificate_manager.h
@@ -10,6 +10,7 @@
 
 #include <open62541/types.h>
 #include <open62541/types_generated.h>
+#include <open62541/plugin/certstore.h>
 
 _UA_BEGIN_DECLS
 
@@ -29,23 +30,28 @@ _UA_BEGIN_DECLS
  * The lifecycle of the plugin is attached to a server or client config. The
  * ``clear`` method is called automatically when the config is destroyed. */
 
-struct UA_CertificateVerification;
-typedef struct UA_CertificateVerification UA_CertificateVerification;
+struct UA_CertificateManager;
+typedef struct UA_CertificateManager UA_CertificateManager;
 
-struct UA_CertificateVerification {
+struct UA_CertificateManager {
     void *context;
 
     /* Verify the certificate against the configured policies and trust chain. */
-    UA_StatusCode (*verifyCertificate)(void *verificationContext,
+    UA_StatusCode (*verifyCertificate)(UA_CertificateManager *certificateManager,
+                                       UA_PKIStore *pkiStore,
                                        const UA_ByteString *certificate);
 
     /* Verify that the certificate has the applicationURI in the subject name. */
-    UA_StatusCode (*verifyApplicationURI)(void *verificationContext,
+    UA_StatusCode (*verifyApplicationURI)(UA_CertificateManager *certificateManager,
+                                          UA_PKIStore *pkiStore,
                                           const UA_ByteString *certificate,
                                           const UA_String *applicationURI);
 
+    /* Reloads the trust list from storage, discarding all unsaved changes. */
+    UA_StatusCode (*reloadTrustList)(void *certificateManager);
+
     /* Delete the certificate verification context */
-    void (*clear)(UA_CertificateVerification *cv);
+    void (*clear)(UA_CertificateManager *certificateManager);
 };
 
 _UA_END_DECLS

--- a/include/open62541/plugin/certstore.h
+++ b/include/open62541/plugin/certstore.h
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2022 (c) Mark Giraud, Fraunhofer IOSB
+ */
+
+
+#ifndef OPEN62541_CERTSTORE_H
+#define OPEN62541_CERTSTORE_H
+
+#include <open62541/types.h>
+#include <open62541/types_generated.h>
+
+typedef struct UA_PKIStore UA_PKIStore;
+
+struct UA_PKIStore {
+    /* The nodeId of the certificate group this pki store is associated with */
+    UA_NodeId certificateGroupId;
+
+    UA_StatusCode (*loadTrustList)(UA_PKIStore *pkiStore, UA_TrustListDataType *trustList);
+
+    UA_StatusCode (*storeTrustList)(UA_PKIStore *pkiStore, const UA_TrustListDataType *trustList);
+
+    UA_StatusCode (*loadRejectedList)(UA_PKIStore *pkiStore, UA_ByteString **rejectedList, size_t *rejectedListSize);
+
+    /* Overwrites the rejected list in the PKIStore with the supplied one */
+    UA_StatusCode (*storeRejectedList)(UA_PKIStore *pkiStore,
+                                       const UA_ByteString *rejectedList,
+                                       size_t rejectedListSize);
+
+    /* Appends the supplied certificate to the rejected list */
+    UA_StatusCode (*appendRejectedList)(UA_PKIStore *pkiStore, const UA_ByteString *certificate);
+
+    UA_StatusCode (*loadCertificate)(UA_PKIStore *pkiStore, const UA_NodeId certType, UA_ByteString *cert);
+
+    UA_StatusCode (*storeCertificate)(UA_PKIStore *pkiStore, const UA_NodeId certType, const UA_ByteString *cert);
+
+    UA_StatusCode (*loadPrivateKey)(UA_PKIStore *pkiStore, const UA_NodeId certType, UA_ByteString *privateKey);
+
+    UA_StatusCode (*storePrivateKey)(UA_PKIStore *pkiStore, const UA_NodeId certType, const UA_ByteString *privateKey);
+
+    UA_StatusCode (*clear)(UA_PKIStore *pkiStore);
+
+    void *context;
+};
+
+#endif //OPEN62541_CERTSTORE_H

--- a/include/open62541/plugin/securitypolicy.h
+++ b/include/open62541/plugin/securitypolicy.h
@@ -12,7 +12,8 @@
 
 #include <open62541/util.h>
 #include <open62541/plugin/log.h>
-#include <open62541/plugin/pki.h>
+#include <open62541/plugin/certificate_manager.h>
+#include "certstore.h"
 
 _UA_BEGIN_DECLS
 
@@ -167,6 +168,7 @@ typedef struct {
      * @return if the thumbprints match UA_STATUSCODE_GOOD is returned. If they
      *         don't match or an error occurred an error code is returned. */
     UA_StatusCode (*compareCertificateThumbprint)(const UA_SecurityPolicy *securityPolicy,
+                                                  UA_PKIStore *pkiStore,
                                                   const UA_ByteString *certificateThumbprint)
     UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 
@@ -216,6 +218,9 @@ typedef struct {
      * @param securityPolicy the policy context of the endpoint that is connected
      *                       to. It will be stored in the channelContext for
      *                       further access by the policy.
+     * @param pkiStore the PKIStore object that contains the keys associated with
+     *                 the created channel. The SecurityPolicy will store and load
+     *                 keys to and from this pki store.
      * @param remoteCertificate the remote certificate contains the remote
      *                          asymmetric key. The certificate will be verified
      *                          and then stored in the context so that its
@@ -223,6 +228,7 @@ typedef struct {
      * @param channelContext the initialized channelContext that is passed to
      *                       functions that work on a context. */
     UA_StatusCode (*newContext)(const UA_SecurityPolicy *securityPolicy,
+                                UA_PKIStore *pkiStore,
                                 const UA_ByteString *remoteCertificate,
                                 void **channelContext)
     UA_FUNC_ATTR_WARN_UNUSED_RESULT;
@@ -298,9 +304,7 @@ struct UA_SecurityPolicy {
     /* The policy uri that identifies the implemented algorithms */
     UA_String policyUri;
 
-    /* The local certificate is specific for each SecurityPolicy since it
-     * depends on the used key length. */
-    UA_ByteString localCertificate;
+    UA_NodeId certificateTypeId;
 
     /* Function pointers grouped into modules */
     UA_SecurityPolicyAsymmetricModule asymmetricModule;
@@ -310,11 +314,11 @@ struct UA_SecurityPolicy {
 
     const UA_Logger *logger;
 
-    /* Updates the ApplicationInstanceCertificate and the corresponding private
-     * key at runtime. */
-    UA_StatusCode (*updateCertificateAndPrivateKey)(UA_SecurityPolicy *policy,
-                                                    const UA_ByteString newCertificate,
-                                                    const UA_ByteString newPrivateKey);
+    /* Gets the certificate associated with this security policy. */
+    UA_StatusCode (*getLocalCertificate)(const UA_SecurityPolicy *policy, UA_PKIStore *pkiStore, UA_ByteString *cert);
+
+    /* Checks if the certificates and keys in the pkiStore are valid and can be loaded */
+    UA_StatusCode (*sanityCheckPKIStore)(const UA_SecurityPolicy *policy, UA_PKIStore *pkiStore);
 
     /* Deletes the dynamic content of the policy */
     void (*clear)(UA_SecurityPolicy *policy);

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -30,7 +30,9 @@
 #include <open62541/plugin/nodestore.h>
 #include <open62541/plugin/network.h>
 #include <open62541/plugin/log.h>
-#include <open62541/plugin/pki.h>
+#include <open62541/plugin/certificate_manager.h>
+#include <open62541/plugin/certstore.h>
+#include <open62541/endpoint.h>
 
 #ifdef UA_ENABLE_PUBSUB
 #include <open62541/plugin/pubsub.h>
@@ -185,8 +187,12 @@ struct UA_ServerConfig {
     size_t securityPoliciesSize;
     UA_SecurityPolicy* securityPolicies;
 
+    /* One PKIStore corresponds to one certificate Group */
+    size_t pkiStoresSize;
+    UA_PKIStore *pkiStores;
+
     size_t endpointsSize;
-    UA_EndpointDescription *endpoints;
+    UA_Endpoint *endpoints;
 
     /* Only allow the following discovery services to be executed on a
      * SecureChannel with SecurityPolicyNone: GetEndpointsRequest,
@@ -197,7 +203,7 @@ struct UA_ServerConfig {
      * securityPolicies list. */
     UA_Boolean securityPolicyNoneDiscoveryOnly;
 
-    UA_CertificateVerification certificateVerification;
+    UA_CertificateManager certificateManager;
 
     /**
      * See the section for :ref:`access-control

--- a/plugins/crypto/certstore/ua_certstore_file.c
+++ b/plugins/crypto/certstore/ua_certstore_file.c
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2022 (c) Mark Giraud, Fraunhofer IOSB
+ */
+
+#include <open62541/plugin/certstore.h>
+#include <open62541/plugin/certstore_default.h>
+#include <dirent.h>
+#include <open62541/types_generated_handling.h>
+#include <sys/stat.h>
+#include <libgen.h>
+
+// TODO: Move to util?
+static UA_StatusCode
+readFileToByteString(const char *const path, UA_ByteString *data) {
+    /* Open the file */
+    FILE *fp = fopen(path, "rb");
+    if(!fp) {
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+
+    /* Get the file length, allocate the data and read */
+    fseek(fp, 0, SEEK_END);
+    UA_StatusCode retval = UA_ByteString_allocBuffer(data, (size_t)ftell(fp));
+    if(retval == UA_STATUSCODE_GOOD) {
+        fseek(fp, 0, SEEK_SET);
+        size_t read = fread(data->data, sizeof(UA_Byte), data->length * sizeof(UA_Byte), fp);
+        if(read != data->length) {
+            UA_ByteString_clear(data);
+        }
+    } else {
+        data->length = 0;
+    }
+    fclose(fp);
+
+    return UA_STATUSCODE_GOOD;
+}
+
+static int
+mkpath(char *dir, mode_t mode) {
+    struct stat sb;
+    if(!dir) {
+        errno = EINVAL;
+        return 1;
+    }
+    if(!stat(dir, &sb))
+        return 0;
+    mkpath(dirname(strdupa(dir)), mode);
+    return mkdir(dir, mode);
+}
+
+typedef struct FilePKIStore {
+    char *trustedCertDir;
+    size_t trustedCertDirLen;
+    char *trustedCrlDir;
+    size_t trustedCrlDirLen;
+    char *trustedIssuerCertDir;
+    size_t trustedIssuerCertDirLen;
+    char *trustedIssuerCrlDir;
+    size_t trustedIssuerCrlDirLen;
+    char *certificateDir;
+    size_t certificateDirLen;
+    char *keyDir;
+    size_t keyDirLen;
+} FilePKIStore;
+
+static UA_StatusCode
+loadList(UA_ByteString **list, size_t *listSize, const char *listPath) {
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    size_t numCerts = 0;
+
+    DIR *dir = opendir(listPath);
+    if(dir) {
+        struct dirent *dirent;
+        while((dirent = readdir(dir)) != NULL) {
+            if(dirent->d_type == DT_REG) {
+                // TODO: Load cert file
+            }
+        }
+        closedir(dir);
+    }
+    retval = UA_Array_resize((void **)list, listSize, numCerts, &UA_TYPES[UA_TYPES_BYTESTRING]);
+    return retval;
+}
+
+static UA_StatusCode
+loadTrustList_file(UA_PKIStore *certStore, UA_TrustListDataType *trustList) {
+    FilePKIStore *context = (FilePKIStore *)certStore->context;
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    if(trustList->specifiedLists & UA_TRUSTLISTMASKS_TRUSTEDCERTIFICATES) {
+        retval = loadList(&trustList->trustedCertificates, &trustList->trustedCertificatesSize,
+                          context->trustedCertDir);
+        if(retval != UA_STATUSCODE_GOOD) {
+            return retval;
+        }
+    }
+    if(trustList->specifiedLists & UA_TRUSTLISTMASKS_TRUSTEDCRLS) {
+        retval = loadList(&trustList->trustedCrls, &trustList->trustedCrlsSize,
+                          context->trustedCrlDir);
+        if(retval != UA_STATUSCODE_GOOD) {
+            return retval;
+        }
+    }
+    if(trustList->specifiedLists & UA_TRUSTLISTMASKS_ISSUERCERTIFICATES) {
+        retval = loadList(&trustList->issuerCertificates, &trustList->issuerCertificatesSize,
+                          context->trustedIssuerCertDir);
+        if(retval != UA_STATUSCODE_GOOD) {
+            return retval;
+        }
+    }
+    if(trustList->specifiedLists & UA_TRUSTLISTMASKS_ISSUERCRLS) {
+        retval = loadList(&trustList->issuerCrls, &trustList->issuerCrlsSize,
+                          context->trustedIssuerCrlDir);
+        if(retval != UA_STATUSCODE_GOOD) {
+            return retval;
+        }
+    }
+    return retval;
+}
+
+static UA_StatusCode
+clear_file(UA_PKIStore *certStore) {
+    FilePKIStore *context = (FilePKIStore *)certStore->context;
+    if(context) {
+        if(context->trustedCertDir)
+            UA_free(context->trustedCertDir);
+        if(context->trustedCrlDir)
+            UA_free(context->trustedCrlDir);
+        if(context->trustedIssuerCertDir)
+            UA_free(context->trustedIssuerCertDir);
+        if(context->trustedIssuerCrlDir)
+            UA_free(context->trustedIssuerCrlDir);
+        if(context->certificateDir)
+            UA_free(context->certificateDir);
+        if(context->keyDir)
+            UA_free(context->keyDir);
+        UA_free(context);
+    }
+
+    UA_NodeId_clear(&certStore->certificateGroupId);
+
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+storeTrustList_file(UA_PKIStore *certStore, const UA_TrustListDataType *trustList) {
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+loadCertificate_file(UA_PKIStore *pkiStore, const UA_NodeId certType, UA_ByteString *cert) {
+    if(pkiStore == NULL || cert == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    UA_ByteString_clear(cert);
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+
+    UA_String nodeIdStr;
+    UA_String_init(&nodeIdStr);
+    UA_NodeId_print(&certType, &nodeIdStr);
+
+    FilePKIStore *context = (FilePKIStore *)pkiStore->context;
+    char filename[FILENAME_MAX];
+    if(snprintf(filename, FILENAME_MAX, "%s/%s", context->certificateDir, nodeIdStr.data) < 0) {
+        retval = UA_STATUSCODE_BADINTERNALERROR;
+        goto cleanup;
+    }
+
+    retval = readFileToByteString(filename, cert);
+
+cleanup:
+
+    UA_String_clear(&nodeIdStr);
+    return retval;
+}
+
+static UA_StatusCode
+setupPkiDir(char *directory, char *cwd, size_t cwdLen, char **out) {
+    strncpy(&cwd[cwdLen], directory, PATH_MAX - cwdLen);
+    *out = strndup(cwd, PATH_MAX - cwdLen);
+    if(*out == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    mkpath(*out, 0777);
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_PKIStore_File(UA_PKIStore *pkiStore, UA_NodeId *certificateGroupId) {
+    if(pkiStore == NULL || certificateGroupId == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    memset(pkiStore, 0, sizeof(UA_PKIStore));
+    char cwd[PATH_MAX];
+    if(getcwd(cwd, PATH_MAX) == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    size_t cwdLen = strnlen(cwd, PATH_MAX);
+
+    FilePKIStore *context = (FilePKIStore *)UA_malloc(sizeof(FilePKIStore));
+    pkiStore->loadTrustList = loadTrustList_file;
+    pkiStore->storeTrustList = storeTrustList_file;
+    pkiStore->loadCertificate = loadCertificate_file;
+    pkiStore->clear = clear_file;
+    pkiStore->context = context;
+
+    strncpy(&cwd[cwdLen], "/pki/", PATH_MAX - cwdLen);
+    cwdLen = strnlen(cwd, PATH_MAX);
+
+    UA_String nodeIdStr;
+    UA_String_init(&nodeIdStr);
+    UA_NodeId_print(certificateGroupId, &nodeIdStr);
+    strncpy(&cwd[cwdLen], (char *)nodeIdStr.data, PATH_MAX - cwdLen);
+    cwdLen = strnlen(cwd, PATH_MAX);
+    UA_String_clear(&nodeIdStr);
+
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    retval |= setupPkiDir("/trusted/certs", cwd, cwdLen, &context->trustedCertDir);
+    retval |= setupPkiDir("/trusted/crls", cwd, cwdLen, &context->trustedCrlDir);
+    retval |= setupPkiDir("/issuer/certs", cwd, cwdLen, &context->trustedIssuerCertDir);
+    retval |= setupPkiDir("/issuer/crls", cwd, cwdLen, &context->trustedIssuerCrlDir);
+    retval |= setupPkiDir("/own/certs", cwd, cwdLen, &context->certificateDir);
+    retval |= setupPkiDir("/own/keys", cwd, cwdLen, &context->keyDir);
+    if(retval != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
+
+    UA_NodeId_copy(certificateGroupId, &pkiStore->certificateGroupId);
+
+    return UA_STATUSCODE_GOOD;
+
+error:
+    pkiStore->clear(pkiStore);
+    return UA_STATUSCODE_BADINTERNALERROR;
+}

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
@@ -1,5 +1,5 @@
 #include <open62541/plugin/securitypolicy.h>
-#include <open62541/plugin/pki.h>
+#include <open62541/plugin/certificate_manager.h>
 #include <open62541/types.h>
 
 #if defined(UA_ENABLE_ENCRYPTION_MBEDTLS) || defined(UA_ENABLE_PUBSUB_ENCRYPTION)
@@ -12,6 +12,7 @@
 #include <mbedtls/error.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
 #include <mbedtls/version.h>
 #include <mbedtls/x509_crt.h>
 
@@ -132,8 +133,44 @@ mbedtls_verifySig_sha1(mbedtls_x509_crt *certificate, const UA_ByteString *messa
 }
 
 UA_StatusCode
-mbedtls_sign_sha1(mbedtls_pk_context *localPrivateKey,
-                  mbedtls_ctr_drbg_context *drbgContext,
+mbedtls_sign_sha256(ChannelContext_mbedtls *cc,
+                    mbedtls_pk_context *privateKey,
+                    const UA_ByteString *message,
+                    UA_ByteString *signature) {
+    unsigned char hash[UA_SHA256_LENGTH];
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    // TODO check return status
+    mbedtls_sha256_ret(message->data, message->length, hash, 0);
+#else
+    mbedtls_sha256(message->data, message->length, hash, 0);
+#endif
+
+    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*privateKey);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256);
+
+    size_t sigLen = 0;
+
+    /* For RSA keys, the default padding type is PKCS#1 v1.5 in mbedtls_pk_sign */
+    /* Alternatively use more specific function mbedtls_rsa_rsassa_pkcs1_v15_sign() */
+    int mbedErr = mbedtls_pk_sign(privateKey,
+                                  MBEDTLS_MD_SHA256, hash,
+                                  UA_SHA256_LENGTH, signature->data,
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+        signature->length,
+#endif
+                                  &sigLen, mbedtls_ctr_drbg_random,
+                                  &cc->policyContext->drbgContext);
+
+    if(mbedErr) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+mbedtls_sign_sha1(ChannelContext_mbedtls *cc,
+                  mbedtls_pk_context *privateKey,
                   const UA_ByteString *message,
                   UA_ByteString *signature) {
     unsigned char hash[UA_SHA1_LENGTH];
@@ -143,17 +180,17 @@ mbedtls_sign_sha1(mbedtls_pk_context *localPrivateKey,
     mbedtls_sha1(message->data, message->length, hash);
 #endif
 
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*localPrivateKey);
+    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*privateKey);
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
 
     size_t sigLen = 0;
-    int mbedErr = mbedtls_pk_sign(localPrivateKey, MBEDTLS_MD_SHA1, hash,
+    int mbedErr = mbedtls_pk_sign(privateKey, MBEDTLS_MD_SHA1, hash,
                                   UA_SHA1_LENGTH, signature->data,
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
-                                  signature->length,
+        signature->length,
 #endif
                                   &sigLen,
-                                  mbedtls_ctr_drbg_random, drbgContext);
+                                  mbedtls_ctr_drbg_random, &cc->policyContext->drbgContext);
     if(mbedErr)
         return UA_STATUSCODE_BADINTERNALERROR;
     return UA_STATUSCODE_GOOD;
@@ -228,10 +265,10 @@ mbedtls_encrypt_rsaOaep(mbedtls_rsa_context *context,
 }
 
 UA_StatusCode
-mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
-                        mbedtls_ctr_drbg_context *drbgContext,
+mbedtls_decrypt_rsaOaep(ChannelContext_mbedtls *cc,
+                        mbedtls_pk_context *privateKey,
                         UA_ByteString *data) {
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*localPrivateKey);
+    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*privateKey);
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     size_t keylen = rsaContext->len;
@@ -249,7 +286,7 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
     while(inOffset < data->length) {
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
         int mbedErr = mbedtls_rsa_rsaes_oaep_decrypt(rsaContext, mbedtls_ctr_drbg_random,
-                                                     drbgContext, MBEDTLS_RSA_PRIVATE,
+                                                     &cc->policyContext->drbgContext, MBEDTLS_RSA_PRIVATE,
                                                      NULL, 0, &outLength,
                                                      data->data + inOffset,
                                                      buf, 512);
@@ -274,7 +311,7 @@ mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
 }
 
 int
-UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, void *p_rng) {
+UA_mbedTLS_parsePrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, void *p_rng) {
     UA_ByteString data = UA_mbedTLS_CopyDataFormatAware(key);
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
     int mbedErr = mbedtls_pk_parse_key(target, data.data, data.length, NULL, 0);
@@ -285,10 +322,46 @@ UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, 
     return mbedErr;
 }
 
+/**
+ * Loads the key specified by certificateTypeId from the supplied pkiStore.
+ * Initializes the supplied pkContext.
+ * The pkContext is only initialized if the function returns successfully.
+ */
 UA_StatusCode
-UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData,
-                                UA_ByteString *target) {
-    UA_ByteString data = UA_mbedTLS_CopyDataFormatAware(certData);
+UA_mbedTLS_loadPrivateKey(UA_PKIStore *pkiStore, void *p_rng,
+                          const UA_NodeId certificateTypeId,
+                          mbedtls_pk_context *pkContext) {
+    mbedtls_pk_init(pkContext);
+    UA_ByteString localPrivateKey;
+    UA_ByteString_init(&localPrivateKey);
+    UA_StatusCode retval = pkiStore->loadPrivateKey(pkiStore, certificateTypeId, &localPrivateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        mbedtls_pk_free(pkContext);
+        return retval;
+    }
+
+    int mbedErr = UA_mbedTLS_parsePrivateKey(&localPrivateKey, pkContext, &p_rng);
+    if(mbedErr) {
+        mbedtls_pk_free(pkContext);
+        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+        goto cleanup;
+    }
+
+cleanup:
+    UA_ByteString_clear(&localPrivateKey);
+    return retval;
+}
+
+UA_StatusCode
+UA_mbedTLS_LoadLocalCertificate(const UA_SecurityPolicy *policy, UA_PKIStore *pkiStore, UA_ByteString *target) {
+    UA_ByteString localCertificate;
+    UA_ByteString_init(&localCertificate);
+    UA_StatusCode retval = pkiStore->loadCertificate(pkiStore, policy->certificateTypeId, &localCertificate);
+    if(!UA_StatusCode_isGood(retval))
+        return retval;
+
+    UA_ByteString data = UA_mbedTLS_CopyDataFormatAware(&localCertificate);
+    UA_ByteString_clear(&localCertificate);
 
     mbedtls_x509_crt cert;
     mbedtls_x509_crt_init(&cert);
@@ -297,14 +370,18 @@ UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData,
 
     UA_StatusCode result = UA_STATUSCODE_BADINVALIDARGUMENT;
 
-    if (!mbedErr) {
+    if(!mbedErr) {
         UA_ByteString tmp;
         tmp.data = cert.raw.p;
         tmp.length = cert.raw.len;
-
-        result = UA_ByteString_copy(&tmp, target);
+        if(target != NULL) {
+            result = UA_ByteString_copy(&tmp, target);
+        }
     } else {
-        UA_ByteString_init(target);
+        if(target != NULL) {
+            UA_ByteString_init(target);
+        }
+        result = UA_STATUSCODE_BADNOTFOUND;
     }
 
     UA_ByteString_clear(&data);
@@ -331,6 +408,280 @@ UA_mbedTLS_CopyDataFormatAware(const UA_ByteString *data) {
     }
 
     return result;
+}
+
+UA_StatusCode
+mbedtls_parseRemoteCertificate(ChannelContext_mbedtls *cc,
+                               const size_t minAsymKeyLen,
+                               const size_t maxAsymKeyLen,
+                               const UA_ByteString *remoteCertificate) {
+    if(remoteCertificate == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    /* Parse the certificate */
+    int mbedErr = mbedtls_x509_crt_parse(&cc->remoteCertificate, remoteCertificate->data,
+                                         remoteCertificate->length);
+    if(mbedErr)
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
+    /* Check the key length */
+#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
+    if(rsaContext->len < minAsymKeyLen ||
+       rsaContext->len > maxAsymKeyLen)
+        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
+#else
+    size_t keylen = mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
+    if(keylen < minAsymKeyLen ||
+       keylen > maxAsymKeyLen)
+        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
+#endif
+
+    return UA_STATUSCODE_GOOD;
+}
+
+void
+channelContext_mbedtls_deleteContext(ChannelContext_mbedtls *cc) {
+    UA_NodeId_clear(&cc->certificateTypeId);
+    UA_ByteString_clear(&cc->localSymSigningKey);
+    UA_ByteString_clear(&cc->localSymEncryptingKey);
+    UA_ByteString_clear(&cc->localSymIv);
+
+    UA_ByteString_clear(&cc->remoteSymSigningKey);
+    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
+    UA_ByteString_clear(&cc->remoteSymIv);
+
+    mbedtls_x509_crt_free(&cc->remoteCertificate);
+
+    UA_free(cc);
+}
+
+UA_StatusCode
+channelContext_mbedtls_newContext(const UA_SecurityPolicy *securityPolicy,
+                                  UA_PKIStore *pkiStore,
+                                  const UA_ByteString *remoteCertificate,
+                                  const size_t minAsymKeyLen,
+                                  const size_t maxAsymKeyLen,
+                                  void **pp_contextData) {
+    if(securityPolicy == NULL || remoteCertificate == NULL || pp_contextData == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    /* Allocate the channel context */
+    *pp_contextData = UA_malloc(sizeof(ChannelContext_mbedtls));
+    if(*pp_contextData == NULL)
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+
+    ChannelContext_mbedtls *cc = (ChannelContext_mbedtls *)*pp_contextData;
+
+    /* Initialize the channel context */
+    cc->policyContext = (PolicyContext_mbedtls *)securityPolicy->policyContext;
+    cc->pkiStore = pkiStore;
+    UA_StatusCode retval = UA_NodeId_copy(&securityPolicy->certificateTypeId, &cc->certificateTypeId);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_free(*pp_contextData);
+        return retval;
+    }
+
+    UA_ByteString_init(&cc->localSymSigningKey);
+    UA_ByteString_init(&cc->localSymEncryptingKey);
+    UA_ByteString_init(&cc->localSymIv);
+
+    UA_ByteString_init(&cc->remoteSymSigningKey);
+    UA_ByteString_init(&cc->remoteSymEncryptingKey);
+    UA_ByteString_init(&cc->remoteSymIv);
+
+    mbedtls_x509_crt_init(&cc->remoteCertificate);
+
+    // TODO: this can be optimized so that we dont allocate memory before parsing the certificate
+    retval = mbedtls_parseRemoteCertificate(cc, minAsymKeyLen, maxAsymKeyLen, remoteCertificate);
+    if(retval != UA_STATUSCODE_GOOD) {
+        channelContext_mbedtls_deleteContext(cc);
+        *pp_contextData = NULL;
+    }
+    return retval;
+}
+
+UA_StatusCode
+channelContext_mbedtls_setRemoteSymIv(ChannelContext_mbedtls *cc, const UA_ByteString *iv) {
+    if(iv == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString_clear(&cc->remoteSymIv);
+    return UA_ByteString_copy(iv, &cc->remoteSymIv);
+}
+
+UA_StatusCode
+channelContext_mbedtls_setRemoteSymSigningKey(ChannelContext_mbedtls *cc, const UA_ByteString *key) {
+    if(key == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString_clear(&cc->remoteSymSigningKey);
+    return UA_ByteString_copy(key, &cc->remoteSymSigningKey);
+}
+
+UA_StatusCode
+channelContext_mbedtls_setRemoteSymEncryptingKey(ChannelContext_mbedtls *cc, const UA_ByteString *key) {
+    if(key == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
+    return UA_ByteString_copy(key, &cc->remoteSymEncryptingKey);
+}
+
+UA_StatusCode
+channelContext_mbedtls_setLocalSymIv(ChannelContext_mbedtls *cc, const UA_ByteString *iv) {
+    if(iv == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString_clear(&cc->localSymIv);
+    return UA_ByteString_copy(iv, &cc->localSymIv);
+}
+
+UA_StatusCode
+channelContext_mbedtls_setLocalSymSigningKey(ChannelContext_mbedtls *cc, const UA_ByteString *key) {
+    if(key == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString_clear(&cc->localSymSigningKey);
+    return UA_ByteString_copy(key, &cc->localSymSigningKey);
+}
+
+UA_StatusCode
+channelContext_mbedtls_setLocalSymEncryptingKey(ChannelContext_mbedtls *cc, const UA_ByteString *key) {
+    if(key == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString_clear(&cc->localSymEncryptingKey);
+    return UA_ByteString_copy(key, &cc->localSymEncryptingKey);
+}
+
+UA_StatusCode
+channelContext_mbedtls_compareCertificate(const ChannelContext_mbedtls *cc, const UA_ByteString *certificate) {
+    if(cc == NULL || certificate == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    mbedtls_x509_crt cert;
+    mbedtls_x509_crt_init(&cert);
+    int mbedErr = mbedtls_x509_crt_parse(&cert, certificate->data, certificate->length);
+    if(mbedErr)
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    if(cert.raw.len != cc->remoteCertificate.raw.len ||
+       memcmp(cert.raw.p, cc->remoteCertificate.raw.p, cert.raw.len) != 0)
+        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
+    mbedtls_x509_crt_free(&cert);
+    return retval;
+}
+
+UA_StatusCode
+channelContext_mbedtls_loadKeyThenSign(ChannelContext_mbedtls *cc,
+                                       const UA_ByteString *message,
+                                       UA_ByteString *signature,
+                                       UA_StatusCode (*sign)(ChannelContext_mbedtls *,
+                                                             mbedtls_pk_context *,
+                                                             const UA_ByteString *,
+                                                             UA_ByteString *)) {
+    if(cc == NULL || message == NULL || signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    mbedtls_pk_context privateKey;
+    UA_StatusCode retval =
+        UA_mbedTLS_loadPrivateKey(cc->pkiStore, &cc->policyContext->drbgContext,
+                                  cc->certificateTypeId,
+                                  &privateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        return retval;
+    }
+
+    retval = sign(cc, &privateKey, message, signature);
+    mbedtls_pk_free(&privateKey);
+    return retval;
+}
+
+UA_StatusCode
+channelContext_mbedtls_loadKeyThenCrypt(ChannelContext_mbedtls *cc,
+                                        UA_ByteString *data,
+                                        UA_StatusCode (*crypt)(ChannelContext_mbedtls *,
+                                                               mbedtls_pk_context *,
+                                                               UA_ByteString *)) {
+    if(cc == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    mbedtls_pk_context privateKey;
+    UA_StatusCode retval =
+        UA_mbedTLS_loadPrivateKey(cc->pkiStore, &cc->policyContext->drbgContext,
+                                  cc->certificateTypeId,
+                                  &privateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        return retval;
+    }
+
+    retval = crypt(cc, &privateKey, data);
+    mbedtls_pk_free(&privateKey);
+    return retval;
+}
+
+size_t
+channelContext_mbedtls_loadKeyThenGetSize(const ChannelContext_mbedtls *cc,
+                                          size_t (*getSize)(const ChannelContext_mbedtls *,
+                                                            const mbedtls_pk_context *)) {
+    if(cc == NULL)
+        return 0;
+
+    mbedtls_pk_context privateKey;
+    UA_StatusCode retval =
+        UA_mbedTLS_loadPrivateKey(cc->pkiStore, &cc->policyContext->drbgContext,
+                                  cc->certificateTypeId,
+                                  &privateKey);
+    if(retval != UA_STATUSCODE_GOOD) {
+        return 0;
+    }
+
+    size_t size = getSize(cc, &privateKey);
+    mbedtls_pk_free(&privateKey);
+    return size;
+}
+
+UA_StatusCode
+mbedtls_compare_thumbprints(const UA_SecurityPolicy *securityPolicy,
+                            UA_PKIStore *pkiStore,
+                            const UA_ByteString *certificateThumbprint,
+                            UA_StatusCode (*thumbprint)(const UA_SecurityPolicy *,
+                                                        const UA_ByteString *,
+                                                        UA_ByteString *)) {
+    if(securityPolicy == NULL || pkiStore == NULL || certificateThumbprint == NULL || thumbprint == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString localCertificate;
+    UA_ByteString_init(&localCertificate);
+    UA_StatusCode retval = pkiStore->loadCertificate(pkiStore, securityPolicy->certificateTypeId, &localCertificate);
+    if(retval != UA_STATUSCODE_GOOD) {
+        return retval;
+    }
+
+    UA_ByteString localCertThumbprint;
+    UA_ByteString_init(&localCertThumbprint);
+    retval = UA_ByteString_allocBuffer(&localCertThumbprint, UA_SHA1_LENGTH);
+    if(retval != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
+    retval = thumbprint(securityPolicy,
+                        &localCertificate,
+                        &localCertThumbprint);
+    if(retval != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
+    if(!UA_ByteString_equal(certificateThumbprint, &localCertThumbprint)) {
+        retval = UA_STATUSCODE_BADCERTIFICATEINVALID;
+        goto error;
+    }
+
+    return UA_STATUSCODE_GOOD;
+error:
+    UA_ByteString_clear(&localCertificate);
+    return retval;
 }
 
 #endif

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
@@ -14,12 +14,104 @@
 #include <mbedtls/md.h>
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/version.h>
 
 // MBEDTLS_ENTROPY_HARDWARE_ALT should be defined if your hardware does not supportd platform entropy
 
 #define UA_SHA1_LENGTH 20
+#define UA_SHA256_LENGTH 32
 
 _UA_BEGIN_DECLS
+
+typedef struct {
+    mbedtls_ctr_drbg_context drbgContext;
+    mbedtls_entropy_context entropyContext;
+    mbedtls_md_context_t mdContext;
+} PolicyContext_mbedtls;
+
+typedef struct {
+    PolicyContext_mbedtls *policyContext;
+    UA_PKIStore *pkiStore;
+    UA_NodeId certificateTypeId;
+
+    UA_ByteString localSymSigningKey;
+    UA_ByteString localSymEncryptingKey;
+    UA_ByteString localSymIv;
+
+    UA_ByteString remoteSymSigningKey;
+    UA_ByteString remoteSymEncryptingKey;
+    UA_ByteString remoteSymIv;
+
+    mbedtls_x509_crt remoteCertificate;
+} ChannelContext_mbedtls;
+
+UA_StatusCode
+channelContext_mbedtls_loadKeyThenSign(ChannelContext_mbedtls *cc,
+                                       const UA_ByteString *message,
+                                       UA_ByteString *signature,
+                                       UA_StatusCode (*sign)(ChannelContext_mbedtls *,
+                                                             mbedtls_pk_context *,
+                                                             const UA_ByteString *,
+                                                             UA_ByteString *));
+
+UA_StatusCode
+channelContext_mbedtls_loadKeyThenCrypt(ChannelContext_mbedtls *cc,
+                                        UA_ByteString *data,
+                                        UA_StatusCode (*crypt)(ChannelContext_mbedtls *,
+                                                               mbedtls_pk_context *,
+                                                               UA_ByteString *));
+
+size_t
+channelContext_mbedtls_loadKeyThenGetSize(const ChannelContext_mbedtls *cc,
+                                          size_t (*getSize)(const ChannelContext_mbedtls *,
+                                                            const mbedtls_pk_context *));
+
+UA_StatusCode
+channelContext_mbedtls_setLocalSymEncryptingKey(ChannelContext_mbedtls *cc,
+                                                const UA_ByteString *key);
+
+UA_StatusCode
+channelContext_mbedtls_setLocalSymSigningKey(ChannelContext_mbedtls *cc,
+                                             const UA_ByteString *key);
+
+UA_StatusCode
+channelContext_mbedtls_setLocalSymIv(ChannelContext_mbedtls *cc,
+                                     const UA_ByteString *iv);
+
+UA_StatusCode
+channelContext_mbedtls_setRemoteSymEncryptingKey(ChannelContext_mbedtls *cc,
+                                                 const UA_ByteString *key);
+
+UA_StatusCode
+channelContext_mbedtls_setRemoteSymSigningKey(ChannelContext_mbedtls *cc,
+                                              const UA_ByteString *key);
+
+UA_StatusCode
+channelContext_mbedtls_setRemoteSymIv(ChannelContext_mbedtls *cc,
+                                      const UA_ByteString *iv);
+
+UA_StatusCode
+channelContext_mbedtls_compareCertificate(const ChannelContext_mbedtls *cc,
+                                          const UA_ByteString *certificate);
+
+/* Assumes that the certificate has been verified externally */
+UA_StatusCode
+mbedtls_parseRemoteCertificate(ChannelContext_mbedtls *cc,
+                               const size_t minAsymKeyLen,
+                               const size_t maxAsymKeyLen,
+                               const UA_ByteString *remoteCertificate);
+
+void
+channelContext_mbedtls_deleteContext(ChannelContext_mbedtls *cc);
+
+UA_StatusCode
+channelContext_mbedtls_newContext(const UA_SecurityPolicy *securityPolicy,
+                                  UA_PKIStore *pkiStore,
+                                  const UA_ByteString *remoteCertificate,
+                                  const size_t minAsymKeyLen,
+                                  const size_t maxAsymKeyLen,
+                                  void **pp_contextData);
 
 void
 swapBuffers(UA_ByteString *const bufA, UA_ByteString *const bufB);
@@ -38,8 +130,14 @@ mbedtls_verifySig_sha1(mbedtls_x509_crt *certificate, const UA_ByteString *messa
                        const UA_ByteString *signature);
 
 UA_StatusCode
-mbedtls_sign_sha1(mbedtls_pk_context *localPrivateKey,
-                  mbedtls_ctr_drbg_context *drbgContext,
+mbedtls_sign_sha256(ChannelContext_mbedtls *cc,
+                    mbedtls_pk_context *privateKey,
+                    const UA_ByteString *message,
+                    UA_ByteString *signature);
+
+UA_StatusCode
+mbedtls_sign_sha1(ChannelContext_mbedtls *cc,
+                  mbedtls_pk_context *privateKey,
                   const UA_ByteString *message,
                   UA_ByteString *signature);
 
@@ -55,15 +153,32 @@ mbedtls_encrypt_rsaOaep(mbedtls_rsa_context *context,
                         UA_ByteString *data, const size_t plainTextBlockSize);
 
 UA_StatusCode
-mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
-                        mbedtls_ctr_drbg_context *drbgContext,
+mbedtls_decrypt_rsaOaep(ChannelContext_mbedtls *cc,
+                        mbedtls_pk_context *privateKey,
                         UA_ByteString *data);
 
-int UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, void *p_rng);
+UA_StatusCode
+mbedtls_compare_thumbprints(const UA_SecurityPolicy *securityPolicy,
+                            UA_PKIStore *pkiStore,
+                            const UA_ByteString *certificateThumbprint,
+                            UA_StatusCode (*thumbprint)(const UA_SecurityPolicy *,
+                                                        const UA_ByteString *,
+                                                        UA_ByteString *));
 
-UA_StatusCode UA_mbedTLS_LoadLocalCertificate(const UA_ByteString *certData, UA_ByteString *target);
+int
+UA_mbedTLS_parsePrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, void *p_rng);
 
-UA_ByteString UA_mbedTLS_CopyDataFormatAware(const UA_ByteString *data);
+UA_StatusCode
+UA_mbedTLS_loadPrivateKey(UA_PKIStore *pkiStore, void *p_rng,
+                          const UA_NodeId certificateTypeId,
+                          mbedtls_pk_context *pkContext);
+
+/* Try to load certificate. Checks validity. If target is NULL, will only check for validity. */
+UA_StatusCode
+UA_mbedTLS_LoadLocalCertificate(const UA_SecurityPolicy *policy, UA_PKIStore *pkiStore, UA_ByteString *target);
+
+UA_ByteString
+UA_mbedTLS_CopyDataFormatAware(const UA_ByteString *data);
 
 _UA_END_DECLS
 

--- a/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
+++ b/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
@@ -42,7 +42,7 @@ typedef struct {
     const UA_PubSubSecurityPolicy *securityPolicy;
     mbedtls_ctr_drbg_context drbgContext;
     mbedtls_entropy_context entropyContext;
-    mbedtls_md_context_t sha256MdContext;
+    mbedtls_md_context_t mdContext;
 } PUBSUB_AES256CTR_PolicyContext;
 
 typedef struct {
@@ -72,7 +72,7 @@ verify_sp_pubsub_aes256ctr(PUBSUB_AES256CTR_ChannelContext *cc,
     unsigned char mac[UA_SHA256_LENGTH];
     UA_ByteString signingKey =
         {UA_AES256CTR_SIGNING_KEY_LENGTH, cc->signingKey};
-    mbedtls_hmac(&pc->sha256MdContext, &signingKey, message, mac);
+    mbedtls_hmac(&pc->mdContext, &signingKey, message, mac);
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA256_LENGTH))
@@ -87,7 +87,7 @@ sign_sp_pubsub_aes256ctr(PUBSUB_AES256CTR_ChannelContext *cc,
         return UA_STATUSCODE_BADINTERNALERROR;
     UA_ByteString signingKey =
         {UA_AES256CTR_SIGNING_KEY_LENGTH, cc->signingKey};
-    mbedtls_hmac(&cc->policyContext->sha256MdContext, &signingKey, message,
+    mbedtls_hmac(&cc->policyContext->mdContext, &signingKey, message,
                  signature->data);
     return UA_STATUSCODE_GOOD;
 }
@@ -170,7 +170,7 @@ generateKey_sp_pubsub_aes256ctr(void *policyContext,
 
     PUBSUB_AES256CTR_PolicyContext *pc = (PUBSUB_AES256CTR_PolicyContext *)policyContext;
 
-    return mbedtls_generateKey(&pc->sha256MdContext, secret, seed, out);
+    return mbedtls_generateKey(&pc->mdContext, secret, seed, out);
 }
 /* This nonce does not to be  a
 cryptographically random number, it can be pseudo-random */
@@ -266,7 +266,7 @@ deleteMembers_sp_pubsub_aes256ctr(UA_PubSubSecurityPolicy *securityPolicy) {
 
     mbedtls_ctr_drbg_free(&pc->drbgContext);
     mbedtls_entropy_free(&pc->entropyContext);
-    mbedtls_md_free(&pc->sha256MdContext);
+    mbedtls_md_free(&pc->mdContext);
     UA_LOG_DEBUG(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Deleted members of EndpointContext for sp_PUBSUB_AES256CTR");
     UA_free(pc);
@@ -291,12 +291,12 @@ policyContext_newContext_sp_pubsub_aes256ctr(UA_PubSubSecurityPolicy *securityPo
     memset(pc, 0, sizeof(PUBSUB_AES256CTR_PolicyContext));
     mbedtls_ctr_drbg_init(&pc->drbgContext);
     mbedtls_entropy_init(&pc->entropyContext);
-    mbedtls_md_init(&pc->sha256MdContext);
+    mbedtls_md_init(&pc->mdContext);
     pc->securityPolicy = securityPolicy;
 
     /* Initialized the message digest */
     const mbedtls_md_info_t *const mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    int mbedErr = mbedtls_md_setup(&pc->sha256MdContext, mdInfo, MBEDTLS_MD_SHA256);
+    int mbedErr = mbedtls_md_setup(&pc->mdContext, mdInfo, MBEDTLS_MD_SHA256);
     if(mbedErr) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto error;

--- a/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
@@ -13,6 +13,7 @@
 
 #ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
 
+#include <open62541/nodeids.h>
 #include "securitypolicy_mbedtls_common.h"
 
 #include <mbedtls/aes.h>
@@ -41,36 +42,13 @@
 #define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH 256
 #define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH 512
 
-typedef struct {
-    UA_ByteString localCertThumbprint;
-
-    mbedtls_ctr_drbg_context drbgContext;
-    mbedtls_entropy_context entropyContext;
-    mbedtls_md_context_t sha256MdContext;
-    mbedtls_pk_context localPrivateKey;
-} Aes128Sha256PsaOaep_PolicyContext;
-
-typedef struct {
-    Aes128Sha256PsaOaep_PolicyContext *policyContext;
-
-    UA_ByteString localSymSigningKey;
-    UA_ByteString localSymEncryptingKey;
-    UA_ByteString localSymIv;
-
-    UA_ByteString remoteSymSigningKey;
-    UA_ByteString remoteSymEncryptingKey;
-    UA_ByteString remoteSymIv;
-
-    mbedtls_x509_crt remoteCertificate;
-} Aes128Sha256PsaOaep_ChannelContext;
-
 /********************/
 /* AsymmetricModule */
 /********************/
 
 /* VERIFY AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+asym_verify_sp_aes128sha256rsaoaep(ChannelContext_mbedtls *cc,
                                    const UA_ByteString *message,
                                    const UA_ByteString *signature) {
     if(message == NULL || signature == NULL || cc == NULL)
@@ -105,54 +83,28 @@ asym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
 
 /* AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_sign_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+asym_sign_sp_aes128sha256rsaoaep(ChannelContext_mbedtls *cc,
                                  const UA_ByteString *message,
                                  UA_ByteString *signature) {
-    if(message == NULL || signature == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    unsigned char hash[UA_SHA256_LENGTH];
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    // TODO check return status
-    mbedtls_sha256_ret(message->data, message->length, hash, 0);
-#else
-    mbedtls_sha256(message->data, message->length, hash, 0);
-#endif
-
-    Aes128Sha256PsaOaep_PolicyContext *pc = cc->policyContext;
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(pc->localPrivateKey);
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256);
-
-    size_t sigLen = 0;
-
-    /* For RSA keys, the default padding type is PKCS#1 v1.5 in mbedtls_pk_sign */
-    /* Alternatively use more specific function mbedtls_rsa_rsassa_pkcs1_v15_sign() */
-    int mbedErr = mbedtls_pk_sign(&pc->localPrivateKey,
-                                  MBEDTLS_MD_SHA256, hash,
-                                  UA_SHA256_LENGTH, signature->data,
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-                                  signature->length,
-#endif
-                                  &sigLen, mbedtls_ctr_drbg_random,
-                                  &pc->drbgContext);
-    if(mbedErr)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    return UA_STATUSCODE_GOOD;
+    return channelContext_mbedtls_loadKeyThenSign(cc, message, signature, mbedtls_sign_sha256);
 }
 
 static size_t
-asym_getLocalSignatureSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
-    if(cc == NULL)
-        return 0;
+getSignatureSize_sp_basic128sha256(const ChannelContext_mbedtls *cc, const mbedtls_pk_context *privateKey) {
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    return mbedtls_pk_rsa(cc->policyContext->localPrivateKey)->len;
+    return mbedtls_pk_rsa(*privateKey)->len;
 #else
-    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->policyContext->localPrivateKey));
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(*privateKey));
 #endif
 }
 
 static size_t
-asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
+asym_getLocalSignatureSize_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc) {
+    return channelContext_mbedtls_loadKeyThenGetSize(cc, getSignatureSize_sp_basic128sha256);
+}
+
+static size_t
+asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -163,7 +115,7 @@ asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_Cha
 }
 
 static size_t
-asym_getRemoteBlockSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
+asym_getRemoteBlockSize_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -174,7 +126,7 @@ asym_getRemoteBlockSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_Channel
 }
 
 static size_t
-asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
+asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -189,7 +141,7 @@ asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOae
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_encrypt_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+asym_encrypt_sp_aes128sha256rsaoaep(ChannelContext_mbedtls *cc,
                                     UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -205,21 +157,24 @@ asym_encrypt_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_decrypt_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+asym_decrypt_sp_aes128sha256rsaoaep(ChannelContext_mbedtls *cc,
                                     UA_ByteString *data) {
-    if(cc == NULL || data == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
-                                   &cc->policyContext->drbgContext, data);
+    return channelContext_mbedtls_loadKeyThenCrypt(cc, data, mbedtls_decrypt_rsaOaep);
 }
 
 static size_t
-asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
-    return mbedtls_pk_get_len(&cc->policyContext->localPrivateKey) * 8;
+do_asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc,
+                                                           const mbedtls_pk_context *privateKey) {
+    return mbedtls_pk_get_len(privateKey) * 8;
 }
 
 static size_t
-asym_getRemoteEncryptionKeyLength_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
+asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc) {
+    return channelContext_mbedtls_loadKeyThenGetSize(cc, do_asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep);
+}
+
+static size_t
+asym_getRemoteEncryptionKeyLength_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc) {
     return mbedtls_pk_get_len(&cc->remoteCertificate.pk) * 8;
 }
 
@@ -234,15 +189,12 @@ asym_makeThumbprint_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPoli
 
 static UA_StatusCode
 asymmetricModule_compareCertificateThumbprint_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                                     UA_PKIStore *pkiStore,
                                                                      const UA_ByteString *certificateThumbprint) {
-    if(securityPolicy == NULL || certificateThumbprint == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
-    if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
-        return UA_STATUSCODE_BADCERTIFICATEINVALID;
-
-    return UA_STATUSCODE_GOOD;
+    return mbedtls_compare_thumbprints(securityPolicy,
+                                       pkiStore,
+                                       certificateThumbprint,
+                                       asym_makeThumbprint_sp_aes128sha256rsaoaep);
 }
 
 /*******************/
@@ -250,7 +202,7 @@ asymmetricModule_compareCertificateThumbprint_sp_aes128sha256rsaoaep(const UA_Se
 /*******************/
 
 static UA_StatusCode
-sym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+sym_verify_sp_aes128sha256rsaoaep(ChannelContext_mbedtls *cc,
                                   const UA_ByteString *message,
                                   const UA_ByteString *signature) {
     if(cc == NULL || message == NULL || signature == NULL)
@@ -259,9 +211,9 @@ sym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
     /* Compute MAC */
     if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-    Aes128Sha256PsaOaep_PolicyContext *pc = cc->policyContext;
+    PolicyContext_mbedtls *pc = cc->policyContext;
     unsigned char mac[UA_SHA256_LENGTH];
-    mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
+    mbedtls_hmac(&pc->mdContext, &cc->remoteSymSigningKey, message, mac);
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA256_LENGTH))
@@ -270,13 +222,13 @@ sym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
 }
 
 static UA_StatusCode
-sym_sign_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
+sym_sign_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc,
                                 const UA_ByteString *message,
                                 UA_ByteString *signature) {
     if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
+    mbedtls_hmac(&cc->policyContext->mdContext, &cc->localSymSigningKey,
                  message, signature->data);
     return UA_STATUSCODE_GOOD;
 }
@@ -307,7 +259,7 @@ sym_getPlainTextBlockSize_sp_aes128sha256rsaoaep(const void *channelContext) {
 }
 
 static UA_StatusCode
-sym_encrypt_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
+sym_encrypt_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc,
                                    UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -341,7 +293,7 @@ sym_encrypt_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
 }
 
 static UA_StatusCode
-sym_decrypt_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
+sym_decrypt_sp_aes128sha256rsaoaep(const ChannelContext_mbedtls *cc,
                                    UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -378,183 +330,33 @@ sym_generateKey_sp_aes128sha256rsaoaep(void *policyContext, const UA_ByteString 
                                        const UA_ByteString *seed, UA_ByteString *out) {
     if(secret == NULL || seed == NULL || out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)policyContext;
-    return mbedtls_generateKey(&pc->sha256MdContext, secret, seed, out);
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)policyContext;
+    return mbedtls_generateKey(&pc->mdContext, secret, seed, out);
 }
 
 static UA_StatusCode
 sym_generateNonce_sp_aes128sha256rsaoaep(void *policyContext, UA_ByteString *out) {
     if(out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
-    Aes128Sha256PsaOaep_PolicyContext *pc =
-        (Aes128Sha256PsaOaep_PolicyContext *)policyContext;
+    PolicyContext_mbedtls *pc =
+        (PolicyContext_mbedtls *)policyContext;
     int mbedErr = mbedtls_ctr_drbg_random(&pc->drbgContext, out->data, out->length);
     if(mbedErr)
         return UA_STATUSCODE_BADUNEXPECTEDERROR;
     return UA_STATUSCODE_GOOD;
 }
 
-/*****************/
-/* ChannelModule */
-/*****************/
-
-/* Assumes that the certificate has been verified externally */
-static UA_StatusCode
-parseRemoteCertificate_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                              const UA_ByteString *remoteCertificate) {
-    if(remoteCertificate == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Parse the certificate */
-    int mbedErr = mbedtls_x509_crt_parse(&cc->remoteCertificate, remoteCertificate->data,
-                                         remoteCertificate->length);
-    if(mbedErr)
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    /* Check the key length */
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    size_t keylen = rsaContext->len;
-#else
-    size_t keylen = mbedtls_rsa_get_len(rsaContext);
-#endif
-    if(keylen < UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH ||
-       keylen > UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH)
-        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
-    return UA_STATUSCODE_GOOD;
-}
-
-static void
-channelContext_deleteContext_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc) {
-    UA_ByteString_clear(&cc->localSymSigningKey);
-    UA_ByteString_clear(&cc->localSymEncryptingKey);
-    UA_ByteString_clear(&cc->localSymIv);
-
-    UA_ByteString_clear(&cc->remoteSymSigningKey);
-    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
-    UA_ByteString_clear(&cc->remoteSymIv);
-
-    mbedtls_x509_crt_free(&cc->remoteCertificate);
-
-    UA_free(cc);
-}
-
 static UA_StatusCode
 channelContext_newContext_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+                                                 UA_PKIStore *pkiStore,
                                                  const UA_ByteString *remoteCertificate,
                                                  void **pp_contextData) {
-    if(securityPolicy == NULL || remoteCertificate == NULL || pp_contextData == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Allocate the channel context */
-    *pp_contextData = UA_malloc(sizeof(Aes128Sha256PsaOaep_ChannelContext));
-    if(*pp_contextData == NULL)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-
-    Aes128Sha256PsaOaep_ChannelContext *cc = (Aes128Sha256PsaOaep_ChannelContext *)*pp_contextData;
-
-    /* Initialize the channel context */
-    cc->policyContext = (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
-
-    UA_ByteString_init(&cc->localSymSigningKey);
-    UA_ByteString_init(&cc->localSymEncryptingKey);
-    UA_ByteString_init(&cc->localSymIv);
-
-    UA_ByteString_init(&cc->remoteSymSigningKey);
-    UA_ByteString_init(&cc->remoteSymEncryptingKey);
-    UA_ByteString_init(&cc->remoteSymIv);
-
-    mbedtls_x509_crt_init(&cc->remoteCertificate);
-
-    // TODO: this can be optimized so that we dont allocate memory before parsing the certificate
-    UA_StatusCode retval = parseRemoteCertificate_sp_aes128sha256rsaoaep(cc, remoteCertificate);
-    if(retval != UA_STATUSCODE_GOOD) {
-        channelContext_deleteContext_sp_aes128sha256rsaoaep(cc);
-        *pp_contextData = NULL;
-    }
-    return retval;
-}
-
-static UA_StatusCode
-channelContext_setLocalSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                                               const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymEncryptingKey);
-    return UA_ByteString_copy(key, &cc->localSymEncryptingKey);
-}
-
-static UA_StatusCode
-channelContext_setLocalSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                                            const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymSigningKey);
-    return UA_ByteString_copy(key, &cc->localSymSigningKey);
-}
-
-
-static UA_StatusCode
-channelContext_setLocalSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                                    const UA_ByteString *iv) {
-    if(iv == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymIv);
-    return UA_ByteString_copy(iv, &cc->localSymIv);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                                                const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
-    return UA_ByteString_copy(key, &cc->remoteSymEncryptingKey);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                                             const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymSigningKey);
-    return UA_ByteString_copy(key, &cc->remoteSymSigningKey);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                                     const UA_ByteString *iv) {
-    if(iv == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymIv);
-    return UA_ByteString_copy(iv, &cc->remoteSymIv);
-}
-
-static UA_StatusCode
-channelContext_compareCertificate_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
-                                                         const UA_ByteString *certificate) {
-    if(cc == NULL || certificate == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    mbedtls_x509_crt cert;
-    mbedtls_x509_crt_init(&cert);
-    int mbedErr = mbedtls_x509_crt_parse(&cert, certificate->data, certificate->length);
-    if(mbedErr)
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    if(cert.raw.len != cc->remoteCertificate.raw.len ||
-       memcmp(cert.raw.p, cc->remoteCertificate.raw.p, cert.raw.len) != 0)
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    mbedtls_x509_crt_free(&cert);
-    return retval;
+    return channelContext_mbedtls_newContext(securityPolicy,
+                                             pkiStore,
+                                             remoteCertificate,
+                                             UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH,
+                                             UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH,
+                                             pp_contextData);
 }
 
 static void
@@ -562,20 +364,16 @@ clear_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy) {
     if(securityPolicy == NULL)
         return;
 
-    UA_ByteString_clear(&securityPolicy->localCertificate);
-
     if(securityPolicy->policyContext == NULL)
         return;
 
     /* delete all allocated members in the context */
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)
         securityPolicy->policyContext;
 
     mbedtls_ctr_drbg_free(&pc->drbgContext);
     mbedtls_entropy_free(&pc->entropyContext);
-    mbedtls_pk_free(&pc->localPrivateKey);
-    mbedtls_md_free(&pc->sha256MdContext);
-    UA_ByteString_clear(&pc->localCertThumbprint);
+    mbedtls_md_free(&pc->mdContext);
 
     UA_LOG_DEBUG(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Deleted members of EndpointContext for sp_aes128sha256rsaoaep");
@@ -585,74 +383,11 @@ clear_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy) {
 }
 
 static UA_StatusCode
-updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy,
-                                                      const UA_ByteString newCertificate,
-                                                      const UA_ByteString newPrivateKey) {
-    if(securityPolicy == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    if(securityPolicy->policyContext == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Aes128Sha256PsaOaep_PolicyContext *pc =
-            (Aes128Sha256PsaOaep_PolicyContext *) securityPolicy->policyContext;
-
-    UA_ByteString_clear(&securityPolicy->localCertificate);
-
-    UA_StatusCode retval = UA_ByteString_allocBuffer(&securityPolicy->localCertificate,
-                                                     newCertificate.length + 1);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-    memcpy(securityPolicy->localCertificate.data, newCertificate.data, newCertificate.length);
-    securityPolicy->localCertificate.data[newCertificate.length] = '\0';
-    securityPolicy->localCertificate.length--;
-
-    /* Set the new private key */
-    mbedtls_pk_free(&pc->localPrivateKey);
-    mbedtls_pk_init(&pc->localPrivateKey);
-#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    int mbedErr = mbedtls_pk_parse_key(&pc->localPrivateKey, newPrivateKey.data,
-                                       newPrivateKey.length, NULL, 0);
-#else
-    int mbedErr = mbedtls_pk_parse_key(&pc->localPrivateKey, newPrivateKey.data,
-                                       newPrivateKey.length, NULL, 0, mbedtls_entropy_func, &pc->drbgContext);
-#endif
-    if(mbedErr) {
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-        goto error;
-    }
-
-    retval = asym_makeThumbprint_sp_aes128sha256rsaoaep(securityPolicy,
-                                                        &securityPolicy->localCertificate,
-                                                        &pc->localCertThumbprint);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-
-    return retval;
-
-    error:
-    UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                 "Could not update certificate and private key");
-    if(securityPolicy->policyContext != NULL)
-        clear_sp_aes128sha256rsaoaep(securityPolicy);
-    return retval;
-}
-
-static UA_StatusCode
-policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy,
-                                                const UA_ByteString localPrivateKey) {
+policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    if(securityPolicy == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
 
-    if (localPrivateKey.length == 0) {
-        UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                     "Can not initialize security policy. Private key is empty.");
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    }
-
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)
-        UA_malloc(sizeof(Aes128Sha256PsaOaep_PolicyContext));
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)
+        UA_malloc(sizeof(PolicyContext_mbedtls));
     securityPolicy->policyContext = (void *)pc;
     if(!pc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -660,15 +395,14 @@ policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolic
     }
 
     /* Initialize the PolicyContext */
-    memset(pc, 0, sizeof(Aes128Sha256PsaOaep_PolicyContext));
+    memset(pc, 0, sizeof(PolicyContext_mbedtls));
     mbedtls_ctr_drbg_init(&pc->drbgContext);
     mbedtls_entropy_init(&pc->entropyContext);
-    mbedtls_pk_init(&pc->localPrivateKey);
-    mbedtls_md_init(&pc->sha256MdContext);
+    mbedtls_md_init(&pc->mdContext);
 
     /* Initialized the message digest */
     const mbedtls_md_info_t *const mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    int mbedErr = mbedtls_md_setup(&pc->sha256MdContext, mdInfo, MBEDTLS_MD_SHA256);
+    int mbedErr = mbedtls_md_setup(&pc->mdContext, mdInfo, MBEDTLS_MD_SHA256);
     if(mbedErr) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto error;
@@ -691,23 +425,6 @@ policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolic
         goto error;
     }
 
-    /* Set the private key */
-    mbedErr = UA_mbedTLS_LoadPrivateKey(&localPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
-    if(mbedErr) {
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-        goto error;
-    }
-
-    /* Set the local certificate thumbprint */
-    retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-    retval = asym_makeThumbprint_sp_aes128sha256rsaoaep(securityPolicy,
-                                                        &securityPolicy->localCertificate,
-                                                        &pc->localCertThumbprint);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-
     return UA_STATUSCODE_GOOD;
 
 error:
@@ -719,21 +436,16 @@ error:
 }
 
 UA_StatusCode
-UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy, const UA_ByteString localCertificate,
-                                 const UA_ByteString localPrivateKey, const UA_Logger *logger) {
+UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy, const UA_Logger *logger) {
     memset(policy, 0, sizeof(UA_SecurityPolicy));
     policy->logger = logger;
 
     policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep");
+    policy->certificateTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_RSASHA256APPLICATIONCERTIFICATETYPE);
 
     UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
     UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
-
-    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
-
-    if (retval != UA_STATUSCODE_GOOD)
-        return retval;
 
     /* AsymmetricModule */
     UA_SecurityPolicySignatureAlgorithm *asym_signatureAlgorithm =
@@ -809,30 +521,28 @@ UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy, const UA_ByteSt
 
     /* ChannelModule */
     channelModule->newContext = channelContext_newContext_sp_aes128sha256rsaoaep;
-    channelModule->deleteContext = (void (*)(void *))
-        channelContext_deleteContext_sp_aes128sha256rsaoaep;
+    channelModule->deleteContext = (void (*)(void *))channelContext_mbedtls_deleteContext;
 
     channelModule->setLocalSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymEncryptingKey_sp_aes128sha256rsaoaep;
+        channelContext_mbedtls_setLocalSymEncryptingKey;
     channelModule->setLocalSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymSigningKey_sp_aes128sha256rsaoaep;
+        channelContext_mbedtls_setLocalSymSigningKey;
     channelModule->setLocalSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymIv_sp_aes128sha256rsaoaep;
+        channelContext_mbedtls_setLocalSymIv;
 
     channelModule->setRemoteSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymEncryptingKey_sp_aes128sha256rsaoaep;
+        channelContext_mbedtls_setRemoteSymEncryptingKey;
     channelModule->setRemoteSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymSigningKey_sp_aes128sha256rsaoaep;
+        channelContext_mbedtls_setRemoteSymSigningKey;
     channelModule->setRemoteSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymIv_sp_aes128sha256rsaoaep;
+        channelContext_mbedtls_setRemoteSymIv;
 
     channelModule->compareCertificate = (UA_StatusCode (*)(const void *, const UA_ByteString *))
-        channelContext_compareCertificate_sp_aes128sha256rsaoaep;
+        channelContext_mbedtls_compareCertificate;
 
-    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep;
     policy->clear = clear_sp_aes128sha256rsaoaep;
 
-    UA_StatusCode res = policyContext_newContext_sp_aes128sha256rsaoaep(policy, localPrivateKey);
+    UA_StatusCode res = policyContext_newContext_sp_aes128sha256rsaoaep(policy);
     if(res != UA_STATUSCODE_GOOD)
         clear_sp_aes128sha256rsaoaep(policy);
 

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
@@ -11,13 +11,14 @@
  */
 
 #include <open62541/plugin/securitypolicy.h>
-#include <open62541/plugin/pki.h>
+#include <open62541/plugin/certificate_manager.h>
 #include <open62541/types.h>
 #include <open62541/util.h>
 
 #ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
 
 #include <open62541/plugin/securitypolicy_default.h>
+#include <open62541/nodeids.h>
 #include "securitypolicy_mbedtls_common.h"
 
 #include <mbedtls/aes.h>
@@ -39,30 +40,7 @@
 #define UA_SECURITYPOLICY_BASIC256_SYM_ENCRYPTION_BLOCK_SIZE 16
 #define UA_SECURITYPOLICY_BASIC256_SYM_PLAIN_TEXT_BLOCK_SIZE 16
 #define UA_SECURITYPOLICY_BASIC256_MINASYMKEYLENGTH 128
-#define UA_SECURITYPOLICY_BASIC256_MAXASYMKEYLENGTH 512
-
-typedef struct {
-    UA_ByteString localCertThumbprint;
-
-    mbedtls_ctr_drbg_context drbgContext;
-    mbedtls_entropy_context entropyContext;
-    mbedtls_md_context_t sha1MdContext;
-    mbedtls_pk_context localPrivateKey;
-} Basic256_PolicyContext;
-
-typedef struct {
-    Basic256_PolicyContext *policyContext;
-
-    UA_ByteString localSymSigningKey;
-    UA_ByteString localSymEncryptingKey;
-    UA_ByteString localSymIv;
-
-    UA_ByteString remoteSymSigningKey;
-    UA_ByteString remoteSymEncryptingKey;
-    UA_ByteString remoteSymIv;
-
-    mbedtls_x509_crt remoteCertificate;
-} Basic256_ChannelContext;
+#define UA_SECURITYPOLICY_BASIC256_MAXASYMKEYLENGTH 256
 
 /********************/
 /* AsymmetricModule */
@@ -70,7 +48,7 @@ typedef struct {
 
 /* VERIFY AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_verify_sp_basic256(Basic256_ChannelContext *cc,
+asym_verify_sp_basic256(ChannelContext_mbedtls *cc,
                         const UA_ByteString *message,
                         const UA_ByteString *signature) {
     if(message == NULL || signature == NULL || cc == NULL)
@@ -81,41 +59,35 @@ asym_verify_sp_basic256(Basic256_ChannelContext *cc,
 
 /* AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_sign_sp_basic256(Basic256_ChannelContext *cc,
+asym_sign_sp_basic256(ChannelContext_mbedtls *cc,
                       const UA_ByteString *message,
                       UA_ByteString *signature) {
-    if(message == NULL || signature == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Basic256_PolicyContext *pc = cc->policyContext;
-    return mbedtls_sign_sha1(&pc->localPrivateKey, &pc->drbgContext,
-                             message, signature);
+    return channelContext_mbedtls_loadKeyThenSign(cc, message, signature, mbedtls_sign_sha1);
 }
 
 static size_t
-asym_getLocalSignatureSize_sp_basic256(const Basic256_ChannelContext *cc) {
-    if(cc == NULL)
-        return 0;
+getSignatureSize_sp_basic256(const ChannelContext_mbedtls *cc, const mbedtls_pk_context *privateKey) {
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    return mbedtls_pk_rsa(cc->policyContext->localPrivateKey)->len;
+    return mbedtls_pk_rsa(*privateKey)->len;
 #else
-    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->policyContext->localPrivateKey));
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(*privateKey));
 #endif
 }
 
 static size_t
-asym_getRemoteSignatureSize_sp_basic256(const Basic256_ChannelContext *cc) {
-    if(cc == NULL)
-        return 0;
-#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    return mbedtls_pk_rsa(cc->remoteCertificate.pk)->len;
-#else
-    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
-#endif
+asym_getLocalSignatureSize_sp_basic256(const ChannelContext_mbedtls *cc) {
+    return channelContext_mbedtls_loadKeyThenGetSize(cc, getSignatureSize_sp_basic256);
 }
 
 static size_t
-asym_getRemotePlainTextBlockSize_sp_basic256(const Basic256_ChannelContext *cc) {
+asym_getRemoteSignatureSize_sp_basic256(const ChannelContext_mbedtls *cc) {
+    if(cc == NULL)
+        return 0;
+    return getSignatureSize_sp_basic256(cc, &cc->remoteCertificate.pk);
+}
+
+static size_t
+asym_getRemotePlainTextBlockSize_sp_basic256(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -129,7 +101,7 @@ asym_getRemotePlainTextBlockSize_sp_basic256(const Basic256_ChannelContext *cc) 
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_encrypt_sp_basic256(Basic256_ChannelContext *cc,
+asym_encrypt_sp_basic256(ChannelContext_mbedtls *cc,
                          UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -145,26 +117,28 @@ asym_encrypt_sp_basic256(Basic256_ChannelContext *cc,
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_decrypt_sp_basic256(Basic256_ChannelContext *cc,
+asym_decrypt_sp_basic256(ChannelContext_mbedtls *cc,
                          UA_ByteString *data) {
-    if(cc == NULL || data == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
-                                   &cc->policyContext->drbgContext, data);
+    return channelContext_mbedtls_loadKeyThenCrypt(cc, data, mbedtls_decrypt_rsaOaep);
 }
 
 static size_t
-asym_getLocalEncryptionKeyLength_sp_basic256(const Basic256_ChannelContext *cc) {
-    return mbedtls_pk_get_len(&cc->policyContext->localPrivateKey) * 8;
+getKeySize_sp_basic256(const ChannelContext_mbedtls *cc, const mbedtls_pk_context *privateKey) {
+    return mbedtls_pk_get_len(privateKey) * 8;
 }
 
 static size_t
-asym_getRemoteEncryptionKeyLength_sp_basic256(const Basic256_ChannelContext *cc) {
-    return mbedtls_pk_get_len(&cc->remoteCertificate.pk) * 8;
+asym_getLocalEncryptionKeyLength_sp_basic256(const ChannelContext_mbedtls *cc) {
+    return channelContext_mbedtls_loadKeyThenGetSize(cc, getKeySize_sp_basic256);
 }
 
 static size_t
-asym_getRemoteBlockSize_sp_basic256(const Basic256_ChannelContext *cc) {
+asym_getRemoteEncryptionKeyLength_sp_basic256(const ChannelContext_mbedtls *cc) {
+    return getKeySize_sp_basic256(cc, &cc->remoteCertificate.pk);
+}
+
+static size_t
+asym_getRemoteBlockSize_sp_basic256(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -186,15 +160,12 @@ asym_makeThumbprint_sp_basic256(const UA_SecurityPolicy *securityPolicy,
 
 static UA_StatusCode
 asymmetricModule_compareCertificateThumbprint_sp_basic256(const UA_SecurityPolicy *securityPolicy,
+                                                          UA_PKIStore *pkiStore,
                                                           const UA_ByteString *certificateThumbprint) {
-    if(securityPolicy == NULL || certificateThumbprint == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Basic256_PolicyContext *pc = (Basic256_PolicyContext *)securityPolicy->policyContext;
-    if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
-        return UA_STATUSCODE_BADCERTIFICATEINVALID;
-
-    return UA_STATUSCODE_GOOD;
+    return mbedtls_compare_thumbprints(securityPolicy,
+                                       pkiStore,
+                                       certificateThumbprint,
+                                       asym_makeThumbprint_sp_basic256);
 }
 
 /*******************/
@@ -202,7 +173,7 @@ asymmetricModule_compareCertificateThumbprint_sp_basic256(const UA_SecurityPolic
 /*******************/
 
 static UA_StatusCode
-sym_verify_sp_basic256(Basic256_ChannelContext *cc,
+sym_verify_sp_basic256(ChannelContext_mbedtls *cc,
                        const UA_ByteString *message,
                        const UA_ByteString *signature) {
     if(cc == NULL || message == NULL || signature == NULL)
@@ -212,10 +183,10 @@ sym_verify_sp_basic256(Basic256_ChannelContext *cc,
     if(signature->length != UA_SHA1_LENGTH)
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
-    Basic256_PolicyContext *pc = cc->policyContext;
+    PolicyContext_mbedtls *pc = cc->policyContext;
     
     unsigned char mac[UA_SHA1_LENGTH];
-    mbedtls_hmac(&pc->sha1MdContext, &cc->remoteSymSigningKey, message, mac);
+    mbedtls_hmac(&pc->mdContext, &cc->remoteSymSigningKey, message, mac);
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA1_LENGTH))
@@ -224,12 +195,12 @@ sym_verify_sp_basic256(Basic256_ChannelContext *cc,
 }
 
 static UA_StatusCode
-sym_sign_sp_basic256(const Basic256_ChannelContext *cc,
+sym_sign_sp_basic256(const ChannelContext_mbedtls *cc,
                      const UA_ByteString *message, UA_ByteString *signature) {
     if(signature->length != UA_SHA1_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    mbedtls_hmac(&cc->policyContext->sha1MdContext, &cc->localSymSigningKey,
+    mbedtls_hmac(&cc->policyContext->mdContext, &cc->localSymSigningKey,
                  message, signature->data);
     return UA_STATUSCODE_GOOD;
 }
@@ -260,7 +231,7 @@ sym_getPlainTextBlockSize_sp_basic256(const void *const channelContext) {
 }
 
 static UA_StatusCode
-sym_encrypt_sp_basic256(const Basic256_ChannelContext *cc,
+sym_encrypt_sp_basic256(const ChannelContext_mbedtls *cc,
                         UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -293,7 +264,7 @@ sym_encrypt_sp_basic256(const Basic256_ChannelContext *cc,
 }
 
 static UA_StatusCode
-sym_decrypt_sp_basic256(const Basic256_ChannelContext *cc,
+sym_decrypt_sp_basic256(const ChannelContext_mbedtls *cc,
                         UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -329,183 +300,32 @@ sym_generateKey_sp_basic256(void *policyContext, const UA_ByteString *secret,
                             const UA_ByteString *seed, UA_ByteString *out) {
     if(secret == NULL || seed == NULL || out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
-    Basic256_PolicyContext *pc = (Basic256_PolicyContext *)policyContext;
-    return mbedtls_generateKey(&pc->sha1MdContext, secret, seed, out);
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)policyContext;
+    return mbedtls_generateKey(&pc->mdContext, secret, seed, out);
 }
 
 static UA_StatusCode
 sym_generateNonce_sp_basic256(void *policyContext, UA_ByteString *out) {
     if(out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
-    Basic256_PolicyContext *pc = (Basic256_PolicyContext *)policyContext;
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)policyContext;
     int mbedErr = mbedtls_ctr_drbg_random(&pc->drbgContext, out->data, out->length);
     if(mbedErr)
         return UA_STATUSCODE_BADUNEXPECTEDERROR;
     return UA_STATUSCODE_GOOD;
 }
 
-/*****************/
-/* ChannelModule */
-/*****************/
-
-/* Assumes that the certificate has been verified externally */
-static UA_StatusCode
-parseRemoteCertificate_sp_basic256(Basic256_ChannelContext *cc,
-                                   const UA_ByteString *remoteCertificate) {
-    if(remoteCertificate == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Parse the certificate */
-    int mbedErr = mbedtls_x509_crt_parse(&cc->remoteCertificate, remoteCertificate->data,
-                                         remoteCertificate->length);
-    if(mbedErr)
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    /* Check the key length */
-#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    size_t keylen = rsaContext->len;
-#else
-    size_t keylen = mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
-#endif
-    if(keylen < UA_SECURITYPOLICY_BASIC256_MINASYMKEYLENGTH ||
-       keylen > UA_SECURITYPOLICY_BASIC256_MAXASYMKEYLENGTH)
-        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
-
-    return UA_STATUSCODE_GOOD;
-}
-
-static void
-channelContext_deleteContext_sp_basic256(Basic256_ChannelContext *cc) {
-    UA_ByteString_clear(&cc->localSymSigningKey);
-    UA_ByteString_clear(&cc->localSymEncryptingKey);
-    UA_ByteString_clear(&cc->localSymIv);
-
-    UA_ByteString_clear(&cc->remoteSymSigningKey);
-    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
-    UA_ByteString_clear(&cc->remoteSymIv);
-
-    mbedtls_x509_crt_free(&cc->remoteCertificate);
-
-    UA_free(cc);
-}
-
 static UA_StatusCode
 channelContext_newContext_sp_basic256(const UA_SecurityPolicy *securityPolicy,
+                                      UA_PKIStore *pkiStore,
                                       const UA_ByteString *remoteCertificate,
                                       void **pp_contextData) {
-    if(securityPolicy == NULL || remoteCertificate == NULL || pp_contextData == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Allocate the channel context */
-    *pp_contextData = UA_malloc(sizeof(Basic256_ChannelContext));
-    if(*pp_contextData == NULL)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-
-    Basic256_ChannelContext *cc = (Basic256_ChannelContext *)*pp_contextData;
-
-    /* Initialize the channel context */
-    cc->policyContext = (Basic256_PolicyContext *)securityPolicy->policyContext;
-
-    UA_ByteString_init(&cc->localSymSigningKey);
-    UA_ByteString_init(&cc->localSymEncryptingKey);
-    UA_ByteString_init(&cc->localSymIv);
-
-    UA_ByteString_init(&cc->remoteSymSigningKey);
-    UA_ByteString_init(&cc->remoteSymEncryptingKey);
-    UA_ByteString_init(&cc->remoteSymIv);
-
-    mbedtls_x509_crt_init(&cc->remoteCertificate);
-
-    // TODO: this can be optimized so that we dont allocate memory before parsing the certificate
-    UA_StatusCode retval = parseRemoteCertificate_sp_basic256(cc, remoteCertificate);
-    if(retval != UA_STATUSCODE_GOOD) {
-        channelContext_deleteContext_sp_basic256(cc);
-        *pp_contextData = NULL;
-    }
-    return retval;
-}
-
-static UA_StatusCode
-channelContext_setLocalSymEncryptingKey_sp_basic256(Basic256_ChannelContext *cc,
-                                                    const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymEncryptingKey);
-    return UA_ByteString_copy(key, &cc->localSymEncryptingKey);
-}
-
-static UA_StatusCode
-channelContext_setLocalSymSigningKey_sp_basic256(Basic256_ChannelContext *cc,
-                                                 const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymSigningKey);
-    return UA_ByteString_copy(key, &cc->localSymSigningKey);
-}
-
-
-static UA_StatusCode
-channelContext_setLocalSymIv_sp_basic256(Basic256_ChannelContext *cc,
-                                         const UA_ByteString *iv) {
-    if(iv == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymIv);
-    return UA_ByteString_copy(iv, &cc->localSymIv);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymEncryptingKey_sp_basic256(Basic256_ChannelContext *cc,
-                                                     const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
-    return UA_ByteString_copy(key, &cc->remoteSymEncryptingKey);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymSigningKey_sp_basic256(Basic256_ChannelContext *cc,
-                                                  const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymSigningKey);
-    return UA_ByteString_copy(key, &cc->remoteSymSigningKey);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymIv_sp_basic256(Basic256_ChannelContext *cc,
-                                          const UA_ByteString *iv) {
-    if(iv == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymIv);
-    return UA_ByteString_copy(iv, &cc->remoteSymIv);
-}
-
-static UA_StatusCode
-channelContext_compareCertificate_sp_basic256(const Basic256_ChannelContext *cc,
-                                              const UA_ByteString *certificate) {
-    if(cc == NULL || certificate == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    mbedtls_x509_crt cert;
-    mbedtls_x509_crt_init(&cert);
-    int mbedErr = mbedtls_x509_crt_parse(&cert, certificate->data, certificate->length);
-    if(mbedErr)
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    if(cert.raw.len != cc->remoteCertificate.raw.len ||
-       memcmp(cert.raw.p, cc->remoteCertificate.raw.p, cert.raw.len) != 0)
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    mbedtls_x509_crt_free(&cert);
-    return retval;
+    return channelContext_mbedtls_newContext(securityPolicy,
+                                             pkiStore,
+                                             remoteCertificate,
+                                             UA_SECURITYPOLICY_BASIC256_MINASYMKEYLENGTH,
+                                             UA_SECURITYPOLICY_BASIC256_MAXASYMKEYLENGTH,
+                                             pp_contextData);
 }
 
 static void
@@ -513,20 +333,16 @@ clear_sp_basic256(UA_SecurityPolicy *securityPolicy) {
     if(securityPolicy == NULL)
         return;
 
-    UA_ByteString_clear(&securityPolicy->localCertificate);
-
     if(securityPolicy->policyContext == NULL)
         return;
 
     /* delete all allocated members in the context */
-    Basic256_PolicyContext *pc = (Basic256_PolicyContext *)
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)
         securityPolicy->policyContext;
 
     mbedtls_ctr_drbg_free(&pc->drbgContext);
     mbedtls_entropy_free(&pc->entropyContext);
-    mbedtls_pk_free(&pc->localPrivateKey);
-    mbedtls_md_free(&pc->sha1MdContext);
-    UA_ByteString_clear(&pc->localCertThumbprint);
+    mbedtls_md_free(&pc->mdContext);
 
     UA_LOG_DEBUG(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Deleted members of EndpointContext for sp_basic256");
@@ -536,67 +352,13 @@ clear_sp_basic256(UA_SecurityPolicy *securityPolicy) {
 }
 
 static UA_StatusCode
-updateCertificateAndPrivateKey_sp_basic256(UA_SecurityPolicy *securityPolicy,
-                                           const UA_ByteString newCertificate,
-                                           const UA_ByteString newPrivateKey) {
-    if(securityPolicy == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    if(securityPolicy->policyContext == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Basic256_PolicyContext *pc = (Basic256_PolicyContext *)
-        securityPolicy->policyContext;
-
-    UA_ByteString_clear(&securityPolicy->localCertificate);
-
-    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&newCertificate, &securityPolicy->localCertificate);
-
-    if (retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    /* Set the new private key */
-    mbedtls_pk_free(&pc->localPrivateKey);
-    mbedtls_pk_init(&pc->localPrivateKey);
-
-    int mbedErr = UA_mbedTLS_LoadPrivateKey(&newPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
-
-    if(mbedErr) {
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-        goto error;
-    }
-
-    retval = asym_makeThumbprint_sp_basic256(securityPolicy,
-                                             &securityPolicy->localCertificate,
-                                             &pc->localCertThumbprint);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-
-    return retval;
-
-    error:
-    UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                 "Could not update certificate and private key");
-    if(securityPolicy->policyContext != NULL)
-        clear_sp_basic256(securityPolicy);
-    return retval;
-}
-
-static UA_StatusCode
-policyContext_newContext_sp_basic256(UA_SecurityPolicy *securityPolicy,
-                                     const UA_ByteString localPrivateKey) {
+policyContext_newContext_sp_basic256(UA_SecurityPolicy *securityPolicy) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(securityPolicy == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    if (localPrivateKey.length == 0) {
-        UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                     "Can not initialize security policy. Private key is empty.");
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    }
-
-    Basic256_PolicyContext *pc = (Basic256_PolicyContext *)
-        UA_malloc(sizeof(Basic256_PolicyContext));
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)
+        UA_malloc(sizeof(PolicyContext_mbedtls));
     securityPolicy->policyContext = (void *)pc;
     if(!pc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -604,15 +366,14 @@ policyContext_newContext_sp_basic256(UA_SecurityPolicy *securityPolicy,
     }
 
     /* Initialize the PolicyContext */
-    memset(pc, 0, sizeof(Basic256_PolicyContext));
+    memset(pc, 0, sizeof(PolicyContext_mbedtls));
     mbedtls_ctr_drbg_init(&pc->drbgContext);
     mbedtls_entropy_init(&pc->entropyContext);
-    mbedtls_pk_init(&pc->localPrivateKey);
-    mbedtls_md_init(&pc->sha1MdContext);
+    mbedtls_md_init(&pc->mdContext);
 
     /* Initialized the message digest */
     const mbedtls_md_info_t *mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA1);
-    int mbedErr = mbedtls_md_setup(&pc->sha1MdContext, mdInfo, MBEDTLS_MD_SHA1);
+    int mbedErr = mbedtls_md_setup(&pc->mdContext, mdInfo, MBEDTLS_MD_SHA1);
     if(mbedErr) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto error;
@@ -635,23 +396,6 @@ policyContext_newContext_sp_basic256(UA_SecurityPolicy *securityPolicy,
         goto error;
     }
 
-    /* Set the private key */
-    mbedErr = UA_mbedTLS_LoadPrivateKey(&localPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
-    if(mbedErr) {
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-        goto error;
-    }
-
-    /* Set the local certificate thumbprint */
-    retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-    retval = asym_makeThumbprint_sp_basic256(securityPolicy,
-                                             &securityPolicy->localCertificate,
-                                             &pc->localCertThumbprint);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-
     return UA_STATUSCODE_GOOD;
 
 error:
@@ -663,21 +407,16 @@ error:
 }
 
 UA_StatusCode
-UA_SecurityPolicy_Basic256(UA_SecurityPolicy *policy, const UA_ByteString localCertificate,
-                           const UA_ByteString localPrivateKey, const UA_Logger *logger) {
+UA_SecurityPolicy_Basic256(UA_SecurityPolicy *policy, const UA_Logger *logger) {
     memset(policy, 0, sizeof(UA_SecurityPolicy));
     policy->logger = logger;
 
     policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256\0");
+    policy->certificateTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_RSAMINAPPLICATIONCERTIFICATETYPE);
 
     UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
     UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
-
-    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
-
-    if (retval != UA_STATUSCODE_GOOD)
-        return retval;
 
     /* AsymmetricModule */
     UA_SecurityPolicySignatureAlgorithm *asym_signatureAlgorithm =
@@ -755,30 +494,28 @@ UA_SecurityPolicy_Basic256(UA_SecurityPolicy *policy, const UA_ByteString localC
 
     /* ChannelModule */
     channelModule->newContext = channelContext_newContext_sp_basic256;
-    channelModule->deleteContext = (void (*)(void *))
-        channelContext_deleteContext_sp_basic256;
+    channelModule->deleteContext = (void (*)(void *))channelContext_mbedtls_deleteContext;
 
     channelModule->setLocalSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymEncryptingKey_sp_basic256;
+        channelContext_mbedtls_setLocalSymEncryptingKey;
     channelModule->setLocalSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymSigningKey_sp_basic256;
+        channelContext_mbedtls_setLocalSymSigningKey;
     channelModule->setLocalSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymIv_sp_basic256;
+        channelContext_mbedtls_setLocalSymIv;
 
     channelModule->setRemoteSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymEncryptingKey_sp_basic256;
+        channelContext_mbedtls_setRemoteSymEncryptingKey;
     channelModule->setRemoteSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymSigningKey_sp_basic256;
+        channelContext_mbedtls_setRemoteSymSigningKey;
     channelModule->setRemoteSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymIv_sp_basic256;
+        channelContext_mbedtls_setRemoteSymIv;
 
     channelModule->compareCertificate = (UA_StatusCode (*)(const void *, const UA_ByteString *))
-        channelContext_compareCertificate_sp_basic256;
+        channelContext_mbedtls_compareCertificate;
 
-    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_basic256;
     policy->clear = clear_sp_basic256;
 
-    UA_StatusCode res = policyContext_newContext_sp_basic256(policy, localPrivateKey);
+    UA_StatusCode res = policyContext_newContext_sp_basic256(policy);
     if(res != UA_STATUSCODE_GOOD)
         clear_sp_basic256(policy);
 

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
@@ -14,6 +14,7 @@
 
 #ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
 
+#include <open62541/nodeids.h>
 #include "securitypolicy_mbedtls_common.h"
 
 #include <mbedtls/aes.h>
@@ -42,36 +43,13 @@
 #define UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH 256
 #define UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH 512
 
-typedef struct {
-    UA_ByteString localCertThumbprint;
-
-    mbedtls_ctr_drbg_context drbgContext;
-    mbedtls_entropy_context entropyContext;
-    mbedtls_md_context_t sha256MdContext;
-    mbedtls_pk_context localPrivateKey;
-} Basic256Sha256_PolicyContext;
-
-typedef struct {
-    Basic256Sha256_PolicyContext *policyContext;
-
-    UA_ByteString localSymSigningKey;
-    UA_ByteString localSymEncryptingKey;
-    UA_ByteString localSymIv;
-
-    UA_ByteString remoteSymSigningKey;
-    UA_ByteString remoteSymEncryptingKey;
-    UA_ByteString remoteSymIv;
-
-    mbedtls_x509_crt remoteCertificate;
-} Basic256Sha256_ChannelContext;
-
 /********************/
 /* AsymmetricModule */
 /********************/
 
 /* VERIFY AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_verify_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+asym_verify_sp_basic256sha256(ChannelContext_mbedtls *cc,
                               const UA_ByteString *message,
                               const UA_ByteString *signature) {
     if(message == NULL || signature == NULL || cc == NULL)
@@ -106,54 +84,28 @@ asym_verify_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
 
 /* AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_sign_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+asym_sign_sp_basic256sha256(ChannelContext_mbedtls *cc,
                             const UA_ByteString *message,
                             UA_ByteString *signature) {
-    if(message == NULL || signature == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    unsigned char hash[UA_SHA256_LENGTH];
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    // TODO check return status
-    mbedtls_sha256_ret(message->data, message->length, hash, 0);
-#else
-    mbedtls_sha256(message->data, message->length, hash, 0);
-#endif
-
-    Basic256Sha256_PolicyContext *pc = cc->policyContext;
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(pc->localPrivateKey);
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256);
-
-    size_t sigLen = 0;
-
-    /* For RSA keys, the default padding type is PKCS#1 v1.5 in mbedtls_pk_sign */
-    /* Alternatively use more specific function mbedtls_rsa_rsassa_pkcs1_v15_sign() */
-    int mbedErr = mbedtls_pk_sign(&pc->localPrivateKey,
-                                  MBEDTLS_MD_SHA256, hash,
-                                  UA_SHA256_LENGTH, signature->data,
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-                                  signature->length,
-#endif
-                                  &sigLen, mbedtls_ctr_drbg_random,
-                                  &pc->drbgContext);
-    if(mbedErr)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    return UA_STATUSCODE_GOOD;
+    return channelContext_mbedtls_loadKeyThenSign(cc, message, signature, mbedtls_sign_sha256);
 }
 
 static size_t
-asym_getLocalSignatureSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
-    if(cc == NULL)
-        return 0;
+getSignatureSize_sp_basic256sha256(const ChannelContext_mbedtls *cc, const mbedtls_pk_context *privateKey) {
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    return mbedtls_pk_rsa(cc->policyContext->localPrivateKey)->len;
+    return mbedtls_pk_rsa(*privateKey)->len;
 #else
-    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->policyContext->localPrivateKey));
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(*privateKey));
 #endif
 }
 
 static size_t
-asym_getRemoteSignatureSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
+asym_getLocalSignatureSize_sp_basic256sha256(ChannelContext_mbedtls *cc) {
+    return channelContext_mbedtls_loadKeyThenGetSize(cc, getSignatureSize_sp_basic256sha256);
+}
+
+static size_t
+asym_getRemoteSignatureSize_sp_basic256sha256(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -164,7 +116,7 @@ asym_getRemoteSignatureSize_sp_basic256sha256(const Basic256Sha256_ChannelContex
 }
 
 static size_t
-asym_getRemoteBlockSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
+asym_getRemoteBlockSize_sp_basic256sha256(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -176,7 +128,7 @@ asym_getRemoteBlockSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *c
 }
 
 static size_t
-asym_getRemotePlainTextBlockSize_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
+asym_getRemotePlainTextBlockSize_sp_basic256sha256(const ChannelContext_mbedtls *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -191,7 +143,7 @@ asym_getRemotePlainTextBlockSize_sp_basic256sha256(const Basic256Sha256_ChannelC
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_encrypt_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+asym_encrypt_sp_basic256sha256(ChannelContext_mbedtls *cc,
                                UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -207,22 +159,26 @@ asym_encrypt_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
 
 /* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
 static UA_StatusCode
-asym_decrypt_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+asym_decrypt_sp_basic256sha256(ChannelContext_mbedtls *cc,
                                UA_ByteString *data) {
-    if(cc == NULL || data == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
-                                   &cc->policyContext->drbgContext, data);
+    return channelContext_mbedtls_loadKeyThenCrypt(cc, data, mbedtls_decrypt_rsaOaep);
 }
 
 static size_t
-asym_getLocalEncryptionKeyLength_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
-    return mbedtls_pk_get_len(&cc->policyContext->localPrivateKey) * 8;
+getKeyLen_sp256sha256(const ChannelContext_mbedtls *cc,
+                      const mbedtls_pk_context *privateKey) {
+    return mbedtls_pk_get_len(privateKey) * 8;
 }
 
 static size_t
-asym_getRemoteEncryptionKeyLength_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc) {
-    return mbedtls_pk_get_len(&cc->remoteCertificate.pk) * 8;
+asym_getLocalEncryptionKeyLength_sp_basic256sha256(const ChannelContext_mbedtls *cc) {
+    return channelContext_mbedtls_loadKeyThenGetSize(cc, getKeyLen_sp256sha256);
+}
+
+static size_t
+asym_getRemoteEncryptionKeyLength_sp_basic256sha256(const ChannelContext_mbedtls *cc) {
+    if(cc == NULL) { return 0; }
+    return getKeyLen_sp256sha256(cc, &cc->remoteCertificate.pk);
 }
 
 static UA_StatusCode
@@ -236,15 +192,12 @@ asym_makeThumbprint_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
 
 static UA_StatusCode
 asymmetricModule_compareCertificateThumbprint_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                                                UA_PKIStore *pkiStore,
                                                                 const UA_ByteString *certificateThumbprint) {
-    if(securityPolicy == NULL || certificateThumbprint == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
-    if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
-        return UA_STATUSCODE_BADCERTIFICATEINVALID;
-
-    return UA_STATUSCODE_GOOD;
+    return mbedtls_compare_thumbprints(securityPolicy,
+                                       pkiStore,
+                                       certificateThumbprint,
+                                       asym_makeThumbprint_sp_basic256sha256);
 }
 
 /*******************/
@@ -252,7 +205,7 @@ asymmetricModule_compareCertificateThumbprint_sp_basic256sha256(const UA_Securit
 /*******************/
 
 static UA_StatusCode
-sym_verify_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
+sym_verify_sp_basic256sha256(ChannelContext_mbedtls *cc,
                              const UA_ByteString *message,
                              const UA_ByteString *signature) {
     if(cc == NULL || message == NULL || signature == NULL)
@@ -262,9 +215,9 @@ sym_verify_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
     if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
-    Basic256Sha256_PolicyContext *pc = cc->policyContext;
+    PolicyContext_mbedtls *pc = cc->policyContext;
     unsigned char mac[UA_SHA256_LENGTH];
-    mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
+    mbedtls_hmac(&pc->mdContext, &cc->remoteSymSigningKey, message, mac);
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA256_LENGTH))
@@ -273,13 +226,13 @@ sym_verify_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
 }
 
 static UA_StatusCode
-sym_sign_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
+sym_sign_sp_basic256sha256(const ChannelContext_mbedtls *cc,
                            const UA_ByteString *message,
                            UA_ByteString *signature) {
     if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
+    mbedtls_hmac(&cc->policyContext->mdContext, &cc->localSymSigningKey,
                  message, signature->data);
     return UA_STATUSCODE_GOOD;
 }
@@ -310,7 +263,7 @@ sym_getPlainTextBlockSize_sp_basic256sha256(const void *channelContext) {
 }
 
 static UA_StatusCode
-sym_encrypt_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
+sym_encrypt_sp_basic256sha256(const ChannelContext_mbedtls *cc,
                               UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -344,7 +297,7 @@ sym_encrypt_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
 }
 
 static UA_StatusCode
-sym_decrypt_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
+sym_decrypt_sp_basic256sha256(const ChannelContext_mbedtls *cc,
                               UA_ByteString *data) {
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -380,15 +333,15 @@ sym_generateKey_sp_basic256sha256(void *policyContext, const UA_ByteString *secr
                                   const UA_ByteString *seed, UA_ByteString *out) {
     if(secret == NULL || seed == NULL || out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)policyContext;
-    return mbedtls_generateKey(&pc->sha256MdContext, secret, seed, out);
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)policyContext;
+    return mbedtls_generateKey(&pc->mdContext, secret, seed, out);
 }
 
 static UA_StatusCode
 sym_generateNonce_sp_basic256sha256(void *policyContext, UA_ByteString *out) {
     if(out == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)policyContext;
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)policyContext;
     int mbedErr = mbedtls_ctr_drbg_random(&pc->drbgContext, out->data, out->length);
     if(mbedErr)
         return UA_STATUSCODE_BADUNEXPECTEDERROR;
@@ -399,164 +352,17 @@ sym_generateNonce_sp_basic256sha256(void *policyContext, UA_ByteString *out) {
 /* ChannelModule */
 /*****************/
 
-/* Assumes that the certificate has been verified externally */
-static UA_StatusCode
-parseRemoteCertificate_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                         const UA_ByteString *remoteCertificate) {
-    if(remoteCertificate == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Parse the certificate */
-    int mbedErr = mbedtls_x509_crt_parse(&cc->remoteCertificate, remoteCertificate->data,
-                                         remoteCertificate->length);
-    if(mbedErr)
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    /* Check the key length */
-#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    size_t keylen = rsaContext->len;
-#else
-    size_t keylen = mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
-#endif
-    if(keylen < UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH ||
-       keylen > UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH)
-        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
-
-    return UA_STATUSCODE_GOOD;
-}
-
-static void
-channelContext_deleteContext_sp_basic256sha256(Basic256Sha256_ChannelContext *cc) {
-    UA_ByteString_clear(&cc->localSymSigningKey);
-    UA_ByteString_clear(&cc->localSymEncryptingKey);
-    UA_ByteString_clear(&cc->localSymIv);
-
-    UA_ByteString_clear(&cc->remoteSymSigningKey);
-    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
-    UA_ByteString_clear(&cc->remoteSymIv);
-
-    mbedtls_x509_crt_free(&cc->remoteCertificate);
-
-    UA_free(cc);
-}
-
 static UA_StatusCode
 channelContext_newContext_sp_basic256sha256(const UA_SecurityPolicy *securityPolicy,
+                                            UA_PKIStore *pkiStore,
                                             const UA_ByteString *remoteCertificate,
                                             void **pp_contextData) {
-    if(securityPolicy == NULL || remoteCertificate == NULL || pp_contextData == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Allocate the channel context */
-    *pp_contextData = UA_malloc(sizeof(Basic256Sha256_ChannelContext));
-    if(*pp_contextData == NULL)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-
-    Basic256Sha256_ChannelContext *cc = (Basic256Sha256_ChannelContext *)*pp_contextData;
-
-    /* Initialize the channel context */
-    cc->policyContext = (Basic256Sha256_PolicyContext *)securityPolicy->policyContext;
-
-    UA_ByteString_init(&cc->localSymSigningKey);
-    UA_ByteString_init(&cc->localSymEncryptingKey);
-    UA_ByteString_init(&cc->localSymIv);
-
-    UA_ByteString_init(&cc->remoteSymSigningKey);
-    UA_ByteString_init(&cc->remoteSymEncryptingKey);
-    UA_ByteString_init(&cc->remoteSymIv);
-
-    mbedtls_x509_crt_init(&cc->remoteCertificate);
-
-    // TODO: this can be optimized so that we dont allocate memory before parsing the certificate
-    UA_StatusCode retval = parseRemoteCertificate_sp_basic256sha256(cc, remoteCertificate);
-    if(retval != UA_STATUSCODE_GOOD) {
-        channelContext_deleteContext_sp_basic256sha256(cc);
-        *pp_contextData = NULL;
-    }
-    return retval;
-}
-
-static UA_StatusCode
-channelContext_setLocalSymEncryptingKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                          const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymEncryptingKey);
-    return UA_ByteString_copy(key, &cc->localSymEncryptingKey);
-}
-
-static UA_StatusCode
-channelContext_setLocalSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                       const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymSigningKey);
-    return UA_ByteString_copy(key, &cc->localSymSigningKey);
-}
-
-
-static UA_StatusCode
-channelContext_setLocalSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                               const UA_ByteString *iv) {
-    if(iv == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->localSymIv);
-    return UA_ByteString_copy(iv, &cc->localSymIv);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymEncryptingKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                           const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
-    return UA_ByteString_copy(key, &cc->remoteSymEncryptingKey);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymSigningKey_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                        const UA_ByteString *key) {
-    if(key == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymSigningKey);
-    return UA_ByteString_copy(key, &cc->remoteSymSigningKey);
-}
-
-static UA_StatusCode
-channelContext_setRemoteSymIv_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
-                                                const UA_ByteString *iv) {
-    if(iv == NULL || cc == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString_clear(&cc->remoteSymIv);
-    return UA_ByteString_copy(iv, &cc->remoteSymIv);
-}
-
-static UA_StatusCode
-channelContext_compareCertificate_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
-                                                    const UA_ByteString *certificate) {
-    if(cc == NULL || certificate == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    mbedtls_x509_crt cert;
-    mbedtls_x509_crt_init(&cert);
-    int mbedErr = mbedtls_x509_crt_parse(&cert, certificate->data, certificate->length);
-    if(mbedErr)
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    if(cert.raw.len != cc->remoteCertificate.raw.len ||
-       memcmp(cert.raw.p, cc->remoteCertificate.raw.p, cert.raw.len) != 0)
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-
-    mbedtls_x509_crt_free(&cert);
-    return retval;
+    return channelContext_mbedtls_newContext(securityPolicy,
+                                             pkiStore,
+                                             remoteCertificate,
+                                             UA_SECURITYPOLICY_BASIC256SHA256_MINASYMKEYLENGTH,
+                                             UA_SECURITYPOLICY_BASIC256SHA256_MAXASYMKEYLENGTH,
+                                             pp_contextData);
 }
 
 static void
@@ -564,20 +370,17 @@ clear_sp_basic256sha256(UA_SecurityPolicy *securityPolicy) {
     if(securityPolicy == NULL)
         return;
 
-    UA_ByteString_clear(&securityPolicy->localCertificate);
-
     if(securityPolicy->policyContext == NULL)
         return;
 
     /* delete all allocated members in the context */
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)
         securityPolicy->policyContext;
 
     mbedtls_ctr_drbg_free(&pc->drbgContext);
     mbedtls_entropy_free(&pc->entropyContext);
-    mbedtls_pk_free(&pc->localPrivateKey);
-    mbedtls_md_free(&pc->sha256MdContext);
-    UA_ByteString_clear(&pc->localCertThumbprint);
+    mbedtls_md_free(&pc->mdContext);
+    UA_NodeId_clear(&securityPolicy->certificateTypeId);
 
     UA_LOG_DEBUG(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Deleted members of EndpointContext for sp_basic256sha256");
@@ -587,65 +390,11 @@ clear_sp_basic256sha256(UA_SecurityPolicy *securityPolicy) {
 }
 
 static UA_StatusCode
-updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
-                                                 const UA_ByteString newCertificate,
-                                                 const UA_ByteString newPrivateKey) {
-    if(securityPolicy == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    if(securityPolicy->policyContext == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Basic256Sha256_PolicyContext *pc =
-            (Basic256Sha256_PolicyContext *) securityPolicy->policyContext;
-
-    UA_ByteString_clear(&securityPolicy->localCertificate);
-
-    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&newCertificate, &securityPolicy->localCertificate);
-
-    if (retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    /* Set the new private key */
-    mbedtls_pk_free(&pc->localPrivateKey);
-    mbedtls_pk_init(&pc->localPrivateKey);
-    int mbedErr = UA_mbedTLS_LoadPrivateKey(&newPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
-    if(mbedErr) {
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-        goto error;
-    }
-
-    retval = asym_makeThumbprint_sp_basic256sha256(securityPolicy,
-                                                   &securityPolicy->localCertificate,
-                                                   &pc->localCertThumbprint);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-
-    return retval;
-
-    error:
-    UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                 "Could not update certificate and private key");
-    if(securityPolicy->policyContext != NULL)
-        clear_sp_basic256sha256(securityPolicy);
-    return retval;
-}
-
-static UA_StatusCode
-policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
-                                           const UA_ByteString localPrivateKey) {
+policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    if(securityPolicy == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
 
-    if (localPrivateKey.length == 0) {
-        UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                     "Can not initialize security policy. Private key is empty.");
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    }
-
-    Basic256Sha256_PolicyContext *pc = (Basic256Sha256_PolicyContext *)
-        UA_malloc(sizeof(Basic256Sha256_PolicyContext));
+    PolicyContext_mbedtls *pc = (PolicyContext_mbedtls *)
+        UA_malloc(sizeof(PolicyContext_mbedtls));
     securityPolicy->policyContext = (void *)pc;
     if(!pc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -653,15 +402,14 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
     }
 
     /* Initialize the PolicyContext */
-    memset(pc, 0, sizeof(Basic256Sha256_PolicyContext));
+    memset(pc, 0, sizeof(PolicyContext_mbedtls));
     mbedtls_ctr_drbg_init(&pc->drbgContext);
     mbedtls_entropy_init(&pc->entropyContext);
-    mbedtls_pk_init(&pc->localPrivateKey);
-    mbedtls_md_init(&pc->sha256MdContext);
+    mbedtls_md_init(&pc->mdContext);
 
     /* Initialized the message digest */
     const mbedtls_md_info_t *const mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    int mbedErr = mbedtls_md_setup(&pc->sha256MdContext, mdInfo, MBEDTLS_MD_SHA256);
+    int mbedErr = mbedtls_md_setup(&pc->mdContext, mdInfo, MBEDTLS_MD_SHA256);
     if(mbedErr) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
         goto error;
@@ -684,23 +432,6 @@ policyContext_newContext_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
         goto error;
     }
 
-    /* Set the private key */
-    mbedErr = UA_mbedTLS_LoadPrivateKey(&localPrivateKey, &pc->localPrivateKey, &pc->entropyContext);
-    if(mbedErr) {
-        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-        goto error;
-    }
-
-    /* Set the local certificate thumbprint */
-    retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-    retval = asym_makeThumbprint_sp_basic256sha256(securityPolicy,
-                                                  &securityPolicy->localCertificate,
-                                                  &pc->localCertThumbprint);
-    if(retval != UA_STATUSCODE_GOOD)
-        goto error;
-
     return UA_STATUSCODE_GOOD;
 
 error:
@@ -712,21 +443,18 @@ error:
 }
 
 UA_StatusCode
-UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_ByteString localCertificate,
-                                 const UA_ByteString localPrivateKey, const UA_Logger *logger) {
+UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_Logger *logger) {
+    if(policy == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
     memset(policy, 0, sizeof(UA_SecurityPolicy));
     policy->logger = logger;
 
     policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
+    policy->certificateTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_RSASHA256APPLICATIONCERTIFICATETYPE);
 
     UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
     UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
-
-    UA_StatusCode retval = UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
-
-    if (retval != UA_STATUSCODE_GOOD)
-        return retval;
 
     /* AsymmetricModule */
     UA_SecurityPolicySignatureAlgorithm *asym_signatureAlgorithm =
@@ -804,30 +532,28 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_ByteString 
 
     /* ChannelModule */
     channelModule->newContext = channelContext_newContext_sp_basic256sha256;
-    channelModule->deleteContext = (void (*)(void *))
-        channelContext_deleteContext_sp_basic256sha256;
+    channelModule->deleteContext = (void (*)(void *))channelContext_mbedtls_deleteContext;
 
     channelModule->setLocalSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymEncryptingKey_sp_basic256sha256;
+        channelContext_mbedtls_setLocalSymEncryptingKey;
     channelModule->setLocalSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymSigningKey_sp_basic256sha256;
+        channelContext_mbedtls_setLocalSymSigningKey;
     channelModule->setLocalSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymIv_sp_basic256sha256;
+        channelContext_mbedtls_setLocalSymIv;
 
     channelModule->setRemoteSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymEncryptingKey_sp_basic256sha256;
+        channelContext_mbedtls_setRemoteSymEncryptingKey;
     channelModule->setRemoteSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymSigningKey_sp_basic256sha256;
+        channelContext_mbedtls_setRemoteSymSigningKey;
     channelModule->setRemoteSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymIv_sp_basic256sha256;
+        channelContext_mbedtls_setRemoteSymIv;
 
     channelModule->compareCertificate = (UA_StatusCode (*)(const void *, const UA_ByteString *))
-        channelContext_compareCertificate_sp_basic256sha256;
+        channelContext_mbedtls_compareCertificate;
 
-    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_basic256sha256;
     policy->clear = clear_sp_basic256sha256;
 
-    UA_StatusCode res = policyContext_newContext_sp_basic256sha256(policy, localPrivateKey);
+    UA_StatusCode res = policyContext_newContext_sp_basic256sha256(policy);
     if(res != UA_STATUSCODE_GOOD)
         clear_sp_basic256sha256(policy);
 

--- a/plugins/crypto/ua_pki_none.c
+++ b/plugins/crypto/ua_pki_none.c
@@ -7,24 +7,27 @@
 #include <open62541/plugin/pki_default.h>
 
 static UA_StatusCode
-verifyCertificateAllowAll(void *verificationContext,
-               const UA_ByteString *certificate) {
+verifyCertificateAllowAll(UA_CertificateManager *certificateManager,
+                          UA_PKIStore *pkiStore,
+                          const UA_ByteString *certificate) {
     return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-verifyApplicationURIAllowAll(void *verificationContext,
+verifyApplicationURIAllowAll(UA_CertificateManager *verificationContext,
+                             UA_PKIStore *pkiStore,
                              const UA_ByteString *certificate,
                              const UA_String *applicationURI) {
     return UA_STATUSCODE_GOOD;
 }
 
 static void
-clearVerifyAllowAll(UA_CertificateVerification *cv) {
+clearVerifyAllowAll(UA_CertificateManager *cv) {
 
 }
 
-void UA_CertificateVerification_AcceptAll(UA_CertificateVerification *cv) {
+void
+UA_CertificateManager_AcceptAll(UA_CertificateManager *cv) {
     cv->verifyCertificate = verifyCertificateAllowAll;
     cv->verifyApplicationURI = verifyApplicationURIAllowAll;
     cv->clear = clearVerifyAllowAll;

--- a/plugins/include/open62541/plugin/accesscontrol_default.h
+++ b/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -26,7 +26,8 @@ typedef struct {
 UA_EXPORT UA_StatusCode
 UA_AccessControl_default(UA_ServerConfig *config,
                          UA_Boolean allowAnonymous,
-                         UA_CertificateVerification *verifyX509,
+                         UA_CertificateManager *verifyX509,
+                         UA_PKIStore *pkiStore,
                          const UA_ByteString *userTokenPolicyUri,
                          size_t usernamePasswordLoginSize,
                          const UA_UsernamePasswordLogin *usernamePasswordLogin);

--- a/plugins/include/open62541/plugin/certstore_default.h
+++ b/plugins/include/open62541/plugin/certstore_default.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2022 (c) Mark Giraud, Fraunhofer IOSB
+ */
+
+
+#ifndef OPEN62541_CERTSTORE_DEFAULT_H
+#define OPEN62541_CERTSTORE_DEFAULT_H
+
+#include <open62541/types.h>
+#include <open62541/plugin/certstore.h>
+
+UA_StatusCode
+UA_PKIStore_File(UA_PKIStore *pkiStore, UA_NodeId *certificateGroupId);
+
+#endif //OPEN62541_CERTSTORE_DEFAULT_H

--- a/plugins/include/open62541/plugin/pki_default.h
+++ b/plugins/include/open62541/plugin/pki_default.h
@@ -8,33 +8,28 @@
 #ifndef UA_PKI_CERTIFICATE_H_
 #define UA_PKI_CERTIFICATE_H_
 
-#include <open62541/plugin/pki.h>
+#include <open62541/plugin/certificate_manager.h>
+#include <open62541/plugin/certstore.h>
 
 _UA_BEGIN_DECLS
 
 /* Default implementation that accepts all certificates */
 UA_EXPORT void
-UA_CertificateVerification_AcceptAll(UA_CertificateVerification *cv);
+UA_CertificateManager_AcceptAll(UA_CertificateManager *cv);
 
 #ifdef UA_ENABLE_ENCRYPTION
 
 /* Accept certificates based on a trust-list and a revocation-list. Based on
  * mbedTLS. */
 UA_EXPORT UA_StatusCode
-UA_CertificateVerification_Trustlist(UA_CertificateVerification *cv,
-                                     const UA_ByteString *certificateTrustList,
-                                     size_t certificateTrustListSize,
-                                     const UA_ByteString *certificateIssuerList,
-                                     size_t certificateIssuerListSize,
-                                     const UA_ByteString *certificateRevocationList,
-                                     size_t certificateRevocationListSize);
+UA_CertificateManager_Trustlist(UA_CertificateManager *certificateManager);
 
 #ifdef __linux__ /* Linux only so far */
 UA_EXPORT UA_StatusCode
-UA_CertificateVerification_CertFolders(UA_CertificateVerification *cv,
-                                       const char *trustListFolder,
-                                       const char *issuerListFolder,
-                                       const char *revocationListFolder);
+UA_CertificateManager_CertFolders(UA_CertificateManager *certificateManager,
+                                  const char *trustListFolder,
+                                  const char *issuerListFolder,
+                                  const char *revocationListFolder);
 #endif
 
 #endif

--- a/plugins/include/open62541/plugin/securitypolicy_default.h
+++ b/plugins/include/open62541/plugin/securitypolicy_default.h
@@ -14,35 +14,21 @@
 _UA_BEGIN_DECLS
 
 UA_EXPORT UA_StatusCode
-UA_SecurityPolicy_None(UA_SecurityPolicy *policy,
-                       const UA_ByteString localCertificate,
-                       const UA_Logger *logger);
+UA_SecurityPolicy_None(UA_SecurityPolicy *policy, const UA_Logger *logger);
 
 #ifdef UA_ENABLE_ENCRYPTION
 
 UA_EXPORT UA_StatusCode
-UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy,
-                                const UA_ByteString localCertificate,
-                                const UA_ByteString localPrivateKey,
-                                const UA_Logger *logger);
+UA_SecurityPolicy_Basic128Rsa15(UA_SecurityPolicy *policy, const UA_Logger *logger);
 
 UA_EXPORT UA_StatusCode
-UA_SecurityPolicy_Basic256(UA_SecurityPolicy *policy,
-                           const UA_ByteString localCertificate,
-                           const UA_ByteString localPrivateKey,
-                           const UA_Logger *logger);
+UA_SecurityPolicy_Basic256(UA_SecurityPolicy *policy, const UA_Logger *logger);
 
 UA_EXPORT UA_StatusCode
-UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy,
-                                 const UA_ByteString localCertificate,
-                                 const UA_ByteString localPrivateKey,
-                                 const UA_Logger *logger);
+UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy, const UA_Logger *logger);
 
 UA_EXPORT UA_StatusCode
-UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy,
-                                 const UA_ByteString localCertificate,
-                                 const UA_ByteString localPrivateKey,
-                                 const UA_Logger *logger);
+UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy, const UA_Logger *logger);
 
 #endif
 

--- a/plugins/include/open62541/server_config_default.h
+++ b/plugins/include/open62541/server_config_default.h
@@ -65,16 +65,8 @@ UA_ServerConfig_setMinimal(UA_ServerConfig *config, UA_UInt16 portNumber,
 #ifdef UA_ENABLE_ENCRYPTION
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
-                                               UA_UInt16 portNumber,
-                                               const UA_ByteString *certificate,
-                                               const UA_ByteString *privateKey,
-                                               const UA_ByteString *trustList,
-                                               size_t trustListSize,
-                                               const UA_ByteString *issuerList,
-                                               size_t issuerListSize,
-                                               const UA_ByteString *revocationList,
-                                               size_t revocationListSize);
+UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf, UA_UInt16 portNumber,
+                                               const UA_ByteString *pkiDir);
 
 #endif
 
@@ -121,8 +113,7 @@ UA_ServerConfig_addNetworkLayerWS(UA_ServerConfig *conf, UA_UInt16 portNumber,
  * @param certificate The optional server certificate.
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config, 
-                                      const UA_ByteString *certificate);
+UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config);
 
 #ifdef UA_ENABLE_ENCRYPTION
 
@@ -137,9 +128,7 @@ UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config,
  * @param privateKey The private key that corresponds to the certificate.
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config, 
-                                               const UA_ByteString *certificate,
-                                               const UA_ByteString *privateKey);
+UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config);
 
 /* Adds the security policy ``SecurityPolicy#Basic256`` to the server. A
  * server certificate may be supplied but is optional.
@@ -152,9 +141,7 @@ UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config,
  * @param privateKey The private key that corresponds to the certificate.
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config, 
-                                          const UA_ByteString *certificate,
-                                          const UA_ByteString *privateKey);
+UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config);
 
 /* Adds the security policy ``SecurityPolicy#Basic256Sha256`` to the server. A
  * server certificate may be supplied but is optional.
@@ -167,9 +154,7 @@ UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config,
  * @param privateKey The private key that corresponds to the certificate.
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config, 
-                                                const UA_ByteString *certificate,
-                                                const UA_ByteString *privateKey);
+UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config);
 
 /* Adds the security policy ``SecurityPolicy#Aes128Sha256RsaOaep`` to the server. A
  * server certificate may be supplied but is optional.
@@ -182,9 +167,7 @@ UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config,
  * @param privateKey The private key that corresponds to the certificate.
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config,
-                                                     const UA_ByteString *certificate,
-                                                     const UA_ByteString *privateKey);
+UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config);
 
 /* Adds all supported security policies and sets up certificate
  * validation procedures.
@@ -201,9 +184,7 @@ UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config,
  * @param revocationListSize The revocationList size.
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config,
-                                       const UA_ByteString *certificate,
-                                       const UA_ByteString *privateKey);
+UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config);
 
 #endif
 
@@ -215,15 +196,19 @@ UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config,
  * @param securityMode The security mode for which to add the endpoint.
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addEndpoint(UA_ServerConfig *config, const UA_String securityPolicyUri, 
-                            UA_MessageSecurityMode securityMode);
+UA_ServerConfig_addEndpoint(UA_ServerConfig *config,
+                            const UA_String *securityPolicyUri,
+                            const UA_NodeId *certificateGroupId,
+                            UA_Boolean allowNone,
+                            UA_Boolean allowSign,
+                            UA_Boolean allowSignAndEncrypt);
 
 /* Adds endpoints for all configured security policies in each mode.
  *
  * @param config The configuration to manipulate
  */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addAllEndpoints(UA_ServerConfig *config);
+UA_ServerConfig_addAllEndpoints(UA_ServerConfig *config, const UA_NodeId *certificateGroupId);
 
 _UA_END_DECLS
 

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -21,7 +21,8 @@ typedef struct {
     UA_Boolean allowAnonymous;
     size_t usernamePasswordLoginSize;
     UA_UsernamePasswordLogin *usernamePasswordLogin;
-    UA_CertificateVerification verifyX509;
+    UA_CertificateManager *verifyX509;
+    UA_PKIStore *pkiStore;
 } AccessControlContext;
 
 #define ANONYMOUS_POLICY "open62541-anonymous-policy"
@@ -115,18 +116,16 @@ activateSession_default(UA_Server *server, UA_AccessControl *ac,
 
     /* x509 certificate */
     if(userIdentityToken->content.decoded.type == &UA_TYPES[UA_TYPES_X509IDENTITYTOKEN]) {
+        if(!context->verifyX509 || !context->pkiStore)
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+
         const UA_X509IdentityToken *userToken = (UA_X509IdentityToken*)
             userIdentityToken->content.decoded.data;
 
         if(!UA_String_equal(&userToken->policyId, &certificate_policy))
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 
-        if(!context->verifyX509.verifyCertificate)
-            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
-
-        return context->verifyX509.
-            verifyCertificate(context->verifyX509.context,
-                              &userToken->certificateData);
+        return context->verifyX509->verifyCertificate(context->verifyX509, context->pkiStore, &userToken->certificateData);
     }
 
     /* Unsupported token type */
@@ -260,8 +259,8 @@ static void clear_default(UA_AccessControl *ac) {
         if(context->usernamePasswordLoginSize > 0)
             UA_free(context->usernamePasswordLogin);
 
-        if(context->verifyX509.clear)
-            context->verifyX509.clear(&context->verifyX509);
+        if(context->verifyX509 && context->verifyX509->clear)
+            context->verifyX509->clear(context->verifyX509);
 
         UA_free(ac->context);
         ac->context = NULL;
@@ -271,7 +270,8 @@ static void clear_default(UA_AccessControl *ac) {
 UA_StatusCode
 UA_AccessControl_default(UA_ServerConfig *config,
                          UA_Boolean allowAnonymous,
-                         UA_CertificateVerification *verifyX509,
+                         UA_CertificateManager *verifyX509,
+                         UA_PKIStore *pkiStore,
                          const UA_ByteString *userTokenPolicyUri,
                          size_t usernamePasswordLoginSize,
                          const UA_UsernamePasswordLogin *usernamePasswordLogin) {
@@ -320,11 +320,12 @@ UA_AccessControl_default(UA_ServerConfig *config,
     }
 
     /* Allow x509 certificates? Move the plugin over. */
-    if(verifyX509) {
-        context->verifyX509 = *verifyX509;
-        memset(verifyX509, 0, sizeof(UA_CertificateVerification));
+    if(verifyX509 && pkiStore) {
+        context->verifyX509 = verifyX509;
+        context->pkiStore = pkiStore;
+        memset(verifyX509, 0, sizeof(UA_CertificateManager));
     } else {
-        memset(&context->verifyX509, 0, sizeof(UA_CertificateVerification));
+        context->verifyX509 = NULL;
         UA_LOG_INFO(&config->logger, UA_LOGCATEGORY_SERVER,
                     "AccessControl: x509 certificate user authentication is enabled");
     }

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -23,6 +23,7 @@
 #include <open62541/plugin/nodestore_default.h>
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/pki_default.h>
+#include <open62541/plugin/certstore_default.h>
 #include <open62541/plugin/securitypolicy_default.h>
 #include <open62541/server_config_default.h>
 
@@ -84,38 +85,6 @@ const UA_ConnectionConfig UA_ConnectionConfig_default = {
 #define STRINGIFY(arg) #arg
 #define VERSION(MAJOR, MINOR, PATCH, LABEL) \
     STRINGIFY(MAJOR) "." STRINGIFY(MINOR) "." STRINGIFY(PATCH) LABEL
-
-static UA_StatusCode
-createEndpoint(UA_ServerConfig *conf, UA_EndpointDescription *endpoint,
-               const UA_SecurityPolicy *securityPolicy,
-               UA_MessageSecurityMode securityMode) {
-    UA_EndpointDescription_init(endpoint);
-
-    endpoint->securityMode = securityMode;
-    UA_String_copy(&securityPolicy->policyUri, &endpoint->securityPolicyUri);
-    endpoint->transportProfileUri =
-        UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
-
-    /* Add security level value for the corresponding message security mode */
-    endpoint->securityLevel = (UA_Byte) securityMode;
-
-    /* Enable all login mechanisms from the access control plugin  */
-    UA_StatusCode retval = UA_Array_copy(conf->accessControl.userTokenPolicies,
-                                         conf->accessControl.userTokenPoliciesSize,
-                                         (void **)&endpoint->userIdentityTokens,
-                                         &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
-    if(retval != UA_STATUSCODE_GOOD){
-        UA_String_clear(&endpoint->securityPolicyUri);
-        UA_String_clear(&endpoint->transportProfileUri);
-        return retval;
-    }
-    endpoint->userIdentityTokensSize = conf->accessControl.userTokenPoliciesSize;
-
-    UA_String_copy(&securityPolicy->localCertificate, &endpoint->serverCertificate);
-    UA_ApplicationDescription_copy(&conf->applicationDescription, &endpoint->server);
-
-    return UA_STATUSCODE_GOOD;
-}
 
 static const size_t usernamePasswordsSize = 2;
 static UA_UsernamePasswordLogin usernamePasswords[2] = {
@@ -199,10 +168,10 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
     /* Networking */
     /* Set up the local ServerUrls. They are used during startup to initialize
      * the server sockets. */
-    UA_String serverUrls[2];
+    UA_String serverUrls[3];
     size_t serverUrlsSize = 0;
     char hostnamestr[256];
-    char serverUrlBuffer[2][512];
+    char serverUrlBuffer[3][512];
 
     if(portNumber == 0) {
         UA_LOG_WARNING(&conf->logger, UA_LOGCATEGORY_USERLAND,
@@ -220,9 +189,9 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
         /* 1) Listen on all interfaces (also external). This must be the first
          * entry if this is desired. Otherwise some interfaces may be blocked
          * (already in use) with a hostname that is only locally reachable.*/
-        UA_snprintf(serverUrlBuffer[0], sizeof(serverUrlBuffer[0]),
+        UA_snprintf(serverUrlBuffer[serverUrlsSize], sizeof(serverUrlBuffer[serverUrlsSize]),
                     "opc.tcp://:%u", portNumber);
-        serverUrls[serverUrlsSize] = UA_STRING(serverUrlBuffer[0]);
+        serverUrls[serverUrlsSize] = UA_STRING(serverUrlBuffer[serverUrlsSize]);
         serverUrlsSize++;
 
         /* 2) Use gethostname to get the local hostname. For that temporarily
@@ -237,11 +206,16 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
 #endif
 
         if(err == 0) {
-            UA_snprintf(serverUrlBuffer[1], sizeof(serverUrlBuffer[1]),
+            UA_snprintf(serverUrlBuffer[serverUrlsSize], sizeof(serverUrlBuffer[serverUrlsSize]),
                         "opc.tcp://%s:%u", hostnamestr, portNumber);
-            serverUrls[serverUrlsSize] = UA_STRING(serverUrlBuffer[1]);
+            serverUrls[serverUrlsSize] = UA_STRING(serverUrlBuffer[serverUrlsSize]);
             serverUrlsSize++;
         }
+
+        UA_snprintf(serverUrlBuffer[serverUrlsSize], sizeof(serverUrlBuffer[serverUrlsSize]),
+                    "opc.tcp://localhost:%u", portNumber);
+        serverUrls[serverUrlsSize] = UA_STRING(serverUrlBuffer[serverUrlsSize]);
+        serverUrlsSize++;
 
         /* 3) Add to the config */
         UA_StatusCode retval =
@@ -251,13 +225,13 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
             return retval;
         conf->serverUrlsSize = serverUrlsSize;
     }
-    
+
     /* Endpoints */
     /* conf->endpoints = {0, NULL}; */
 
     /* Certificate Verification that accepts every certificate. Can be
      * overwritten when the policy is specialized. */
-    UA_CertificateVerification_AcceptAll(&conf->certificateVerification);
+    UA_CertificateManager_AcceptAll(&conf->certificateManager);
 
     /* * Global Node Lifecycle * */
     /* conf->nodeLifecycle.constructor = NULL; */
@@ -365,8 +339,7 @@ UA_ServerConfig_addNetworkLayerWS(UA_ServerConfig *conf, UA_UInt16 portNumber,
 #endif
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config, 
-                                      const UA_ByteString *certificate) {
+UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config) {
     /* Allocate the SecurityPolicies */
     UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
         UA_realloc(config->securityPolicies,
@@ -374,14 +347,10 @@ UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config,
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
-    UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    if(certificate)
-        localCertificate = *certificate;
     UA_StatusCode retval =
-        UA_SecurityPolicy_None(&config->securityPolicies[config->securityPoliciesSize],
-                               localCertificate, &config->logger);
+        UA_SecurityPolicy_None(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -395,74 +364,85 @@ UA_ServerConfig_addSecurityPolicyNone(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addEndpoint(UA_ServerConfig *config, const UA_String securityPolicyUri, 
-                            UA_MessageSecurityMode securityMode) {
+UA_ServerConfig_addEndpoint(UA_ServerConfig *config,
+                            const UA_String *securityPolicyUri,
+                            const UA_NodeId *certificateGroupId,
+                            UA_Boolean allowNone,
+                            UA_Boolean allowSign,
+                            UA_Boolean allowSignAndEncrypt) {
     /* Allocate the endpoint */
-    UA_EndpointDescription *tmp = (UA_EndpointDescription *)
+    UA_assert(config->serverUrlsSize > 0);
+    UA_Endpoint *tmp = (UA_Endpoint *)
         UA_realloc(config->endpoints,
-                   sizeof(UA_EndpointDescription) * (1 + config->endpointsSize));
+                   sizeof(UA_Endpoint) * ((config->serverUrlsSize - 1) + config->endpointsSize));
     if(!tmp) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     config->endpoints = tmp;
 
     /* Lookup the security policy */
-    const UA_SecurityPolicy *policy = NULL;
-    for (size_t i = 0; i < config->securityPoliciesSize; ++i) {
-        if (UA_String_equal(&securityPolicyUri, &config->securityPolicies[i].policyUri)) {
+    UA_SecurityPolicy *policy = NULL;
+    for(size_t i = 0; i < config->securityPoliciesSize; ++i) {
+        if(UA_String_equal(securityPolicyUri, &config->securityPolicies[i].policyUri)) {
             policy = &config->securityPolicies[i];
             break;
         }
     }
-    if (!policy)
+    if(policy == NULL) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
+    UA_PKIStore *pkiStore = NULL;
+    for(size_t i = 0; i < config->pkiStoresSize; ++i) {
+        if(UA_NodeId_equal(certificateGroupId, &config->pkiStores[i].certificateGroupId)) {
+            pkiStore = &config->pkiStores[i];
+        }
+    }
+    if(pkiStore == NULL) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
 
     /* Populate the endpoint */
-    UA_StatusCode retval =
-        createEndpoint(config, &config->endpoints[config->endpointsSize],
-                       policy, securityMode);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-    config->endpointsSize++;
+    for(size_t i = 1; i < config->serverUrlsSize; ++i) {
+        UA_StatusCode retval = UA_Endpoint_init(&config->endpoints[config->endpointsSize],
+                                                &config->serverUrls[i],
+                                                pkiStore,
+                                                policy,
+                                                allowNone,
+                                                allowSign,
+                                                allowSignAndEncrypt,
+                                                config->applicationDescription,
+                                                config->accessControl.userTokenPolicies,
+                                                config->accessControl.userTokenPoliciesSize);
+        if(retval != UA_STATUSCODE_GOOD)
+            return retval;
+        config->endpointsSize++;
+    }
 
     return UA_STATUSCODE_GOOD;
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addAllEndpoints(UA_ServerConfig *config) {
-    /* Allocate the endpoints */
-    UA_EndpointDescription * tmp = (UA_EndpointDescription *)
-        UA_realloc(config->endpoints,
-                   sizeof(UA_EndpointDescription) *
-                   (2 * config->securityPoliciesSize + config->endpointsSize));
-    if(!tmp) {
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-    }
-    config->endpoints = tmp;
-
+UA_ServerConfig_addAllEndpoints(UA_ServerConfig *config, const UA_NodeId *certificateGroupId) {
     /* Populate the endpoints */
     for(size_t i = 0; i < config->securityPoliciesSize; ++i) {
         if(UA_String_equal(&UA_SECURITY_POLICY_NONE_URI, &config->securityPolicies[i].policyUri)) {
             UA_StatusCode retval =
-                createEndpoint(config, &config->endpoints[config->endpointsSize],
-                               &config->securityPolicies[i], UA_MESSAGESECURITYMODE_NONE);
+                UA_ServerConfig_addEndpoint(config,
+                                            &config->securityPolicies[i].policyUri,
+                                            certificateGroupId,
+                                            true,
+                                            false,
+                                            false);
             if(retval != UA_STATUSCODE_GOOD)
                 return retval;
             config->endpointsSize++;
         } else {
-            UA_StatusCode retval =
-                createEndpoint(config, &config->endpoints[config->endpointsSize],
-                               &config->securityPolicies[i], UA_MESSAGESECURITYMODE_SIGN);
-            if(retval != UA_STATUSCODE_GOOD)
-                return retval;
-            config->endpointsSize++;
-
-            retval = createEndpoint(config, &config->endpoints[config->endpointsSize],
-                                    &config->securityPolicies[i],
-                                    UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
-            if(retval != UA_STATUSCODE_GOOD)
-                return retval;
-            config->endpointsSize++;
+            UA_ServerConfig_addEndpoint(config,
+                                        &config->securityPolicies[i].policyUri,
+                                        certificateGroupId,
+                                        false,
+                                        true,
+                                        true);
         }
     }
 
@@ -487,15 +467,29 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     config->tcpBufSize = recvBufferSize;
 
     /* Allocate the SecurityPolicies */
-    retval = UA_ServerConfig_addSecurityPolicyNone(config, certificate);
+    retval = UA_ServerConfig_addSecurityPolicyNone(config);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(config);
         return retval;
     }
 
+    UA_NodeId certificateGroupId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTAPPLICATIONGROUP);
+    config->pkiStores = UA_malloc(sizeof(UA_PKIStore));
+    if(config->pkiStores == NULL) {
+        UA_ServerConfig_clean(config);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    retval = UA_PKIStore_File(&config->pkiStores[0], &certificateGroupId);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ServerConfig_clean(config);
+        return retval;
+    }
+    config->pkiStoresSize++;
+
     /* Initialize the Access Control plugin */
-    retval = UA_AccessControl_default(config, true, NULL,
-                                      &config->securityPolicies[config->securityPoliciesSize-1].policyUri,
+    retval = UA_AccessControl_default(config, true, NULL, NULL,
+                                      &config->securityPolicies[config->securityPoliciesSize - 1].policyUri,
                                       usernamePasswordsSize, usernamePasswords);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(config);
@@ -503,8 +497,8 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     }
 
     /* Allocate the endpoint */
-    retval = UA_ServerConfig_addEndpoint(config, UA_SECURITY_POLICY_NONE_URI,
-                                         UA_MESSAGESECURITYMODE_NONE);
+    retval = UA_ServerConfig_addEndpoint(config, &UA_SECURITY_POLICY_NONE_URI, &certificateGroupId,
+                                         true, false, false);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(config);
         return retval;
@@ -520,9 +514,7 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
 #ifdef UA_ENABLE_ENCRYPTION
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config, 
-                                               const UA_ByteString *certificate,
-                                               const UA_ByteString *privateKey) {
+UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config) {
     /* Allocate the SecurityPolicies */
     UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
         UA_realloc(config->securityPolicies,
@@ -530,17 +522,9 @@ UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config,
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
-    /* Populate the SecurityPolicies */
-    UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
-    if(certificate)
-        localCertificate = *certificate;
-    if(privateKey)
-       localPrivateKey = *privateKey;
+
     UA_StatusCode retval =
-        UA_SecurityPolicy_Basic128Rsa15(&config->securityPolicies[config->securityPoliciesSize],
-                                        localCertificate, localPrivateKey, &config->logger);
+        UA_SecurityPolicy_Basic128Rsa15(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -554,9 +538,7 @@ UA_ServerConfig_addSecurityPolicyBasic128Rsa15(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config, 
-                                          const UA_ByteString *certificate,
-                                          const UA_ByteString *privateKey) {
+UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config) {
     /* Allocate the SecurityPolicies */
     UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
         UA_realloc(config->securityPolicies,
@@ -564,17 +546,10 @@ UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config,
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
-    UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
-    if(certificate)
-        localCertificate = *certificate;
-    if(privateKey)
-       localPrivateKey = *privateKey;
     UA_StatusCode retval =
-        UA_SecurityPolicy_Basic256(&config->securityPolicies[config->securityPoliciesSize],
-                                   localCertificate, localPrivateKey, &config->logger);
+        UA_SecurityPolicy_Basic256(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -588,9 +563,7 @@ UA_ServerConfig_addSecurityPolicyBasic256(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config, 
-                                                const UA_ByteString *certificate,
-                                                const UA_ByteString *privateKey) {
+UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config) {
     /* Allocate the SecurityPolicies */
     UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
         UA_realloc(config->securityPolicies,
@@ -598,17 +571,10 @@ UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config,
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
-    UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
-    if(certificate)
-        localCertificate = *certificate;
-    if(privateKey)
-       localPrivateKey = *privateKey;
     UA_StatusCode retval =
-        UA_SecurityPolicy_Basic256Sha256(&config->securityPolicies[config->securityPoliciesSize],
-                                         localCertificate, localPrivateKey, &config->logger);
+        UA_SecurityPolicy_Basic256Sha256(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -622,9 +588,7 @@ UA_ServerConfig_addSecurityPolicyBasic256Sha256(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config, 
-                                                const UA_ByteString *certificate,
-                                                const UA_ByteString *privateKey) {
+UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config) {
     /* Allocate the SecurityPolicies */
     UA_SecurityPolicy *tmp = (UA_SecurityPolicy *)
         UA_realloc(config->securityPolicies,
@@ -632,17 +596,10 @@ UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config,
     if(!tmp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = tmp;
-    
+
     /* Populate the SecurityPolicies */
-    UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
-    if(certificate)
-        localCertificate = *certificate;
-    if(privateKey)
-       localPrivateKey = *privateKey;
     UA_StatusCode retval =
-        UA_SecurityPolicy_Aes128Sha256RsaOaep(&config->securityPolicies[config->securityPoliciesSize],
-                                              localCertificate, localPrivateKey, &config->logger);
+        UA_SecurityPolicy_Aes128Sha256RsaOaep(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         if(config->securityPoliciesSize == 0) {
             UA_free(config->securityPolicies);
@@ -657,46 +614,37 @@ UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config,
 
 /* Always returns UA_STATUSCODE_GOOD. Logs a warning if policies could not be added. */
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config,
-                                       const UA_ByteString *certificate,
-                                       const UA_ByteString *privateKey) {
+UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config) {
     /* Populate the SecurityPolicies */
-    UA_ByteString localCertificate = UA_BYTESTRING_NULL;
-    UA_ByteString localPrivateKey  = UA_BYTESTRING_NULL;
-    if(certificate)
-        localCertificate = *certificate;
-    if(privateKey)
-       localPrivateKey = *privateKey;
-
-    UA_StatusCode retval = UA_ServerConfig_addSecurityPolicyNone(config, &localCertificate);
+    UA_StatusCode retval = UA_ServerConfig_addSecurityPolicyNone(config);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#None with error code %s",
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_ServerConfig_addSecurityPolicyBasic128Rsa15(config, &localCertificate, &localPrivateKey);
+    retval = UA_ServerConfig_addSecurityPolicyBasic128Rsa15(config);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#Basic128Rsa15 with error code %s",
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_ServerConfig_addSecurityPolicyBasic256(config, &localCertificate, &localPrivateKey);
+    retval = UA_ServerConfig_addSecurityPolicyBasic256(config);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#Basic256 with error code %s",
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_ServerConfig_addSecurityPolicyBasic256Sha256(config, &localCertificate, &localPrivateKey);
+    retval = UA_ServerConfig_addSecurityPolicyBasic256Sha256(config);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#Basic256Sha256 with error code %s",
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(config, &localCertificate, &localPrivateKey);
+    retval = UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(config);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                        "Could not add SecurityPolicy#Aes128Sha256RsaOaep with error code %s",
@@ -707,49 +655,39 @@ UA_ServerConfig_addAllSecurityPolicies(UA_ServerConfig *config,
 }
 
 UA_EXPORT UA_StatusCode
-UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
-                                               UA_UInt16 portNumber,
-                                               const UA_ByteString *certificate,
-                                               const UA_ByteString *privateKey,
-                                               const UA_ByteString *trustList,
-                                               size_t trustListSize,
-                                               const UA_ByteString *issuerList,
-                                               size_t issuerListSize,
-                                               const UA_ByteString *revocationList,
-                                               size_t revocationListSize) {
+UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf, UA_UInt16 portNumber,
+                                               const UA_ByteString *pkiDir) {
     UA_StatusCode retval = setDefaultConfig(conf, portNumber);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;
     }
 
-    retval = UA_CertificateVerification_Trustlist(&conf->certificateVerification,
-                                                  trustList, trustListSize,
-                                                  issuerList, issuerListSize,
-                                                  revocationList, revocationListSize);
-    if (retval != UA_STATUSCODE_GOOD)
+    conf->pkiStores = UA_malloc(sizeof(UA_PKIStore));
+
+    retval = UA_PKIStore_File(&conf->pkiStores[conf->pkiStoresSize++], NULL);
+    if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
-    retval = UA_ServerConfig_addAllSecurityPolicies(conf, certificate, privateKey);
+    retval = UA_CertificateManager_Trustlist(&conf->certificateManager);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    retval = UA_ServerConfig_addAllSecurityPolicies(conf);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;
     }
 
-    UA_CertificateVerification accessControlVerification;
-    retval = UA_CertificateVerification_Trustlist(&accessControlVerification,
-                                                  trustList, trustListSize,
-                                                  issuerList, issuerListSize,
-                                                  revocationList, revocationListSize);
-    retval |= UA_AccessControl_default(conf, true, &accessControlVerification,
-                &conf->securityPolicies[conf->securityPoliciesSize-1].policyUri,
-                usernamePasswordsSize, usernamePasswords);
+    retval |= UA_AccessControl_default(conf, true, &conf->certificateManager, &conf->pkiStores[0],
+                                       &conf->securityPolicies[conf->securityPoliciesSize - 1].policyUri,
+                                       usernamePasswordsSize, usernamePasswords);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;
     }
 
-    retval = UA_ServerConfig_addAllEndpoints(conf);
+    retval = UA_ServerConfig_addAllEndpoints(conf, NULL);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;
@@ -810,7 +748,7 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
 
     /* Certificate Verification that accepts every certificate. Can be
      * overwritten when the policy is specialized. */
-    UA_CertificateVerification_AcceptAll(&config->certificateVerification);
+    UA_CertificateManager_AcceptAll(&config->certificateManager);
     UA_LOG_WARNING(&config->logger, UA_LOGCATEGORY_USERLAND,
                    "AcceptAll Certificate Verification. "
                    "Any remote certificate will be accepted.");
@@ -829,8 +767,7 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     config->securityPolicies = (UA_SecurityPolicy*)UA_malloc(sizeof(UA_SecurityPolicy));
     if(!config->securityPolicies)
         return UA_STATUSCODE_BADOUTOFMEMORY;
-    UA_StatusCode retval = UA_SecurityPolicy_None(config->securityPolicies,
-                                                  UA_BYTESTRING_NULL, &config->logger);
+    UA_StatusCode retval = UA_SecurityPolicy_None(config->securityPolicies, &config->logger);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_free(config->securityPolicies);
         config->securityPolicies = NULL;
@@ -868,22 +805,18 @@ UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
-    retval = UA_CertificateVerification_Trustlist(&config->certificateVerification,
-                                                  trustList, trustListSize,
-                                                  NULL, 0,
-                                                  revocationList, revocationListSize);
+    retval = UA_CertificateManager_Trustlist(&config->certificateManager);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
     /* Populate SecurityPolicies */
-    UA_SecurityPolicy *sp = (UA_SecurityPolicy*)
+    UA_SecurityPolicy *sp = (UA_SecurityPolicy *)
         UA_realloc(config->securityPolicies, sizeof(UA_SecurityPolicy) * 5);
     if(!sp)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     config->securityPolicies = sp;
-                  
-    retval = UA_SecurityPolicy_Basic128Rsa15(&config->securityPolicies[config->securityPoliciesSize],
-                                             localCertificate, privateKey, &config->logger);
+
+    retval = UA_SecurityPolicy_Basic128Rsa15(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval == UA_STATUSCODE_GOOD) {
         ++config->securityPoliciesSize;
     } else {
@@ -892,8 +825,7 @@ UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_SecurityPolicy_Basic256(&config->securityPolicies[config->securityPoliciesSize],
-                                        localCertificate, privateKey, &config->logger);
+    retval = UA_SecurityPolicy_Basic256(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval == UA_STATUSCODE_GOOD) {
         ++config->securityPoliciesSize;
     } else {
@@ -902,8 +834,7 @@ UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
                        UA_StatusCode_name(retval));
     }
 
-    retval = UA_SecurityPolicy_Basic256Sha256(&config->securityPolicies[config->securityPoliciesSize],
-                                              localCertificate, privateKey, &config->logger);
+    retval = UA_SecurityPolicy_Basic256Sha256(&config->securityPolicies[config->securityPoliciesSize], &config->logger);
     if(retval == UA_STATUSCODE_GOOD) {
         ++config->securityPoliciesSize;
     } else {
@@ -913,7 +844,7 @@ UA_ClientConfig_setDefaultEncryption(UA_ClientConfig *config,
     }
 
     retval = UA_SecurityPolicy_Aes128Sha256RsaOaep(&config->securityPolicies[config->securityPoliciesSize],
-                                                   localCertificate, privateKey, &config->logger);
+                                                   &config->logger);
     if(retval == UA_STATUSCODE_GOOD) {
         ++config->securityPoliciesSize;
     } else {

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -59,8 +59,8 @@ UA_ClientConfig_clear(UA_ClientConfig *config) {
     UA_EndpointDescription_clear(&config->endpoint);
     UA_UserTokenPolicy_clear(&config->userTokenPolicy);
 
-    if(config->certificateVerification.clear)
-        config->certificateVerification.clear(&config->certificateVerification);
+    if(config->certificateManager.clear)
+        config->certificateManager.clear(&config->certificateManager);
 
     /* Delete the SecurityPolicies */
     if(config->securityPolicies == 0)

--- a/src/server/endpoint.c
+++ b/src/server/endpoint.c
@@ -1,0 +1,108 @@
+//
+// Created by mark on 10.05.22.
+//
+
+#include <open62541/endpoint.h>
+#include <open62541/plugin/securitypolicy.h>
+#include "ua_util_internal.h"
+
+typedef struct EndpointContext {
+    UA_EndpointDescription endpointDescription;
+} EndpointContext;
+
+UA_StatusCode
+UA_Endpoint_init(UA_Endpoint *endpoint,
+                 const UA_String *endpointUrl,
+                 UA_PKIStore *pkiStore,
+                 UA_SecurityPolicy *securityPolicy,
+                 UA_Boolean allowNone,
+                 UA_Boolean allowSign,
+                 UA_Boolean allowSignAndEncrypt,
+                 UA_ApplicationDescription applicationDescription,
+                 UA_UserTokenPolicy *userTokenPolicies,
+                 size_t userTokenPoliciesSize) {
+    if(endpoint == NULL || endpointUrl == NULL || pkiStore == NULL || securityPolicy == NULL) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
+    endpoint->pkiStore = pkiStore;
+    endpoint->securityPolicy = securityPolicy;
+    endpoint->allowNone = allowNone;
+    endpoint->allowSign = allowSign;
+    endpoint->allowSignAndEncrypt = allowSignAndEncrypt;
+    UA_String_copy(endpointUrl, &endpoint->endpointUrl);
+    endpoint->context = UA_malloc(sizeof(EndpointContext));
+    if(endpoint->context == NULL) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    EndpointContext *context = (EndpointContext *)endpoint->context;
+    UA_EndpointDescription *endpointDescription = &context->endpointDescription;
+    UA_EndpointDescription_init(endpointDescription);
+
+    endpointDescription->securityMode = UA_MESSAGESECURITYMODE_INVALID;
+    UA_String_copy(&securityPolicy->policyUri, &endpointDescription->securityPolicyUri);
+    endpointDescription->transportProfileUri =
+        UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
+
+    /* Add security level value for the corresponding message security mode */
+    endpointDescription->securityLevel = (UA_Byte)UA_MESSAGESECURITYMODE_INVALID;
+
+    /* Enable all login mechanisms from the access control plugin  */
+    UA_StatusCode retval = UA_Array_copy(userTokenPolicies,
+                                         userTokenPoliciesSize,
+                                         (void **)&endpointDescription->userIdentityTokens,
+                                         &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_String_clear(&endpointDescription->securityPolicyUri);
+        UA_String_clear(&endpointDescription->transportProfileUri);
+        return retval;
+    }
+    endpointDescription->userIdentityTokensSize = userTokenPoliciesSize;
+
+    return UA_ApplicationDescription_copy(&applicationDescription, &endpointDescription->server);
+}
+
+UA_StatusCode
+UA_Endpoint_toEndpointDescription(const UA_Endpoint *endpoint,
+                                  UA_EndpointDescription *endpointDescription,
+                                  UA_MessageSecurityMode securityMode) {
+    EndpointContext *context = (EndpointContext *)endpoint->context;
+    switch(securityMode) {
+    case UA_MESSAGESECURITYMODE_NONE:
+        if(!endpoint->allowNone) return UA_STATUSCODE_BADINTERNALERROR;
+        break;
+    case UA_MESSAGESECURITYMODE_SIGN:
+        if(!endpoint->allowSign) return UA_STATUSCODE_BADINTERNALERROR;
+        break;
+    case UA_MESSAGESECURITYMODE_SIGNANDENCRYPT:
+        if(!endpoint->allowSignAndEncrypt) return UA_STATUSCODE_BADINTERNALERROR;
+        break;
+    default:
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    UA_StatusCode retval = UA_EndpointDescription_copy(&context->endpointDescription, endpointDescription);
+    UA_CHECK_STATUS(retval, return retval);
+    endpointDescription->securityMode = securityMode;
+    endpointDescription->securityLevel = (UA_Byte)securityMode;
+    retval = UA_String_copy(&endpoint->endpointUrl, &endpointDescription->endpointUrl);
+    UA_CHECK_STATUS(retval, return retval);
+    retval = endpoint->securityPolicy->getLocalCertificate(endpoint->securityPolicy,
+                                                           endpoint->pkiStore,
+                                                           &endpointDescription->serverCertificate);
+    return retval;
+}
+
+void
+UA_Endpoint_clear(UA_Endpoint *endpoint) {
+    EndpointContext *context = (EndpointContext *)endpoint->context;
+    UA_String_clear(&endpoint->endpointUrl);
+    UA_EndpointDescription_clear(&context->endpointDescription);
+    UA_free(context);
+}
+
+UA_StatusCode
+UA_Endpoint_updateApplicationDescription(UA_Endpoint *endpoint,
+                                         const UA_ApplicationDescription *applicationDescription) {
+    EndpointContext *context = (EndpointContext *)endpoint->context;
+    UA_ApplicationDescription_clear(&context->endpointDescription.server);
+    return UA_ApplicationDescription_copy(applicationDescription, &context->endpointDescription.server);
+}

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -55,22 +55,20 @@ UA_ServerConfig_clean(UA_ServerConfig *config) {
     config->securityPolicies = NULL;
     config->securityPoliciesSize = 0;
 
-    for(size_t i = 0; i < config->endpointsSize; ++i)
-        UA_EndpointDescription_clear(&config->endpoints[i]);
+    if(config->endpoints != NULL) {
+        for(size_t i = 0; i < config->endpointsSize; ++i)
+            UA_Endpoint_clear(&config->endpoints[i]);
 
-    UA_free(config->endpoints);
-    config->endpoints = NULL;
-    config->endpointsSize = 0;
+        UA_free(config->endpoints);
+        config->endpoints = NULL;
+        config->endpointsSize = 0;
+    }
 
     /* Nodestore */
     if(config->nodestore.context && config->nodestore.clear) {
         config->nodestore.clear(config->nodestore.context);
         config->nodestore.context = NULL;
     }
-
-    /* Certificate Validation */
-    if(config->certificateVerification.clear)
-        config->certificateVerification.clear(&config->certificateVerification);
 
     /* Access Control */
     if(config->accessControl.clear)
@@ -81,6 +79,20 @@ UA_ServerConfig_clean(UA_ServerConfig *config) {
     if(config->historyDatabase.clear)
         config->historyDatabase.clear(&config->historyDatabase);
 #endif
+
+    /* Certificate Validation */
+    if(config->certificateManager.clear)
+        config->certificateManager.clear(&config->certificateManager);
+
+    if(config->pkiStores != NULL) {
+        for(size_t i = 0; i < config->pkiStoresSize; ++i) {
+            if(config->pkiStores[i].clear)
+                config->pkiStores[i].clear(&config->pkiStores[i]);
+        }
+        UA_free(config->pkiStores);
+        config->pkiStores = NULL;
+        config->pkiStoresSize = 0;
+    }
 
     /* Logger */
     if(config->logger.clear)

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -182,7 +182,7 @@ signCreateSessionResponse(UA_Server *server, UA_SecureChannel *channel,
        channel->securityMode != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
         return UA_STATUSCODE_GOOD;
 
-    const UA_SecurityPolicy *securityPolicy = channel->securityPolicy;
+    const UA_SecurityPolicy *securityPolicy = channel->endpoint->securityPolicy;
     UA_SignatureData *signatureData = &response->serverSignature;
 
     /* Prepare the signature */
@@ -269,7 +269,7 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
          * first certificate of each chain. The end certificate shall be located
          * first in the chain according to the OPC UA specification Part 6 (1.04),
          * chapter 6.2.3.*/
-        UA_StatusCode retval = channel->securityPolicy->channelModule.
+        UA_StatusCode retval = channel->endpoint->securityPolicy->channelModule.
             compareCertificate(channel->channelContext, &request->clientCertificate);
         if(retval != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
@@ -281,7 +281,7 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
 
     UA_assert(channel->securityToken.channelId != 0);
 
-    if(!UA_ByteString_equal(&channel->securityPolicy->policyUri,
+    if(!UA_ByteString_equal(&channel->endpoint->securityPolicy->policyUri,
                             &UA_SECURITY_POLICY_NONE_URI) &&
        request->clientNonce.length < 32) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADNONCEINVALID;
@@ -289,9 +289,9 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
     }
 
     if(request->clientCertificate.length > 0) {
-        UA_CertificateVerification *cv = &server->config.certificateVerification;
+        UA_CertificateManager *cm = &server->config.certificateManager;
         response->responseHeader.serviceResult =
-            cv->verifyApplicationURI(cv->context, &request->clientCertificate,
+            cm->verifyApplicationURI(cm->context, channel->endpoint->pkiStore, &request->clientCertificate,
                                      &request->clientDescription.applicationUri);
         if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,
@@ -315,25 +315,52 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
     UA_assert(newSession != NULL);
 
     /* Allocate the response */
+    size_t endpointDescriptionsSize = 0;
+    for(size_t i = 0; i < server->config.endpointsSize; ++i) {
+        if(server->config.endpoints[i].allowNone) {
+            endpointDescriptionsSize++;
+        }
+        if(server->config.endpoints[i].allowSign) {
+            endpointDescriptionsSize++;
+        }
+        if(server->config.endpoints[i].allowSignAndEncrypt) {
+            endpointDescriptionsSize++;
+        }
+    }
     response->serverEndpoints = (UA_EndpointDescription *)
-        UA_Array_new(server->config.endpointsSize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
+        UA_Array_new(endpointDescriptionsSize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
     if(!response->serverEndpoints) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADOUTOFMEMORY;
-        UA_Server_removeSessionByToken(server, &newSession->header.authenticationToken,
-                                       UA_DIAGNOSTICEVENT_REJECT);
-        return;
+        goto error;
     }
-    response->serverEndpointsSize = server->config.endpointsSize;
-
+    response->serverEndpointsSize = endpointDescriptionsSize;
+    endpointDescriptionsSize = 0;
     /* Copy the server's endpointdescriptions into the response */
-    for(size_t i = 0; i < server->config.endpointsSize; ++i)
-        response->responseHeader.serviceResult |=
-            UA_EndpointDescription_copy(&server->config.endpoints[i],
-                                        &response->serverEndpoints[i]);
+    for(size_t i = 0;
+        i < server->config.endpointsSize && endpointDescriptionsSize < response->serverEndpointsSize;
+        ++i) {
+        UA_Endpoint *endpoint = &server->config.endpoints[i];
+        if(endpoint->allowNone) {
+            response->responseHeader.serviceResult |=
+                UA_Endpoint_toEndpointDescription(endpoint,
+                                                  &response->serverEndpoints[endpointDescriptionsSize++],
+                                                  UA_MESSAGESECURITYMODE_NONE);
+        }
+        if(endpoint->allowSign) {
+            response->responseHeader.serviceResult |=
+                UA_Endpoint_toEndpointDescription(endpoint,
+                                                  &response->serverEndpoints[endpointDescriptionsSize++],
+                                                  UA_MESSAGESECURITYMODE_SIGN);
+        }
+        if(endpoint->allowSignAndEncrypt) {
+            response->responseHeader.serviceResult |=
+                UA_Endpoint_toEndpointDescription(endpoint,
+                                                  &response->serverEndpoints[endpointDescriptionsSize++],
+                                                  UA_MESSAGESECURITYMODE_SIGNANDENCRYPT);
+        }
+    }
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-        UA_Server_removeSessionByToken(server, &newSession->header.authenticationToken,
-                                       UA_DIAGNOSTICEVENT_REJECT);
-        return;
+        goto error;
     }
 
     /* Mirror back the endpointUrl */
@@ -367,19 +394,13 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
 
     UA_ByteString_init(&response->serverCertificate);
 
-    if(server->config.endpointsSize > 0)
-       for(size_t i = 0; i < response->serverEndpointsSize; ++i) {
-          if(response->serverEndpoints[i].securityMode==channel->securityMode &&
-             UA_ByteString_equal(&response->serverEndpoints[i].securityPolicyUri,
-                                 &channel->securityPolicy->policyUri) &&
-             UA_String_equal(&response->serverEndpoints[i].endpointUrl,
-                             &request->endpointUrl))
-          {
-             response->responseHeader.serviceResult |=
-                 UA_ByteString_copy(&response->serverEndpoints[i].serverCertificate,
-                                    &response->serverCertificate);
-          }
-       }
+    response->responseHeader.serviceResult =
+        channel->endpoint->securityPolicy->getLocalCertificate(channel->endpoint->securityPolicy,
+                                                               channel->endpoint->pkiStore,
+                                                               &response->serverCertificate);
+    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
 
     /* Create a session nonce */
     response->responseHeader.serviceResult |= UA_Session_generateNonce(newSession);
@@ -388,52 +409,61 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
 
     /* Sign the signature */
     response->responseHeader.serviceResult |=
-       signCreateSessionResponse(server, channel, request, response);
+        signCreateSessionResponse(server, channel, request, response);
 
     /* Failure -> remove the session */
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-        UA_Server_removeSessionByToken(server, &newSession->header.authenticationToken,
-                                       UA_DIAGNOSTICEVENT_REJECT);
-        return;
+        goto error;
     }
 
 #ifdef UA_ENABLE_DIAGNOSTICS
-    newSession->diagnostics.clientConnectionTime = UA_DateTime_now();
-    newSession->diagnostics.clientLastContactTime =
-        newSession->diagnostics.clientConnectionTime;
+        newSession->diagnostics.clientConnectionTime = UA_DateTime_now();
+        newSession->diagnostics.clientLastContactTime =
+            newSession->diagnostics.clientConnectionTime;
 
-    /* Create the object in the information model */
-    createSessionObject(server, newSession);
+        /* Create the object in the information model */
+        createSessionObject(server, newSession);
 #endif
 
     UA_LOG_INFO_SESSION(&server->config.logger, newSession, "Session created");
+    return;
+
+error:
+    UA_Server_removeSessionByToken(server, &newSession->header.authenticationToken,
+                                   UA_DIAGNOSTICEVENT_REJECT);
 }
 
 static UA_StatusCode
-checkSignature(const UA_Server *server, const UA_SecurityPolicy *securityPolicy,
+checkSignature(const UA_Server *server, const UA_Endpoint *endpoint,
                void *channelContext, const UA_ByteString *serverNonce,
                const UA_SignatureData *signature) {
     /* Check for zero signature length */
     if(signature->signature.length == 0)
         return UA_STATUSCODE_BADAPPLICATIONSIGNATUREINVALID;
 
-    if(!securityPolicy)
+    if(!endpoint)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    const UA_ByteString *localCertificate = &securityPolicy->localCertificate;
+    const UA_SecurityPolicy *const securityPolicy = endpoint->securityPolicy;
+    UA_PKIStore *const pkiStore = endpoint->pkiStore;
+    UA_ByteString localCertificate;
+    UA_StatusCode retval = securityPolicy->getLocalCertificate(securityPolicy, pkiStore, &localCertificate);
+    if(!UA_StatusCode_isGood(retval))
+        return retval;
     /* Data to verify is calculated by appending the serverNonce to the local certificate */
     UA_ByteString dataToVerify;
-    size_t dataToVerifySize = localCertificate->length + serverNonce->length;
-    UA_StatusCode retval = UA_ByteString_allocBuffer(&dataToVerify, dataToVerifySize);
+    size_t dataToVerifySize = localCertificate.length + serverNonce->length;
+    retval = UA_ByteString_allocBuffer(&dataToVerify, dataToVerifySize);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
-    memcpy(dataToVerify.data, localCertificate->data, localCertificate->length);
-    memcpy(dataToVerify.data + localCertificate->length,
+    memcpy(dataToVerify.data, localCertificate.data, localCertificate.length);
+    memcpy(dataToVerify.data + localCertificate.length,
            serverNonce->data, serverNonce->length);
     retval = securityPolicy->certificateSigningAlgorithm.
         verify(channelContext, &dataToVerify, &signature->signature);
     UA_ByteString_clear(&dataToVerify);
+    UA_ByteString_clear(&localCertificate);
     return retval;
 }
 
@@ -499,68 +529,70 @@ decryptPassword(UA_SecurityPolicy *securityPolicy, void *tempChannelContext,
 #endif
 
 static void
-selectEndpointAndTokenPolicy(UA_Server *server, UA_SecureChannel *channel,
-                             const UA_ExtensionObject *identityToken,
-                             const UA_EndpointDescription **ed,
-                             const UA_UserTokenPolicy **utp) {
-    for(size_t i = 0; i < server->config.endpointsSize; ++i) {
-        const UA_EndpointDescription *desc = &server->config.endpoints[i];
+selectTokenPolicy(UA_SecureChannel *channel,
+                  const UA_ExtensionObject *identityToken,
+                  UA_UserTokenPolicy **utp) {
+    const UA_UserTokenPolicy *pol = NULL;
+    UA_EndpointDescription desc;
+    UA_EndpointDescription_init(&desc);
+    UA_StatusCode retval = UA_Endpoint_toEndpointDescription(channel->endpoint, &desc, channel->securityMode);
+    if(retval != UA_STATUSCODE_GOOD){
+        return;
+    }
+    /* Match the UserTokenType */
+    const UA_DataType *tokenDataType = identityToken->content.decoded.type;
+    for(size_t j = 0; j < desc.userIdentityTokensSize; j++) {
+        pol = &desc.userIdentityTokens[j];
 
-        /* Match the Security Mode */
-        if(desc->securityMode != channel->securityMode)
+        /* Part 4, Section 5.6.3.2, Table 17: A NULL or empty
+         * UserIdentityToken should be treated as Anonymous */
+        if(identityToken->encoding == UA_EXTENSIONOBJECT_ENCODED_NOBODY &&
+           pol->tokenType == UA_USERTOKENTYPE_ANONYMOUS) {
+            goto out;
+        }
+
+        /* Expect decoded content */
+        if(!tokenDataType)
             continue;
 
-        /* Match the SecurityPolicy of the endpoint with the current channel */
-        if(!UA_String_equal(&desc->securityPolicyUri, &channel->securityPolicy->policyUri))
+        if(pol->tokenType == UA_USERTOKENTYPE_ANONYMOUS) {
+            if(tokenDataType != &UA_TYPES[UA_TYPES_ANONYMOUSIDENTITYTOKEN])
+                continue;
+        } else if(pol->tokenType == UA_USERTOKENTYPE_USERNAME) {
+            if(tokenDataType != &UA_TYPES[UA_TYPES_USERNAMEIDENTITYTOKEN])
+                continue;
+        } else if(pol->tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
+            if(tokenDataType != &UA_TYPES[UA_TYPES_X509IDENTITYTOKEN])
+                continue;
+        } else if(pol->tokenType == UA_USERTOKENTYPE_ISSUEDTOKEN) {
+            if(tokenDataType != &UA_TYPES[UA_TYPES_ISSUEDIDENTITYTOKEN])
+                continue;
+        } else {
+            continue;
+        }
+
+        /* All valid token data types start with a string policyId */
+        UA_AnonymousIdentityToken *token = (UA_AnonymousIdentityToken*)
+            identityToken->content.decoded.data;
+
+        if(!UA_String_equal(&pol->policyId, &token->policyId))
             continue;
 
-        /* Match the UserTokenType */
-        const UA_DataType *tokenDataType = identityToken->content.decoded.type;
-        for(size_t j = 0; j < desc->userIdentityTokensSize; j++) {
-            const UA_UserTokenPolicy *pol = &desc->userIdentityTokens[j];
-
-            /* Part 4, Section 5.6.3.2, Table 17: A NULL or empty
-             * UserIdentityToken should be treated as Anonymous */
-            if(identityToken->encoding == UA_EXTENSIONOBJECT_ENCODED_NOBODY &&
-               pol->tokenType == UA_USERTOKENTYPE_ANONYMOUS) {
-                *ed = desc;
-                *utp = pol;
-                return;
-            }
-
-            /* Expect decoded content */
-            if(!tokenDataType)
-                continue;
-
-            if(pol->tokenType == UA_USERTOKENTYPE_ANONYMOUS) {
-                if(tokenDataType != &UA_TYPES[UA_TYPES_ANONYMOUSIDENTITYTOKEN])
-                    continue;
-            } else if(pol->tokenType == UA_USERTOKENTYPE_USERNAME) {
-                if(tokenDataType != &UA_TYPES[UA_TYPES_USERNAMEIDENTITYTOKEN])
-                    continue;
-            } else if(pol->tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
-                if(tokenDataType != &UA_TYPES[UA_TYPES_X509IDENTITYTOKEN])
-                    continue;
-            } else if(pol->tokenType == UA_USERTOKENTYPE_ISSUEDTOKEN) {
-                if(tokenDataType != &UA_TYPES[UA_TYPES_ISSUEDIDENTITYTOKEN])
-                    continue;
-            } else {
-                continue;
-            }
-
-            /* All valid token data types start with a string policyId */
-            UA_AnonymousIdentityToken *token = (UA_AnonymousIdentityToken*)
-                identityToken->content.decoded.data;
-
-            if(!UA_String_equal(&pol->policyId, &token->policyId))
-                continue;
-
-            /* Match found */
-            *ed = desc;
-            *utp = pol;
-            return;
+        /* Match found */
+        goto out;
+    }
+    UA_EndpointDescription_clear(&desc);
+    return;
+out:
+    *utp = UA_UserTokenPolicy_new();
+    if(*utp != NULL) {
+        retval = UA_UserTokenPolicy_copy(pol, *utp);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_UserTokenPolicy_delete(*utp);
+            *utp = NULL;
         }
     }
+    UA_EndpointDescription_clear(&desc);
 }
 
 #ifdef UA_ENABLE_DIAGNOSTICS
@@ -611,8 +643,6 @@ void
 Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
                         const UA_ActivateSessionRequest *request,
                         UA_ActivateSessionResponse *response) {
-    const UA_EndpointDescription *ed = NULL;
-    const UA_UserTokenPolicy *utp = NULL;
     UA_String *tmpLocaleIds;
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
@@ -649,7 +679,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
     if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGN ||
        channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT) {
         response->responseHeader.serviceResult =
-            checkSignature(server, channel->securityPolicy, channel->channelContext,
+            checkSignature(server, channel->endpoint, channel->channelContext,
                            &session->serverNonce, &request->clientSignature);
         if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING_SESSION(&server->config.logger, session,
@@ -659,29 +689,30 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         }
     }
 
-    /* Find the matching Endpoint with UserTokenPolicy */
-    selectEndpointAndTokenPolicy(server, channel, &request->userIdentityToken, &ed, &utp);
-    if(!ed) {
+    /* Find the matching UserTokenPolicy */
+    UA_UserTokenPolicy *utp = NULL;
+    selectTokenPolicy(channel, &request->userIdentityToken, &utp);
+    if(!utp) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADIDENTITYTOKENINVALID;
         goto rejected;
     }
 
     /* If it is a UserNameIdentityToken, the password may be encrypted */
     if(utp->tokenType == UA_USERTOKENTYPE_USERNAME) {
-       UA_UserNameIdentityToken *userToken = (UA_UserNameIdentityToken *)
-           request->userIdentityToken.content.decoded.data;
+        UA_UserNameIdentityToken *userToken = (UA_UserNameIdentityToken *)
+            request->userIdentityToken.content.decoded.data;
 
-       /* If the userTokenPolicy doesn't specify a security policy the security
-        * policy of the secure channel is used. */
-       UA_SecurityPolicy* securityPolicy;
-       if(!utp->securityPolicyUri.data)
-           securityPolicy = getSecurityPolicyByUri(server, &ed->securityPolicyUri);
-       else
-           securityPolicy = getSecurityPolicyByUri(server, &utp->securityPolicyUri);
-       if(!securityPolicy) {
-          response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
-          goto securityRejected;
-       }
+        /* If the userTokenPolicy doesn't specify a security policy the security
+         * policy of the secure channel is used. */
+        UA_SecurityPolicy *securityPolicy;
+        if(!utp->securityPolicyUri.data)
+            securityPolicy = channel->endpoint->securityPolicy;
+        else
+            securityPolicy = getSecurityPolicyByUri(server, &utp->securityPolicyUri);
+        if(!securityPolicy) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
+            goto securityRejected;
+        }
 
        /* Test if the encryption algorithm is correctly specified */
        if(!UA_String_equal(&userToken->encryptionAlgorithm,
@@ -696,20 +727,22 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
            /* Create a temporary channel context if a different SecurityPolicy is
             * used for the password from the SecureChannel */
            void *tempChannelContext = channel->channelContext;
-           if(securityPolicy != channel->securityPolicy) {
+           if(securityPolicy != channel->endpoint->securityPolicy) {
                /* We use our own certificate to create a temporary channel
                 * context. Because the client does not provide one in a #None
                 * SecureChannel. We should not need a ChannelContext at all for
                 * asymmetric decryption where the remote certificate is not
                 * used. */
                UA_UNLOCK(&server->serviceMutex);
+               UA_ByteString localCertificate;
+               UA_ByteString_init(&localCertificate);
+               securityPolicy->getLocalCertificate(securityPolicy, channel->endpoint->pkiStore, &localCertificate);
                response->responseHeader.serviceResult = securityPolicy->channelModule.
-                   newContext(securityPolicy, &securityPolicy->localCertificate,
-                              &tempChannelContext);
+                   newContext(securityPolicy, channel->endpoint->pkiStore, &localCertificate, &tempChannelContext);
                UA_LOCK(&server->serviceMutex);
                if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-                   UA_LOG_WARNING_SESSION(&server->config.logger, session, "ActivateSession: "
-                                          "Failed to create a context for the SecurityPolicy %.*s",
+                   UA_LOG_WARNING_SESSION(&server->config.logger, session,
+                                          "ActivateSession: Failed to create a context for the SecurityPolicy %.*s",
                                           (int)securityPolicy->policyUri.length,
                                           securityPolicy->policyUri.data);
                    goto securityRejected;
@@ -721,7 +754,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
                decryptPassword(securityPolicy, tempChannelContext, &session->serverNonce, userToken);
 
            /* Remove the temporary channel context */
-           if(securityPolicy != channel->securityPolicy) {
+           if(securityPolicy != channel->endpoint->securityPolicy) {
                UA_UNLOCK(&server->serviceMutex);
                securityPolicy->channelModule.deleteContext(tempChannelContext);
                UA_LOCK(&server->serviceMutex);
@@ -755,7 +788,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
          * policy of the secure channel is used. */
         UA_SecurityPolicy* securityPolicy;
         if(!utp->securityPolicyUri.data)
-            securityPolicy = getSecurityPolicyByUri(server, &ed->securityPolicyUri);
+            securityPolicy = channel->endpoint->securityPolicy;
         else
             securityPolicy = getSecurityPolicyByUri(server, &utp->securityPolicyUri);
         if(!securityPolicy) {
@@ -768,7 +801,10 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         void *tempChannelContext;
         UA_UNLOCK(&server->serviceMutex);
         response->responseHeader.serviceResult = securityPolicy->channelModule.
-            newContext(securityPolicy, &userCertToken->certificateData, &tempChannelContext);
+            newContext(securityPolicy,
+                       channel->endpoint->pkiStore,
+                       &userCertToken->certificateData,
+                       &tempChannelContext);
         UA_LOCK(&server->serviceMutex);
         if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING_SESSION(&server->config.logger, session, "ActivateSession: "
@@ -780,7 +816,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
 
         /* Check the user token signature */
         response->responseHeader.serviceResult =
-            checkSignature(server, channel->securityPolicy, tempChannelContext,
+            checkSignature(server, channel->endpoint, tempChannelContext,
                            &session->serverNonce, &request->userTokenSignature);
 
         /* Delete the temporary channel context */
@@ -789,8 +825,8 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         UA_LOCK(&server->serviceMutex);
         if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING_SESSION(&server->config.logger, session,
-                "ActivateSession: User token signature check failed with StatusCode %s",
-                UA_StatusCode_name(response->responseHeader.serviceResult));
+                                   "ActivateSession: User token signature check failed with StatusCode %s",
+                                   UA_StatusCode_name(response->responseHeader.serviceResult));
             goto securityRejected;
         }
     }
@@ -798,13 +834,25 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
 
     /* Callback into userland access control */
     UA_UNLOCK(&server->serviceMutex);
+    UA_EndpointDescription ed;
+    UA_EndpointDescription_init(&ed);
+    response->responseHeader.serviceResult = UA_Endpoint_toEndpointDescription(channel->endpoint,
+                                                                               &ed,
+                                                                               channel->securityMode);
+    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+        UA_LOG_WARNING_SESSION(&server->config.logger, session,
+                               "ActivateSession: Error while creating the endpoint description: %s",
+                               UA_StatusCode_name(response->responseHeader.serviceResult));
+        goto securityRejected;
+    }
     response->responseHeader.serviceResult = server->config.accessControl.
-        activateSession(server, &server->config.accessControl, ed, &channel->remoteCertificate,
+        activateSession(server, &server->config.accessControl, &ed, &channel->remoteCertificate,
                         &session->sessionId, &request->userIdentityToken, &session->sessionHandle);
+    UA_EndpointDescription_clear(&ed);
     UA_LOCK(&server->serviceMutex);
     if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING_SESSION(&server->config.logger, session, "ActivateSession: The AccessControl "
-                               "plugin denied the activation with the StatusCode %s",
+                                                                "plugin denied the activation with the StatusCode %s",
                                UA_StatusCode_name(response->responseHeader.serviceResult));
         goto securityRejected;
     }

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -96,7 +96,7 @@ UA_Session_detachFromSecureChannel(UA_Session *session) {
 UA_StatusCode
 UA_Session_generateNonce(UA_Session *session) {
     UA_SecureChannel *channel = session->header.channel;
-    if(!channel || !channel->securityPolicy)
+    if(!channel || !channel->endpoint)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* Is the length of the previous nonce correct? */
@@ -108,8 +108,8 @@ UA_Session_generateNonce(UA_Session *session) {
             return retval;
     }
 
-    return channel->securityPolicy->symmetricModule.
-        generateNonce(channel->securityPolicy->policyContext, &session->serverNonce);
+    return channel->endpoint->securityPolicy->symmetricModule.
+        generateNonce(channel->endpoint->securityPolicy->policyContext, &session->serverNonce);
 }
 
 void UA_Session_updateLifetime(UA_Session *session) {

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -42,7 +42,7 @@ static void
 setup_secureChannel(void) {
     TestingPolicy(&dummyPolicy, dummyCertificate, &fCalled, &keySizes);
     UA_SecureChannel_init(&testChannel, &UA_ConnectionConfig_default);
-    UA_SecureChannel_setSecurityPolicy(&testChannel, &dummyPolicy, &dummyCertificate);
+    UA_SecureChannel_setEndpoint(&testChannel, &dummyPolicy);
 
     testingConnection =
         createDummyConnection(UA_ConnectionConfig_default.sendBufferSize, &sentData);
@@ -98,7 +98,7 @@ START_TEST(SecureChannel_initAndDelete) {
 
     UA_SecureChannel channel;
     UA_SecureChannel_init(&channel, &UA_ConnectionConfig_default);
-    retval = UA_SecureChannel_setSecurityPolicy(&channel, &dummyPolicy, &dummyCertificate);
+    retval = UA_SecureChannel_setEndpoint(&channel, &dummyPolicy);
 
     ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected StatusCode to be good");
     ck_assert_msg(channel.state == UA_SECURECHANNELSTATE_FRESH, "Expected state to be new/fresh");

--- a/tests/client/check_client_encryption.c
+++ b/tests/client/check_client_encryption.c
@@ -56,10 +56,7 @@ static void setup(void) {
 
     server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
-                                                   trustList, trustListSize,
-                                                   issuerList, issuerListSize,
-                                                   revocationList, revocationListSize);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, NULL);
 
     /* Set the ApplicationUri used in the certificate */
     UA_String_clear(&config->applicationDescription.applicationUri);

--- a/tests/encryption/check_encryption_aes128sha256rsaoaep.c
+++ b/tests/encryption/check_encryption_aes128sha256rsaoaep.c
@@ -69,10 +69,7 @@ static void setup(void) {
 
     server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
-                                                   trustList, trustListSize,
-                                                   issuerList, issuerListSize,
-                                                   revocationList, revocationListSize);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, NULL);
 
     /* Set the ApplicationUri used in the certificate */
     UA_String_clear(&config->applicationDescription.applicationUri);

--- a/tests/encryption/check_encryption_basic128rsa15.c
+++ b/tests/encryption/check_encryption_basic128rsa15.c
@@ -66,10 +66,7 @@ static void setup(void) {
 
     server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
-                                                   trustList, trustListSize,
-                                                   issuerList, issuerListSize,
-                                                   revocationList, revocationListSize);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, NULL);
 
     /* Set the ApplicationUri used in the certificate */
     UA_String_clear(&config->applicationDescription.applicationUri);

--- a/tests/encryption/check_encryption_basic256.c
+++ b/tests/encryption/check_encryption_basic256.c
@@ -69,10 +69,7 @@ static void setup(void) {
 
     server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
-                                                   trustList, trustListSize,
-                                                   issuerList, issuerListSize,
-                                                   revocationList, revocationListSize);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, NULL);
 
     /* Set the ApplicationUri used in the certificate */
     UA_String_clear(&config->applicationDescription.applicationUri);

--- a/tests/encryption/check_encryption_basic256sha256.c
+++ b/tests/encryption/check_encryption_basic256sha256.c
@@ -69,10 +69,7 @@ static void setup(void) {
 
     server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
-                                                   trustList, trustListSize,
-                                                   issuerList, issuerListSize,
-                                                   revocationList, revocationListSize);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, NULL);
 
     /* Set the ApplicationUri used in the certificate */
     UA_String_clear(&config->applicationDescription.applicationUri);

--- a/tests/server/check_server_monitoringspeed.c
+++ b/tests/server/check_server_monitoringspeed.c
@@ -29,7 +29,7 @@ static void setup(void) {
 
     TestingPolicy(&dummyPolicy, UA_BYTESTRING_NULL, &funcsCalled, &keySizes);
     UA_SecureChannel_init(&testChannel, &UA_ConnectionConfig_default);
-    UA_SecureChannel_setSecurityPolicy(&testChannel, &dummyPolicy, &UA_BYTESTRING_NULL);
+    UA_SecureChannel_setEndpoint(&testChannel, &dummyPolicy);
 
     testingConnection = createDummyConnection(65535, NULL);
     UA_Connection_attachSecureChannel(&testingConnection, &testChannel);

--- a/tests/server/check_server_speed_addnodes.c
+++ b/tests/server/check_server_speed_addnodes.c
@@ -28,7 +28,7 @@ static void setup(void) {
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     TestingPolicy(&dummyPolicy, UA_BYTESTRING_NULL, &funcsCalled, &keySizes);
     UA_SecureChannel_init(&testChannel, &UA_ConnectionConfig_default);
-    UA_SecureChannel_setSecurityPolicy(&testChannel, &dummyPolicy, &UA_BYTESTRING_NULL);
+    UA_SecureChannel_setEndpoint(&testChannel, &dummyPolicy);
     testingConnection = createDummyConnection(65535, NULL);
     UA_Connection_attachSecureChannel(&testingConnection, &testChannel);
     testChannel.connection = &testingConnection;


### PR DESCRIPTION
This PR adds support for multiple PKI infrastructures.
In OPC UA a PKI infrastructure corresponds to a CertificateGroup. A CertificateGroup has an issuer authority that issues certificates. This PR adds support such that a server can belong to multiple different CertificateGroups. Endpoints can be assigned to a specific CertificateGroup.

These features require changes to the public and private key loading and to some security related code.