### PR TITLE
WIP feat(server) overhaul access control examples and fix check of method execution right with async methods

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -86,7 +86,7 @@ add_example(tutorial_server_object tutorial_server_object.c)
 if(UA_ENABLE_METHODCALLS)
     add_example(tutorial_server_method tutorial_server_method.c)
     if (UA_MULTITHREADING GREATER_EQUAL 100)
-        add_example(tutorial_server_method_async tutorial_server_method_async.c)
+        add_example(server_method_async async_operations/server_method_async.c)
     endif()
 endif()
 
@@ -128,11 +128,11 @@ install(PROGRAMS $<TARGET_FILE:client>
         DESTINATION bin
         RENAME ua_client)
 
-add_example(client_async client_async.c)
+add_example(client_async_api async_operations/client_async_api.c)
 
 if(UA_ENABLE_METHODCALLS)
     if (UA_MULTITHREADING GREATER_EQUAL 100)
-        add_example(client_method_async client_method_async.c)
+        add_example(client_method_async async_operations/client_method_async.c)
     endif()
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -85,7 +85,7 @@ add_example(tutorial_server_object tutorial_server_object.c)
 
 if(UA_ENABLE_METHODCALLS)
     add_example(tutorial_server_method tutorial_server_method.c)
-    if (UA_MULTITHREADING EQUAL 100)
+    if (UA_MULTITHREADING GREATER_EQUAL 100)
         add_example(tutorial_server_method_async tutorial_server_method_async.c)
     endif()
 endif()
@@ -131,7 +131,7 @@ install(PROGRAMS $<TARGET_FILE:client>
 add_example(client_async client_async.c)
 
 if(UA_ENABLE_METHODCALLS)
-    if (UA_MULTITHREADING EQUAL 100)
+    if (UA_MULTITHREADING GREATER_EQUAL 100)
         add_example(client_method_async client_method_async.c)
     endif()
 endif()

--- a/examples/access_control/client_access_control.c
+++ b/examples/access_control/client_access_control.c
@@ -61,6 +61,15 @@ int main(void) {
     retCode = UA_Client_deleteNode(client, newVariableId, UA_TRUE);
     printf("deleteNode returned: %s\n", UA_StatusCode_name(retCode));
 
+    UA_UInt32 inputValue = 42;
+    UA_Variant inputVariant;
+    UA_Variant_setScalar(&inputVariant, &inputValue, &UA_TYPES[UA_TYPES_UINT32]);
+    retCode = UA_Client_call(client, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER),
+                             UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_GETMONITOREDITEMS),
+                             1, &inputVariant, NULL, NULL);
+    printf("call method returned: %s\n", UA_StatusCode_name(retCode));
+
+
     /* Clean up */
     UA_VariableAttributes_clear(&newVariableAttributes);
     UA_Client_delete(client); /* Disconnects the client internally */

--- a/examples/access_control/server_access_control.c
+++ b/examples/access_control/server_access_control.c
@@ -41,6 +41,24 @@ allowDeleteReference(UA_Server *server, UA_AccessControl *ac,
     return UA_TRUE;
 }
 
