### PR TITLE
fix(examples): Fix usage of publisherId in pubsub_interrupt_publish.c

### DIFF
--- a/examples/pubsub_realtime/pubsub_interrupt_publish.c
+++ b/examples/pubsub_realtime/pubsub_interrupt_publish.c
@@ -276,7 +276,9 @@ addPubSubConfiguration(UA_Server* server) {
         {UA_STRING(ETH_INTERFACE), UA_STRING(ETH_PUBLISH_ADDRESS)};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    connectionConfig.publisherId.numeric = UA_UInt32_random();
+    connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT32;
+    connectionConfig.publisherId.uint32 = UA_UInt32_random();
+
     UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
 
     UA_PublishedDataSetConfig publishedDataSetConfig;


### PR DESCRIPTION
This file was missed in commit fd76d7faaea38843eb74f578f6b82bf8252b98b7, which breaks build for a few examples.