### PR TITLE
fix(pubsub): Fix memory access at udp close

### DIFF
--- a/plugins/ua_pubsub_udp.c
+++ b/plugins/ua_pubsub_udp.c
@@ -114,9 +114,11 @@ UA_PubSub_udpCallbackPublish(UA_ConnectionManager *cm, uintptr_t connectionId,
 static UA_StatusCode
 UA_PubSubChannelUDP_close(UA_PubSubChannel *channel) {
     UA_UDPConnectionContext *ctx = (UA_UDPConnectionContext *) channel->handle;
-    UA_KeyValueMap_clear(&ctx->subscriberParams);
-    UA_KeyValueMap_clear(&ctx->publisherParams);
-    UA_free(ctx);
+    if (ctx != NULL) {
+        UA_KeyValueMap_clear(&ctx->subscriberParams);
+        UA_KeyValueMap_clear(&ctx->publisherParams);
+        UA_free(ctx);
+    }
     UA_free(channel);
     return UA_STATUSCODE_GOOD;
 }


### PR DESCRIPTION
Freeing the memory with the previous commit
cfcf9753f284ce0ad49dc119b1f13a4c12460818 resulted in a memory access error.