### PR TITLE
fix(pubsub): fix memory issue after reading publishedData property

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -176,8 +176,8 @@ onReadLocked(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext
                 pvd[counter].attributeId = UA_ATTRIBUTEID_VALUE;
                 pvd[counter].publishedVariable =
                     field->config.field.variable.publishParameters.publishedVariable;
-                //UA_NodeId_copy(&field->config.field.variable.publishParameters.publishedVariable,
-                //               &pvd[counter].publishedVariable);
+                UA_NodeId_copy(&field->config.field.variable.publishParameters.publishedVariable,
+                               &pvd[counter].publishedVariable);
                 counter++;
             }
             UA_Variant_setArray(&value, pvd, publishedDataSet->fieldSize,


### PR DESCRIPTION
Copy nodeId when reading UA_NS0ID_PUBLISHEDDATAITEMSTYPE_PUBLISHEDDATA.

