### PR TITLE
fix (example): Correctly set port in register and multicast examples

### DIFF
--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -1,5 +1,8 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
- * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
+ *
+ * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
+ */
 
 /*
  * A simple server instance which registers with the discovery server.
@@ -222,8 +225,7 @@ int main(int argc, char **argv) {
 
     UA_Server *server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    // use port 0 to dynamically assign port
-    UA_ServerConfig_setMinimal(config, 0, NULL);
+    UA_ServerConfig_setMinimal(config, 4841, NULL);
 
     // An LDS server normally has the application type to DISCOVERYSERVER.
     // Since this instance implements LDS and other OPC UA services, we set the type to SERVER.

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -1,5 +1,8 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
- * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
+ *
+ * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
+ */
 /*
  * A simple server instance which registers with the discovery server (see server_lds.c).
  * Before shutdown it has to unregister itself.
@@ -66,8 +69,7 @@ int main(int argc, char **argv) {
 
     UA_Server *server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    // use port 0 to dynamically assign port
-    UA_ServerConfig_setMinimal(config, 0, NULL);
+    UA_ServerConfig_setMinimal(config, 4841, NULL);
 
     UA_String_clear(&config->applicationDescription.applicationUri);
     config->applicationDescription.applicationUri =


### PR DESCRIPTION
Until 1.2 it was possible to set Port address dynamically but in version 1.3 it is not possible. Setting it to 0 will resolve to 4840, which will conflict with port assinged by default to LDS server in the example. Also the comment is misleading in the example. Therefore the comment is deleted and a fixed port 4841 is assinged to register and multicast server examples.

Signed-off-by: Muddasir Shakil <muddasir.shakil@linutronix.de>