### PR TITLE
fix(pubsub): fixed program crashing when sending too long strings

### DIFF
--- a/src/pubsub/ua_pubsub_networkmessage_binary.c
+++ b/src/pubsub/ua_pubsub_networkmessage_binary.c
@@ -1404,6 +1404,9 @@ UA_DataSetMessage_keyFrame_encodeBinary(const UA_DataSetMessage* src, UA_Byte **
                 if(fmd->maxStringLength != 0 &&
                    (v->value.type->typeKind == UA_DATATYPEKIND_STRING ||
                     v->value.type->typeKind == UA_DATATYPEKIND_BYTESTRING)) {
+                    if(((UA_String *)v->value.data)->length > fmd->maxStringLength){
+                        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+                    }
                     rv = UA_encodeBinaryInternal(valuePtr, v->value.type, bufPos, &bufEnd,
                                                  NULL, NULL, NULL);
                     size_t lengthDifference = fmd->maxStringLength - ((UA_String *)valuePtr)->length;


### PR DESCRIPTION
Trying to send too long string would result in program crashing:  when the string length exceeded maxStringLength, lengthDifference would underflow and we would try to zero out gigabytes of memory. Added check to avoid that.

Would that be the correct approach? to just return with error and try sending the message later?
Is this the correct statuscode to return in such case?