### PR TITLE
test(core): fix 32 bit sign-conversion compiler errors

### DIFF
--- a/tests/testing-plugins/testing_clock.c
+++ b/tests/testing-plugins/testing_clock.c
@@ -34,8 +34,8 @@ UA_realSleep(UA_UInt32 duration) {
 #ifdef _WIN32
     Sleep(duration);
 #else
-    UA_UInt32 sec = duration / 1000;
-    UA_UInt32 ns = (duration % 1000) * NANO_SECOND_MULTIPLIER;
+    UA_Int32 sec = duration / 1000;
+    UA_Int32 ns = (duration % 1000) * NANO_SECOND_MULTIPLIER;
     struct timespec sleepValue;
     sleepValue.tv_sec = sec;
     sleepValue.tv_nsec = ns;


### PR DESCRIPTION
When compiled with clang on 32 bit platforms, -Wsign-conversion
prevents implicit conversion from UA_UInt32 to long.  Make sec and
ns UA_Int32 which is compatible with time_t and long in struct
timespec.