### PR TITLE
when use UDP address, don't need an interface.

### DIFF
--- a/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
@@ -1352,11 +1352,13 @@ int main(int argc, char **argv) {
         }
     }
 
+#ifdef UA_ENABLE_PUBSUB_ETH_UADP
     if (!interface) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Need a network interface to run");
         usage(progname);
         return -1;
     }
+#endif
 
     if (cycleTimeInMsec < 0.125) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "%f Bad cycle time", cycleTimeInMsec);


### PR DESCRIPTION
when use UDP address as pubUri and subUri, we don't need to set the interface .
just set the route of OS.
If we set the interface, the program will crash. see below:


```
    //If you are running for UDP provide ip address as input. Connection creation
    //Failed if we provide the interface name
```