### PR TITLE
[Review] feat (pubsub): SKS SecurityGroups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1002,6 +1002,7 @@ set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c
                 ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_manager.c
                 ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_ns0.c
                 ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_keystorage.c
+                ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_securitygroup.c
                 # services
                 ${PROJECT_SOURCE_DIR}/src/server/ua_services_view.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_services_method.c

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -904,6 +904,25 @@ typedef struct {
 } UA_SecurityGroupConfig;
 
 /**
+ * @brief Creates a SecurityGroup object and add it to the list in PubSub Manager. If the
+ * information model is enabled then the SecurityGroup object Node is also created in the
+ * server. A keyStorage with initial list of keys is created with a SecurityGroup. A
+ * callback is added to new SecurityGroup which updates the keys periodically at each
+ * KeyLifeTime expire.
+ *
+ * @param server The server instance
+ * @param securityGroupFolderNodeId The parent node of the SecurityGroup. It must be of
+ * SecurityGroupFolderType
+ * @param securityGroupConfig The security settings of a SecurityGroup
+ * @param securityGroupNodeId The output nodeId of the new SecurityGroup
+ * @return UA_StatusCode The return status code
+ */
+UA_StatusCode UA_EXPORT
+UA_Server_addSecurityGroup(UA_Server *server, UA_NodeId securityGroupFolderNodeId,
+                           const UA_SecurityGroupConfig *securityGroupConfig,
+                           UA_NodeId *securityGroupNodeId);
+
+/**
  * @brief Removes the SecurityGroup from PubSub Manager. It removes the KeyStorage
  * associated with the SecurityGroup from the server.
  *

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -903,6 +903,17 @@ typedef struct {
     UA_UInt32 maxPastKeyCount;
 } UA_SecurityGroupConfig;
 
+/**
+ * @brief Removes the SecurityGroup from PubSub Manager. It removes the KeyStorage
+ * associated with the SecurityGroup from the server.
+ *
+ * @param server The server instance
+ * @param securityGroup The nodeId of the securityGroup to be removed
+ * @return UA_StatusCode The returned status code.
+ */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_removeSecurityGroup(UA_Server *server, const UA_NodeId securityGroup);
+
 #endif /* UA_ENABLE_PUBSUB_SKS */
 
 #endif /* UA_ENABLE_PUBSUB */

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -877,6 +877,33 @@ UA_Server_setReaderGroupEncryptionKeys(UA_Server *server, UA_NodeId readerGroup,
                                        UA_ByteString keyNonce);
 #endif
 
