### PR TITLE
[REVIEW]feat(server): Add Aes256-Sha256-RsaPss security policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1029,6 +1029,7 @@ list(INSERT default_plugin_sources 1
      ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
+     ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_aes256sha256rsapss.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_pki_mbedtls.c)
 endif()
 
@@ -1047,6 +1048,7 @@ list(INSERT default_plugin_sources 0
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_basic256.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_basic256sha256.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
+     ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_create_certificate.c
      ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_pki_openssl.c)
 endif()

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
@@ -230,12 +230,13 @@ mbedtls_encrypt_rsaOaep(mbedtls_rsa_context *context,
 UA_StatusCode
 mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
                         mbedtls_ctr_drbg_context *drbgContext,
-                        UA_ByteString *data) {
+                        UA_ByteString *data, int hash_id) {
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(*localPrivateKey);
-    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, hash_id);
     size_t keylen = rsaContext->len;
 #else
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, (mbedtls_md_type_t)hash_id);
     size_t keylen = mbedtls_rsa_get_len(rsaContext);
 #endif
     if(data->length % keylen != 0)

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
@@ -57,7 +57,7 @@ mbedtls_encrypt_rsaOaep(mbedtls_rsa_context *context,
 UA_StatusCode
 mbedtls_decrypt_rsaOaep(mbedtls_pk_context *localPrivateKey,
                         mbedtls_ctr_drbg_context *drbgContext,
-                        UA_ByteString *data);
+                        UA_ByteString *data, int hash_id);
 
 int UA_mbedTLS_LoadPrivateKey(const UA_ByteString *key, mbedtls_pk_context *target, void *p_rng);
 

--- a/plugins/crypto/mbedtls/ua_securitypolicy_aes256sha256rsapss.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_aes256sha256rsapss.c
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
- *    Copyright 2018 (c) Daniel Feist, Precitec GmbH & Co. KG
- *    Copyright 2018 (c) HMS Industrial Networks AB (Author: Jonas Green)
- *    Copyright 2020 (c) Wind River Systems, Inc.
+ *    Copyright 2022 (c) Fraunhofer IOSB (Author: Noel Graf)
  */
 
 #include <open62541/plugin/securitypolicy_default.h>
@@ -31,15 +28,15 @@
  * https://tls.mbed.org/discussions/generic/in-place-decryption-with-aes256-same-input-output-buffer
  */
 
-#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN 42
 #define UA_SHA1_LENGTH 20
 #define UA_SHA256_LENGTH 32
-#define UA_AES128SHA256RSAOAEP_SYM_SIGNING_KEY_LENGTH 32
-#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_KEY_LENGTH 16
-#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE 16
-#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_PLAIN_TEXT_BLOCK_SIZE 16
-#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH 256
-#define UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH 512
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_RSAPADDING_LEN 66 /* UA_SHA256_LENGTH * 2 + 2 */
+#define UA_AES256SHA256RSAPSS_SYM_SIGNING_KEY_LENGTH 32
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_KEY_LENGTH 32 /*16*/
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_PLAIN_TEXT_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_MINASYMKEYLENGTH 256
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_MAXASYMKEYLENGTH 512
 
 typedef struct {
     UA_ByteString localCertThumbprint;
@@ -48,10 +45,10 @@ typedef struct {
     mbedtls_entropy_context entropyContext;
     mbedtls_md_context_t sha256MdContext;
     mbedtls_pk_context localPrivateKey;
-} Aes128Sha256PsaOaep_PolicyContext;
+} Aes256Sha256RsaPss_PolicyContext;
 
 typedef struct {
-    Aes128Sha256PsaOaep_PolicyContext *policyContext;
+    Aes256Sha256RsaPss_PolicyContext *policyContext;
 
     UA_ByteString localSymSigningKey;
     UA_ByteString localSymEncryptingKey;
@@ -62,7 +59,7 @@ typedef struct {
     UA_ByteString remoteSymIv;
 
     mbedtls_x509_crt remoteCertificate;
-} Aes128Sha256PsaOaep_ChannelContext;
+} Aes256Sha256RsaPss_ChannelContext;
 
 /********************/
 /* AsymmetricModule */
@@ -70,7 +67,335 @@ typedef struct {
 
 /* VERIFY AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+asym_verify_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
+                                   const UA_ByteString *message,
+                                   const UA_ByteString *signature) {
+    if(message == NULL || signature == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    unsigned char hash[UA_SHA256_LENGTH];
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    // TODO check return status
+    mbedtls_sha256_ret(message->data, message->length, hash, 0);
+#else
+    mbedtls_sha256(message->data, message->length, hash, 0);
+#endif
+
+    /* Set the RSA settings */
+    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+
+#if MBEDTLS_VERSION_NUMBER < 0x03000000
+    Aes256Sha256RsaPss_PolicyContext *pc = cc->policyContext;
+    int mbedErr = mbedtls_rsa_pkcs1_verify(rsaContext, mbedtls_ctr_drbg_random, &pc->drbgContext,
+                                                MBEDTLS_RSA_PUBLIC, MBEDTLS_MD_SHA256, UA_SHA256_LENGTH,
+                                                hash, signature->data);
+#else
+    int mbedErr = mbedtls_rsa_pkcs1_verify(rsaContext, MBEDTLS_MD_SHA256,
+                                         UA_SHA256_LENGTH, hash, signature->data);
+#endif
+
+    if(mbedErr)
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+    return UA_STATUSCODE_GOOD;
+}
+
+/* AsymmetricSignatureAlgorithm_RSA-PSS-SHA2-256 */
+static UA_StatusCode
+asym_sign_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
+                                 const UA_ByteString *message,
+                                 UA_ByteString *signature) {
+    if(message == NULL || signature == NULL || cc == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    unsigned char hash[UA_SHA256_LENGTH];
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    // TODO check return status
+    mbedtls_sha256_ret(message->data, message->length, hash, 0);
+#else
+    mbedtls_sha256(message->data, message->length, hash, 0);
+#endif
+
+    Aes256Sha256RsaPss_PolicyContext *pc = cc->policyContext;
+    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(pc->localPrivateKey);
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+
+#if MBEDTLS_VERSION_NUMBER < 0x03000000
+    int mbedErr =  mbedtls_rsa_pkcs1_sign(rsaContext, mbedtls_ctr_drbg_random, &pc->drbgContext,
+                                          MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA256, UA_SHA256_LENGTH,
+                                          hash, signature->data);
+#else
+    int mbedErr =  mbedtls_rsa_pkcs1_sign(rsaContext, mbedtls_ctr_drbg_random, &pc->drbgContext,
+                                          MBEDTLS_MD_SHA256, UA_SHA256_LENGTH,
+                                          hash, signature->data);
+#endif
+
+
+    if(mbedErr)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    return UA_STATUSCODE_GOOD;
+}
+
+static size_t
+asym_getLocalSignatureSize_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
+    if(cc == NULL)
+        return 0;
+#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    return mbedtls_pk_rsa(cc->policyContext->localPrivateKey)->len;
+#else
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->policyContext->localPrivateKey));
+#endif
+}
+
+static size_t
+asym_getRemoteSignatureSize_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
+    if(cc == NULL)
+        return 0;
+#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    return mbedtls_pk_rsa(cc->remoteCertificate.pk)->len;
+#else
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
+#endif
+}
+
+static size_t
+asym_getRemoteBlockSize_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
+    if(cc == NULL)
+        return 0;
+#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    return mbedtls_pk_rsa(cc->remoteCertificate.pk)->len;
+#else
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
+#endif
+}
+
+static size_t
+asym_getRemotePlainTextBlockSize_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
+    if(cc == NULL)
+        return 0;
+#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
+    mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
+    return rsaContext->len - UA_SECURITYPOLICY_AES256SHA256RSAPSS_RSAPADDING_LEN;
+#else
+    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk)) -
+        UA_SECURITYPOLICY_AES256SHA256RSAPSS_RSAPADDING_LEN;
+#endif
+}
+
+
+/* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA2 */
+static UA_StatusCode
+asym_encrypt_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
+                                    UA_ByteString *data) {
+    if(cc == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const size_t plainTextBlockSize = asym_getRemotePlainTextBlockSize_sp_aes256sha256rsapss(cc);
+
+    mbedtls_rsa_context *remoteRsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
+    mbedtls_rsa_set_padding(remoteRsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+
+    return mbedtls_encrypt_rsaOaep(remoteRsaContext, &cc->policyContext->drbgContext,
+                                   data, plainTextBlockSize);
+}
+
+/* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA2 */
+static UA_StatusCode
+asym_decrypt_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
+                                    UA_ByteString *data) {
+    if(cc == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
+                                   &cc->policyContext->drbgContext, data, MBEDTLS_MD_SHA256);
+}
+
+static size_t
+asym_getLocalEncryptionKeyLength_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
+    return mbedtls_pk_get_len(&cc->policyContext->localPrivateKey) * 8;
+}
+
+static size_t
+asym_getRemoteEncryptionKeyLength_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
+    return mbedtls_pk_get_len(&cc->remoteCertificate.pk) * 8;
+}
+
+static UA_StatusCode
+asym_makeThumbprint_sp_aes256sha256rsapss(const UA_SecurityPolicy *securityPolicy,
+                                           const UA_ByteString *certificate,
+                                           UA_ByteString *thumbprint) {
+    if(securityPolicy == NULL || certificate == NULL || thumbprint == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    return mbedtls_thumbprint_sha1(certificate, thumbprint);
+}
+
+static UA_StatusCode
+asymmetricModule_compareCertificateThumbprint_sp_aes256sha256rsapss(const UA_SecurityPolicy *securityPolicy,
+                                                                     const UA_ByteString *certificateThumbprint) {
+    if(securityPolicy == NULL || certificateThumbprint == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Aes256Sha256RsaPss_PolicyContext *pc = (Aes256Sha256RsaPss_PolicyContext *)securityPolicy->policyContext;
+    if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
+        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+
+    return UA_STATUSCODE_GOOD;
+}
+
+/*******************/
+/* SymmetricModule */
+/*******************/
+
+static UA_StatusCode
+sym_verify_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
+                                  const UA_ByteString *message,
+                                  const UA_ByteString *signature) {
+    if(cc == NULL || message == NULL || signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    /* Compute MAC */
+    if(signature->length != UA_SHA256_LENGTH)
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+    Aes256Sha256RsaPss_PolicyContext *pc = cc->policyContext;
+    unsigned char mac[UA_SHA256_LENGTH];
+    mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
+
+    /* Compare with Signature */
+    if(!UA_constantTimeEqual(signature->data, mac, UA_SHA256_LENGTH))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+sym_sign_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc,
+                                const UA_ByteString *message,
+                                UA_ByteString *signature) {
+    if(signature->length != UA_SHA256_LENGTH)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
+                 message, signature->data);
+    return UA_STATUSCODE_GOOD;
+}
+
+static size_t
+sym_getSignatureSize_sp_aes256sha256rsapss(const void *channelContext) {
+    return UA_SHA256_LENGTH;
+}
+
+static size_t
+sym_getSigningKeyLength_sp_aes256sha256rsapss(const void *channelContext) {
+    return UA_AES256SHA256RSAPSS_SYM_SIGNING_KEY_LENGTH;
+}
+
+static size_t
+sym_getEncryptionKeyLength_sp_aes256sha256rsapss(const void *channelContext) {
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_KEY_LENGTH;
+}
+
+static size_t
+sym_getEncryptionBlockSize_sp_aes256sha256rsapss(const void *channelContext) {
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_BLOCK_SIZE;
+}
+
+static size_t
+sym_getPlainTextBlockSize_sp_aes256sha256rsapss(const void *channelContext) {
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_PLAIN_TEXT_BLOCK_SIZE;
+}
+
+static UA_StatusCode
+sym_encrypt_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc,
+                                   UA_ByteString *data) {
+    if(cc == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    if(cc->localSymIv.length != UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_BLOCK_SIZE)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    size_t plainTextBlockSize = UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_PLAIN_TEXT_BLOCK_SIZE;
+
+    if(data->length % plainTextBlockSize != 0)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    /* Keylength in bits */
+    unsigned int keylength = (unsigned int)(cc->localSymEncryptingKey.length * 8);
+    mbedtls_aes_context aesContext;
+    int mbedErr = mbedtls_aes_setkey_enc(&aesContext, cc->localSymEncryptingKey.data, keylength);
+    if(mbedErr)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString ivCopy;
+    UA_StatusCode retval = UA_ByteString_copy(&cc->localSymIv, &ivCopy);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    mbedErr = mbedtls_aes_crypt_cbc(&aesContext, MBEDTLS_AES_ENCRYPT, data->length,
+                                    ivCopy.data, data->data, data->data);
+    if(mbedErr)
+        retval = UA_STATUSCODE_BADINTERNALERROR;
+    UA_ByteString_clear(&ivCopy);
+    return retval;
+}
+
+static UA_StatusCode
+sym_decrypt_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc,
+                                   UA_ByteString *data) {
+    if(cc == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    size_t encryptionBlockSize = UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_BLOCK_SIZE;
+
+    if(cc->remoteSymIv.length != encryptionBlockSize)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    if(data->length % encryptionBlockSize != 0)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    unsigned int keylength = (unsigned int)(cc->remoteSymEncryptingKey.length * 8);
+    mbedtls_aes_context aesContext;
+    int mbedErr = mbedtls_aes_setkey_dec(&aesContext, cc->remoteSymEncryptingKey.data, keylength);
+    if(mbedErr)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ByteString ivCopy;
+    UA_StatusCode retval = UA_ByteString_copy(&cc->remoteSymIv, &ivCopy);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    mbedErr = mbedtls_aes_crypt_cbc(&aesContext, MBEDTLS_AES_DECRYPT, data->length,
+                                    ivCopy.data, data->data, data->data);
+    if(mbedErr)
+        retval = UA_STATUSCODE_BADINTERNALERROR;
+    UA_ByteString_clear(&ivCopy);
+    return retval;
+}
+
+static UA_StatusCode
+sym_generateKey_sp_aes256sha256rsapss(void *policyContext, const UA_ByteString *secret,
+                                       const UA_ByteString *seed, UA_ByteString *out) {
+    if(secret == NULL || seed == NULL || out == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Aes256Sha256RsaPss_PolicyContext *pc = (Aes256Sha256RsaPss_PolicyContext *)policyContext;
+    return mbedtls_generateKey(&pc->sha256MdContext, secret, seed, out);
+}
+
+static UA_StatusCode
+sym_generateNonce_sp_aes256sha256rsapss(void *policyContext, UA_ByteString *out) {
+    if(out == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Aes256Sha256RsaPss_PolicyContext *pc =
+        (Aes256Sha256RsaPss_PolicyContext *)policyContext;
+    int mbedErr = mbedtls_ctr_drbg_random(&pc->drbgContext, out->data, out->length);
+    if(mbedErr)
+        return UA_STATUSCODE_BADUNEXPECTEDERROR;
+    return UA_STATUSCODE_GOOD;
+}
+
+/***********************************/
+/* CertificateSigningAlgorithms    */
+/***********************************/
+
+static UA_StatusCode
+asym_cert_verify_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                    const UA_ByteString *message,
                                    const UA_ByteString *signature) {
     if(message == NULL || signature == NULL || cc == NULL)
@@ -105,7 +430,7 @@ asym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
 
 /* AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256 */
 static UA_StatusCode
-asym_sign_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+asym_cert_sign_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                  const UA_ByteString *message,
                                  UA_ByteString *signature) {
     if(message == NULL || signature == NULL || cc == NULL)
@@ -119,7 +444,7 @@ asym_sign_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
     mbedtls_sha256(message->data, message->length, hash, 0);
 #endif
 
-    Aes128Sha256PsaOaep_PolicyContext *pc = cc->policyContext;
+    Aes256Sha256RsaPss_PolicyContext *pc = cc->policyContext;
     mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(pc->localPrivateKey);
     mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_SHA256);
 
@@ -131,7 +456,7 @@ asym_sign_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
                                   MBEDTLS_MD_SHA256, hash,
                                   UA_SHA256_LENGTH, signature->data,
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
-                                  signature->length,
+        signature->length,
 #endif
                                   &sigLen, mbedtls_ctr_drbg_random,
                                   &pc->drbgContext);
@@ -141,7 +466,7 @@ asym_sign_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
 }
 
 static size_t
