### PR TITLE
fix(pubsub): Set correct block counter for aes128 encryption

### DIFF
--- a/plugins/crypto/mbedtls/securitypolicy_pubsub_aes128ctr.c
+++ b/plugins/crypto/mbedtls/securitypolicy_pubsub_aes128ctr.c
@@ -138,13 +138,15 @@ encrypt_sp_pubsub_aes128ctr(const PUBSUB_AES128CTR_ChannelContext *cc,
     if(mbedErr)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    /* Prepare the counterBlock required for encryption/decryption */
+    /* Prepare the counterBlock required for encryption/decryption 
+     * Block counter starts at 1 according to part 14 (7.2.2.4.3.2)*/
     UA_Byte counterBlockCopy[UA_AES128CTR_ENCRYPTION_BLOCK_SIZE];
+    UA_Byte counterInitialValue[4] = {0,0,0,1};
     memcpy(counterBlockCopy, cc->keyNonce, UA_AES128CTR_KEYNONCE_LENGTH);
     memcpy(counterBlockCopy + UA_AES128CTR_KEYNONCE_LENGTH,
            cc->messageNonce, UA_AES128CTR_MESSAGENONCE_LENGTH);
-    memset(counterBlockCopy + UA_AES128CTR_KEYNONCE_LENGTH +
-           UA_AES128CTR_MESSAGENONCE_LENGTH, 0, 4);
+    memcpy(counterBlockCopy + UA_AES128CTR_KEYNONCE_LENGTH +
+           UA_AES128CTR_MESSAGENONCE_LENGTH, &counterInitialValue, 4);
 
     size_t counterblockoffset = 0;
     UA_Byte aesBuffer[UA_AES128CTR_ENCRYPTION_BLOCK_SIZE];

--- a/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
+++ b/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
@@ -135,13 +135,15 @@ encrypt_sp_pubsub_aes256ctr(const PUBSUB_AES256CTR_ChannelContext *cc,
     if(mbedErr)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    /* Prepare the counterBlock required for encryption/decryption */
+    /* Prepare the counterBlock required for encryption/decryption
+     * Block counter starts at 1 according to part 14 (7.2.2.4.3.2)*/
     UA_Byte counterBlockCopy[UA_AES256CTR_ENCRYPTION_BLOCK_SIZE];
+    UA_Byte counterInitialValue[4] = {0,0,0,1};
     memcpy(counterBlockCopy, cc->keyNonce, UA_AES256CTR_KEYNONCE_LENGTH);
     memcpy(counterBlockCopy + UA_AES256CTR_KEYNONCE_LENGTH,
            cc->messageNonce, UA_AES256CTR_MESSAGENONCE_LENGTH);
-    memset(counterBlockCopy + UA_AES256CTR_KEYNONCE_LENGTH +
-           UA_AES256CTR_MESSAGENONCE_LENGTH, 0, 4);
+    memcpy(counterBlockCopy + UA_AES256CTR_KEYNONCE_LENGTH +
+           UA_AES256CTR_MESSAGENONCE_LENGTH, &counterInitialValue, 4);
 
     size_t counterblockoffset = 0;
     UA_Byte aesBuffer[UA_AES256CTR_ENCRYPTION_BLOCK_SIZE];

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -135,12 +135,12 @@ hexstr_to_char(const char *hexstr) {
 #define MSG_LENGTH_DECRYPTED 39
 #define MSG_HEADER "f111ba08016400014df4030100000008b02d012e01000000"
 #define MSG_HEADER_NO_SEC "f101ba08016400014df4"
-#define MSG_PAYLOAD_ENC "da434ce02ee19922c6e916c8154123baa25f67288e3378d613f3203909"
+#define MSG_PAYLOAD_ENC "1c26767c41d1b02e506daece57546ce9c958279e1b6be3e28c0f775648"
 #define MSG_PAYLOAD_DEC "e1101054c2949f3a" \
                         "d701b4205f69841e" \
                         "5f6901000d7657c2" \
                         "949F3ad701"
-#define MSG_SIG "6e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
+#define MSG_SIG "31eb5d01b947a70cee7f82d4c77924811b06e7e1c93d1e7f03dd2125fc48fc5a"
 #define MSG_SIG_INVALID "5e08a9ff14b83ea2247792eeffc757c85ac99c0ffa79e4fbe5629783dc77b403"
 
 // static void


### PR DESCRIPTION
According to part 14 the initial value of AES128 encryption block counter should be set to 1, not 0.
![obraz](https://user-images.githubusercontent.com/99327189/199470990-ebdd46f7-0038-4b60-a323-f5d670957b31.png)

