### PR TITLE
fix(test): use correct timeout in check_client_securechannel test

### DIFF
--- a/tests/client/check_client_securechannel.c
+++ b/tests/client/check_client_securechannel.c
@@ -117,7 +117,7 @@ START_TEST(SecureChannel_timeout_fail) {
 
     UA_ClientConfig *cconfig = UA_Client_getConfig(client);
     UA_fakeSleep(cconfig->secureChannelLifeTime + 1);
-    UA_realSleep(50 + 1); // UA_MAXTIMEOUT+1 wait to be sure UA_Server_run_iterate can be completely executed
+    UA_realSleep(200 + 1); // UA_MAXTIMEOUT+1 wait to be sure UA_Server_run_iterate can be completely executed
 
     UA_Variant val;
     UA_Variant_init(&val);

--- a/tests/encryption/check_save_rejected_cert.c
+++ b/tests/encryption/check_save_rejected_cert.c
@@ -375,7 +375,7 @@ static void setup(void) {
     size_t revocationListSize = 0;
 
     UA_StatusCode res =
-        UA_ServerConfig_setDefaultWithSecurityPolicies(*config, 4840,
+        UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840,
                                                        &certificate, &privateKey,
                                                        trustList, trustListSize,
                                                        issuerList, issuerListSize,


### PR DESCRIPTION
The maximum server timeout has been increased from 50 to 200 with
commit 384a67276457223d505c2060c3224e567ce1930d.

fix(test): fix pointer parameter in check_save_rejected_cert