### PR TITLE
fix(pubsub): set a correct builtInTypeId in FieldMetaData

### DIFF
--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -240,7 +240,7 @@ generateFieldMetaData(UA_Server *server, UA_PublishedDataSet *pds,
 #endif
         /* Check if the datatype is a builtInType, if yes set the builtinType. */
         if(currentDataType->typeKind <= UA_DATATYPEKIND_ENUM)
-            fieldMetaData->builtInType = (UA_Byte)currentDataType->typeKind;
+            fieldMetaData->builtInType = (UA_Byte)currentDataType->typeId.identifier.numeric;
         /* set the maxStringLength attribute */
         if(field->config.field.variable.maxStringLength != 0){
             if(currentDataType->typeKind == UA_DATATYPEKIND_BYTESTRING ||


### PR DESCRIPTION
By mistake the internal typeKind was set instead of a numeric identifier of the type's NodeId.

In future the special cases should be handled as specified:

![image](https://user-images.githubusercontent.com/70644594/217833347-b0f955b6-6e41-42e2-91cf-67f4ea1960fa.png)
