### PR TITLE
feat(server): add ReferenceTypes HasArgumentDescription...

### DIFF
--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -160,6 +160,12 @@ UA_Server_createNS0_base(UA_Server *server) {
     ret |= addReferenceTypeNode(server, "HasInterface", "InterfaceOf",
                          UA_NS0ID_HASINTERFACE, false, false, UA_NS0ID_NONHIERARCHICALREFERENCES);
 
+    ret |= addReferenceTypeNode(server, "HasArgumentDescription", "ArgumentDescriptionOf", 
+                         UA_NS0ID_HASARGUMENTDESCRIPTION, false, false, UA_NS0ID_HASCOMPONENT);
+
+    ret |= addReferenceTypeNode(server, "HasOptionalInputArgumentDescription", "OptionalInputArgumentDescriptionOf",
+                         UA_NS0ID_HASOPTIONALINPUTARGUMENTDESCRIPTION, false, false, UA_NS0ID_HASARGUMENTDESCRIPTION);                         
+
     /**************/
     /* Data Types */
     /**************/


### PR DESCRIPTION
…and HasOptionalInputArgumentDescription

This allows applications to add variable nodes for method input arguments,
e.g. to provide default values and engineering units.
(see OPC 10000-3, 5.7.2 - 5.7.3)