### PR TITLE
[Review] fix(pubsub): Fix generation of the defaultDatagramPublisherId

### DIFF
--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -183,7 +183,7 @@ UA_ReserveId_createId(UA_Server *server,  UA_NodeId sessionId, UA_String transpo
         next_id = next_id_writer;
 
     for(;numberOfIds > 0;numberOfIds--) {
-#ifndef UA_ENABLE_REDUCED_ITERATIONS_FOR_TESTING        
+#ifndef UA_ENABLE_REDUCED_ITERATIONS_FOR_TESTING
         if(next_id < UA_RESERVEID_FIRST_ID)
             next_id = UA_RESERVEID_FIRST_ID;
 #else
@@ -719,21 +719,23 @@ UA_PubSubManager_generateUniqueGuid(UA_Server *server) {
     }
 }
 
+static UA_UInt64
+generateRandomUInt64(UA_Server *server) {
+    UA_UInt64 id = 0;
+    UA_Guid ident = UA_Guid_random();
+
+    id = id + ident.data1;
+    id = (id << 32) + ident.data2;
+    id = (id << 16) + ident.data3;
+    return id;
+}
+
 /* Initialization the PubSub configuration. */
 void
 UA_PubSubManager_init(UA_Server *server, UA_PubSubManager *pubSubManager) {
-    /* ToDo: Must be correctly generated from Mac address and port. */
-    UA_Guid *ident = NULL;
-    ident = UA_Guid_new();
-    if(!ident) {
-        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
-                     "PubSub generate defaultPublisherId failed.");
-        return;
-    }
-    *ident = UA_Guid_random();
-    pubSubManager->defaultPublisherId = *(UA_UInt64*)ident;
-    LIST_INIT(&pubSubManager->reserveIds);
-    UA_free(ident);
+    //TODO: Using the Mac address to generate the defaultPublisherId.
+    // In the future, this can be retrieved from the eventloop.
+    pubSubManager->defaultPublisherId = generateRandomUInt64(server);
 }
 
 /* Delete the current PubSub configuration including all nested members. This

--- a/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
+++ b/tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml
@@ -54,6 +54,7 @@
       <Reference ReferenceType="HasComponent">i=23622</Reference>
       <Reference ReferenceType="HasComponent">i=16598</Reference>
       <Reference ReferenceType="HasComponent">i=14432</Reference>
+      <Reference ReferenceType="HasProperty">i=25432</Reference> <!--DefaultDatagramPublisherId-->
       <Reference ReferenceType="HasSubtype" IsForward="false">i=15906</Reference>
     </References>
   </UAObjectType>
@@ -65,7 +66,14 @@
       <Reference ReferenceType="HasProperty" IsForward="false">i=14416</Reference>
     </References>
   </UAVariable>
-
+  <UAVariable NodeId="i=25432" BrowseName="DefaultDatagramPublisherId" ParentNodeId="i=14416" DataType="UInt64">
+    <DisplayName>DefaultDatagramPublisherId</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=14416</Reference>
+    </References>
+  </UAVariable>
   <UAObjectType NodeId="i=14477" BrowseName="DataSetFolderType">
     <DisplayName>DataSetFolderType</DisplayName>
     <References>
@@ -2162,6 +2170,7 @@
       <Reference ReferenceType="HasComponent">i=17371</Reference>
       <Reference ReferenceType="HasComponent" IsForward="false">i=2253</Reference>
       <Reference ReferenceType="HasComponent">i=25451</Reference> <!-- PubSubConfiguration -->
+      <Reference ReferenceType="HasProperty">i=25480</Reference> <!-- DefaultDatagramPublisherId -->
       <Reference ReferenceType="HasTypeDefinition">i=14416</Reference>
     </References>
   </UAObject>
@@ -2410,6 +2419,13 @@
   </UAObject>
   <UAVariable NodeId="i=17481" BrowseName="SupportedTransportProfiles" ParentNodeId="i=14443" DataType="String" ValueRank="1">
     <DisplayName>SupportedTransportProfiles</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">i=14443</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="i=25480" BrowseName="DefaultDatagramPublisherId" ParentNodeId="i=14443" DataType="UInt64">
+    <DisplayName>DefaultDatagramPublisherId</DisplayName>
     <References>
       <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
       <Reference ReferenceType="HasProperty" IsForward="false">i=14443</Reference>


### PR DESCRIPTION
Correct generation of the defaultDatagramPublisherId when starting the server. According to the specification (6.2.7.1), it is recommended to assign the MAC address of one of the network interfaces to the first 6 bytes and the OPC UA Server Port of the OPC UA application to the remaining two bytes.

- [x] Include DefaultDatagramPublisherId in NS0
- [x] Get the MAC address
- [x] Generate DefaultDatagramPublisherId from MAC address and port.