### PR TITLE
feat(server): Add init function for setting basic server configuration with port

### DIFF
--- a/plugins/include/open62541/server_config_default.h
+++ b/plugins/include/open62541/server_config_default.h
@@ -81,11 +81,13 @@ UA_ServerConfig_setDefault(UA_ServerConfig *config) {
     return UA_ServerConfig_setMinimal(config, 4840, NULL);
 }
 
-/* Creates a new server config with no network layer and no endpoints.
+/* Creates a new server config with no security policies and no endpoints.
  *
  * It initializes reasonable defaults for many things, but does not
- * add any network layer, security policies and endpoints.
+ * add any security policies and endpoints.
  * Use the various UA_ServerConfig_addXxx functions to add them.
+ * The config will set the tcp network layer to the default port 4840 if the
+ * eventloop is not already set.
  *
  * @param conf The configuration to manipulate
  */

--- a/plugins/include/open62541/server_config_default.h
+++ b/plugins/include/open62541/server_config_default.h
@@ -94,6 +94,21 @@ UA_ServerConfig_setDefault(UA_ServerConfig *config) {
 UA_EXPORT UA_StatusCode
 UA_ServerConfig_setBasics(UA_ServerConfig *conf);
 
+/* Creates a new server config with no security policies and no endpoints.
+ *
+ * It initializes reasonable defaults for many things, but does not
+ * add any security policies and endpoints.
+ * Use the various UA_ServerConfig_addXxx functions to add them.
+ * The config will set the tcp network layer to the given port if the
+ * eventloop is not already set.
+ *
+ * @param conf The configuration to manipulate
+ * @param portNumber The port number for the tcp network layer
+ */
+UA_EXPORT UA_StatusCode
+UA_ServerConfig_setBasics_withPort(UA_ServerConfig *conf,
+                                   UA_UInt16 portNumber);
+
 #ifdef UA_ENABLE_WEBSOCKET_SERVER
 /* Adds a Websocket network layer with custom buffer sizes
  *

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -446,7 +446,12 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
 
 UA_EXPORT UA_StatusCode
 UA_ServerConfig_setBasics(UA_ServerConfig* conf) {
-    UA_StatusCode res = setDefaultConfig(conf, 4840);
+    return UA_ServerConfig_setBasics_withPort(conf, 4840);
+}
+
+UA_EXPORT UA_StatusCode
+UA_ServerConfig_setBasics_withPort(UA_ServerConfig* conf, UA_UInt16 portNumber) {
+    UA_StatusCode res = setDefaultConfig(conf, portNumber);
     UA_LOG_WARNING(&conf->logger, UA_LOGCATEGORY_USERLAND,
                    "AcceptAll Certificate Verification. "
                    "Any remote certificate will be accepted.");

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -40,9 +40,6 @@ UA_DURATIONRANGE(UA_Duration min, UA_Duration max) {
     return range;
 }
 
-static UA_StatusCode
-setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber);
-
 UA_Server *
 UA_Server_new(void) {
     UA_ServerConfig config;


### PR DESCRIPTION
In the version 1.3 the port was settable after calling UA_ServerConfig_setBasics
with the function UA_ServerConfig_addNetworkLayerTCP.
This function has been removed with commit
https://github.com/open62541/open62541/commit/86c20068e3ff92d9a1601bfbc5d9c5c4e530f517, so provide a new function
UA_ServerConfig_setBasics_withPort to set the port.

Also fix documentation and minor cleanup.