### PR TITLE
feat(tests): Node ordering test case for open62541-nodeset-loader

### DIFF
--- a/tests/nodeset-loader/CMakeLists.txt
+++ b/tests/nodeset-loader/CMakeLists.txt
@@ -35,6 +35,9 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     add_compile_definitions(OPEN62541_TESTNODESET_DIR="${CMAKE_BINARY_DIR}/../deps/nodesetloader/nodesets/open62541/")
     ua_add_test(check_nodeset_loader_testnodeset.c)
 
+    add_compile_definitions(OPEN62541_ORDERING_DIR="${CMAKE_BINARY_DIR}/../deps/nodesetloader/nodesets/open62541/")
+    ua_add_test(check_nodeset_loader_ordering_di.c)
+
 endif()
 
 add_subdirectory(add_node_integration_test)

--- a/tests/nodeset-loader/add_node_integration_test/CMakeLists.txt
+++ b/tests/nodeset-loader/add_node_integration_test/CMakeLists.txt
@@ -4,20 +4,26 @@
 
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
-    add_executable(client client.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
-    set_target_properties(client PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-    target_link_libraries(client ${LIBS})
+    add_executable(add_node_integration_test_client client.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+    set_target_properties(add_node_integration_test_client PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+    target_link_libraries(add_node_integration_test_client ${LIBS})
 
-    add_executable(server server.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
-    set_target_properties(server PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-    target_link_libraries(server ${LIBS})
+    add_executable(add_node_integration_test_server server.c $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-testplugins>)
+    set_target_properties(add_node_integration_test_server PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+    target_link_libraries(add_node_integration_test_server ${LIBS})
 
     find_program(BASH_PROGRAM bash)
 
     add_test(check_nodeset_loader_add_node_integration
              ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/run_test.sh 
-             "${CMAKE_CURRENT_BINARY_DIR}/client"
-             "${CMAKE_CURRENT_BINARY_DIR}/server"
+             "${CMAKE_CURRENT_BINARY_DIR}/add_node_integration_test_client"
+             "${CMAKE_CURRENT_BINARY_DIR}/add_node_integration_test_server"
+    )
+
+    add_test(check_nodeset_loader_DI_ordering_integration
+             ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/run_test_ordering.sh
+             "${CMAKE_CURRENT_BINARY_DIR}/add_node_integration_test_client"
+             "${CMAKE_CURRENT_BINARY_DIR}/add_node_integration_test_server"
     )
 
 endif()

--- a/tests/nodeset-loader/add_node_integration_test/run_test_ordering.sh
+++ b/tests/nodeset-loader/add_node_integration_test/run_test_ordering.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# NodesetLoader `AddNode()` integration test use-case for the
+# ordering of the nodes within nodeset XML file. Two different
+# versions of DI companion standard are tested:
+#      - Official version
+#      - Version where the ordering is invalid:
+#          * Parent node (ns=1;i=15001) is defined after child nodes:
+#              + ns=1;i=15002
+#              + ns=1;i=15003
+#              + ns=1;i=15004
+#              + ns=1;i=15005
+#              + ns=1;i=15006
+#              + ns=1;i=15007
+#              + ns=1;i=15008
+#              + ns=1;i=15031
+#              + ns=1;i=15032
+#              + ns=1;i=15033
+#
+
+IFS=
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )
+
+argv=("$@")
+argc=$#
+CLIENT_BINARY_PATH="${argv[0]}"
+SERVER_BINARY_PATH="${argv[1]}"
+SERVER_PID=
+CustomNsStartNum=
+declare -a NodeIdFiles=()
+
+function start_server() {
+    echo "Start server: "$@
+    $SERVER_BINARY_PATH $@ & disown
+    SERVER_PID=$!
+}
+
+function prepare_nodeids() {
+    CustomNsStartNum=2
+    for nodeset in "$@"
+    do
+        nodesetIdPath=$(basename $nodeset)
+        nodesetIdPath=${nodesetIdPath%.*}
+
+        grep --line-buffered -R '<UAObjectType\|<UAObject\|<UAVariable\|<UAVariableType\|<UAMethod\|<UADataType\|<UAReferenceType\|<UAView' \
+                                $nodeset | awk '{ sub(/.*\ NodeId="/, ""); sub(/".*/, ""); print $1}' >> $nodesetIdPath
+        sed -i "s/ns=1;/ns=$CustomNsStartNum;/gI" $nodesetIdPath
+
+        NodeIdFiles+=("$nodesetIdPath")
+        CustomNsStartNum=$((CustomNsStartNum+1))
+    done
+}
+
+function run_client() {
+    echo "Start client: "$@
+    $CLIENT_BINARY_PATH $@
+    clientResult=$?
+    if [ $clientResult -ne 0 ] ; then
+        stop_server
+        rm ${NodeIdFiles[@]}
+        exit 1
+    fi
+}
+
+function stop_server() {
+    echo "Stop server:"
+    kill -9 $SERVER_PID
+    if [ $? -ne 0 ] ; then
+        echo "Error: stopping the server failed"
+        echo "PID = " $SERVER_PID
+        rm ${NodeIdFiles[@]}
+        exit 1
+    fi
+}
+
+function add_node_integration_test() {
+    nodesetName=$1
+    shift 1
+    prepare_nodeids $@
+    start_server $@
+    sleep 3
+    run_client $nodesetName ${NodeIdFiles[@]}
+    stop_server
+    rm ${NodeIdFiles[@]}
+    NodeIdFiles=()
+}
+
+add_node_integration_test "DI" \
+    $SCRIPT_DIR/../../../deps/ua-nodeset/DI/Opc.Ua.Di.NodeSet2.xml
+
+add_node_integration_test "DI-Invalid-Ordering" \
+    $SCRIPT_DIR/../../../deps/nodesetloader/nodesets/open62541/Opc.Ua.Di.NodeSet2_invalid_ordering.xml

--- a/tests/nodeset-loader/check_nodeset_loader_ordering_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ordering_di.c
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include "check.h"
+#include "testing_clock.h"
+
+UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_new();
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(Server_loadInvalidOrderingDiNodeset) {
+    bool retVal = UA_Server_loadNodeset(server,
+        OPEN62541_ORDERING_DIR "Opc.Ua.Di.NodeSet2_invalid_ordering.xml", NULL);
+    ck_assert_uint_eq(retVal, true);
+}
+END_TEST
+
+static Suite* testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    TCase *tc_server = tcase_create("Server invalid ordering DI nodeset");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_loadInvalidOrderingDiNodeset);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Within this PR, the ordering of the nodes within a nodeset XML file is tested for the [open62541-nodeset-loader](https://github.com/open62541/open62541-nodeset-loader). A modified version of the [DI](https://github.com/OPCFoundation/UA-Nodeset/blob/latest/DI/Opc.Ua.Di.NodeSet2.xml) companion specification is used as an example, where the parent node with id **ns=1;i=15001** is defined after its child nodes:

- ns=1;i=15002
- ns=1;i=15003
- ns=1;i=15004
- ns=1;i=15005
- ns=1;i=15006
- ns=1;i=15007
- ns=1;i=15008
- ns=1;i=15031
- ns=1;i=15032
- ns=1;i=15033

**NOTE**: Before this PR can be considered as completed, the dependency PR [#218](https://github.com/open62541/open62541-nodeset-loader/pull/218) must be merged.