-asym_getLocalSignatureSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
+asym_cert_getLocalSignatureSize_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -152,7 +477,7 @@ asym_getLocalSignatureSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_Chan
 }
 
 static size_t
-asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
+asym_cert_getRemoteSignatureSize_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc) {
     if(cc == NULL)
         return 0;
 #if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
@@ -160,238 +485,6 @@ asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_Cha
 #else
     return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
 #endif
-}
-
-static size_t
-asym_getRemoteBlockSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
-    if(cc == NULL)
-        return 0;
-#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    return mbedtls_pk_rsa(cc->remoteCertificate.pk)->len;
-#else
-    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk));
-#endif
-}
-
-static size_t
-asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
-    if(cc == NULL)
-        return 0;
-#if MBEDTLS_VERSION_NUMBER >= 0x02060000 && MBEDTLS_VERSION_NUMBER < 0x03000000
-    mbedtls_rsa_context *const rsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    return rsaContext->len - UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN;
-#else
-    return mbedtls_rsa_get_len(mbedtls_pk_rsa(cc->remoteCertificate.pk)) -
-        UA_SECURITYPOLICY_AES128SHA256RSAOAEP_RSAPADDING_LEN;
-#endif
-}
-
-
-/* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
-static UA_StatusCode
-asym_encrypt_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                    UA_ByteString *data) {
-    if(cc == NULL || data == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    const size_t plainTextBlockSize = asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep(cc);
-
-    mbedtls_rsa_context *remoteRsaContext = mbedtls_pk_rsa(cc->remoteCertificate.pk);
-    mbedtls_rsa_set_padding(remoteRsaContext, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
-
-    return mbedtls_encrypt_rsaOaep(remoteRsaContext, &cc->policyContext->drbgContext,
-                                   data, plainTextBlockSize);
-}
-
-/* AsymmetricEncryptionAlgorithm_RSA-OAEP-SHA1 */
-static UA_StatusCode
-asym_decrypt_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                    UA_ByteString *data) {
-    if(cc == NULL || data == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
-                                   &cc->policyContext->drbgContext, data, MBEDTLS_MD_SHA1);
-}
-
-static size_t
-asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
-    return mbedtls_pk_get_len(&cc->policyContext->localPrivateKey) * 8;
-}
-
-static size_t
-asym_getRemoteEncryptionKeyLength_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc) {
-    return mbedtls_pk_get_len(&cc->remoteCertificate.pk) * 8;
-}
-
-static UA_StatusCode
-asym_makeThumbprint_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
-                                           const UA_ByteString *certificate,
-                                           UA_ByteString *thumbprint) {
-    if(securityPolicy == NULL || certificate == NULL || thumbprint == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    return mbedtls_thumbprint_sha1(certificate, thumbprint);
-}
-
-static UA_StatusCode
-asymmetricModule_compareCertificateThumbprint_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
-                                                                     const UA_ByteString *certificateThumbprint) {
-    if(securityPolicy == NULL || certificateThumbprint == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
-    if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
-        return UA_STATUSCODE_BADCERTIFICATEINVALID;
-
-    return UA_STATUSCODE_GOOD;
-}
-
-/*******************/
-/* SymmetricModule */
-/*******************/
-
-static UA_StatusCode
-sym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
-                                  const UA_ByteString *message,
-                                  const UA_ByteString *signature) {
-    if(cc == NULL || message == NULL || signature == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Compute MAC */
-    if(signature->length != UA_SHA256_LENGTH)
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-    Aes128Sha256PsaOaep_PolicyContext *pc = cc->policyContext;
-    unsigned char mac[UA_SHA256_LENGTH];
-    mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
-
-    /* Compare with Signature */
-    if(!UA_constantTimeEqual(signature->data, mac, UA_SHA256_LENGTH))
-        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
-    return UA_STATUSCODE_GOOD;
-}
-
-static UA_StatusCode
-sym_sign_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
-                                const UA_ByteString *message,
-                                UA_ByteString *signature) {
-    if(signature->length != UA_SHA256_LENGTH)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
-                 message, signature->data);
-    return UA_STATUSCODE_GOOD;
-}
-
-static size_t
-sym_getSignatureSize_sp_aes128sha256rsaoaep(const void *channelContext) {
-    return UA_SHA256_LENGTH;
-}
-
-static size_t
-sym_getSigningKeyLength_sp_aes128sha256rsaoaep(const void *channelContext) {
-    return UA_AES128SHA256RSAOAEP_SYM_SIGNING_KEY_LENGTH;
-}
-
-static size_t
-sym_getEncryptionKeyLength_sp_aes128sha256rsaoaep(const void *channelContext) {
-    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_KEY_LENGTH;
-}
-
-static size_t
-sym_getEncryptionBlockSize_sp_aes128sha256rsaoaep(const void *channelContext) {
-    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE;
-}
-
-static size_t
-sym_getPlainTextBlockSize_sp_aes128sha256rsaoaep(const void *channelContext) {
-    return UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_PLAIN_TEXT_BLOCK_SIZE;
-}
-
-static UA_StatusCode
-sym_encrypt_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
-                                   UA_ByteString *data) {
-    if(cc == NULL || data == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    if(cc->localSymIv.length != UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    size_t plainTextBlockSize = UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_PLAIN_TEXT_BLOCK_SIZE;
-
-    if(data->length % plainTextBlockSize != 0)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    /* Keylength in bits */
-    unsigned int keylength = (unsigned int)(cc->localSymEncryptingKey.length * 8);
-    mbedtls_aes_context aesContext;
-    int mbedErr = mbedtls_aes_setkey_enc(&aesContext, cc->localSymEncryptingKey.data, keylength);
-    if(mbedErr)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString ivCopy;
-    UA_StatusCode retval = UA_ByteString_copy(&cc->localSymIv, &ivCopy);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    mbedErr = mbedtls_aes_crypt_cbc(&aesContext, MBEDTLS_AES_ENCRYPT, data->length,
-                                    ivCopy.data, data->data, data->data);
-    if(mbedErr)
-        retval = UA_STATUSCODE_BADINTERNALERROR;
-    UA_ByteString_clear(&ivCopy);
-    return retval;
-}
-
-static UA_StatusCode
-sym_decrypt_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
-                                   UA_ByteString *data) {
-    if(cc == NULL || data == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    size_t encryptionBlockSize = UA_SECURITYPOLICY_AES128SHA256RSAOAEP_SYM_ENCRYPTION_BLOCK_SIZE;
-
-    if(cc->remoteSymIv.length != encryptionBlockSize)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    if(data->length % encryptionBlockSize != 0)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    unsigned int keylength = (unsigned int)(cc->remoteSymEncryptingKey.length * 8);
-    mbedtls_aes_context aesContext;
-    int mbedErr = mbedtls_aes_setkey_dec(&aesContext, cc->remoteSymEncryptingKey.data, keylength);
-    if(mbedErr)
-        return UA_STATUSCODE_BADINTERNALERROR;
-
-    UA_ByteString ivCopy;
-    UA_StatusCode retval = UA_ByteString_copy(&cc->remoteSymIv, &ivCopy);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    mbedErr = mbedtls_aes_crypt_cbc(&aesContext, MBEDTLS_AES_DECRYPT, data->length,
-                                    ivCopy.data, data->data, data->data);
-    if(mbedErr)
-        retval = UA_STATUSCODE_BADINTERNALERROR;
-    UA_ByteString_clear(&ivCopy);
-    return retval;
-}
-
-static UA_StatusCode
-sym_generateKey_sp_aes128sha256rsaoaep(void *policyContext, const UA_ByteString *secret,
-                                       const UA_ByteString *seed, UA_ByteString *out) {
-    if(secret == NULL || seed == NULL || out == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)policyContext;
-    return mbedtls_generateKey(&pc->sha256MdContext, secret, seed, out);
-}
-
-static UA_StatusCode
-sym_generateNonce_sp_aes128sha256rsaoaep(void *policyContext, UA_ByteString *out) {
-    if(out == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    Aes128Sha256PsaOaep_PolicyContext *pc =
-        (Aes128Sha256PsaOaep_PolicyContext *)policyContext;
-    int mbedErr = mbedtls_ctr_drbg_random(&pc->drbgContext, out->data, out->length);
-    if(mbedErr)
-        return UA_STATUSCODE_BADUNEXPECTEDERROR;
-    return UA_STATUSCODE_GOOD;
 }
 
 /*****************/
@@ -400,7 +493,7 @@ sym_generateNonce_sp_aes128sha256rsaoaep(void *policyContext, UA_ByteString *out
 
 /* Assumes that the certificate has been verified externally */
 static UA_StatusCode
-parseRemoteCertificate_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+parseRemoteCertificate_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                               const UA_ByteString *remoteCertificate) {
     if(remoteCertificate == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -418,14 +511,14 @@ parseRemoteCertificate_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext
 #else
     size_t keylen = mbedtls_rsa_get_len(rsaContext);
 #endif
-    if(keylen < UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MINASYMKEYLENGTH ||
-       keylen > UA_SECURITYPOLICY_AES128SHA256RSAOAEP_MAXASYMKEYLENGTH)
+    if(keylen < UA_SECURITYPOLICY_AES256SHA256RSAPSS_MINASYMKEYLENGTH ||
+       keylen > UA_SECURITYPOLICY_AES256SHA256RSAPSS_MAXASYMKEYLENGTH)
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
     return UA_STATUSCODE_GOOD;
 }
 
 static void
-channelContext_deleteContext_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc) {
+channelContext_deleteContext_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc) {
     UA_ByteString_clear(&cc->localSymSigningKey);
     UA_ByteString_clear(&cc->localSymEncryptingKey);
     UA_ByteString_clear(&cc->localSymIv);
@@ -440,21 +533,21 @@ channelContext_deleteContext_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelC
 }
 
 static UA_StatusCode
-channelContext_newContext_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securityPolicy,
+channelContext_newContext_sp_aes256sha256rsapss(const UA_SecurityPolicy *securityPolicy,
                                                  const UA_ByteString *remoteCertificate,
                                                  void **pp_contextData) {
     if(securityPolicy == NULL || remoteCertificate == NULL || pp_contextData == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* Allocate the channel context */
-    *pp_contextData = UA_malloc(sizeof(Aes128Sha256PsaOaep_ChannelContext));
+    *pp_contextData = UA_malloc(sizeof(Aes256Sha256RsaPss_ChannelContext));
     if(*pp_contextData == NULL)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    Aes128Sha256PsaOaep_ChannelContext *cc = (Aes128Sha256PsaOaep_ChannelContext *)*pp_contextData;
+    Aes256Sha256RsaPss_ChannelContext *cc = (Aes256Sha256RsaPss_ChannelContext *)*pp_contextData;
 
     /* Initialize the channel context */
-    cc->policyContext = (Aes128Sha256PsaOaep_PolicyContext *)securityPolicy->policyContext;
+    cc->policyContext = (Aes256Sha256RsaPss_PolicyContext *)securityPolicy->policyContext;
 
     UA_ByteString_init(&cc->localSymSigningKey);
     UA_ByteString_init(&cc->localSymEncryptingKey);
@@ -467,16 +560,16 @@ channelContext_newContext_sp_aes128sha256rsaoaep(const UA_SecurityPolicy *securi
     mbedtls_x509_crt_init(&cc->remoteCertificate);
 
     // TODO: this can be optimized so that we dont allocate memory before parsing the certificate
-    UA_StatusCode retval = parseRemoteCertificate_sp_aes128sha256rsaoaep(cc, remoteCertificate);
+    UA_StatusCode retval = parseRemoteCertificate_sp_aes256sha256rsapss(cc, remoteCertificate);
     if(retval != UA_STATUSCODE_GOOD) {
-        channelContext_deleteContext_sp_aes128sha256rsaoaep(cc);
+        channelContext_deleteContext_sp_aes256sha256rsapss(cc);
         *pp_contextData = NULL;
     }
     return retval;
 }
 
 static UA_StatusCode
-channelContext_setLocalSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+channelContext_setLocalSymEncryptingKey_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                                                const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -486,7 +579,7 @@ channelContext_setLocalSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOa
 }
 
 static UA_StatusCode
-channelContext_setLocalSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+channelContext_setLocalSymSigningKey_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                                             const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -497,7 +590,7 @@ channelContext_setLocalSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_
 
 
 static UA_StatusCode
-channelContext_setLocalSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+channelContext_setLocalSymIv_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                                     const UA_ByteString *iv) {
     if(iv == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -507,7 +600,7 @@ channelContext_setLocalSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelC
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+channelContext_setRemoteSymEncryptingKey_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                                                 const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -517,7 +610,7 @@ channelContext_setRemoteSymEncryptingKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaO
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+channelContext_setRemoteSymSigningKey_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                                              const UA_ByteString *key) {
     if(key == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -527,7 +620,7 @@ channelContext_setRemoteSymSigningKey_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep
 }
 
 static UA_StatusCode
-channelContext_setRemoteSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
+channelContext_setRemoteSymIv_sp_aes256sha256rsapss(Aes256Sha256RsaPss_ChannelContext *cc,
                                                      const UA_ByteString *iv) {
     if(iv == NULL || cc == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -537,7 +630,7 @@ channelContext_setRemoteSymIv_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_Channel
 }
 
 static UA_StatusCode
-channelContext_compareCertificate_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
+channelContext_compareCertificate_sp_aes256sha256rsapss(const Aes256Sha256RsaPss_ChannelContext *cc,
                                                          const UA_ByteString *certificate) {
     if(cc == NULL || certificate == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -558,7 +651,7 @@ channelContext_compareCertificate_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOa
 }
 
 static void
-clear_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy) {
+clear_sp_aes256sha256rsapss(UA_SecurityPolicy *securityPolicy) {
     if(securityPolicy == NULL)
         return;
 
@@ -568,7 +661,7 @@ clear_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy) {
         return;
 
     /* delete all allocated members in the context */
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)
+    Aes256Sha256RsaPss_PolicyContext *pc = (Aes256Sha256RsaPss_PolicyContext *)
         securityPolicy->policyContext;
 
     mbedtls_ctr_drbg_free(&pc->drbgContext);
@@ -578,14 +671,14 @@ clear_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy) {
     UA_ByteString_clear(&pc->localCertThumbprint);
 
     UA_LOG_DEBUG(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
-                 "Deleted members of EndpointContext for sp_aes128sha256rsaoaep");
+                 "Deleted members of EndpointContext for sp_aes256sha256rsapss");
 
     UA_free(pc);
     securityPolicy->policyContext = NULL;
 }
 
 static UA_StatusCode
-updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy,
+updateCertificateAndPrivateKey_sp_aes256sha256rsapss(UA_SecurityPolicy *securityPolicy,
                                                       const UA_ByteString newCertificate,
                                                       const UA_ByteString newPrivateKey) {
     if(securityPolicy == NULL)
@@ -594,8 +687,8 @@ updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securit
     if(securityPolicy->policyContext == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    Aes128Sha256PsaOaep_PolicyContext *pc =
-            (Aes128Sha256PsaOaep_PolicyContext *) securityPolicy->policyContext;
+    Aes256Sha256RsaPss_PolicyContext *pc =
+        (Aes256Sha256RsaPss_PolicyContext *) securityPolicy->policyContext;
 
     UA_ByteString_clear(&securityPolicy->localCertificate);
 
@@ -622,7 +715,7 @@ updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securit
         goto error;
     }
 
-    retval = asym_makeThumbprint_sp_aes128sha256rsaoaep(securityPolicy,
+    retval = asym_makeThumbprint_sp_aes256sha256rsapss(securityPolicy,
                                                         &securityPolicy->localCertificate,
                                                         &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
@@ -630,16 +723,16 @@ updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securit
 
     return retval;
 
-    error:
+error:
     UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Could not update certificate and private key");
     if(securityPolicy->policyContext != NULL)
-        clear_sp_aes128sha256rsaoaep(securityPolicy);
+        clear_sp_aes256sha256rsapss(securityPolicy);
     return retval;
 }
 
 static UA_StatusCode
-policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolicy,
+policyContext_newContext_sp_aes256sha256rsapss(UA_SecurityPolicy *securityPolicy,
                                                 const UA_ByteString localPrivateKey) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(securityPolicy == NULL)
@@ -651,8 +744,8 @@ policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolic
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    Aes128Sha256PsaOaep_PolicyContext *pc = (Aes128Sha256PsaOaep_PolicyContext *)
-        UA_malloc(sizeof(Aes128Sha256PsaOaep_PolicyContext));
+    Aes256Sha256RsaPss_PolicyContext *pc = (Aes256Sha256RsaPss_PolicyContext *)
+        UA_malloc(sizeof(Aes256Sha256RsaPss_PolicyContext));
     securityPolicy->policyContext = (void *)pc;
     if(!pc) {
         retval = UA_STATUSCODE_BADOUTOFMEMORY;
@@ -660,7 +753,7 @@ policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolic
     }
 
     /* Initialize the PolicyContext */
-    memset(pc, 0, sizeof(Aes128Sha256PsaOaep_PolicyContext));
+    memset(pc, 0, sizeof(Aes256Sha256RsaPss_PolicyContext));
     mbedtls_ctr_drbg_init(&pc->drbgContext);
     mbedtls_entropy_init(&pc->entropyContext);
     mbedtls_pk_init(&pc->localPrivateKey);
@@ -702,7 +795,7 @@ policyContext_newContext_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securityPolic
     retval = UA_ByteString_allocBuffer(&pc->localCertThumbprint, UA_SHA1_LENGTH);
     if(retval != UA_STATUSCODE_GOOD)
         goto error;
-    retval = asym_makeThumbprint_sp_aes128sha256rsaoaep(securityPolicy,
+    retval = asym_makeThumbprint_sp_aes256sha256rsapss(securityPolicy,
                                                         &securityPolicy->localCertificate,
                                                         &pc->localCertThumbprint);
     if(retval != UA_STATUSCODE_GOOD)
@@ -714,17 +807,17 @@ error:
     UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
                  "Could not create securityContext: %s", UA_StatusCode_name(retval));
     if(securityPolicy->policyContext != NULL)
-        clear_sp_aes128sha256rsaoaep(securityPolicy);
+        clear_sp_aes256sha256rsapss(securityPolicy);
     return retval;
 }
 
 UA_StatusCode
-UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy, const UA_ByteString localCertificate,
-                                 const UA_ByteString localPrivateKey, const UA_Logger *logger) {
+UA_SecurityPolicy_Aes256Sha256RsaPss(UA_SecurityPolicy *policy, const UA_ByteString localCertificate,
+                                      const UA_ByteString localPrivateKey, const UA_Logger *logger) {
     memset(policy, 0, sizeof(UA_SecurityPolicy));
     policy->logger = logger;
 
-    policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep");
+    policy->policyUri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss");
 
     UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
     UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
@@ -739,102 +832,113 @@ UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy, const UA_ByteSt
     UA_SecurityPolicySignatureAlgorithm *asym_signatureAlgorithm =
         &asymmetricModule->cryptoModule.signatureAlgorithm;
     asym_signatureAlgorithm->uri =
-        UA_STRING("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\0");
+        UA_STRING("http://opcfoundation.org/UA/security/rsa-pss-sha2-256\0");
     asym_signatureAlgorithm->verify =
-        (UA_StatusCode (*)(void *, const UA_ByteString *, const UA_ByteString *))asym_verify_sp_aes128sha256rsaoaep;
+        (UA_StatusCode (*)(void *, const UA_ByteString *, const UA_ByteString *))asym_verify_sp_aes256sha256rsapss;
     asym_signatureAlgorithm->sign =
-        (UA_StatusCode (*)(void *, const UA_ByteString *, UA_ByteString *))asym_sign_sp_aes128sha256rsaoaep;
+        (UA_StatusCode (*)(void *, const UA_ByteString *, UA_ByteString *))asym_sign_sp_aes256sha256rsapss;
     asym_signatureAlgorithm->getLocalSignatureSize =
-        (size_t (*)(const void *))asym_getLocalSignatureSize_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))asym_getLocalSignatureSize_sp_aes256sha256rsapss;
     asym_signatureAlgorithm->getRemoteSignatureSize =
-        (size_t (*)(const void *))asym_getRemoteSignatureSize_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))asym_getRemoteSignatureSize_sp_aes256sha256rsapss;
     asym_signatureAlgorithm->getLocalKeyLength = NULL; // TODO: Write function
     asym_signatureAlgorithm->getRemoteKeyLength = NULL; // TODO: Write function
 
     UA_SecurityPolicyEncryptionAlgorithm *asym_encryptionAlgorithm =
         &asymmetricModule->cryptoModule.encryptionAlgorithm;
-    asym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#rsa-oaep\0");
+    asym_encryptionAlgorithm->uri = UA_STRING("http://opcfoundation.org/UA/security/rsa-oaep-sha2-256\0");
     asym_encryptionAlgorithm->encrypt =
-        (UA_StatusCode(*)(void *, UA_ByteString *))asym_encrypt_sp_aes128sha256rsaoaep;
+        (UA_StatusCode(*)(void *, UA_ByteString *))asym_encrypt_sp_aes256sha256rsapss;
     asym_encryptionAlgorithm->decrypt =
-        (UA_StatusCode(*)(void *, UA_ByteString *)) asym_decrypt_sp_aes128sha256rsaoaep;
+        (UA_StatusCode(*)(void *, UA_ByteString *)) asym_decrypt_sp_aes256sha256rsapss;
     asym_encryptionAlgorithm->getLocalKeyLength =
-        (size_t (*)(const void *))asym_getLocalEncryptionKeyLength_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))asym_getLocalEncryptionKeyLength_sp_aes256sha256rsapss;
     asym_encryptionAlgorithm->getRemoteKeyLength =
-        (size_t (*)(const void *))asym_getRemoteEncryptionKeyLength_sp_aes128sha256rsaoaep;
-    asym_encryptionAlgorithm->getRemoteBlockSize = (size_t (*)(const void *))asym_getRemoteBlockSize_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))asym_getRemoteEncryptionKeyLength_sp_aes256sha256rsapss;
+    asym_encryptionAlgorithm->getRemoteBlockSize = (size_t (*)(const void *))asym_getRemoteBlockSize_sp_aes256sha256rsapss;
     asym_encryptionAlgorithm->getRemotePlainTextBlockSize =
