### PR TITLE
[Review] fix(server): Multithreading fixes in refresh and refresh2

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -11,7 +11,7 @@
  *    Copyright 2017 (c) Henrik Norrman
  *    Copyright 2018 (c) Fabian Arndt, Root-Core
  *    Copyright 2017-2020 (c) HMS Industrial Networks AB (Author: Jonas Green)
- *    Copyright 2020-2021 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and umati)
+ *    Copyright 2020-2022 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and umati)
  */
 
 #ifndef UA_SERVER_H_
@@ -1586,7 +1586,7 @@ UA_Server_createCondition(UA_Server *server,
  * @param value Variant Value to be written to the Field
  * @param fieldName Name of the Field in which the value should be written
  * @return The StatusCode of the UA_Server_setConditionField method*/
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_setConditionField(UA_Server *server,
                             const UA_NodeId condition,
                             const UA_Variant *value,

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -13,6 +13,7 @@
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
  *    Copyright 2019 (c) HMS Industrial Networks AB (Author: Jonas Green)
  *    Copyright 2021 (c) Fraunhofer IOSB (Author: Andreas Ebner)
+ *    Copyright 2022 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
  */
 
 #ifndef UA_SERVER_INTERNAL_H_
@@ -444,6 +445,11 @@ browseSimplifiedBrowsePath(UA_Server *server, const UA_NodeId origin,
 UA_StatusCode
 writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
                     const UA_QualifiedName propertyName, const UA_Variant value);
+
+UA_StatusCode
+writeObjectProperty_scalar(UA_Server *server, const UA_NodeId objectId,
+                                     const UA_QualifiedName propertyName,
+                                     const void *value, const UA_DataType *type);
 
 UA_StatusCode
 getNodeContext(UA_Server *server, UA_NodeId nodeId, void **nodeContext);

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -2098,15 +2098,23 @@ writeObjectProperty(UA_Server *server, const UA_NodeId objectId,
     return retval;
 }
 
-UA_StatusCode UA_EXPORT
-UA_Server_writeObjectProperty_scalar(UA_Server *server, const UA_NodeId objectId,
+UA_StatusCode
+writeObjectProperty_scalar(UA_Server *server, const UA_NodeId objectId,
                                      const UA_QualifiedName propertyName,
                                      const void *value, const UA_DataType *type) {
     UA_Variant var;
     UA_Variant_init(&var);
     UA_Variant_setScalar(&var, (void*)(uintptr_t)value, type);
+    return writeObjectProperty(server, objectId, propertyName, var);
+}
+
+UA_StatusCode UA_EXPORT
+UA_Server_writeObjectProperty_scalar(UA_Server *server, const UA_NodeId objectId,
+                                     const UA_QualifiedName propertyName,
+                                     const void *value, const UA_DataType *type) {
     UA_LOCK(&server->serviceMutex);
-    UA_StatusCode retval = writeObjectProperty(server, objectId, propertyName, var);
+    UA_StatusCode retval = 
+        writeObjectProperty_scalar(server, objectId, propertyName, value, type);
     UA_UNLOCK(&server->serviceMutex);
     return retval;
 }

--- a/src/server/ua_subscription_events_filter.c
+++ b/src/server/ua_subscription_events_filter.c
@@ -881,6 +881,7 @@ UA_Server_evaluateWhereClauseContentFilter(UA_Server *server, UA_Session *sessio
                                            const UA_NodeId *eventNode,
                                            const UA_ContentFilter *contentFilter,
                                            UA_ContentFilterResult *contentFilterResult) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
     if(contentFilter->elementsSize == 0)
         return UA_STATUSCODE_GOOD;
     /* TODO add maximum lenth size to the server config */
@@ -899,7 +900,6 @@ UA_Server_evaluateWhereClauseContentFilter(UA_Server *server, UA_Session *sessio
     ctx.contentFilterResult = contentFilterResult;
     ctx.valueResult = valueResult;
     ctx.index = 0;
-
     UA_StatusCode res = evaluateWhereClauseContentFilter(&ctx);
     for(size_t i = 0; i < ctx.contentFilter->elementsSize; i++) {
         if(!UA_Variant_isEmpty(&ctx.valueResult[i]))
@@ -911,6 +911,7 @@ UA_Server_evaluateWhereClauseContentFilter(UA_Server *server, UA_Session *sessio
 static UA_Boolean
 isValidEvent(UA_Server *server, const UA_NodeId *validEventParent,
              const UA_NodeId *eventId) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
     /* find the eventType variableNode */
     UA_QualifiedName findName = UA_QUALIFIEDNAME(0, "EventType");
     UA_BrowsePathResult bpr = browseSimplifiedBrowsePath(server, *eventId, 1, &findName);
@@ -922,7 +923,6 @@ isValidEvent(UA_Server *server, const UA_NodeId *validEventParent,
     /* Get the EventType Property Node */
     UA_Variant tOutVariant;
     UA_Variant_init(&tOutVariant);
-
     /* Read the Value of EventType Property Node (the Value should be a NodeId) */
     UA_StatusCode retval = readWithReadValue(server, &bpr.targets[0].targetId.nodeId,
                                              UA_ATTRIBUTEID_VALUE, &tOutVariant);
@@ -962,6 +962,7 @@ UA_StatusCode
 filterEvent(UA_Server *server, UA_Session *session,
             const UA_NodeId *eventNode, UA_EventFilter *filter,
             UA_EventFieldList *efl, UA_EventFilterResult *result) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
     if(filter->selectClausesSize == 0)
         return UA_STATUSCODE_BADEVENTFILTERINVALID;
 


### PR DESCRIPTION
This fixes the refresh() and the refresh2() callback, in a (default) multithreaded build.

Tested using commit: 671a7f45
Subscribing to Conditions/Events cause several asserts. E.g.:
```
#0  0x767bb68b in msvcrt!abort () from C:\WINDOWS\System32\msvcrt.dll
#1  0x00e58ccc in _wassert ()
#2  0x00e58d69 in _assert ()
#3  0x00838bfa in UA_LOCK_ASSERT (lock=0x50ca044, num=1)
    at <hidden>/Sample-Server/deps/open62541/arch/win32/ua_architecture.h:192
#4  0x008393c8 in UA_Server_getSessionById (server=0x50c9ba8, sessionId=0x77e7108)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_services_session.c:156
#5  0x00d681c7 in refreshMethodCallback (server=0x50c9ba8, sessionId=0x77e7108, sessionContext=0x0,
    methodId=0x5196fc8, methodContext=0x0, objectId=0x5195fc0, objectContext=0x0, inputSize=1, input=0x4f3ea18,
    outputSize=0, output=0x1)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_subscription_alarms_conditions.c:1685
#6  0x00838546 in callWithMethodAndObject (server=0x50c9ba8, session=0x77e7098, request=0x77e7448, result=0x77e5758,
    method=0x5196fc8, object=0x5195fc0)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_services_method.c:364
#7  0x008386b9 in Operation_CallMethodAsync (server=0x50c9ba8, session=0x77e7098, requestId=21, requestHandle=181,
    opIndex=0, opRequest=0x77e7448, opResult=0x77e5758, ar=0x4f3f15c)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_services_method.c:411
#8  0x00833f70 in UA_Server_processServiceOperationsAsync (server=0x50c9ba8, session=0x77e7098, requestId=21,
    requestHandle=181, operationCallback=0x838574 <Operation_CallMethodAsync>, requestOperations=0x4f3f448,
    requestOperationsType=0x10697c0 <UA_TYPES+16800>, responseOperations=0x4f3f380,
    responseOperationsType=0x10697fc <UA_TYPES+16860>, ar=0x4f3f15c)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_server_async.c:410
#9  0x00838826 in Service_CallAsync (server=0x50c9ba8, session=0x77e7098, requestId=21, request=0x4f3f3f0,
    response=0x4f3f320, finished=0x4f3f1df)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_services_method.c:452
#10 0x008317f0 in processMSGDecoded (server=0x50c9ba8, channel=0x77e6f28, requestId=21,
    service=0x838a03 <Service_Call>, request=0x4f3f3f0, requestType=0x1069838 <UA_TYPES+16920>, response=0x4f3f320,
    responseType=0x1069874 <UA_TYPES+16980>, sessionRequired=true, counterOffset=0)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_server_binary.c:685
#11 0x00831cc6 in processMSG (server=0x50c9ba8, channel=0x77e6f28, requestId=21, msg=0x77e5ea4)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_server_binary.c:816
#12 0x00831ea7 in processSecureChannelMessage (application=0x50c9ba8, channel=0x77e6f28,
    messagetype=UA_MESSAGETYPE_MSG, requestId=21, message=0x77e5ea4)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_server_binary.c:844
#13 0x00d7d6da in assembleProcessMessage (channel=0x77e6f28, application=0x50c9ba8,
    callback=0x831d00 <processSecureChannelMessage>)
    at <hidden>/Sample-Server\deps\open62541\src\ua_securechannel.c:637
#14 0x00d7dc98 in processChunks (channel=0x77e6f28, application=0x50c9ba8,
    callback=0x831d00 <processSecureChannelMessage>)
    at <hidden>/Sample-Server\deps\open62541\src\ua_securechannel.c:784
#15 0x00d7e072 in UA_SecureChannel_processBuffer (channel=0x77e6f28, application=0x50c9ba8,
    callback=0x831d00 <processSecureChannelMessage>, buffer=0x4f3f6dc)
    at <hidden>/Sample-Server\deps\open62541\src\ua_securechannel.c:900
#16 0x00832192 in UA_Server_processBinaryMessage (server=0x50c9ba8, connection=0x7650728, message=0x4f3f6dc)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_server_binary.c:914
#17 0x0082a5e0 in UA_Server_networkCallback (cm=0x5aa17a8, connectionId=620, application=0x50c9ba8,
    connectionContext=0x7570bcc, state=0, paramsSize=0, params=0x0, msg=...)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_server.c:655
#18 0x00d7282f in TCP_connectionSocketCallback (cm=0x5aa17a8, rfd=0x7570ba0, event=1)
    at <hidden>/Sample-Server\deps\open62541\arch\eventloop_posix_tcp.c:236
#19 0x00d71f17 in UA_EventLoopPOSIX_pollFDs (el=0x5aa7c40, listenTimeout=97025)
    at <hidden>/Sample-Server\deps\open62541\arch\eventloop_posix_select.c:162
#20 0x00d71361 in UA_EventLoopPOSIX_run (el=0x5aa7c40, timeout=50)
    at <hidden>/Sample-Server\deps\open62541\arch\eventloop_posix.c:254
#21 0x0082ac93 in UA_Server_run_iterate (server=0x50c9ba8, waitInternal=false)
    at <hidden>/Sample-Server\deps\open62541\src\server\ua_server.c:855
#22 0x0042171b in main (argc=1, argv=0x5aa2e28) at <hidden>/Sample-Server\SampleServer.cpp:250
```

As i require quite many `UNLOCK <Function witch locks inside> LOCK`, this does not feel right:
E.g.:
```
UA_UNLOCK(&server->serviceMutex);
UA_StatusCode retval = UA_Server_setConditionField(server, *refreshEventNodId, &value, fieldSeverity);
UA_LOCK(&server->serviceMutex);
```

PS: For debugging with gdb, an additional break point is required to break at abort/assert (assert does internally use abort):
* `gdb ServerApp`
* `b abort`  Break on Abort
* `r` Run ServerApp
* Trigger the functions calls (e.g. by subscribing to Events)
