### PR TITLE
[Review] Add WebAssembly architecture support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,15 +119,17 @@ GET_PROPERTY(ua_architecture_headers_beginning GLOBAL PROPERTY UA_ARCHITECTURE_H
 
 GET_PROPERTY(ua_architecture_sources GLOBAL PROPERTY UA_ARCHITECTURE_SOURCES)
 
-set(ua_architecture_sources ${ua_architecture_sources}
-    ${PROJECT_SOURCE_DIR}/arch/eventloop_posix.h
-    ${PROJECT_SOURCE_DIR}/arch/eventloop_posix.c
-    ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_select.c
-    ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_epoll.c
-    ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_tcp.c
-    ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_udp.c
-    ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_interrupt.c
-)
+if(${UA_ARCHITECTURE} STREQUAL "posix" OR ${UA_ARCHITECTURE} STREQUAL "win32")
+    set(ua_architecture_sources ${ua_architecture_sources}
+        ${PROJECT_SOURCE_DIR}/arch/eventloop_posix.h
+        ${PROJECT_SOURCE_DIR}/arch/eventloop_posix.c
+        ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_select.c
+        ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_epoll.c
+        ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_tcp.c
+        ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_udp.c
+        ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_interrupt.c
+    )
+endif()
 
 set(ua_architecture_headers ${ua_architecture_headers}
     ${PROJECT_SOURCE_DIR}/include/open62541/architecture_functions.h

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(freertosLWIP)
 add_subdirectory(vxworks)
 add_subdirectory(eCos)
 add_subdirectory(wec7)
+add_subdirectory(wasm)
 
 SET(UA_ARCH_EXTRA_INCLUDES "" CACHE STRING "Folders to include from the architecture")
 mark_as_advanced(UA_ARCH_EXTRA_INCLUDES)

--- a/arch/wasm/CMakeLists.txt
+++ b/arch/wasm/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(SOURCE_GROUP ${SOURCE_GROUP}\\wasm)
+    
+ua_add_architecture("wasm")
+
+list (FIND UA_AMALGAMATION_ARCHITECTURES "wasm" _index)
+if (${_index} GREATER -1 OR "${UA_ARCHITECTURE}" STREQUAL "wasm")
+    ua_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+    ua_add_architecture_file(${CMAKE_CURRENT_SOURCE_DIR}/ua_clock.c)
+endif()

--- a/arch/wasm/ua_architecture.h
+++ b/arch/wasm/ua_architecture.h
@@ -1,0 +1,103 @@
+#ifndef PLUGINS_ARCH_WASM_UA_ARCHITECTURE_H_
+#define PLUGINS_ARCH_WASM_UA_ARCHITECTURE_H_
+
+/*
+* Define and include all that's needed for your architecture
+*/
+
+#if UA_MULTITHREADING >= 100
+#error Multithreading unsupported
+#else
+#define UA_LOCK_INIT(lock)
+#define UA_LOCK_DESTROY(lock)
+#define UA_LOCK(lock)
+#define UA_UNLOCK(lock)
+#define UA_LOCK_ASSERT(lock, num)
+#endif
+
+
+#ifndef UA_free
+# include <stdlib.h>
+# define UA_free free
+# define UA_malloc malloc
+# define UA_calloc calloc
+# define UA_realloc realloc
+#endif
+
+#ifndef UA_snprintf
+# include <stdio.h>
+# define UA_snprintf snprintf
+#endif
+
+/*
+* Define OPTVAL_TYPE for non windows systems. In doubt, use int //TODO: Is this really necessary
+*/
+
+/*
+* Define the following network options
+*/
+
+
+#define UA_IPV6 0
+#define UA_SOCKET int
+#define UA_INVALID_SOCKET -1
+//#define UA_ERRNO  
+//#define UA_INTERRUPTED
+//#define UA_AGAIN
+//#define UA_EAGAIN
+//#define UA_WOULDBLOCK
+//#define UA_ERR_CONNECTION_PROGRESS
+//#define UA_INTERRUPTED
+
+/*
+* Define the ua_getnameinfo if your architecture supports it
+*/
+
+/*
+* Use #define for the functions defined in ua_architecture_functions.h
+* or implement them in a ua_architecture_functions.c file and 
+* put it in your new_arch folder and add it in the CMakeLists.txt file 
+* using ua_add_architecture_file(${CMAKE_CURRENT_SOURCE_DIR}/ua_architecture_functions.c)
+*/ 
+
+void NotImplemented(void *, ...);
+
+#define UA_sleep_ms NotImplemented
+#define UA_send NotImplemented
+#define UA_sendto NotImplemented
+#define UA_select NotImplemented
+#define UA_recv NotImplemented
+#define UA_recvfrom NotImplemented
+#define UA_recvmsg NotImplemented
+#define UA_shutdown NotImplemented
+#define UA_socket NotImplemented
+#define UA_bind NotImplemented
+#define UA_listen NotImplemented
+#define UA_accept NotImplemented
+#define UA_close NotImplemented
+#define UA_connect NotImplemented
+#define UA_fd_set NotImplemented
+#define UA_fd_isset NotImplemented
+#define UA_getaddrinfo NotImplemented
+#define UA_htonl NotImplemented
+#define UA_ntohl NotImplemented
+#define UA_inet_pton NotImplemented
+#define UA_socket_set_blocking NotImplemented
+#define UA_socket_set_nonblocking NotImplemented
+#define UA_ioctl NotImplemented
+#define UA_getsockopt NotImplemented
+#define UA_setsockopt NotImplemented
+#define UA_freeaddrinfo NotImplemented
+#define UA_gethostname(name, len) -1
+#define UA_getsockname NotImplemented
+#define UA_initialize_architecture_network NotImplemented
+#define UA_deinitialize_architecture_network NotImplemented
+
+/*
+* Define UA_LOG_SOCKET_ERRNO_WRAP(LOG) which prints the string error given a char* errno_str variable
+* Do the same for UA_LOG_SOCKET_ERRNO_GAI_WRAP(LOG) for errors related to getaddrinfo
+*/
+
+#include <open62541/architecture_functions.h>
+
+#endif /* PLUGINS_ARCH_WASM_UA_ARCHITECTURE_H_ */

--- a/arch/wasm/ua_clock.c
+++ b/arch/wasm/ua_clock.c
@@ -1,0 +1,19 @@
+#include <open62541/types.h>
+
+#define IMPORT(name) __attribute__((import_module("ua"), import_name(name)))
+
+IMPORT("DateTime_now") UA_DateTime Host_DateTime_now(void);
+IMPORT("DateTime_localTimeUtcOffset") UA_Int64 Host_DateTime_localTimeUtcOffset(void);
+IMPORT("DateTime_nowMonotonic") UA_DateTime Host_DateTime_nowMonotonic(void);
+
+UA_DateTime UA_DateTime_now(void) {
+  return Host_DateTime_now();
+}
+
+UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
+  return Host_DateTime_localTimeUtcOffset();
+}
+
+UA_DateTime UA_DateTime_nowMonotonic(void) {
+  return Host_DateTime_nowMonotonic();
+}

--- a/include/open62541/architecture_definitions.h
+++ b/include/open62541/architecture_definitions.h
@@ -337,6 +337,8 @@ extern UA_THREAD_LOCAL void * (*UA_reallocSingleton)(void *ptr, size_t size);
 # if defined(_LIL_END)
 #  define UA_LITTLE_ENDIAN 1
 # endif
+#elif defined(__wasm__)
+# define UA_LITTLE_ENDIAN 1
 #endif
 #ifndef UA_LITTLE_ENDIAN
 # define UA_LITTLE_ENDIAN 0
@@ -364,7 +366,7 @@ UA_STATIC_ASSERT(sizeof(bool) == 1, cannot_overlay_integers_with_large_bool);
 # define UA_FLOAT_IEEE754 1
 #elif defined(__i386__) || defined(__x86_64__) || defined(__amd64__) || \
     defined(__ia64__) || defined(__powerpc__) || defined(__sparc__) || \
-    defined(__arm__)
+    defined(__arm__) || defined(__wasm__)
 # define UA_FLOAT_IEEE754 1
 #elif defined(__STDC_IEC_559__)
 # define UA_FLOAT_IEEE754 1
@@ -379,7 +381,8 @@ UA_STATIC_ASSERT(sizeof(bool) == 1, cannot_overlay_integers_with_large_bool);
  * while integers are represented in little-endian form. */
 #if defined(_WIN32)
 # define UA_FLOAT_LITTLE_ENDIAN 1
-#elif defined(__i386__) || defined(__x86_64__) || defined(__amd64__)
+#elif defined(__i386__) || defined(__x86_64__) || defined(__amd64__) || \
+    defined(__wasm__)
 # define UA_FLOAT_LITTLE_ENDIAN 1
 #elif defined(__FLOAT_WORD_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
     (__FLOAT_WORD_ORDER__ == __ORDER_LITTLE_ENDIAN__) /* Defined only in GCC */

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -134,6 +134,7 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
     if(!conf->logger.log)
         conf->logger = UA_Log_Stdout_withLevel(UA_LOGLEVEL_TRACE);
 
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
     /* EventLoop */
     if(conf->eventLoop == NULL) {
         conf->eventLoop = UA_EventLoop_new_POSIX(&conf->logger);
@@ -151,6 +152,7 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
         if(udpCM)
             conf->eventLoop->registerEventSource(conf->eventLoop, (UA_EventSource *)udpCM);
     }
+#endif
 
     /* --> Start setting the default static config <-- */
 
@@ -763,6 +765,8 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
 /* Default Client Settings */
 /***************************/
 
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
+
 UA_Client * UA_Client_new(void) {
     UA_ClientConfig config;
     memset(&config, 0, sizeof(UA_ClientConfig));
@@ -796,6 +800,8 @@ UA_Client * UA_Client_new(void) {
     return c;
 }
 
+#endif
+
 UA_StatusCode
 UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     config->timeout = 5000;
@@ -805,6 +811,7 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
         config->logger = UA_Log_Stdout_withLevel(UA_LOGLEVEL_INFO);
     }
 
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
     /* EventLoop */
     if(config->eventLoop == NULL) {
         config->eventLoop = UA_EventLoop_new_POSIX(&config->logger);
@@ -820,6 +827,7 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
             UA_ConnectionManager_new_POSIX_UDP(UA_STRING("udp connection manager"));
         config->eventLoop->registerEventSource(config->eventLoop, (UA_EventSource *)udpCM);
     }
+#endif
 
     if(config->sessionLocaleIdsSize > 0 && config->sessionLocaleIds) {
         UA_Array_delete(config->sessionLocaleIds,

--- a/tools/cmake/Toolchain-wasm32-wasi.cmake
+++ b/tools/cmake/Toolchain-wasm32-wasi.cmake
@@ -1,0 +1,28 @@
+# Toolchain for 32-bit WebAssembly with WASI based libc
+#
+# https://github.com/WebAssembly/wasi-sdk
+#
+# The WASI sysroot must be provided in the environment variable WASI_SYSROOT.
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_SYSTEM_PROCESSOR wasm32)
+set(triple ${CMAKE_SYSTEM_PROCESSOR}-wasi)
+
+set(CMAKE_SYSROOT $ENV{WASI_SYSROOT})
+
+set(CMAKE_EXECUTABLE_SUFFIX_C ".wasm")
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_C_FLAGS_INIT "-D__wasi__")
+
+set(CMAKE_EXECUTABLE_SUFFIX_CXX ".wasm")
+set(CMAKE_CXX_COMPILER clang)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_FLAGS_INIT "-D__wasi__")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+


