### PR TITLE
feat(ci): Enable nodesetLoader for CI builds

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -15,7 +15,7 @@ jobs:
             cmd_deps: |
                 sudo dpkg --add-architecture i386
                 sudo apt-get update
-                sudo apt-get install -y -qq gcc-multilib libsubunit-dev:i386 check:i386
+                sudo apt-get install -y -qq gcc-multilib libsubunit-dev:i386 check:i386 libxml2-dev:i386
             cmd_action: unit_tests_32
           - build_name: "Debug Build & Unit Tests without Subscriptions (gcc)"
             cmd_deps: ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1272,6 +1272,11 @@ if(UA_ENABLE_NODESETLOADER)
     list(APPEND default_plugin_sources
                 ${PROJECT_SOURCE_DIR}/plugins/ua_nodesetloader.c)
     list(APPEND open62541_LIBRARIES ${NODESETLOADER_DEPS_LIBS})
+
+    if(UA_ENABLE_AMALGAMATION)
+        list(APPEND exported_headers ${NODESETLOADER_PUBLIC_HEADERS})
+        list(APPEND internal_headers ${NODESETLOADER_PRIVATE_HEADERS})
+    endif()
 endif()
 
 #########################
@@ -1472,6 +1477,11 @@ if(UA_ENABLE_AMALGAMATION)
     endif()
     if(UA_ENABLE_ENCRYPTION_LIBRESSL)
         target_include_directories(open62541-object PRIVATE ${LIBRESSL_INCLUDE_DIR})
+    endif()
+    if(UA_ENABLE_NODESETLOADER)
+        target_include_directories(open62541-object PRIVATE
+                                   ${NODESETLOADER_PUBLIC_INCLUDES}
+                                   ${NODESETLOADER_PRIVATE_INCLUDES})
     endif()
 
     # make sure the open62541_amalgamation target builds before so that amalgamation is finished and it is not executed again for open62541-object

--- a/tests/check_types_builtin_xml.c
+++ b/tests/check_types_builtin_xml.c
@@ -1666,8 +1666,7 @@ START_TEST(UA_Float_xml_nan_decode) {
     UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_FLOAT], NULL);
 
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-#if (defined(__GNUC__) && (defined(__armhf__) || defined(__i386__))) || \
-    (defined(__linux__) && defined(__clang__))
+#if !defined(__TINYC__) && (defined(__clang__) || (!defined(__aarch64__) && !defined(__amd64__)))
     // gcc 32-bit and linux clang specific
     // 0 11111111 10000000000000000000000
     // 7f c0 00 00
