### PR TITLE
fix(pubsub): prevent segfault on reception of a broken UADP message

### DIFF
--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -1110,7 +1110,8 @@ UA_NetworkMessage_clear(UA_NetworkMessage* p) {
     }
 
     if(p->networkMessageType == UA_NETWORKMESSAGE_DATASET) {
-        if(p->payloadHeader.dataSetPayloadHeader.dataSetWriterIds)
+        if(p->payloadHeader.dataSetPayloadHeader.dataSetWriterIds &&
+           p->payloadHeader.dataSetPayloadHeader.dataSetWriterIds != UA_EMPTY_ARRAY_SENTINEL)
             UA_free(p->payloadHeader.dataSetPayloadHeader.dataSetWriterIds);
 
         if(p->payload.dataSetPayload.sizes)


### PR DESCRIPTION
UDP subscriber crashed when it received the following message.

![image](https://user-images.githubusercontent.com/70644594/218015769-cf15577b-095c-4d1c-ad81-0568ff4603c3.png)

Without discussing if this is even a valid message, such crash shall not happen in any case. How can it be checked in the best way that stack is resistant to any malformed message?