### PR TITLE
Explicitly set encoding to UTF-8 when reading file

### DIFF
--- a/tools/generate_statuscode_descriptions.py
+++ b/tools/generate_statuscode_descriptions.py
@@ -14,7 +14,7 @@ parser.add_argument('outfile', help='outfile w/o extension')
 args = parser.parse_args()
 
 rows = []
-with open(args.statuscodes, mode="rt") as f:
+with open(args.statuscodes, mode="rt", encoding='utf8') as f:
     lines = f.readlines()
     for l in lines:
         rows.append(tuple(l.strip().split(',')))


### PR DESCRIPTION
I would like to request an explicit switch to UTF-8 when reading the file.
The rest of the files (a few lines below) are already opened as UTF-8.
(If the patch gets accepted, it would be great to have it end up both in 1.3 and master branch.)