### PR TITLE
fix command in the examples-section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ To build the examples, we recommend to install the open62541 project as mentione
 
 The following simple server example can be built using gcc, after you installed open62541 on your system.
 
-Using the GCC compiler, just run ```gcc -std=c99 -lopen62541 -DUA_ARCHITECTURE_POSIX <server.c> -o server``` (under Windows you may need to add ``` -lws2_32``` 
+Using the GCC compiler, just run ```gcc -std=c99 -DUA_ARCHITECTURE_POSIX <server.c> -lopen62541 -o server``` (under Windows you may need to add ``` -lws2_32``` 
 and change `-DUA_ARCHITECTURE_POSIX` to `-DUA_ARCHITECTURE_WIN32`).
 ```c
 #include <signal.h>


### PR DESCRIPTION
fix the gcc linking argument in the examples-section of the README, see https://github.com/open62541/open62541/issues/3248#issuecomment-568370301