### PR TITLE
fix(el): Check event loop pointer before access

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -224,7 +224,7 @@ void UA_Server_delete(UA_Server *server) {
     UA_AsyncManager_clear(&server->asyncManager, server);
 #endif
 
-    if(server->config.eventLoop) {
+    if(server->config.eventLoop && !server->config.externalEventLoop) {
         /* Stop the EventLoop and iterate until stopped or an error occurs */
         if(server->config.eventLoop->state == UA_EVENTLOOPSTATE_STARTED)
             server->config.eventLoop->stop(server->config.eventLoop);

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -227,21 +227,6 @@ void UA_Server_delete(UA_Server *server) {
     /* Clean up the Admin Session */
     UA_Session_clear(&server->adminSession, server);
 
-    if(server->config.eventLoop && !server->config.externalEventLoop) {
-        /* Stop the EventLoop and iterate until stopped or an error occurs */
-        if(server->config.eventLoop->state == UA_EVENTLOOPSTATE_STARTED)
-            server->config.eventLoop->stop(server->config.eventLoop);
-        UA_StatusCode res = UA_STATUSCODE_GOOD;
-        while(res == UA_STATUSCODE_GOOD &&
-              (server->config.eventLoop->state != UA_EVENTLOOPSTATE_FRESH &&
-               server->config.eventLoop->state != UA_EVENTLOOPSTATE_STOPPED)) {
-
-            UA_UNLOCK(&server->serviceMutex);
-            res = server->config.eventLoop->run(server->config.eventLoop, 100);
-            UA_LOCK(&server->serviceMutex);
-        }
-    }
-
     UA_UNLOCK(&server->serviceMutex); /* The timer has its own mutex */
 
     /* Clean up the config */

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -224,6 +224,9 @@ void UA_Server_delete(UA_Server *server) {
     UA_AsyncManager_clear(&server->asyncManager, server);
 #endif
 
+    /* Clean up the Admin Session */
+    UA_Session_clear(&server->adminSession, server);
+
     if(server->config.eventLoop && !server->config.externalEventLoop) {
         /* Stop the EventLoop and iterate until stopped or an error occurs */
         if(server->config.eventLoop->state == UA_EVENTLOOPSTATE_STARTED)
@@ -238,9 +241,6 @@ void UA_Server_delete(UA_Server *server) {
             UA_LOCK(&server->serviceMutex);
         }
     }
-
-    /* Clean up the Admin Session */
-    UA_Session_clear(&server->adminSession, server);
 
     UA_UNLOCK(&server->serviceMutex); /* The timer has its own mutex */
 

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -224,17 +224,19 @@ void UA_Server_delete(UA_Server *server) {
     UA_AsyncManager_clear(&server->asyncManager, server);
 #endif
 
-    /* Stop the EventLoop and iterate until stopped or an error occurs */
-    if(server->config.eventLoop->state == UA_EVENTLOOPSTATE_STARTED)
-        server->config.eventLoop->stop(server->config.eventLoop);
-    UA_StatusCode res = UA_STATUSCODE_GOOD;
-    while(res == UA_STATUSCODE_GOOD &&
-          (server->config.eventLoop->state != UA_EVENTLOOPSTATE_FRESH &&
-           server->config.eventLoop->state != UA_EVENTLOOPSTATE_STOPPED)) {
+    if(server->config.eventLoop) {
+        /* Stop the EventLoop and iterate until stopped or an error occurs */
+        if(server->config.eventLoop->state == UA_EVENTLOOPSTATE_STARTED)
+            server->config.eventLoop->stop(server->config.eventLoop);
+        UA_StatusCode res = UA_STATUSCODE_GOOD;
+        while(res == UA_STATUSCODE_GOOD &&
+              (server->config.eventLoop->state != UA_EVENTLOOPSTATE_FRESH &&
+               server->config.eventLoop->state != UA_EVENTLOOPSTATE_STOPPED)) {
 
-        UA_UNLOCK(&server->serviceMutex);
-        res = server->config.eventLoop->run(server->config.eventLoop, 100);
-        UA_LOCK(&server->serviceMutex);
+            UA_UNLOCK(&server->serviceMutex);
+            res = server->config.eventLoop->run(server->config.eventLoop, 100);
+            UA_LOCK(&server->serviceMutex);
+        }
     }
 
     /* Clean up the Admin Session */
@@ -476,7 +478,9 @@ UA_Server_changeRepeatedCallbackInterval(UA_Server *server, UA_UInt64 callbackId
 void
 removeCallback(UA_Server *server, UA_UInt64 callbackId) {
     UA_EventLoop *el = server->config.eventLoop;
-    el->removeCyclicCallback(el, callbackId);
+    if(el) {
+        el->removeCyclicCallback(el, callbackId);
+    }
 }
 
 void


### PR DESCRIPTION
fix(el): Check event loop pointer before access

In case of an initialization error of event loop an invalid pointer was accessed in function UA_server_delete.

fix(el): do not stop external event loop at exit

fix (el): Stop server event loop after cleaning admin session

Cleanup of admin session adds a delayed callback to the event loop.
If the event loop is stopped before, this callback is not executed any more.

fix (el): Remove duplicate stop of server eventloop

Eventloop is already stopped in UA_ServerConfig_clean.