+#ifdef UA_ENABLE_PUBSUB_SKS
+/**
+ * SecurityGroup
+ * -------------
+ *
+ * A SecurityGroup is an abstraction that represents the message security settings and
+ * security keys for a subset of NetworkMessages exchanged between Publishers and
+ * Subscribers. The SecurityGroup objects are created on a Security Key Service (SKS). The
+ * SKS manages the access to the keys based on the role permission for a user assigned to
+ * a SecurityGroup Object. A SecurityGroup is identified with a unique identifier called
+ * the SecurityGroupId. It is unique within the SKS.
+ *
+ * .. note:: The access to the SecurityGroup and therefore the securitykeys managed by SKS
+ *           requires management of Roles and Permissions in the SKS. The Role Permission
+ *           model is not supported at the time of writing. However, the access control plugin can
+ *           be used to create and manage role permission on SecurityGroup object.
+ */
+
+typedef struct {
+    UA_String securityGroupName;
+    UA_Duration keyLifeTime;
+    UA_String securityPolicyUri;
+    UA_UInt32 maxFutureKeyCount;
+    UA_UInt32 maxPastKeyCount;
+} UA_SecurityGroupConfig;
+
+#endif /* UA_ENABLE_PUBSUB_SKS */
 
 #endif /* UA_ENABLE_PUBSUB */
 

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -917,7 +917,7 @@ typedef struct {
  * @param securityGroupNodeId The output nodeId of the new SecurityGroup
  * @return UA_StatusCode The return status code
  */
-UA_StatusCode UA_EXPORT
+UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_addSecurityGroup(UA_Server *server, UA_NodeId securityGroupFolderNodeId,
                            const UA_SecurityGroupConfig *securityGroupConfig,
                            UA_NodeId *securityGroupNodeId);

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -604,6 +604,16 @@ struct UA_SecurityGroup {
     TAILQ_ENTRY(UA_SecurityGroup) listEntry;
 };
 
+/* finds the SecurityGroup within the server by NodeId*/
+UA_SecurityGroup *
+UA_SecurityGroup_findSGbyId(UA_Server *server, UA_NodeId identifier);
+
+void
+UA_SecurityGroup_delete(UA_SecurityGroup *securityGroup);
+
+UA_StatusCode
+removeSecurityGroup(UA_Server *server, const UA_NodeId securityGroupNodeId);
+
 #endif /* UA_ENABLE_PUBSUB_SKS */
 
 #endif /* UA_ENABLE_PUBSUB */

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -604,6 +604,14 @@ struct UA_SecurityGroup {
     TAILQ_ENTRY(UA_SecurityGroup) listEntry;
 };
 
+UA_StatusCode
+UA_SecurityGroupConfig_copy(const UA_SecurityGroupConfig *src,
+                            UA_SecurityGroupConfig *dst);
+
+/* finds the SecurityGroup within the server by SecurityGroup Name/Id*/
+UA_SecurityGroup *
+UA_SecurityGroup_findSGbyName(UA_Server *server, UA_String securityGroupName);
+
 /* finds the SecurityGroup within the server by NodeId*/
 UA_SecurityGroup *
 UA_SecurityGroup_findSGbyId(UA_Server *server, UA_NodeId identifier);

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -38,6 +38,9 @@ typedef struct UA_WriterGroup UA_WriterGroup;
 struct UA_ReaderGroup;
 typedef struct UA_ReaderGroup UA_ReaderGroup;
 
+struct UA_SecurityGroup;
+typedef struct UA_SecurityGroup UA_SecurityGroup;
+
 /**********************************************/
 /*            PublishedDataSet                */
 /**********************************************/
@@ -583,6 +586,25 @@ void processMqttSubscriberCallback(UA_Server *server, UA_ReaderGroup *readerGrou
 UA_StatusCode
 decodeNetworkMessageJson(UA_Server *server, UA_ByteString *buffer, size_t *pos,
                          UA_NetworkMessage *nm, UA_PubSubConnection *connection);
+
+#ifdef UA_ENABLE_PUBSUB_SKS
+/*********************************************************/
+/*                    SecurityGroup                      */
+/*********************************************************/
+struct UA_SecurityGroup {
+    UA_String securityGroupId;
+    UA_SecurityGroupConfig config;
+    UA_PubSubKeyStorage *keyStorage;
+    UA_NodeId securityGroupNodeId;
+    UA_UInt64 callbackId;
+    UA_DateTime baseTime;
+#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+    UA_NodeId securityGroupFolderId;
+#endif
+    TAILQ_ENTRY(UA_SecurityGroup) listEntry;
+};
+
+#endif /* UA_ENABLE_PUBSUB_SKS */
 
 #endif /* UA_ENABLE_PUBSUB */
 

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -619,8 +619,8 @@ UA_SecurityGroup_findSGbyId(UA_Server *server, UA_NodeId identifier);
 void
 UA_SecurityGroup_delete(UA_SecurityGroup *securityGroup);
 
-UA_StatusCode
-removeSecurityGroup(UA_Server *server, const UA_NodeId securityGroupNodeId);
+void
+removeSecurityGroup(UA_Server *server, UA_SecurityGroup *securityGroup);
 
 #endif /* UA_ENABLE_PUBSUB_SKS */
 

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -779,6 +779,14 @@ UA_PubSubManager_delete(UA_Server *server, UA_PubSubManager *pubSubManager) {
     }
 
 #ifdef UA_ENABLE_PUBSUB_SKS
+    /* Remove the SecurityGroups */
+    UA_SecurityGroup *tmpSG1, *tmpSG2;
+    TAILQ_FOREACH_SAFE(tmpSG1, &server->pubSubManager.securityGroups,
+                       listEntry, tmpSG2)
+        removeSecurityGroup(server, tmpSG1->securityGroupNodeId);
+#endif
+
+#ifdef UA_ENABLE_PUBSUB_SKS
     /* Remove the keyStorages */
     UA_PubSubKeyStorage *ks, *ksTmp;
     LIST_FOREACH_SAFE(ks, &server->pubSubManager.pubSubKeyList, keyStorageList, ksTmp)

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -781,9 +781,9 @@ UA_PubSubManager_delete(UA_Server *server, UA_PubSubManager *pubSubManager) {
 #ifdef UA_ENABLE_PUBSUB_SKS
     /* Remove the SecurityGroups */
     UA_SecurityGroup *tmpSG1, *tmpSG2;
-    TAILQ_FOREACH_SAFE(tmpSG1, &server->pubSubManager.securityGroups,
-                       listEntry, tmpSG2)
-        removeSecurityGroup(server, tmpSG1->securityGroupNodeId);
+    TAILQ_FOREACH_SAFE(tmpSG1, &server->pubSubManager.securityGroups, listEntry, tmpSG2) {
+        removeSecurityGroup(server, tmpSG1);
+    }
 #endif
 
 #ifdef UA_ENABLE_PUBSUB_SKS

--- a/src/pubsub/ua_pubsub_manager.h
+++ b/src/pubsub/ua_pubsub_manager.h
@@ -58,6 +58,8 @@ typedef struct UA_PubSubManager {
 
 #ifdef UA_ENABLE_PUBSUB_SKS
     LIST_HEAD(PubSubKeyList, UA_PubSubKeyStorage) pubSubKeyList;
+    size_t securityGroupsSize;
+    TAILQ_HEAD(UA_ListOfSecurityGroup, UA_SecurityGroup) securityGroups;
 #endif
 
 #ifndef UA_ENABLE_PUBSUB_INFORMATIONMODEL

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -1498,6 +1498,16 @@ addReaderGroupAction(UA_Server *server,
 }
 #endif
 
+#ifdef UA_ENABLE_PUBSUB_SKS
+#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+UA_StatusCode
+UA_removeSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup) {
+    UA_StatusCode retval = deleteNode(server, securityGroup->securityGroupNodeId, true);
+    return  retval;
+}
+#endif /* UA_ENABLE_PUBSUB_INFORMATIONMODEL*/
+#endif /* UA_ENABLE_PUBSUB_SKS */
+
 /**********************************************/
 /*               DataSetWriter                */
 /**********************************************/

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -1500,6 +1500,115 @@ addReaderGroupAction(UA_Server *server,
 
 #ifdef UA_ENABLE_PUBSUB_SKS
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+static UA_Boolean
+isValidParentNode(UA_Server *server, UA_NodeId parentId) {
+    UA_Boolean retval = UA_TRUE;
+    const UA_Node *parentNodeType;
+    const UA_NodeId parentNodeTypeId =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_SECURITYGROUPFOLDERTYPE);
+    const UA_Node *parentNode = UA_NODESTORE_GET(server, &parentId);
+
+    if(parentNode) {
+        parentNodeType = getNodeType(server, &parentNode->head);
+        if(parentNodeType) {
+            retval = UA_NodeId_equal(&parentNodeType->head.nodeId, &parentNodeTypeId);
+            UA_NODESTORE_RELEASE(server, parentNodeType);
+        }
+        UA_NODESTORE_RELEASE(server, parentNode);
+    }
+    return retval;
+}
+
+static UA_StatusCode
+updateSecurityGroupProperties(UA_Server *server, UA_NodeId *securityGroupNodeId,
+                              UA_SecurityGroupConfig *config) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_Variant value;
+    UA_Variant_init(&value);
+    UA_Variant_setScalar(&value, &config->securityGroupName, &UA_TYPES[UA_TYPES_STRING]);
+    retval = UA_Server_writeObjectProperty(server, *securityGroupNodeId,
+                                           UA_QUALIFIEDNAME(0, "SecurityGroupId"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /*AddValueCallback*/
+    UA_Variant_setScalar(&value, &config->securityPolicyUri, &UA_TYPES[UA_TYPES_STRING]);
+    retval = UA_Server_writeObjectProperty(
+        server, *securityGroupNodeId, UA_QUALIFIEDNAME(0, "SecurityPolicyUri"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    UA_Variant_setScalar(&value, &config->keyLifeTime, &UA_TYPES[UA_TYPES_DURATION]);
+    retval = UA_Server_writeObjectProperty(server, *securityGroupNodeId,
+                                           UA_QUALIFIEDNAME(0, "KeyLifetime"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    UA_Variant_setScalar(&value, &config->maxFutureKeyCount, &UA_TYPES[UA_TYPES_UINT32]);
+    retval = UA_Server_writeObjectProperty(
+        server, *securityGroupNodeId, UA_QUALIFIEDNAME(0, "MaxFutureKeyCount"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    UA_Variant_setScalar(&value, &config->maxPastKeyCount, &UA_TYPES[UA_TYPES_UINT32]);
+    retval = UA_Server_writeObjectProperty(server, *securityGroupNodeId,
+                                           UA_QUALIFIEDNAME(0, "MaxPastKeyCount"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    return retval;
+}
+
+UA_StatusCode
+addSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+
+    UA_SecurityGroupConfig *securityGroupConfig = &securityGroup->config;
+    if(!isValidParentNode(server, securityGroup->securityGroupFolderId))
+        return UA_STATUSCODE_BADPARENTNODEIDINVALID;
+
+    if(securityGroupConfig->securityGroupName.length <= 0)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    size_t sgNamelength = securityGroupConfig->securityGroupName.length;
+    char *sgName = (char *)UA_malloc(sgNamelength);
+    if(!sgName)
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+
+    memset(sgName, 0, sgNamelength);
+    memcpy(sgName, securityGroupConfig->securityGroupName.data,
+           securityGroupConfig->securityGroupName.length);
+    sgName[securityGroupConfig->securityGroupName.length] = '\0';
+
+    UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
+    object_attr.displayName = UA_LOCALIZEDTEXT("", sgName);
+
+    retval = UA_Server_addObjectNode(
+        server, UA_NODEID_NUMERIC(1, 0), securityGroup->securityGroupFolderId,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT), UA_QUALIFIEDNAME(0, sgName),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_SECURITYGROUPTYPE), object_attr, NULL,
+        &securityGroup->securityGroupNodeId);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "Add SecurityGroup failed with error: %s.",
+                     UA_StatusCode_name(retval));
+        goto cleanup;;
+    }
+
+    retval = updateSecurityGroupProperties(server, &securityGroup->securityGroupNodeId,
+                                           securityGroupConfig);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(&server->config.logger, UA_LOGCATEGORY_SERVER,
+                     "Add SecurityGroup failed with error: %s.",
+                     UA_StatusCode_name(retval));
+        UA_removeSecurityGroupRepresentation(server, securityGroup);
+    }
+cleanup:
+    if(sgName)
+        UA_free(sgName);
+    return retval;
+}
+
 UA_StatusCode
 UA_removeSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup) {
     UA_StatusCode retval = deleteNode(server, securityGroup->securityGroupNodeId, true);

--- a/src/pubsub/ua_pubsub_ns0.h
+++ b/src/pubsub/ua_pubsub_ns0.h
@@ -5,6 +5,7 @@
  * Copyright (c) 2017-2018 Fraunhofer IOSB (Author: Andreas Ebner)
  * Copyright (c) 2019 Kalycito Infotech Private Limited
  * Copyright (c) 2022 Siemens AG (Author: Thomas Fischer)
+ * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
  */
 
 #ifndef UA_PUBSUB_NS0_H_
@@ -64,6 +65,11 @@ removeReaderGroupRepresentation(UA_Server *server, UA_ReaderGroup *readerGroup);
 
 UA_StatusCode
 connectDataSetReaderToDataSet(UA_Server *server, UA_NodeId dsrId, UA_NodeId standaloneSdsId);
+
+#ifdef UA_ENABLE_PUBSUB_SKS
+UA_StatusCode
+UA_removeSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup);
+#endif /* UA_ENABLE_PUBSUB_SKS */
 
 #endif /* UA_ENABLE_PUBSUB_INFORMATIONMODEL */
 

--- a/src/pubsub/ua_pubsub_ns0.h
+++ b/src/pubsub/ua_pubsub_ns0.h
@@ -68,6 +68,9 @@ connectDataSetReaderToDataSet(UA_Server *server, UA_NodeId dsrId, UA_NodeId stan
 
 #ifdef UA_ENABLE_PUBSUB_SKS
 UA_StatusCode
+addSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup);
+
+UA_StatusCode
 UA_removeSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup);
 #endif /* UA_ENABLE_PUBSUB_SKS */
 

--- a/src/pubsub/ua_pubsub_securitygroup.c
+++ b/src/pubsub/ua_pubsub_securitygroup.c
@@ -258,18 +258,15 @@ addSecurityGroup(UA_Server *server, UA_NodeId securityGroupFolderNodeId,
     UA_PubSubManager_generateUniqueNodeId(&server->pubSubManager,
                                           &newSecurityGroup->securityGroupNodeId);
 #endif
-
     if(securityGroupNodeId)
         UA_NodeId_copy(&newSecurityGroup->securityGroupNodeId, securityGroupNodeId);
 
-    if(server->pubSubManager.securityGroupsSize != 0) {
-        TAILQ_INSERT_TAIL(&server->pubSubManager.securityGroups, newSecurityGroup,
-                          listEntry);
-    } else {
+    if(server->pubSubManager.securityGroupsSize == 0)
         TAILQ_INIT(&server->pubSubManager.securityGroups);
-        TAILQ_INSERT_HEAD(&server->pubSubManager.securityGroups, newSecurityGroup,
+
+    TAILQ_INSERT_TAIL(&server->pubSubManager.securityGroups, newSecurityGroup,
                           listEntry);
-    }
+
     server->pubSubManager.securityGroupsSize++;
     return retval;
 }

--- a/src/pubsub/ua_pubsub_securitygroup.c
+++ b/src/pubsub/ua_pubsub_securitygroup.c
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2019 ifak e.V. Magdeburg (Holger Zipper)
+ * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
+ */
+
+#include <open62541/server_pubsub.h>
+
+#include "ua_pubsub_ns0.h"
+
+#ifdef UA_ENABLE_PUBSUB_SKS /* conditional compilation */
+
+#include "server/ua_server_internal.h"
+
+UA_SecurityGroup *
+UA_SecurityGroup_findSGbyId(UA_Server *server, UA_NodeId identifier) {
+    UA_SecurityGroup *tmpSG;
+    TAILQ_FOREACH(tmpSG, &server->pubSubManager.securityGroups, listEntry) {
+        if(UA_NodeId_equal(&identifier, &tmpSG->securityGroupNodeId))
+            return tmpSG;
+    }
+    return NULL;
+}
+
+static void
+UA_SecurityGroupConfig_clear(UA_SecurityGroupConfig *config) {
+    config->keyLifeTime = 0;
+    config->maxFutureKeyCount = 0;
+    UA_String_clear(&config->securityGroupName);
+    UA_String_clear(&config->securityPolicyUri);
+}
+
+static void
+UA_SecurityGroup_clear(UA_SecurityGroup *securityGroup) {
+    UA_SecurityGroupConfig_clear(&securityGroup->config);
+    UA_String_clear(&securityGroup->securityGroupId);
+    UA_NodeId_clear(&securityGroup->securityGroupFolderId);
+    UA_NodeId_clear(&securityGroup->securityGroupNodeId);
+}
+
+void
+UA_SecurityGroup_delete(UA_SecurityGroup *securityGroup) {
+    UA_SecurityGroup_clear(securityGroup);
+    UA_free(securityGroup);
+}
+
+UA_StatusCode
+removeSecurityGroup(UA_Server *server, UA_NodeId securityGroup) {
+    UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroup);
+    if(!sg)
+        return UA_STATUSCODE_BADNOTFOUND;
+
+#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+    UA_removeSecurityGroupRepresentation(server, sg);
+#endif
+    /* Unlink from the server */
+    TAILQ_REMOVE(&server->pubSubManager.securityGroups, sg, listEntry);
+    server->pubSubManager.securityGroupsSize--;
+    if(sg->callbackId > 0)
+        removeCallback(server, sg->callbackId);
+
+    UA_PubSubKeyStorage_removeKeyStorage(server, sg->keyStorage);
+
+    UA_SecurityGroup_delete(sg);
+
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_removeSecurityGroup(UA_Server *server, const UA_NodeId securityGroup) {
+    UA_LOCK(&server->serviceMutex);
+    UA_StatusCode retval = removeSecurityGroup(server, securityGroup);
+    UA_UNLOCK(&server->serviceMutex);
+    return retval;
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -317,6 +317,7 @@ if(UA_ENABLE_PUBSUB)
         if(UA_ENABLE_PUBSUB_SKS)
             ua_add_test(pubsub/check_pubsub_keystorage.c)
             ua_add_test(pubsub/check_pubsub_sks_push.c)
+            ua_add_test(pubsub/check_pubsub_sks_securitygroups.c)
         endif()
     endif()
 

--- a/tests/pubsub/check_pubsub_sks_securitygroups.c
+++ b/tests/pubsub/check_pubsub_sks_securitygroups.c
@@ -1,0 +1,351 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
+ */
+
+#include <open62541/client.h>
+#include <open62541/client_config_default.h>
+#include <open62541/client_highlevel.h>
+#include <open62541/plugin/pubsub_udp.h>
+#include <open62541/plugin/securitypolicy_default.h>
+#include <open62541/server_config_default.h>
+#include <open62541/server_pubsub.h>
+
+#include "ua_pubsub.h"
+#include "ua_pubsub_keystorage.h"
+#include "ua_server_internal.h"
+
+#include <check.h>
+#include <testing_clock.h>
+
+#include "../encryption/certificates.h"
+#include "thread_wrapper.h"
+
+UA_Server *server = NULL;
+UA_Boolean running;
+
+static void
+securityGroup_setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    /* Instantiate the PubSub SecurityPolicy */
+    config->pubSubConfig.securityPolicies =
+        (UA_PubSubSecurityPolicy *)UA_calloc(2, sizeof(UA_PubSubSecurityPolicy));
+    config->pubSubConfig.securityPoliciesSize = 2;
+    UA_PubSubSecurityPolicy_Aes128Ctr(&config->pubSubConfig.securityPolicies[0],
+                                      &config->logger);
+    UA_PubSubSecurityPolicy_Aes256Ctr(&config->pubSubConfig.securityPolicies[1],
+                                      &config->logger);
+
+    UA_Server_run_startup(server);
+}
+
+static void
+securityGroup_teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(AddSecurityGroupWithNullConfig) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    retval = UA_Server_addSecurityGroup(
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS), NULL,
+        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADINVALIDARGUMENT);
+}
+END_TEST
+
+START_TEST(AddSecurityGroupWithInvalidKeyLifeTime) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 0;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 10;
+    config.maxPastKeyCount = 5;
+    retval = UA_Server_addSecurityGroup(
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS), &config,
+        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADINVALIDARGUMENT);
+}
+END_TEST
+
+START_TEST(AddSecurityGroupWithInvalidSecurityGroupName) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 2000;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING_NULL;
+    config.maxFutureKeyCount = 10;
+    config.maxPastKeyCount = 5;
+    retval = UA_Server_addSecurityGroup(
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS), &config,
+        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADINVALIDARGUMENT);
+}
+END_TEST
+
+START_TEST(AddSecurityGroupWithInvalidPolicy) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 2000;
+    config.securityPolicyUri = UA_STRING_NULL;
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 10;
+    config.maxPastKeyCount = 5;
+    retval = UA_Server_addSecurityGroup(
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS), &config,
+        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADINVALIDARGUMENT);
+
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#InvalidPolicy");
+    retval = UA_Server_addSecurityGroup(
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS), &config,
+        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADSECURITYPOLICYREJECTED);
+}
+END_TEST
+
+START_TEST(AddSecurityGroupWithInvalidSecurityGroupFolderNodeId) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 2000;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 10;
+    config.maxPastKeyCount = 5;
+    retval =
+        UA_Server_addSecurityGroup(server, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                   &config, &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADPARENTNODEIDINVALID);
+}
+END_TEST
+
+START_TEST(AddSecurityGroupWithvalidConfig) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_NodeId securityGroupParent =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS);
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 2000;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 10;
+    config.maxPastKeyCount = 5;
+
+    retval = UA_Server_addSecurityGroup(server, securityGroupParent, &config,
+                                        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
+    ck_assert_ptr_ne(sg, NULL);
+    ck_assert(UA_NodeId_equal(&sg->securityGroupNodeId, &securityGroupNodeId) == UA_TRUE);
+    ck_assert(UA_NodeId_equal(&sg->securityGroupFolderId, &securityGroupParent) ==
+              UA_TRUE);
+    ck_assert(UA_String_equal(&sg->securityGroupId, &config.securityGroupName) ==
+              UA_TRUE);
+#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+    /*check properties*/
+    UA_Variant value;
+    UA_Variant_init(&value);
+    retval = UA_Server_readObjectProperty(server, securityGroupNodeId,
+                                          UA_QUALIFIEDNAME(0, "SecurityGroupId"), &value);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(value.type == &UA_TYPES[UA_TYPES_STRING]);
+    ck_assert(UA_String_equal(&config.securityGroupName, (UA_String *)value.data) ==
+              UA_TRUE);
+
+    UA_Variant_clear(&value);
+    retval = UA_Server_readObjectProperty(
+        server, securityGroupNodeId, UA_QUALIFIEDNAME(0, "SecurityPolicyUri"), &value);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(UA_String_equal(&config.securityPolicyUri, (UA_String *)value.data) ==
+              UA_TRUE);
+
+    UA_Variant_clear(&value);
+    retval = UA_Server_readObjectProperty(server, securityGroupNodeId,
+                                          UA_QUALIFIEDNAME(0, "KeyLifetime"), &value);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(config.keyLifeTime == *(UA_Duration *)value.data);
+
+    UA_Variant_clear(&value);
+    retval = UA_Server_readObjectProperty(
+        server, securityGroupNodeId, UA_QUALIFIEDNAME(0, "MaxFutureKeyCount"), &value);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(config.maxFutureKeyCount == *(UA_UInt32 *)value.data);
+
+    UA_Variant_clear(&value);
+    retval = UA_Server_readObjectProperty(server, securityGroupNodeId,
+                                          UA_QUALIFIEDNAME(0, "MaxPastKeyCount"), &value);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(config.maxPastKeyCount == *(UA_UInt32 *)value.data);
+#endif /*UA_ENABLE_PUBSUB_INFORMATIONMODEL */
+}
+END_TEST
+
+START_TEST(AddTwoSecurityGroupsWithSameSecurityGroupName) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 2000;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 10;
+    config.maxPastKeyCount = 5;
+    retval = UA_Server_addSecurityGroup(
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS), &config,
+        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    retval = UA_Server_addSecurityGroup(
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS), &config,
+        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADNODEIDEXISTS);
+}
+END_TEST
+
+START_TEST(RemoveSecurityGroup) {
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_NodeId securityGroupParent =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS);
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 2000;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 10;
+    config.maxPastKeyCount = 5;
+
+    retval = UA_Server_addSecurityGroup(server, securityGroupParent, &config,
+                                        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
+    ck_assert_ptr_ne(sg, NULL);
+
+    UA_Server_removeSecurityGroup(server, securityGroupNodeId);
+
+    sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
+    ck_assert_ptr_eq(sg, NULL);
+} END_TEST
+
+START_TEST(AddSecurityGroupWithKeyManagement){
+     UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_NodeId securityGroupParent =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS);
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 2000;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 1;
+    config.maxPastKeyCount = 1;
+
+    retval = UA_Server_addSecurityGroup(server, securityGroupParent, &config,
+                                        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
+    ck_assert_ptr_ne(sg, NULL);
+    UA_PubSubKeyStorage *ks = UA_Server_findKeyStorage(server, sg->securityGroupId);
+    ck_assert_ptr_ne(ks, NULL);
+    ck_assert_uint_eq(ks->keyListSize, 1 + config.maxFutureKeyCount);
+    UA_UInt32 expectKeyId = 1;
+    UA_PubSubKeyListItem *iterator = TAILQ_FIRST(&ks->keyList);
+    for (size_t i = 0; i < ks->keyListSize; i++) {
+        ck_assert_ptr_ne(iterator, NULL);
+        ck_assert_uint_eq(iterator->keyID, expectKeyId);
+        ck_assert(UA_ByteString_equal(&iterator->key, &UA_BYTESTRING_NULL) != UA_TRUE);
+        iterator = TAILQ_NEXT(iterator, keyListEntry);
+        expectKeyId++;
+    }
+} END_TEST
+
+START_TEST(SecurityGroupPeriodicInsertNewKeys){
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_NodeId securityGroupNodeId;
+    UA_NodeId securityGroupParent =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_SECURITYGROUPS);
+    UA_SecurityGroupConfig config;
+    memset(&config, 0, sizeof(UA_SecurityGroupConfig));
+    config.keyLifeTime = 500;
+    config.securityPolicyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#PubSub-Aes256-CTR");
+    config.securityGroupName = UA_STRING("TestSecurityGroup");
+    config.maxFutureKeyCount = 1;
+    config.maxPastKeyCount = 1;
+
+    retval = UA_Server_addSecurityGroup(server, securityGroupParent, &config,
+                                        &securityGroupNodeId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
+    ck_assert_ptr_ne(sg, NULL);
+    UA_PubSubKeyStorage *ks = UA_Server_findKeyStorage(server, sg->securityGroupId);
+    ck_assert_ptr_ne(ks, NULL);
+
+    UA_UInt32 expectKeyId = 1;
+    UA_PubSubKeyListItem *preLastItem = TAILQ_LAST(&ks->keyList, keyListItems);
+    for (size_t i = 0; i < ks->keyListSize; i++) {
+        UA_fakeSleep(500);
+        UA_Server_run_iterate(server, false);
+        UA_PubSubKeyListItem *newlastItem = TAILQ_LAST(&ks->keyList, keyListItems);
+        ck_assert_uint_eq(ks->keyListSize, config.maxPastKeyCount + 1 + config.maxFutureKeyCount);
+        ck_assert_ptr_eq(preLastItem->keyListEntry.tqe_next, newlastItem);
+        ck_assert_uint_eq(preLastItem->keyID + 1 ,  newlastItem->keyID);
+        ck_assert(UA_ByteString_equal(&preLastItem->keyListEntry.tqe_next->key, &newlastItem->key) == UA_TRUE);
+        preLastItem = newlastItem;
+        expectKeyId++;
+    }
+} END_TEST
+int
+main(void) {
+    int number_failed = 0;
+    TCase *tc_pubsub_sks_securityGroup = tcase_create("PubSub SKS SecurityGroup");
+    tcase_add_checked_fixture(tc_pubsub_sks_securityGroup, securityGroup_setup,
+                              securityGroup_teardown);
+    tcase_add_test(tc_pubsub_sks_securityGroup, AddSecurityGroupWithvalidConfig);
+    tcase_add_test(tc_pubsub_sks_securityGroup, AddSecurityGroupWithNullConfig);
+    tcase_add_test(tc_pubsub_sks_securityGroup, AddSecurityGroupWithInvalidKeyLifeTime);
+    tcase_add_test(tc_pubsub_sks_securityGroup,
+                   AddSecurityGroupWithInvalidSecurityGroupName);
+    tcase_add_test(tc_pubsub_sks_securityGroup, AddSecurityGroupWithInvalidPolicy);
+    tcase_add_test(tc_pubsub_sks_securityGroup,
+                   AddSecurityGroupWithInvalidSecurityGroupFolderNodeId);
+    tcase_add_test(tc_pubsub_sks_securityGroup,
+                   AddTwoSecurityGroupsWithSameSecurityGroupName);
+    tcase_add_test(tc_pubsub_sks_securityGroup, RemoveSecurityGroup);
+    tcase_add_test(tc_pubsub_sks_securityGroup, AddSecurityGroupWithKeyManagement);
+    tcase_add_test(tc_pubsub_sks_securityGroup, SecurityGroupPeriodicInsertNewKeys);
+    Suite *s = suite_create("PubSub SKS SecurityGroups");
+    suite_add_tcase(s, tc_pubsub_sks_securityGroup);
+
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
This PR is the second in series of SKS support. It adds the support for managing SecurityGroups on SKS server side. A securitygroup is an abstraction that represents the message security settings and security keys for a subset of NetworkMessages exchanged between Publishers and Subscribers. A SKS manages the SecurityGroups and maintains the mapping
between Roles and their access Permissions.

In the implementation two server API methods are added to create and remove the SecurityGroup in the server. With a securitygroup a keystorage with initial keys is also created in the server. The keystorage is updated periodically with new keys
by a callback function. The period of update cycle is set by KeyLifeTime parameter in SecurityGroup configuration. The conditional compilation with information model support is also added for SecurityGroup.