### PR TITLE
fix(examples): parsing argument frequency in tutorial_pubsub_mqtt_pub…

### DIFF
--- a/examples/pubsub/tutorial_pubsub_mqtt_publish.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt_publish.c
@@ -437,6 +437,7 @@ int main(int argc, char **argv) {
                 usage();
                 return -1;
             }
+            argpos++;
             if(sscanf(argv[argpos], "%d", &interval) != 1) {
                 usage();
                 return -1;


### PR DESCRIPTION
…lish

argpos needs to be incremented before reading the value of the interval.

Signed-off-by: Tobias Zimmermann <Tobias.Zimmermann@tq-group.com>