### PR TITLE
test(core): fix sign-conversion compiler errors

### DIFF
--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -365,7 +365,7 @@ START_TEST(Securechannel_sendAsymmetricOPNMessage_extraPaddingPresentWhenKeyLarg
     if(extraPadding) {
         extraPaddingByte = paddingByte;
         paddingByte = sentData.data[sentData.length - keySizes.asym_lcl_sig_size - 2];
-        paddingSize = (extraPaddingByte << 8u) + paddingByte;
+        paddingSize = ((size_t)extraPaddingByte << 8u) + paddingByte;
         paddingSize += 1;
     }
 

--- a/tests/check_types_builtin.c
+++ b/tests/check_types_builtin.c
@@ -195,7 +195,7 @@ END_TEST
 START_TEST(UA_Int64_decodeShallRespectSign) {
     // given
     UA_ByteString rawMessage;
-    UA_UInt64 expectedVal = ((UA_UInt64)0xFF) << 56;
+    UA_Int64 expectedVal = ((UA_Int64)0xFF) << 56;
     UA_Byte  mem[8]      = { 00, 00, 00, 00, 0x00, 0x00, 0x00, 0xFF };
     rawMessage.data   = mem;
     rawMessage.length = 8;

--- a/tests/client/check_client_encryption.c
+++ b/tests/client/check_client_encryption.c
@@ -90,12 +90,12 @@ START_TEST(encryption_reconnect_session) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* Secure client initialization */
     client = UA_Client_new();

--- a/tests/encryption/check_encryption_aes128sha256rsaoaep.c
+++ b/tests/encryption/check_encryption_aes128sha256rsaoaep.c
@@ -107,12 +107,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -188,12 +188,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/encryption/check_encryption_basic128rsa15.c
+++ b/tests/encryption/check_encryption_basic128rsa15.c
@@ -104,12 +104,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -185,12 +185,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/encryption/check_encryption_basic256.c
+++ b/tests/encryption/check_encryption_basic256.c
@@ -107,12 +107,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -188,12 +188,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/encryption/check_encryption_basic256sha256.c
+++ b/tests/encryption/check_encryption_basic256sha256.c
@@ -107,12 +107,12 @@ START_TEST(encryption_connect) {
     UA_ByteString certificate;
     certificate.length = CERT_DER_LENGTH;
     certificate.data = CERT_DER_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_DER_LENGTH;
     privateKey.data = KEY_DER_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability
@@ -188,12 +188,12 @@ START_TEST(encryption_connect_pem) {
     UA_ByteString certificate;
     certificate.length = CERT_PEM_LENGTH;
     certificate.data = CERT_PEM_DATA;
-    ck_assert_int_ne(certificate.length, 0);
+    ck_assert_uint_ne(certificate.length, 0);
 
     UA_ByteString privateKey;
     privateKey.length = KEY_PEM_LENGTH;
     privateKey.data = KEY_PEM_DATA;
-    ck_assert_int_ne(privateKey.length, 0);
+    ck_assert_uint_ne(privateKey.length, 0);
 
     /* The Get endpoint (discovery service) is done with
      * security mode as none to see the server's capability

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -112,26 +112,26 @@ START_TEST(readValueRank) {
     ck_assert_int_eq(rank, -2);
     UA_Variant_init(&dims);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10002), &dims);
-    ck_assert_int_eq(dims.arrayLength, 0);
+    ck_assert_uint_eq(dims.arrayLength, 0);
     UA_Variant_clear(&dims);
     // 1-dim
     UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10007), &rank);
     ck_assert_int_eq(rank, 1);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10007), &dims);
-    ck_assert_int_eq(dims.arrayLength, 1);
+    ck_assert_uint_eq(dims.arrayLength, 1);
     ck_assert_int_eq(*((UA_UInt32 *)dims.data), 0);
     UA_Variant_clear(&dims);
     UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10004), &rank);
     ck_assert_int_eq(rank, 1);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10004), &dims);
-    ck_assert_int_eq(dims.arrayLength, 1);
+    ck_assert_uint_eq(dims.arrayLength, 1);
     ck_assert_int_eq(*((UA_UInt32 *)dims.data), 4);
     UA_Variant_clear(&dims);
     // 2-dim
     UA_Server_readValueRank(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10006), &rank);
     ck_assert_int_eq(rank, 2);
     UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(testNamespaceIndex, 10006), &dims);
-    ck_assert_int_eq(dims.arrayLength, 2);
+    ck_assert_uint_eq(dims.arrayLength, 2);
     UA_UInt32 *dimensions = (UA_UInt32 *)dims.data;
     ck_assert_int_eq(dimensions[0], 2);
     ck_assert_int_eq(dimensions[1], 2);

--- a/tests/server/check_interfaces.c
+++ b/tests/server/check_interfaces.c
@@ -56,7 +56,7 @@ START_TEST(check_interface_instantiation) {
 
     UA_BrowsePathResult bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
     ck_assert_int_eq(bpr.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(bpr.targetsSize, 1);
+    ck_assert_uint_eq(bpr.targetsSize, 1);
 
     const UA_NodeId objectWithInterfacesId = bpr.targets->targetId.nodeId;
     UA_BrowsePathResult_clear(&bpr);
@@ -73,7 +73,7 @@ START_TEST(check_interface_instantiation) {
 
     UA_BrowseResult br = UA_Server_browse(server, 1000, &bd);
     ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_gt(br.referencesSize, 0);
+    ck_assert_uint_gt(br.referencesSize, 0);
 
     bool found = false;
     for (size_t i = 0; i < br.referencesSize; ++i) {
@@ -150,7 +150,7 @@ START_TEST(check_interface_instantiation) {
 
     bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
     ck_assert_int_eq(bpr.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(bpr.targetsSize, 1);
+    ck_assert_uint_eq(bpr.targetsSize, 1);
 
     const UA_NodeId baseObjectWithInterfaceId = bpr.targets->targetId.nodeId;
     UA_BrowsePathResult_clear(&bpr);
@@ -164,7 +164,7 @@ START_TEST(check_interface_instantiation) {
 
     br = UA_Server_browse(server, 1000, &bd);
     ck_assert_int_eq(br.statusCode, UA_STATUSCODE_GOOD);
-    ck_assert_int_gt(br.referencesSize, 0);
+    ck_assert_uint_gt(br.referencesSize, 0);
 
     found = false;
     for (size_t i = 0; i < br.referencesSize; ++i) {

--- a/tests/server/check_services_attributes.c
+++ b/tests/server/check_services_attributes.c
@@ -199,7 +199,7 @@ START_TEST(ReadSingleServerAttribute) {
     UA_DataValue resp = UA_Server_read(server, &rvi, UA_TIMESTAMPSTORETURN_BOTH);
 
     ck_assert_int_eq(resp.status, UA_STATUSCODE_GOOD);
-    ck_assert_int_eq(0, resp.value.arrayLength);
+    ck_assert_uint_eq(0, resp.value.arrayLength);
     ck_assert_int_eq(resp.serverTimestamp, UA_DateTime_now());
     ck_assert_int_eq(resp.sourceTimestamp, UA_DateTime_now());
     UA_DataValue_clear(&resp);
@@ -825,7 +825,7 @@ START_TEST(WriteSingleAttributeValueWithServerTimestamp) {
     ck_assert(resp.hasValue);
     ck_assert_int_eq(20, *(UA_Int32*)resp.value.data);
     ck_assert(resp.hasServerTimestamp);
-    ck_assert_uint_eq(resp.serverTimestamp, UA_DateTime_now());
+    ck_assert_int_eq(resp.serverTimestamp, UA_DateTime_now());
     UA_DataValue_clear(&resp);
 } END_TEST
 

--- a/tests/server/check_services_nodemanagement.c
+++ b/tests/server/check_services_nodemanagement.c
@@ -596,7 +596,7 @@ START_TEST(ObjectWithDynamicVariableChild) {
 
     UA_BrowsePathResult bpr = UA_Server_translateBrowsePathToNodeIds(server, &bp);
 
-    ck_assert_int_eq(bpr.targetsSize, 1);
+    ck_assert_uint_eq(bpr.targetsSize, 1);
 
     UA_WriteValue wv;
     UA_WriteValue_init(&wv);

--- a/tests/testing-plugins/testing_clock.c
+++ b/tests/testing-plugins/testing_clock.c
@@ -34,8 +34,8 @@ UA_realSleep(UA_UInt32 duration) {
 #ifdef _WIN32
     Sleep(duration);
 #else
-    UA_UInt32 sec = duration / 1000;
-    UA_UInt32 ns = (duration % 1000) * NANO_SECOND_MULTIPLIER;
+    UA_Int32 sec = duration / 1000;
+    UA_Int32 ns = (duration % 1000) * NANO_SECOND_MULTIPLIER;
     struct timespec sleepValue;
     sleepValue.tv_sec = sec;
     sleepValue.tv_nsec = ns;


### PR DESCRIPTION
These fixes to compile with clang 13 are already in master branch.
Having them also in 1.3 branch also, make testing easier for me.
If you fear too much fallout when merging, just drop this pull request.
