### PR TITLE
[CLIENT] update subscription lastActivity

### DIFF
--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -532,6 +532,8 @@ ua_Client_MonitoredItems_create(UA_Client *client,
         return;
     }
 
+    sub->lastActivity = UA_DateTime_nowMonotonic();
+    
     /* Call the service. Use data->request as it contains the client handle
      * information. */
     __UA_Client_Service(client, &data.request,


### PR DESCRIPTION
When I create a loop that will create a large number of ua_Client_MonitoredItems_create and if my server is a bit busy, my loop will take a long time. If it takes longer than maxSilence then my inactivity callback is called directly.

https://github.com/open62541/open62541/blob/05205ddeb56adc7649b0f5e0c2d873cc1a654b8c/src/client/ua_client_subscriptions.c#L1209-L1221



This patch fix the issue by updating the last subscription activity in ua_Client_MonitoredItems_create.