-        (size_t (*)(const void *))asym_getRemotePlainTextBlockSize_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))asym_getRemotePlainTextBlockSize_sp_aes256sha256rsapss;
 
-    asymmetricModule->makeCertificateThumbprint = asym_makeThumbprint_sp_aes128sha256rsaoaep;
+    asymmetricModule->makeCertificateThumbprint = asym_makeThumbprint_sp_aes256sha256rsapss;
     asymmetricModule->compareCertificateThumbprint =
-        asymmetricModule_compareCertificateThumbprint_sp_aes128sha256rsaoaep;
+        asymmetricModule_compareCertificateThumbprint_sp_aes256sha256rsapss;
 
     /* SymmetricModule */
-    symmetricModule->generateKey = sym_generateKey_sp_aes128sha256rsaoaep;
-    symmetricModule->generateNonce = sym_generateNonce_sp_aes128sha256rsaoaep;
+    symmetricModule->generateKey = sym_generateKey_sp_aes256sha256rsapss;
+    symmetricModule->generateNonce = sym_generateNonce_sp_aes256sha256rsapss;
 
     UA_SecurityPolicySignatureAlgorithm *sym_signatureAlgorithm =
         &symmetricModule->cryptoModule.signatureAlgorithm;
     sym_signatureAlgorithm->uri =
