### PR TITLE
refactor(pubsub): Removed unused field from DSR and RG config

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -695,14 +695,6 @@ UA_Server_DataSetReader_createTargetVariables(UA_Server *server,
  * on the Subscriber side. DataSetReader must be linked with a
  * SubscribedDataSet and be contained within a ReaderGroup. */
 
-/* Parameters for PubSubSecurity */
-typedef struct {
-    UA_Int32 securityMode;          /* placeholder datatype 'MessageSecurityMode' */
-    UA_String securityGroupId;
-    size_t keyServersSize;
-    UA_Int32 *keyServers;
-} UA_PubSubSecurityParameters;
-
 typedef enum {
     UA_PUBSUB_RT_UNKNOWN = 0,
     UA_PUBSUB_RT_VARIANT = 1,
@@ -719,7 +711,6 @@ typedef struct {
     UA_DataSetMetaDataType dataSetMetaData;
     UA_DataSetFieldContentMask dataSetFieldContentMask;
     UA_Double messageReceiveTimeout;
-    UA_PubSubSecurityParameters securityParameters;
     UA_ExtensionObject messageSettings;
     UA_ExtensionObject transportSettings;
     UA_SubscribedDataSetEnumType subscribedDataSetType;
@@ -793,7 +784,6 @@ UA_Server_removeStandaloneSubscribedDataSet(UA_Server *server, const UA_NodeId s
 /* ReaderGroup configuration */
 typedef struct {
     UA_String name;
-    UA_PubSubSecurityParameters securityParameters;
     /* PubSub Manager Callback */
     UA_PubSub_CallbackLifecycle pubsubManagerCallback;
     /* non std. field */

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -743,8 +743,6 @@ UA_DataSetReaderConfig_copy(const UA_DataSetReaderConfig *src,
     dst->dataSetFieldContentMask = src->dataSetFieldContentMask;
     dst->messageReceiveTimeout = src->messageReceiveTimeout;
 
-    /* Currently memcpy is used to copy the securityParameters */
-    memcpy(&dst->securityParameters, &src->securityParameters, sizeof(UA_PubSubSecurityParameters));
     retVal = UA_ExtensionObject_copy(&src->messageSettings, &dst->messageSettings);
     if(retVal != UA_STATUSCODE_GOOD)
         return retVal;


### PR DESCRIPTION
SecurityParameters member of reader and readerGroup config was not used anywhere and was a single instance of UA_PubSubSecurityParameters type. ReaderGroupConfig already contains this info in other memebers.