### PR TITLE
fix: Check for successful file creation

### DIFF
--- a/plugins/crypto/mbedtls/ua_pki_mbedtls.c
+++ b/plugins/crypto/mbedtls/ua_pki_mbedtls.c
@@ -497,13 +497,17 @@ certificateVerification_verify(void *verificationContext,
             UA_ByteString_clear(&thumbprint);
 
             char *rejectedFullFileName = (char *) calloc(ci->rejectedListFolder.length + 1 /* '/' */ + strlen(rejectedFileName) + 1, sizeof(char));
-            memcpy(rejectedFullFileName, ci->rejectedListFolder.data, ci->rejectedListFolder.length);
-            rejectedFullFileName[ci->rejectedListFolder.length] = '/';
-            memcpy(&rejectedFullFileName[ci->rejectedListFolder.length + 1], rejectedFileName, strlen(rejectedFileName));
-            FILE * fp_rejectedFile = fopen(rejectedFullFileName, "wb");
-            fwrite(certificate->data, sizeof(certificate->data[0]), certificate->length, fp_rejectedFile);
-            free(rejectedFullFileName);
-            fclose(fp_rejectedFile);
+            if (rejectedFullFileName) {
+                memcpy(rejectedFullFileName, ci->rejectedListFolder.data, ci->rejectedListFolder.length);
+                rejectedFullFileName[ci->rejectedListFolder.length] = '/';
+                memcpy(&rejectedFullFileName[ci->rejectedListFolder.length + 1], rejectedFileName, strlen(rejectedFileName));
+                FILE * fp_rejectedFile = fopen(rejectedFullFileName, "wb");
+                if (fp_rejectedFile) {
+                    fwrite(certificate->data, sizeof(certificate->data[0]), certificate->length, fp_rejectedFile);
+                    fclose(fp_rejectedFile);
+                }
+                free(rejectedFullFileName);
+            }
         }
 #endif
     }

--- a/tests/encryption/check_save_rejected_cert.c
+++ b/tests/encryption/check_save_rejected_cert.c
@@ -473,13 +473,15 @@ START_TEST(encryption_connect_reject_cert) {
     strcat(rejectedFileName, ".der");
     FILE * fp_rejectedFile = fopen(rejectedFileName, "rb");
 
-    UA_Byte readBuffer[CLIENT_CERTIFICATE_DER_SIZE] = {0};
-    fread(readBuffer, CLIENT_CERTIFICATE_DER_SIZE, 1, fp_rejectedFile);
+    if (fp_rejectedFile) {
+        UA_Byte readBuffer[CLIENT_CERTIFICATE_DER_SIZE] = {0};
+        fread(readBuffer, CLIENT_CERTIFICATE_DER_SIZE, 1, fp_rejectedFile);
 
-    for(size_t i=0; i<CLIENT_CERTIFICATE_DER_SIZE; i++) {
-        ck_assert(readBuffer[i] == clientCertificateDer[i]);
+        for(size_t i=0; i<CLIENT_CERTIFICATE_DER_SIZE; i++) {
+           ck_assert(readBuffer[i] == clientCertificateDer[i]);
+        }
+        fclose(fp_rejectedFile);
     }
-    fclose(fp_rejectedFile);
 
     UA_Client_disconnect(client);
 #endif

--- a/tests/fuzz/ua_debug_dump_pkgs_file.c
+++ b/tests/fuzz/ua_debug_dump_pkgs_file.c
@@ -173,9 +173,11 @@ UA_debug_dumpCompleteChunk(UA_Server *const server, UA_Connection *const connect
                 "Dumping package %s", dumpOutputFile);
 
     FILE *write_ptr = fopen(dumpOutputFile, "ab");
-    fwrite(messageBuffer->data, messageBuffer->length, 1, write_ptr); // write 10 bytes from our buffer
-    // add the available memory size. See the UA_DUMP_RAM_SIZE define for more info.
-    uint32_t ramSize = UA_DUMP_RAM_SIZE;
-    fwrite(&ramSize, sizeof(ramSize), 1, write_ptr);
-    fclose(write_ptr);
+    if (write_ptr) {
+        fwrite(messageBuffer->data, messageBuffer->length, 1, write_ptr); // write 10 bytes from our buffer
+        // add the available memory size. See the UA_DUMP_RAM_SIZE define for more info.
+        uint32_t ramSize = UA_DUMP_RAM_SIZE;
+        fwrite(&ramSize, sizeof(ramSize), 1, write_ptr);
+        fclose(write_ptr);
+    }
 }


### PR DESCRIPTION
fclose should only be called on valid FILE pointers, as fclose(0) is undefined.