### PR TITLE
fix(server): fix to compile server without pubsub sources when pubsub…

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -25,7 +25,9 @@
 #include "ua_pubsub_ns0.h"
 #endif
 
+#ifdef UA_ENABLE_PUBSUB
 #include "ua_pubsub_manager.h"
+#endif
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 #include "ua_subscription.h"


### PR DESCRIPTION
The fix allow to compile the server without pubsub folders when pubsub feature is disabled.
Before this fix, an include of ua_pubsub_manager.h was done into ua_server.c without conditional compilation on UA_ENABLE_PUBSUB. This led to compilation crash if path to this file was not provided.