### PR TITLE
feat(pubsub): Pass the server pointer to the PubSub StateChangeCallback

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -198,7 +198,7 @@ struct UA_PubSubConfiguration {
      * change from operational to error in case of a DataSetReader
      * MessageReceiveTimeout. The status code provides additional
      * information. */
-    void (*stateChangeCallback)(UA_NodeId *Id, UA_PubSubState state,
+    void (*stateChangeCallback)(UA_Server *server, UA_NodeId *id, UA_PubSubState state,
                                 UA_StatusCode status);
     /* TODO: maybe status code provides not enough information about the state change */
 

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -772,7 +772,7 @@ UA_DataSetReader_setPubSubState(UA_Server *server,
         UA_ServerConfig *pConfig = UA_Server_getConfig(server);
         if(pConfig->pubSubConfig.stateChangeCallback != 0) {
             pConfig->pubSubConfig.
-                stateChangeCallback(&dataSetReader->identifier, state, cause);
+                stateChangeCallback(server, &dataSetReader->identifier, state, cause);
         }
     }
     return ret;

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -413,7 +413,7 @@ UA_ReaderGroup_setPubSubState(UA_Server *server,
         UA_ServerConfig *pConfig = UA_Server_getConfig(server);
         if(pConfig->pubSubConfig.stateChangeCallback != 0) {
             pConfig->pubSubConfig.
-                stateChangeCallback(&readerGroup->identifier, state, cause);
+                stateChangeCallback(server, &readerGroup->identifier, state, cause);
         }
     }
     return ret;

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -746,7 +746,7 @@ UA_DataSetWriter_setPubSubState(UA_Server *server,
         UA_ServerConfig *pConfig = UA_Server_getConfig(server);
         if(pConfig->pubSubConfig.stateChangeCallback != 0) {
             pConfig->pubSubConfig.
-                stateChangeCallback(&dataSetWriter->identifier, state, cause);
+                stateChangeCallback(server, &dataSetWriter->identifier, state, cause);
         }
     }
     return ret;

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -744,7 +744,7 @@ UA_WriterGroup_setPubSubState(UA_Server *server,
         UA_ServerConfig *pConfig = UA_Server_getConfig(server);
         if(pConfig->pubSubConfig.stateChangeCallback != 0) {
             pConfig->pubSubConfig.
-                stateChangeCallback(&writerGroup->identifier, state, cause);
+                stateChangeCallback(server, &writerGroup->identifier, state, cause);
         }
     }
     return ret;

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -407,9 +407,12 @@ static void ValidatePublishSubscribe_fast_path(
 /***************************************************************************************************/
 
 /***************************************************************************************************/
-static void PubSubStateChangeCallback_basic (UA_NodeId *pubsubComponentId,
+static void PubSubStateChangeCallback_basic (UA_Server *hostServer,
+                                UA_NodeId *pubsubComponentId,
                                 UA_PubSubState state,
                                 UA_StatusCode status) {
+    ck_assert(hostServer == server);
+
     UA_String strId;
     UA_String_init(&strId);
     UA_NodeId_print(pubsubComponentId, &strId);
@@ -714,8 +717,10 @@ START_TEST(Test_basic) {
 /* Test different message receive timeouts */
 
 static void
-PubSubStateChangeCallback_different_timeouts(UA_NodeId *pubsubComponentId,
+PubSubStateChangeCallback_different_timeouts(UA_Server *hostServer, UA_NodeId *pubsubComponentId,
                                              UA_PubSubState state, UA_StatusCode status) {
+    ck_assert(hostServer == server);
+    
     /* Disable some checks during shutdown */
     if(!runtime)
         return;
@@ -938,9 +943,12 @@ START_TEST(Test_different_timeouts) {
 
 /***************************************************************************************************/
 static void PubSubStateChangeCallback_wrong_timeout (
+    UA_Server *hostServer,
     UA_NodeId *pubsubComponentId,
     UA_PubSubState state,
     UA_StatusCode status) {
+    
+    ck_assert(hostServer == server);
 
     UA_String strId;
     UA_String_init(&strId);
@@ -1055,8 +1063,10 @@ START_TEST(Test_wrong_timeout) {
 
 /***************************************************************************************************/
 static void
-PubSubStateChangeCallback_many_components(UA_NodeId *pubsubComponentId,
+PubSubStateChangeCallback_many_components(UA_Server *hostServer, UA_NodeId *pubsubComponentId,
                                           UA_PubSubState state, UA_StatusCode status) {
+    ck_assert(hostServer == server);
+    
     if(!runtime)
         return;
     
@@ -1624,8 +1634,10 @@ START_TEST(Test_many_components) {
     count no of message receive timeouts
 */
 static void
-PubSubStateChangeCallback_update_config(UA_NodeId *pubsubComponentId,
+PubSubStateChangeCallback_update_config(UA_Server *hostServer, UA_NodeId *pubsubComponentId,
                                         UA_PubSubState state, UA_StatusCode status) {
+    ck_assert(hostServer == server);
+    
     if(!runtime)
         return;
     
@@ -1807,9 +1819,11 @@ START_TEST(Test_add_remove) {
 
 
 /***************************************************************************************************/
-static void PubSubStateChangeCallback_fast_path (UA_NodeId *pubsubComponentId,
+static void PubSubStateChangeCallback_fast_path (UA_Server *hostServer, UA_NodeId *pubsubComponentId,
                                 UA_PubSubState state,
                                 UA_StatusCode status) {
+    ck_assert(hostServer == server);
+
     UA_String strId;
     UA_String_init(&strId);
     UA_NodeId_print(pubsubComponentId, &strId);


### PR DESCRIPTION
Allow applications to access the server data inside the callback. Since the server config can store also an application context, also the application data can be accessed from within the callback.