-        UA_STRING("http://www.w3.org/2000/09/xmldsig#hmac-sha1\0");
+        UA_STRING("http://www.w3.org/2000/09/xmldsig#hmac-sha2-256\0");
     sym_signatureAlgorithm->verify =
-        (UA_StatusCode (*)(void *, const UA_ByteString *, const UA_ByteString *))sym_verify_sp_aes128sha256rsaoaep;
+        (UA_StatusCode (*)(void *, const UA_ByteString *, const UA_ByteString *))sym_verify_sp_aes256sha256rsapss;
     sym_signatureAlgorithm->sign =
-        (UA_StatusCode (*)(void *, const UA_ByteString *, UA_ByteString *))sym_sign_sp_aes128sha256rsaoaep;
-    sym_signatureAlgorithm->getLocalSignatureSize = sym_getSignatureSize_sp_aes128sha256rsaoaep;
-    sym_signatureAlgorithm->getRemoteSignatureSize = sym_getSignatureSize_sp_aes128sha256rsaoaep;
+        (UA_StatusCode (*)(void *, const UA_ByteString *, UA_ByteString *))sym_sign_sp_aes256sha256rsapss;
+    sym_signatureAlgorithm->getLocalSignatureSize = sym_getSignatureSize_sp_aes256sha256rsapss;
+    sym_signatureAlgorithm->getRemoteSignatureSize = sym_getSignatureSize_sp_aes256sha256rsapss;
     sym_signatureAlgorithm->getLocalKeyLength =
-        (size_t (*)(const void *))sym_getSigningKeyLength_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))sym_getSigningKeyLength_sp_aes256sha256rsapss;
     sym_signatureAlgorithm->getRemoteKeyLength =
-        (size_t (*)(const void *))sym_getSigningKeyLength_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))sym_getSigningKeyLength_sp_aes256sha256rsapss;
 
     UA_SecurityPolicyEncryptionAlgorithm *sym_encryptionAlgorithm =
         &symmetricModule->cryptoModule.encryptionAlgorithm;
-    sym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#aes128-cbc");
+    sym_encryptionAlgorithm->uri = UA_STRING("http://www.w3.org/2001/04/xmlenc#aes256-cbc\0");
     sym_encryptionAlgorithm->encrypt =
-        (UA_StatusCode(*)(void *, UA_ByteString *))sym_encrypt_sp_aes128sha256rsaoaep;
+        (UA_StatusCode(*)(void *, UA_ByteString *))sym_encrypt_sp_aes256sha256rsapss;
     sym_encryptionAlgorithm->decrypt =
-        (UA_StatusCode(*)(void *, UA_ByteString *))sym_decrypt_sp_aes128sha256rsaoaep;
-    sym_encryptionAlgorithm->getLocalKeyLength = sym_getEncryptionKeyLength_sp_aes128sha256rsaoaep;
-    sym_encryptionAlgorithm->getRemoteKeyLength = sym_getEncryptionKeyLength_sp_aes128sha256rsaoaep;
+        (UA_StatusCode(*)(void *, UA_ByteString *))sym_decrypt_sp_aes256sha256rsapss;
+    sym_encryptionAlgorithm->getLocalKeyLength = sym_getEncryptionKeyLength_sp_aes256sha256rsapss;
+    sym_encryptionAlgorithm->getRemoteKeyLength = sym_getEncryptionKeyLength_sp_aes256sha256rsapss;
     sym_encryptionAlgorithm->getRemoteBlockSize =
-        (size_t (*)(const void *))sym_getEncryptionBlockSize_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))sym_getEncryptionBlockSize_sp_aes256sha256rsapss;
     sym_encryptionAlgorithm->getRemotePlainTextBlockSize =
-        (size_t (*)(const void *))sym_getPlainTextBlockSize_sp_aes128sha256rsaoaep;
+        (size_t (*)(const void *))sym_getPlainTextBlockSize_sp_aes256sha256rsapss;
     symmetricModule->secureChannelNonceLength = 32;
 
-    // Use the same signature algorithm as the asymmetric component for certificate signing (see standard)
-    policy->certificateSigningAlgorithm = policy->asymmetricModule.cryptoModule.signatureAlgorithm;
+    /* Certificate Signing Algorithm */
+    policy->certificateSigningAlgorithm.uri =
+        UA_STRING("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\0");
+    policy->certificateSigningAlgorithm.verify =
+        (UA_StatusCode (*)(void *, const UA_ByteString *, const UA_ByteString *))asym_cert_verify_sp_aes256sha256rsapss;
+    policy->certificateSigningAlgorithm.sign =
+        (UA_StatusCode (*)(void *, const UA_ByteString *, UA_ByteString *))asym_cert_sign_sp_aes256sha256rsapss;
+    policy->certificateSigningAlgorithm.getLocalSignatureSize =
+        (size_t (*)(const void *))asym_cert_getLocalSignatureSize_sp_aes256sha256rsapss;
+    policy->certificateSigningAlgorithm.getRemoteSignatureSize =
+        (size_t (*)(const void *))asym_cert_getRemoteSignatureSize_sp_aes256sha256rsapss;
+    policy->certificateSigningAlgorithm.getLocalKeyLength = NULL; // TODO: Write function
+    policy->certificateSigningAlgorithm.getRemoteKeyLength = NULL; // TODO: Write function
 
     /* ChannelModule */
-    channelModule->newContext = channelContext_newContext_sp_aes128sha256rsaoaep;
+    channelModule->newContext = channelContext_newContext_sp_aes256sha256rsapss;
     channelModule->deleteContext = (void (*)(void *))
-        channelContext_deleteContext_sp_aes128sha256rsaoaep;
+        channelContext_deleteContext_sp_aes256sha256rsapss;
 
     channelModule->setLocalSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymEncryptingKey_sp_aes128sha256rsaoaep;
+        channelContext_setLocalSymEncryptingKey_sp_aes256sha256rsapss;
     channelModule->setLocalSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymSigningKey_sp_aes128sha256rsaoaep;
+        channelContext_setLocalSymSigningKey_sp_aes256sha256rsapss;
     channelModule->setLocalSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setLocalSymIv_sp_aes128sha256rsaoaep;
+        channelContext_setLocalSymIv_sp_aes256sha256rsapss;
 
     channelModule->setRemoteSymEncryptingKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymEncryptingKey_sp_aes128sha256rsaoaep;
+        channelContext_setRemoteSymEncryptingKey_sp_aes256sha256rsapss;
     channelModule->setRemoteSymSigningKey = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymSigningKey_sp_aes128sha256rsaoaep;
+        channelContext_setRemoteSymSigningKey_sp_aes256sha256rsapss;
     channelModule->setRemoteSymIv = (UA_StatusCode (*)(void *, const UA_ByteString *))
-        channelContext_setRemoteSymIv_sp_aes128sha256rsaoaep;
+        channelContext_setRemoteSymIv_sp_aes256sha256rsapss;
 
     channelModule->compareCertificate = (UA_StatusCode (*)(const void *, const UA_ByteString *))
-        channelContext_compareCertificate_sp_aes128sha256rsaoaep;
+        channelContext_compareCertificate_sp_aes256sha256rsapss;
 
-    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep;
-    policy->clear = clear_sp_aes128sha256rsaoaep;
+    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_aes256sha256rsapss;
+    policy->clear = clear_sp_aes256sha256rsapss;
 
-    UA_StatusCode res = policyContext_newContext_sp_aes128sha256rsaoaep(policy, localPrivateKey);
+    UA_StatusCode res = policyContext_newContext_sp_aes256sha256rsapss(policy, localPrivateKey);
     if(res != UA_STATUSCODE_GOOD)
