### PR TITLE
fix(core) remove special case for enum handling in type compatible check

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -809,19 +809,11 @@ typeEquivalence(const UA_DataType *t) {
     return k;
 }
 
-//static const UA_NodeId enumNodeId = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_ENUMERATION}};
-
 UA_Boolean
 compatibleValueDataType(UA_Server *server, const UA_DataType *dataType,
                         const UA_NodeId *constraintDataType) {
     if(compatibleDataTypes(server, &dataType->typeId, constraintDataType))
         return true;
-
-    /* The constraint is an enum -> allow writing Int32 */
-    //if(UA_NodeId_equal(&dataType->typeId, &UA_TYPES[UA_TYPES_INT32].typeId) &&
-    //   isNodeInTree_singleRef(server, constraintDataType, &enumNodeId,
-    //                          UA_REFERENCETYPEINDEX_HASSUBTYPE))
-    //    return true;
 
     /* For actual values, the constraint DataType may be a subtype of the
      * DataType of the value -- subtyping in the wrong direction. E.g. UtcTime

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -809,11 +809,19 @@ typeEquivalence(const UA_DataType *t) {
     return k;
 }
 
+//static const UA_NodeId enumNodeId = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_ENUMERATION}};
+
 UA_Boolean
 compatibleValueDataType(UA_Server *server, const UA_DataType *dataType,
                         const UA_NodeId *constraintDataType) {
     if(compatibleDataTypes(server, &dataType->typeId, constraintDataType))
         return true;
+
+    /* The constraint is an enum -> allow writing Int32 */
+    //if(UA_NodeId_equal(&dataType->typeId, &UA_TYPES[UA_TYPES_INT32].typeId) &&
+    //   isNodeInTree_singleRef(server, constraintDataType, &enumNodeId,
+    //                          UA_REFERENCETYPEINDEX_HASSUBTYPE))
+    //    return true;
 
     /* For actual values, the constraint DataType may be a subtype of the
      * DataType of the value -- subtyping in the wrong direction. E.g. UtcTime

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -809,18 +809,10 @@ typeEquivalence(const UA_DataType *t) {
     return k;
 }
 
-static const UA_NodeId enumNodeId = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_ENUMERATION}};
-
 UA_Boolean
 compatibleValueDataType(UA_Server *server, const UA_DataType *dataType,
                         const UA_NodeId *constraintDataType) {
     if(compatibleDataTypes(server, &dataType->typeId, constraintDataType))
-        return true;
-
-    /* The constraint is an enum -> allow writing Int32 */
-    if(UA_NodeId_equal(&dataType->typeId, &UA_TYPES[UA_TYPES_INT32].typeId) &&
-       isNodeInTree_singleRef(server, constraintDataType, &enumNodeId,
-                              UA_REFERENCETYPEINDEX_HASSUBTYPE))
         return true;
 
     /* For actual values, the constraint DataType may be a subtype of the

--- a/tools/schema/datatypes_minimal.txt
+++ b/tools/schema/datatypes_minimal.txt
@@ -117,3 +117,4 @@ ServerState
 ServerDiagnosticsSummaryDataType
 RedundancySupport
 KeyValuePair
+NamingRuleType


### PR DESCRIPTION
During the write of a value, we check if the node datatype and the incoming value are compatible. In some cases a automatic adjustment can be done. With changes in the master, the adjust behavior for enums was not triggered anymore. This PR changes the compatible type check and therefore enables the enum-type transformation (from int32 to dedicated enum type).