### PR TITLE
examples: CMakeLists.txt: fix multithreading check

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -87,7 +87,7 @@ add_example(tutorial_server_reverseconnect tutorial_server_reverseconnect.c)
 
 if(UA_ENABLE_METHODCALLS)
     add_example(tutorial_server_method tutorial_server_method.c)
-    if (UA_MULTITHREADING EQUAL 100)
+    if (UA_MULTITHREADING GREATER_EQUAL 100)
         add_example(tutorial_server_method_async tutorial_server_method_async.c)
     endif()
 endif()
@@ -133,7 +133,7 @@ install(PROGRAMS $<TARGET_FILE:client>
 add_example(client_async client_async.c)
 
 if(UA_ENABLE_METHODCALLS)
-    if (UA_MULTITHREADING EQUAL 100)
+    if (UA_MULTITHREADING GREATER_EQUAL 100)
         add_example(client_method_async client_method_async.c)
     endif()
 endif()


### PR DESCRIPTION
UA_MULTITHREADING can be greater than 100, in which case these examples won't be built.