### PR TITLE
Fix the build error in pubsub_interrupt_publish_tsn.c

### DIFF
--- a/examples/pubsub_realtime/vxworks/pubsub_interrupt_publish_tsn.c
+++ b/examples/pubsub_realtime/vxworks/pubsub_interrupt_publish_tsn.c
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- *   Copyright (c) 2020 Wind River Systems, Inc.
+ *   Copyright (c) 2020, 2022 Wind River Systems, Inc.
  */
 
 #include <vxWorks.h>
@@ -307,7 +307,7 @@ addPubSubConfiguration(UA_Server* server) {
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
     writerGroupConfig.rtLevel = UA_PUBSUB_RT_FIXED_SIZE;
     writerGroupConfig.pubsubManagerCallback.addCustomCallback = addApplicationCallback;
-    writerGroupConfig.pubsubManagerCallback.changeCustomCallbackInterval = changeApplicationCallbackInterval;
+    writerGroupConfig.pubsubManagerCallback.changeCustomCallback = changeApplicationCallbackInterval;
     writerGroupConfig.pubsubManagerCallback.removeCustomCallback = removeApplicationPubSubCallback;
     UA_Server_addWriterGroup(server, connectionIdent,
                              &writerGroupConfig, &writerGroupIdent);
@@ -444,13 +444,8 @@ static void open62541ServerTask(void) {
 
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
-    config->pubsubTransportLayers = (UA_PubSubTransportLayer *)UA_malloc(sizeof(UA_PubSubTransportLayer));
-    if(config->pubsubTransportLayers == NULL) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Cannot allocate a UA_PubSubTransportLayer");
-        goto serverCleanup;
-    }
-    config->pubsubTransportLayers[0] = UA_PubSubTransportLayerEthernet();
-    config->pubsubTransportLayersSize++;
+	
+    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerEthernet());
 
     addServerNodes(server);
     addPubSubConfiguration(server);


### PR DESCRIPTION
For OPEN62541 upgraded, some variables and functions are removed or changed. So change the file,
pubsub_interrupt_publish_tsn.c to meet the upgradation.