### PR TITLE
[REVIEW]: feat(plugin): Integration of nodesetLoader functionality within open62541

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,12 +77,14 @@ Makefile
 /exampleClient
 /exampleClient_legacy
 /src_generated/
-/build
+**/build
 /cmake-build*
 /tools/certs/certs/*
 Pipfile
 Pipfile.lock
 .vscode
+**/libxml2
+debian/*
 
 # clangd cache
 .cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,7 @@
 	path = deps/mqtt-c
 	url = https://github.com/LiamBindle/MQTT-C.git
 	branch = master
+[submodule "deps/nodesetLoader"]
+	path = deps/nodesetLoader
+	url = https://github.com/open62541/nodesetLoader
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ option(UA_ENABLE_DA "Enable OPC UA DataAccess (Part 8) definitions" ON)
 option(UA_ENABLE_HISTORIZING "Enable basic support for historical access (client and server)" OFF)
 option(UA_ENABLE_DISCOVERY "Enable Discovery Service (LDS)" OFF)
 option(UA_ENABLE_JSON_ENCODING "Enable JSON encoding" ON)
+option(UA_ENABLE_NODESETLOADER "Enable nodesetLoader public API" OFF)
 
 set(MULTITHREADING_DEFAULT 0)
 if(WIN32 OR UNIX)
@@ -1228,6 +1229,22 @@ if(UA_BUILD_FUZZING OR UA_BUILD_OSS_FUZZ)
         ${PROJECT_SOURCE_DIR}/tests/fuzz/custom_memory_manager.c)
 endif()
 
+if(UA_ENABLE_NODESETLOADER)
+    # This is required because of issues with policy CMP0077.
+    # Source: https://stackoverflow.com/a/54404924
+    option(ENABLE_BUILD_INTO_OPEN62541 "make nodesetLoader part of the open62541 library" off)
+    set(ENABLE_BUILD_INTO_OPEN62541 on)
+
+    add_subdirectory(${PROJECT_SOURCE_DIR}/deps/nodesetLoader)
+
+    list(APPEND lib_sources ${NODESETLOADER_SOURCES})
+    list(APPEND default_plugin_headers
+                ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/nodesetloader.h)
+    list(APPEND default_plugin_sources
+                ${PROJECT_SOURCE_DIR}/plugins/ua_nodesetloader.c)
+    list(APPEND open62541_LIBRARIES ${NODESETLOADER_DEPS_LIBS})
+endif()
+
 #########################
 # Generate source files #
 #########################
@@ -1513,6 +1530,10 @@ else()
                                "${PROJECT_SOURCE_DIR}/src/pubsub"
                                "${PROJECT_BINARY_DIR}/src_generated")
 
+    if(UA_ENABLE_NODESETLOADER)
+        include_directories_public(${NODESETLOADER_PUBLIC_INCLUDES})
+    endif()
+
     # Private includes
     include_directories_private("${PROJECT_BINARY_DIR}")
 
@@ -1525,12 +1546,14 @@ else()
     if(UA_ENABLE_ENCRYPTION_LIBRESSL)
         include_directories_private(${LIBRESSL_INCLUDE_DIR})
     endif()
+    if(UA_ENABLE_NODESETLOADER)
+        include_directories_private(${NODESETLOADER_PRIVATE_INCLUDES})
+    endif()
 
     # Option-specific includes
     if(UA_ENABLE_DISCOVERY)
         include_directories_private("${PROJECT_SOURCE_DIR}/src/client")
     endif()
-
 endif()
 
 add_dependencies(open62541-object open62541-code-generation)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -274,3 +274,10 @@ if(UA_ENABLE_PUBSUB)
         endif()
     endif()
 endif()
+
+###########################
+# Nodeser Loader Examples #
+###########################
+if(UA_ENABLE_NODESETLOADER)
+    add_subdirectory(nodeset_loader)
+endif()

--- a/examples/custom_datatype/client_types_custom.c
+++ b/examples/custom_datatype/client_types_custom.c
@@ -20,7 +20,7 @@ int main(void) {
 
     /* Attention! Here the custom datatypes are allocated on the stack. So they
      * cannot be accessed from parallel (worker) threads. */
-    UA_DataTypeArray customDataTypes = {NULL, 4, types};
+    UA_DataTypeArray customDataTypes = {NULL, 4, types, UA_FALSE};
 
     UA_Client *client = UA_Client_new();
     UA_ClientConfig *cc = UA_Client_getConfig(client);

