### PR TITLE
fixe(server) samplingInterval when negative number

### DIFF
--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -11,7 +11,7 @@
  *    Copyright 2018 (c) Ari Breitkreuz, fortiss GmbH
  *    Copyright 2017 (c) Mattias Bornhager
  *    Copyright 2017 (c) Henrik Norrman
- *    Copyright 2017-2018 (c) Thomas Stalder, Blue Time Concept SA
+ *    Copyright 2017-2023 (c) Thomas Stalder, Blue Time Concept SA
  *    Copyright 2018 (c) Fabian Arndt, Root-Core
  *    Copyright 2020 (c) Kalycito Infotech Private Limited
  *    Copyright 2021 (c) Uranik, Berisha
@@ -219,10 +219,14 @@ checkAdjustMonitoredItemParams(UA_Server *server, UA_Session *session,
     }
         
     /* Adjust to sampling interval to lie within the limits */
-    if(params->samplingInterval <= 0.0) {
-        /* A sampling interval of zero is possible and indicates that the
-         * MonitoredItem is checked for every write operation */
-        params->samplingInterval = 0.0;
+    if(params->samplingInterval < 0.0) {
+        /* A negative number indicates that the default sampling interval
+         * defined by the publishing interval of the Subscriptionis requested. */
+        if (mon->subscription) {
+            params->samplingInterval = mon->subscription->publishingInterval;
+        } else {
+            params->samplingInterval = server->config.samplingIntervalLimits.min;
+        }
     } else {
         UA_BOUNDEDVALUE_SETWBOUNDS(server->config.samplingIntervalLimits,
                                    params->samplingInterval, params->samplingInterval);

--- a/tests/server/check_services_subscriptions.c
+++ b/tests/server/check_services_subscriptions.c
@@ -16,6 +16,7 @@
 static UA_Server *server = NULL;
 static UA_Session *session = NULL;
 static UA_UInt32 monitored = 0; /* Number of active MonitoredItems */
+static UA_Double defaultRequestedPublishingInterval = 100;  /* in ms */
 
 static void
 monitoredRegisterCallback(UA_Server *s,
@@ -142,7 +143,7 @@ START_TEST(Server_modifySubscription) {
     UA_ModifySubscriptionRequest_init(&request);
     request.subscriptionId = subscriptionId;
     // just some arbitrary numbers to test. They have no specific reason
-    request.requestedPublishingInterval = 100; // in ms
+    request.requestedPublishingInterval = defaultRequestedPublishingInterval;
     request.requestedLifetimeCount = 1000;
     request.requestedMaxKeepAliveCount = 1000;
     request.maxNotificationsPerPublish = 1;
@@ -809,7 +810,7 @@ START_TEST(Server_invalidPublishingInterval) {
 }
 END_TEST
 
-START_TEST(Server_invalidSamplingInterval) {
+START_TEST(Server_negativeSamplingInterval) {
     createSubscription();
 
     UA_Double savedSamplingIntervalLimitsMin = server->config.samplingIntervalLimits.min;
@@ -830,7 +831,7 @@ START_TEST(Server_invalidSamplingInterval) {
     item.monitoringMode = UA_MONITORINGMODE_REPORTING;
     UA_MonitoringParameters params;
     UA_MonitoringParameters_init(&params);
-    params.samplingInterval = -5.0; // Must be positive
+    params.samplingInterval = -5.0;
     item.requestedParameters = params;
     request.itemsToCreateSize = 1;
     request.itemsToCreate = &item;
@@ -843,7 +844,7 @@ START_TEST(Server_invalidSamplingInterval) {
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(response.resultsSize, 1);
     ck_assert_uint_eq(response.results[0].statusCode, UA_STATUSCODE_GOOD);
-    ck_assert(response.results[0].revisedSamplingInterval == 0.0);
+    ck_assert(response.results[0].revisedSamplingInterval == defaultRequestedPublishingInterval);
 
     UA_MonitoredItemCreateRequest_clear(&item);
     UA_CreateMonitoredItemsResponse_clear(&response);
@@ -862,7 +863,7 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_server, Server_createSubscription);
     tcase_add_test(tc_server, Server_modifySubscription);
     tcase_add_test(tc_server, Server_setPublishingMode);
-    tcase_add_test(tc_server, Server_invalidSamplingInterval);
+    tcase_add_test(tc_server, Server_negativeSamplingInterval);
     tcase_add_test(tc_server, Server_createMonitoredItems);
     tcase_add_test(tc_server, Server_modifyMonitoredItems);
     tcase_add_test(tc_server, Server_overflow);


### PR DESCRIPTION
According to https://reference.opcfoundation.org/Core/Part4/v104/docs/5.12.1.2, a negative Sampling interval number indicates that the default sampling interval defined by the publishing interval of the Subscription is requested.