### PR TITLE
fix(examples): remove sys/io.h

### DIFF
--- a/examples/pubsub_realtime/pubsub_TSN_loopback.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback.c
@@ -77,7 +77,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <linux/types.h>
-#include <sys/io.h>
 #include <getopt.h>
 
 /* For thread operations */

--- a/examples/pubsub_realtime/pubsub_TSN_loopback_single_thread.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback_single_thread.c
@@ -54,7 +54,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <linux/types.h>
-#include <sys/io.h>
 #include <getopt.h>
 
 /* For thread operations */

--- a/examples/pubsub_realtime/pubsub_TSN_publisher.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher.c
@@ -78,7 +78,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <linux/types.h>
-#include <sys/io.h>
 #include <getopt.h>
 
 /* For thread operations */

--- a/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher_multiple_thread.c
@@ -57,7 +57,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <linux/types.h>
-#include <sys/io.h>
 #include <getopt.h>
 
 /* For thread operations */


### PR DESCRIPTION
For Arm processors sys/io.h does not exist, which
results in a build error. On x86 the header is not needed. Therefore it can be removed. This is also a fix for #4345