### PR TITLE
fix(pubsub): fixed string field length calculations for RawData DatasetMessages

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -233,6 +233,29 @@ UA_DataSetReader_create(UA_Server *server, UA_NodeId readerGroupIdentifier,
         }
     }
 
+    /* Check if used dataSet metaData is valid in context of the rest of the config */
+    if(newDataSetReader->config.dataSetFieldContentMask &
+       UA_DATASETFIELDCONTENTMASK_RAWDATA) {
+        for(size_t fieldIdx = 0;
+            fieldIdx < newDataSetReader->config.dataSetMetaData.fieldsSize; fieldIdx++) {
+            const UA_FieldMetaData *field =
+                &newDataSetReader->config.dataSetMetaData.fields[fieldIdx];
+            if((field->builtInType == UA_TYPES_STRING ||
+                field->builtInType == UA_TYPES_BYTESTRING) &&
+               field->maxStringLength == 0) {
+                /* Fields of type String or ByteString need to have defined
+                 * MaxStringLength*/
+                UA_LOG_ERROR_READER(server->config.logging, newDataSetReader,
+                                    "Add DataSetReader failed. MaxStringLength must be "
+                                    "set in MetaData when using RawData field encoding.");
+                UA_DataSetReaderConfig_clear(&newDataSetReader->config);
+                UA_free(newDataSetReader);
+                newDataSetReader = NULL;
+                return UA_STATUSCODE_BADCONFIGURATIONERROR;
+            }
+        }
+    }
+
     if(readerIdentifier)
         UA_NodeId_copy(&newDataSetReader->identifier, readerIdentifier);
 


### PR DESCRIPTION
We can't use the size of UA_String structure for field length calculation in dataSetMessages in form of rawData. It contains pointer to allocated memory, so the size is the same for all strings. Also the size of UA_String varies between platforms, since sizeof(size_t) and sizeof(byte*) are 4 bytes on 32-bit systems and 8 bytes on 64-bit systems. Length of binary encoded string = 4 (string length encoded as uint32) + N bytes (actual string data). For fixed message layout N equals maxStringlength.