### PR TITLE
fix(server): Fix ConditionRefresh events with multiple server instances

### DIFF
--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -169,6 +169,7 @@ struct UA_Server {
 
 # ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
     LIST_HEAD(, UA_ConditionSource) conditionSources;
+    UA_NodeId refreshEvents[2];
 # endif
 
 #endif


### PR DESCRIPTION
Refresh event node ids were stored in a static variable; this failed if there were more than one server instance in the same address space. The node ids are now moved to UA_Server.