-        clear_sp_aes128sha256rsaoaep(policy);
+        clear_sp_aes256sha256rsapss(policy);
 
     return res;
 }

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
@@ -150,7 +150,7 @@ asym_decrypt_sp_basic256(Basic256_ChannelContext *cc,
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
     return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
-                                   &cc->policyContext->drbgContext, data);
+                                   &cc->policyContext->drbgContext, data, MBEDTLS_MD_SHA1);
 }
 
 static size_t

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
@@ -212,7 +212,7 @@ asym_decrypt_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
     if(cc == NULL || data == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
     return mbedtls_decrypt_rsaOaep(&cc->policyContext->localPrivateKey,
-                                   &cc->policyContext->drbgContext, data);
+                                   &cc->policyContext->drbgContext, data, MBEDTLS_MD_SHA1);
 }
 
 static size_t

--- a/plugins/crypto/openssl/securitypolicy_openssl_common.h
+++ b/plugins/crypto/openssl/securitypolicy_openssl_common.h
@@ -30,6 +30,12 @@ UA_StatusCode
 UA_OpenSSL_RSA_PKCS1_V15_SHA256_Verify(const UA_ByteString *msg,
                                        X509 *publicKeyX509,
                                        const UA_ByteString *signature);
+
+UA_StatusCode
+UA_OpenSSL_RSA_PSS_SHA256_Verify (const UA_ByteString * msg,
+                                  X509 *publicKeyX509,
+                                  const UA_ByteString * signature);
+
 UA_StatusCode
 UA_Openssl_X509_GetCertificateThumbprint(const UA_ByteString *certficate,
                                          UA_ByteString *pThumbprint,
@@ -37,11 +43,21 @@ UA_Openssl_X509_GetCertificateThumbprint(const UA_ByteString *certficate,
 UA_StatusCode
 UA_Openssl_RSA_Oaep_Decrypt(UA_ByteString *data,
                             EVP_PKEY *privateKey);
+
+UA_StatusCode
+UA_Openssl_RSA_Oaep_Sha2_Decrypt (UA_ByteString *data,
+                            EVP_PKEY *privateKey);
+
 UA_StatusCode
 UA_Openssl_RSA_OAEP_Encrypt(UA_ByteString *data, /* The data that is encrypted.
                                                     The encrypted data will overwrite
                                                     the data that was supplied.  */
                              size_t paddingSize, X509 *publicX509);
+
+UA_StatusCode
+UA_Openssl_RSA_OAEP_SHA2_Encrypt (UA_ByteString * data,
+                                  size_t          paddingSize,
+                                  X509 *          publicX509);
 
 UA_StatusCode
 UA_Openssl_Random_Key_PSHA256_Derive(const UA_ByteString *secret,
@@ -55,6 +71,11 @@ UA_StatusCode
 UA_Openssl_RSA_PKCS1_V15_SHA256_Sign(const UA_ByteString *data,
                                      EVP_PKEY *privateKey,
                                      UA_ByteString *outSignature);
+
+UA_StatusCode
+UA_Openssl_RSA_PSS_SHA256_Sign (const UA_ByteString * message,
+                                EVP_PKEY * privateKey,
+                                UA_ByteString *       outSignature);
 
 UA_StatusCode
 UA_OpenSSL_HMAC_SHA256_Verify(const UA_ByteString *message,

--- a/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
+++ b/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
@@ -1,0 +1,692 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2022 (c) Fraunhofer IOSB (Author: Noel Graf)
+ */
+
+#include <open62541/plugin/securitypolicy_default.h>
+#include <open62541/util.h>
+
+#if defined(UA_ENABLE_ENCRYPTION_OPENSSL) || defined(UA_ENABLE_ENCRYPTION_LIBRESSL)
+
+#include "securitypolicy_openssl_common.h"
+
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+
+#define UA_SHA256_LENGTH 32 /* 256 bit */
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_RSAPADDING_LEN 66
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_SIGNING_KEY_LENGTH 32
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_KEY_LENGTH 32
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_PLAIN_TEXT_BLOCK_SIZE 16
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_MINASYMKEYLENGTH 256
+#define UA_SECURITYPOLICY_AES256SHA256RSAPSS_MAXASYMKEYLENGTH 512
+
+typedef struct {
+    EVP_PKEY *localPrivateKey;
+    UA_ByteString localCertThumbprint;
+    const UA_Logger *logger;
+} Policy_Context_Aes256Sha256RsaPss;
+
+typedef struct {
+    UA_ByteString localSymSigningKey;
+    UA_ByteString localSymEncryptingKey;
+    UA_ByteString localSymIv;
+    UA_ByteString remoteSymSigningKey;
+    UA_ByteString remoteSymEncryptingKey;
+    UA_ByteString remoteSymIv;
+
+    Policy_Context_Aes256Sha256RsaPss *policyContext;
+    UA_ByteString remoteCertificate;
+    X509 *remoteCertificateX509; /* X509 */
+} Channel_Context_Aes256Sha256RsaPss;
+
+/* create the policy context */
+
+static UA_StatusCode
+UA_Policy_Aes256Sha256RsaPss_New_Context(UA_SecurityPolicy *securityPolicy,
+                                          const UA_ByteString localPrivateKey,
+                                          const UA_Logger *logger) {
+    Policy_Context_Aes256Sha256RsaPss *context =
+        (Policy_Context_Aes256Sha256RsaPss *)UA_malloc(
+            sizeof(Policy_Context_Aes256Sha256RsaPss));
+    if(context == NULL) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    context->localPrivateKey = UA_OpenSSL_LoadPrivateKey(&localPrivateKey);
+    if (!context->localPrivateKey) {
+        UA_free(context);
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
+
+    UA_StatusCode retval = UA_Openssl_X509_GetCertificateThumbprint(
+        &securityPolicy->localCertificate, &context->localCertThumbprint, true);
+    if(retval != UA_STATUSCODE_GOOD) {
+        EVP_PKEY_free(context->localPrivateKey);
+        UA_free(context);
+        return retval;
+    }
+
+    context->logger = logger;
+    securityPolicy->policyContext = context;
+
+    return UA_STATUSCODE_GOOD;
+}
+
+/* clear the policy context */
+
+static void
+UA_Policy_Aes256Sha256RsaPss_Clear_Context(UA_SecurityPolicy *policy) {
+    if(policy == NULL)
+        return;
+
+    UA_ByteString_clear(&policy->localCertificate);
+
+    /* delete all allocated members in the context */
+
+    Policy_Context_Aes256Sha256RsaPss *pc =
+        (Policy_Context_Aes256Sha256RsaPss *)policy->policyContext;
+    if (pc == NULL) {
+        return;
+    }
+
+    EVP_PKEY_free(pc->localPrivateKey);
+    UA_ByteString_clear(&pc->localCertThumbprint);
+    UA_free(pc);
+
+    return;
+}
+
+/* create the channel context */
+
+static UA_StatusCode
+UA_ChannelModule_Aes256Sha256RsaPss_New_Context(const UA_SecurityPolicy *securityPolicy,
+                                                 const UA_ByteString *remoteCertificate,
+                                                 void **channelContext) {
+    if(securityPolicy == NULL || remoteCertificate == NULL || channelContext == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    Channel_Context_Aes256Sha256RsaPss *context =
+        (Channel_Context_Aes256Sha256RsaPss *)UA_malloc(
+            sizeof(Channel_Context_Aes256Sha256RsaPss));
+    if(context == NULL) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    UA_ByteString_init(&context->localSymSigningKey);
+    UA_ByteString_init(&context->localSymEncryptingKey);
+    UA_ByteString_init(&context->localSymIv);
+    UA_ByteString_init(&context->remoteSymSigningKey);
+    UA_ByteString_init(&context->remoteSymEncryptingKey);
+    UA_ByteString_init(&context->remoteSymIv);
+
+    UA_StatusCode retval =
+        UA_copyCertificate(&context->remoteCertificate, remoteCertificate);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_free(context);
+        return retval;
+    }
+
+    /* decode to X509 */
+    context->remoteCertificateX509 = UA_OpenSSL_LoadCertificate(&context->remoteCertificate);
+    if (context->remoteCertificateX509 == NULL) {
+        UA_ByteString_clear (&context->remoteCertificate);
+        UA_free (context);
+        return UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
+    }
+
+    context->policyContext =
+        (Policy_Context_Aes256Sha256RsaPss *)(securityPolicy->policyContext);
+
+    *channelContext = context;
+
+    UA_LOG_INFO(
+        securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+        "The Aes256Sha256RsaPss security policy channel with openssl is created.");
+
+    return UA_STATUSCODE_GOOD;
+}
+
+/* delete the channel context */
+
+static void
+UA_ChannelModule_Aes256Sha256RsaPss_Delete_Context(void *channelContext) {
+    if(channelContext != NULL) {
+        Channel_Context_Aes256Sha256RsaPss *cc =
+            (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+        X509_free(cc->remoteCertificateX509);
+        UA_ByteString_clear(&cc->remoteCertificate);
+        UA_ByteString_clear(&cc->localSymSigningKey);
+        UA_ByteString_clear(&cc->localSymEncryptingKey);
+        UA_ByteString_clear(&cc->localSymIv);
+        UA_ByteString_clear(&cc->remoteSymSigningKey);
+        UA_ByteString_clear(&cc->remoteSymEncryptingKey);
+        UA_ByteString_clear(&cc->remoteSymIv);
+
+        UA_LOG_INFO(
+            cc->policyContext->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+            "The Aes256Sha256RsaPss security policy channel with openssl is deleted.");
+        UA_free(cc);
+    }
+}
+
+/* Verifies the signature of the message using the provided keys in the context.
+ * AsymmetricSignatureAlgorithm_RSA-PKCS15-SHA2-256
+ */
+
+static UA_StatusCode
+UA_AsySig_Aes256Sha256RsaPss_Verify(void *channelContext, const UA_ByteString *message,
+                                     const UA_ByteString *signature) {
+    if(message == NULL || signature == NULL || channelContext == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_StatusCode retval = UA_OpenSSL_RSA_PSS_SHA256_Verify(
+        message, cc->remoteCertificateX509, signature);
+
+    return retval;
+}
+
+/* Compares the supplied certificate with the certificate
+ * in the endpoint context
+ */
+
+static UA_StatusCode
+UA_compareCertificateThumbprint_Aes256Sha256RsaPss(const UA_SecurityPolicy *securityPolicy,
+                                                    const UA_ByteString *certificateThumbprint) {
+    if(securityPolicy == NULL || certificateThumbprint == NULL) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
+    Policy_Context_Aes256Sha256RsaPss *pc =
+        (Policy_Context_Aes256Sha256RsaPss *)securityPolicy->policyContext;
+    if(!UA_ByteString_equal(certificateThumbprint, &pc->localCertThumbprint))
+        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+    return UA_STATUSCODE_GOOD;
+}
+
+/* Generates a thumbprint for the specified certificate */
+
+static UA_StatusCode
+UA_makeCertificateThumbprint_Aes256Sha256RsaPss(const UA_SecurityPolicy *securityPolicy,
+                                                 const UA_ByteString *certificate,
+                                                 UA_ByteString *thumbprint) {
+    return UA_Openssl_X509_GetCertificateThumbprint(certificate, thumbprint, false);
+}
+
+static UA_StatusCode
+UA_Asym_Aes256Sha256RsaPss_Decrypt(void *channelContext, UA_ByteString *data) {
+    if(channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    Channel_Context_Aes256Sha256RsaPss *cc = (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_StatusCode ret = UA_Openssl_RSA_Oaep_Sha2_Decrypt(data, cc->policyContext->localPrivateKey);
+    return ret;
+}
+
+static size_t
+UA_Asym_Aes256Sha256RsaPss_getRemoteSignatureSize(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc = (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen;
+}
+
+static size_t
+UA_AsySig_Aes256Sha256RsaPss_getLocalSignatureSize(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc = (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    Policy_Context_Aes256Sha256RsaPss *pc = cc->policyContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Private_GetKeyLength(pc->localPrivateKey, &keyLen);
+    return (size_t)keyLen;
+}
+
+static size_t
+UA_AsymEn_Aes256Sha256RsaPss_getRemotePlainTextBlockSize(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc =
+        (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen - UA_SECURITYPOLICY_AES256SHA256RSAPSS_RSAPADDING_LEN;
+}
+
+static size_t
+UA_AsymEn_Aes256Sha256RsaPss_getRemoteBlockSize(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc =
+        (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen;
+}
+
+static size_t
+UA_AsymEn_Aes256Sha256RsaPss_getRemoteKeyLength(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc =
+        (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen * 8;
+}
+
+static UA_StatusCode
+UA_Sym_Aes256Sha256RsaPss_generateNonce(void *policyContext,
+                                         UA_ByteString *out) {
+    UA_Int32 rc = RAND_bytes(out->data, (int)out->length);
+    if(rc != 1) {
+        return UA_STATUSCODE_BADUNEXPECTEDERROR;
+    }
+    return UA_STATUSCODE_GOOD;
+}
+
+static size_t
+UA_SymEn_Aes256Sha256RsaPss_getLocalKeyLength(const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_KEY_LENGTH;
+}
+
+static size_t
+UA_SymSig_Aes256Sha256RsaPss_getLocalKeyLength(const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_SIGNING_KEY_LENGTH;
+}
+
+static UA_StatusCode
+UA_Sym_Aes256Sha256RsaPss_generateKey(void *policyContext,
+                                       const UA_ByteString *secret,
+                                       const UA_ByteString *seed, UA_ByteString *out) {
+    return UA_Openssl_Random_Key_PSHA256_Derive(secret, seed, out);
+}
+
+static UA_StatusCode
+UA_CertSig_Aes256Sha256RsaPss_Verify(void *channelContext, const UA_ByteString *message,
+                                     const UA_ByteString *signature) {
+    if(message == NULL || signature == NULL || channelContext == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_StatusCode retval = UA_OpenSSL_RSA_PKCS1_V15_SHA256_Verify(
+        message, cc->remoteCertificateX509, signature);
+
+    return retval;
+}
+
+static UA_StatusCode
+UA_CertSig_Aes256Sha256RsaPss_sign(void *channelContext, const UA_ByteString *message,
+                                   UA_ByteString *signature) {
+    if(channelContext == NULL || message == NULL ||
+       signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc = (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    Policy_Context_Aes256Sha256RsaPss *pc = cc->policyContext;
+    return UA_Openssl_RSA_PKCS1_V15_SHA256_Sign(message, pc->localPrivateKey, signature);
+}
+
+static size_t
+UA_CertSig_Aes256Sha256RsaPss_getRemoteSignatureSize(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc = (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Public_GetKeyLength(cc->remoteCertificateX509, &keyLen);
+    return (size_t)keyLen;
+}
+
+static size_t
+UA_CertSig_Aes256Sha256RsaPss_getLocalSignatureSize(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc = (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    Policy_Context_Aes256Sha256RsaPss *pc = cc->policyContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Private_GetKeyLength(pc->localPrivateKey, &keyLen);
+    return (size_t)keyLen;
+}
+
+static UA_StatusCode
+UA_ChannelModule_Aes256Sha256RsaPss_setLocalSymSigningKey(void *channelContext,
+                                                           const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_ByteString_clear(&cc->localSymSigningKey);
+    return UA_ByteString_copy(key, &cc->localSymSigningKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes256Sha256RsaPss_setLocalSymEncryptingKey(void *channelContext,
+                                                         const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_ByteString_clear(&cc->localSymEncryptingKey);
+    return UA_ByteString_copy(key, &cc->localSymEncryptingKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes256Sha256RsaPss_setLocalSymIv(void *channelContext,
+                                              const UA_ByteString *iv) {
+    if(iv == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_ByteString_clear(&cc->localSymIv);
+    return UA_ByteString_copy(iv, &cc->localSymIv);
+}
+
+static size_t
+UA_SymEn_Aes256Sha256RsaPss_getRemoteKeyLength(const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_KEY_LENGTH;
+}
+
+static size_t
+UA_SymEn_Aes256Sha256RsaPss_getBlockSize(const void *channelContext) {
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_ENCRYPTION_BLOCK_SIZE;
+}
+
+static size_t
+UA_SymSig_Aes256Sha256RsaPss_getRemoteKeyLength(const void *channelContext) {
+    /* 32 bytes 256 bits */
+    return UA_SECURITYPOLICY_AES256SHA256RSAPSS_SYM_SIGNING_KEY_LENGTH;
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes256Sha256RsaPss_setRemoteSymSigningKey(void *channelContext,
+                                                       const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_ByteString_clear(&cc->remoteSymSigningKey);
+    return UA_ByteString_copy(key, &cc->remoteSymSigningKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes256Sha256RsaPss_setRemoteSymEncryptingKey(void *channelContext,
+                                                          const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_ByteString_clear(&cc->remoteSymEncryptingKey);
+    return UA_ByteString_copy(key, &cc->remoteSymEncryptingKey);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes256Sha256RsaPss_setRemoteSymIv(void *channelContext,
+                                               const UA_ByteString *key) {
+    if(key == NULL || channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    UA_ByteString_clear(&cc->remoteSymIv);
+    return UA_ByteString_copy(key, &cc->remoteSymIv);
+}
+
+static UA_StatusCode
+UA_AsySig_Aes256Sha256RsaPss_sign(void *channelContext, const UA_ByteString *message,
+                                   UA_ByteString *signature) {
+    if(channelContext == NULL || message == NULL ||
+       signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    Policy_Context_Aes256Sha256RsaPss *pc = cc->policyContext;
+    return UA_Openssl_RSA_PSS_SHA256_Sign(message, pc->localPrivateKey, signature);
+}
+
+static UA_StatusCode
+UA_AsymEn_Aes256Sha256RsaPss_encrypt(void *channelContext, UA_ByteString *data) {
+    if(channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    return UA_Openssl_RSA_OAEP_SHA2_Encrypt(
+        data, UA_SECURITYPOLICY_AES256SHA256RSAPSS_RSAPADDING_LEN,
+        cc->remoteCertificateX509);
+}
+
+static size_t
+UA_SymSig_Aes256Sha256RsaPss_getRemoteSignatureSize(const void *channelContext) {
+    return UA_SHA256_LENGTH;
+}
+
+static UA_StatusCode
+UA_SymSig_Aes256Sha256RsaPss_verify(void *channelContext, const UA_ByteString *message,
+                                     const UA_ByteString *signature) {
+    if(channelContext == NULL || message == NULL ||
+       signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    return UA_OpenSSL_HMAC_SHA256_Verify(message, &cc->remoteSymSigningKey, signature);
+}
+
+static UA_StatusCode
+UA_SymSig_Aes256Sha256RsaPss_sign(void *channelContext, const UA_ByteString *message,
+                                   UA_ByteString *signature) {
+    if(channelContext == NULL || message == NULL ||
+       signature == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    return UA_OpenSSL_HMAC_SHA256_Sign(message, &cc->localSymSigningKey, signature);
+}
+
+static size_t
+UA_SymSig_Aes256Sha256RsaPss_getLocalSignatureSize(const void *channelContext) {
+    return UA_SHA256_LENGTH;
+}
+
+static UA_StatusCode
+UA_SymEn_Aes256Sha256RsaPss_decrypt(void *channelContext, UA_ByteString *data) {
+    if(channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    return UA_OpenSSL_AES_256_CBC_Decrypt(&cc->remoteSymIv, &cc->remoteSymEncryptingKey,
+                                          data);
+}
+
+static UA_StatusCode
+UA_SymEn_Aes256Sha256RsaPss_encrypt(void *channelContext, UA_ByteString *data) {
+    if(channelContext == NULL || data == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Channel_Context_Aes256Sha256RsaPss *cc =
+        (Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    return UA_OpenSSL_AES_256_CBC_Encrypt(&cc->localSymIv, &cc->localSymEncryptingKey,
+                                          data);
+}
+
+static UA_StatusCode
+UA_ChannelM_Aes256Sha256RsaPss_compareCertificate(const void *channelContext,
+                                                   const UA_ByteString *certificate) {
+    if(channelContext == NULL || certificate == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc =
+        (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    return UA_OpenSSL_X509_compare(certificate, cc->remoteCertificateX509);
+}
+
+static size_t
+UA_AsymEn_Aes256Sha256RsaPss_getLocalKeyLength(const void *channelContext) {
+    if(channelContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    const Channel_Context_Aes256Sha256RsaPss *cc =
+        (const Channel_Context_Aes256Sha256RsaPss *)channelContext;
+    Policy_Context_Aes256Sha256RsaPss *pc = cc->policyContext;
+    UA_Int32 keyLen = 0;
+    UA_Openssl_RSA_Private_GetKeyLength(pc->localPrivateKey, &keyLen);
+    return (size_t)keyLen * 8;
+}
+
+/* the main entry of Aes256Sha256RsaPss */
+
+UA_StatusCode
+UA_SecurityPolicy_Aes256Sha256RsaPss(UA_SecurityPolicy *policy,
+                                      const UA_ByteString localCertificate,
+                                      const UA_ByteString localPrivateKey,
+                                      const UA_Logger *logger) {
+
+    UA_SecurityPolicyAsymmetricModule *const asymmetricModule = &policy->asymmetricModule;
+    UA_SecurityPolicySymmetricModule *const symmetricModule = &policy->symmetricModule;
+    UA_SecurityPolicyChannelModule *const channelModule = &policy->channelModule;
+    UA_StatusCode retval;
+
+    UA_LOG_INFO(logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                "The Aes256Sha256RsaPss security policy with openssl is added.");
+
+    UA_Openssl_Init();
+    memset(policy, 0, sizeof(UA_SecurityPolicy));
+    policy->logger = logger;
+    policy->policyUri =
+        UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss\0");
+
+    /* set ChannelModule context  */
+
+    channelModule->newContext = UA_ChannelModule_Aes256Sha256RsaPss_New_Context;
+    channelModule->deleteContext = UA_ChannelModule_Aes256Sha256RsaPss_Delete_Context;
+    channelModule->setLocalSymSigningKey =
+        UA_ChannelModule_Aes256Sha256RsaPss_setLocalSymSigningKey;
+    channelModule->setLocalSymEncryptingKey =
+        UA_ChannelM_Aes256Sha256RsaPss_setLocalSymEncryptingKey;
+    channelModule->setLocalSymIv = UA_ChannelM_Aes256Sha256RsaPss_setLocalSymIv;
+    channelModule->setRemoteSymSigningKey =
+        UA_ChannelM_Aes256Sha256RsaPss_setRemoteSymSigningKey;
+    channelModule->setRemoteSymEncryptingKey =
+        UA_ChannelM_Aes256Sha256RsaPss_setRemoteSymEncryptingKey;
+    channelModule->setRemoteSymIv = UA_ChannelM_Aes256Sha256RsaPss_setRemoteSymIv;
+    channelModule->compareCertificate =
+        UA_ChannelM_Aes256Sha256RsaPss_compareCertificate;
+
+    /* Copy the certificate and add a NULL to the end */
+
+    retval = UA_copyCertificate(&policy->localCertificate, &localCertificate);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* AsymmetricModule - signature algorithm */
+
+    UA_SecurityPolicySignatureAlgorithm *asySigAlgorithm =
+        &asymmetricModule->cryptoModule.signatureAlgorithm;
+    asySigAlgorithm->uri =
+        UA_STRING("http://opcfoundation.org/UA/security/rsa-pss-sha2-256\0");
+    asySigAlgorithm->verify = UA_AsySig_Aes256Sha256RsaPss_Verify;
+    asySigAlgorithm->getRemoteSignatureSize =
+        UA_Asym_Aes256Sha256RsaPss_getRemoteSignatureSize;
+    asySigAlgorithm->getLocalSignatureSize =
+        UA_AsySig_Aes256Sha256RsaPss_getLocalSignatureSize;
+    asySigAlgorithm->sign = UA_AsySig_Aes256Sha256RsaPss_sign;
+    asySigAlgorithm->getLocalKeyLength = NULL;
+    asySigAlgorithm->getRemoteKeyLength = NULL;
+
+    /*  AsymmetricModule encryption algorithm */
+
+    UA_SecurityPolicyEncryptionAlgorithm *asymEncryAlg =
+        &asymmetricModule->cryptoModule.encryptionAlgorithm;
+    asymEncryAlg->uri = UA_STRING("http://opcfoundation.org/UA/security/rsa-oaep-sha2-256\0");
+    asymEncryAlg->decrypt = UA_Asym_Aes256Sha256RsaPss_Decrypt;
+    asymEncryAlg->getRemotePlainTextBlockSize =
+        UA_AsymEn_Aes256Sha256RsaPss_getRemotePlainTextBlockSize;
+    asymEncryAlg->getRemoteBlockSize = UA_AsymEn_Aes256Sha256RsaPss_getRemoteBlockSize;
+    asymEncryAlg->getRemoteKeyLength = UA_AsymEn_Aes256Sha256RsaPss_getRemoteKeyLength;
+    asymEncryAlg->encrypt = UA_AsymEn_Aes256Sha256RsaPss_encrypt;
+    asymEncryAlg->getLocalKeyLength = UA_AsymEn_Aes256Sha256RsaPss_getLocalKeyLength;
+
+    /* asymmetricModule */
+
+    asymmetricModule->compareCertificateThumbprint =
+        UA_compareCertificateThumbprint_Aes256Sha256RsaPss;
+    asymmetricModule->makeCertificateThumbprint =
+        UA_makeCertificateThumbprint_Aes256Sha256RsaPss;
+
+    /* SymmetricModule */
+
+    symmetricModule->secureChannelNonceLength = 32;
+    symmetricModule->generateNonce = UA_Sym_Aes256Sha256RsaPss_generateNonce;
+    symmetricModule->generateKey = UA_Sym_Aes256Sha256RsaPss_generateKey;
+
+    /* Symmetric encryption Algorithm */
+
+    UA_SecurityPolicyEncryptionAlgorithm *symEncryptionAlgorithm =
+        &symmetricModule->cryptoModule.encryptionAlgorithm;
+    symEncryptionAlgorithm->uri =
+        UA_STRING("http://www.w3.org/2001/04/xmlenc#aes256-cbc\0");
+    symEncryptionAlgorithm->getLocalKeyLength = UA_SymEn_Aes256Sha256RsaPss_getLocalKeyLength;
+    symEncryptionAlgorithm->getRemoteKeyLength = UA_SymEn_Aes256Sha256RsaPss_getRemoteKeyLength;
+    symEncryptionAlgorithm->getRemoteBlockSize = UA_SymEn_Aes256Sha256RsaPss_getBlockSize;
+    symEncryptionAlgorithm->getRemotePlainTextBlockSize = UA_SymEn_Aes256Sha256RsaPss_getBlockSize;
+    symEncryptionAlgorithm->decrypt = UA_SymEn_Aes256Sha256RsaPss_decrypt;
+    symEncryptionAlgorithm->encrypt = UA_SymEn_Aes256Sha256RsaPss_encrypt;
+
+    /* Symmetric signature Algorithm */
+
+    UA_SecurityPolicySignatureAlgorithm *symSignatureAlgorithm =
+        &symmetricModule->cryptoModule.signatureAlgorithm;
+    symSignatureAlgorithm->uri = UA_STRING("http://www.w3.org/2000/09/xmldsig#hmac-sha2-256\0");
+    symSignatureAlgorithm->getLocalKeyLength = UA_SymSig_Aes256Sha256RsaPss_getLocalKeyLength;
+    symSignatureAlgorithm->getRemoteKeyLength = UA_SymSig_Aes256Sha256RsaPss_getRemoteKeyLength;
+    symSignatureAlgorithm->getRemoteSignatureSize = UA_SymSig_Aes256Sha256RsaPss_getRemoteSignatureSize;
+    symSignatureAlgorithm->verify = UA_SymSig_Aes256Sha256RsaPss_verify;
+    symSignatureAlgorithm->sign = UA_SymSig_Aes256Sha256RsaPss_sign;
+    symSignatureAlgorithm->getLocalSignatureSize = UA_SymSig_Aes256Sha256RsaPss_getLocalSignatureSize;
+
+    retval = UA_Policy_Aes256Sha256RsaPss_New_Context(policy, localPrivateKey, logger);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_ByteString_clear(&policy->localCertificate);
+        return retval;
+    }
+    policy->clear = UA_Policy_Aes256Sha256RsaPss_Clear_Context;
+
+    /* Certificate Signing Algorithm */
+    policy->certificateSigningAlgorithm.uri =
+        UA_STRING("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\0");
+    policy->certificateSigningAlgorithm.verify =
+        (UA_StatusCode (*)(void *, const UA_ByteString *, const UA_ByteString *))UA_CertSig_Aes256Sha256RsaPss_Verify;
+    policy->certificateSigningAlgorithm.sign =
+        (UA_StatusCode (*)(void *, const UA_ByteString *, UA_ByteString *))UA_CertSig_Aes256Sha256RsaPss_sign;
+    policy->certificateSigningAlgorithm.getLocalSignatureSize =
+        (size_t (*)(const void *))UA_CertSig_Aes256Sha256RsaPss_getLocalSignatureSize;
+    policy->certificateSigningAlgorithm.getRemoteSignatureSize =
+        (size_t (*)(const void *))UA_CertSig_Aes256Sha256RsaPss_getRemoteSignatureSize;
+    policy->certificateSigningAlgorithm.getLocalKeyLength = NULL; // TODO: Write function
+    policy->certificateSigningAlgorithm.getRemoteKeyLength = NULL; // TODO: Write function
+
+    return UA_STATUSCODE_GOOD;
+}
+
+#endif

--- a/plugins/include/open62541/plugin/securitypolicy_default.h
+++ b/plugins/include/open62541/plugin/securitypolicy_default.h
@@ -44,6 +44,12 @@ UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy,
                                  const UA_ByteString localPrivateKey,
                                  const UA_Logger *logger);
 
+UA_EXPORT UA_StatusCode
+UA_SecurityPolicy_Aes256Sha256RsaPss(UA_SecurityPolicy *policy,
+                                     const UA_ByteString localCertificate,
+                                     const UA_ByteString localPrivateKey,
+                                     const UA_Logger *logger);
+
 #endif
 
 #ifdef UA_ENABLE_PUBSUB_ENCRYPTION

--- a/plugins/include/open62541/server_config_default.h
+++ b/plugins/include/open62541/server_config_default.h
@@ -181,6 +181,21 @@ UA_ServerConfig_addSecurityPolicyAes128Sha256RsaOaep(UA_ServerConfig *config,
                                                      const UA_ByteString *certificate,
                                                      const UA_ByteString *privateKey);
 
+/* Adds the security policy ``SecurityPolicy#Aes256Sha256RsaPss`` to the server. A
+ * server certificate may be supplied but is optional.
+ *
+ * Certificate verification should be configured before calling this
+ * function. See PKI plugin.
+ *
+ * @param config The configuration to manipulate
+ * @param certificate The server certificate.
+ * @param privateKey The private key that corresponds to the certificate.
+ */
+UA_EXPORT UA_StatusCode
+UA_ServerConfig_addSecurityPolicyAes256Sha256RsaPss(UA_ServerConfig *config,
+                                                    const UA_ByteString *certificate,
+                                                    const UA_ByteString *privateKey);
+
 /* Adds all supported security policies and sets up certificate
  * validation procedures.
  *

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -100,9 +100,9 @@ signActivateSessionRequest(UA_Client *client, UA_SecureChannel *channel,
     UA_SignatureData *sd = &request->clientSignature;
 
     /* Prepare the clientSignature */
-    size_t signatureSize = sp->certificateSigningAlgorithm.
+    size_t signatureSize = sp->asymmetricModule.cryptoModule.signatureAlgorithm.
         getLocalSignatureSize(channel->channelContext);
-    UA_StatusCode retval = UA_String_copy(&sp->certificateSigningAlgorithm.uri,
+    UA_StatusCode retval = UA_String_copy(&sp->asymmetricModule.cryptoModule.signatureAlgorithm.uri,
                                           &sd->algorithm);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
@@ -127,7 +127,7 @@ signActivateSessionRequest(UA_Client *client, UA_SecureChannel *channel,
            channel->remoteCertificate.length);
     memcpy(dataToSign.data + channel->remoteCertificate.length,
            client->serverSessionNonce.data, client->serverSessionNonce.length);
-    retval = sp->certificateSigningAlgorithm.sign(channel->channelContext,
+    retval = sp->asymmetricModule.cryptoModule.signatureAlgorithm.sign(channel->channelContext,
                                                   &dataToSign, &sd->signature);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
@@ -150,9 +150,9 @@ if(client->config.userTokenPolicy.tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
     if(retval != UA_STATUSCODE_GOOD)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    size_t userTokenSignatureSize = utpSecurityPolicy->certificateSigningAlgorithm.
+    size_t userTokenSignatureSize = utpSecurityPolicy->asymmetricModule.cryptoModule.signatureAlgorithm.
         getLocalSignatureSize(tempChannelContext);
-    retval = UA_String_copy(&utpSecurityPolicy->certificateSigningAlgorithm.uri,
+    retval = UA_String_copy(&utpSecurityPolicy->asymmetricModule.cryptoModule.signatureAlgorithm.uri,
                             &utsd->algorithm);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
@@ -177,7 +177,7 @@ if(client->config.userTokenPolicy.tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
            channel->remoteCertificate.length);
     memcpy(userTokenSign.data + channel->remoteCertificate.length,
            client->serverSessionNonce.data, client->serverSessionNonce.length);
-    retval = utpSecurityPolicy->certificateSigningAlgorithm.sign(tempChannelContext,
+    retval = utpSecurityPolicy->asymmetricModule.cryptoModule.signatureAlgorithm.sign(tempChannelContext,
                                                   &userTokenSign, &utsd->signature);
     /* Clean up */
     UA_ByteString_clear(&userTokenSign);
@@ -316,7 +316,7 @@ checkCreateSessionSignature(UA_Client *client, const UA_SecureChannel *channel,
     memcpy(dataToVerify.data + lc->length, client->clientSessionNonce.data,
            client->clientSessionNonce.length);
 
-    retval = sp->certificateSigningAlgorithm.verify(channel->channelContext, &dataToVerify,
+    retval = sp->asymmetricModule.cryptoModule.signatureAlgorithm.verify(channel->channelContext, &dataToVerify,
                                                     &response->serverSignature.signature);
     UA_ByteString_clear(&dataToVerify);
     return retval;

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -190,9 +190,9 @@ signCreateSessionResponse(UA_Server *server, UA_SecureChannel *channel,
     UA_SignatureData *signatureData = &response->serverSignature;
 
     /* Prepare the signature */
-    size_t signatureSize = securityPolicy->certificateSigningAlgorithm.
+    size_t signatureSize = securityPolicy->asymmetricModule.cryptoModule.signatureAlgorithm.
         getLocalSignatureSize(channel->channelContext);
-    UA_StatusCode retval = UA_String_copy(&securityPolicy->certificateSigningAlgorithm.uri,
+    UA_StatusCode retval = UA_String_copy(&securityPolicy->asymmetricModule.cryptoModule.signatureAlgorithm.uri,
                                           &signatureData->algorithm);
     retval |= UA_ByteString_allocBuffer(&signatureData->signature, signatureSize);
     if(retval != UA_STATUSCODE_GOOD)
@@ -209,7 +209,7 @@ signCreateSessionResponse(UA_Server *server, UA_SecureChannel *channel,
     memcpy(dataToSign.data, request->clientCertificate.data, request->clientCertificate.length);
     memcpy(dataToSign.data + request->clientCertificate.length,
            request->clientNonce.data, request->clientNonce.length);
-    retval = securityPolicy->certificateSigningAlgorithm.
+    retval = securityPolicy->asymmetricModule.cryptoModule.signatureAlgorithm.
         sign(channel->channelContext, &dataToSign, &signatureData->signature);
 
     /* Clean up */
@@ -435,7 +435,7 @@ checkSignature(const UA_Server *server, const UA_SecurityPolicy *securityPolicy,
     memcpy(dataToVerify.data, localCertificate->data, localCertificate->length);
     memcpy(dataToVerify.data + localCertificate->length,
            serverNonce->data, serverNonce->length);
-    retval = securityPolicy->certificateSigningAlgorithm.
+    retval = securityPolicy->asymmetricModule.cryptoModule.signatureAlgorithm.
         verify(channelContext, &dataToVerify, &signature->signature);
     UA_ByteString_clear(&dataToVerify);
     if(retval != UA_STATUSCODE_GOOD)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ if(UA_ENABLE_ENCRYPTION_MBEDTLS)
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
+       ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_aes256sha256rsapss.c
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_pki_mbedtls.c)
 endif()
 
@@ -122,6 +123,7 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_ENCRYPTION_LIBRESSL)
               ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_basic256.c
               ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_basic256sha256.c
               ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
+              ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
               ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_openssl_create_certificate.c
               ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/ua_pki_openssl.c)
 endif()
@@ -427,6 +429,7 @@ if(UA_ENABLE_ENCRYPTION_MBEDTLS)
     ua_add_test(encryption/check_encryption_basic256.c)
     ua_add_test(encryption/check_encryption_basic256sha256.c)
     ua_add_test(encryption/check_encryption_aes128sha256rsaoaep.c)
+    ua_add_test(encryption/check_encryption_aes256sha256rsapss.c)
 endif()
 
 if(UA_ENABLE_ENCRYPTION_MBEDTLS AND UA_ENABLE_CERT_REJECTED_DIR)
@@ -438,6 +441,7 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_ENCRYPTION_LIBRESSL)
     ua_add_test(encryption/check_encryption_basic256.c)
     ua_add_test(encryption/check_encryption_basic256sha256.c)
     ua_add_test(encryption/check_encryption_aes128sha256rsaoaep.c)
+    ua_add_test(encryption/check_encryption_aes256sha256rsapss.c)
     ua_add_test(encryption/check_cert_generation.c)
 endif()
 

--- a/tests/encryption/check_encryption_aes256sha256rsapss.c
+++ b/tests/encryption/check_encryption_aes256sha256rsapss.c
@@ -1,0 +1,287 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2022 (c) Fraunhofer IOSB (Author: Noel Graf)
+ *
+ */
+
+#include <open62541/client.h>
+#include <open62541/client_config_default.h>
+#include <open62541/client_highlevel.h>
+#include <open62541/plugin/securitypolicy.h>
+#include <open62541/plugin/pki_default.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+
+#include "client/ua_client_internal.h"
+#include "ua_server_internal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "certificates.h"
+#include "check.h"
+#include "testing_clock.h"
+#include "testing_networklayers.h"
+#include "thread_wrapper.h"
+
+UA_Server *server;
+UA_Boolean running;
+THREAD_HANDLE server_thread;
+
+THREAD_CALLBACK(serverloop) {
+    while(running)
+    UA_Server_run_iterate(server, true);
+    return 0;
+}
+
+static void setup(void) {
+    running = true;
+
+    /* Load certificate and private key */
+    UA_ByteString certificate;
+    certificate.length = CERT_DER_LENGTH;
+    certificate.data = CERT_DER_DATA;
+
+    UA_ByteString privateKey;
+    privateKey.length = KEY_DER_LENGTH;
+    privateKey.data = KEY_DER_DATA;
+
+    /* Load the trustlist */
+    size_t trustListSize = 0;
+    UA_ByteString *trustList = NULL;
+
+    /* Load the issuerList */
+    size_t issuerListSize = 0;
+    UA_ByteString *issuerList = NULL;
+
+    /* TODO test trustList
+    if(argc > 3)
+        trustListSize = (size_t)argc-3;
+    UA_STACKARRAY(UA_ByteString, trustList, trustListSize);
+    for(size_t i = 0; i < trustListSize; i++)
+        trustList[i] = loadFile(argv[i+3]);
+    */
+
+    /* Loading of a revocation list currently unsupported */
+    UA_ByteString *revocationList = NULL;
+    size_t revocationListSize = 0;
+
+    server = UA_Server_new();
+    ck_assert(server != NULL);
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
+                                                   trustList, trustListSize,
+                                                   issuerList, issuerListSize,
+                                                   revocationList, revocationListSize);
+
+    UA_CertificateVerification_AcceptAll(&config->secureChannelPKI);
+    UA_CertificateVerification_AcceptAll(&config->sessionPKI);
+
+    /* Set the ApplicationUri used in the certificate */
+    UA_String_clear(&config->applicationDescription.applicationUri);
+    config->applicationDescription.applicationUri =
+        UA_STRING_ALLOC("urn:unconfigured:application");
+
+    for(size_t i = 0; i < trustListSize; i++)
+        UA_ByteString_clear(&trustList[i]);
+
+    UA_Server_run_startup(server);
+    THREAD_CREATE(server_thread, serverloop);
+}
+
+static void teardown(void) {
+    running = false;
+    THREAD_JOIN(server_thread);
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(encryption_connect) {
+    UA_Client *client = NULL;
+    UA_EndpointDescription* endpointArray = NULL;
+    size_t endpointArraySize = 0;
+    UA_ByteString *trustList = NULL;
+    size_t trustListSize = 0;
+    UA_ByteString *revocationList = NULL;
+    size_t revocationListSize = 0;
+
+    /* Load certificate and private key */
+    UA_ByteString certificate;
+    certificate.length = CERT_DER_LENGTH;
+    certificate.data = CERT_DER_DATA;
+    ck_assert_uint_ne(certificate.length, 0);
+
+    UA_ByteString privateKey;
+    privateKey.length = KEY_DER_LENGTH;
+    privateKey.data = KEY_DER_DATA;
+    ck_assert_uint_ne(privateKey.length, 0);
+
+    /* The Get endpoint (discovery service) is done with
+     * security mode as none to see the server's capability
+     * and certificate */
+    client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+    ck_assert(client != NULL);
+    UA_StatusCode retval = UA_Client_getEndpoints(client, "opc.tcp://localhost:4840",
+                                                  &endpointArraySize, &endpointArray);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(endpointArraySize > 0);
+
+    UA_Array_delete(endpointArray, endpointArraySize,
+                    &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
+
+    /* TODO test trustList Load revocationList is not supported now
+    if(argc > MIN_ARGS) {
+        trustListSize = (size_t)argc-MIN_ARGS;
+        retval = UA_ByteString_allocBuffer(trustList, trustListSize);
+        if(retval != UA_STATUSCODE_GOOD) {
+            cleanupClient(client, remoteCertificate);
+            return (int)retval;
+        }
+
+        for(size_t trustListCount = 0; trustListCount < trustListSize; trustListCount++) {
+            trustList[trustListCount] = loadFile(argv[trustListCount+3]);
+        }
+    }
+    */
+
+    UA_Client_delete(client);
+
+    /* Secure client initialization */
+    client = UA_Client_new();
+    UA_ClientConfig *cc = UA_Client_getConfig(client);
+    UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
+                                         trustList, trustListSize,
+                                         revocationList, revocationListSize);
+    cc->certificateVerification.clear(&cc->certificateVerification);
+    UA_CertificateVerification_AcceptAll(&cc->certificateVerification);
+    cc->securityPolicyUri =
+        UA_STRING_ALLOC("http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss");
+    ck_assert(client != NULL);
+
+    for(size_t deleteCount = 0; deleteCount < trustListSize; deleteCount++) {
+        UA_ByteString_clear(&trustList[deleteCount]);
+    }
+
+    /* Secure client connect */
+    retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Variant val;
+    UA_Variant_init(&val);
+    UA_NodeId nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
+    retval = UA_Client_readValueAttribute(client, nodeId, &val);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_Variant_clear(&val);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(encryption_connect_pem) {
+    UA_Client *client = NULL;
+    UA_EndpointDescription* endpointArray = NULL;
+    size_t endpointArraySize = 0;
+    UA_ByteString *trustList = NULL;
+    size_t trustListSize = 0;
+    UA_ByteString *revocationList = NULL;
+    size_t revocationListSize = 0;
+
+    /* Load certificate and private key */
+    UA_ByteString certificate;
+    certificate.length = CERT_PEM_LENGTH;
+    certificate.data = CERT_PEM_DATA;
+    ck_assert_uint_ne(certificate.length, 0);
+
+    UA_ByteString privateKey;
+    privateKey.length = KEY_PEM_LENGTH;
+    privateKey.data = KEY_PEM_DATA;
+    ck_assert_uint_ne(privateKey.length, 0);
+
+    /* The Get endpoint (discovery service) is done with
+     * security mode as none to see the server's capability
+     * and certificate */
+    client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+    ck_assert(client != NULL);
+    UA_StatusCode retval = UA_Client_getEndpoints(client, "opc.tcp://localhost:4840",
+                                                  &endpointArraySize, &endpointArray);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(endpointArraySize > 0);
+
+    UA_Array_delete(endpointArray, endpointArraySize,
+                    &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
+
+    /* TODO test trustList Load revocationList is not supported now
+    if(argc > MIN_ARGS) {
+        trustListSize = (size_t)argc-MIN_ARGS;
+        retval = UA_ByteString_allocBuffer(trustList, trustListSize);
+        if(retval != UA_STATUSCODE_GOOD) {
+            cleanupClient(client, remoteCertificate);
+            return (int)retval;
+        }
+
+        for(size_t trustListCount = 0; trustListCount < trustListSize; trustListCount++) {
+            trustList[trustListCount] = loadFile(argv[trustListCount+3]);
+        }
+    }
+    */
+
+    UA_Client_delete(client);
+
+    /* Secure client initialization */
+    client = UA_Client_new();
+    UA_ClientConfig *cc = UA_Client_getConfig(client);
+    UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
+                                         trustList, trustListSize,
+                                         revocationList, revocationListSize);
+    cc->certificateVerification.clear(&cc->certificateVerification);
+    UA_CertificateVerification_AcceptAll(&cc->certificateVerification);
+    cc->securityPolicyUri =
+        UA_STRING_ALLOC("http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss");
+    ck_assert(client != NULL);
+
+    for(size_t deleteCount = 0; deleteCount < trustListSize; deleteCount++) {
+        UA_ByteString_clear(&trustList[deleteCount]);
+    }
+
+    /* Secure client connect */
+    retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Variant val;
+    UA_Variant_init(&val);
+    UA_NodeId nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
+    retval = UA_Client_readValueAttribute(client, nodeId, &val);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_Variant_clear(&val);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static Suite* testSuite_encryption(void) {
+    Suite *s = suite_create("Encryption");
+    TCase *tc_encryption = tcase_create("Encryption Aes256Sha256RsaPss security policy");
+    tcase_add_checked_fixture(tc_encryption, setup, teardown);
+#ifdef UA_ENABLE_ENCRYPTION
+    tcase_add_test(tc_encryption, encryption_connect);
+    tcase_add_test(tc_encryption, encryption_connect_pem);
+#endif /* UA_ENABLE_ENCRYPTION */
+    suite_add_tcase(s,tc_encryption);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_encryption();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -93,6 +93,7 @@ if(UA_ENABLE_ENCRYPTION OR UA_ENABLE_ENCRYPTION STREQUAL "MBEDTLS" OR UA_ENABLE_
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
+       ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_securitypolicy_aes256sha256rsapss.c
        ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/ua_pki_mbedtls.c)
 endif()
 


### PR DESCRIPTION
Adding the new security policy Aes256-Sha256-RsaPss.

- [x] Added for openssl
- [x] Added for mbedTLS
- [x] Create unit test
- [x] Implementation cross-checked with another client (e.g UAExpert)