### PR TITLE
WIP: fix(ci): Increase win_msys64 job timeout to 120 minutes

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -33,6 +33,7 @@ jobs:
     displayName: "Publish Artifact: open62541-$(CC_SHORTNAME)"
 
 - job: 'win_msys64'
+  timeoutInMinutes: 120
   displayName: 'Windows (msys64)'
   pool:
     vmImage: 'windows-2019'


### PR DESCRIPTION
The job timed out sporadically with the previous timeout of 60 minutes.