### PR TITLE
fix(tests): network is not instant

### DIFF
--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -179,7 +179,7 @@ START_TEST(Client_renewSecureChannel) {
     UA_fakeSleep((UA_UInt32)((UA_Double)cc->secureChannelLifeTime * 0.8));
 
     /* Make the client renew the channel */
-    retval = UA_Client_run_iterate(client, 0);
+    retval = UA_Client_run_iterate(client, 1);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     /* Now read */
@@ -223,7 +223,7 @@ START_TEST(Client_renewSecureChannelWithActiveSubscription) {
     for(int i = 0; i < 15; ++i) {
         UA_fakeSleep(1000);
         UA_Server_run_iterate(server, true);
-        retval = UA_Client_run_iterate(client, 0);
+        retval = UA_Client_run_iterate(client, 1);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     }
 

--- a/tests/client/check_client_async_connect.c
+++ b/tests/client/check_client_async_connect.c
@@ -75,6 +75,8 @@ START_TEST(Client_connect_async) {
             UA_Client_sendAsyncBrowseRequest(client, &bReq, asyncBrowseCallback,
                                              &asyncCounter, &reqId);
         }
+        /* Give network a chance to process packet */
+        sleep(0);
         /* Manual clock for unit tests */
         UA_Server_run_iterate(server, false);
         retval = UA_Client_run_iterate(client, 0);
@@ -145,7 +147,7 @@ START_TEST(Client_no_connection) {
     //simulating unconnected server
     UA_Client_recvTesting_result = UA_STATUSCODE_BADCONNECTIONCLOSED;
     UA_Server_run_iterate(server, false);
-    retval = UA_Client_run_iterate(client, 0);  /* Open connection */
+    retval = UA_Client_run_iterate(client, 1);  /* Open connection */
     UA_Server_run_iterate(server, false);
     retval |= UA_Client_run_iterate(client, 0); /* Send HEL */
     UA_Server_run_iterate(server, false);


### PR DESCRIPTION
The client itereate call without timeout in the tests works only
if the TCP connect is instant.  That seems to be the case for github
Linux continuous integration.  But it may fail on other operating
systems or in real live.  Set the iterate timeout after conntect
to 1 second.  That should be enough for loopback interface.

Also sending an async browse request may not reach the server before
iterating it.  A sleep(0) to reschedule the process is enough for
my setup.  Then the server can read the request from its socket.