### PR TITLE
prevent NULL pointer assinment error in UA_ClientConnectionTCP_poll()

### DIFF
--- a/arch/network_tcp.c
+++ b/arch/network_tcp.c
@@ -700,6 +700,10 @@ UA_ClientConnectionTCP_poll(UA_Connection *connection, UA_UInt32 timeout,
 
     /* Connection timeout? */
     TCPClientConnection *tcpConnection = (TCPClientConnection*) connection->handle;
+    if(tcpConnection == NULL) {
+        connection->state = UA_CONNECTIONSTATE_CLOSED;
+        return UA_STATUSCODE_BADDISCONNECT;  // some thing is wrong
+    }
     if((UA_Double) (UA_DateTime_nowMonotonic() - tcpConnection->connStart)
        > (UA_Double) tcpConnection->timeout * UA_DATETIME_MSEC ) {
         UA_LOG_WARNING(logger, UA_LOGCATEGORY_NETWORK, "Timed out");


### PR DESCRIPTION
With  VS2019 i had a NULL pointer assinment error in my client.c example delivered from yours.
I had subscribed 3 variables from an S7-1500 CPU with OPC-UA and it was working fine. 
I have droped the ethernet cable many times to watch reconnect, and than i got this error, and fixed it.
I cant find this in master and 1.3 branch.
The reconnect dose not work, in your example, but that's no proplem here.

Regards Jörg
