### PR TITLE
[Review] fix(nc): add --export-macro option to generate_datatypes.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1275,6 +1275,7 @@ ua_generate_datatypes(
     NAME "types"
     TARGET_SUFFIX "types"
     NAMESPACE_IDX 0
+    EXPORT_MACRO "UA_EXPORT"
     FILE_CSV "${UA_FILE_NODEIDS}"
     FILES_BSD "${UA_FILE_TYPES_BSD}"
     FILES_SELECTED ${UA_FILE_DATATYPES}
@@ -1286,6 +1287,7 @@ ua_generate_datatypes(
     NAME "transport"
     TARGET_SUFFIX "transport"
     NAMESPACE_IDX 1
+    EXPORT_MACRO "UA_EXPORT"
     FILE_CSV "${UA_FILE_NODEIDS}"
     IMPORT_BSD "TYPES#${UA_FILE_TYPES_BSD}"
     FILES_BSD "${PROJECT_SOURCE_DIR}/tools/schema/Custom.Opc.Ua.Transport.bsd"

--- a/tools/cmake/macros_public.cmake
+++ b/tools/cmake/macros_public.cmake
@@ -89,6 +89,7 @@ endfunction()
 #   [TARGET_PREFIX] Optional prefix for the resulting target. Default `open62541-generator`
 #   [OUTPUT_DIR]    Optional target directory for the generated files. Default is '${PROJECT_BINARY_DIR}/src_generated'
 #   FILE_CSV        Path to the .csv file containing the node ids, e.g. 'OpcUaDiModel.csv'
+#   [EXPORT_MACRO]  Optional export macro added to the generated code
 #
 #   Arguments taking multiple values:
 #
@@ -108,7 +109,7 @@ endfunction()
 #
 function(ua_generate_datatypes)
     set(options BUILTIN INTERNAL)
-    set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_CSV)
+    set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_CSV EXPORT_MACRO)
     set(multiValueArgs FILES_BSD IMPORT_BSD FILES_SELECTED NAMESPACE_MAP)
     cmake_parse_arguments(UA_GEN_DT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -159,6 +160,11 @@ function(ua_generate_datatypes)
         set(UA_GEN_DT_INTERNAL_ARG "--internal")
     endif()
 
+    set(UA_GEN_DT_EXPORT_MACRO_ARG "")
+    if (UA_GEN_DT_EXPORT_MACRO)
+        set(UA_GEN_DT_EXPORT_MACRO_ARG "--export-macro=${UA_GEN_DT_EXPORT_MACRO}")
+    endif()
+
     set(SELECTED_TYPES_TMP "")
     foreach(f ${UA_GEN_DT_FILES_SELECTED})
         set(SELECTED_TYPES_TMP ${SELECTED_TYPES_TMP} "--selected-types=${f}")
@@ -201,6 +207,7 @@ function(ua_generate_datatypes)
         --type-csv=${UA_GEN_DT_FILE_CSV}
         ${UA_GEN_DT_NO_BUILTIN}
         ${UA_GEN_DT_INTERNAL_ARG}
+        ${UA_GEN_DT_EXPORT_MACRO_ARG}
         ${UA_GEN_DT_OUTPUT_DIR}/${UA_GEN_DT_NAME}
         DEPENDS ${open62541_TOOLS_DIR}/generate_datatypes.py
         ${UA_GEN_DT_FILES_BSD}

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -76,6 +76,15 @@ parser.add_argument('-i', '--import',
 parser.add_argument('outfile',
                     metavar='<outputFile>',
                     help='output file w/o extension')
+
+parser.add_argument('--export-macro',
+                    metavar='<exportMacro>',
+                    type=str,
+                    dest="export_macro",
+                    action='store',
+                    default="",
+                    help='set the export macro of the generated code')
+
 args = parser.parse_args()
 
 outname = args.outfile.split("/")[-1]
@@ -94,5 +103,5 @@ parser = CSVBSDTypeParser(args.opaque_map, args.selected_types, args.no_builtin,
                           args.type_bsd, args.type_csv, namespaceMap)
 parser.create_types()
 
-generator = backend.CGenerator(parser, inname, args.outfile, args.internal, namespaceMap)
+generator = backend.CGenerator(parser, inname, args.outfile, args.internal, namespaceMap, args.export_macro)
 generator.write_definitions()

--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -62,7 +62,7 @@ def getNodeidTypeAndId(nodeId):
         return "UA_NODEIDTYPE_STRING, {{ .string = UA_STRING_STATIC(\"{id}\") }}".format(id=strId.replace("\"", "\\\""))
 
 class CGenerator(object):
-    def __init__(self, parser, inname, outfile, is_internal_types, namespaceMap):
+    def __init__(self, parser, inname, outfile, is_internal_types, namespaceMap, export_macro):
         self.parser = parser
         self.inname = inname
         self.outfile = outfile
@@ -73,6 +73,7 @@ class CGenerator(object):
         self.ff = None
         self.fc = None
         self.fe = None
+        self.export_macro = export_macro
 
     @staticmethod
     def get_type_index(datatype):
@@ -430,7 +431,9 @@ _UA_BEGIN_DECLS
         if totalCount > 0:
 
             self.printh(
-                "extern UA_EXPORT const UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
+                "extern " + self.export_macro + (" " if self.export_macro else "") +
+                "const UA_DataType UA_" + self.parser.outname.upper() +
+                "[UA_" + self.parser.outname.upper() + "_COUNT];")
 
             for ns in self.filtered_types:
                 for i, t_name in enumerate(self.filtered_types[ns]):


### PR DESCRIPTION
Hello,

I have prepared a little PR for an issue related to DLL import and export specifier and the nodeset compiler generated code.

The problem arises if the user links the open62541 stack dynamically on Windows and generate datatypes with the nodeset compiler.
Then the datatypes array in the generated code is prefixed with UA_EXPORT.
E.g.:
"extern UA_EXPORT const UA_DataType UA_USERNAMESPACE_GEN_TYPES[UA_USERNAMESPACE_GEN_TYPES_COUNT];"

In case the of a dynamically linked open62541 stack, UA_EXPORT is set to “__declspec(dllimport)”, which lead to several linker warnings about locally defined symbols with import specifier.

With the –export-macro option added in this PR, the UA_EXPORT macro is only used for the generated types included in the open62541 library.

E.g. in types_generated.h:
"extern UA_EXPORT const UA_DataType UA_TYPES[UA_TYPES_COUNT];"

In the code generated by a user invocation of the nodeset compiler, the user can freely choose the export macro.

E.g. omit it:
"extern const UA_DataType UA_USERNAMESPACE_GEN_TYPES[UA_USERNAMESPACE_GEN_TYPES_COUNT];"
Or set a different macro:
"extern USERNAMESPACE_EXPORT const UA_DataType UA_USERNAMESPACE_GEN_TYPES[UA_USERNAMESPACE_GEN_TYPES_COUNT];"

Please have a look if this could be relevant and feel free to comment.

Best regards,
zsteroe