### PR DESCRIPTION
WebAssembly allows a browser to use the open62541 client to connect to an OPC-UA server with WebSocket (and potentially HTTP) support. I've successfully done this with the 1.3 release, but had bad timing with the advent of event loop support 😄.

To be able to use the open62541 client, additional code is necessary to implement an event loop for the callback based WebSocket API of a browser and marshalling data between JavaScript and wasm. The object model of open62541 can be used to implement this quite elegantly 👍.

This initial patch set allows compilation of open62451 as a wasm32 static library. To compile this, you'll need the WASI sysroot from [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) and set the environment variable `WASI_SYSROOT`. The default `clang` package from Debian supports `wasm32` compilation but lacks some necessary support libs which can be obtained from the wasi-sdk releases aswell.

    export WASI_SYSROOT=...
    mkdir build
    cd build
    cmake -DCMAKE_TOOLCHAIN_FILE=../tools/cmake/Toolchain-wasm32-wasi.cmake -DCMAKE_BUILD_TYPE=Release -DUA_ARCHITECTURE=wasm -DUA_ENABLE_HARDENING=OFF ..

I stumbled over a couple of minor issues that might need a better solution:
 - The assumption that every architecture supports TCP connections wouldn't hold true anymore.
 - The assumption that every architecture is either POSIX or win32 compatible wouldn't hold true anymore. I guarded the POSIX event loop sources to only be included in `posix` and `win32` archs, but this might break some of the other architectures. Not sure how the project would prefer to handle this.

Things that need more work
 - Implementing the client event loop for a callback based WebSocket API (I implemented the old `init/pollConnectionFunc` API and haven't done the event loop yet to see if it is complete enough. First impression is pretty good. The old API needed one minor change to allow the callback style network implementation to iterate the client for async operation)
 - It's possible to use `mbedtls` to support crypto, but none of the integrated entropy sources can be used. A custom architecture specific entropy source is needed, e.g. based on `window.crypt.getRandomValues`. The current implementation uses the default context (and runs self-tests that are not context specific and will never succeed in this scenario).
 - With the old network stack the WebSocket server performs very poorly if the TCP network stack is also enabled. Hopefully this can be avoided by adding a open62541 event loop wrapper for libwebsockets.