### PR TITLE
Openssl runtime server cert update

### DIFF
--- a/plugins/crypto/openssl/ua_openssl_basic128rsa15.c
+++ b/plugins/crypto/openssl/ua_openssl_basic128rsa15.c
@@ -97,6 +97,53 @@ UA_Policy_Basic128Rsa15_Clear_Context (UA_SecurityPolicy *policy) {
     return;
 }
 
+static UA_StatusCode
+updateCertificateAndPrivateKey_sp_basic128rsa15(UA_SecurityPolicy *securityPolicy,
+                                                const UA_ByteString newCertificate,
+                                                const UA_ByteString newPrivateKey) {
+    if(securityPolicy == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    if(securityPolicy->policyContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Policy_Context_Basic128Rsa15 *pc =
+        (Policy_Context_Basic128Rsa15 *)securityPolicy->policyContext;
+
+    UA_ByteString_clear(&securityPolicy->localCertificate);
+
+    UA_StatusCode retval = UA_OpenSSL_LoadLocalCertificate(
+        &newCertificate, &securityPolicy->localCertificate);
+
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* Set the new private key */
+    EVP_PKEY_free(pc->localPrivateKey);
+
+    pc->localPrivateKey = UA_OpenSSL_LoadPrivateKey(&newPrivateKey);
+
+    if(!pc->localPrivateKey) {
+        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+        goto error;
+    }
+
+    retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
+                                                      &pc->localCertThumbprint, true);
+    if(retval != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
+
+    return retval;
+
+error:
+    UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                 "Could not update certificate and private key");
+    if(securityPolicy->policyContext != NULL)
+        UA_Policy_Basic128Rsa15_Clear_Context(securityPolicy);
+    return retval;
+}
+
 /* create the channel context */
 
 static UA_StatusCode
@@ -598,6 +645,8 @@ UA_SecurityPolicy_Basic128Rsa15 (UA_SecurityPolicy * policy,
         UA_ByteString_clear (&policy->localCertificate);
         return retval;
     }
+    policy->updateCertificateAndPrivateKey =
+        updateCertificateAndPrivateKey_sp_basic128rsa15;
     policy->clear = UA_Policy_Basic128Rsa15_Clear_Context;
 
     /* Use the same signature algorithm as the asymmetric component for

--- a/plugins/crypto/openssl/ua_openssl_basic256.c
+++ b/plugins/crypto/openssl/ua_openssl_basic256.c
@@ -95,6 +95,53 @@ UA_Policy_Basic256_Clear_Context (UA_SecurityPolicy *policy) {
     return;
 }
 
+static UA_StatusCode
+updateCertificateAndPrivateKey_sp_basic256(UA_SecurityPolicy *securityPolicy,
+                                           const UA_ByteString newCertificate,
+                                           const UA_ByteString newPrivateKey) {
+    if(securityPolicy == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    if(securityPolicy->policyContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Policy_Context_Basic256 *pc =
+        (Policy_Context_Basic256 *)securityPolicy->policyContext;
+
+    UA_ByteString_clear(&securityPolicy->localCertificate);
+
+    UA_StatusCode retval = UA_OpenSSL_LoadLocalCertificate(
+        &newCertificate, &securityPolicy->localCertificate);
+
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* Set the new private key */
+    EVP_PKEY_free(pc->localPrivateKey);
+
+    pc->localPrivateKey = UA_OpenSSL_LoadPrivateKey(&newPrivateKey);
+
+    if(!pc->localPrivateKey) {
+        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+        goto error;
+    }
+
+    retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
+                                                      &pc->localCertThumbprint, true);
+    if(retval != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
+
+    return retval;
+
+error:
+    UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                 "Could not update certificate and private key");
+    if(securityPolicy->policyContext != NULL)
+        UA_Policy_Basic256_Clear_Context(securityPolicy);
+    return retval;
+}
+
 /* create the channel context */
 
 static UA_StatusCode
@@ -598,6 +645,7 @@ UA_SecurityPolicy_Basic256 (UA_SecurityPolicy * policy,
         UA_ByteString_clear (&policy->localCertificate);
         return retval;
     }
+    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_basic256;
     policy->clear = UA_Policy_Basic256_Clear_Context;
 
     /* Use the same signature algorithm as the asymmetric component for

--- a/plugins/crypto/openssl/ua_openssl_basic256sha256.c
+++ b/plugins/crypto/openssl/ua_openssl_basic256sha256.c
@@ -96,6 +96,53 @@ UA_Policy_Clear_Context(UA_SecurityPolicy *policy) {
     return;
 }
 
+static UA_StatusCode
+updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPolicy,
+                                           const UA_ByteString newCertificate,
+                                           const UA_ByteString newPrivateKey) {
+    if(securityPolicy == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    if(securityPolicy->policyContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Policy_Context_Basic256Sha256 *pc =
+        (Policy_Context_Basic256Sha256 *)securityPolicy->policyContext;
+
+    UA_ByteString_clear(&securityPolicy->localCertificate);
+
+    UA_StatusCode retval = UA_OpenSSL_LoadLocalCertificate(
+        &newCertificate, &securityPolicy->localCertificate);
+
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* Set the new private key */
+    EVP_PKEY_free(pc->localPrivateKey);
+
+    pc->localPrivateKey = UA_OpenSSL_LoadPrivateKey(&newPrivateKey);
+
+    if(!pc->localPrivateKey) {
+        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+        goto error;
+    }
+
+    retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
+                                                      &pc->localCertThumbprint, true);
+    if(retval != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
+
+    return retval;
+
+error:
+    UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                 "Could not update certificate and private key");
+    if(securityPolicy->policyContext != NULL)
+        UA_Policy_Clear_Context(securityPolicy);
+    return retval;
+}
+
 /* create the channel context */
 
 static UA_StatusCode
@@ -570,6 +617,8 @@ UA_SecurityPolicy_Basic256Sha256(UA_SecurityPolicy *policy,
     symSignatureAlgorithm->getRemoteKeyLength =
         UA_SymSig_Basic256Sha256_getRemoteKeyLength;
 
+    policy->updateCertificateAndPrivateKey =
+        updateCertificateAndPrivateKey_sp_basic256sha256;
     policy->clear = UA_Policy_Clear_Context;
     retval = UA_Policy_New_Context(policy, localPrivateKey, logger);
     if(retval != UA_STATUSCODE_GOOD) {


### PR DESCRIPTION
[Update the Server Certificate at Runtime](https://www.open62541.org/doc/master/server.html#update-the-server-certificate-at-runtime) only works for the mbedTLS implementation. For openssl the updateCertificateAndPrivateKey function pointers are missing. This leads to an segmentation fault at runtime. So I added those functions for all 4 secure endpoints.