### PR TITLE
refactor(plugin): Use pointer to pointer to logger for pki plugins

### DIFF
--- a/include/open62541/client.h
+++ b/include/open62541/client.h
@@ -70,7 +70,10 @@ _UA_BEGIN_DECLS
 
 typedef struct {
     void *clientContext; /* User-defined pointer attached to the client */
-    UA_Logger logger;    /* Logger used by the client */
+    UA_Logger logger;    /* Logger used by the client.
+                            logger is deprecated but still supported at this time.
+                            Use logging pointer instead. */
+    UA_Logger *logging; /* If NULL and "logger" is set, make this point to "logger" */
 
     /* Response timeout in ms (0 -> no timeout). If the server does not answer a
      * request within this time a StatusCode UA_STATUSCODE_BADTIMEOUT is

--- a/include/open62541/plugin/pki.h
+++ b/include/open62541/plugin/pki.h
@@ -37,11 +37,11 @@ struct UA_CertificateVerification {
     void *context;
 
     /* Verify the certificate against the configured policies and trust chain. */
-    UA_StatusCode (*verifyCertificate)(void *verificationContext,
+    UA_StatusCode (*verifyCertificate)(const UA_CertificateVerification *cv,
                                        const UA_ByteString *certificate);
 
     /* Verify that the certificate has the applicationURI in the subject name. */
-    UA_StatusCode (*verifyApplicationURI)(void *verificationContext,
+    UA_StatusCode (*verifyApplicationURI)(const UA_CertificateVerification *cv,
                                           const UA_ByteString *certificate,
                                           const UA_String *applicationURI);
 
@@ -52,7 +52,10 @@ struct UA_CertificateVerification {
     /* Delete the certificate verification context */
     void (*clear)(UA_CertificateVerification *cv);
 
-    const UA_Logger *logger;
+    /* Pointer to logging pointer in the server/client configuration.
+       If the logging pointer is changed outside of the plugin, the new
+       logger is used automatically*/
+    UA_Logger **logging;
 };
 
 _UA_END_DECLS

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -81,7 +81,9 @@ typedef struct {
  * The :ref:`tutorials` provide a good starting point for this. */
 
 struct UA_ServerConfig {
-    UA_Logger logger;
+    UA_Logger logger;   /* logger is deprecated but still supported at this time.
+                           Use logging pointer instead. */
+    UA_Logger *logging; /* If NULL and "logger" is set, make this point to "logger" */
     void *context; /* Used to attach custom data to a server config. This can
                     * then be retrieved e.g. in a callback that forwards a
                     * pointer to the server. */

--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -76,7 +76,7 @@ typedef struct {
     STACK_OF(X509) *      skTrusted;
     STACK_OF(X509_CRL) *  skCrls; /* Revocation list*/
 
-    const UA_Logger *logger;
+    UA_CertificateVerification *cv;
 } CertContext;
 
 static UA_StatusCode
@@ -99,18 +99,14 @@ UA_CertContext_sk_free (CertContext * context) {
 }
 
 static UA_StatusCode
-UA_CertContext_Init (CertContext * context, const UA_Logger *logger) {
+UA_CertContext_Init (CertContext * context, UA_CertificateVerification *cv) {
     (void) memset (context, 0, sizeof (CertContext));
     UA_ByteString_init (&context->trustListFolder);
     UA_ByteString_init (&context->issuerListFolder);
     UA_ByteString_init (&context->revocationListFolder);
     UA_ByteString_init (&context->rejectedListFolder);
 
-    if(logger) {
-        context->logger = logger;
-    } else {
-        context->logger = UA_Log_Stdout;
-    }
+    context->cv = cv;
 
     return UA_CertContext_sk_Init (context);
 }
@@ -118,7 +114,7 @@ UA_CertContext_Init (CertContext * context, const UA_Logger *logger) {
 static void
 UA_CertificateVerification_clear (UA_CertificateVerification * cv) {
     if (cv == NULL) {
-        return ;
+        return;
     }
     CertContext * context = (CertContext *) cv->context;
     if (context == NULL) {
@@ -130,7 +126,7 @@ UA_CertificateVerification_clear (UA_CertificateVerification * cv) {
     UA_ByteString_clear (&context->rejectedListFolder);
 
     UA_CertContext_sk_free (context);
-    context->logger = NULL;
+    context->cv = NULL;
     UA_free (context);
 
     cv->context = NULL;
@@ -296,7 +292,7 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
     UA_ByteString_init (&strCert);
 
     if (ctx->trustListFolder.length > 0) {
-        UA_LOG_INFO(ctx->logger, UA_LOGCATEGORY_SERVER, "Reloading the trust-list");
+        UA_LOG_INFO(*(ctx->cv->logging), UA_LOGCATEGORY_SERVER, "Reloading the trust-list");
 
         sk_X509_pop_free (ctx->skTrusted, X509_free);
         ctx->skTrusted = sk_X509_new_null();
@@ -317,12 +313,12 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
             }
             ret = UA_loadCertFromFile (certFile, &strCert);
             if (ret != UA_STATUSCODE_GOOD) {
-                UA_LOG_INFO (ctx->logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_INFO (*(ctx->cv->logging), UA_LOGCATEGORY_SERVER,
                             "Failed to load the certificate file %s", certFile);
                 continue;  /* continue or return ? */
             }
             if (UA_skTrusted_Cert2X509 (&strCert, 1, ctx) != UA_STATUSCODE_GOOD) {
-                UA_LOG_INFO (ctx->logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_INFO (*(ctx->cv->logging), UA_LOGCATEGORY_SERVER,
                             "Failed to decode the certificate file %s", certFile);
                 UA_ByteString_clear (&strCert);
                 continue;  /* continue or return ? */
@@ -332,7 +328,7 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
     }
 
     if (ctx->issuerListFolder.length > 0) {
-        UA_LOG_INFO(ctx->logger, UA_LOGCATEGORY_SERVER, "Reloading the issuer-list");
+        UA_LOG_INFO(*(ctx->cv->logging), UA_LOGCATEGORY_SERVER, "Reloading the issuer-list");
 
         sk_X509_pop_free (ctx->skIssue, X509_free);
         ctx->skIssue = sk_X509_new_null();
@@ -352,12 +348,12 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
             }
             ret = UA_loadCertFromFile (certFile, &strCert);
             if (ret != UA_STATUSCODE_GOOD) {
-                UA_LOG_INFO (ctx->logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_INFO (*(ctx->cv->logging), UA_LOGCATEGORY_SERVER,
                             "Failed to load the certificate file %s", certFile);
                 continue;  /* continue or return ? */
             }
             if (UA_skIssuer_Cert2X509 (&strCert, 1, ctx) != UA_STATUSCODE_GOOD) {
-                UA_LOG_INFO (ctx->logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_INFO (*(ctx->cv->logging), UA_LOGCATEGORY_SERVER,
                             "Failed to decode the certificate file %s", certFile);
                 UA_ByteString_clear (&strCert);
                 continue;  /* continue or return ? */
@@ -367,7 +363,7 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
     }
 
     if (ctx->revocationListFolder.length > 0) {
-        UA_LOG_INFO(ctx->logger, UA_LOGCATEGORY_SERVER, "Reloading the revocation-list");
+        UA_LOG_INFO(*(ctx->cv->logging), UA_LOGCATEGORY_SERVER, "Reloading the revocation-list");
 
         sk_X509_CRL_pop_free (ctx->skCrls, X509_CRL_free);
         ctx->skCrls = sk_X509_CRL_new_null();
@@ -387,12 +383,12 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
             }
             ret = UA_loadCertFromFile (certFile, &strCert);
             if (ret != UA_STATUSCODE_GOOD) {
-                UA_LOG_INFO (ctx->logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_INFO (*(ctx->cv->logging), UA_LOGCATEGORY_SERVER,
                             "Failed to load the revocation file %s", certFile);
                 continue;  /* continue or return ? */
             }
             if (UA_skCrls_Cert2X509 (&strCert, 1, ctx) != UA_STATUSCODE_GOOD) {
-                UA_LOG_INFO (ctx->logger, UA_LOGCATEGORY_SERVER,
+                UA_LOG_INFO (*(ctx->cv->logging), UA_LOGCATEGORY_SERVER,
                             "Failed to decode the revocation file %s", certFile);
                 UA_ByteString_clear (&strCert);
                 continue;  /* continue or return ? */
@@ -445,7 +441,7 @@ UA_X509_Store_CTX_Error_To_UAError (int opensslErr) {
     }
 
 static UA_StatusCode
-UA_CertificateVerification_Verify (void *                verificationContext,
+UA_CertificateVerification_Verify (const UA_CertificateVerification *cv,
                                    const UA_ByteString * certificate) {
     X509_STORE_CTX*       storeCtx;
     X509_STORE*           store;
@@ -454,10 +450,10 @@ UA_CertificateVerification_Verify (void *                verificationContext,
     int                   opensslRet;
     X509 *                certificateX509 = NULL;
 
-    if (verificationContext == NULL) {
+    if ((cv == NULL) || (cv->context == NULL)) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
-    ctx = (CertContext *) verificationContext;
+    ctx = (CertContext *) cv->context;
 
     store = X509_STORE_new();
     storeCtx = X509_STORE_CTX_new();
@@ -597,7 +593,7 @@ cleanup:
 }
 
 static UA_StatusCode
-UA_CertificateVerification_VerifyApplicationURI (void *                verificationContext,
+UA_CertificateVerification_VerifyApplicationURI (const UA_CertificateVerification *cv,
                                                  const UA_ByteString * certificate,
                                                  const UA_String *     applicationURI) {
     const unsigned char * pData;
@@ -606,21 +602,25 @@ UA_CertificateVerification_VerifyApplicationURI (void *                verificat
     GENERAL_NAMES *       pNames;
     int                   i;
     UA_StatusCode         ret;
-    CertContext *         ctx = (CertContext *)verificationContext;
+    CertContext *         ctx;
 
+    if (cv == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    ctx = (CertContext *)cv->context;
     if (ctx == NULL) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
     pData = certificate->data;
     if (pData == NULL) {
-        UA_LOG_ERROR(ctx->logger, UA_LOGCATEGORY_USERLAND, "Error Empty Certificate");
+        UA_LOG_ERROR(*(cv->logging), UA_LOGCATEGORY_USERLAND, "Error Empty Certificate");
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     }
 
     certificateX509 = UA_OpenSSL_LoadCertificate(certificate);
     if (certificateX509 == NULL) {
-        UA_LOG_ERROR(ctx->logger, UA_LOGCATEGORY_USERLAND, "Error loading X509 Certificate");
+        UA_LOG_ERROR(*(cv->logging), UA_LOGCATEGORY_USERLAND, "Error loading X509 Certificate");
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     }
 
@@ -628,7 +628,7 @@ UA_CertificateVerification_VerifyApplicationURI (void *                verificat
                                                 NULL, NULL);
     if (pNames == NULL) {
         X509_free (certificateX509);
-        UA_LOG_ERROR(ctx->logger, UA_LOGCATEGORY_USERLAND, "Error processing X509 Certificate");
+        UA_LOG_ERROR(*(cv->logging), UA_LOGCATEGORY_USERLAND, "Error processing X509 Certificate");
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     }
     for (i = 0; i < sk_GENERAL_NAME_num (pNames); i++) {
@@ -637,7 +637,7 @@ UA_CertificateVerification_VerifyApplicationURI (void *                verificat
              subjectURI.length = (size_t) (value->d.ia5->length);
              subjectURI.data = (UA_Byte *) UA_malloc (subjectURI.length);
              if (subjectURI.data == NULL) {
-                 UA_LOG_ERROR(ctx->logger, UA_LOGCATEGORY_USERLAND, "Error Empty subjectURI");
+                 UA_LOG_ERROR(*(cv->logging), UA_LOGCATEGORY_USERLAND, "Error Empty subjectURI");
                  X509_free (certificateX509);
                  sk_GENERAL_NAME_pop_free(pNames, GENERAL_NAME_free);
                  return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
@@ -651,7 +651,7 @@ UA_CertificateVerification_VerifyApplicationURI (void *                verificat
     ret = UA_STATUSCODE_GOOD;
     if (UA_Bstrstr (subjectURI.data, subjectURI.length,
                     applicationURI->data, applicationURI->length) == NULL) {
-        UA_LOG_ERROR(ctx->logger, UA_LOGCATEGORY_USERLAND, "Empty comparing subjectURI and applicationURI");
+        UA_LOG_ERROR(*(cv->logging), UA_LOGCATEGORY_USERLAND, "Empty comparing subjectURI and applicationURI");
         ret = UA_STATUSCODE_BADCERTIFICATEURIINVALID;
     }
 
@@ -710,12 +710,15 @@ UA_CertificateVerification_Trustlist(UA_CertificateVerification * cv,
     if (cv == NULL) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
+    if (cv->logging == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
 
     CertContext * context = (CertContext *) UA_malloc (sizeof (CertContext));
     if (context == NULL) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    ret = UA_CertContext_Init (context, cv->logger);
+    ret = UA_CertContext_Init (context, cv);
     if (ret != UA_STATUSCODE_GOOD) {
         return ret;
     }
@@ -769,12 +772,15 @@ UA_CertificateVerification_CertFolders(UA_CertificateVerification * cv,
     if (cv == NULL) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
+    if (cv->logging == NULL) {
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
 
     CertContext * context = (CertContext *) UA_malloc (sizeof (CertContext));
     if (context == NULL) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    ret = UA_CertContext_Init (context, cv->logger);
+    ret = UA_CertContext_Init (context, cv);
     if (ret != UA_STATUSCODE_GOOD) {
         return ret;
     }

--- a/plugins/crypto/ua_pki_none.c
+++ b/plugins/crypto/ua_pki_none.c
@@ -7,13 +7,13 @@
 #include <open62541/plugin/pki_default.h>
 
 static UA_StatusCode
-verifyCertificateAllowAll(void *verificationContext,
+verifyCertificateAllowAll(const UA_CertificateVerification *cv,
                const UA_ByteString *certificate) {
     return UA_STATUSCODE_GOOD;
 }
 
 static UA_StatusCode
-verifyApplicationURIAllowAll(void *verificationContext,
+verifyApplicationURIAllowAll(const UA_CertificateVerification *cv,
                              const UA_ByteString *certificate,
                              const UA_String *applicationURI) {
     return UA_STATUSCODE_GOOD;

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -125,7 +125,7 @@ activateSession_default(UA_Server *server, UA_AccessControl *ac,
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
 
         return context->verifyX509.
-            verifyCertificate(context->verifyX509.context,
+            verifyCertificate(&context->verifyX509,
                               &userToken->certificateData);
     }
 
@@ -319,16 +319,19 @@ UA_AccessControl_default(UA_ServerConfig *config,
                     "AccessControl: Anonymous login is enabled");
     }
 
+    if(config->logging == NULL) {
+        config->logging = &config->logger;
+    }
     /* Allow x509 certificates? Move the plugin over. */
     if(verifyX509) {
         context->verifyX509 = *verifyX509;
         memset(verifyX509, 0, sizeof(UA_CertificateVerification));
-        if (context->verifyX509.logger == NULL) {
-            context->verifyX509.logger = &config->logger;
+        if(context->verifyX509.logging == NULL) {
+            context->verifyX509.logging = &config->logging;
         }
     } else {
         memset(&context->verifyX509, 0, sizeof(UA_CertificateVerification));
-        context->verifyX509.logger = &config->logger;
+        context->verifyX509.logging = &config->logging;
         UA_LOG_INFO(&config->logger, UA_LOGCATEGORY_SERVER,
                     "AccessControl: x509 certificate user authentication is enabled");
     }

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -836,9 +836,11 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
                                                   trustList, trustListSize,
                                                   issuerList, issuerListSize,
                                                   revocationList, revocationListSize);
-    retval |= UA_AccessControl_default(conf, true, &accessControlVerification,
-                &conf->securityPolicies[conf->securityPoliciesSize-1].policyUri,
-                usernamePasswordsSize, usernamePasswords);
+    if(retval == UA_STATUSCODE_GOOD) {
+        retval = UA_AccessControl_default(conf, true, &accessControlVerification,
+                    &conf->securityPolicies[conf->securityPoliciesSize-1].policyUri,
+                    usernamePasswordsSize, usernamePasswords);
+    }
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -231,6 +231,8 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
     /* Logging */
     if(!conf->logger.log)
         conf->logger = UA_Log_Stdout_withLevel(UA_LOGLEVEL_TRACE);
+    if(conf->logging == NULL)
+        conf->logging = &conf->logger;
 
     /* EventLoop */
     if(conf->eventLoop == NULL) {
@@ -372,10 +374,10 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
     /* Endpoints */
     /* conf->endpoints = {0, NULL}; */
 
-    if(!conf->certificateVerification.logger) {
+    if(!conf->certificateVerification.logging) {
         /* Set Logger for Certificate Verification */
-        conf->certificateVerification.logger = &conf->logger;
-    }
+        conf->certificateVerification.logging = &conf->logging;
+   }
 
     /* Certificate Verification that accepts every certificate. Can be
      * overwritten when the policy is specialized. */
@@ -832,6 +834,7 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
 
     UA_CertificateVerification accessControlVerification;
     memset(&accessControlVerification, 0, sizeof(accessControlVerification));
+    accessControlVerification.logging = &conf->logging;
     retval = UA_CertificateVerification_Trustlist(&accessControlVerification,
                                                   trustList, trustListSize,
                                                   issuerList, issuerListSize,
@@ -897,6 +900,8 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     if(!config->logger.log) {
         config->logger = UA_Log_Stdout_withLevel(UA_LOGLEVEL_INFO);
     }
+    if(config->logging == NULL)
+        config->logging = &config->logger;
 
     /* EventLoop */
     if(config->eventLoop == NULL) {
@@ -917,9 +922,9 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
     if(config->localConnectionConfig.recvBufferSize == 0)
         config->localConnectionConfig = UA_ConnectionConfig_default;
 
-    if(!config->certificateVerification.logger) {
+    if(!config->certificateVerification.logging) {
         /* Set Logger for Certificate Verification */
-        config->certificateVerification.logger = &config->logger;
+        config->certificateVerification.logging = &config->logging;
     }
 
     if(!config->certificateVerification.verifyCertificate) {

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1144,7 +1144,7 @@ verifyClientApplicationURI(const UA_Client *client) {
 
         UA_StatusCode retval =
             client->config.certificateVerification.
-            verifyApplicationURI(client->config.certificateVerification.context,
+            verifyApplicationURI(&client->config.certificateVerification,
                                  &sp->localCertificate,
                                  &client->config.clientDescription.applicationUri);
         if(retval != UA_STATUSCODE_GOOD) {

--- a/src/pubsub/ua_pubsub_keystorage.c
+++ b/src/pubsub/ua_pubsub_keystorage.c
@@ -710,7 +710,7 @@ UA_Server_setSksClient(UA_Server *server, UA_String securityGroupId,
         return retval;
     }
 
-    ks->sksConfig.clientConfig = *clientConfig;
+    UA_ClientConfig_copy(clientConfig, &ks->sksConfig.clientConfig);
     memset(clientConfig, 0, sizeof(UA_ClientConfig));
     ks->sksConfig.endpointUrl = endpointUrl;
     ks->sksConfig.userNotifyCallback = callback;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -395,8 +395,13 @@ UA_Server_newWithConfig(UA_ServerConfig *config) {
     if(server->config.eventLoop->logger == &config->logger)
         server->config.eventLoop->logger = &server->config.logger;
 
-    if(server->config.certificateVerification.logger == &config->logger)
-        server->config.certificateVerification.logger = &server->config.logger;
+    if((server->config.logging == NULL) ||
+       (server->config.logging == &config->logger)) {
+        /* re-set the logger pointer */
+        server->config.logging = &server->config.logger;
+    }
+    if(server->config.certificateVerification.logging == &config->logging)
+        server->config.certificateVerification.logging = &server->config.logging;
 
     /* Reset the old config */
     memset(config, 0, sizeof(UA_ServerConfig));
@@ -557,7 +562,7 @@ verifyServerApplicationURI(const UA_Server *server) {
         if(UA_String_equal(&sp->policyUri, &securityPolicyNoneUri) && (sp->localCertificate.length == 0))
             continue;
         UA_StatusCode retval = server->config.certificateVerification.
-            verifyApplicationURI(server->config.certificateVerification.context,
+            verifyApplicationURI(&server->config.certificateVerification,
                                  &sp->localCertificate,
                                  &server->config.applicationDescription.applicationUri);
 

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -85,6 +85,13 @@ UA_ServerConfig_clean(UA_ServerConfig *config) {
 #endif
 
     /* Logger */
+    if(config->logging != NULL) {
+        if((config->logging != &config->logger) &&
+           (config->logging->clear != NULL)) {
+            config->logging->clear(config->logging->context);
+        }
+        config->logging = NULL;
+    }
     if(config->logger.clear)
         config->logger.clear(config->logger.context);
     config->logger.log = NULL;

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -295,7 +295,7 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
     if(request->clientCertificate.length > 0) {
         UA_CertificateVerification *cv = &server->config.certificateVerification;
         response->responseHeader.serviceResult =
-            cv->verifyApplicationURI(cv->context, &request->clientCertificate,
+            cv->verifyApplicationURI(cv, &request->clientCertificate,
                                      &request->clientDescription.applicationUri);
         if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING_CHANNEL(&server->config.logger, channel,

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -583,7 +583,7 @@ unpackPayloadOPN(UA_SecureChannel *channel, UA_Chunk *chunk, void *application) 
     if(asymHeader.senderCertificate.length > 0) {
         if(channel->certificateVerification)
             res = channel->certificateVerification->
-                verifyCertificate(channel->certificateVerification->context,
+                verifyCertificate(channel->certificateVerification,
                                   &asymHeader.senderCertificate);
         else
             res = UA_STATUSCODE_BADINTERNALERROR;


### PR DESCRIPTION
Also the logger in the callback context must be updated when the client or server configuration is moved.

Fixes commit b0da4178d23b4bbb882da49339879a8dc0fdbd9a.