### PR TITLE
feat(pubsub) add pre-operational state for DataSetReaders

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -119,6 +119,10 @@ onRead(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
             UA_Variant_setScalar(&value, dataSetReader->config.publisherId.data,
                                  dataSetReader->config.publisherId.type);
             break;
+        case UA_NS0ID_DATASETREADERTYPE_STATUS_STATE:
+            UA_Variant_setScalar(&value, &dataSetReader->state,
+                                 &UA_TYPES[UA_TYPES_PUBSUBSTATE]);
+            break;
         default:
             UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER,
                            "Read error! Unknown property.");
@@ -770,7 +774,7 @@ addDataSetReaderRepresentation(UA_Server *server, UA_DataSetReader *dataSetReade
     dsrName[dataSetReader->config.name.length] = '\0';
 
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
-    UA_NodeId publisherIdNode, writerGroupIdNode, dataSetwriterIdNode;
+    UA_NodeId publisherIdNode, writerGroupIdNode, dataSetwriterIdNode, stateParentNode, stateNode;
 
     UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
     object_attr.displayName = UA_LOCALIZEDTEXT("", dsrName);
@@ -792,6 +796,12 @@ addDataSetReaderRepresentation(UA_Server *server, UA_DataSetReader *dataSetReade
     dataSetwriterIdNode = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "DataSetWriterId"),
                                               UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY),
                                               dataSetReader->identifier);
+    stateParentNode = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "Status"),
+                                              UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                              dataSetReader->identifier);
+    stateNode = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "State"),
+                                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                            stateParentNode);
 
     if(UA_NodeId_isNull(&publisherIdNode) ||
        UA_NodeId_isNull(&writerGroupIdNode) ||
@@ -809,6 +819,14 @@ addDataSetReaderRepresentation(UA_Server *server, UA_DataSetReader *dataSetReade
     valueCallback.onWrite = NULL;
     retVal |= addVariableValueSource(server, valueCallback, publisherIdNode,
                                      dataSetReaderPublisherIdContext);
+
+    UA_NodePropertyContext *dataSetReaderStateContext =
+        (UA_NodePropertyContext *) UA_malloc(sizeof(UA_NodePropertyContext));
+    dataSetReaderStateContext->parentNodeId = dataSetReader->identifier;
+    dataSetReaderStateContext->parentClassifier = UA_NS0ID_DATASETREADERTYPE;
+    dataSetReaderStateContext->elementClassiefier = UA_NS0ID_DATASETREADERTYPE_STATUS_STATE;
+    retVal |= addVariableValueSource(server, valueCallback, stateNode,
+                                     dataSetReaderStateContext);
 
     /* Update childNode with values from Publisher */
     UA_Variant value;
@@ -1706,9 +1724,19 @@ dataSetReaderTypeDestructor(UA_Server *server,
     UA_NodeId publisherIdNode =
         findSingleChildNode(server, UA_QUALIFIEDNAME(0, "PublisherId"),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY), *nodeId);
+    UA_NodeId stateParentNode = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "Status"),
+                                          UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                          *nodeId);
+    UA_NodeId stateNode = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "State"),
+                                    UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                    stateParentNode);
+
     UA_NodePropertyContext *ctx;
     UA_Server_getNodeContext(server, publisherIdNode, (void **)&ctx);
     if(!UA_NodeId_isNull(&publisherIdNode))