@@ -1804,8 +1803,7 @@ START_TEST(UA_Double_nan_xml_decode) {
     UA_StatusCode retval = UA_decodeXml(&buf, &out, &UA_TYPES[UA_TYPES_DOUBLE], NULL);
 
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
-#if (defined(__GNUC__) && (defined(__armhf__) || defined(__i386__))) || \
-    (defined(__linux__) && defined(__clang__))
+#if !defined(__TINYC__) && (defined(__clang__) || (!defined(__aarch64__) && !defined(__amd64__)))
     // gcc 32-bit and linux clang specific
     // 0 11111111111 1000000000000000000000000000000000000000000000000000
     // ff f8 00 00 00 00 00 00

--- a/tests/nodeset-loader/CMakeLists.txt
+++ b/tests/nodeset-loader/CMakeLists.txt
@@ -2,13 +2,14 @@
 # Test nodeset loader on a subset of nodeset files #
 ####################################################
 
+add_compile_definitions(OPEN62541_NODESET_DIR="${UA_NODESET_DIR}/")
+ua_add_test(check_nodeset_loader_di.c)
+ua_add_test(check_nodeset_loader_autoid.c)
+ua_add_test(check_nodeset_loader_plc.c)
+ua_add_test(check_nodeset_loader_input.c)
+
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
-    add_compile_definitions(OPEN62541_NODESET_DIR="${UA_NODESET_DIR}/")
-    ua_add_test(check_nodeset_loader_di.c)
     ua_add_test(check_nodeset_loader_adi.c)
-    ua_add_test(check_nodeset_loader_autoid.c)
-    ua_add_test(check_nodeset_loader_plc.c)
-    ua_add_test(check_nodeset_loader_input.c)
     ua_add_test(check_nodeset_loader_ua_nodeset.c)
 
     set(GENERATE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/src_generated/tests")
@@ -32,12 +33,11 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     target_link_libraries(check_nodeset_loader_compare_di ${LIBS})
     add_test_valgrind(check_nodeset_loader_compare_di ${TESTS_BINARY_DIR}/check_nodeset_loader_compare_di)
 
-    add_compile_definitions(OPEN62541_TESTNODESET_DIR="${CMAKE_BINARY_DIR}/../deps/nodesetloader/nodesets/open62541/")
+    add_compile_definitions(OPEN62541_TESTNODESET_DIR="${CMAKE_BINARY_DIR}/../deps/nodesetLoader/nodesets/open62541/")
     ua_add_test(check_nodeset_loader_testnodeset.c)
 
-    add_compile_definitions(OPEN62541_ORDERING_DIR="${CMAKE_BINARY_DIR}/../deps/nodesetloader/nodesets/open62541/")
+    add_compile_definitions(OPEN62541_ORDERING_DIR="${CMAKE_BINARY_DIR}/../deps/nodesetLoader/nodesets/open62541/")
     ua_add_test(check_nodeset_loader_ordering_di.c)
-
 endif()
 
 add_subdirectory(add_node_integration_test)

--- a/tests/nodeset-loader/add_node_integration_test/run_test.sh
+++ b/tests/nodeset-loader/add_node_integration_test/run_test.sh
@@ -3,7 +3,7 @@
 # Test case for all standardized companion nodesets. You can
 # find the specifications at https://github.com/OPCFoundation/UA-Nodeset.
 #      - branch: latest
-#      - commit: a2208e8
+#      - commit: 54e3513
 # 
 # Currently this test case is missing the following UA-Nodesets:
 #   * NodesetLoader related issues:
@@ -12,8 +12,14 @@
 #      - ${OPEN62541_NODESET_DIR}PNRIO/Opc.Ua.PnRio.Nodeset2.xml
 #      - ${OPEN62541_NODESET_DIR}TMC/Opc.Ua.TMC.NodeSet2.xml
 #
+#   * NodesetLoader XML decoding not supported for certain types issues:
+#      - ${OPEN62541_NODESET_DIR}IJT/Tightening/Opc.Ua.Ijt.Tightening.NodeSet2.xml
+#      - ${OPEN62541_NODESET_DIR}MachineVision/Opc.Ua.MachineVision.NodeSet2.xml
+#      - ${OPEN62541_NODESET_DIR}Pumps/Opc.Ua.Pumps.NodeSet2.xml
+#
 #   * Nodesets with known 'AddNode()' issues:
 #      - ${OPEN62541_NODESET_DIR}AML/Opc.Ua.AMLBaseTypes.NodeSet2.xml
+#      - ${OPEN62541_NODESET_DIR}CSPPlusForMachine/Opc.Ua.CSPPlusForMachine.NodeSet2.xml
 #      - ${OPEN62541_NODESET_DIR}FDI/Opc.Ua.Fdi5.NodeSet2.xml
 #      - ${OPEN62541_NODESET_DIR}FDI/Opc.Ua.Fdi7.NodeSet2.xml
 #      - ${OPEN62541_NODESET_DIR}IEC61850/Opc.Ua.IEC61850-6.NodeSet2.xml
@@ -30,6 +36,8 @@
 #
 
 IFS=
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )
 
 argv=("$@")
 argc=$#
@@ -109,7 +117,7 @@ function add_node_integration_test() {
     NodeIdFiles=()
 }
 
-UA_NODESET_PATH=/usr/local/share/open62541/tools/ua-nodeset
+UA_NODESET_PATH=$SCRIPT_DIR/../../../deps/ua-nodeset
 
 add_node_integration_test "ADI" \
     $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
@@ -121,6 +129,9 @@ add_node_integration_test "AMB" \
 add_node_integration_test "AutoID" \
     $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
     $UA_NODESET_PATH/AutoID/Opc.Ua.AutoID.NodeSet2.xml
+
+add_node_integration_test "BACnet" \
+    $UA_NODESET_PATH/BACnet/Opc.Ua.BACnet.NodeSet2.xml
 
 add_node_integration_test "CAS" \
     $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
@@ -134,10 +145,6 @@ add_node_integration_test "CNC" \
 add_node_integration_test "CommercialKitchenEquipment" \
     $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
     $UA_NODESET_PATH/CommercialKitchenEquipment/Opc.Ua.CommercialKitchenEquipment.NodeSet2.xml
-
-add_node_integration_test "CSPPlusForMachine" \
-    $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
-    $UA_NODESET_PATH/CSPPlusForMachine/Opc.Ua.CSPPlusForMachine.NodeSet2.xml
 
 add_node_integration_test "DEXPI" \
     $UA_NODESET_PATH/DEXPI/Opc.Ua.DEXPI.NodeSet2.xml
@@ -182,11 +189,6 @@ add_node_integration_test "IEC61850-7-4" \
     $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml \
     $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-4.NodeSet2.xml
 
-add_node_integration_test "IJT" \
-    $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
-    $UA_NODESET_PATH/Machinery/Opc.Ua.Machinery.NodeSet2.xml \
-    $UA_NODESET_PATH/IJT/Tightening/Opc.Ua.Ijt.Tightening.NodeSet2.xml
-
 add_node_integration_test "IOLinkIODD" \
     $UA_NODESET_PATH/IOLink/Opc.Ua.IOLinkIODD.NodeSet2.xml
 
@@ -208,9 +210,6 @@ add_node_integration_test "MachineTool" \
     $UA_NODESET_PATH/Machinery/Opc.Ua.Machinery.NodeSet2.xml \
     $UA_NODESET_PATH/IA/Opc.Ua.IA.NodeSet2.xml \
     $UA_NODESET_PATH/MachineTool/Opc.Ua.MachineTool.NodeSet2.xml
-
-add_node_integration_test "MachineVision" \
-    $UA_NODESET_PATH/MachineVision/Opc.Ua.MachineVision.NodeSet2.xml
 
 add_node_integration_test "MDIS" \
     $UA_NODESET_PATH/MDIS/Opc.MDIS.NodeSet2.xml
@@ -512,11 +511,6 @@ add_node_integration_test "PNEM" \
 
 add_node_integration_test "PROFINET" \
     $UA_NODESET_PATH/PROFINET/Opc.Ua.Pn.NodeSet2.xml
-
-add_node_integration_test "Pumps" \
-    $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
-    $UA_NODESET_PATH/Machinery/Opc.Ua.Machinery.NodeSet2.xml \
-    $UA_NODESET_PATH/Pumps/Opc.Ua.Pumps.NodeSet2.xml
 
 add_node_integration_test "Robotics" \
     $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \

--- a/tests/nodeset-loader/add_node_integration_test/run_test_ordering.sh
+++ b/tests/nodeset-loader/add_node_integration_test/run_test_ordering.sh
@@ -90,4 +90,4 @@ add_node_integration_test "DI" \
     $SCRIPT_DIR/../../../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml
 
 add_node_integration_test "DI-Invalid-Ordering" \
-    $SCRIPT_DIR/../../../deps/nodesetloader/nodesets/open62541/Opc.Ua.Di.NodeSet2_invalid_ordering.xml
+    $SCRIPT_DIR/../../../deps/nodesetLoader/nodesets/open62541/Opc.Ua.Di.NodeSet2_invalid_ordering.xml

--- a/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
@@ -5,7 +5,7 @@
 /* Test case for all standardized companion nodesets. You can
  * find the specifications at https://github.com/OPCFoundation/UA-Nodeset.
  *      - branch: latest
- *      - commit: a2208e8
+ *      - commit: 54e3513
  * 
  * Currently this test case is missing the following UA-Nodesets:
  *    * NodesetLoader related issues:
@@ -83,6 +83,13 @@ END_TEST
 START_TEST(Server_loadAutoIDNodeset) {
     bool retVal = UA_Server_loadNodeset(server,
         OPEN62541_NODESET_DIR "AutoID/Opc.Ua.AutoID.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+START_TEST(Server_loadBACnetNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "BACnet/Opc.Ua.BACnet.NodeSet2.xml", NULL);
     ck_assert_uint_eq(retVal, true);
 }
 END_TEST
@@ -654,6 +661,12 @@ static Suite* testSuite_Client(void) {
         tcase_add_unchecked_fixture(tc_server, setup, teardown);
         tcase_add_test(tc_server, Server_loadDINodeset);
         tcase_add_test(tc_server, Server_loadAutoIDNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load BACnet nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadBACnetNodeset);
         suite_add_tcase(s, tc_server);
     }
     {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -94,6 +94,7 @@ function build_amalgamation {
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
@@ -111,6 +112,7 @@ function build_amalgamation_mt {
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
@@ -142,6 +144,7 @@ function unit_tests {
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_MQTT=ON \
@@ -168,6 +171,7 @@ function unit_tests_32 {
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
@@ -204,6 +208,7 @@ function unit_tests_diag {
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
@@ -239,6 +244,8 @@ function unit_tests_alarms {
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
           -DUA_ENABLE_DA=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
+          -DUA_ENABLE_XML_ENCODING=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
 	      -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON \
           -DUA_NAMESPACE_ZERO=FULL \
@@ -321,6 +328,7 @@ function unit_tests_with_coverage {
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_MQTT=ON \
@@ -353,6 +361,7 @@ function unit_tests_valgrind {
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_MQTT=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
@@ -382,6 +391,7 @@ function build_clang_analyzer {
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \


### PR DESCRIPTION
Fixes #5501.

Also, included the following unit tests for the nodesetLoader in the CI:

- check_nodeset_loader_di
- check_nodeset_loader_autoid
- check_nodeset_loader_plc
- check_nodeset_loader_input

Included nodesetLoader (XML encoding) features within **unit_tests_alarms** CI pipeline, to test whole nodeset functionality, because of supported _UA_NAMESPACE_ZERO=FULL_ option:

- check_nodeset_loader_adi
- check_nodeset_loader_ua_nodeset
- check_nodeset_loader_compare_di
- check_nodeset_loader_testnodeset
- check_nodeset_loader_add_node_integration

Updated nodesetLoader UA-Nodeset tests with the latest version of the ua-nodeset dependency project [54e3513](https://github.com/OPCFoundation/UA-Nodeset/tree/54e35134bb6629789c017f82360e4fdc1577298b)

**NOTE**: For the CI to finish successfully, the changes from the nodesetLoader PR [#216](https://github.com/open62541/nodesetLoader/pull/216) need to be merged.