### PR TITLE
fix(doc) set correct branch for documentation upload

### DIFF
--- a/.github/workflows/doc_upload.yml
+++ b/.github/workflows/doc_upload.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           repository: open62541/open62541-www
           path: open62541-www
+          ref: main
           persist-credentials: false
       - name: Get the current branch name
         shell: bash


### PR DESCRIPTION
The gh-pages branch is used in default mode. The PR forces to use the main branch in the github action.