### PR TITLE
feat(nc): support new subtypes of String

### DIFF
--- a/tools/nodeset_compiler/opaque_type_mapping.py
+++ b/tools/nodeset_compiler/opaque_type_mapping.py
@@ -76,6 +76,16 @@ opaque_type_mapping = {
         'id': 12,
         'name': 'String'
     },
+    'UriString': {
+        'ns': 0,
+        'id': 12,
+        'name': 'String'
+    },
+    'SemanticVersionString': {
+        'ns': 0,
+        'id': 12,
+        'name': 'String'
+    },
     'Duration': {
         'ns': 0,
         'id': 11,


### PR DESCRIPTION
New types were added in OPC UA 1.05 which need to be added to the mapping table to be handled by the NodesetCompiler.
UriString is used now for example in OPC UA FX models.