### PR TITLE
fix(client) connect iterate without timeout

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -825,7 +825,7 @@ UA_ClientConnectionTCP_poll(UA_Connection *connection, UA_UInt32 timeout,
                        tcpConnection->endpointUrl.data, strerror(UA_ERRNO));
         ClientNetworkLayerTCP_close(connection);
         return UA_STATUSCODE_BADDISCONNECT;
-    } else if (ret == 0) {
+    } else if (timeout && ret == 0) {
         UA_LOG_WARNING(logger, UA_LOGCATEGORY_NETWORK,
                        "Connection to %.*s timed out",
                        (int)tcpConnection->endpointUrl.length,

--- a/tests/client/check_client_async_connect.c
+++ b/tests/client/check_client_async_connect.c
@@ -169,6 +169,25 @@ START_TEST(Client_without_run_iterate) {
 }
 END_TEST
 
+START_TEST(Client_run_iterate) {
+    UA_StatusCode retval;
+    UA_Client *client = UA_Client_new();
+    UA_ClientConfig *cc = UA_Client_getConfig(client);
+    UA_ClientConfig_setDefault(cc);
+    cc->stateCallback = currentState;
+    connected = false;
+    retval = UA_Client_connectAsync(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    while (!connected) {
+        UA_Server_run_iterate(server, false);
+        retval = UA_Client_run_iterate(client, 0);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        sleep(0);
+    }
+    UA_Client_delete(client);
+}
+END_TEST
+
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Client");
     TCase *tc_client_connect = tcase_create("Client Connect Async");
@@ -177,6 +196,7 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_client_connect, Client_connect_async_abort);
     tcase_add_test(tc_client_connect, Client_no_connection);
     tcase_add_test(tc_client_connect, Client_without_run_iterate);
+    tcase_add_test(tc_client_connect, Client_run_iterate);
     suite_add_tcase(s,tc_client_connect);
     return s;
 }


### PR DESCRIPTION
Commit ef4394b1144e845df93760b951ef0f6bef63d053 may have fixed the
connect timeout, but it broke async connect without timeout.  That
made it impossible to continue processing during TCP handshake.
While the connect operation is in progress, the select system call
will return immediately if the timeout is 0.  Do not close the
connection in this case, but allow the application to call run_iterate()
again.  For the tests in the CI this makes no difference as connect
over Linux loopback interface succeeds immediately.