### PR TITLE
fix(server) Refine fixup of logger pointers

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -366,9 +366,11 @@ UA_Server_newWithConfig(UA_ServerConfig *config) {
     /* The config might have been "moved" into the server struct. Ensure that
      * the logger pointer is correct. */
     for(size_t i = 0; i < server->config.securityPoliciesSize; i++)
-        server->config.securityPolicies[i].logger = &server->config.logger;
+        if(server->config.securityPolicies[i].logger == &config->logger)
+            server->config.securityPolicies[i].logger = &server->config.logger;
 
-    server->config.eventLoop->logger = &server->config.logger;
+    if(server->config.eventLoop->logger == &config->logger)
+        server->config.eventLoop->logger = &server->config.logger;
 
     /* Reset the old config */
     memset(config, 0, sizeof(UA_ServerConfig));


### PR DESCRIPTION
Only fix up the loggers of the event loop and security policies if they pointed into the supplied config.  E.g. a shared external event loop may use a logger with a different context from that of the server instance.