### PR TITLE
fix(pubsub): fix double free in openssl secured mqtt connection

### DIFF
--- a/plugins/mqtt/ua_mqtt-c_adapter.c
+++ b/plugins/mqtt/ua_mqtt-c_adapter.c
@@ -310,7 +310,7 @@ disconnectMqtt(UA_PubSubChannelDataMQTT* channelData){
         mqtt_disconnect(client);
         yieldMqtt(channelData, 10);
 #ifdef UA_ENABLE_MQTT_TLS_OPENSSL //mbedTLS condition is missing
-        BIO_free_all(client->socketfd);
+        client->socketfd = NULL;
 #endif
     }
 


### PR DESCRIPTION
(for UA_ENABLE_MQTT_TLS_OPENSSL=ON) client->socketfd is the same pointer as
channeldata->sockfd. client->sockfd is freed in disconnectMqtt() and again
afterwards in freeTLS(). Therefore set it to NULL in disconnectMqtt and free
it in freeTLS only.

Signed-off-by: Tobias Zimmermann <Tobias.Zimmermann@tq-group.com>