### PR TITLE
[REVIEW] Patch/error binding socket

### DIFF
--- a/arch/eventloop_posix_tcp.c
+++ b/arch/eventloop_posix_tcp.c
@@ -404,7 +404,7 @@ TCP_registerListenSocket(UA_ConnectionManager *cm, struct addrinfo *ai,
         UA_close(listenSocket);
         return UA_STATUSCODE_BADINTERNALERROR;
     }
-
+#ifndef _WIN32
     /* Allow rebinding to the IP/port combination. Eg. to restart the server. */
     if(UA_setsockopt(listenSocket, SOL_SOCKET, SO_REUSEPORT,
                      (const char *)&optval, sizeof(optval)) == -1) {
@@ -414,7 +414,7 @@ TCP_registerListenSocket(UA_ConnectionManager *cm, struct addrinfo *ai,
         UA_close(listenSocket);
         return UA_STATUSCODE_BADINTERNALERROR;
     }
-
+#endif
     /* Set the socket non-blocking */
     if(UA_EventLoopPOSIX_setNonBlocking(listenSocket) != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,

--- a/arch/eventloop_posix_tcp.c
+++ b/arch/eventloop_posix_tcp.c
@@ -399,7 +399,17 @@ TCP_registerListenSocket(UA_ConnectionManager *cm, struct addrinfo *ai,
     if(UA_setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR,
                      (const char *)&optval, sizeof(optval)) == -1) {
         UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
-                       "TCP %u\t| Could not make the socket reusable",
+                       "TCP %u\t| Could not make the socket addr reusable",
+                       (unsigned)listenSocket);
+        UA_close(listenSocket);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    /* Allow rebinding to the IP/port combination. Eg. to restart the server. */
+    if(UA_setsockopt(listenSocket, SOL_SOCKET, SO_REUSEPORT,
+                     (const char *)&optval, sizeof(optval)) == -1) {
+        UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                       "TCP %u\t| Could not make the socket port reusable",
                        (unsigned)listenSocket);
         UA_close(listenSocket);
         return UA_STATUSCODE_BADINTERNALERROR;


### PR DESCRIPTION
Add REUSEPORT for linux so binding to multiple addresses for the same port is allowed, which we do with the default config. This will get rid of error "address already in use" upon binding.

![image](https://user-images.githubusercontent.com/10834314/188436135-1adf7b01-cf6a-4a0f-b279-9853a76aeb3e.png)
