### PR TITLE
Build examples with open62541 not being a root of the CMake project.

### DIFF
--- a/examples/nodeset/CMakeLists.txt
+++ b/examples/nodeset/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     ua_generate_nodeset_and_datatypes(
         NAME "example"
         FILE_NS "${FILE_NS_DIRPREFIX}/server_nodeset.xml"
-        DEPENDS "${CMAKE_SOURCE_DIR}/tools/schema/Opc.Ua.NodeSet2.Reduced.xml"
+        DEPENDS "${CMAKE_CURRENT_LIST_DIR}/../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml"
     )
 else()
     # standalone examples build expects already installed Opc.Ua.NodeSet2.Reduced.xml

--- a/examples/pubsub_realtime/nodeset/CMakeLists.txt
+++ b/examples/pubsub_realtime/nodeset/CMakeLists.txt
@@ -16,12 +16,12 @@ set(PROJECT_BINARY_DIR ${CMAKE_BINARY_DIR})
 ua_generate_nodeset_and_datatypes(
     NAME "example_publisher"
     FILE_NS "${FILE_NS_DIRPREFIX}/pubDataModel.xml"
-    DEPENDS "${CMAKE_SOURCE_DIR}/tools/schema/Opc.Ua.NodeSet2.Reduced.xml"
+    DEPENDS "${CMAKE_CURRENT_LIST_DIR}/../../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml"
 )
 ua_generate_nodeset_and_datatypes(
     NAME "example_subscriber"
     FILE_NS "${FILE_NS_DIRPREFIX}/subDataModel.xml"
-    DEPENDS "${CMAKE_SOURCE_DIR}/tools/schema/Opc.Ua.NodeSet2.Reduced.xml"
+    DEPENDS "${CMAKE_CURRENT_LIST_DIR}/../../../tools/schema/Opc.Ua.NodeSet2.Reduced.xml"
 )
 # The .csv file can be created from within UaModeler or manually
 ua_generate_nodeid_header(


### PR DESCRIPTION
Currently building of the examples fails when open62541 is included inside another CMake project due to incorrect paths.