--- a/examples/custom_datatype/server_types_custom.c
+++ b/examples/custom_datatype/server_types_custom.c
@@ -279,7 +279,7 @@ int main(void) {
 
     /* Attention! Here the custom datatypes are allocated on the stack. So they
      * cannot be accessed from parallel (worker) threads. */
-    UA_DataTypeArray customDataTypes = {config->customDataTypes, 4, types};
+    UA_DataTypeArray customDataTypes = {config->customDataTypes, 4, types, UA_FALSE};
     config->customDataTypes = &customDataTypes;
 
     add3DPointDataType(server);

--- a/examples/nodeset/server_testnodeset.c
+++ b/examples/nodeset/server_testnodeset.c
@@ -15,7 +15,7 @@
 
 UA_Boolean running = true;
 
-UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTNODESET_COUNT, UA_TYPES_TESTNODESET};
+UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTNODESET_COUNT, UA_TYPES_TESTNODESET, UA_FALSE};
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");

--- a/examples/nodeset_loader/CMakeLists.txt
+++ b/examples/nodeset_loader/CMakeLists.txt
@@ -1,0 +1,8 @@
+###########################
+# Nodeset Loader Examples #
+###########################
+
+if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+    add_example(nodeset_loader nodeset_loader.c)
+    add_example(server_nodeset_loader server_nodeset_loader.c)
+endif()