+        UA_free(ctx);
+    UA_Server_getNodeContext(server, stateNode, (void **)&ctx);
+    if(!UA_NodeId_isNull(&stateNode))
         UA_free(ctx);
 }
 

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -423,8 +423,8 @@ UA_Server_addDataSetReader(UA_Server *server, UA_NodeId readerGroupIdentifier,
 
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     newDataSetReader->componentType = UA_PUBSUB_COMPONENT_DATASETREADER;
-    if(readerGroup->state == UA_PUBSUBSTATE_OPERATIONAL) {
-        retVal = UA_DataSetReader_setPubSubState(server, newDataSetReader, UA_PUBSUBSTATE_OPERATIONAL,
+    if(readerGroup->state == UA_PUBSUBSTATE_OPERATIONAL || readerGroup->state == UA_PUBSUBSTATE_PREOPERATIONAL) {
+        retVal = UA_DataSetReader_setPubSubState(server, newDataSetReader, UA_PUBSUBSTATE_PREOPERATIONAL,
                                                  UA_STATUSCODE_GOOD);
         if(retVal != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR_READERGROUP(&server->config.logger, readerGroup,
@@ -846,6 +846,9 @@ UA_DataSetReader_setPubSubState(UA_Server *server,
         case UA_PUBSUBSTATE_PAUSED:
             ret = UA_STATUSCODE_BADNOTSUPPORTED;
             break;
+        case UA_PUBSUBSTATE_PREOPERATIONAL:
+            dataSetReader->state = UA_PUBSUBSTATE_PREOPERATIONAL;
+            break;
         case UA_PUBSUBSTATE_OPERATIONAL:
             dataSetReader->state = UA_PUBSUBSTATE_OPERATIONAL;
             break;
@@ -1168,6 +1171,11 @@ UA_DataSetReader_process(UA_Server *server, UA_ReaderGroup *rg,
          *     }
          * } */
         return;
+    }
+
+    /* Message is valid, if DSR is preoperational, we can change it to operational*/
+    if(dsr->state == UA_PUBSUBSTATE_PREOPERATIONAL){
+        UA_DataSetReader_setPubSubState(server, dsr, UA_PUBSUBSTATE_OPERATIONAL, UA_STATUSCODE_GOOD);
     }
 
     if(msg->header.dataSetMessageType != UA_DATASETMESSAGE_DATAKEYFRAME) {

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -801,6 +801,7 @@ UA_DataSetReader_setState_disabled(UA_Server *server, UA_DataSetReader *dsr) {
     case UA_PUBSUBSTATE_PAUSED:
         dsr->state = UA_PUBSUBSTATE_DISABLED;
         return UA_STATUSCODE_GOOD;
+    case UA_PUBSUBSTATE_PREOPERATIONAL:
     case UA_PUBSUBSTATE_OPERATIONAL:
 #ifdef UA_ENABLE_PUBSUB_MONITORING
         /* Stop MessageReceiveTimeout timer */

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -335,6 +335,35 @@ UA_ReaderGroup_setPubSubState_paused(UA_Server *server,
 }
 
 static UA_StatusCode
+UA_ReaderGroup_setPubSubState_preoperational(UA_Server *server,
+                                            UA_ReaderGroup *rg,
+                                            UA_StatusCode cause) {
+    UA_DataSetReader *dataSetReader;
+    switch(rg->state) {
+        case UA_PUBSUBSTATE_DISABLED:
+            LIST_FOREACH(dataSetReader, &rg->readers, listEntry) {
+                UA_DataSetReader_setPubSubState(server, dataSetReader, UA_PUBSUBSTATE_PREOPERATIONAL,
+                                                cause);
+            }
+            rg->state = UA_PUBSUBSTATE_PREOPERATIONAL;
+            return UA_STATUSCODE_GOOD;
+        case UA_PUBSUBSTATE_PAUSED:
+            break;
+        case UA_PUBSUBSTATE_PREOPERATIONAL:
+            break;
+        case UA_PUBSUBSTATE_OPERATIONAL:
+            return UA_STATUSCODE_GOOD;
+        case UA_PUBSUBSTATE_ERROR:
+            break;
+        default:
+            UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                           "Unknown PubSub state!");
+            return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    return UA_STATUSCODE_BADNOTSUPPORTED;
+}
+
+static UA_StatusCode
 UA_ReaderGroup_setPubSubState_operational(UA_Server *server,
                                           UA_ReaderGroup *rg,
                                           UA_StatusCode cause) {
@@ -342,7 +371,7 @@ UA_ReaderGroup_setPubSubState_operational(UA_Server *server,
     switch(rg->state) {
     case UA_PUBSUBSTATE_DISABLED:
         LIST_FOREACH(dataSetReader, &rg->readers, listEntry) {
-            UA_DataSetReader_setPubSubState(server, dataSetReader, UA_PUBSUBSTATE_OPERATIONAL,
+            UA_DataSetReader_setPubSubState(server, dataSetReader, UA_PUBSUBSTATE_PREOPERATIONAL,
                                             cause);
         }
         UA_ReaderGroup_addSubscribeCallback(server, rg);
@@ -401,6 +430,9 @@ UA_ReaderGroup_setPubSubState(UA_Server *server,
             break;
         case UA_PUBSUBSTATE_PAUSED:
             ret = UA_ReaderGroup_setPubSubState_paused(server, readerGroup, cause);
+            break;
+        case UA_PUBSUBSTATE_PREOPERATIONAL:
+            ret = UA_ReaderGroup_setPubSubState_preoperational(server, readerGroup, cause);
             break;
         case UA_PUBSUBSTATE_OPERATIONAL:
             ret = UA_ReaderGroup_setPubSubState_operational(server, readerGroup, cause);

--- a/tests/pubsub/check_pubsub_get_state.c
+++ b/tests/pubsub/check_pubsub_get_state.c
@@ -306,7 +306,7 @@ START_TEST(Test_normal_operation) {
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_ReaderGroup_getState(server, RGId_Conn1_RG1, &state));
     ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state));
-    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+    ck_assert_int_eq(UA_PUBSUBSTATE_PREOPERATIONAL, state);
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "set groups disabled");
     ck_assert(UA_Server_setWriterGroupDisabled(server, WGId_Conn1_WG1) == UA_STATUSCODE_GOOD);
@@ -390,7 +390,7 @@ START_TEST(Test_corner_cases) {
     ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
     /* DataSetReader should be operational as well */
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state));
-    ck_assert_int_eq(UA_PUBSUBSTATE_OPERATIONAL, state);
+    ck_assert_int_eq(UA_PUBSUBSTATE_PREOPERATIONAL, state);
 
     /* test wrong nodeIds */
     ck_assert(UA_STATUSCODE_GOOD != UA_Server_DataSetReader_getState(server, RGId_Conn1_RG1, &state));

--- a/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
+++ b/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
@@ -1485,6 +1485,23 @@
       <Reference ReferenceType="HasComponent" IsForward="false">i=15298</Reference>
     </References>
   </UAObject>
+  <UAObject NodeId="i=15307" BrowseName="Status" ParentNodeId="i=15306">
+    <DisplayName>Status</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent">i=15308</Reference>
+      <Reference ReferenceType="HasTypeDefinition">i=14643</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=15306</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="i=15308" BrowseName="State" ParentNodeId="i=15307" DataType="i=14647">
+    <DisplayName>State</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=15307</Reference>
+    </References>
+  </UAVariable>
   <UAObjectType NodeId="i=23795" BrowseName="SubscribedDataSetFolderType">
     <DisplayName>SubscribedDataSetFolderType</DisplayName>
     <Category>PubSub Model SubscribedDataSet Standalone</Category>
@@ -2603,7 +2620,7 @@
       <Reference ReferenceType="HasProperty">i=17494</Reference> <!--DataSetReaderProperties-->
       <Reference ReferenceType="HasComponent">i=15311</Reference> <!--TransportSettings-->
       <Reference ReferenceType="HasComponent">i=21103</Reference> <!-- MessageSettings-->
-      <!-- <Reference ReferenceType="HasComponent">i=15307</Reference> Status-->
+      <Reference ReferenceType="HasComponent">i=15307</Reference> <!--Status-->
       <!-- <Reference ReferenceType="HasComponent">i=19609</Reference> Diagnostics-->
       <Reference ReferenceType="HasComponent">i=15316</Reference> <!-- SubscribedDataSet-->
       <!-- <Reference ReferenceType="HasComponent">i=17386</Reference> CreateTargetVariables-->


### PR DESCRIPTION
Adding support for the Pre-Operational PubSub-State. In addition, this PR introduces the functionality to access the pubsub state via the information model.