### PR TITLE
fix(pubsub): correct errors in file config

### DIFF
--- a/tests/pubsub/check_pubsub_configuration.c
+++ b/tests/pubsub/check_pubsub_configuration.c
@@ -32,7 +32,8 @@ static void teardown(void) {
 }
 
 START_TEST(AddPublisherUsingBinaryFile) {
-    UA_ByteString publisherConfiguration = loadFile("../tests/pubsub/check_publisher_configuration.bin");
+    UA_ByteString publisherConfiguration = loadFile("../../tests/pubsub/check_publisher_configuration.bin");
+    ck_assert(publisherConfiguration.length > 0);
     UA_StatusCode retVal = UA_PubSubManager_loadPubSubConfigFromByteString(server, publisherConfiguration);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_PubSubConnection *connection;
@@ -64,7 +65,8 @@ START_TEST(AddPublisherUsingBinaryFile) {
 } END_TEST
 
 START_TEST(AddSubscriberUsingBinaryFile) {
-    UA_ByteString subscriberConfiguration = loadFile("../tests/pubsub/check_subscriber_configuration.bin");
+    UA_ByteString subscriberConfiguration = loadFile("../../tests/pubsub/check_subscriber_configuration.bin");
+    ck_assert(subscriberConfiguration.length > 0);
     UA_StatusCode retVal = UA_PubSubManager_loadPubSubConfigFromByteString(server, subscriberConfiguration);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_PubSubConnection *connection;


### PR DESCRIPTION
Correct usage of server mutex in ua_pubsub_config.c.

Fix wrong path to test .bin files.

Add a length check after loadFile(), so it's
easier to identify an error (e.g. test failed because
file path is wrong or decoding/applying pubsub configuration
does not work)