### PR TITLE
[REVIEW] fix(pubsub): enable remove and add readergroups

### DIFF
--- a/src/pubsub/ua_pubsub_connection.c
+++ b/src/pubsub/ua_pubsub_connection.c
@@ -196,6 +196,10 @@ UA_PubSubConnection_create(UA_Server *server,
 
     assignConnectionIdentifier(server, newConnectionsField, connectionIdentifier);
 
+    /* Open the connection channel */
+    if(newConnectionsField->channel->openSubscriber) {
+        newConnectionsField->channel->openSubscriber(newConnectionsField->channel);
+    }
     return UA_STATUSCODE_GOOD;
 }
 
@@ -233,6 +237,10 @@ removePubSubConnection(UA_Server *server, const UA_NodeId connection) {
                                       UA_STATUSCODE_BADSHUTDOWN);
         UA_ReaderGroup_unfreezeConfiguration(server, readerGroup);
         removeReaderGroup(server, readerGroup->identifier);
+    }
+    /* Close the related channel */
+    if(c->channel->closeSubscriber) {
+        c->channel->closeSubscriber(c->channel);
     }
 
     /* Remove from the information model */

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -334,11 +334,6 @@ UA_ReaderGroup_setPubSubState_disable(UA_Server *server,
         break;
     case UA_PUBSUBSTATE_OPERATIONAL: {
         UA_ReaderGroup_removeSubscribeCallback(server, rg);
-        UA_PubSubConnection *connection = rg->linkedConnection;
-        UA_PubSubChannel *channel = connection->channel;
-        if(channel->closeSubscriber) {
-            channel->closeSubscriber(channel);
-        }
         LIST_FOREACH(dataSetReader, &rg->readers, listEntry) {
             UA_DataSetReader_setPubSubState(server, dataSetReader,
                                             UA_PUBSUBSTATE_DISABLED, cause);
@@ -389,11 +384,6 @@ UA_ReaderGroup_setPubSubState_operational(UA_Server *server,
         LIST_FOREACH(dataSetReader, &rg->readers, listEntry) {
             UA_DataSetReader_setPubSubState(server, dataSetReader, UA_PUBSUBSTATE_OPERATIONAL,
                                             cause);
-        }
-        UA_PubSubConnection *connection = rg->linkedConnection;
-        UA_PubSubChannel *channel = connection->channel;
-        if(channel->openSubscriber) {
-            channel->openSubscriber(channel);
         }
         UA_ReaderGroup_addSubscribeCallback(server, rg);
         rg->state = UA_PUBSUBSTATE_OPERATIONAL;

--- a/tests/pubsub/check_pubsub_udp_unicast.c
+++ b/tests/pubsub/check_pubsub_udp_unicast.c
@@ -197,17 +197,17 @@ static void setupPublishingUnicast(UA_Server *server, UA_NodeId connectionId, co
     setupWrittenData(server, connectionId, outPublishedDataSetId, dstHost, dstPort);
 }
 
-static void setupSubscribing(UA_Server *server, UA_NodeId connectionId, UA_NodeId folderId, UA_UInt32 subscribeVariableNodeId) {
+static void setupSubscribing(UA_Server *server, UA_NodeId connectionId, UA_NodeId targetNodeId, UA_UInt32 subscribeVariableNodeId,
+                             UA_NodeId *outReaderGroupId) {
     /* Reader Group */
     UA_ReaderGroupConfig readerGroupConfig;
     memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
     readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
 
-    UA_NodeId outReaderGroupId;
-    UA_StatusCode retVal =  UA_Server_addReaderGroup(server, connectionId, &readerGroupConfig, &outReaderGroupId);
+    UA_StatusCode retVal =  UA_Server_addReaderGroup(server, connectionId, &readerGroupConfig, outReaderGroupId);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
-    retVal = UA_Server_setReaderGroupOperational(server, outReaderGroupId);
+    retVal = UA_Server_setReaderGroupOperational(server, *outReaderGroupId);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     /* Data Set Reader */
@@ -240,28 +240,17 @@ static void setupSubscribing(UA_Server *server, UA_NodeId connectionId, UA_NodeI
     pMetaData->fields[0].valueRank   = -1; /* scalar */
 
     UA_NodeId readerIdentifier;
-    retVal = UA_Server_addDataSetReader(server, outReaderGroupId, &readerConfig,
+    retVal = UA_Server_addDataSetReader(server, *outReaderGroupId, &readerConfig,
                                          &readerIdentifier);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
-    /* Add Subscribed Variables */
-    /* Variable to subscribe data */
-    UA_NodeId newnodeId;
-    UA_VariableAttributes vAttr = UA_VariableAttributes_default;
-    vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
-    vAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
-    vAttr.dataType    = UA_TYPES[UA_TYPES_INT32].typeId;
-    retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, subscribeVariableNodeId), folderId,
-                                       UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Int32"),
-                                       UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId);
-    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_FieldTargetVariable targetVar;
     memset(&targetVar, 0, sizeof(UA_FieldTargetVariable));
     /* For creating Targetvariable */
     UA_FieldTargetDataType_init(&targetVar.targetVariable);
     targetVar.targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
-    targetVar.targetVariable.targetNodeId = newnodeId;
+    targetVar.targetVariable.targetNodeId = targetNodeId;
     retVal = UA_Server_DataSetReader_createTargetVariables(server, readerIdentifier,
                                                             1, &targetVar);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
@@ -270,21 +259,43 @@ static void setupSubscribing(UA_Server *server, UA_NodeId connectionId, UA_NodeI
 }
 
 /* setup() is to create an environment for test cases */
-static void setup(void) {
+static void setupEnvironment(UA_Server **serverPub, UA_Server **serverSub, UA_ServerConfig **configPub, UA_ServerConfig **configSub,
+                             UA_NodeId *outPublisherConnectionId, UA_NodeId *outSubscriberConnectionId, UA_NodeId *outReaderGroupId,
+                             UA_NodeId *outVariableNodeId) {
     /*Add setup by creating new server with valid configuration */
-    setupPubSubServer(&serverPublisher, &configPublisher, UA_PUBLISHER_PORT, NULL);
-    UA_NodeId publisherConnectionId;
-    addUDPConnection(serverPublisher, "localhost", UA_PUBLISHER_PORT, &publisherConnectionId);
-    setupPublishingUnicast(serverPublisher, publisherConnectionId, "127.0.0.1", UA_SUBSCRIBER_PORT,
+    setupPubSubServer(serverPub, configPub, UA_PUBLISHER_PORT, NULL);
+    addUDPConnection(*serverPub, "localhost", UA_PUBLISHER_PORT, outPublisherConnectionId);
+    setupPublishingUnicast(*serverPub, *outPublisherConnectionId, "127.0.0.1", UA_SUBSCRIBER_PORT,
                            PUBLISHVARIABLE_NODEID);
 
-    setupPubSubServer(&serverSubscriber, &configSubscriber, UA_SUBSCRIBER_PORT,
-                      configPublisher->eventLoop);
+    setupPubSubServer(serverSub, configSub, UA_SUBSCRIBER_PORT,
+                      (*configPub)->eventLoop);
+
     UA_NodeId folderId;
-    setupFolder(serverSubscriber, &folderId);
-    UA_NodeId subscriberConnectionId;
-    addUDPConnection(serverSubscriber, "localhost", UA_SUBSCRIBER_PORT, &subscriberConnectionId);
-    setupSubscribing(serverSubscriber, subscriberConnectionId, folderId, SUBSCRIBEVARIABLE_NODEID);
+    setupFolder(*serverSub, &folderId);
+    addUDPConnection(*serverSub, "localhost", UA_SUBSCRIBER_PORT, outSubscriberConnectionId);
+
+    /* Add Subscribed Variables */
+    /* Variable to subscribe data */
+    UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+    vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
+    vAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Int32");
+    vAttr.dataType    = UA_TYPES[UA_TYPES_INT32].typeId;
+    UA_StatusCode retVal = UA_Server_addVariableNode(*serverSub, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID), folderId,
+                                       UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "Subscribed Int32"),
+                                       UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, outVariableNodeId);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+    setupSubscribing(*serverSub, *outSubscriberConnectionId, *outVariableNodeId, SUBSCRIBEVARIABLE_NODEID, outReaderGroupId);
+}
+
+/* setup() is to create an environment for test cases */
+static void setup(void) {
+
+    // UA_NodeId publisherConnectionId;
+    // UA_NodeId subscriberConnectionId;
+    // setupEnvironment(&serverPublisher, &serverSubscriber, &configPublisher, &configSubscriber,
+    //                  &publisherConnectionId, &subscriberConnectionId);
 }
 
 /* teardown() is to delete the environment set for test cases */
@@ -325,7 +336,14 @@ static void checkReceived(UA_Server *publisher, UA_UInt32 publishVariableNodeId,
 }
 
 START_TEST(SinglePublishSubscribeInt32) {
+    UA_NodeId publisherConnectionId;
+    UA_NodeId subscriberConnectionId;
+    UA_NodeId readerGroupId;
+    UA_NodeId outVariableNodeId;
+    setupEnvironment(&serverPublisher, &serverSubscriber, &configPublisher, &configSubscriber,
+                     &publisherConnectionId, &subscriberConnectionId, &readerGroupId, &outVariableNodeId);
     /* run server - publisher and subscriber */
+
     UA_fakeSleep(PUBLISH_INTERVAL + 1);
     UA_Server_run_iterate(serverPublisher,true);
     UA_fakeSleep(PUBLISH_INTERVAL + 1);
@@ -335,12 +353,52 @@ START_TEST(SinglePublishSubscribeInt32) {
                   serverSubscriber, SUBSCRIBEVARIABLE_NODEID);
 }END_TEST
 
+START_TEST(RemoveAndAddReaderGroup) {
+        UA_NodeId publisherConnectionId;
+        UA_NodeId subscriberConnectionId;
+        UA_NodeId readerGroupId;
+        UA_NodeId outVariableNodeId;
+        setupEnvironment(&serverPublisher, &serverSubscriber, &configPublisher, &configSubscriber,
+                         &publisherConnectionId, &subscriberConnectionId, &readerGroupId, &outVariableNodeId);
+
+        UA_NodeId readerGroupId2;
+        setupSubscribing(serverSubscriber, subscriberConnectionId, outVariableNodeId, SUBSCRIBEVARIABLE_NODEID, &readerGroupId2);
+
+        /* run server - publisher and subscriber */
+        UA_fakeSleep(PUBLISH_INTERVAL + 1);
+        UA_Server_run_iterate(serverPublisher,true);
+        UA_fakeSleep(PUBLISH_INTERVAL + 1);
+        UA_Server_run_iterate(serverSubscriber,true);
+
+        UA_Server_removeReaderGroup(serverSubscriber, readerGroupId2);
+        UA_Server_removePubSubConnection(serverSubscriber, subscriberConnectionId);
+
+        /* run server - publisher and subscriber */
+        UA_fakeSleep(PUBLISH_INTERVAL + 1);
+        UA_Server_run_iterate(serverPublisher,true);
+        UA_fakeSleep(PUBLISH_INTERVAL + 1);
+        UA_Server_run_iterate(serverSubscriber,true);
+
+        addUDPConnection(serverSubscriber, "localhost", UA_SUBSCRIBER_PORT, &subscriberConnectionId);
+        setupSubscribing(serverSubscriber, subscriberConnectionId,
+                         outVariableNodeId, SUBSCRIBEVARIABLE_NODEID,
+                         &readerGroupId);
+
+        /* run server - publisher and subscriber */
+        UA_fakeSleep(PUBLISH_INTERVAL + 1);
+        UA_Server_run_iterate(serverPublisher,true);
+        UA_fakeSleep(PUBLISH_INTERVAL + 1);
+        UA_Server_run_iterate(serverSubscriber,true);
+
+    }END_TEST
+
 int main(void) {
 
     /*Test case to run both publisher and subscriber */
     TCase *tc_pubsub_publish_subscribe = tcase_create("Publisher publishing and Subscriber subscribing");
     tcase_add_checked_fixture(tc_pubsub_publish_subscribe, setup, teardown);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeInt32);
+    tcase_add_test(tc_pubsub_publish_subscribe, RemoveAndAddReaderGroup);
 
     Suite *suite = suite_create("PubSub readerGroups/reader/Fields handling and publishing");
     suite_add_tcase(suite, tc_pubsub_publish_subscribe);


### PR DESCRIPTION
Removing and adding readergroups with pubsub lead to errors when the readergroups were set operational before. This fix opens and closes the communication channel for readergroups that are bound to a connection in the scope of the connection.

Thanks @MurzynJ for the discovery and possible fix of that error.