+static UA_Boolean
+getUserExecutable(UA_Server *server, UA_AccessControl *ac,
+                                const UA_NodeId *sessionId, void *sessionContext,
+                                const UA_NodeId *methodId, void *methodContext){
+    printf("Called getUserExecutable\n");
+    return false;
+}
+
+
+static UA_Boolean
+getUserExecutableOnObject(UA_Server *server, UA_AccessControl *ac,
+                                        const UA_NodeId *sessionId, void *sessionContext,
+                                        const UA_NodeId *methodId, void *methodContext,
+                                        const UA_NodeId *objectId, void *objectContext){
+    printf("Called getUserExecutableOnObject\n");
+    return false;
+}
+
 UA_Boolean running = true;
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
@@ -72,6 +90,8 @@ int main(void) {
     config->accessControl.allowAddReference = allowAddReference;
     config->accessControl.allowDeleteNode = allowDeleteNode;
     config->accessControl.allowDeleteReference = allowDeleteReference;
+    config->accessControl.getUserExecutable = getUserExecutable;
+    config->accessControl.getUserExecutableOnObject = getUserExecutableOnObject;
 
     retval = UA_Server_run(server, &running);
 

--- a/examples/async_operations/client_async_api.c
+++ b/examples/async_operations/client_async_api.c
@@ -1,13 +1,9 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
-#include <open62541/client_config_default.h>
-#include <open62541/client_highlevel_async.h>
-#include <open62541/client_subscriptions.h>
-#include <open62541/plugin/log_stdout.h>
-#include <open62541/server_config_default.h>
-
-#include <stdlib.h>
+#include "open62541/client_config_default.h"
+#include "open62541/client_highlevel_async.h"
+#include "open62541/plugin/log_stdout.h"
 
 #define NODES_EXIST
 /* async connection callback, it only gets called after the completion of the whole
@@ -15,76 +11,76 @@
 static void
 onConnect(UA_Client *client, UA_SecureChannelState channelState,
           UA_SessionState sessionState, UA_StatusCode connectStatus) {
-    printf("Async connect returned with status code %s\n",
-           UA_StatusCode_name(connectStatus));
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                "Async connect returned with status code %s",
+                UA_StatusCode_name(connectStatus));
 }
 
-static
-void
-fileBrowsed(UA_Client *client, void *userdata, UA_UInt32 requestId,
-            UA_BrowseResponse *response) {
-    printf("%-50s%u\n", "Received BrowseResponse for request ", requestId);
-    UA_String us = *(UA_String *) userdata;
-    printf("---%.*s passed safely \n", (int) us.length, us.data);
+static void
+fileBrowsedCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                    UA_BrowseResponse *response) {
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                "Received BrowseResponse for request %u", requestId);
+    char us_chr[512];
+    UA_String_toCharArray((UA_String *) userdata, us_chr, 512);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                "%s passed safely ", us_chr);
 }
 
 /*high-level function callbacks*/
-static
-void
+static void
 readValueAttributeCallback(UA_Client *client, void *userdata,
                            UA_UInt32 requestId, UA_StatusCode status,
                            UA_DataValue *var) {
-    printf("%-50s%u\n", "Read value attribute for request", requestId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                "Read value attribute for request  %u", requestId);
     if(UA_Variant_hasScalarType(&var->value, &UA_TYPES[UA_TYPES_INT32])) {
         UA_Int32 int_val = *(UA_Int32*) var->value.data;
-        printf("---%-40s%-8i\n",
-               "Reading the value of node (1, \"the.answer\"):", int_val);
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                "Reading the value of node (1, \"the.answer\") %u", int_val);
     }
 }
 
 static
 void
-attrWritten(UA_Client *client, void *userdata, UA_UInt32 requestId,
-            UA_WriteResponse *response) {
+attrWrittenCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                    UA_WriteResponse *response) {
     /*assuming no data to be retrieved by writing attributes*/
-    printf("%-50s%u\n", "Wrote value attribute for request ", requestId);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                "Wrote value attribute for request  %u", requestId);
     UA_WriteResponse_clear(response);
 }
 
 #ifdef NODES_EXIST
 #ifdef UA_ENABLE_METHODCALLS
 static void
-methodCalled(UA_Client *client, void *userdata, UA_UInt32 requestId,
-             UA_CallResponse *response) {
+methodCalledCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                     UA_CallResponse *response) {
 
-    printf("%-50s%u\n", "Called method for request ", requestId);
-    size_t outputSize;
-    UA_Variant *output;
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                "Called method for request  %u", requestId);
+    //size_t outputSize;
+    //UA_Variant *output;
     UA_StatusCode retval = response->responseHeader.serviceResult;
     if(retval == UA_STATUSCODE_GOOD) {
         if(response->resultsSize == 1)
             retval = response->results[0].statusCode;
         else
             retval = UA_STATUSCODE_BADUNEXPECTEDERROR;
+        /* Move the output arguments */
+        //output = response->results[0].outputArguments;
+        //outputSize = response->results[0].outputArgumentsSize;
+        //response->results[0].outputArguments = NULL;
+        //response->results[0].outputArgumentsSize = 0;
+        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                    "Method call was successful, returned %lu values", (unsigned long) response->results[0].outputArgumentsSize);
+        //UA_Array_delete(output, outputSize, &UA_TYPES[UA_TYPES_VARIANT]);
     }
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_CallResponse_clear(response);
+        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                    "Method call was unsuccessful, returned %s.", UA_StatusCode_name(retval));
     }
 
