### PR TITLE
fix(server): check for valid channel before access

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -845,7 +845,7 @@ UA_Server_run_iterate(UA_Server *server, UA_Boolean waitInternal) {
     UA_PubSubConnection *connection;
     TAILQ_FOREACH(connection, &server->pubSubManager.connections, listEntry){
         UA_PubSubConnection *ps = connection;
-        if(ps && ps->channel->yield){
+        if(ps && ps->channel && ps->channel->yield){
             ps->channel->yield(ps->channel, 0);
         }
     }


### PR DESCRIPTION
Unit test check_pubsub_informationmodel_methods failed
sporadically because of a nullptr access (see issue #5239).