### PR TITLE
fix(core): Initialize entire nodeid variable

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -434,6 +434,7 @@ UA_INLINABLE(UA_NodeId
              UA_NODEID_NUMERIC(UA_UInt16 nsIndex,
                                UA_UInt32 identifier), {
     UA_NodeId id;
+    memset(&id, 0, sizeof(UA_NodeId));
     id.namespaceIndex = nsIndex;
     id.identifierType = UA_NODEIDTYPE_NUMERIC;
     id.identifier.numeric = identifier;
@@ -443,6 +444,7 @@ UA_INLINABLE(UA_NodeId
 UA_INLINABLE(UA_NodeId
              UA_NODEID_STRING(UA_UInt16 nsIndex, char *chars), {
     UA_NodeId id;
+    memset(&id, 0, sizeof(UA_NodeId));
     id.namespaceIndex = nsIndex;
     id.identifierType = UA_NODEIDTYPE_STRING;
     id.identifier.string = UA_STRING(chars);
@@ -453,6 +455,7 @@ UA_INLINABLE(UA_NodeId
              UA_NODEID_STRING_ALLOC(UA_UInt16 nsIndex,
                                     const char *chars), {
     UA_NodeId id;
+    memset(&id, 0, sizeof(UA_NodeId));
     id.namespaceIndex = nsIndex;
     id.identifierType = UA_NODEIDTYPE_STRING;
     id.identifier.string = UA_STRING_ALLOC(chars);
@@ -462,6 +465,7 @@ UA_INLINABLE(UA_NodeId
 UA_INLINABLE(UA_NodeId
              UA_NODEID_GUID(UA_UInt16 nsIndex, UA_Guid guid), {
     UA_NodeId id;
+    memset(&id, 0, sizeof(UA_NodeId));
     id.namespaceIndex = nsIndex;
     id.identifierType = UA_NODEIDTYPE_GUID;
     id.identifier.guid = guid;
@@ -471,6 +475,7 @@ UA_INLINABLE(UA_NodeId
 UA_INLINABLE(UA_NodeId
              UA_NODEID_BYTESTRING(UA_UInt16 nsIndex, char *chars), {
     UA_NodeId id;
+    memset(&id, 0, sizeof(UA_NodeId));
     id.namespaceIndex = nsIndex;
     id.identifierType = UA_NODEIDTYPE_BYTESTRING;
     id.identifier.byteString = UA_BYTESTRING(chars);
@@ -481,6 +486,7 @@ UA_INLINABLE(UA_NodeId
              UA_NODEID_BYTESTRING_ALLOC(UA_UInt16 nsIndex,
                                         const char *chars), {
     UA_NodeId id;
+    memset(&id, 0, sizeof(UA_NodeId));
     id.namespaceIndex = nsIndex;
     id.identifierType = UA_NODEIDTYPE_BYTESTRING;
     id.identifier.byteString = UA_BYTESTRING_ALLOC(chars);


### PR DESCRIPTION
If entire Nodeid variable was used, valgrind reported uninitialized memory.