### PR TITLE
refactor(server): Remove refactored network statistics

### DIFF
--- a/include/open62541/common.h
+++ b/include/open62541/common.h
@@ -188,27 +188,15 @@ typedef enum {
 } UA_SessionState;
 
 /**
- * Statistic counters
+ * Statistic Counters
  * ------------------
  *
- * The stack manages statistic counters for the following layers:
+ * The stack manages statistic counters for SecureChannels and Sessions.
  *
- * - Network
- * - Secure channel
- * - Session
- *
- * The session layer counters are matching the counters of the
+ * The Session layer counters are matching the counters of the
  * ServerDiagnosticsSummaryDataType that are defined in the OPC UA Part 5
- * specification. Counters of the other layers are not specified by OPC UA but
- * are harmonized with the session layer counters if possible. */
-
-typedef struct {
-    size_t currentConnectionCount;
-    size_t cumulatedConnectionCount;
-    size_t rejectedConnectionCount;
-    size_t connectionTimeoutCount;
-    size_t connectionAbortCount;
-} UA_NetworkStatistics;
+ * specification. The SecureChannel counters are not defined in the OPC UA spec,
+ * but are harmonized with the Session layer counters if possible. */
 
 typedef struct {
     size_t currentChannelCount;

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1879,7 +1879,6 @@ UA_Server_setAsyncOperationResult(UA_Server *server,
 * are structured per OPC UA communication layer. */
 
 typedef struct {
-   UA_NetworkStatistics ns;
    UA_SecureChannelStatistics scs;
    UA_SessionStatistics ss;
 } UA_ServerStatistics;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -550,21 +550,14 @@ verifyServerApplicationURI(const UA_Server *server) {
 UA_ServerStatistics
 UA_Server_getStatistics(UA_Server *server) {
     UA_ServerStatistics stat;
-    stat.ns = server->networkStatistics;
     stat.scs = server->secureChannelStatistics;
-
+    UA_ServerDiagnosticsSummaryDataType *sds = &server->serverDiagnosticsSummary;
     stat.ss.currentSessionCount = server->activeSessionCount;
-    stat.ss.cumulatedSessionCount =
-        server->serverDiagnosticsSummary.cumulatedSessionCount;
-    stat.ss.securityRejectedSessionCount =
-        server->serverDiagnosticsSummary.securityRejectedSessionCount;
-    stat.ss.rejectedSessionCount =
-        server->serverDiagnosticsSummary.rejectedSessionCount;
-    stat.ss.sessionTimeoutCount =
-        server->serverDiagnosticsSummary.sessionTimeoutCount;
-    stat.ss.sessionAbortCount =
-        server->serverDiagnosticsSummary.sessionAbortCount;
-
+    stat.ss.cumulatedSessionCount = sds->cumulatedSessionCount;
+    stat.ss.securityRejectedSessionCount = sds->securityRejectedSessionCount;
+    stat.ss.rejectedSessionCount = sds->rejectedSessionCount;
+    stat.ss.sessionTimeoutCount = sds->sessionTimeoutCount;
+    stat.ss.sessionAbortCount = sds->sessionAbortCount;
     return stat;
 }
 

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -171,7 +171,6 @@ struct UA_Server {
 #endif
 
     /* Statistics */
-    UA_NetworkStatistics networkStatistics;
     UA_SecureChannelStatistics secureChannelStatistics;
     UA_ServerDiagnosticsSummaryDataType serverDiagnosticsSummary;
 };


### PR DESCRIPTION
The indirection between network connections and SecureChannels no longer exists in the server.  The network statistics are made directly on the  SecureChannel level.