### PR TITLE
Find Python 3 in open62541Config.cmake.in

### DIFF
--- a/tools/cmake/open62541Config.cmake.in
+++ b/tools/cmake/open62541Config.cmake.in
@@ -6,7 +6,7 @@ set (open62541_TOOLS_DIR @PACKAGE_open62541_install_tools_dir@ CACHE PATH "Path 
 set (UA_NODESET_DIR @PACKAGE_open62541_install_nodeset_dir@ CACHE PATH "Path to the directory that contains the OPC UA schema repository")
 
 include(CMakeFindDependencyMacro)
-find_dependency(PythonInterp REQUIRED)
+find_dependency(PythonInterp 3 REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/open62541Macros.cmake")
 


### PR DESCRIPTION
On some systems open62541Config.cmake finds python2 instead of python3. 
This leads to fails on re.fullmatch() in: https://github.com/open62541/open62541/blob/4d08612120eadea386af1e45a78a6d458b7f2331/tools/nodeset_compiler/nodeset.py#L431

Solution:
Force cmake to find python3