### PR TITLE
Respond with status code when no memory can be allocated to the response buffer

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -579,7 +579,7 @@ ServerNetworkLayerTCP_listen(UA_ServerNetworkLayer *nl, UA_Server *server,
         } else if(retval == UA_STATUSCODE_BADOUTOFMEMORY) {
             UA_TcpErrorMessage error;
             
-            error.error = retval;
+            error.error = UA_STATUSCODE_BADTCPNOTENOUGHRESOURCES;
             error.reason = UA_STRING_NULL;
             UA_Connection_sendError(&e->connection, &error);
             (&e->connection)->close(&e->connection);

--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -576,6 +576,15 @@ ServerNetworkLayerTCP_listen(UA_ServerNetworkLayer *nl, UA_Server *server,
             /* Process packets */
             UA_Server_processBinaryMessage(server, &e->connection, &buf);
             connection_releaserecvbuffer(&e->connection, &buf);
+        } else if(retval == UA_STATUSCODE_BADOUTOFMEMORY) {
+            UA_TcpErrorMessage error;
+            
+            error.error = retval;
+            error.reason = UA_STRING_NULL;
+            UA_Connection_sendError(&e->connection, &error);
+            (&e->connection)->close(&e->connection);
+
+            return retval;
         } else if(retval == UA_STATUSCODE_BADCONNECTIONCLOSED) {
             /* The socket is shutdown but not closed */
             UA_LOG_INFO(layer->logger, UA_LOGCATEGORY_NETWORK,


### PR DESCRIPTION
Hi,
I think that it would be good to respond with an error when we fail to allocate memory in 
`UA_StatusCode retval = connection_recv(&e->connection, &buf, 0); ` to notify the client instead of not responding.

What do you think?
