### PR TITLE
Add an option to set a write or read context to UA_ValueCallback and UA_DataSource

### DIFF
--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -30,7 +30,8 @@ static UA_StatusCode
 readInteger(UA_Server *server, const UA_NodeId *sessionId,
             void *sessionContext, const UA_NodeId *nodeId,
             void *nodeContext, UA_Boolean includeSourceTimeStamp,
-            const UA_NumericRange *range, UA_DataValue *value) {
+            const UA_NumericRange *range, UA_DataValue *value,
+            void *callbackContext) {
     UA_Int32 *myInteger = (UA_Int32*)nodeContext;
     value->hasValue = true;
     UA_Variant_setScalarCopy(&value->value, myInteger, &UA_TYPES[UA_TYPES_INT32]);
@@ -48,7 +49,7 @@ static UA_StatusCode
 writeInteger(UA_Server *server, const UA_NodeId *sessionId,
              void *sessionContext, const UA_NodeId *nodeId,
              void *nodeContext, const UA_NumericRange *range,
-             const UA_DataValue *value) {
+             const UA_DataValue *value, void *callbackContext) {
     UA_Int32 *myInteger = (UA_Int32*)nodeContext;
     if(value->hasValue && UA_Variant_isScalar(&value->value) &&
        value->value.type == &UA_TYPES[UA_TYPES_INT32] && value->value.data)

--- a/examples/server_ctt.c
+++ b/examples/server_ctt.c
@@ -44,7 +44,8 @@ readTimeData(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -65,7 +66,8 @@ readRandomBoolData(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -86,7 +88,8 @@ readRandomInt16Data(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -107,7 +110,8 @@ readRandomInt32Data(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -128,7 +132,8 @@ readRandomInt64Data(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
     value->hasStatus = true;
     value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -149,7 +154,8 @@ readRandomUInt16Data(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -170,7 +176,8 @@ readRandomUInt32Data(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -191,7 +198,8 @@ readRandomUInt64Data(UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -212,7 +220,8 @@ readRandomStringData (UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -235,7 +244,8 @@ readRandomFloatData (UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -256,7 +266,8 @@ readRandomDoubleData (UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -276,7 +287,8 @@ readByteString (UA_Server *server,
              const UA_NodeId *sessionId, void *sessionContext,
              const UA_NodeId *nodeId, void *nodeContext,
              UA_Boolean sourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NumericRange *range, UA_DataValue *value,
+             void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -300,7 +312,7 @@ static void
 writeEventTrigger(UA_Server *server, const UA_NodeId *sessionId,
                   void *sessionContext, const UA_NodeId *nodeId,
                   void *nodeContext, const UA_NumericRange *range,
-                  const UA_DataValue *data) {
+                  const UA_DataValue *data, void *callbackContext) {
     UA_Server_triggerEvent(server, eventId,
                            UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER),
                            NULL, false);
@@ -407,9 +419,7 @@ setInformationModel(UA_Server *server) {
                               accessDeniedName, baseDataVariableType, myVar, NULL, NULL);
 
     /* add a variable with the datetime data source */
-    UA_DataSource dateDataSource;
-    dateDataSource.read = readTimeData;
-    dateDataSource.write = NULL;
+    UA_DataSource dateDataSource = {readTimeData, NULL, NULL, NULL};
     UA_VariableAttributes v_attr = UA_VariableAttributes_default;
     v_attr.description = UA_LOCALIZEDTEXT("en-US", "current time");
     v_attr.displayName = UA_LOCALIZEDTEXT("en-US", "current time");

--- a/examples/tutorial_server_alarms_conditions.c
+++ b/examples/tutorial_server_alarms_conditions.c
@@ -161,7 +161,7 @@ static void
 afterWriteCallbackVariable_1(UA_Server *server, const UA_NodeId *sessionId,
                              void *sessionContext, const UA_NodeId *nodeId,
                              void *nodeContext, const UA_NumericRange *range,
-                             const UA_DataValue *data) {
+                             const UA_DataValue *data, void *callbackContext) {
     UA_QualifiedName activeStateField = UA_QUALIFIEDNAME(0,"ActiveState");
     UA_QualifiedName activeStateIdField = UA_QUALIFIEDNAME(0,"Id");
     UA_Variant value;
@@ -224,7 +224,7 @@ static void
 afterWriteCallbackVariable_2(UA_Server *server, const UA_NodeId *sessionId,
                              void *sessionContext, const UA_NodeId *nodeId,
                              void *nodeContext, const UA_NumericRange *range,
-                             const UA_DataValue *data) {
+                             const UA_DataValue *data, void *callbackContext) {
    /* Another way to set fields of conditions */
     UA_Server_writeObjectProperty_scalar(server, conditionInstance_2,
                                          UA_QUALIFIEDNAME(0, "Severity"),
@@ -243,7 +243,8 @@ static void
 afterWriteCallbackVariable_3(UA_Server *server,
                const UA_NodeId *sessionId, void *sessionContext,
                const UA_NodeId *nodeId, void *nodeContext,
-               const UA_NumericRange *range, const UA_DataValue *data) {
+               const UA_NumericRange *range, const UA_DataValue *data,
+               void *callbackContext) {
 
     //UA_QualifiedName enabledStateField = UA_QUALIFIEDNAME(0,"EnabledState");
     UA_QualifiedName ackedStateField = UA_QUALIFIEDNAME(0,"AckedState");

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -544,15 +544,15 @@ typedef struct {
                     void *nodeContext, const UA_NumericRange *range,
                     const UA_DataValue *data, void *callbackContext);
 
-    /* @param Context object for write callback. This is usually a pointer to an object
-     * that you want to modify in your callback.
-     */
-    void *writeContext;
-
     /* @param Context object for read callback. This is usually a pointer to an object
      * that you want to fetch the data from in your callback.
      */
     void *readContext;
+
+    /* @param Context object for write callback. This is usually a pointer to an object
+     * that you want to modify in your callback.
+     */
+    void *writeContext;
 } UA_ValueCallback;
 
 typedef struct {
@@ -623,16 +623,15 @@ typedef struct {
                            void *sessionContext, const UA_NodeId *nodeId,
                            void *nodeContext, const UA_NumericRange *range,
                            const UA_DataValue *value, void* callbackContext);
+    /* @param readContext Context object for read callback. This is usually a pointer to
+     * an object that you want to fetch the data from in your callback.
+     */
+    void *readContext;
 
     /* @param writeContext Context object for write callback. This is usually a pointer to an object
      * that you want to modify in your callback.
      */
     void *writeContext;
-
-    /* @param readContext Context object for read callback. This is usually a pointer to an object
-     * that you want to fetch the data from in your callback.
-     */
-    void *readContext;
 } UA_DataSource;
 
 /**

--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -513,11 +513,14 @@ typedef struct {
      * @param nodeid The identifier of the node.
      * @param data Points to the current node value.
      * @param range Points to the numeric range the client wants to read from
-     *        (or NULL). */
+     *        (or NULL).
+     * @param callbackContext Will contain the same value as readContext once
+     *        the callback is triggered
+     */
     void (*onRead)(UA_Server *server, const UA_NodeId *sessionId,
                    void *sessionContext, const UA_NodeId *nodeid,
                    void *nodeContext, const UA_NumericRange *range,
-                   const UA_DataValue *value);
+                   const UA_DataValue *value, void *callbackContext);
 
     /* Called after writing the value attribute. The node is re-opened after
      * writing so that the new value is visible in the callback.
@@ -532,11 +535,24 @@ typedef struct {
      * @param nodeConstructorContext Additional data attached to the node
      *        by the type constructor(s).
      * @param range Points to the numeric range the client wants to write to (or
-     *        NULL). */
+     *        NULL).
+     * @param callbackContext Will contain the same value as writeContext once
+     *        the callback is triggered
+     */
     void (*onWrite)(UA_Server *server, const UA_NodeId *sessionId,
                     void *sessionContext, const UA_NodeId *nodeId,
                     void *nodeContext, const UA_NumericRange *range,
-                    const UA_DataValue *data);
+                    const UA_DataValue *data, void *callbackContext);
+
+    /* @param Context object for write callback. This is usually a pointer to an object
+     * that you want to modify in your callback.
+     */
+    void *writeContext;
+
+    /* @param Context object for read callback. This is usually a pointer to an object
+     * that you want to fetch the data from in your callback.
+     */
+    void *readContext;
 } UA_ValueCallback;
 
 typedef struct {
@@ -569,6 +585,8 @@ typedef struct {
      * @param value The (non-null) DataValue that is returned to the client. The
      *        data source sets the read data, the result status and optionally a
      *        sourcetimestamp.
+     * @param callbackContext Will contain the same value as readContext once
+     *        the callback is triggered
      * @return Returns a status code for logging. Error codes intended for the
      *         original caller are set in the value. If an error is returned,
      *         then no releasing of the value is done
@@ -576,7 +594,8 @@ typedef struct {
     UA_StatusCode (*read)(UA_Server *server, const UA_NodeId *sessionId,
                           void *sessionContext, const UA_NodeId *nodeId,
                           void *nodeContext, UA_Boolean includeSourceTimeStamp,
-                          const UA_NumericRange *range, UA_DataValue *value);
+                          const UA_NumericRange *range, UA_DataValue *value,
+                          void *callbackContext);
 
     /* Write into a data source. This method pointer can be NULL if the
      * operation is unsupported.
@@ -594,6 +613,8 @@ typedef struct {
      * @param value The (non-NULL) DataValue that has been written by the client.
      *        The data source contains the written data, the result status and
      *        optionally a sourcetimestamp
+     * @param callbackContext Will contain the same value as writeContext once
+     *        the callback is triggered
      * @return Returns a status code for logging. Error codes intended for the
      *         original caller are set in the value. If an error is returned,
      *         then no releasing of the value is done
@@ -601,7 +622,17 @@ typedef struct {
     UA_StatusCode (*write)(UA_Server *server, const UA_NodeId *sessionId,
                            void *sessionContext, const UA_NodeId *nodeId,
                            void *nodeContext, const UA_NumericRange *range,
-                           const UA_DataValue *value);
+                           const UA_DataValue *value, void* callbackContext);
+
+    /* @param writeContext Context object for write callback. This is usually a pointer to an object
+     * that you want to modify in your callback.
+     */
+    void *writeContext;
+
+    /* @param readContext Context object for read callback. This is usually a pointer to an object
+     * that you want to fetch the data from in your callback.
+     */
+    void *readContext;
 } UA_DataSource;
 
 /**

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -668,28 +668,31 @@ void createSubscriptionObject(UA_Server *server, UA_Session *session,
 UA_StatusCode
 readDiagnostics(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                 const UA_NodeId *nodeId, void *nodeContext, UA_Boolean sourceTimestamp,
-                const UA_NumericRange *range, UA_DataValue *value);
+                const UA_NumericRange *range, UA_DataValue *value, void *callbackContext);
 
 UA_StatusCode
 readSubscriptionDiagnosticsArray(UA_Server *server,
                                  const UA_NodeId *sessionId, void *sessionContext,
                                  const UA_NodeId *nodeId, void *nodeContext,
                                  UA_Boolean sourceTimestamp,
-                                 const UA_NumericRange *range, UA_DataValue *value);
+                                 const UA_NumericRange *range, UA_DataValue *value,
+                                 void *callbackContext);
 
 UA_StatusCode
 readSessionDiagnosticsArray(UA_Server *server,
                             const UA_NodeId *sessionId, void *sessionContext,
                             const UA_NodeId *nodeId, void *nodeContext,
                             UA_Boolean sourceTimestamp,
-                            const UA_NumericRange *range, UA_DataValue *value);
+                            const UA_NumericRange *range, UA_DataValue *value,
+                            void *callbackContext);
 
 UA_StatusCode
 readSessionSecurityDiagnostics(UA_Server *server,
                                const UA_NodeId *sessionId, void *sessionContext,
                                const UA_NodeId *nodeId, void *nodeContext,
                                UA_Boolean sourceTimestamp,
-                               const UA_NumericRange *range, UA_DataValue *value);
+                               const UA_NumericRange *range, UA_DataValue *value,
+                               void *callbackContext);
 #endif
 
 /***************************/

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -836,7 +836,7 @@ UA_Server_initNS0(UA_Server *server) {
     /* StartTime will be sampled in UA_Server_run_startup()*/
 
     /* CurrentTime */
-    UA_DataSource currentTime = {readCurrentTime, NULL};
+    UA_DataSource currentTime = {readCurrentTime, NULL, NULL, NULL};
     UA_NodeId currTime = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
     retVal |= UA_Server_setVariableNode_dataSource(server, currTime, currentTime);
     retVal |= UA_Server_writeMinimumSamplingInterval(server, currTime, 100.0);
@@ -1023,7 +1023,7 @@ UA_Server_initNS0(UA_Server *server) {
 
 #ifdef UA_ENABLE_DIAGNOSTICS
     /* ServerDiagnostics - ServerDiagnosticsSummary */
-    UA_DataSource serverDiagSummary = {readDiagnostics, NULL};
+    UA_DataSource serverDiagSummary = {readDiagnostics, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SERVERDIAGNOSTICSSUMMARY), serverDiagSummary);
 
@@ -1077,18 +1077,18 @@ UA_Server_initNS0(UA_Server *server) {
 
     /* ServerDiagnostics - SubscriptionDiagnosticsArray */
 #ifdef UA_ENABLE_SUBSCRIPTIONS
-    UA_DataSource serverSubDiagSummary = {readSubscriptionDiagnosticsArray, NULL};
+    UA_DataSource serverSubDiagSummary = {readSubscriptionDiagnosticsArray, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SUBSCRIPTIONDIAGNOSTICSARRAY), serverSubDiagSummary);
 #endif
 
     /* ServerDiagnostics - SessionDiagnosticsSummary - SessionDiagnosticsArray */
-    UA_DataSource sessionDiagSummary = {readSessionDiagnosticsArray, NULL};
+    UA_DataSource sessionDiagSummary = {readSessionDiagnosticsArray, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SESSIONSDIAGNOSTICSSUMMARY_SESSIONDIAGNOSTICSARRAY), sessionDiagSummary);
 
     /* ServerDiagnostics - SessionDiagnosticsSummary - SessionSecurityDiagnosticsArray */
-    UA_DataSource sessionSecDiagSummary = {readSessionSecurityDiagnostics, NULL};
+    UA_DataSource sessionSecDiagSummary = {readSessionSecurityDiagnostics, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SESSIONSDIAGNOSTICSSUMMARY_SESSIONSECURITYDIAGNOSTICSARRAY), sessionSecDiagSummary);
 

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -276,7 +276,7 @@ UA_Server_createNS0_base(UA_Server *server) {
 static UA_StatusCode
 readStatus(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
            const UA_NodeId *nodeId, void *nodeContext, UA_Boolean sourceTimestamp,
-           const UA_NumericRange *range, UA_DataValue *value) {
+           const UA_NumericRange *range, UA_DataValue *value, void* callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -393,7 +393,7 @@ readStatus(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
 static UA_StatusCode
 readServiceLevel(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                  const UA_NodeId *nodeId, void *nodeContext, UA_Boolean includeSourceTimeStamp,
-                 const UA_NumericRange *range, UA_DataValue *value) {
+                 const UA_NumericRange *range, UA_DataValue *value, void* callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -417,8 +417,8 @@ readServiceLevel(UA_Server *server, const UA_NodeId *sessionId, void *sessionCon
 
 static UA_StatusCode
 readAuditing(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
-             const UA_NodeId *nodeId, void *nodeContext, UA_Boolean includeSourceTimeStamp,
-             const UA_NumericRange *range, UA_DataValue *value) {
+             const UA_NodeId *nodeId, void *nodeContext, UA_Boolean includeSourceTimeStamp, const UA_NumericRange *range,
+             UA_DataValue *value, void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -445,7 +445,7 @@ static UA_StatusCode
 readNamespaces(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                const UA_NodeId *nodeid, void *nodeContext, UA_Boolean includeSourceTimeStamp,
                const UA_NumericRange *range,
-               UA_DataValue *value) {
+               UA_DataValue *value, void* callbackContext) {
     /* ensure that the uri for ns1 is set up from the app description */
     setupNs1Uri(server);
 
@@ -470,7 +470,7 @@ readNamespaces(UA_Server *server, const UA_NodeId *sessionId, void *sessionConte
 static UA_StatusCode
 writeNamespaces(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                 const UA_NodeId *nodeid, void *nodeContext, const UA_NumericRange *range,
-                const UA_DataValue *value) {
+                const UA_DataValue *value, void* callbackContext) {
     /* Check the data type */
     if(!value->hasValue ||
        value->value.type != &UA_TYPES[UA_TYPES_STRING])
@@ -509,7 +509,7 @@ writeNamespaces(UA_Server *server, const UA_NodeId *sessionId, void *sessionCont
 static UA_StatusCode
 readCurrentTime(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                 const UA_NodeId *nodeid, void *nodeContext, UA_Boolean sourceTimeStamp,
-                const UA_NumericRange *range, UA_DataValue *value) {
+                const UA_NumericRange *range, UA_DataValue *value, void* callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -532,8 +532,7 @@ readCurrentTime(UA_Server *server, const UA_NodeId *sessionId, void *sessionCont
 static UA_StatusCode
 readMinSamplingInterval(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                const UA_NodeId *nodeid, void *nodeContext, UA_Boolean includeSourceTimeStamp,
-               const UA_NumericRange *range,
-               UA_DataValue *value) {
+               const UA_NumericRange *range, UA_DataValue *value, void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;
@@ -817,7 +816,7 @@ UA_Server_initNS0(UA_Server *server) {
     }
 
     /* NamespaceArray */
-    UA_DataSource namespaceDataSource = {readNamespaces, writeNamespaces};
+    UA_DataSource namespaceDataSource = {readNamespaces, writeNamespaces, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                                                    UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_NAMESPACEARRAY),
                                                    namespaceDataSource);
@@ -830,7 +829,7 @@ UA_Server_initNS0(UA_Server *server) {
     retVal |= UA_Server_writeValueRank(server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERARRAY), 1);
 
     /* ServerStatus */
-    UA_DataSource serverStatus = {readStatus, NULL};
+    UA_DataSource serverStatus = {readStatus, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS), serverStatus);
 
@@ -895,7 +894,7 @@ UA_Server_initNS0(UA_Server *server) {
                                &shutdownReason, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
 
     /* ServiceLevel */
-    UA_DataSource serviceLevel = {readServiceLevel, NULL};
+    UA_DataSource serviceLevel = {readServiceLevel, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVICELEVEL), serviceLevel);
 
@@ -917,7 +916,7 @@ UA_Server_initNS0(UA_Server *server) {
                                          UA_ACCESSLEVELMASK_READ);
 
     /* Auditing */
-    UA_DataSource auditing = {readAuditing, NULL};
+    UA_DataSource auditing = {readAuditing, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_AUDITING), auditing);
 
@@ -967,7 +966,7 @@ UA_Server_initNS0(UA_Server *server) {
                                &maxHistoryContinuationPoints, &UA_TYPES[UA_TYPES_UINT16]);
 
     /* ServerCapabilities - MinSupportedSampleRate */
-    UA_DataSource samplingInterval = {readMinSamplingInterval, NULL};
+    UA_DataSource samplingInterval = {readMinSamplingInterval, NULL, NULL, NULL};
     retVal |= UA_Server_setVariableNode_dataSource(server,
                  UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERCAPABILITIES_MINSUPPORTEDSAMPLERATE),
                                                    samplingInterval);

--- a/src/server/ua_server_ns0_diagnostics.c
+++ b/src/server/ua_server_ns0_diagnostics.c
@@ -72,7 +72,8 @@ readSubscriptionDiagnostics(UA_Server *server,
                             const UA_NodeId *sessionId, void *sessionContext,
                             const UA_NodeId *nodeId, void *nodeContext,
                             UA_Boolean sourceTimestamp,
-                            const UA_NumericRange *range, UA_DataValue *value) {
+                            const UA_NumericRange *range, UA_DataValue *value,
+                            void *callbackContext) {
     /* Check the Subscription pointer */
     UA_Subscription *sub = (UA_Subscription*)nodeContext;
     if(!sub)
@@ -122,7 +123,8 @@ readSubscriptionDiagnosticsArray(UA_Server *server,
                                  const UA_NodeId *sessionId, void *sessionContext,
                                  const UA_NodeId *nodeId, void *nodeContext,
                                  UA_Boolean sourceTimestamp,
-                                 const UA_NumericRange *range, UA_DataValue *value) {
+                                 const UA_NumericRange *range, UA_DataValue *value,
+                                 void *callbackContext) {
     /* Get the current session */
     size_t sdSize = 0;
     UA_Session *session = NULL;
@@ -225,7 +227,7 @@ createSubscriptionObject(UA_Server *server, UA_Session *session,
         goto cleanup;
 
     /* Add the callback to all variables  */
-    UA_DataSource subDiagSource = {readSubscriptionDiagnostics, NULL};
+    UA_DataSource subDiagSource = {readSubscriptionDiagnostics, NULL, NULL, NULL};
     for(size_t i = 0; i < childrenSize; i++) {
         setVariableNode_dataSource(server, children[i].nodeId, subDiagSource);
         setNodeContext(server, children[i].nodeId, sub);
@@ -284,7 +286,8 @@ readSessionDiagnosticsArray(UA_Server *server,
                             const UA_NodeId *sessionId, void *sessionContext,
                             const UA_NodeId *nodeId, void *nodeContext,
                             UA_Boolean sourceTimestamp,
-                            const UA_NumericRange *range, UA_DataValue *value) {
+                            const UA_NumericRange *range, UA_DataValue *value,
+                            void *callbackContext) {
     /* Allocate the output array */
     UA_SessionDiagnosticsDataType *sd = (UA_SessionDiagnosticsDataType*)
         UA_Array_new(server->sessionCount,
@@ -327,7 +330,8 @@ readSessionDiagnostics(UA_Server *server,
                        const UA_NodeId *sessionId, void *sessionContext,
                        const UA_NodeId *nodeId, void *nodeContext,
                        UA_Boolean sourceTimestamp,
-                       const UA_NumericRange *range, UA_DataValue *value) {
+                       const UA_NumericRange *range, UA_DataValue *value,
+                       void *callbackContext) {
     /* Get the Session */
     UA_Session *session = getSessionById(server, sessionId);
     if(!session)
@@ -358,7 +362,7 @@ readSessionDiagnostics(UA_Server *server,
          * session. */
         res = readSubscriptionDiagnosticsArray(server, sessionId, sessionContext,
                                                nodeId, (void*)0x01,
-                                               sourceTimestamp, range, value);
+                                               sourceTimestamp, range, value, NULL);
         goto cleanup;
     } else if(equalBrowseName(&bn.name, "SessionDiagnostics")) {
         setSessionDiagnostics(session, &data.sddt);
@@ -420,7 +424,8 @@ readSessionSecurityDiagnostics(UA_Server *server,
                                const UA_NodeId *sessionId, void *sessionContext,
                                const UA_NodeId *nodeId, void *nodeContext,
                                UA_Boolean sourceTimestamp,
-                               const UA_NumericRange *range, UA_DataValue *value) {
+                               const UA_NumericRange *range, UA_DataValue *value,
+                               void *callbackContext) {
     /* Allocate the output array */
     UA_SessionSecurityDiagnosticsDataType *sd = (UA_SessionSecurityDiagnosticsDataType*)
         UA_Array_new(server->sessionCount,
@@ -476,7 +481,7 @@ createSessionObject(UA_Server *server, UA_Session *session) {
         goto cleanup;
 
     /* Add the callback to all variables  */
-    UA_DataSource sessionDiagSource = {readSessionDiagnostics, NULL};
+    UA_DataSource sessionDiagSource = {readSessionDiagnostics, NULL, NULL, NULL};
     for(size_t i = 0; i < childrenSize; i++) {
         setVariableNode_dataSource(server, children[i].nodeId, sessionDiagSource);
     }
@@ -497,7 +502,7 @@ createSessionObject(UA_Server *server, UA_Session *session) {
 UA_StatusCode
 readDiagnostics(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
                 const UA_NodeId *nodeId, void *nodeContext, UA_Boolean sourceTimestamp,
-                const UA_NumericRange *range, UA_DataValue *value) {
+                const UA_NumericRange *range, UA_DataValue *value, void *callbackContext) {
     if(range) {
         value->hasStatus = true;
         value->status = UA_STATUSCODE_BADINDEXRANGEINVALID;

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -164,7 +164,7 @@ readValueAttributeFromNode(UA_Server *server, UA_Session *session,
                                        session ? &session->sessionId : NULL,
                                        session ? session->sessionHandle : NULL,
                                        &vn->head.nodeId, vn->head.context, rangeptr,
-                                       &vn->value.data.value);
+                                       &vn->value.data.value, vn->value.data.callback.readContext);
         UA_LOCK(&server->serviceMutex);
         vn = (const UA_VariableNode*)
             UA_NODESTORE_GET_SELECTIVE(server, &vn->head.nodeId,
@@ -203,7 +203,7 @@ readValueAttributeFromDataSource(UA_Server *server, UA_Session *session,
              session ? &session->sessionId : NULL,
              session ? session->sessionHandle : NULL,
              &vn->head.nodeId, vn->head.context,
-             sourceTimeStamp, rangeptr, &v2);
+             sourceTimeStamp, rangeptr, &v2, vn->value.dataSource.readContext);
     UA_LOCK(&server->serviceMutex);
     if(v2.hasValue && v2.value.storageType == UA_VARIANT_DATA_NODELETE) {
         retval = UA_DataValue_copy(&v2, v);
@@ -1500,8 +1500,8 @@ writeNodeValueAttribute(UA_Server *server, UA_Session *session,
                     UA_UNLOCK(&server->serviceMutex);
                     node->value.data.callback.
                         onWrite(server, &session->sessionId, session->sessionHandle,
-                                &node->head.nodeId, node->head.context,
-                                rangeptr, &adjustedValue);
+                                &node->head.nodeId, node->head.context, rangeptr, &adjustedValue,
+                                node->value.data.callback.writeContext);
                     UA_LOCK(&server->serviceMutex);
 
                 }
@@ -1510,8 +1510,8 @@ writeNodeValueAttribute(UA_Server *server, UA_Session *session,
                     UA_UNLOCK(&server->serviceMutex);
                     retval = node->value.dataSource.
                         write(server, &session->sessionId, session->sessionHandle,
-                              &node->head.nodeId, node->head.context,
-                              rangeptr, &adjustedValue);
+                              &node->head.nodeId, node->head.context, rangeptr, &adjustedValue,
+                              node->value.dataSource.writeContext);
                     UA_LOCK(&server->serviceMutex);
                 } else {
                     retval = UA_STATUSCODE_BADWRITENOTSUPPORTED;

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -891,7 +891,8 @@ static void
 afterWriteCallbackEnabledStateChange(UA_Server *server,
                                      const UA_NodeId *sessionId, void *sessionContext,
                                      const UA_NodeId *nodeId, void *nodeContext,
-                                     const UA_NumericRange *range, const UA_DataValue *data) {
+                                     const UA_NumericRange *range, const UA_DataValue *data,
+                                     void *callbackContext) {
     UA_LOCK_ASSERT(&server->serviceMutex, 0);
 
     /* Callback for change in EnabledState/Id property.
@@ -941,7 +942,8 @@ static void
 afterWriteCallbackAckedStateChange(UA_Server *server,
                                    const UA_NodeId *sessionId, void *sessionContext,
                                    const UA_NodeId *nodeId, void *nodeContext,
-                                   const UA_NumericRange *range, const UA_DataValue *data) {
+                                   const UA_NumericRange *range, const UA_DataValue *data,
+                                   void *callbackContext) {
     UA_LOCK_ASSERT(&server->serviceMutex, 0);
 
     /* Get the AckedState NodeId then The Condition NodeId */
@@ -1033,7 +1035,8 @@ static void
 afterWriteCallbackConfirmedStateChange(UA_Server *server,
                                        const UA_NodeId *sessionId, void *sessionContext,
                                        const UA_NodeId *nodeId, void *nodeContext,
-                                       const UA_NumericRange *range, const UA_DataValue *data) {
+                                       const UA_NumericRange *range, const UA_DataValue *data,
+                                       void *callbackContext) {
     UA_LOCK_ASSERT(&server->serviceMutex, 0);
 
     UA_Variant value;
@@ -1128,7 +1131,8 @@ static void
 afterWriteCallbackActiveStateChange(UA_Server *server,
                                     const UA_NodeId *sessionId, void *sessionContext,
                                     const UA_NodeId *nodeId, void *nodeContext,
-                                    const UA_NumericRange *range, const UA_DataValue *data) {
+                                    const UA_NumericRange *range, const UA_DataValue *data,
+                                    void *callbackContext) {
     UA_LOCK_ASSERT(&server->serviceMutex, 0);
 
     UA_Variant value;
@@ -1267,7 +1271,8 @@ static void
 afterWriteCallbackQualityChange(UA_Server *server,
                                 const UA_NodeId *sessionId, void *sessionContext,
                                 const UA_NodeId *nodeId, void *nodeContext,
-                                const UA_NumericRange *range, const UA_DataValue *data) {
+                                const UA_NumericRange *range, const UA_DataValue *data,
+                                void *callbackContext) {
     //TODO
 }
 
@@ -1275,7 +1280,8 @@ static void
 afterWriteCallbackSeverityChange(UA_Server *server,
                                  const UA_NodeId *sessionId, void *sessionContext,
                                  const UA_NodeId *nodeId, void *nodeContext,
-                                 const UA_NumericRange *range, const UA_DataValue *data) {
+                                 const UA_NumericRange *range, const UA_DataValue *data,
+                                 void *callbackContext) {
     UA_LOCK_ASSERT(&server->serviceMutex, 0);
 
     UA_QualifiedName fieldLastSeverity = UA_QUALIFIEDNAME(0, CONDITION_FIELD_LASTSEVERITY);

--- a/tests/multithreading/check_mt_readWriteDeleteCallback.c
+++ b/tests/multithreading/check_mt_readWriteDeleteCallback.c
@@ -29,7 +29,7 @@ readTemperature(UA_Server *tmpServer,
                 const UA_NodeId *sessionId, void *sessionContext,
                 const UA_NodeId *nodeId, void *nodeContext,
                 UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
-                UA_DataValue *dataValue) {
+                UA_DataValue *dataValue, void *callbackContext) {
     UA_LOCK(&mu);
     UA_Variant_setScalarCopy(&dataValue->value, &temperature, &UA_TYPES[UA_TYPES_INT32]);
     UA_UNLOCK(&mu);
@@ -41,7 +41,8 @@ static UA_StatusCode
 writeTemperature(UA_Server *tmpServer,
                  const UA_NodeId *sessionId, void *sessionContext,
                  const UA_NodeId *nodeId, void *nodeContext,
-                 const UA_NumericRange *range, const UA_DataValue *data) {
+                 const UA_NumericRange *range, const UA_DataValue *data,
+                 void *callbackContext) {
     UA_LOCK(&mu);
     temperature = *(UA_Int32 *) data->value.data;
     UA_UNLOCK(&mu);
@@ -54,9 +55,7 @@ void AddVariableNode(void) {
     attr.displayName = UA_LOCALIZEDTEXT("en-US", "Temperature");
     attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
 
-    UA_DataSource temperatureSource;
-    temperatureSource.read = readTemperature;
-    temperatureSource.write = writeTemperature;
+    UA_DataSource temperatureSource = {readTemperature, writeTemperature, NULL, NULL};
     UA_StatusCode retval = UA_Server_addDataSourceVariableNode(tc.server, pumpTypeId, UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                                                UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES), UA_QUALIFIEDNAME(1, "Temperature"),
                                                                UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr,

--- a/tests/server/check_services_attributes.c
+++ b/tests/server/check_services_attributes.c
@@ -26,7 +26,7 @@ readCPUTemperature(UA_Server *server_,
                    const UA_NodeId *sessionId, void *sessionContext,
                    const UA_NodeId *nodeId, void *nodeContext,
                    UA_Boolean sourceTimeStamp, const UA_NumericRange *range,
-                   UA_DataValue *dataValue) {
+                   UA_DataValue *dataValue, void *callbackContext) {
     UA_Float temp = 20.5f;
     UA_Variant_setScalarCopy(&dataValue->value, &temp, &UA_TYPES[UA_TYPES_FLOAT]);
     dataValue->hasValue = true;
@@ -74,9 +74,7 @@ static void setup(void) {
 
     /* DataSource VariableNode */
     vattr = UA_VariableAttributes_default;
-    UA_DataSource temperatureDataSource;
-    temperatureDataSource.read = readCPUTemperature;
-    temperatureDataSource.write = NULL;
+    UA_DataSource temperatureDataSource = {readCPUTemperature, NULL, NULL, NULL};
     vattr.description = UA_LOCALIZEDTEXT("en-US","temperature");
     vattr.displayName = UA_LOCALIZEDTEXT("en-US","temperature");
     retval = UA_Server_addDataSourceVariableNode(server, UA_NODEID_STRING(1, "cpu.temperature"),


### PR DESCRIPTION
Example usage:

```
class EventManager{
public:

	WriteArgs
	{
	    const UA_NodeId* nodeId;
	    const UA_DataValue* value;
	};

	void setOnWrite(std::function<UA_StatusCode(WriteArgs args)>){
		UA_ValueCallback valueCallback;
	       valueCallback.onWrite = StaticOnWrite;
	       valueCallback.writeContext = this;
	       UA_Server_setVariableNode_valueCallback(server->getUaServer(), *nodeId, valueCallback);
	}

	static void StaticOnWrite(UA_Server* server,
                              const UA_NodeId* sessionId,
                              void* sessionContext,
                              const UA_NodeId* nodeId,
                              void* nodeContext,
                              const UA_NumericRange* range,
                              const UA_DataValue* value,
                              void* callbackContext)
	{
	    auto manager = (EventManager*) callbackContext;

	    WriteArgs args;
	    args.nodeId = nodeId;
	    args.value = value;

	    manager->writeCallback(args);
	}
}

int main(){
	int counter = 0;

	auto manager = EventManager(nodeId);
	manager.setOnWrite([counter](EventManager::WriteArgs args){
		std::cout << "We can now set callback as lamda functions with a capture clause." << std::endl;
		coutnetr++;
		return UA_STATUSCODE_GOOD;
	});
}
```