### PR TITLE
Disable polling for Windows CE

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -445,10 +445,10 @@ ServerNetworkLayerTCP_start(UA_ServerNetworkLayer *nl, const UA_Logger *logger,
         addServerSocket(layer, ai);
     }
     UA_freeaddrinfo(res);
-    
+
     if(layer->serverSocketsSize == 0) {
         return UA_STATUSCODE_BADCOMMUNICATIONERROR;
-    }    
+    }
 
     /* Get the discovery url from the hostname */
     UA_String du = UA_STRING_NULL;
@@ -846,9 +846,16 @@ UA_ClientConnectionTCP_poll(UA_Connection *connection, UA_UInt32 timeout,
     socklen_t len = sizeof(so_error);
     ret = UA_getsockopt(connection->sockfd, SOL_SOCKET, SO_ERROR, &so_error, &len);
     if(ret != 0 || so_error != 0) {
-        // UA_LOG_SOCKET_ERRNO_GAI_WRAP because of so_error
+        // no UA_LOG_SOCKET_ERRNO_GAI_WRAP because of so_error
 #ifndef _WIN32
         char *errno_str = strerror(ret == 0 ? so_error : UA_ERRNO);
+#elif defined(UNDER_CE)
+        LPVOID errno_str = NULL;
+        FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                        FORMAT_MESSAGE_IGNORE_INSERTS,
+                        NULL, ret == 0 ? so_error : WSAGetLastError(),
+                        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&errno_str, 0,
+                        NULL);
 #else
         char *errno_str = NULL;
         FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |

--- a/arch/wec7/ua_architecture.h
+++ b/arch/wec7/ua_architecture.h
@@ -76,6 +76,15 @@ void UA_sleep_ms(unsigned long ms);
 #define UA_WOULDBLOCK WSAEWOULDBLOCK
 #define UA_ERR_CONNECTION_PROGRESS WSAEWOULDBLOCK
 
+typedef struct pollfd {
+  SOCKET fd;
+  SHORT  events;
+  SHORT  revents;
+} WSAPOLLFD, *PWSAPOLLFD, *LPWSAPOLLFD;
+
+#define UA_POLLIN 0
+#define UA_POLLOUT 0
+
 #define UA_fd_set(fd, fds) FD_SET((UA_SOCKET)fd, fds)
 #define UA_fd_isset(fd, fds) FD_ISSET((UA_SOCKET)fd, fds)
 
@@ -84,6 +93,7 @@ void UA_sleep_ms(unsigned long ms);
 #endif
 
 #define UA_getnameinfo getnameinfo
+#define UA_poll(fds,nfds,timeout) 1
 #define UA_send(sockfd, buf, len, flags) send(sockfd, buf, (int)(len), flags)
 #define UA_recv recv
 #define UA_sendto(sockfd, buf, len, flags, dest_addr, addrlen) sendto(sockfd, (const char*)(buf), (int)(len), flags, dest_addr, (int) (addrlen))

--- a/deps/aa_tree.c
+++ b/deps/aa_tree.c
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2020 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
  */
@@ -8,7 +8,9 @@
 #include "aa_tree.h"
 #include <stddef.h>
 
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#ifdef UNDER_CE
+  /* Windows CE: uintptr_t has already been defined by windows.h */
+#elif !defined(_MSC_VER) || _MSC_VER >= 1800
 # include <inttypes.h>
 #elif !defined(uintptr_t)
   /* Workaround missing standard includes in older Visual Studio */


### PR DESCRIPTION
Windows CE does not support socket status determination via WSAPoll, so that CPU-saving measure needs to be disabled.

This is an attempt to solve issue #5388.

Please note that I am actually working on Windows Embedded Compact 2013 (aka wec8) and not wec7. I got it running there but I have no way to test this on wec7, so it would be great if @fraxh22 could test if this solves the problem.

I am also totally open for input since the changes feel hacky.
If this becomes an agreeable fix eventually, I am also provide the changes to get it running on wec2013, i.e., as a new architecture if the maintainers agree.

Cheers!