### PR TITLE
fix(server): Check server pointer before access

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -179,6 +179,9 @@ cleanup:
 
 /* The server needs to be stopped before it can be deleted */
 void UA_Server_delete(UA_Server *server) {
+    if(server == NULL) {
+        return;
+    }
     UA_LOCK(&server->serviceMutex);
 
     UA_Server_deleteSecureChannels(server);
@@ -951,6 +954,9 @@ UA_Server_run_iterate(UA_Server *server, UA_Boolean waitInternal) {
 
 UA_StatusCode
 UA_Server_run_shutdown(UA_Server *server) {
+    if(server == NULL) {
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
     /* Stop the regular housekeeping tasks */
     if(server->houseKeepingCallbackId != 0) {
         UA_Server_removeCallback(server, server->houseKeepingCallbackId);

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -56,6 +56,7 @@ THREAD_CALLBACK(serverloop) {
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
     addVariable(VARLENGTH);

--- a/tests/client/check_client_async.c
+++ b/tests/client/check_client_async.c
@@ -30,6 +30,7 @@ THREAD_CALLBACK(serverloop) {
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_Server_run_startup(server);

--- a/tests/client/check_client_async_connect.c
+++ b/tests/client/check_client_async_connect.c
@@ -31,6 +31,7 @@ currentState(UA_Client *client, UA_SecureChannelState channelState,
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/client/check_client_authentication.c
+++ b/tests/client/check_client_authentication.c
@@ -62,6 +62,7 @@ static void setup(void) {
     size_t revocationListSize = 0;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
                                                    trustList, trustListSize,

--- a/tests/client/check_client_encryption.c
+++ b/tests/client/check_client_encryption.c
@@ -56,6 +56,7 @@ static void setup(void) {
     size_t revocationListSize = 0;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
                                                    trustList, trustListSize,

--- a/tests/client/check_client_highlevel.c
+++ b/tests/client/check_client_highlevel.c
@@ -29,6 +29,7 @@ THREAD_CALLBACK(serverloop) {
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     ck_assert_uint_eq(2, UA_Server_addNamespace(server, CUSTOM_NS));

--- a/tests/client/check_client_historical_data.c
+++ b/tests/client/check_client_historical_data.c
@@ -76,6 +76,7 @@ static void fillInt64DataValue(UA_DateTime timestamp, UA_Int64 value,
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/client/check_client_securechannel.c
+++ b/tests/client/check_client_securechannel.c
@@ -36,6 +36,7 @@ static void pauseServer(void) {
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
     runServer();

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -34,6 +34,7 @@ static void setup(void) {
     noNewSubscription = false;
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     config->maxPublishReqPerSession = 5;

--- a/tests/encryption/check_cert_generation.c
+++ b/tests/encryption/check_cert_generation.c
@@ -15,6 +15,7 @@ UA_Server *server;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
 }
 
 static void teardown(void) {

--- a/tests/encryption/check_encryption_aes128sha256rsaoaep.c
+++ b/tests/encryption/check_encryption_aes128sha256rsaoaep.c
@@ -69,6 +69,7 @@ static void setup(void) {
     size_t revocationListSize = 0;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
                                                    trustList, trustListSize,

--- a/tests/encryption/check_encryption_basic128rsa15.c
+++ b/tests/encryption/check_encryption_basic128rsa15.c
@@ -66,6 +66,7 @@ static void setup(void) {
     size_t revocationListSize = 0;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
                                                    trustList, trustListSize,

--- a/tests/encryption/check_encryption_basic256.c
+++ b/tests/encryption/check_encryption_basic256.c
@@ -69,6 +69,7 @@ static void setup(void) {
     size_t revocationListSize = 0;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
                                                    trustList, trustListSize,

--- a/tests/encryption/check_encryption_basic256sha256.c
+++ b/tests/encryption/check_encryption_basic256sha256.c
@@ -69,6 +69,7 @@ static void setup(void) {
     size_t revocationListSize = 0;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
                                                    trustList, trustListSize,

--- a/tests/encryption/check_save_rejected_cert.c
+++ b/tests/encryption/check_save_rejected_cert.c
@@ -359,6 +359,7 @@ static void setup(void) {
     privateKey.data = KEY_PEM_DATA;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
 #ifndef __linux__

--- a/tests/multithreading/check_mt_addDeleteObject.c
+++ b/tests/multithreading/check_mt_addDeleteObject.c
@@ -20,6 +20,7 @@
 static void setup(void) {
     tc.running = true;
     tc.server = UA_Server_new();
+    ck_assert(tc.server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(tc.server));
     defineObjectTypes();
     addPumpTypeConstructor(tc.server);

--- a/tests/multithreading/check_mt_addObjectNode.c
+++ b/tests/multithreading/check_mt_addObjectNode.c
@@ -17,6 +17,7 @@
 static void setup(void) {
     tc.running = true;
     tc.server = UA_Server_new();
+    ck_assert(tc.server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(tc.server));
     defineObjectTypes();
     addPumpTypeConstructor(tc.server);

--- a/tests/multithreading/check_mt_addVariableTypeNode.c
+++ b/tests/multithreading/check_mt_addVariableTypeNode.c
@@ -18,6 +18,7 @@
 static void setup(void) {
     tc.running = true;
     tc.server = UA_Server_new();
+    ck_assert(tc.server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(tc.server));
     UA_Server_run_startup(tc.server);
     THREAD_CREATE(server_thread, serverloop);

--- a/tests/multithreading/check_mt_readValueAttribute.c
+++ b/tests/multithreading/check_mt_readValueAttribute.c
@@ -38,6 +38,7 @@ void addVariableNode(void) {
 static void setup(void) {
     tc.running = true;
     tc.server = UA_Server_new();
+    ck_assert(tc.server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(tc.server));
     addVariableNode();
     UA_Server_run_startup(tc.server);

--- a/tests/multithreading/check_mt_readWriteDelete.c
+++ b/tests/multithreading/check_mt_readWriteDelete.c
@@ -45,6 +45,7 @@ void AddVariableNode(void) {
 static void setup(void) {
     tc.running = true;
     tc.server = UA_Server_new();
+    ck_assert(tc.server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(tc.server));
     AddVariableNode();
     UA_Server_run_startup(tc.server);

--- a/tests/multithreading/check_mt_readWriteDeleteCallback.c
+++ b/tests/multithreading/check_mt_readWriteDeleteCallback.c
@@ -68,6 +68,7 @@ void AddVariableNode(void) {
 static void setup(void) {
     tc.running = true;
     tc.server = UA_Server_new();
+    ck_assert(tc.server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(tc.server));
     AddVariableNode();
     UA_Server_run_startup(tc.server);

--- a/tests/multithreading/check_mt_writeValueAttribute.c
+++ b/tests/multithreading/check_mt_writeValueAttribute.c
@@ -41,6 +41,7 @@ void addVariableNode(void) {
 static void setup(void) {
     tc.running = true;
     tc.server = UA_Server_new();
+    ck_assert(tc.server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(tc.server));
     addVariableNode();
     UA_Server_run_startup(tc.server);

--- a/tests/nodeset-compiler/check_nodeset_compiler_adi.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_adi.c
@@ -14,6 +14,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-compiler/check_nodeset_compiler_autoid.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_autoid.c
@@ -16,6 +16,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-compiler/check_nodeset_compiler_plc.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_plc.c
@@ -16,6 +16,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -19,6 +19,7 @@ UA_UInt16 testNamespaceIndex = (UA_UInt16) -1;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     config->customDataTypes = &customTypesArray;

--- a/tests/nodeset-loader/check_nodeset_loader_adi.c
+++ b/tests/nodeset-loader/check_nodeset_loader_adi.c
@@ -13,6 +13,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_autoid.c
+++ b/tests/nodeset-loader/check_nodeset_loader_autoid.c
@@ -13,6 +13,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_compare_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_compare_di.c
@@ -15,6 +15,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_di.c
@@ -13,6 +13,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_input.c
+++ b/tests/nodeset-loader/check_nodeset_loader_input.c
@@ -15,6 +15,7 @@ int nodesetsNum = 0;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_ordering_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ordering_di.c
@@ -13,6 +13,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_plc.c
+++ b/tests/nodeset-loader/check_nodeset_loader_plc.c
@@ -13,6 +13,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_testnodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_testnodeset.c
@@ -40,6 +40,7 @@ typedef struct {
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
@@ -50,6 +50,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/pubsub/check_pubsub_config_freeze.c
+++ b/tests/pubsub/check_pubsub_config_freeze.c
@@ -19,6 +19,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());

--- a/tests/pubsub/check_pubsub_configuration.c
+++ b/tests/pubsub/check_pubsub_configuration.c
@@ -20,6 +20,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/pubsub/check_pubsub_connection_ethernet.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet.c
@@ -27,6 +27,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerEthernet());

--- a/tests/pubsub/check_pubsub_connection_ethernet_etf.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet_etf.c
@@ -25,6 +25,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerEthernet());

--- a/tests/pubsub/check_pubsub_connection_mqtt.c
+++ b/tests/pubsub/check_pubsub_connection_mqtt.c
@@ -24,6 +24,7 @@ UA_ServerConfig *config = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerMQTT());

--- a/tests/pubsub/check_pubsub_connection_udp.c
+++ b/tests/pubsub/check_pubsub_connection_udp.c
@@ -18,6 +18,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_connection_xdp.c
+++ b/tests/pubsub/check_pubsub_connection_xdp.c
@@ -35,6 +35,7 @@ UA_String ethernetInterface;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/pubsub/check_pubsub_encrypted_rt_levels.c
+++ b/tests/pubsub/check_pubsub_encrypted_rt_levels.c
@@ -69,6 +69,7 @@ addMinimalPubSubConfiguration(void){
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     /* Instantiate the PubSub SecurityPolicy */

--- a/tests/pubsub/check_pubsub_encryption.c
+++ b/tests/pubsub/check_pubsub_encryption.c
@@ -29,6 +29,7 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_encryption_aes256.c
+++ b/tests/pubsub/check_pubsub_encryption_aes256.c
@@ -29,6 +29,7 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_get_state.c
+++ b/tests/pubsub/check_pubsub_get_state.c
@@ -16,7 +16,7 @@ static void setup(void) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "setup");
 
     server = UA_Server_new();
-    assert(server != 0);
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());

--- a/tests/pubsub/check_pubsub_informationmodel.c
+++ b/tests/pubsub/check_pubsub_informationmodel.c
@@ -28,6 +28,7 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -31,6 +31,7 @@ THREAD_CALLBACK(serverloop) {
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_mqtt.c
+++ b/tests/pubsub/check_pubsub_mqtt.c
@@ -34,6 +34,7 @@ UA_DataSetReaderConfig readerConfig;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerMQTT());

--- a/tests/pubsub/check_pubsub_multiple_layer.c
+++ b/tests/pubsub/check_pubsub_multiple_layer.c
@@ -24,6 +24,7 @@ static void teardown(void) {
 
 START_TEST(AddMultipleTransportLayers){
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
@@ -51,6 +51,7 @@ addMinimalPubSubConfiguration(void){
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_pds.c
+++ b/tests/pubsub/check_pubsub_pds.c
@@ -17,6 +17,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -22,6 +22,7 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());

--- a/tests/pubsub/check_pubsub_publish_ethernet.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet.c
@@ -33,6 +33,7 @@ UA_NodeId connection_test;
 static void setup(void) {
     /*Add setup by creating new server with valid configuration */
     server = UA_Server_new();
+    ck_assert(server != NULL);
     config = UA_Server_getConfig(server);
     UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerEthernet());

--- a/tests/pubsub/check_pubsub_publish_ethernet_etf.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet_etf.c
@@ -43,6 +43,7 @@ UA_PubSubConnection *connection; /* setup() is to create an environment for test
 static void setup(void) {
     /*Add setup by creating new server with valid configuration */
     server = UA_Server_new();
+    ck_assert(server != NULL);
     config = UA_Server_getConfig(server);
     UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerEthernet());

--- a/tests/pubsub/check_pubsub_publish_json.c
+++ b/tests/pubsub/check_pubsub_publish_json.c
@@ -20,6 +20,7 @@ UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/pubsub/check_pubsub_publish_rt_levels.c
+++ b/tests/pubsub/check_pubsub_publish_rt_levels.c
@@ -51,6 +51,7 @@ addMinimalPubSubConfiguration(void){
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_publish_uadp.c
+++ b/tests/pubsub/check_pubsub_publish_uadp.c
@@ -18,6 +18,7 @@ UA_NodeId connection1, publishedDataSetIdent, dataSetFieldIdent, writerGroupIden
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_publisherid.c
+++ b/tests/pubsub/check_pubsub_publisherid.c
@@ -27,6 +27,7 @@ static void setup(void) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "\n\nsetup\n\n");
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     ck_assert(config != 0);
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_ServerConfig_setDefault(config));

--- a/tests/pubsub/check_pubsub_publishspeed.c
+++ b/tests/pubsub/check_pubsub_publishspeed.c
@@ -20,6 +20,7 @@ UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -92,6 +92,7 @@ static void addVariables(void) {
 static void setup(void) {
     /*Add setup by creating new server with valid configuration */
     server = UA_Server_new();
+    ck_assert(server != NULL);
     config = UA_Server_getConfig(server);
     UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
     UA_Server_run_startup(server);

--- a/tests/pubsub/check_pubsub_subscribe_config_freeze.c
+++ b/tests/pubsub/check_pubsub_subscribe_config_freeze.c
@@ -19,6 +19,7 @@ UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());

--- a/tests/pubsub/check_pubsub_subscribe_encrypted.c
+++ b/tests/pubsub/check_pubsub_subscribe_encrypted.c
@@ -49,6 +49,7 @@ UA_NodeId publishedDataSetTest;
 static void setup(void) {
     /*Add setup by creating new server with valid configuration */
     server = UA_Server_new();
+    ck_assert(server != NULL);
     config = UA_Server_getConfig(server);
     UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
 

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -43,6 +43,7 @@ static void setup(void) {
     pExpectedComponentCallbackIds = 0;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -66,6 +66,7 @@ addMinimalPubSubConfiguration(void){
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());

--- a/tests/server/check_accesscontrol.c
+++ b/tests/server/check_accesscontrol.c
@@ -25,6 +25,7 @@ THREAD_CALLBACK(serverloop) {
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
     THREAD_CREATE(server_thread, serverloop);

--- a/tests/server/check_interfaces.c
+++ b/tests/server/check_interfaces.c
@@ -24,6 +24,7 @@ static UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_StatusCode setupResult = namespace_tests_interfaces_generated(server);

--- a/tests/server/check_local_monitored_item.c
+++ b/tests/server/check_local_monitored_item.c
@@ -32,6 +32,7 @@ UA_NodeId outNodeId;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_StatusCode retval = UA_Server_run_startup(server);
@@ -198,6 +199,7 @@ END_TEST
 
 static void setupIndexRange(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_StatusCode retval = UA_Server_run_startup(server);

--- a/tests/server/check_monitoreditem_filter.c
+++ b/tests/server/check_monitoreditem_filter.c
@@ -53,6 +53,7 @@ static void pauseServer(void) {
 static void setup(void) {
     UA_DataValue_init(&lastValue);
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
     runServer();

--- a/tests/server/check_node_inheritance.c
+++ b/tests/server/check_node_inheritance.c
@@ -13,6 +13,7 @@ UA_UInt32 valueToBeInherited = 42;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/server/check_server.c
+++ b/tests/server/check_server.c
@@ -22,6 +22,7 @@ static UA_Server *server = NULL;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 }
 

--- a/tests/server/check_server_asyncop.c
+++ b/tests/server/check_server_asyncop.c
@@ -47,6 +47,7 @@ static void setup(void) {
     clientCounter = 0;
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     config->asyncOperationTimeout = 2000.0; /* 2 seconds */

--- a/tests/server/check_server_callbacks.c
+++ b/tests/server/check_server_callbacks.c
@@ -222,6 +222,7 @@ THREAD_CALLBACK(serverloop) {
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
     addCurrentTimeVariable();

--- a/tests/server/check_server_historical_data.c
+++ b/tests/server/check_server_historical_data.c
@@ -48,6 +48,7 @@ static void setup(void) {
     running = true;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/server/check_server_historical_data_circular.c
+++ b/tests/server/check_server_historical_data_circular.c
@@ -43,6 +43,7 @@ static void setup(void) {
     running = true;
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/server/check_server_jobs.c
+++ b/tests/server/check_server_jobs.c
@@ -15,6 +15,7 @@ UA_Boolean *executed;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
 }

--- a/tests/server/check_server_monitoringspeed.c
+++ b/tests/server/check_server_monitoringspeed.c
@@ -17,6 +17,7 @@ static UA_Server *server;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 }
 

--- a/tests/server/check_server_readspeed.c
+++ b/tests/server/check_server_readspeed.c
@@ -25,6 +25,7 @@ static UA_NodeId readNodeIds[READNODES];
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
 }
 
 static void teardown(void) {

--- a/tests/server/check_server_reverseconnect.c
+++ b/tests/server/check_server_reverseconnect.c
@@ -121,6 +121,7 @@ static void setup(void) {
     setupListeningSocket();
 
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 }
 

--- a/tests/server/check_server_speed_addnodes.c
+++ b/tests/server/check_server_speed_addnodes.c
@@ -11,6 +11,7 @@ static UA_Server *server;
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     /* Disable logging */
     UA_ServerConfig *config = UA_Server_getConfig(server);

--- a/tests/server/check_services_attributes.c
+++ b/tests/server/check_services_attributes.c
@@ -39,6 +39,7 @@ static void teardown(void) {
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
 

--- a/tests/server/check_services_call.c
+++ b/tests/server/check_services_call.c
@@ -33,6 +33,7 @@ methodCallback(UA_Server *serverArg,
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_MethodAttributes noFpAttr = UA_MethodAttributes_default;

--- a/tests/server/check_services_nodemanagement.c
+++ b/tests/server/check_services_nodemanagement.c
@@ -29,6 +29,7 @@ globalInstantiationMethod(UA_Server *server_,
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 

--- a/tests/server/check_services_subscriptions.c
+++ b/tests/server/check_services_subscriptions.c
@@ -41,6 +41,7 @@ createSession(void) {
 
 static void setup(void) {
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     config->monitoredItemRegisterCallback = monitoredRegisterCallback;

--- a/tests/server/check_services_view.c
+++ b/tests/server/check_services_view.c
@@ -51,6 +51,7 @@ static void teardown_server(void) {
 
 START_TEST(Service_Browse_CheckSubTypes) {
     UA_Server *server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_NodeId hierarchRefs = UA_NODEID_NUMERIC(0, UA_NS0ID_HIERARCHICALREFERENCES);
@@ -104,6 +105,7 @@ browseWithMaxResults(UA_Server *server, UA_NodeId nodeId, UA_UInt32 maxResults) 
 
 START_TEST(Service_Browse_WithMaxResults) {
     UA_Server *server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_BrowseDescription bd;
@@ -131,6 +133,7 @@ END_TEST
 
 START_TEST(Service_Browse_WithBrowseName) {
     UA_Server *server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_BrowseDescription bd;
@@ -153,6 +156,7 @@ END_TEST
 
 START_TEST(Service_Browse_ClassMask) {
     UA_Server *server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     /* add a variable node to the address space */
@@ -219,6 +223,7 @@ END_TEST
 
 START_TEST(Service_Browse_ReferenceTypes) {
     UA_Server *server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     /* add a variable node to the address space */
@@ -273,6 +278,7 @@ END_TEST
 
 START_TEST(Service_Browse_Recursive) {
     UA_Server *server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     size_t resultSize = 0;
@@ -305,6 +311,7 @@ END_TEST
 
 START_TEST(Service_Browse_Localization) {
     UA_Server *server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
 
     UA_NodeId outerObjectId = UA_NODEID_STRING(1, "EntryPoint");

--- a/tests/server/check_session.c
+++ b/tests/server/check_session.c
@@ -28,6 +28,7 @@ THREAD_CALLBACK(serverloop) {
 static void setup(void) {
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig_setDefault(UA_Server_getConfig(server));
     UA_Server_run_startup(server);
     THREAD_CREATE(server_thread, serverloop);

--- a/tests/server/check_subscription_event_filter.c
+++ b/tests/server/check_subscription_event_filter.c
@@ -192,6 +192,7 @@ static void setup(void){
     }
     running = true;
     server = UA_Server_new();
+    ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
 


### PR DESCRIPTION
fix(server): Check server pointer in UA_Server_delete and UA_Server_run_shutdown

fix (tests): Check server instance in UNIT tests

Failed UNIT tests caused an exception in the server loop, if the server instance could not be created.