### PR TITLE
fix(client): Fix crash during Client_delete (#5649)

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -87,8 +87,15 @@ UA_ClientConfig_clear(UA_ClientConfig *config) {
 
 static void
 UA_Client_clear(UA_Client *client) {
+    /* Prevent new async service calls in UA_Client_AsyncService_removeAll */
+    UA_SessionState oldState = client->sessionState;
+    client->sessionState = UA_SESSIONSTATE_CLOSING;
+
     /* Delete the async service calls with BADHSUTDOWN */
     UA_Client_AsyncService_removeAll(client, UA_STATUSCODE_BADSHUTDOWN);
+
+    /* Reset to the old state to properly close the session */
+    client->sessionState = oldState;
 
     UA_Client_disconnect(client);
     UA_String_clear(&client->endpointUrl);

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -1194,7 +1194,7 @@ UA_Client_Subscriptions_backgroundPublishInactivityCheck(UA_Client *client) {
 
 void
 UA_Client_Subscriptions_backgroundPublish(UA_Client *client) {
-    if(client->sessionState < UA_SESSIONSTATE_ACTIVATED)
+    if(client->sessionState != UA_SESSIONSTATE_ACTIVATED)
         return;
 
     /* The session must have at least one subscription */


### PR DESCRIPTION
UA_Client_AsyncService_removeAll was called "reentrant" leading to an unauthorized memory access.