### PR TITLE
feature(core): XML data encoding for numeric + string built-in types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ option(UA_ENABLE_DA "Enable OPC UA DataAccess (Part 8) definitions" ON)
 option(UA_ENABLE_HISTORIZING "Enable basic support for historical access (client and server)" OFF)
 option(UA_ENABLE_DISCOVERY "Enable Discovery Service (LDS)" OFF)
 option(UA_ENABLE_JSON_ENCODING "Enable JSON encoding" ON)
+option(UA_ENABLE_XML_ENCODING "Enable XML encoding" OFF)
 option(UA_ENABLE_NODESETLOADER "Enable nodesetLoader public API" OFF)
 
 set(MULTITHREADING_DEFAULT 0)
@@ -1198,6 +1199,16 @@ if(UA_ENABLE_JSON_ENCODING)
     list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/deps/cj5.c
                             ${PROJECT_SOURCE_DIR}/deps/parse_num.c
                             ${PROJECT_SOURCE_DIR}/src/ua_types_encoding_json.c)
+endif()
+
+if(UA_ENABLE_XML_ENCODING)
+    add_definitions(-DUA_ENABLE_XML_ENCODING)
+    if(NOT UA_ENABLE_JSON_ENCODING)
+        list(APPEND internal_headers ${PROJECT_SOURCE_DIR}/deps/parse_num.h)
+        list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/deps/parse_num.c)
+    endif()
+    list(APPEND internal_headers ${PROJECT_SOURCE_DIR}/src/ua_types_encoding_xml.h)
+    list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types_encoding_xml.c)
 endif()
 
 if(UA_ENABLE_SUBSCRIPTIONS)

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1325,6 +1325,65 @@ UA_decodeJson(const UA_ByteString *src, void *dst, const UA_DataType *type,
 #endif /* UA_ENABLE_JSON_ENCODING */
 
 /**
+ * XML En/Decoding
+ * ----------------
+ *
+ * The XML decoding can parse the official encoding from the OPC UA
+ * specification.
+ *
+ * These extensions are not intended to be used for the OPC UA protocol on the
+ * network. They were rather added to allow more convenient configuration file
+ * formats that also include data in the OPC UA type system.
+ */
+
+#ifdef UA_ENABLE_XML_ENCODING
+
+typedef struct {
+    UA_Boolean prettyPrint;   /* Add newlines and spaces for legibility */
+} UA_EncodeXmlOptions;
+
+/* Returns the number of bytes the value src takes in xml encoding. Returns
+ * zero if an error occurs. */
+UA_EXPORT size_t
+UA_calcSizeXml(const void *src, const UA_DataType *type,
+               const UA_EncodeXmlOptions *options);
+
+/* Encodes the scalar value described by type to xml encoding.
+ *
+ * @param src The value. Must not be NULL.
+ * @param type The value type. Must not be NULL.
+ * @param outBuf Pointer to ByteString containing the result if the encoding
+ *        was successful
+ * @return Returns a statuscode whether encoding succeeded. */
+UA_StatusCode UA_EXPORT
+UA_encodeXml(const void *src, const UA_DataType *type, UA_ByteString *outBuf,
+             const UA_EncodeXmlOptions *options);
+
+/* The structure with the decoding options may be extended in the future.
+ * Zero-out the entire structure initially to ensure code-compatibility when
+ * more fields are added in a later release. */
+typedef struct {
+    const UA_DataTypeArray *customTypes; /* Begin of a linked list with custom
+                                          * datatype definitions */
+} UA_DecodeXmlOptions;
+
+/* Decodes a scalar value described by type from xml encoding.
+ *
+ * @param src The buffer with the xml encoded value. Must not be NULL.
+ * @param dst The target value. Must not be NULL. The target is assumed to have
+ *        size type->memSize. The value is reset to zero before decoding. If
+ *        decoding fails, members are deleted and the value is reset (zeroed)
+ *        again.
+ * @param type The value type. Must not be NULL.
+ * @param options The options struct for decoding, currently unused
+ * @return Returns a statuscode whether decoding succeeded. */
+UA_StatusCode UA_EXPORT
+UA_decodeXml(const UA_ByteString *src, void *dst, const UA_DataType *type,
+             const UA_DecodeXmlOptions *options);
+
+#endif /* UA_ENABLE_XML_ENCODING */
+
+/**
  * .. _array-handling:
  *
  * Array handling

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -1,0 +1,834 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/config.h>
+#include <open62541/types_generated.h>
+#include <open62541/types_generated_handling.h>
+
+#include "ua_types_encoding_xml.h"
+
+#include "../deps/itoa.h"
+#include "../deps/parse_num.h"
+#include "../deps/libc_time.h"
+
+#ifndef UA_ENABLE_PARSING
+#error UA_ENABLE_PARSING required for XML encoding
+#endif
+
+#ifndef UA_ENABLE_TYPEDESCRIPTION
+#error UA_ENABLE_TYPEDESCRIPTION required for XML encoding
+#endif
+
+/* vs2008 does not have INFINITY and NAN defined */
+#ifndef INFINITY
+# define INFINITY ((UA_Double)(DBL_MAX+DBL_MAX))
+#endif
+#ifndef NAN
+# define NAN ((UA_Double)(INFINITY-INFINITY))
+#endif
+
+/* Have some slack at the end. E.g. for negative and very long years. */
+#define UA_XML_DATETIME_LENGTH 40
+
+/************/
+/* Encoding */
+/************/
+
+#define ENCODE_XML(TYPE) static status \
+    TYPE##_encodeXml(CtxXml *ctx, const UA_##TYPE *src, const UA_DataType *type)
+
+static status UA_FUNC_ATTR_WARN_UNUSED_RESULT
+writeChars(CtxXml *ctx, const char *c, size_t len) {
+    if(ctx->pos + len > ctx->end)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+    if(!ctx->calcOnly)
+        memcpy(ctx->pos, c, len);
+    ctx->pos += len;
+    return UA_STATUSCODE_GOOD;
+}
+
+/* Boolean */
+ENCODE_XML(Boolean) {
+    if(*src == true)
+        return writeChars(ctx, "true", 4);
+    return writeChars(ctx, "false", 5);
+}
+
+static status encodeSigned(CtxXml *ctx, UA_Int64 value, char* buffer) {
+    UA_UInt16 digits = itoaSigned(value, buffer);
+    return writeChars(ctx, buffer, digits);
+}
+
+static status encodeUnsigned(CtxXml *ctx, UA_UInt64 value, char* buffer) {
+    UA_UInt16 digits = itoaUnsigned(value, buffer, 10);
+    return writeChars(ctx, buffer, digits);
+}
+
+/* signed Byte */
+ENCODE_XML(SByte) {
+    char buf[5];
+    return encodeSigned(ctx, *src, buf);
+}
+
+/* Byte */
+ENCODE_XML(Byte) {
+    char buf[4];
+    return encodeUnsigned(ctx, *src, buf);
+}
+
+/* Int16 */
+ENCODE_XML(Int16) {
+    char buf[7];
+    return encodeSigned(ctx, *src, buf);
+}
+
+/* UInt16 */
+ENCODE_XML(UInt16) {
+    char buf[6];
+    return encodeUnsigned(ctx, *src, buf);
+}
+
+/* Int32 */
+ENCODE_XML(Int32) {
+    char buf[12];
+    return encodeSigned(ctx, *src, buf);
+}
+
+/* UInt32 */
+ENCODE_XML(UInt32) {
+    char buf[11];
+    return encodeUnsigned(ctx, *src, buf);
+}
+
+/* Int64 */
+ENCODE_XML(Int64) {
+    char buf[23];
+    return encodeSigned(ctx, *src, buf);
+}
+
+/* UInt64 */
+ENCODE_XML(UInt64) {
+    char buf[23];
+    return encodeUnsigned(ctx, *src, buf);
+}
+
+/* Float */
+ENCODE_XML(Float) {
+    char buffer[200];
+    if(*src != *src) {
+        strcpy(buffer, "NaN");
+    } else if(*src == INFINITY) {
+        strcpy(buffer, "INF");
+    } else if(*src == -INFINITY) {
+        strcpy(buffer, "-INF");
+    } else {
+        /* https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/
+         * Maximum digit counts for float: 149
+         */
+        UA_snprintf(buffer, 200, "%.149g", (UA_Double)*src);
+    }
+
+    size_t len = strlen(buffer);
+    if(len == 0)
+        return UA_STATUSCODE_BADENCODINGERROR;
+
+    return writeChars(ctx, buffer, len);
+}
+
+/* Double */
+ENCODE_XML(Double) {
+    char buffer[2000];
+    if(*src != *src) {
+        strcpy(buffer, "NaN");
+    } else if(*src == INFINITY) {
+        strcpy(buffer, "INF");
+    } else if(*src == -INFINITY) {
+        strcpy(buffer, "-INF");
+    } else {
+        /* https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/
+         * Maximum digit counts for double: 1074
+         */
+        UA_snprintf(buffer, 2000, "%.1074g", *src);
+    }
+
+    size_t len = strlen(buffer);
+    if(len == 0)
+        return UA_STATUSCODE_BADENCODINGERROR;
+
+    return writeChars(ctx, buffer, len);
+}
+
+/* String */
+ENCODE_XML(String) {
+    if(!src->data)
+        return writeChars(ctx, "null", 4);
+    return writeChars(ctx, (const char*)src->data, src->length);
+}
+
+/* Guid */
+ENCODE_XML(Guid) {
+    if(ctx->pos + 36 > ctx->end)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+    if(!ctx->calcOnly)
+        UA_Guid_to_hex(src, ctx->pos, false);
+    ctx->pos += 36;
+    return UA_STATUSCODE_GOOD;
+}
+
+/* DateTime */
+static u8
+printNumber(i32 n, char *pos, u8 min_digits) {
+    char digits[10];
+    u8 len = 0;
+    /* Handle negative values */
+    if(n < 0) {
+        pos[len++] = '-';
+        n = -n;
+    }
+
+    /* Extract the digits */
+    u8 i = 0;
+    for(; i < min_digits || n > 0; i++) {
+        digits[i] = (char)((n % 10) + '0');
+        n /= 10;
+    }
+
+    /* Print in reverse order and return */
+    for(; i > 0; i--)
+        pos[len++] = digits[i-1];
+    return len;
+}
+
+ENCODE_XML(DateTime) {
+    UA_DateTimeStruct tSt = UA_DateTime_toStruct(*src);
+
+    /* Format: -yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z' is used. max 31 bytes.
+     * Note the optional minus for negative years. */
+    char buffer[UA_XML_DATETIME_LENGTH];
+    char *pos = buffer;
+    pos += printNumber(tSt.year, pos, 4);
+    *(pos++) = '-';
+    pos += printNumber(tSt.month, pos, 2);
+    *(pos++) = '-';
+    pos += printNumber(tSt.day, pos, 2);
+    *(pos++) = 'T';
+    pos += printNumber(tSt.hour, pos, 2);
+    *(pos++) = ':';
+    pos += printNumber(tSt.min, pos, 2);
+    *(pos++) = ':';
+    pos += printNumber(tSt.sec, pos, 2);
+    *(pos++) = '.';
+    pos += printNumber(tSt.milliSec, pos, 3);
+    pos += printNumber(tSt.microSec, pos, 3);
+    pos += printNumber(tSt.nanoSec, pos, 3);
+
+    UA_assert(pos <= &buffer[UA_XML_DATETIME_LENGTH]);
+
+    /* Remove trailing zeros */
+    pos--;
+    while(*pos == '0')
+        pos--;
+    if(*pos == '.')
+        pos--;
+
+    *(++pos) = 'Z';
+    UA_String str = {((uintptr_t)pos - (uintptr_t)buffer)+1, (UA_Byte*)buffer};
+
+    return writeChars(ctx, (const char*)str.data, str.length);
+}
+
+/* NodeId */
+ENCODE_XML(NodeId) {
+    UA_StatusCode ret = UA_STATUSCODE_GOOD;
+    UA_String out = UA_STRING_NULL;
+
+    ret |= UA_NodeId_print(src, &out);
+    ret |= encodeXmlJumpTable[UA_DATATYPEKIND_STRING](ctx, &out, NULL);
+
+    UA_String_clear(&out);
+    return ret;
+}
+
+/* ExpandedNodeId */
+ENCODE_XML(ExpandedNodeId) {
+    UA_StatusCode ret = UA_STATUSCODE_GOOD;
+    UA_String out = UA_STRING_NULL;
+
+    ret |= UA_ExpandedNodeId_print(src, &out);
+    ret |= encodeXmlJumpTable[UA_DATATYPEKIND_STRING](ctx, &out, NULL);
+
+    UA_String_clear(&out);
+    return ret;
+}
+
+static status
+encodeXmlNotImplemented(CtxXml *ctx, const void *src, const UA_DataType *type) {
+    (void)ctx, (void)src, (void)type;
+    return UA_STATUSCODE_BADNOTIMPLEMENTED;
+}
+
+const encodeXmlSignature encodeXmlJumpTable[UA_DATATYPEKINDS] = {
+    (encodeXmlSignature)Boolean_encodeXml,          /* Boolean */
+    (encodeXmlSignature)SByte_encodeXml,            /* SByte */
+    (encodeXmlSignature)Byte_encodeXml,             /* Byte */
+    (encodeXmlSignature)Int16_encodeXml,            /* Int16 */
+    (encodeXmlSignature)UInt16_encodeXml,           /* UInt16 */
+    (encodeXmlSignature)Int32_encodeXml,            /* Int32 */
+    (encodeXmlSignature)UInt32_encodeXml,           /* UInt32 */
+    (encodeXmlSignature)Int64_encodeXml,            /* Int64 */
+    (encodeXmlSignature)UInt64_encodeXml,           /* UInt64 */
+    (encodeXmlSignature)Float_encodeXml,            /* Float */
+    (encodeXmlSignature)Double_encodeXml,           /* Double */
+    (encodeXmlSignature)String_encodeXml,           /* String */
+    (encodeXmlSignature)DateTime_encodeXml,         /* DateTime */
+    (encodeXmlSignature)Guid_encodeXml,             /* Guid */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* ByteString */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* XmlElement */
+    (encodeXmlSignature)NodeId_encodeXml,           /* NodeId */
+    (encodeXmlSignature)ExpandedNodeId_encodeXml,   /* ExpandedNodeId */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* StatusCode */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* QualifiedName */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* LocalizedText */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* ExtensionObject */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* DataValue */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* Variant */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* DiagnosticInfo */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* Decimal */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* Enum */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* Structure */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* Structure with optional fields */
+    (encodeXmlSignature)encodeXmlNotImplemented,    /* Union */
+    (encodeXmlSignature)encodeXmlNotImplemented     /* BitfieldCluster */
+};
+
+UA_StatusCode
+UA_encodeXml(const void *src, const UA_DataType *type, UA_ByteString *outBuf,
+             const UA_EncodeXmlOptions *options) {
+    if(!src || !type)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    /* Allocate buffer */
+    UA_Boolean allocated = false;
+    status res = UA_STATUSCODE_GOOD;
+    if(outBuf->length == 0) {
+        size_t len = UA_calcSizeXml(src, type, options);
+        res = UA_ByteString_allocBuffer(outBuf, len);
+        if(res != UA_STATUSCODE_GOOD)
+            return res;
+        allocated = true;
+    }
+
+    /* Set up the context */
+    CtxXml ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.pos = outBuf->data;
+    ctx.end = &outBuf->data[outBuf->length];
+    ctx.depth = 0;
+    ctx.calcOnly = false;
+    if(options)
+        ctx.prettyPrint = options->prettyPrint;
+
+    /* Encode */
+    res = encodeXmlJumpTable[type->typeKind](&ctx, src, type);
+
+    /* Clean up */
+    if(res == UA_STATUSCODE_GOOD)
+        outBuf->length = (size_t)((uintptr_t)ctx.pos - (uintptr_t)outBuf->data);
+    else if(allocated)
+        UA_ByteString_clear(outBuf);
+    return res;
+}
+
+/************/
+/* CalcSize */
+/************/
+
+size_t
+UA_calcSizeXml(const void *src, const UA_DataType *type,
+               const UA_EncodeXmlOptions *options) {
+    if(!src || !type)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    /* Set up the context */
+    CtxXml ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.pos = NULL;
+    ctx.end = (const UA_Byte*)(uintptr_t)SIZE_MAX;
+    ctx.depth = 0;
+    if(options) {
+        ctx.prettyPrint = options->prettyPrint;
+    }
+
+    ctx.calcOnly = true;
+
+    /* Encode */
+    status ret = encodeXmlJumpTable[type->typeKind](&ctx, src, type);
+    if(ret != UA_STATUSCODE_GOOD)
+        return 0;
+    return (size_t)ctx.pos;
+}
+
+/**********/
+/* Decode */
+/**********/
+
+#define CHECK_TOKEN_BOUNDS do {                   \
+    if(ctx->index >= ctx->tokensSize)             \
+        return UA_STATUSCODE_BADDECODINGERROR;    \
+    } while(0)
+
+/* Forward declarations*/
+#define DECODE_XML(TYPE) static status                   \
+    TYPE##_decodeXml(ParseCtxXml *ctx, UA_##TYPE *dst,  \
+                      const UA_DataType *type)
+
+DECODE_XML(Boolean) {
+    if(ctx->length == 4 &&
+       ctx->data[0] == 't' && ctx->data[1] == 'r' &&
+       ctx->data[2] == 'u' && ctx->data[3] == 'e') {
+        *dst = true;
+    } else if(ctx->length == 5 &&
+              ctx->data[0] == 'f' && ctx->data[1] == 'a' &&
+              ctx->data[2] == 'l' && ctx->data[3] == 's' &&
+              ctx->data[4] == 'e') {
+        *dst = false;
+    } else {
+        return UA_STATUSCODE_BADDECODINGERROR;
+    }
+
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+parseSignedInteger(const char *data, size_t dataSize, UA_Int64 *dst) {
+    size_t len = parseInt64(data, dataSize, dst);
+    if(len == 0)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    /* There must only be whitespace between the end of the parsed number and
+     * the end of the XML section */
+    for(size_t i = len; i < dataSize; i++) {
+        if(data[i] != ' ' && data[i] - '\t' >= 5)
+            return UA_STATUSCODE_BADDECODINGERROR;
+    }
+
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+parseUnsignedInteger(const char *data, size_t dataSize, UA_UInt64 *dst) {
+    size_t len = parseUInt64(data, dataSize, dst);
+    if(len == 0)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    /* There must only be whitespace between the end of the parsed number and
+     * the end of the XML section */
+    for(size_t i = len; i < dataSize; i++) {
+        if(data[i] != ' ' && data[i] - '\t' >= 5)
+            return UA_STATUSCODE_BADDECODINGERROR;
+    }
+
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(SByte) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray. */
+    UA_Int64 out = 0;
+    UA_StatusCode s = parseSignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD || out < UA_SBYTE_MIN || out > UA_SBYTE_MAX)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_SByte)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(Byte) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray.
+     *   4. Check if decimal point exists. */
+    UA_UInt64 out = 0;
+    UA_StatusCode s = parseUnsignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD || out > UA_BYTE_MAX)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_Byte)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(Int16) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray.
+     *   4. Check if decimal point exists. */
+    UA_Int64 out = 0;
+    UA_StatusCode s = parseSignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD || out < UA_INT16_MIN || out > UA_INT16_MAX)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_Int16)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(UInt16) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray.
+     *   4. Check if decimal point exists. */
+    UA_UInt64 out = 0;
+    UA_StatusCode s = parseUnsignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD || out > UA_UINT16_MAX)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_UInt16)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(Int32) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray.
+     *   4. Check if decimal point exists.
+     *   5. Check "-0" and "+0", and just remove the sign. */
+    UA_Int64 out = 0;
+    UA_StatusCode s = parseSignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD || out < UA_INT32_MIN || out > UA_INT32_MAX)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_Int32)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(UInt32) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray.
+     *   4. Check if decimal point exists. */
+    UA_UInt64 out = 0;
+    UA_StatusCode s = parseUnsignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD || out > UA_UINT32_MAX)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_UInt32)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(Int64) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray.
+     *   4. Check if decimal point exists. */
+    UA_Int64 out = 0;
+    UA_StatusCode s = parseSignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_Int64)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(UInt64) {
+    /* TODO:
+     *   1. Add support for optional "+" sign.
+     *   2. Add support for optional leading zeros.
+     *   3. Check if the value is in hex, octal or binray.
+     *   4. Check if decimal point exists. */
+    UA_UInt64 out = 0;
+    UA_StatusCode s = parseUnsignedInteger(ctx->data, ctx->length, &out);
+
+    if(s != UA_STATUSCODE_GOOD)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = (UA_UInt64)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(Double) {
+
+    /* https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/
+     * Maximum digit counts for select IEEE floating-point formats: 1074
+     * Sanity check.
+     */
+    if(ctx->length > 1075)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    if(ctx->length == 3 && memcmp(ctx->data, "INF", 3) == 0) {
+        *dst = INFINITY;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    if(ctx->length == 4 && memcmp(ctx->data, "-INF", 4) == 0) {
+        *dst = -INFINITY;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    if(ctx->length == 3 && memcmp(ctx->data, "NaN", 3) == 0) {
+        *dst = NAN;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    size_t len = parseDouble(ctx->data, ctx->length, dst);
+    if(len == 0)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    /* There must only be whitespace between the end of the parsed number and
+     * the end of the token */
+    for(size_t i = len; i < ctx->length; i++) {
+        if(ctx->data[i] != ' ' && ctx->data[i] -'\t' >= 5)
+            return UA_STATUSCODE_BADDECODINGERROR;
+    }
+
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(Float) {
+    UA_Double v = 0.0;
+    UA_StatusCode res = Double_decodeXml(ctx, &v, NULL);
+    *dst = (UA_Float)v;
+    return res;
+}
+
+DECODE_XML(String) {
+    /* Empty string? */
+    if(ctx->length == 0) {
+        dst->data = (UA_Byte*)UA_EMPTY_ARRAY_SENTINEL;
+        dst->length = 0;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    /* Set the output */
+    dst->length = ctx->length;
+    if(dst->length > 0) {
+        dst->data = (UA_Byte*)(uintptr_t)ctx->data;
+    } else {
+        dst->data = (UA_Byte*)UA_EMPTY_ARRAY_SENTINEL;
+    }
+
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(DateTime) {
+    /* The last character has to be 'Z'. We can omit some length checks later on
+     * because we know the atoi functions stop before the 'Z'. */
+    if(ctx->length == 0 || ctx->data[ctx->length - 1] != 'Z')
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    struct mytm dts;
+    memset(&dts, 0, sizeof(dts));
+
+    size_t pos = 0;
+    size_t len;
+
+    /* Parse the year. The ISO standard asks for four digits. But we accept up
+     * to five with an optional plus or minus in front due to the range of the
+     * DateTime 64bit integer. But in that case we require the year and the
+     * month to be separated by a '-'. Otherwise we cannot know where the month
+     * starts. */
+    if(ctx->data[0] == '-' || ctx->data[0] == '+')
+        pos++;
+    UA_Int64 year = 0;
+    len = parseInt64(&ctx->data[pos], 5, &year);
+    pos += len;
+    if(len != 4 && ctx->data[pos] != '-')
+        return UA_STATUSCODE_BADDECODINGERROR;
+    if(ctx->data[0] == '-')
+        year = -year;
+    dts.tm_year = (UA_Int16)year - 1900;
+    if(ctx->data[pos] == '-')
+        pos++;
+
+    /* Parse the month */
+    UA_UInt64 month = 0;
+    len = parseUInt64(&ctx->data[pos], 2, &month);
+    pos += len;
+    UA_CHECK(len == 2, return UA_STATUSCODE_BADDECODINGERROR);
+    dts.tm_mon = (UA_UInt16)month - 1;
+    if(ctx->data[pos] == '-')
+        pos++;
+
+    /* Parse the day and check the T between date and time */
+    UA_UInt64 day = 0;
+    len = parseUInt64(&ctx->data[pos], 2, &day);
+    pos += len;
+    UA_CHECK(len == 2 || ctx->data[pos] != 'T',
+             return UA_STATUSCODE_BADDECODINGERROR);
+    dts.tm_mday = (UA_UInt16)day;
+    pos++;
+
+    /* Parse the hour */
+    UA_UInt64 hour = 0;
+    len = parseUInt64(&ctx->data[pos], 2, &hour);
+    pos += len;
+    UA_CHECK(len == 2, return UA_STATUSCODE_BADDECODINGERROR);
+    dts.tm_hour = (UA_UInt16)hour;
+    if(ctx->data[pos] == ':')
+        pos++;
+
+    /* Parse the minute */
+    UA_UInt64 min = 0;
+    len = parseUInt64(&ctx->data[pos], 2, &min);
+    pos += len;
+    UA_CHECK(len == 2, return UA_STATUSCODE_BADDECODINGERROR);
+    dts.tm_min = (UA_UInt16)min;
+    if(ctx->data[pos] == ':')
+        pos++;
+
+    /* Parse the second */
+    UA_UInt64 sec = 0;
+    len = parseUInt64(&ctx->data[pos], 2, &sec);
+    pos += len;
+    UA_CHECK(len == 2, return UA_STATUSCODE_BADDECODINGERROR);
+    dts.tm_sec = (UA_UInt16)sec;
+
+    /* Compute the seconds since the Unix epoch */
+    long long sinceunix = __tm_to_secs(&dts);
+
+    /* Are we within the range that can be represented? */
+    long long sinceunix_min =
+        (long long)(UA_INT64_MIN / UA_DATETIME_SEC) -
+        (long long)(UA_DATETIME_UNIX_EPOCH / UA_DATETIME_SEC) -
+        (long long)1; /* manual correction due to rounding */
+    long long sinceunix_max = (long long)
+        ((UA_INT64_MAX - UA_DATETIME_UNIX_EPOCH) / UA_DATETIME_SEC);
+    if(sinceunix < sinceunix_min || sinceunix > sinceunix_max)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    /* Convert to DateTime. Add or subtract one extra second here to prevent
+     * underflow/overflow. This is reverted once the fractional part has been
+     * added. */
+    sinceunix -= (sinceunix > 0) ? 1 : -1;
+    UA_DateTime dt = (UA_DateTime)
+        (sinceunix + (UA_DATETIME_UNIX_EPOCH / UA_DATETIME_SEC)) * UA_DATETIME_SEC;
+
+    /* Parse the fraction of the second if defined */
+    if(ctx->data[pos] == ',' || ctx->data[pos] == '.') {
+        pos++;
+        double frac = 0.0;
+        double denom = 0.1;
+        while(pos < ctx->length && ctx->data[pos] >= '0' && ctx->data[pos] <= '9') {
+            frac += denom * (ctx->data[pos] - '0');
+            denom *= 0.1;
+            pos++;
+        }
+        frac += 0.00000005; /* Correct rounding when converting to integer */
+        dt += (UA_DateTime)(frac * UA_DATETIME_SEC);
+    }
+
+    /* Remove the underflow/overflow protection (see above) */
+    if(sinceunix > 0) {
+        if(dt > UA_INT64_MAX - UA_DATETIME_SEC)
+            return UA_STATUSCODE_BADDECODINGERROR;
+        dt += UA_DATETIME_SEC;
+    } else {
+        if(dt < UA_INT64_MIN + UA_DATETIME_SEC)
+            return UA_STATUSCODE_BADDECODINGERROR;
+        dt -= UA_DATETIME_SEC;
+    }
+
+    /* We must be at the end of the string (ending with 'Z' as checked above) */
+    if(pos != ctx->length - 1)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    *dst = dt;
+
+    return UA_STATUSCODE_GOOD;
+}
+
+DECODE_XML(Guid) {
+    UA_String str = {ctx->length, (UA_Byte*)(uintptr_t)ctx->data};
+    return UA_Guid_parse(dst, str);
+}
+
+DECODE_XML(NodeId) {
+    UA_String str = {ctx->length, (UA_Byte*)(uintptr_t)ctx->data};
+    return UA_NodeId_parse(dst, str);
+}
+
+DECODE_XML(ExpandedNodeId) {
+    UA_String str = {ctx->length, (UA_Byte*)(uintptr_t)ctx->data};
+    return UA_ExpandedNodeId_parse(dst, str);
+}
+
+static status
+decodeXmlNotImplemented(ParseCtxXml *ctx, void *dst, const UA_DataType *type) {
+    (void)dst, (void)type, (void)ctx;
+    return UA_STATUSCODE_BADNOTIMPLEMENTED;
+}
+
+const decodeXmlSignature decodeXmlJumpTable[UA_DATATYPEKINDS] = {
+    (decodeXmlSignature)Boolean_decodeXml,          /* Boolean */
+    (decodeXmlSignature)SByte_decodeXml,            /* SByte */
+    (decodeXmlSignature)Byte_decodeXml,             /* Byte */
+    (decodeXmlSignature)Int16_decodeXml,            /* Int16 */
+    (decodeXmlSignature)UInt16_decodeXml,           /* UInt16 */
+    (decodeXmlSignature)Int32_decodeXml,            /* Int32 */
+    (decodeXmlSignature)UInt32_decodeXml,           /* UInt32 */
+    (decodeXmlSignature)Int64_decodeXml,            /* Int64 */
+    (decodeXmlSignature)UInt64_decodeXml,           /* UInt64 */
+    (decodeXmlSignature)Float_decodeXml,            /* Float */
+    (decodeXmlSignature)Double_decodeXml,           /* Double */
+    (decodeXmlSignature)String_decodeXml,           /* String */
+    (decodeXmlSignature)DateTime_decodeXml,         /* DateTime */
+    (decodeXmlSignature)Guid_decodeXml,             /* Guid */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* ByteString */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* XmlElement */
+    (decodeXmlSignature)NodeId_decodeXml,           /* NodeId */
+    (decodeXmlSignature)ExpandedNodeId_decodeXml,   /* ExpandedNodeId */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* StatusCode */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* QualifiedName */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* LocalizedText */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* ExtensionObject */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* DataValue */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* Variant */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* DiagnosticInfo */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* Decimal */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* Enum */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* Structure */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* Structure with optional fields */
+    (decodeXmlSignature)decodeXmlNotImplemented,    /* Union */
+    (decodeXmlSignature)decodeXmlNotImplemented     /* BitfieldCluster */
+};
+
+UA_StatusCode
+UA_decodeXml(const UA_ByteString *src, void *dst, const UA_DataType *type,
+              const UA_DecodeXmlOptions *options) {
+    if(!dst || !src || !type)
+        return UA_STATUSCODE_BADARGUMENTSMISSING;
+
+    /* Set up the context */
+    ParseCtxXml ctx;
+    memset(&ctx, 0, sizeof(ParseCtxXml));
+    ctx.data = (const char*)src->data;
+    ctx.length = src->length;
+    ctx.depth = 0;
+    if(options) {
+        ctx.customTypes = options->customTypes;
+    }
+
+    /* Decode */
+    memset(dst, 0, type->memSize); /* Initialize the value */
+    status ret = decodeXmlJumpTable[type->typeKind](&ctx, dst, type);
+
+    if(ret != UA_STATUSCODE_GOOD) {
+        UA_clear(dst, type);
+        memset(dst, 0, type->memSize);
+    }
+    return ret;
+}

--- a/src/ua_types_encoding_xml.h
+++ b/src/ua_types_encoding_xml.h
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef UA_TYPES_ENCODING_XML_H_
+#define UA_TYPES_ENCODING_XML_H_
+
+#include <open62541/types.h>
+
+#include "ua_util_internal.h"
+
+_UA_BEGIN_DECLS
+
+#define UA_XML_ENCODING_MAX_RECURSION 100
+
+typedef struct {
+    uint8_t *pos;
+    const uint8_t *end;
+
+    uint16_t depth; /* How often did we encoding recurse? */
+    UA_Boolean calcOnly; /* Only compute the length of the decoding */
+    UA_Boolean prettyPrint;
+
+    const UA_DataTypeArray *customTypes;
+} CtxXml;
+
+typedef struct {
+    const char* data;
+    size_t length;
+
+    uint16_t depth; /* How often did we decoding recurse? */
+
+    const UA_DataTypeArray *customTypes;
+} ParseCtxXml;
+
+typedef UA_StatusCode
+(*encodeXmlSignature)(CtxXml *ctx, const void *src, const UA_DataType *type);
+
+typedef UA_StatusCode
+(*decodeXmlSignature)(ParseCtxXml *ctx, void *dst, const UA_DataType *type);
+
+/* Expose the jump tables and some methods */
+extern const encodeXmlSignature encodeXmlJumpTable[UA_DATATYPEKINDS];
+extern const decodeXmlSignature decodeXmlJumpTable[UA_DATATYPEKINDS];
+
+_UA_END_DECLS
+
+#endif /* UA_TYPES_ENCODING_XML_H_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,6 +229,10 @@ if(UA_ENABLE_JSON_ENCODING)
     endif()
 endif()
 
+if(UA_ENABLE_XML_ENCODING)
+    ua_add_test(check_types_builtin_xml.c)
+endif()
+
 ua_add_test(check_types_memory.c)
 ua_add_test(check_types_range.c)
 

--- a/tests/check_types_builtin_xml.c
+++ b/tests/check_types_builtin_xml.c
@@ -1,0 +1,2678 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/types.h>
+#include <open62541/types_generated.h>
+#include <open62541/types_generated_handling.h>
+#include <open62541/util.h>
+
+#include "ua_types_encoding_xml.h"
+
+#include <check.h>
+
+#if defined(_MSC_VER)
+# pragma warning(disable: 4146)
+#endif
+
+/* Boolean */
+START_TEST(UA_Boolean_true_xml_encode) {
+    UA_Boolean *src = UA_Boolean_new();
+    UA_Boolean_init(src);
+    *src = true;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_BOOLEAN];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+    ck_assert_uint_eq(size, 4);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "true";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Boolean_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Boolean_false_xml_encode) {
+    UA_Boolean *src = UA_Boolean_new();
+    UA_Boolean_init(src);
+    *src = false;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_BOOLEAN];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+    ck_assert_uint_eq(size, 5);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "false";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Boolean_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Boolean_true_bufferTooSmall_xml_encode) {
+    UA_Boolean *src = UA_Boolean_new();
+    UA_Boolean_init(src);
+    *src = false;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_BOOLEAN];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_Boolean_delete(src);
+}
+END_TEST
+
+/* SByte */
+START_TEST(UA_SByte_Max_Number_xml_encode) {
+    UA_SByte src = 127;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_SBYTE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "127";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_SByte_Min_Number_xml_encode) {
+    UA_SByte src = -128;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_SBYTE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "-128";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_SByte_Zero_Number_xml_encode) {
+    UA_SByte *src = UA_SByte_new();
+    *src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_SBYTE];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_SByte_delete(src);
+}
+END_TEST
+
+START_TEST(UA_SByte_smallbuf_Number_xml_encode) {
+    UA_SByte *src = UA_SByte_new();
+    *src = 127;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_SBYTE];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_SByte_delete(src);
+}
+END_TEST
+
+/* Byte */
+START_TEST(UA_Byte_Max_Number_xml_encode) {
+    UA_Byte *src = UA_Byte_new();
+    *src = 255;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_BYTE];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "255";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Byte_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Byte_Min_Number_xml_encode) {
+    UA_Byte src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_BYTE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Byte_smallbuf_Number_xml_encode) {
+    UA_Byte src = 255;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_BYTE];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+/* Int16 */
+START_TEST(UA_Int16_Max_Number_xml_encode) {
+    UA_Int16 *src = UA_Int16_new();
+    *src = 32767;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT16];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "32767";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int16_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int16_Min_Number_xml_encode) {
+    UA_Int16 *src = UA_Int16_new();
+    *src = -32768;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT16];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "-32768";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int16_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int16_Zero_Number_xml_encode) {
+    UA_Int16 *src = UA_Int16_new();
+    *src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT16];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int16_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int16_smallbuf_Number_xml_encode) {
+    UA_Int16 *src = UA_Int16_new();
+    *src = 127;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT16];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_Int16_delete(src);
+}
+END_TEST
+
+/* UInt16 */
+START_TEST(UA_UInt16_Max_Number_xml_encode) {
+    UA_UInt16 *src = UA_UInt16_new();
+    *src = 65535;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT16];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "65535";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt16_delete(src);
+}
+END_TEST
+
+START_TEST(UA_UInt16_Min_Number_xml_encode) {
+    UA_UInt16 *src = UA_UInt16_new();
+    *src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT16];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt16_delete(src);
+}
+END_TEST
+
+START_TEST(UA_UInt16_smallbuf_Number_xml_encode) {
+    UA_UInt16 *src = UA_UInt16_new();
+    *src = 255;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT16];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt16_delete(src);
+}
+END_TEST
+
+/* Int32 */
+START_TEST(UA_Int32_Max_Number_xml_encode) {
+    UA_Int32 *src = UA_Int32_new();
+    *src = 2147483647;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT32];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "2147483647";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int32_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int32_Min_Number_xml_encode) {
+    UA_Int32 src = -2147483648;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT32];
+    size_t size = UA_calcSizeXml((void *)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "-2147483648";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Int32_Zero_Number_xml_encode) {
+    UA_Int32 *src = UA_Int32_new();
+    *src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT32];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int32_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int32_smallbuf_Number_xml_encode) {
+    UA_Int32 *src = UA_Int32_new();
+    *src = 127;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT32];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_Int32_delete(src);
+}
+END_TEST
+
+/* UInt32 */
+START_TEST(UA_UInt32_Max_Number_xml_encode) {
+    UA_UInt32 *src = UA_UInt32_new();
+    *src = 4294967295;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT32];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "4294967295";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt32_delete(src);
+}
+END_TEST
+
+START_TEST(UA_UInt32_Min_Number_xml_encode) {
+    UA_UInt32 *src = UA_UInt32_new();
+    *src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT32];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt32_delete(src);
+}
+END_TEST
+
+START_TEST(UA_UInt32_smallbuf_Number_xml_encode) {
+    UA_UInt32 *src = UA_UInt32_new();
+    *src = 127;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT32];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt32_delete(src);
+}
+END_TEST
+
+/* Int64 */
+START_TEST(UA_Int64_Max_Number_xml_encode) {
+    UA_Int64 *src = UA_Int64_new();
+    *src = 9223372036854775807LL;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT64];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "9223372036854775807";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int64_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int64_Min_Number_xml_encode) {
+    UA_Int64 *src = UA_Int64_new();
+    *src = -UA_INT64_MAX - 1LL;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT64];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "-9223372036854775808";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int64_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int64_Zero_Number_xml_encode) {
+    UA_Int64 *src = UA_Int64_new();
+    *src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT64];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_Int64_delete(src);
+}
+END_TEST
+
+START_TEST(UA_Int64_smallbuf_Number_xml_encode) {
+    UA_Int64 *src = UA_Int64_new();
+    *src = 127;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_INT64];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_Int64_delete(src);
+}
+END_TEST
+
+/* UInt64 */
+START_TEST(UA_UInt64_Max_Number_xml_encode) {
+    UA_UInt64 *src = UA_UInt64_new();
+    *src = 18446744073709551615ULL;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT64];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "18446744073709551615";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt64_delete(src);
+}
+END_TEST
+
+START_TEST(UA_UInt64_Min_Number_xml_encode) {
+    UA_UInt64 *src = UA_UInt64_new();
+    *src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT64];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt64_delete(src);
+}
+END_TEST
+
+START_TEST(UA_UInt64_smallbuf_Number_xml_encode) {
+    UA_UInt64 *src = UA_UInt64_new();
+    *src = -9223372036854775808ULL;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_UINT64];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 2);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_UInt64_delete(src);
+}
+END_TEST
+
+/* Float */
+START_TEST(UA_Float_xml_encode) {
+    UA_Float src = 1.0000000000F;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_FLOAT];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "1";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+/* Double */
+START_TEST(UA_Double_xml_encode) {
+    UA_Double src = 1.1234;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "1.1233999999999999541699935434735380113124847412109375";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Double_pluszero_xml_encode) {
+    UA_Double src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Double_minuszero_xml_encode) {
+    UA_Double src = -0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "0";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Double_plusInf_xml_encode) {
+    UA_Double src = INFINITY;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "INF";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Double_minusInf_xml_encode) {
+    UA_Double src = -INFINITY;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "-INF";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Double_nan_xml_encode) {
+    UA_Double src = NAN;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "NaN";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Double_onesmallest_xml_encode) {
+    UA_Double src = 1.0000000000000002220446049250313080847263336181640625;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DOUBLE];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "1.0000000000000002220446049250313080847263336181640625";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+/* String */
+START_TEST(UA_String_xml_encode) {
+    UA_String src = UA_STRING("hello");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "hello";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_String_Empty_xml_encode) {
+    UA_String src = UA_STRING("");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_String_Null_xml_encode) {
+    UA_String src = UA_STRING_NULL;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "null";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_String_escapesimple_xml_encode) {
+    UA_String src = UA_STRING("\b\th\"e\fl\nl\\o\r");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "\b\th\"e\fl\nl\\o\r";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_String_escapeutf_xml_encode) {
+    UA_String src = UA_STRING("he\\zsdl\alo€ \x26\x3A asdasd");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "he\\zsdl\alo€ \x26\x3A asdasd";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_String_special_xml_encode) {
+    UA_String src = UA_STRING("𝄞𠂊𝕥🔍");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "𝄞𠂊𝕥🔍";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+/* DateTime */
+START_TEST(UA_DateTime_xml_encode) {
+    UA_DateTime *src = UA_DateTime_new();
+    *src = UA_DateTime_fromUnixTime(1234567);
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DATETIME];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "1970-01-15T06:56:07Z";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_DateTime_delete(src);
+}
+END_TEST
+
+START_TEST(UA_DateTime_xml_encode_null) {
+    UA_DateTime src = 0;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DATETIME];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "1601-01-01T00:00:00Z";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_DateTime_with_nanoseconds_xml_encode) {
+    UA_DateTime *src = UA_DateTime_new();
+    *src = UA_DateTime_fromUnixTime(1234567) + 8901234;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DATETIME];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "1970-01-15T06:56:07.8901234Z";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_DateTime_delete(src);
+}
+END_TEST
+
+/* Guid */
+START_TEST(UA_Guid_xml_encode) {
+    UA_Guid src = {3, 9, 10, {8, 7, 6, 5, 4, 3, 2, 1}};
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_GUID];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "00000003-0009-000A-0807-060504030201";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_Guid_smallbuf_xml_encode) {
+    UA_Guid *src = UA_Guid_new();
+    *src = UA_Guid_random();
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_GUID];
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+
+    UA_ByteString_clear(&buf);
+    UA_Guid_delete(src);
+}
+END_TEST
+
+/* NodeId */
+START_TEST(UA_NodeId_Numeric_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    *src = UA_NODEID_NUMERIC(0, 5555);
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "i=5555";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_NodeId_Numeric_Namespace_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    *src = UA_NODEID_NUMERIC(4, 5555);
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "ns=4;i=5555";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_NodeId_String_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    *src = UA_NODEID_STRING_ALLOC(0, "foobar");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "s=foobar";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_NodeId_String_Namespace_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    *src = UA_NODEID_STRING_ALLOC(5, "foobar");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "ns=5;s=foobar";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_NodeId_Guid_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    UA_NodeId_init(src);
+    UA_Guid g = {3, 9, 10, {8, 7, 6, 5, 4, 3, 2, 1}};
+    *src = UA_NODEID_GUID(0, g);
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "g=00000003-0009-000a-0807-060504030201";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_NodeId_Guid_Namespace_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    UA_Guid g = {3, 9, 10, {8, 7, 6, 5, 4, 3, 2, 1}};
+    *src = UA_NODEID_GUID(5, g);
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+    ck_assert_uint_eq(size, 43);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "ns=5;g=00000003-0009-000a-0807-060504030201";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_NodeId_ByteString_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    *src = UA_NODEID_BYTESTRING_ALLOC(0, "asdfasdf");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+    ck_assert_uint_eq(size, 14);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "b=YXNkZmFzZGY=";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_NodeId_ByteString_Namespace_xml_encode) {
+    UA_NodeId *src = UA_NodeId_new();
+    *src = UA_NODEID_BYTESTRING_ALLOC(5, "asdfasdf");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_NODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "ns=5;b=YXNkZmFzZGY=";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_NodeId_delete(src);
+}
+END_TEST
+
+/* ExpandedNodeId */
+START_TEST(UA_ExpandedNodeId_xml_encode) {
+    UA_ExpandedNodeId *src = UA_ExpandedNodeId_new();
+    UA_ExpandedNodeId_init(src);
+    *src = UA_EXPANDEDNODEID_STRING_ALLOC(23, "testtestTest");
+    src->namespaceUri = UA_STRING_ALLOC("asdf");
+    src->serverIndex = 1345;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_EXPANDEDNODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "svr=1345;nsu=asdf;s=testtestTest";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_ExpandedNodeId_delete(src);
+}
+END_TEST
+
+START_TEST(UA_ExpandedNodeId_MissingNamespaceUri_xml_encode) {
+    UA_ExpandedNodeId *src = UA_ExpandedNodeId_new();
+    UA_ExpandedNodeId_init(src);
+    *src = UA_EXPANDEDNODEID_STRING_ALLOC(23, "testtestTest");
+    src->namespaceUri = UA_STRING_NULL;
+    src->serverIndex = 1345;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_EXPANDEDNODEID];
+    size_t size = UA_calcSizeXml((void*)src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml((void*)src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char* result = "svr=1345;ns=23;s=testtestTest";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+
+    UA_ByteString_clear(&buf);
+    UA_ExpandedNodeId_delete(src);
+}
+END_TEST
+
+
+// ---------------------------DECODE-------------------------------------
+
+
+/* Boolean */
+START_TEST(UA_Boolean_true_xml_decode) {
+    UA_Boolean out;
+    UA_Boolean_init(&out);
+    UA_ByteString buf = UA_STRING("true");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_BOOLEAN], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out, true);
+
+    UA_Boolean_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Boolean_false_xml_decode) {
+    UA_Boolean out;
+    UA_Boolean_init(&out);
+    UA_ByteString buf = UA_STRING("false");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_BOOLEAN], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out, false);
+
+    UA_Boolean_clear(&out);
+}
+END_TEST
+
+/* SByte */
+START_TEST(UA_SByte_Min_xml_decode) {
+    UA_SByte out;
+    UA_SByte_init(&out);
+    UA_ByteString buf = UA_STRING("-128");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_SBYTE], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out, -128);
+
+    UA_SByte_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_SByte_Max_xml_decode) {
+    UA_SByte out;
+    UA_SByte_init(&out);
+    UA_ByteString buf = UA_STRING("127");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_SBYTE], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out, 127);
+
+    UA_SByte_clear(&out);
+}
+END_TEST
+
+/* Byte */
+START_TEST(UA_Byte_Min_xml_decode) {
+    UA_Byte out;
+    UA_Byte_init(&out);
+    UA_ByteString buf = UA_STRING("0");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_BYTE], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out, 0);
+
+    UA_Byte_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Byte_Max_xml_decode) {
+    UA_Byte out;
+    UA_Byte_init(&out);
+    UA_ByteString buf = UA_STRING("255");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_BYTE], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out, 255);
+
+    UA_Byte_clear(&out);
+}
+END_TEST
+
+/* Int16 */
+START_TEST(UA_Int16_Min_xml_decode) {
+    UA_Int16 out;
+    UA_Int16_init(&out);
+    UA_ByteString buf = UA_STRING("-32768");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT16], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out, -32768);
+
+    UA_Int16_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Int16_Max_xml_decode) {
+    UA_Int16 out;
+    UA_Int16_init(&out);
+    UA_ByteString buf = UA_STRING("32767");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT16], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out, 32767);
+
+    UA_Int16_clear(&out);
+}
+END_TEST
+
+/* UInt16 */
+START_TEST(UA_UInt16_Min_xml_decode) {
+    UA_UInt16 out;
+    UA_UInt16_init(&out);
+    UA_ByteString buf = UA_STRING("0");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_UINT16], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out, 0);
+
+    UA_UInt16_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_UInt16_Max_xml_decode) {
+    UA_UInt16 out;
+    UA_UInt16_init(&out);
+    UA_ByteString buf = UA_STRING("65535");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_UINT16], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out, 65535);
+
+    UA_UInt16_clear(&out);
+}
+END_TEST
+
+/* Int32 */
+START_TEST(UA_Int32_Min_xml_decode) {
+    UA_Int32 out;
+    UA_Int32_init(&out);
+    UA_ByteString buf = UA_STRING("-2147483648");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT32], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(out == -2147483648);
+
+    UA_Int32_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Int32_Max_xml_decode) {
+    UA_Int32 out;
+    UA_Int32_init(&out);
+    UA_ByteString buf = UA_STRING("2147483647");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT32], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out, 2147483647);
+
+    UA_Int32_clear(&out);
+}
+END_TEST
+
+/* UInt32 */
+START_TEST(UA_UInt32_Min_xml_decode) {
+    UA_UInt32 out;
+    UA_UInt32_init(&out);
+    UA_ByteString buf = UA_STRING("0");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_UINT32], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out, 0);
+
+    UA_UInt32_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_UInt32_Max_xml_decode) {
+    UA_UInt32 out;
+    UA_UInt32_init(&out);
+    UA_ByteString buf = UA_STRING("4294967295");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_UINT32], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out, 4294967295);
+
+    UA_UInt32_clear(&out);
+}
+END_TEST
+
+/* Int64 */
+START_TEST(UA_Int64_Min_xml_decode) {
+    UA_Int64 out;
+    UA_Int64_init(&out);
+    UA_ByteString buf = UA_STRING("-9223372036854775808");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0x00);
+    ck_assert_int_eq(((u8*)&out)[7], 0x80);
+
+    UA_Int64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Int64_Max_xml_decode) {
+    UA_Int64 out;
+    UA_Int64_init(&out);
+    UA_ByteString buf = UA_STRING("9223372036854775807");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[1], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[2], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[3], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[4], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[5], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[6], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[7], 0x7F);
+
+    UA_Int64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Int64_Overflow_xml_decode) {
+    UA_Int64 out;
+    UA_Int64_init(&out);
+    UA_ByteString buf = UA_STRING("9223372036854775808");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Int64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Int64_TooBig_xml_decode) {
+    UA_Int64 out;
+    UA_Int64_init(&out);
+    UA_ByteString buf = UA_STRING("111111111111111111111111111111");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Int64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Int64_NoDigit_xml_decode) {
+    UA_Int64 out;
+    UA_Int64_init(&out);
+    UA_ByteString buf = UA_STRING("a");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Int64_clear(&out);
+}
+END_TEST
+
+/* UInt64 */
+START_TEST(UA_UInt64_Min_xml_decode) {
+    UA_UInt64 out;
+    UA_UInt64_init(&out);
+    UA_ByteString buf = UA_STRING("0");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_UINT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0x00);
+    ck_assert_int_eq(((u8*)&out)[7], 0x00);
+
+    UA_UInt64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_UInt64_Max_xml_decode) {
+    UA_UInt64 out;
+    UA_UInt64_init(&out);
+    UA_ByteString buf = UA_STRING("18446744073709551615");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_UINT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[1], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[2], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[3], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[4], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[5], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[6], 0xFF);
+    ck_assert_int_eq(((u8*)&out)[7], 0xFF);
+
+    UA_UInt64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_UInt64_Overflow_xml_decode) {
+    UA_UInt64 out;
+    UA_UInt64_init(&out);
+    UA_ByteString buf = UA_STRING("18446744073709551616");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_UINT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_UInt64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_UInt64_TooBig_xml_decode) {
+    UA_Int64 out;
+    UA_Int64_init(&out);
+    UA_ByteString buf = UA_STRING("111111111111111111111111111111");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Int64_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_UInt64_NoDigit_xml_decode) {
+    UA_Int64 out;
+    UA_Int64_init(&out);
+    UA_ByteString buf = UA_STRING("a");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_INT64], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Int64_clear(&out);
+}
+END_TEST
+
+/* Float */
+START_TEST(UA_Float_xml_decode) {
+    UA_Float out;
+    UA_Float_init(&out);
+    UA_ByteString buf = UA_STRING("3.1415927410");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_FLOAT], NULL);
+
+    // 0 10000000 10010010000111111011011
+    // 40 49 0f db
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0xdb);
+    ck_assert_int_eq(((u8*)&out)[1], 0x0f);
+    ck_assert_int_eq(((u8*)&out)[2], 0x49);
+    ck_assert_int_eq(((u8*)&out)[3], 0x40);
+    UA_Float_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Float_xml_one_decode) {
+    UA_Float out;
+    UA_Float_init(&out);
+    UA_ByteString buf = UA_STRING("1");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_FLOAT], NULL);
+
+    // 0 01111111 00000000000000000000000
+    // 3f 80 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x80);
+    ck_assert_int_eq(((u8*)&out)[3], 0x3f);
+
+    UA_Float_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Float_xml_inf_decode) {
+    UA_Float out;
+    UA_Float_init(&out);
+    UA_ByteString buf = UA_STRING("INF");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_FLOAT], NULL);
+
+    // 0 11111111 00000000000000000000000
+    // 7f 80 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x80);
+    ck_assert_int_eq(((u8*)&out)[3], 0x7f);
+
+    UA_Float_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Float_xml_neginf_decode) {
+    UA_Float out;
+    UA_Float_init(&out);
+    UA_ByteString buf = UA_STRING("-INF");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_FLOAT], NULL);
+
+    // 1 11111111 00000000000000000000000
+    // ff 80 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x80);
+    ck_assert_int_eq(((u8*)&out)[3], 0xff);
+
+    UA_Float_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Float_xml_nan_decode) {
+    UA_Float out;
+    UA_Float_init(&out);
+    UA_ByteString buf = UA_STRING("NaN");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_FLOAT], NULL);
+
+    // 1 11111111 10000000000000000000000
+    // ff c0 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0xc0);
+    ck_assert_int_eq(((u8*)&out)[3], 0xff);
+
+    UA_Float val = out;
+    ck_assert(val != val); /* Check if not a number */
+
+    UA_Float_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Float_xml_negnan_decode) {
+    UA_Float out;
+    UA_Float_init(&out);
+    UA_ByteString buf = UA_STRING("-NaN");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_FLOAT], NULL);
+
+    // 1 11111111 10000000000000000000000
+    // ff c0 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0xc0);
+    ck_assert_int_eq(((u8*)&out)[3], 0xff);
+
+    UA_Float val = out;
+    ck_assert(val != val); /* Check if not a number */
+
+    UA_Float_clear(&out);
+}
+END_TEST
+
+/* Double */
+START_TEST(UA_Double_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("1.1234");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 0 01111111111 0001111110010111001001000111010001010011100011101111
+    // 3f f1 f9 72 47 45 38 ef
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0xef);
+    ck_assert_int_eq(((u8*)&out)[1], 0x38);
+    ck_assert_int_eq(((u8*)&out)[2], 0x45);
+    ck_assert_int_eq(((u8*)&out)[3], 0x47);
+    ck_assert_int_eq(((u8*)&out)[4], 0x72);
+    ck_assert_int_eq(((u8*)&out)[5], 0xf9);
+    ck_assert_int_eq(((u8*)&out)[6], 0xf1);
+    ck_assert_int_eq(((u8*)&out)[7], 0x3f);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_corrupt_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("1.12.34");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_one_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("1");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 0 01111111111 0000000000000000000000000000000000000000000000000000
+    // 3f f0 00 00 00 00 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0xf0);
+    ck_assert_int_eq(((u8*)&out)[7], 0x3f);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_onepointsmallest_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("1.0000000000000002");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 0 01111111111 0000000000000000000000000000000000000000000000000001
+    // 3f f0 00 00 00 00 00 01
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x01);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0xf0);
+    ck_assert_int_eq(((u8*)&out)[7], 0x3f);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_nan_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("NaN");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 1 11111111111 1000000000000000000000000000000000000000000000000000
+    // ff f8 00 00 00 00 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0xf8);
+    ck_assert_int_eq(((u8*)&out)[7], 0xff);
+
+    UA_Double val = out;
+    ck_assert(val != val); /* Check if not a number */
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_negnan_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("-NaN");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 1 11111111111 1000000000000000000000000000000000000000000000000000
+    // ff f8 00 00 00 00 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0xf8);
+    ck_assert_int_eq(((u8*)&out)[7], 0xff);
+
+    UA_Double val = out;
+    ck_assert(val != val); /* Check if not a number */
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_inf_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("INF");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 0 11111111111 0000000000000000000000000000000000000000000000000000
+    // 7f f0 00 00 00 00 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0xf0);
+    ck_assert_int_eq(((u8*)&out)[7], 0x7f);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_neginf_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("-INF");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 1 11111111111 0000000000000000000000000000000000000000000000000000
+    // ff f0 00 00 00 00 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0xf0);
+    ck_assert_int_eq(((u8*)&out)[7], 0xff);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_zero_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("0");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 0 00000000000 0000000000000000000000000000000000000000000000000000
+    // 00 00 00 00 00 00 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0x00);
+    ck_assert_int_eq(((u8*)&out)[7], 0x00);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Double_negzero_xml_decode) {
+    UA_Double out;
+    UA_Double_init(&out);
+    UA_ByteString buf = UA_STRING("-0");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
+
+    // 1 00000000000 0000000000000000000000000000000000000000000000000000
+    // 80 00 00 00 00 00 00 00
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(((u8*)&out)[0], 0x00);
+    ck_assert_int_eq(((u8*)&out)[1], 0x00);
+    ck_assert_int_eq(((u8*)&out)[2], 0x00);
+    ck_assert_int_eq(((u8*)&out)[3], 0x00);
+    ck_assert_int_eq(((u8*)&out)[4], 0x00);
+    ck_assert_int_eq(((u8*)&out)[5], 0x00);
+    ck_assert_int_eq(((u8*)&out)[6], 0x00);
+    ck_assert_int_eq(((u8*)&out)[7], 0x80);
+
+    UA_Double_clear(&out);
+}
+END_TEST
+
+/* String */
+START_TEST(UA_String_xml_decode) {
+    UA_String out;
+    UA_String_init(&out);
+    UA_ByteString buf = UA_STRING("abcdef");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_STRING], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.length, 6);
+    ck_assert_int_eq(out.data[0], 'a');
+    ck_assert_int_eq(out.data[1], 'b');
+    ck_assert_int_eq(out.data[2], 'c');
+    ck_assert_int_eq(out.data[3], 'd');
+    ck_assert_int_eq(out.data[4], 'e');
+    ck_assert_int_eq(out.data[5], 'f');
+}
+END_TEST
+
+START_TEST(UA_String_empty_xml_decode) {
+    UA_String out;
+    UA_String_init(&out);
+    UA_ByteString buf = UA_STRING("");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_STRING], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.length, 0);
+    ck_assert_ptr_eq(out.data, UA_EMPTY_ARRAY_SENTINEL);
+}
+END_TEST
+
+START_TEST(UA_String_unescapeBS_xml_decode) {
+    UA_String out;
+    UA_String_init(&out);
+    UA_ByteString buf = UA_STRING("ab\tcdef");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_STRING], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.length, 7);
+    ck_assert_int_eq(out.data[0], 'a');
+    ck_assert_int_eq(out.data[1], 'b');
+    ck_assert_int_eq(out.data[2], '\t');
+    ck_assert_int_eq(out.data[3], 'c');
+    ck_assert_int_eq(out.data[4], 'd');
+    ck_assert_int_eq(out.data[5], 'e');
+    ck_assert_int_eq(out.data[6], 'f');
+}
+END_TEST
+
+START_TEST(UA_String_escape2_xml_decode) {
+    UA_String out;
+    UA_String_init(&out);
+    UA_ByteString buf = UA_STRING("\b\th\"e\fl\nl\\o\r");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_STRING], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.length, 12);
+    ck_assert_int_eq(out.data[0], '\b');
+    ck_assert_int_eq(out.data[1], '\t');
+    ck_assert_int_eq(out.data[2], 'h');
+    ck_assert_int_eq(out.data[3], '\"');
+    ck_assert_int_eq(out.data[4], 'e');
+    ck_assert_int_eq(out.data[5], '\f');
+    ck_assert_int_eq(out.data[6], 'l');
+    ck_assert_int_eq(out.data[7], '\n');
+    ck_assert_int_eq(out.data[8], 'l');
+    ck_assert_int_eq(out.data[9], '\\');
+    ck_assert_int_eq(out.data[10], 'o');
+    ck_assert_int_eq(out.data[11], '\r');
+}
+END_TEST
+
+/* DateTime */
+START_TEST(UA_DateTime_xml_decode) {
+    UA_DateTime out;
+    UA_DateTime_init(&out);
+    UA_ByteString buf = UA_STRING("1970-01-02T01:02:03.005Z");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
+    ck_assert_int_eq(dts.year, 1970);
+    ck_assert_int_eq(dts.month, 1);
+    ck_assert_int_eq(dts.day, 2);
+    ck_assert_int_eq(dts.hour, 1);
+    ck_assert_int_eq(dts.min, 2);
+    ck_assert_int_eq(dts.sec, 3);
+    ck_assert_int_eq(dts.milliSec, 5);
+    ck_assert_int_eq(dts.microSec, 0);
+    ck_assert_int_eq(dts.nanoSec, 0);
+
+    UA_DateTime_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_DateTime_xml_decode_large) {
+    UA_DateTime out;
+    UA_DateTime_init(&out);
+    UA_ByteString buf = UA_STRING("10970-01-02T01:02:03.005Z");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
+    ck_assert_int_eq(dts.year, 10970);
+    ck_assert_int_eq(dts.month, 1);
+    ck_assert_int_eq(dts.day, 2);
+    ck_assert_int_eq(dts.hour, 1);
+    ck_assert_int_eq(dts.min, 2);
+    ck_assert_int_eq(dts.sec, 3);
+    ck_assert_int_eq(dts.milliSec, 5);
+    ck_assert_int_eq(dts.microSec, 0);
+    ck_assert_int_eq(dts.nanoSec, 0);
+    UA_DateTime_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_DateTime_xml_decode_negative) {
+    UA_DateTime out;
+    UA_DateTime_init(&out);
+    UA_ByteString buf = UA_STRING("-0050-01-02T01:02:03.005Z");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
+    ck_assert_int_eq(dts.year, -50);
+    ck_assert_int_eq(dts.month, 1);
+    ck_assert_int_eq(dts.day, 2);
+    ck_assert_int_eq(dts.hour, 1);
+    ck_assert_int_eq(dts.min, 2);
+    ck_assert_int_eq(dts.sec, 3);
+    ck_assert_int_eq(dts.milliSec, 5);
+    ck_assert_int_eq(dts.microSec, 0);
+    ck_assert_int_eq(dts.nanoSec, 0);
+
+    UA_DateTime_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_DateTime_xml_decode_min) {
+    UA_DateTime dt_min = (UA_DateTime)UA_INT64_MIN;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DATETIME];
+
+    UA_Byte data[128];
+    UA_ByteString buf;
+    buf.data = data;
+    buf.length = 128;
+
+    status s = UA_encodeXml((void*)&dt_min, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    UA_DateTime out;
+    s = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME], NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    ck_assert_int_eq(dt_min, out);
+    UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
+    ck_assert_int_eq(dts.year, -27627);
+    ck_assert_int_eq(dts.month, 4);
+    ck_assert_int_eq(dts.day, 19);
+    ck_assert_int_eq(dts.hour, 21);
+    ck_assert_int_eq(dts.min, 11);
+    ck_assert_int_eq(dts.sec, 54);
+    ck_assert_int_eq(dts.milliSec, 522);
+    ck_assert_int_eq(dts.microSec, 419);
+    ck_assert_int_eq(dts.nanoSec, 200);
+}
+END_TEST
+
+START_TEST(UA_DateTime_xml_decode_max) {
+    UA_DateTime dt_max = (UA_DateTime)UA_INT64_MAX;
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_DATETIME];
+
+    UA_Byte data[128];
+    UA_ByteString buf;
+    buf.data = data;
+    buf.length = 128;
+
+    status s = UA_encodeXml((void*)&dt_max, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    UA_DateTime out;
+    s = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME], NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(dt_max, out);
+
+    UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
+    ck_assert_int_eq(dts.year, 30828);
+    ck_assert_int_eq(dts.month, 9);
+    ck_assert_int_eq(dts.day, 14);
+    ck_assert_int_eq(dts.hour, 2);
+    ck_assert_int_eq(dts.min, 48);
+    ck_assert_int_eq(dts.sec, 5);
+    ck_assert_int_eq(dts.milliSec, 477);
+    ck_assert_int_eq(dts.microSec, 580);
+    ck_assert_int_eq(dts.nanoSec, 700);
+}
+END_TEST
+
+START_TEST(UA_DateTime_micro_xml_decode) {
+    UA_DateTime out;
+    UA_DateTime_init(&out);
+    UA_ByteString buf = UA_STRING("1970-01-02T01:02:03.042Z");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DATETIME], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    UA_DateTimeStruct dts = UA_DateTime_toStruct(out);
+    ck_assert_int_eq(dts.year, 1970);
+    ck_assert_int_eq(dts.month, 1);
+    ck_assert_int_eq(dts.day, 2);
+    ck_assert_int_eq(dts.hour, 1);
+    ck_assert_int_eq(dts.min, 2);
+    ck_assert_int_eq(dts.sec, 3);
+    ck_assert_int_eq(dts.milliSec, 42);
+    ck_assert_int_eq(dts.microSec, 0);
+    ck_assert_int_eq(dts.nanoSec, 0);
+
+    UA_DateTime_clear(&out);
+}
+END_TEST
+
+/* Guid */
+START_TEST(UA_Guid_xml_decode) {
+    UA_Guid out;
+    UA_Guid_init(&out);
+    UA_ByteString buf = UA_STRING("00000001-0002-0003-0405-060708090A0B");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_GUID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out.data1, 1);
+    ck_assert_int_eq(out.data2, 2);
+    ck_assert_int_eq(out.data3, 3);
+    ck_assert_int_eq(out.data4[0], 4);
+    ck_assert_int_eq(out.data4[1], 5);
+    ck_assert_int_eq(out.data4[2], 6);
+    ck_assert_int_eq(out.data4[3], 7);
+    ck_assert_int_eq(out.data4[4], 8);
+    ck_assert_int_eq(out.data4[5], 9);
+    ck_assert_int_eq(out.data4[6], 10);
+    ck_assert_int_eq(out.data4[7], 11);
+
+    UA_Guid_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Guid_lower_xml_decode) {
+    UA_Guid out;
+    UA_Guid_init(&out);
+    UA_ByteString buf = UA_STRING("00000001-0002-0003-0405-060708090a0b");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_GUID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out.data1, 1);
+    ck_assert_int_eq(out.data2, 2);
+    ck_assert_int_eq(out.data3, 3);
+    ck_assert_int_eq(out.data4[0], 4);
+    ck_assert_int_eq(out.data4[1], 5);
+    ck_assert_int_eq(out.data4[2], 6);
+    ck_assert_int_eq(out.data4[3], 7);
+    ck_assert_int_eq(out.data4[4], 8);
+    ck_assert_int_eq(out.data4[5], 9);
+    ck_assert_int_eq(out.data4[6], 10);
+    ck_assert_int_eq(out.data4[7], 11);
+
+    UA_Guid_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Guid_tooShort_xml_decode) {
+    UA_Guid out;
+    UA_Guid_init(&out);
+    UA_ByteString buf = UA_STRING("00000001-00");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_GUID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Guid_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Guid_tooLong_xml_decode) {
+    UA_Guid out;
+    UA_Guid_init(&out);
+    UA_ByteString buf = UA_STRING("00000001-0002-0003-0405-060708090A0B00000001");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_GUID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Guid_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_Guid_wrong_xml_decode) {
+    UA_Guid out;
+    UA_Guid_init(&out);
+    UA_ByteString buf = UA_STRING("00000=01-0002-0003-0405-060708090A0B");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_GUID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_BADDECODINGERROR);
+
+    UA_Guid_clear(&out);
+}
+END_TEST
+
+/* NodeId */
+START_TEST(UA_NodeId_Nummeric_xml_decode) {
+    UA_NodeId out;
+    UA_NodeId_init(&out);
+    UA_ByteString buf = UA_STRING("i=42");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_NODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.identifier.numeric, 42);
+    ck_assert_uint_eq(out.namespaceIndex, 0);
+    ck_assert_int_eq(out.identifierType, UA_NODEIDTYPE_NUMERIC);
+
+    UA_NodeId_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_NodeId_Nummeric_Namespace_xml_decode) {
+    UA_NodeId out;
+    UA_NodeId_init(&out);
+    UA_ByteString buf = UA_STRING("ns=123;i=42");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_NODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.identifier.numeric, 42);
+    ck_assert_uint_eq(out.namespaceIndex, 123);
+    ck_assert_int_eq(out.identifierType, UA_NODEIDTYPE_NUMERIC);
+
+    UA_NodeId_clear(&out);
+}
+END_TEST
+
+
+START_TEST(UA_NodeId_String_xml_decode) {
+    UA_NodeId out;
+    UA_NodeId_init(&out);
+    UA_ByteString buf = UA_STRING("s=test123");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_NODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.identifier.string.length, 7);
+    ck_assert_int_eq(out.identifier.string.data[0], 't');
+    ck_assert_int_eq(out.identifier.string.data[1], 'e');
+    ck_assert_int_eq(out.identifier.string.data[2], 's');
+    ck_assert_int_eq(out.identifier.string.data[3], 't');
+    ck_assert_int_eq(out.identifier.string.data[4], '1');
+    ck_assert_int_eq(out.identifier.string.data[5], '2');
+    ck_assert_int_eq(out.identifier.string.data[6], '3');
+    ck_assert_int_eq(out.namespaceIndex, 0);
+    ck_assert_int_eq(out.identifierType, UA_NODEIDTYPE_STRING);
+
+    UA_NodeId_clear(&out);
+}
+END_TEST
+
+
+START_TEST(UA_NodeId_Guid_xml_decode) {
+    UA_NodeId out;
+    UA_NodeId_init(&out);
+    UA_ByteString buf = UA_STRING("g=00000001-0002-0003-0405-060708090A0B");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_NODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out.namespaceIndex, 0);
+    ck_assert_int_eq(out.identifierType, UA_NODEIDTYPE_GUID);
+    ck_assert_int_eq(out.identifier.guid.data1, 1);
+    ck_assert_int_eq(out.identifier.guid.data2, 2);
+    ck_assert_int_eq(out.identifier.guid.data3, 3);
+    ck_assert_int_eq(out.identifier.guid.data4[0], 4);
+    ck_assert_int_eq(out.identifier.guid.data4[1], 5);
+    ck_assert_int_eq(out.identifier.guid.data4[2], 6);
+    ck_assert_int_eq(out.identifier.guid.data4[3], 7);
+    ck_assert_int_eq(out.identifier.guid.data4[4], 8);
+    ck_assert_int_eq(out.identifier.guid.data4[5], 9);
+    ck_assert_int_eq(out.identifier.guid.data4[6], 10);
+    ck_assert_int_eq(out.identifier.guid.data4[7], 11);
+
+    UA_NodeId_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_NodeId_ByteString_xml_decode) {
+    UA_NodeId out;
+    UA_NodeId_init(&out);
+    UA_ByteString buf = UA_STRING("b=YXNkZmFzZGY=");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_NODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out.namespaceIndex, 0);
+    ck_assert_int_eq(out.identifierType, UA_NODEIDTYPE_BYTESTRING);
+    ck_assert_uint_eq(out.identifier.byteString.length, 8);
+    ck_assert_int_eq(out.identifier.byteString.data[0], 'a');
+    ck_assert_int_eq(out.identifier.byteString.data[1], 's');
+    ck_assert_int_eq(out.identifier.byteString.data[2], 'd');
+    ck_assert_int_eq(out.identifier.byteString.data[3], 'f');
+    ck_assert_int_eq(out.identifier.byteString.data[4], 'a');
+    ck_assert_int_eq(out.identifier.byteString.data[5], 's');
+    ck_assert_int_eq(out.identifier.byteString.data[6], 'd');
+    ck_assert_int_eq(out.identifier.byteString.data[7], 'f');
+
+    UA_NodeId_clear(&out);
+}
+END_TEST
+
+/* ExpandedNodeId */
+START_TEST(UA_ExpandedNodeId_Nummeric_xml_decode) {
+    UA_ExpandedNodeId out;
+    UA_ExpandedNodeId_init(&out);
+    UA_ByteString buf = UA_STRING("i=42");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(out.nodeId.identifier.numeric, 42);
+    ck_assert_int_eq(out.nodeId.identifierType, UA_NODEIDTYPE_NUMERIC);
+    ck_assert_ptr_eq(out.namespaceUri.data, NULL);
+    ck_assert_uint_eq(out.namespaceUri.length, 0);
+    ck_assert_int_eq(out.serverIndex, 0);
+
+    UA_ExpandedNodeId_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_ExpandedNodeId_String_xml_decode) {
+    UA_ExpandedNodeId out;
+    UA_ExpandedNodeId_init(&out);
+    UA_ByteString buf = UA_STRING("s=test");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.nodeId.identifier.string.length, 4);
+    ck_assert_int_eq(out.nodeId.identifier.string.data[0], 't');
+    ck_assert_int_eq(out.nodeId.identifierType, UA_NODEIDTYPE_STRING);
+    ck_assert_ptr_eq(out.namespaceUri.data, NULL);
+    ck_assert_uint_eq(out.namespaceUri.length, 0);
+    ck_assert_int_eq(out.serverIndex, 0);
+
+    UA_ExpandedNodeId_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_ExpandedNodeId_String_Namespace_xml_decode) {
+    UA_ExpandedNodeId out;
+    UA_ExpandedNodeId_init(&out);
+    UA_ByteString buf = UA_STRING("nsu=abcdef;s=test");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.nodeId.identifier.string.length, 4);
+    ck_assert_int_eq(out.nodeId.identifier.string.data[0], 't');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[1], 'e');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[2], 's');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[3], 't');
+    ck_assert_int_eq(out.nodeId.identifierType, UA_NODEIDTYPE_STRING);
+    ck_assert_uint_eq(out.namespaceUri.length, 6);
+    ck_assert_int_eq(out.namespaceUri.data[0], 'a');
+    ck_assert_int_eq(out.namespaceUri.data[1], 'b');
+    ck_assert_int_eq(out.namespaceUri.data[2], 'c');
+    ck_assert_int_eq(out.namespaceUri.data[3], 'd');
+    ck_assert_int_eq(out.namespaceUri.data[4], 'e');
+    ck_assert_int_eq(out.namespaceUri.data[5], 'f');
+    ck_assert_int_eq(out.serverIndex, 0);
+
+    UA_ExpandedNodeId_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_ExpandedNodeId_String_NamespaceAsIndex_xml_decode) {
+    UA_ExpandedNodeId out;
+    UA_ExpandedNodeId_init(&out);
+    UA_ByteString buf = UA_STRING("ns=42;s=test");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.nodeId.identifier.string.length, 4);
+    ck_assert_int_eq(out.nodeId.identifier.string.data[0], 't');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[1], 'e');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[2], 's');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[3], 't');
+    ck_assert_int_eq(out.nodeId.identifierType, UA_NODEIDTYPE_STRING);
+    ck_assert_uint_eq(out.namespaceUri.length, 0);
+    ck_assert_ptr_eq(out.namespaceUri.data, NULL);
+    ck_assert_uint_eq(out.nodeId.namespaceIndex, 42);
+    ck_assert_uint_eq(out.serverIndex, 0);
+
+    UA_ExpandedNodeId_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_ExpandedNodeId_String_Namespace_ServerUri_xml_decode) {
+    UA_ExpandedNodeId out;
+    UA_ExpandedNodeId_init(&out);
+    UA_ByteString buf = UA_STRING("svr=13;nsu=test;s=test");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.nodeId.identifier.string.length, 4);
+    ck_assert_int_eq(out.nodeId.identifier.string.data[0], 't');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[1], 'e');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[2], 's');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[3], 't');
+    ck_assert_int_eq(out.nodeId.identifierType, UA_NODEIDTYPE_STRING);
+    ck_assert_uint_eq(out.serverIndex, 13);
+    ck_assert_int_eq(out.namespaceUri.data[0], 't');
+    ck_assert_int_eq(out.namespaceUri.data[1], 'e');
+    ck_assert_int_eq(out.namespaceUri.data[2], 's');
+    ck_assert_int_eq(out.namespaceUri.data[3], 't');
+
+    UA_ExpandedNodeId_clear(&out);
+}
+END_TEST
+
+START_TEST(UA_ExpandedNodeId_ByteString_xml_decode) {
+    UA_ExpandedNodeId out;
+    UA_ExpandedNodeId_init(&out);
+    UA_ByteString buf = UA_STRING("svr=13;nsu=test;b=YXNkZmFzZGY=");
+
+    UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_EXPANDEDNODEID], NULL);
+
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(out.nodeId.identifier.string.length, 8);
+    ck_assert_int_eq(out.nodeId.identifier.string.data[0], 'a');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[1], 's');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[2], 'd');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[3], 'f');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[4], 'a');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[5], 's');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[6], 'd');
+    ck_assert_int_eq(out.nodeId.identifier.string.data[7], 'f');
+    ck_assert_int_eq(out.nodeId.identifierType, UA_NODEIDTYPE_BYTESTRING);
+    ck_assert_uint_eq(out.serverIndex, 13);
+    ck_assert_int_eq(out.namespaceUri.data[0], 't');
+    ck_assert_int_eq(out.namespaceUri.data[1], 'e');
+    ck_assert_int_eq(out.namespaceUri.data[2], 's');
+    ck_assert_int_eq(out.namespaceUri.data[3], 't');
+
+    UA_ExpandedNodeId_clear(&out);
+}
+END_TEST
+
+
+static Suite *testSuite_builtin_xml(void) {
+    Suite *s = suite_create("Built-in Data Types 62541-5 Xml");
+
+    TCase *tc_xml_encode = tcase_create("xml_encode");
+    tcase_add_test(tc_xml_encode, UA_Boolean_true_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Boolean_false_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Boolean_true_bufferTooSmall_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_SByte_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_SByte_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_SByte_Zero_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_SByte_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_Byte_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Byte_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Byte_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_Int16_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int16_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int16_Zero_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int16_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_UInt16_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_UInt16_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_UInt16_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_Int32_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int32_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int32_Zero_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int32_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_UInt32_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_UInt32_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_UInt32_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_Int64_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int64_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int64_Zero_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Int64_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_UInt64_Max_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_UInt64_Min_Number_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_UInt64_smallbuf_Number_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_Float_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_Double_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Double_onesmallest_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Double_pluszero_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Double_minuszero_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Double_plusInf_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Double_minusInf_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Double_nan_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_String_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_String_Empty_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_String_Null_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_String_escapesimple_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_String_escapeutf_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_String_special_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_DateTime_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_DateTime_xml_encode_null);
+    tcase_add_test(tc_xml_encode, UA_DateTime_with_nanoseconds_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_Guid_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_Guid_smallbuf_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_NodeId_Numeric_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_NodeId_Numeric_Namespace_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_NodeId_String_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_NodeId_String_Namespace_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_NodeId_Guid_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_NodeId_Guid_Namespace_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_NodeId_ByteString_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_NodeId_ByteString_Namespace_xml_encode);
+
+    tcase_add_test(tc_xml_encode, UA_ExpandedNodeId_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_ExpandedNodeId_MissingNamespaceUri_xml_encode);
+
+    suite_add_tcase(s, tc_xml_encode);
+
+    TCase *tc_xml_decode = tcase_create("xml_decode");
+
+    tcase_add_test(tc_xml_decode, UA_Boolean_true_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Boolean_false_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_SByte_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_SByte_Max_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_Byte_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Byte_Max_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_Int16_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Int16_Max_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_UInt16_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_UInt16_Max_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_UInt32_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_UInt32_Max_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_Int32_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Int32_Max_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_Int64_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Int64_Max_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Int64_Overflow_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Int64_TooBig_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Int64_NoDigit_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_UInt64_Min_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_UInt64_Max_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_UInt64_Overflow_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_UInt64_TooBig_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_UInt64_NoDigit_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_Float_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Float_xml_one_decode);
+    tcase_add_test(tc_xml_decode, UA_Float_xml_inf_decode);
+    tcase_add_test(tc_xml_decode, UA_Float_xml_neginf_decode);
+    tcase_add_test(tc_xml_decode, UA_Float_xml_nan_decode);
+    tcase_add_test(tc_xml_decode, UA_Float_xml_negnan_decode);
+
+    tcase_add_test(tc_xml_decode, UA_Double_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_one_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_corrupt_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_onepointsmallest_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_nan_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_negnan_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_negzero_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_zero_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_inf_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Double_neginf_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_String_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_String_empty_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_String_unescapeBS_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_String_escape2_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_DateTime_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_DateTime_xml_decode_large);
+    tcase_add_test(tc_xml_decode, UA_DateTime_xml_decode_negative);
+    tcase_add_test(tc_xml_decode, UA_DateTime_xml_decode_min);
+    tcase_add_test(tc_xml_decode, UA_DateTime_xml_decode_max);
+    tcase_add_test(tc_xml_decode, UA_DateTime_micro_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_Guid_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Guid_lower_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Guid_tooShort_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Guid_tooLong_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_Guid_wrong_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_NodeId_Nummeric_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_NodeId_Nummeric_Namespace_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_NodeId_String_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_NodeId_Guid_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_NodeId_ByteString_xml_decode);
+
+    tcase_add_test(tc_xml_decode, UA_ExpandedNodeId_Nummeric_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_ExpandedNodeId_String_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_ExpandedNodeId_String_Namespace_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_ExpandedNodeId_String_NamespaceAsIndex_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_ExpandedNodeId_String_Namespace_ServerUri_xml_decode);
+    tcase_add_test(tc_xml_decode, UA_ExpandedNodeId_ByteString_xml_decode);
+
+    suite_add_tcase(s, tc_xml_decode);
+
+    return s;
+}
+
+int main(void) {
+    int      number_failed = 0;
+    Suite   *s;
+    SRunner *sr;
+
+    s  = testSuite_builtin_xml();
+    sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed += srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Initial PR for XML data encoding. Implemented encoding for the following data types:

- Boolean
- SByte
- Byte
- Int16
- UInt16
- Int32
- UInt32
- Int64
- UInt64
- Float
- Double
- String
- DateTime
- Guid
- NodeId
- ExpandedNodeId

Unsupported data types when trying to en-/decode shall throw an _UA_STATUSCODE_BADNOTIMPLEMENTED_ error. Also, included unit tests to validate functionality of both encoding and decoding of data values.

**NOTE**: Added TODO comments within decoding section, which note the restrictions of certain data types.