### PR TITLE
fix(pubsub): fix generateDeltaFrameMessage issue

### DIFF
--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -1191,6 +1191,8 @@ UA_PubSubDataSetWriter_generateKeyFrameMessage(UA_Server *server,
     return UA_STATUSCODE_GOOD;
 }
 
+/* the input message is already initialized and that the method 
+ * must not be called twice for the same message */
 #ifdef UA_ENABLE_PUBSUB_DELTAFRAMES
 static UA_StatusCode
 UA_PubSubDataSetWriter_generateDeltaFrameMessage(UA_Server *server,
@@ -1202,7 +1204,6 @@ UA_PubSubDataSetWriter_generateDeltaFrameMessage(UA_Server *server,
         return UA_STATUSCODE_BADNOTFOUND;
 
     /* Prepare DataSetMessageContent */
-    memset(dataSetMessage, 0, sizeof(UA_DataSetMessage));
     dataSetMessage->header.dataSetMessageValid = true;
     dataSetMessage->header.dataSetMessageType = UA_DATASETMESSAGE_DATADELTAFRAME;
     if(currentDataSet->fieldSize == 0)


### PR DESCRIPTION
don't clear dataSetMessage in UA_PubSubDataSetWriter_generateDeltaFrameMessage(), since some fields of dataSetMessage have been set in the UA_DataSetWriter_generateDataSetMessage().