### PR TITLE
fix(server) include custom-datatypes in automatic type adjust logic

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1153,7 +1153,7 @@ adjustValueType(UA_Server *server, UA_Variant *value,
     /* Unwrap ExtensionObject arrays if they all contain the same DataType */
     unwrapEOArray(server, value);
 
-    const UA_DataType *targetDataType = UA_findDataType(targetDataTypeId);
+    const UA_DataType *targetDataType = UA_findDataTypeWithCustom(targetDataTypeId, server->config.customDataTypes);
     if(!targetDataType) {
         /* Type might not have been found, if it's a non-NS0 type or an abstract type. */
         return;


### PR DESCRIPTION
The automatic adjust type logic does currently not check custom datatypes. E.g. the automatic UInt32 <--> ENUM conversion is not possible if the ENUM is defined in a custom namespace. 