### PR TITLE
refactor(pubsub): don't clear TargetVariables twice

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -626,12 +626,6 @@ removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier) {
 
     UA_NodeId_clear(&dsr->identifier);
     UA_NodeId_clear(&dsr->linkedReaderGroup);
-    if(dsr->config.subscribedDataSetType == UA_PUBSUB_SDS_TARGET) {
-        UA_TargetVariables_clear(&dsr->config.subscribedDataSet.subscribedDataSetTarget);
-    } else {
-        UA_LOG_ERROR_READER(&server->config.logger, dsr,
-                     "UA_DataSetReader_delete(): unsupported subscribed dataset enum type");
-    }
 
     /* Free memory allocated for DataSetReader */
     UA_free(dsr);


### PR DESCRIPTION
TargetVariables structure was cleared twice unnecessarily. It's cleared for the first time in UA_DataSetReaderConfig_clear just above.