--- a/examples/nodeset_loader/nodeset_loader.c
+++ b/examples/nodeset_loader/nodeset_loader.c
@@ -1,0 +1,34 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+UA_Boolean running = true;
+static void stopHandler(int sign) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
+    running = false;
+}
+
+int main(int argc, const char *argv[]) {
+    signal(SIGINT, stopHandler);
+    signal(SIGTERM, stopHandler);
+
+    UA_Server *server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+
+    for (int cnt = 1; cnt < argc; cnt++) {
+        if (!UA_Server_loadNodeset(server, argv[cnt], NULL)) {
+            printf("Nodeset %s could not be loaded, exit\n", argv[cnt]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+
+    return EXIT_SUCCESS;
+}

--- a/examples/nodeset_loader/server_nodeset_loader.c
+++ b/examples/nodeset_loader/server_nodeset_loader.c
@@ -1,0 +1,33 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+UA_Boolean running = true;
+static void stopHandler(int sign) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
+    running = false;
+}
+
+int main(int argc, const char *argv[]) {
+    signal(SIGINT, stopHandler);
+    signal(SIGTERM, stopHandler);
+
+    UA_Server *server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+
+    for (int cnt = 1; cnt < argc; cnt++) {
+        if (!UA_Server_loadNodeset(server, argv[cnt], NULL)) {
+            printf("Nodeset %s could not be loaded, exit\n", argv[cnt]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    UA_StatusCode retval = UA_Server_run(server, &running);
+    UA_Server_delete(server);
+
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/pubsub/tutorial_pubsub_publish_raw.c
+++ b/examples/pubsub/tutorial_pubsub_publish_raw.c
@@ -276,7 +276,7 @@ static int run(UA_String *transportProfile,
     types[0] = PointType;
     types[0].members = pointMembers;
 
-    UA_DataTypeArray customDataTypes = {config->customDataTypes, 1, types};
+    UA_DataTypeArray customDataTypes = {config->customDataTypes, 1, types, UA_FALSE};
     config->customDataTypes = &customDataTypes;
 
     add3DPointDataType(server);

--- a/examples/pubsub/tutorial_pubsub_subscribe_raw.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe_raw.c
@@ -328,7 +328,7 @@ run(UA_String *transportProfile, UA_NetworkAddressUrlDataType *networkAddressUrl
     types[0] = PointType;
     types[0].members = pointMembers;
 
-    UA_DataTypeArray customDataTypes = {config->customDataTypes, 1, types};
+    UA_DataTypeArray customDataTypes = {config->customDataTypes, 1, types, UA_FALSE};
     config->customDataTypes = &customDataTypes;
 
     add3DPointDataType(server);

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1074,6 +1074,9 @@ typedef struct UA_DataTypeArray {
     const struct UA_DataTypeArray *next;
     const size_t typesSize;
     const UA_DataType *types;
+    UA_Boolean cleanup; /* Free the array structure and its content
+                           when the client or server configuration
+                           containing it is cleaned up */
 } UA_DataTypeArray;
 
 /* Returns the offset and type of a structure member. The return value is false

--- a/plugins/include/open62541/plugin/nodesetloader.h
+++ b/plugins/include/open62541/plugin/nodesetloader.h
@@ -1,0 +1,24 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
+ *
+ *    Copyright 2019 (c) Julius Pfrommer, Fraunhofer IOSB
+ */
+
+#ifndef UA_NODESET_LOADER_DEFAULT_H_
+#define UA_NODESET_LOADER_DEFAULT_H_
+
+#include <open62541/util.h>
+
+_UA_BEGIN_DECLS
+
+typedef void UA_NodeSetLoaderOptions;
+
+/* Load the typemodel at runtime, without the need to statically compile the model.
+ * This is an alternative to the Python nodeset compiler approach. */
+UA_EXPORT UA_StatusCode
+UA_Server_loadNodeset(UA_Server *server, const char *nodeset2XmlFilePath,
+                      UA_NodeSetLoaderOptions *options);
+
+_UA_END_DECLS
+
+#endif /* UA_NODESET_LOADER_DEFAULT_H_ */

--- a/plugins/ua_nodesetloader.c
+++ b/plugins/ua_nodesetloader.c
@@ -1,0 +1,20 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
+ *
+ *    Copyright 2014-2019 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
+ *    Copyright 2017 (c) Julian Grothoff
+ *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
+ */
+
+#include <open62541/plugin/nodesetloader.h>
+#include <NodesetLoader/backendOpen62541.h>
+#include <NodesetLoader/dataTypes.h>
+#include <open62541/server.h>
+
+UA_StatusCode
+UA_Server_loadNodeset(UA_Server *server, const char *nodeset2XmlFilePath,
+                      UA_NodeSetLoaderOptions *options) {
+    return NodesetLoader_loadFile(server,
+                                  nodeset2XmlFilePath,
+                                  (NodesetLoader_ExtensionInterface*)options);
+}

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -104,6 +104,9 @@ UA_ClientConfig_clear(UA_ClientConfig *config) {
     }
     config->sessionLocaleIds = NULL;
     config->sessionLocaleIdsSize = 0;
+
+    /* Custom Data Types */
+    UA_cleanupDataTypeWithCustom(config->customDataTypes);
 }
 
 static void

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -8,6 +8,8 @@
 
 #include <open62541/server.h>
 
+#include "ua_server_internal.h"
+
 void
 UA_ServerConfig_clean(UA_ServerConfig *config) {
     if(!config)
@@ -100,6 +102,9 @@ UA_ServerConfig_clean(UA_ServerConfig *config) {
     }
 #endif
 #endif /* UA_ENABLE_PUBSUB */
+
+    /* Custom Data Types */
+    UA_cleanupDataTypeWithCustom(config->customDataTypes);
 }
 
 #ifdef UA_ENABLE_PUBSUB

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -83,6 +83,27 @@ UA_findDataType(const UA_NodeId *typeId) {
     return UA_findDataTypeWithCustom(typeId, NULL);
 }
 
+void
+UA_cleanupDataTypeWithCustom(const UA_DataTypeArray *customTypes) {
+    while (customTypes) {
+        const UA_DataTypeArray *next = customTypes->next;
+        if (customTypes->cleanup) {
+            for(size_t i = 0; i < customTypes->typesSize; ++i) {
+                const UA_DataType *type = &customTypes->types[i];
+                UA_free((void*)(uintptr_t)type->typeName);
+                for(size_t j = 0; j < type->membersSize; ++j) {
+                    const UA_DataTypeMember *m = &type->members[j];
+                    UA_free((void*)(uintptr_t)m->memberName);
+                }
+                UA_free((void*)type->members);
+            }
+            UA_free((void*)(uintptr_t)customTypes->types);
+            UA_free((void*)(uintptr_t)customTypes);
+        }
+        customTypes = next;
+    }
+}
+
 /***************************/
 /* Random Number Generator */
 /***************************/

--- a/src/ua_util_internal.h
+++ b/src/ua_util_internal.h
@@ -175,6 +175,9 @@ const UA_DataType *
 UA_findDataTypeWithCustom(const UA_NodeId *typeId,
                           const UA_DataTypeArray *customTypes);
 
+void
+UA_cleanupDataTypeWithCustom(const UA_DataTypeArray *customTypes);
+
 /* Get the number of optional fields contained in an structure type */
 size_t UA_EXPORT
 getCountOfOptionalFields(const UA_DataType *type);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,10 @@ if(UA_ENABLE_PUBSUB)
     endif()
 endif()
 
+if(UA_ENABLE_NODESETLOADER)
+    list(APPEND test_plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_nodesetloader.c)
+endif()
+
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     set(NODESET_COMPILER_OUTPUT_DIR "${CMAKE_BINARY_DIR}/src_generated/tests")
 
@@ -415,6 +419,11 @@ endif()
 
 # Tests for Nodeset Compiler
 add_subdirectory(nodeset-compiler)
+
+# Tests for Nodeset Loader
+if(UA_ENABLE_NODESETLOADER)
+    add_subdirectory(nodeset-loader)
+endif()
 
 # Tests for interfaces
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -79,7 +79,7 @@ static const UA_DataType PointType = {
     members
 };
 
-const UA_DataTypeArray customDataTypes = {NULL, 1, &PointType};
+const UA_DataTypeArray customDataTypes = {NULL, 1, &PointType, UA_FALSE};
 
 typedef struct {
     UA_Int16 a;
@@ -129,7 +129,7 @@ static const UA_DataType OptType = {
         Opt_members
 };
 
-const UA_DataTypeArray customDataTypesOptStruct = {&customDataTypes, 2, &OptType};
+const UA_DataTypeArray customDataTypesOptStruct = {&customDataTypes, 2, &OptType, UA_FALSE};
 
 typedef struct {
     UA_String description;
@@ -178,7 +178,7 @@ static const UA_DataType ArrayOptType = {
     ArrayOptStruct_members
 };
 
-const UA_DataTypeArray customDataTypesOptArrayStruct = {&customDataTypesOptStruct, 3, &ArrayOptType};
+const UA_DataTypeArray customDataTypesOptArrayStruct = {&customDataTypesOptStruct, 3, &ArrayOptType, UA_FALSE};
 
 typedef enum {UA_UNISWITCH_NONE = 0, UA_UNISWITCH_OPTIONA = 1, UA_UNISWITCH_OPTIONB = 2} UA_UniSwitch;
 
@@ -219,7 +219,7 @@ static const UA_DataType UniType = {
         Uni_members
 };
 
-const UA_DataTypeArray customDataTypesUnion = {&customDataTypesOptArrayStruct, 2, &UniType};
+const UA_DataTypeArray customDataTypesUnion = {&customDataTypesOptArrayStruct, 2, &UniType, UA_FALSE};
 
 typedef enum {
     UA_SELFCONTAININGUNIONSWITCH_NONE = 0,
@@ -270,7 +270,7 @@ const UA_DataType selfContainingUnionType = {
     SelfContainingUnion_members  /* .members */
 };
 
-const UA_DataTypeArray customDataTypesSelfContainingUnion = {NULL, 1, &selfContainingUnionType};
+const UA_DataTypeArray customDataTypesSelfContainingUnion = {NULL, 1, &selfContainingUnionType, UA_FALSE};
 
 START_TEST(parseCustomScalar) {
     Point p;

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -14,7 +14,7 @@
 #include "unistd.h"
 
 UA_Server *server = NULL;
-UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTS_TESTNODESET_COUNT, UA_TYPES_TESTS_TESTNODESET};
+UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTS_TESTNODESET_COUNT, UA_TYPES_TESTS_TESTNODESET, UA_FALSE};
 UA_UInt16 testNamespaceIndex = (UA_UInt16) -1;
 
 static void setup(void) {

--- a/tests/nodeset-loader/CMakeLists.txt
+++ b/tests/nodeset-loader/CMakeLists.txt
@@ -1,0 +1,13 @@
+####################################################
+# Test nodeset loader on a subset of nodeset files #
+####################################################
+
+if(UA_NAMESPACE_ZERO STREQUAL "FULL")
+    add_compile_definitions(OPEN62541_NODESET_DIR="${UA_NODESET_DIR}/")
+    ua_add_test(check_nodeset_loader_di.c)
+    ua_add_test(check_nodeset_loader_adi.c)
+    ua_add_test(check_nodeset_loader_autoid.c)
+    ua_add_test(check_nodeset_loader_plc.c)
+    ua_add_test(check_nodeset_loader_input.c)
+    ua_add_test(check_nodeset_loader_ua_nodeset.c)
+endif()

--- a/tests/nodeset-loader/check_nodeset_loader_adi.c
+++ b/tests/nodeset-loader/check_nodeset_loader_adi.c
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include "check.h"
+#include "testing_clock.h"
+
+UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(Server_loadDiNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadAdiNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "ADI/Opc.Ua.Adi.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+static Suite* testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    TCase *tc_server = tcase_create("Server DI and ADI nodeset");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_loadDiNodeset);
+    tcase_add_test(tc_server, Server_loadAdiNodeset);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-loader/check_nodeset_loader_autoid.c
+++ b/tests/nodeset-loader/check_nodeset_loader_autoid.c
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include "check.h"
+#include "testing_clock.h"
+
+UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(Server_loadDiNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadAutoIDNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "AutoID/Opc.Ua.AutoID.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+static Suite* testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    TCase *tc_server = tcase_create("Server DI and AutoID nodeset");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_loadDiNodeset);
+    tcase_add_test(tc_server, Server_loadAutoIDNodeset);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-loader/check_nodeset_loader_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_di.c
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include "check.h"
+#include "testing_clock.h"
+
+UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(Server_loadDiNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+static Suite* testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    TCase *tc_server = tcase_create("Server DI nodeset");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_loadDiNodeset);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-loader/check_nodeset_loader_input.c
+++ b/tests/nodeset-loader/check_nodeset_loader_input.c
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include "check.h"
+#include "testing_clock.h"
+
+UA_Server *server = NULL;
+char **nodesetPaths = NULL;
+int nodesetsNum = 0;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(Server_loadInputNodesets) {
+    for (int cnt = 0; cnt < nodesetsNum; cnt++) {
+        bool retVal = UA_Server_loadNodeset(server, nodesetPaths[cnt], NULL);
+        ck_assert_uint_eq(retVal, true);
+    }
+}
+END_TEST
+
+static Suite* testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    TCase *tc_server = tcase_create("Server load input nodesets");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_loadInputNodesets);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        nodesetPaths = (char**)malloc(sizeof(char*));
+        nodesetPaths[0] = OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml";
+        nodesetsNum = 1;
+    }
+    else {
+        nodesetPaths = &argv[1];
+        nodesetsNum = argc - 1;
+    }
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-loader/check_nodeset_loader_plc.c
+++ b/tests/nodeset-loader/check_nodeset_loader_plc.c
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include "check.h"
+#include "testing_clock.h"
+
+UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(Server_loadDiNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlcNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "PLCopen/Opc.Ua.PLCopen.NodeSet2_V1.02.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+static Suite* testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    TCase *tc_server = tcase_create("Server DI and PLCopen nodeset");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_loadDiNodeset);
+    tcase_add_test(tc_server, Server_loadPlcNodeset);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
@@ -1,0 +1,1231 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Test case for all standardized companion nodesets. You can
+ * find the specifications at https://github.com/OPCFoundation/UA-Nodeset.
+ *      - branch: latest
+ *      - commit: a2208e8
+ * 
+ * Currently this test case is missing the following UA-Nodesets:
+ *    * NodesetLoader related issues:
+ *      - ${OPEN62541_NODESET_DIR}AML/Opc.Ua.AMLLibraries.NodeSet2.xml
+ *      - ${OPEN62541_NODESET_DIR}ISA95-JOBCONTROL/opc.ua.isa95-jobcontrol.nodeset2.xml
+ *      - ${OPEN62541_NODESET_DIR}PNRIO/Opc.Ua.PnRio.Nodeset2.xml
+ *      - ${OPEN62541_NODESET_DIR}TMC/Opc.Ua.TMC.NodeSet2.xml
+ *
+ *    * Memory leak issues (libXML2 library related):
+ *      - ${OPEN62541_NODESET_DIR}CNC/Opc.Ua.CNC.NodeSet.xml
+ *      - ${OPEN62541_NODESET_DIR}IJT/Tightening/Opc.Ua.Ijt.Tightening.NodeSet2.xml
+ *      - $(OPEN62541_NODESET_DIR)MachineVision/Opc.Ua.MachineVision.NodeSet2.xml
+ *      - $(OPEN62541_NODESET_DIR)Mining/General/1.0.0/Opc.Ua.Mining.General.NodeSet2.xml
+ *          - Dependent Nodesets:
+ *              * $(OPEN62541_NODESET_DIR)Mining/DevelopmentSupport/Dozer/1.0.0/Opc.Ua.Mining.DevelopmentSupport.Dozer.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/DevelopmentSupport/RoofSupportSystem/1.0.0/Opc.Ua.Mining.DevelopmentSupport.RoofSupportSystem.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/Extraction/ShearerLoader/1.0.0/Opc.Ua.Mining.Extraction.ShearerLoader.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/Loading/General/1.0.0/Opc.Ua.Mining.Loading.General.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/Loading/HydraulicExcavator/1.0.0/Opc.Ua.Mining.Loading.HydraulicExcavator.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/MineralProcessing/RockCrusher/1.0.0/Opc.Ua.Mining.MineralProcessing.RockCrusher.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/PELOServices/FaceAlignmentSystem/1.0.0/Opc.Ua.Mining.PELOServices.FaceAlignmentSystem.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/PELOServices/General/1.0.0/Opc.Ua.Mining.PELOServices.General.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/TransportDumping/ArmouredFaceConveyor/1.0.0/Opc.Ua.Mining.TransportDumping.ArmouredFaceConveyor.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/TransportDumping/General/1.0.0/Opc.Ua.Mining.TransportDumping.General.NodeSet2.xml
+ *              * $(OPEN62541_NODESET_DIR)Mining/TransportDumping/RearDumpTruck/1.0.0/Opc.Ua.Mining.TransportDumping.RearDumpTruck.NodeSet2.xml
+ *      - $(OPEN62541_NODESET_DIR)PADIM/Opc.Ua.IRDI.NodeSet2.xml
+ *          - Dependent Nodesets:
+ *              * $(OPEN62541_NODESET_DIR)PADIM/Opc.Ua.PADIM.NodeSet2.xml
+ *      - $(OPEN62541_NODESET_DIR)POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml
+ *      - $(OPEN62541_NODESET_DIR)Pumps/Opc.Ua.Pumps.NodeSet2.xml
+ *      - $(OPEN62541_NODESET_DIR)Scales/Opc.Ua.Scales.NodeSet2.xml
+ */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include "check.h"
+#include "testing_clock.h"
+
+UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(Server_loadADINodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "ADI/Opc.Ua.Adi.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadAMBNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "AMB/Opc.Ua.AMB.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadAMLBaseTypesNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "AML/Opc.Ua.AMLBaseTypes.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadAutoIDNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "AutoID/Opc.Ua.AutoID.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadCASNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "CAS/Opc.Ua.CAS.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadCommercialKitchenEquipmentNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "CommercialKitchenEquipment/Opc.Ua.CommercialKitchenEquipment.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadCSPPlusForMachineNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "CSPPlusForMachine/Opc.Ua.CSPPlusForMachine.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadDEXPINodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DEXPI/Opc.Ua.DEXPI.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadDINodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadDotNetNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DotNet/Opc.Ua.NodeSet.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadFDI5Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "FDI/Opc.Ua.Fdi5.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadFDI7Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "FDI/Opc.Ua.Fdi7.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadFDTNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "FDT/Opc.Ua.FDT.NodeSet.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadGDSNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "GDS/Opc.Ua.Gds.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadServer_loadGDSPart12Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "GDS/Opc.Ua.Gds.NodeSet2.Part12.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadServer_loadGlassNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Glass/Flat/Opc.Ua.Glass.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadI4AASNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "I4AAS/Opc.Ua.I4AAS.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadIANodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IA/Opc.Ua.IA.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadIAExamplesNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IA/Opc.Ua.IA.NodeSet2.examples.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadIEC61850_6_Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IEC61850/Opc.Ua.IEC61850-6.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadIEC61850_7_3_Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadIEC61850_7_4_Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IEC61850/Opc.Ua.IEC61850-7-4.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadIOLinkIODDNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IOLink/Opc.Ua.IOLinkIODD.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadIOLinkNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IOLink/Opc.Ua.IOLink.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadISA95Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "ISA-95/Opc.ISA95.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMachineryNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Machinery/Opc.Ua.Machinery.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMachineryExamplesNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Machinery/Opc.Ua.Machinery.Examples.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMachineToolNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "MachineTool/Opc.Ua.MachineTool.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMDISNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "MDIS/Opc.MDIS.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMiningDevelopmentSupportGeneralNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/DevelopmentSupport/General/1.0.0/Opc.Ua.Mining.DevelopmentSupport.General.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMiningExtractionGeneralNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/Extraction/General/1.0.0/Opc.Ua.Mining.Extraction.General.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMiningMineralProcessingGeneralNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/MineralProcessing/General/1.0.0/Opc.Ua.Mining.MineralProcessing.General.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMiningMonitoringSupervisionServicesGeneralNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/MonitoringSupervisionServices/General/1.0.0/Opc.Ua.Mining.MonitoringSupervisionServices.General.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadMTConnectNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "MTConnect/Opc.Ua.MTConnect.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadOPENSCSNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "OpenSCS/Opc.Ua.OPENSCS.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPackMLNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "PackML/Opc.Ua.PackML.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionCalenderNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Calender/1.00/Opc.Ua.PlasticsRubber.Extrusion.Calender.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionCalibratorNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Calibrator/1.00/Opc.Ua.PlasticsRubber.Extrusion.Calibrator.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionCorrugatorNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Corrugator/1.00/Opc.Ua.PlasticsRubber.Extrusion.Corrugator.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionCutterNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Cutter/1.00/Opc.Ua.PlasticsRubber.Extrusion.Cutter.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionDieNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Die/1.00/Opc.Ua.PlasticsRubber.Extrusion.Die.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionExtruderNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Extruder/1.00/Opc.Ua.PlasticsRubber.Extrusion.Extruder.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionExtrusionLineNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/ExtrusionLine/1.00/Opc.Ua.PlasticsRubber.Extrusion.ExtrusionLine.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionFilterNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Filter/1.00/Opc.Ua.PlasticsRubber.Extrusion.Filter.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/GeneralTypes/1.00/Opc.Ua.PlasticsRubber.Extrusion.GeneralTypes.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_1_Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/GeneralTypes/1.01/Opc.Ua.PlasticsRubber.Extrusion.GeneralTypes.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionHaulOffNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/HaulOff/1.00/Opc.Ua.PlasticsRubber.Extrusion.HaulOff.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionMeltPumpNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/MeltPump/1.00/Opc.Ua.PlasticsRubber.Extrusion.MeltPump.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionPelletizerNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion/Pelletizer/1.00/Opc.Ua.PlasticsRubber.Extrusion.Pelletizer.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2CalenderNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Calender/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Calender.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2CalibratorNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Calibrator/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Calibrator.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2CorrugatorNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Corrugator/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Corrugator.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2CutterNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Cutter/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Cutter.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2DieNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Die/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Die.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2ExtruderNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Extruder/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Extruder.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2ExtrusionLineNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/ExtrusionLine/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.ExtrusionLine.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2FilterNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Filter/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Filter.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/GeneralTypes/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.GeneralTypes.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2HaulOffNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/HaulOff/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.HaulOff.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2MeltPumpNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/MeltPump/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.MeltPump.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberExtrusionv2PelletizerNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/Extrusion_v2/Pelletizer/2.00/Opc.Ua.PlasticsRubber.Extrusion_v2.Pelletizer.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/GeneralTypes/1.02/Opc.Ua.PlasticsRubber.GeneralTypes.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/GeneralTypes/1.03/Opc.Ua.PlasticsRubber.GeneralTypes.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberHotRunnerNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/HotRunner/1.00/Opc.Ua.PlasticsRubber.HotRunner.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberIMM2MESNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/IMM2MES/1.01/Opc.Ua.PlasticsRubber.IMM2MES.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberLDSNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR 
+        "PlasticsRubber/LDS/1.00/Opc.Ua.PlasticsRubber.LDS.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPlasticsRubberTCDNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "PlasticsRubber/TCD/1.01/Opc.Ua.PlasticsRubber.TCD.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPLCopenNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "PLCopen/Opc.Ua.PLCopen.NodeSet2_V1.02.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPnEmNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "PNEM/Opc.Ua.PnEm.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadPROFINETNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "PROFINET/Opc.Ua.Pn.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadRoboticsNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Robotics/Opc.Ua.Robotics.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadSafetyNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Safety/Opc.Ua.Safety.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadSercosNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Sercos/Sercos.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadWeihenstephanNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Weihenstephan/Opc.Ua.Weihenstephan.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadWoodworkingEumaboisNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Woodworking/Opc.Ua.Eumabois.Nodeset2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadWoodworkingNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Woodworking/Opc.Ua.Woodworking.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+static Suite* testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    {
+        TCase *tc_server = tcase_create("Server load ADI nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadADINodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load AMB nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadAMBNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load AMLBaseTypes nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadAMLBaseTypesNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load AutoID nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadAutoIDNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load CAS nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadCASNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load CommercialKitchenEquipment nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadCommercialKitchenEquipmentNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load CSPPlusForMachine nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadCSPPlusForMachineNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load DEXPI nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDEXPINodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load DI nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load DotNet nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDotNetNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load FDI5 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadFDI5Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load FDI7 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadFDI7Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load FDT nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadFDTNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load GDS nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadGDSNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load GDSPart12 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadServer_loadGDSPart12Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Glass nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadServer_loadGlassNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load I4AAS nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadI4AASNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IA nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IAExamples nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadIAExamplesNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IEC61850-6 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadIEC61850_7_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadIEC61850_6_Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IEC61850-7-3 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadIEC61850_7_3_Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IEC61850-7-4 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadIEC61850_7_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadIEC61850_7_4_Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IOLinkIODD nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadIOLinkIODDNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IOLink nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIOLinkNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load ISA95 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadISA95Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Machinery nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MachineryExamples nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMachineryExamplesNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MachineTool nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineToolNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MDIS nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMDISNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MiningDevelopmentSupportGeneral nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMiningDevelopmentSupportGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MiningExtractionGeneral nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMiningExtractionGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MiningMineralProcessingGeneral nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMiningMineralProcessingGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MiningMonitoringSupervisionServicesGeneral nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMiningMonitoringSupervisionServicesGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MTConnect nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMTConnectNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load OPENSCS nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadOPENSCSNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PackML nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadPackMLNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionCalender nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_1_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionCalenderNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionCalibrator nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionCalibratorNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionCorrugator nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionHaulOffNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionCorrugatorNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionCutter nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionCutterNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionDie nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionDieNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionExtruder nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionExtruderNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionExtrusionLine nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionExtrusionLineNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionFilter nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionFilterNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionGeneralTypes v1.00 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionGeneralTypes v1.01 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_1_Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionHaulOff nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionHaulOffNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionMeltPump nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionMeltPumpNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionPelletizer nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionGeneralTypes_v1_0_0_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionPelletizerNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Calender nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2CalenderNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Calibrator nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2CalibratorNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Corrugator nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2HaulOffNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2CorrugatorNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Cutter nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2CutterNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Die nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2DieNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Extruder nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2ExtruderNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2ExtrusionLine nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2ExtrusionLineNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Filter nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2FilterNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2GeneralTypes nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2HaulOff nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2HaulOffNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2MeltPump nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2MeltPumpNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberExtrusionv2Pelletizer nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2GeneralTypesNodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberExtrusionv2PelletizerNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberGeneralTypes v1.02 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberGeneralTypes v1.03 nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberHotRunner nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberHotRunnerNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberIMM2MES nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberIMM2MESNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberLDS nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_3_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberLDSNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PlasticsRubberTCD nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberGeneralTypes_v1_0_2_Nodeset);
+        tcase_add_test(tc_server, Server_loadPlasticsRubberTCDNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PLCopen nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPLCopenNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PNEM nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPnEmNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PROFINET nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadPROFINETNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Robotics nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadRoboticsNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Safety nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadSafetyNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Sercos nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadSercosNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Weihenstephan nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPackMLNodeset);
+        tcase_add_test(tc_server, Server_loadWeihenstephanNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load WoodworkingEumabois nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadWoodworkingNodeset);
+        tcase_add_test(tc_server, Server_loadWoodworkingEumaboisNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Woodworking nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadWoodworkingNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/server/check_local_monitored_item.c
+++ b/tests/server/check_local_monitored_item.c
@@ -148,7 +148,7 @@ static UA_DataType PointType = {
     members
 };
 
-UA_DataTypeArray customDataTypes = {NULL, 1, &PointType};
+UA_DataTypeArray customDataTypes = {NULL, 1, &PointType, UA_FALSE};
 
 START_TEST(Server_LocalMonitoredItem_CustomType) {
     callbackCount = 0;

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -292,7 +292,8 @@ _UA_END_DECLS
         writec("\nstatic UA_DataTypeArray custom" + arr + " = {")
         writec("    NULL,")
         writec("    " + arr + "_COUNT,")
-        writec("    " + arr + "\n};")
+        writec("    " + arr + ",")
+        writec("    UA_FALSE\n};")
 
     writec("""
 UA_StatusCode %s(UA_Server *server) {


### PR DESCRIPTION
Work regarding this feature has been supported by OSADL phase 4: Open Source open62541 support project. This feature represents the initial solution to the following work package:

- _Load and store information data model at runtime through binary file (no statically compiled in firmware)_

The official open62541 [nodesetLoader](https://github.com/open62541/nodesetLoader) repository is integrated as a **submodule**, and the source and header files are exported to the open62541 build. Added option **UA_ENABLE_NODESETLOADER** for enabling/disabling this feature. The nodesetLoader functionality of loading the information model at runtime is added as an open62541 plugin. The following methods are provided:

```
UA_EXPORT UA_StatusCode
UA_Server_loadNodeset(UA_Server *server, const char *nodeset2XmlFilePath,
                      UA_NodeSetLoaderOptions *options);
```

The following test cases are provided within the initial PR:

- **check_nodeset_loader_adi** (test loading of [ADI](https://github.com/OPCFoundation/UA-Nodeset/blob/latest/ADI/Opc.Ua.Adi.NodeSet2.xml) companion specification)
- **check_nodeset_loader_autoid** (test loading of [AutoID](https://github.com/OPCFoundation/UA-Nodeset/blob/latest/AutoID/Opc.Ua.AutoID.NodeSet2.xml) companion specification)
- **check_nodeset_loader_di** (test loading of [DI](https://github.com/OPCFoundation/UA-Nodeset/blob/latest/DI/Opc.Ua.Di.NodeSet2.xml) companion specification)
- **check_nodeset_loader_input** (test loading of nodeset specifications provided through command-line arguments)
- **check_nodeset_loader_plc** (test loading of [PLCopen](https://github.com/OPCFoundation/UA-Nodeset/blob/latest/PLCopen/Opc.Ua.PLCopen.NodeSet2_V1.02.xml) companion specification)
- **check_nodeset_loader_ua_nodeset** (test all currently supported OPC Foundation companion [UA-Nodeset](https://github.com/OPCFoundation/UA-Nodeset))

Also, the option is added within the _UA_DataTypeArray_ to choose whether to free the content of the data types automatically with the cleanup of the client/server configuration or not:
```
/* Datatype arrays with custom type definitions can be added in a linked list to
 * the client or server configuration. */
typedef struct UA_DataTypeArray {
    const struct UA_DataTypeArray *next;
    const size_t typesSize;
    const UA_DataType *types;
    UA_Boolean cleanup; /* Free the array structure and its content
                           when the client or server configuration
                           containing it is cleaned up */
} UA_DataTypeArray;
```

The following examples are provided within the initial PR:

- **nodeset_loader** (loading of nodeset specifications provided through command-line arguments without running the server)
- **server_nodeset_loader** (loading of nodeset specifications provided through command-line arguments and starting the server)

**NOTE**: This feature heavily depends on another PR within the nodesetLoader repository: [#196](https://github.com/open62541/nodesetLoader/pull/196). Consider merging the nodesetLoader PR before continuing with this merge-request.