### PR TITLE
fix(build): replace absolute paths of OpenSSL with imported target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,7 +663,7 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_MQTT_TLS_OPENSSL)
     # use the OpenSSL encryption library
     # https://cmake.org/cmake/help/v3.0/module/FindOpenSSL.html
     find_package(OpenSSL REQUIRED)
-    list(APPEND open62541_LIBRARIES ${OPENSSL_LIBRARIES})
+    list(APPEND open62541_LIBRARIES OpenSSL::Crypto OpenSSL::SSL)
     endif ()
 
 if(UA_ENABLE_ENCRYPTION_LIBRESSL)


### PR DESCRIPTION
${OPENSSL_LIBRARIES} contains the absolute paths to the OpenSSL library. Instead, the imported targets are used. This is important when using exported targets e.g. while cross compiling. This is fixing #5421.