-    /* Move the output arguments */
-    output = response->results[0].outputArguments;
-    outputSize = response->results[0].outputArgumentsSize;
-    response->results[0].outputArguments = NULL;
-    response->results[0].outputArgumentsSize = 0;
-
-    if(retval == UA_STATUSCODE_GOOD) {
-        printf("---Method call was successful, returned %lu values.\n",
-               (unsigned long) outputSize);
-        UA_Array_delete(output, outputSize, &UA_TYPES[UA_TYPES_VARIANT]);
-    } else {
-        printf("---Method call was unsuccessful, returned %x values.\n",
-                retval);
-    }
     UA_CallResponse_clear(response);
 }
 
@@ -96,9 +92,13 @@ main(int argc, char *argv[]) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig *cc = UA_Client_getConfig(client);
     UA_ClientConfig_setDefault(cc);
+
+    cc->stateCallback = onConnect;
+    UA_Client_connectAsync(client, "opc.tcp://localhost:4840");
+    UA_sleep_ms(100);
+
     UA_UInt32 reqId = 0;
     UA_String userdata = UA_STRING("userdata");
-
     UA_BrowseRequest bReq;
     UA_BrowseRequest_init(&bReq);
     bReq.requestedMaxReferencesPerNode = 0;
@@ -107,14 +107,7 @@ main(int argc, char *argv[]) {
     bReq.nodesToBrowse[0].nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
     bReq.nodesToBrowse[0].resultMask = UA_BROWSERESULTMASK_ALL; /* return everything */
 
-    cc->stateCallback = onConnect;
-    UA_Client_connectAsync(client, "opc.tcp://localhost:4840");
-
-    /*Windows needs time to response*/
-    UA_sleep_ms(100);
-
-    /* What happens if client tries to send request before connected? */
-    UA_Client_sendAsyncBrowseRequest(client, &bReq, fileBrowsed, &userdata, &reqId);
+    UA_Client_sendAsyncBrowseRequest(client, &bReq, fileBrowsedCallback, &userdata, &reqId);
 
     UA_DateTime startTime = UA_DateTime_nowMonotonic();
     do {
@@ -122,7 +115,7 @@ main(int argc, char *argv[]) {
         UA_Client_getState(client, NULL, &ss, NULL);
         if(ss == UA_SESSIONSTATE_ACTIVATED) {
             /* If not connected requests are not sent */
-            UA_Client_sendAsyncBrowseRequest(client, &bReq, fileBrowsed, &userdata, &reqId);
+            UA_Client_sendAsyncBrowseRequest(client, &bReq, fileBrowsedCallback, &userdata, &reqId);
         }
         /* Requests are processed */
         UA_BrowseRequest_clear(&bReq);
@@ -151,7 +144,7 @@ main(int argc, char *argv[]) {
             value++;
             UA_Client_writeValueAttribute_async(client,
                                                 UA_NODEID_STRING(1, "the.answer"),
-                                                &myVariant, attrWritten, NULL,
+                                                &myVariant, attrWrittenCallback, NULL,
                                                 &reqId);
             UA_Variant_clear(&myVariant);
 
@@ -169,16 +162,19 @@ main(int argc, char *argv[]) {
             UA_Client_call_async(client,
                                  UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                  UA_NODEID_NUMERIC(1, 62541), 1, &input,
-                                 methodCalled, NULL, &reqId);
+                                 methodCalledCallback, NULL, &reqId);
             UA_String_clear(&stringValue);
 #endif /* UA_ENABLE_METHODCALLS */
 #endif
-            /* How often UA_Client_run_iterate is called depends on the number of request sent */
-            UA_Client_run_iterate(client, 0);
-            UA_Client_run_iterate(client, 0);
         }
     }
-    UA_Client_run_iterate(client, 0);
+
+    /* Loop for 10 seconds to keep the session open and receive the responses */
+    UA_DateTime dt = UA_DateTime_nowMonotonic();
+    while((dt + 10 * UA_DATETIME_SEC) > UA_DateTime_nowMonotonic()){
+        UA_Client_run_iterate(client, 0);
+        UA_sleep_ms(10);
+    }
 
     /* Async disconnect kills unprocessed requests */
     // UA_Client_disconnect_async (client, &reqId); //can only be used when connected = true

--- a/examples/async_operations/server_method_async.c
+++ b/examples/async_operations/server_method_async.c
@@ -30,10 +30,10 @@
  * prepended. The type and length of the input arguments is checked internally
  * by the SDK, so that we don't have to verify the arguments in the callback. */
 
-#include <open62541/client_config_default.h>
-#include <open62541/plugin/log_stdout.h>
-#include <open62541/server.h>
-#include <open62541/server_config_default.h>
+#include "open62541/client_config_default.h"
+#include "open62541/plugin/log_stdout.h"
+#include "open62541/server.h"
+#include "open62541/server_config_default.h"
 
 #include <signal.h>
 #include <stdlib.h>

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -11,6 +11,8 @@
  *    Copyright 2015-2016 (c) Oleksiy Vasylyev
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  *    Copyright 2017 (c) Thomas Stalder, Blue Time Concept SA
+ *    Copyright 2020-2022 (c) Fraunhofer IOSB (Author: Andreas Ebner)
+
  */
 
 #ifndef UA_TYPES_H_
@@ -195,6 +197,9 @@ typedef struct {
 /* Copies the content on the heap. Returns a null-string when alloc fails */
 UA_String UA_EXPORT
 UA_String_fromChars(const char *src) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
+
+UA_StatusCode UA_EXPORT
+UA_String_toCharArray(UA_String *s, char * c, size_t maxLength);
 
 UA_Boolean UA_EXPORT
 UA_String_equal(const UA_String *s1, const UA_String *s2);

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -241,6 +241,7 @@ UA_StatusCode
 UA_AsyncManager_createAsyncOp(UA_AsyncManager *am, UA_Server *server,
                               UA_AsyncResponse *ar, size_t opIndex,
                               const UA_CallMethodRequest *opRequest) {
+
     if(server->config.maxAsyncOperationQueueSize != 0 &&
        am->opsCount >= server->config.maxAsyncOperationQueueSize) {
         UA_LOG_WARNING(&server->config.logger, UA_LOGCATEGORY_SERVER,

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -389,6 +389,22 @@ Operation_CallMethodAsync(UA_Server *server, UA_Session *session, UA_UInt32 requ
 
     /* <-- Async method call --> */
 
+    /* Verify access rights in case of async execution*/
+    UA_Boolean executable = method->methodNode.executable;
+    if(session != &server->adminSession) {
+        UA_UNLOCK(&server->serviceMutex);
+        executable = executable && server->config.accessControl.
+            getUserExecutableOnObject(server, &server->config.accessControl,
+                                      &session->sessionId, session->sessionHandle,
+                                      &opRequest->methodId, method->head.context,
+                                      &opRequest->objectId, object->head.context);
+        UA_LOCK(&server->serviceMutex);
+    }
+    if(!executable) {
+        opResult->statusCode = UA_STATUSCODE_BADNOTEXECUTABLE;
+        goto cleanup;
+    }
+
     /* No AsyncResponse allocated so far */
     if(!*ar) {
         opResult->statusCode =

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- *    Copyright 2020 (c) Fraunhofer IOSB (Author: Andreas Ebner)
+ *    Copyright 2020-2022 (c) Fraunhofer IOSB (Author: Andreas Ebner)
  *    Copyright 2014-2017 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  *    Copyright 2014, 2016-2017 (c) Florian Palm
  *    Copyright 2014-2016 (c) Sten Grüner
@@ -124,6 +124,15 @@ UA_String_fromChars(const char *src) {
         s.data = (u8*)UA_EMPTY_ARRAY_SENTINEL;
     }
     return s;
+}
+
+UA_StatusCode
+UA_String_toCharArray(UA_String *s, char *c, size_t maxLength) {
+    if(s->length+1 > maxLength)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    memcpy(c, s->data, s->length);
+    c[s->length] = '\0';
+    return UA_STATUSCODE_GOOD;
 }
 
 static UA_Order


### PR DESCRIPTION
The PR contains the following changes:

- Restructure the async tutorials structure.
- Fix currently crashing async example.
- Fix the test of user method execution rights in case of async methods (server side)
- Extend server with util function for generating a c-string (null terminated) from a UA_String

ToDo:
From my point of view, the current implementation of the client_method_async makes no sense. There is a call of a methods in the method callback, which results in an endless loop.