### PR TITLE
Make the Certificate expiration configurable

### DIFF
--- a/examples/encryption/server_encryption.c
+++ b/examples/encryption/server_encryption.c
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
             UA_CreateCertificate(UA_Log_Stdout,
                                  subject, lenSubject,
                                  subjectAltName, lenSubjectAltName,
-                                 0, UA_CERTIFICATEFORMAT_DER,
+                                 365, 0, UA_CERTIFICATEFORMAT_DER,
                                  &privateKey, &certificate);
 
         if(statusCertGen != UA_STATUSCODE_GOOD) {

--- a/examples/encryption/server_encryption.c
+++ b/examples/encryption/server_encryption.c
@@ -52,9 +52,8 @@ int main(int argc, char* argv[]) {
         UA_UInt32 lenSubjectAltName = 2;
         UA_KeyValueMap *kvm = UA_KeyValueMap_new();
         UA_UInt16 expiresIn = 14;
-        UA_KeyValueMap_setScalar(kvm, CreateCertificateParams[CERT_EXPIRES_IN_DAYS].name,
-                                 (void *)&expiresIn,
-                                 CreateCertificateParams[CERT_EXPIRES_IN_DAYS].type);
+        UA_KeyValueMap_setScalar(kvm, UA_QUALIFIEDNAME(0, "expires-in-days"),
+                                 (void *)&expiresIn, &UA_TYPES[UA_TYPES_UINT16]);
         UA_StatusCode statusCertGen = UA_CreateCertificate(
             UA_Log_Stdout, subject, lenSubject, subjectAltName, lenSubjectAltName,
             UA_CERTIFICATEFORMAT_DER, kvm, &privateKey, &certificate);

--- a/examples/encryption/server_encryption.c
+++ b/examples/encryption/server_encryption.c
@@ -50,12 +50,15 @@ int main(int argc, char* argv[]) {
             UA_STRING_STATIC("URI:urn:open62541.server.application")
         };
         UA_UInt32 lenSubjectAltName = 2;
-        UA_StatusCode statusCertGen =
-            UA_CreateCertificate(UA_Log_Stdout,
-                                 subject, lenSubject,
-                                 subjectAltName, lenSubjectAltName,
-                                 365, 0, UA_CERTIFICATEFORMAT_DER,
-                                 &privateKey, &certificate);
+        UA_KeyValueMap *kvm = UA_KeyValueMap_new();
+        UA_UInt16 expiresIn = 14;
+        UA_KeyValueMap_setScalar(kvm, CreateCertificateParams[CERT_EXPIRES_IN_DAYS].name,
+                                 (void *)&expiresIn,
+                                 CreateCertificateParams[CERT_EXPIRES_IN_DAYS].type);
+        UA_StatusCode statusCertGen = UA_CreateCertificate(
+            UA_Log_Stdout, subject, lenSubject, subjectAltName, lenSubjectAltName,
+            UA_CERTIFICATEFORMAT_DER, kvm, &privateKey, &certificate);
+        UA_KeyValueMap_delete(kvm);
 
         if(statusCertGen != UA_STATUSCODE_GOOD) {
             UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,

--- a/plugins/crypto/openssl/ua_openssl_create_certificate.c
+++ b/plugins/crypto/openssl/ua_openssl_create_certificate.c
@@ -124,14 +124,12 @@ UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
 
     if(params) {
         const UA_UInt16 *keySizeBitsValue = (const UA_UInt16 *)UA_KeyValueMap_getScalar(
-            params, CreateCertificateParams[CERT_KEY_SIZE_BITS].name,
-            CreateCertificateParams[CERT_KEY_SIZE_BITS].type);
+            params, UA_QUALIFIEDNAME(0, "key-size-bits"), &UA_TYPES[UA_TYPES_UINT16]);
         if(keySizeBitsValue)
             keySizeBits = *keySizeBitsValue;
 
         const UA_UInt16 *expiresInDaysValue = (const UA_UInt16 *)UA_KeyValueMap_getScalar(
-            params, CreateCertificateParams[CERT_EXPIRES_IN_DAYS].name,
-            CreateCertificateParams[CERT_EXPIRES_IN_DAYS].type);
+            params, UA_QUALIFIEDNAME(0, "expires-in-days"), &UA_TYPES[UA_TYPES_UINT16]);
         if(expiresInDaysValue)
             expiresInDays = *expiresInDaysValue;
     }

--- a/plugins/crypto/openssl/ua_openssl_create_certificate.c
+++ b/plugins/crypto/openssl/ua_openssl_create_certificate.c
@@ -107,9 +107,9 @@ static EVP_PKEY * UA_RSA_Generate_Key (size_t keySizeBits){
 #endif
 
 UA_StatusCode
-UA_CreateCertificate(const UA_Logger *logger,
-                     const UA_String *subject, size_t subjectSize,
-                     const UA_String *subjectAltName, size_t subjectAltNameSize,
+UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
+                     size_t subjectSize, const UA_String *subjectAltName,
+                     size_t subjectAltNameSize, UA_UInt32 expiresInDays,
                      size_t keySizeBits, UA_CertificateFormat certFormat,
                      UA_ByteString *outPrivateKey, UA_ByteString *outCertificate) {
     if(!outPrivateKey || !outCertificate || !logger || !subjectAltName ||
@@ -120,6 +120,10 @@ UA_CreateCertificate(const UA_Logger *logger,
     /* Use the maximum size */
     if(keySizeBits == 0)
         keySizeBits = 4096;
+
+     /* Default to 1 year */
+     if(expiresInDays == 0)
+       expiresInDays = 365;
 
     UA_ByteString_init(outPrivateKey);
     UA_ByteString_init(outCertificate);
@@ -203,7 +207,8 @@ UA_CreateCertificate(const UA_Logger *logger,
         goto cleanup;
     }
 
-    if(X509_gmtime_adj(X509_get_notAfter(x509), (UA_Int64) 60 * 60 * 24 * 365) == NULL) {
+    if(X509_gmtime_adj(X509_get_notAfter(x509), (UA_Int64)60 * 60 * 24 * expiresInDays) ==
+       NULL) {
         UA_LOG_ERROR(logger, UA_LOGCATEGORY_SECURECHANNEL,
                      "Create Certificate: Setting 'not before' failed.");
         errRet = UA_STATUSCODE_BADINTERNALERROR;

--- a/plugins/crypto/openssl/ua_openssl_create_certificate.c
+++ b/plugins/crypto/openssl/ua_openssl_create_certificate.c
@@ -109,21 +109,32 @@ static EVP_PKEY * UA_RSA_Generate_Key (size_t keySizeBits){
 UA_StatusCode
 UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
                      size_t subjectSize, const UA_String *subjectAltName,
-                     size_t subjectAltNameSize, UA_UInt32 expiresInDays,
-                     size_t keySizeBits, UA_CertificateFormat certFormat,
-                     UA_ByteString *outPrivateKey, UA_ByteString *outCertificate) {
-    if(!outPrivateKey || !outCertificate || !logger || !subjectAltName ||
-       !subject || subjectAltNameSize == 0 || subjectSize == 0 ||
-       (certFormat != UA_CERTIFICATEFORMAT_DER && certFormat != UA_CERTIFICATEFORMAT_PEM ))
+                     size_t subjectAltNameSize, UA_CertificateFormat certFormat,
+                     UA_KeyValueMap *params, UA_ByteString *outPrivateKey,
+                     UA_ByteString *outCertificate) {
+    if(!outPrivateKey || !outCertificate || !logger || !subjectAltName || !subject ||
+       subjectAltNameSize == 0 || subjectSize == 0 ||
+       (certFormat != UA_CERTIFICATEFORMAT_DER && certFormat != UA_CERTIFICATEFORMAT_PEM))
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
     /* Use the maximum size */
-    if(keySizeBits == 0)
-        keySizeBits = 4096;
+    UA_UInt16 keySizeBits = 4096;
+    /* Default to 1 year */
+    UA_UInt16 expiresInDays = 365;
 
-     /* Default to 1 year */
-     if(expiresInDays == 0)
-       expiresInDays = 365;
+    if(params) {
+        const UA_UInt16 *keySizeBitsValue = (const UA_UInt16 *)UA_KeyValueMap_getScalar(
+            params, CreateCertificateParams[CERT_KEY_SIZE_BITS].name,
+            CreateCertificateParams[CERT_KEY_SIZE_BITS].type);
+        if(keySizeBitsValue)
+            keySizeBits = *keySizeBitsValue;
+
+        const UA_UInt16 *expiresInDaysValue = (const UA_UInt16 *)UA_KeyValueMap_getScalar(
+            params, CreateCertificateParams[CERT_EXPIRES_IN_DAYS].name,
+            CreateCertificateParams[CERT_EXPIRES_IN_DAYS].type);
+        if(expiresInDaysValue)
+            expiresInDays = *expiresInDaysValue;
+    }
 
     UA_ByteString_init(outPrivateKey);
     UA_ByteString_init(outCertificate);

--- a/plugins/include/open62541/plugin/create_certificate.h
+++ b/plugins/include/open62541/plugin/create_certificate.h
@@ -10,6 +10,7 @@
 
 #include <open62541/plugin/log.h>
 #include <open62541/types.h>
+#include <open62541/util.h>
 
 _UA_BEGIN_DECLS
 
@@ -18,6 +19,21 @@ typedef enum {
     UA_CERTIFICATEFORMAT_DER,
     UA_CERTIFICATEFORMAT_PEM
 } UA_CertificateFormat;
+
+typedef struct {
+    const UA_QualifiedName name;
+    const UA_DataType *type;
+} UA_CreateCertificateParams;
+
+/* Configuration parameters */
+#define CREATECERTIFICATEPARAMSSIZE 2
+#define CERT_EXPIRES_IN_DAYS 0
+#define CERT_KEY_SIZE_BITS 1
+
+static const UA_CreateCertificateParams
+    CreateCertificateParams[CREATECERTIFICATEPARAMSSIZE] = {
+        {{0, UA_STRING_STATIC("expiresInDays")}, &UA_TYPES[UA_TYPES_UINT16]},
+        {{0, UA_STRING_STATIC("keySizeBits")}, &UA_TYPES[UA_TYPES_UINT16]}};
 
 /**
  * Create a self-signed certificate
@@ -29,16 +45,17 @@ typedef enum {
  *                  e.g. ["C=DE", "O=SampleOrganization", "CN=Open62541Server@localhost"]
  * \param subjectAltName Elements for SubjectAltName,
  *                  e.g. ["DNS:localhost", "URI:urn:open62541.server.application"]
- * \param expiresInDays after these the cert expires
- * \param keySizeBits Size of the generated key in bits. If set to 0, the maximum key
- *                  size is used. Possible values are: [0, 1024 (deprecated), 2048, 4096]
+ * \param params key value map with optional parameters:
+ *                  - expiresInDays after these the cert expires default: 365
+ *                  - keySizeBits Size of the generated key in bits. Possible values are:
+ *                    [0, 1024 (deprecated), 2048, 4096] default: 4096
  */
 UA_StatusCode UA_EXPORT
 UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
                      size_t subjectSize, const UA_String *subjectAltName,
-                     size_t subjectAltNameSize, UA_UInt32 expiresInDays,
-                     size_t keySizeBits, UA_CertificateFormat certFormat,
-                     UA_ByteString *outPrivateKey, UA_ByteString *outCertificate);
+                     size_t subjectAltNameSize, UA_CertificateFormat certFormat,
+                     UA_KeyValueMap *params, UA_ByteString *outPrivateKey,
+                     UA_ByteString *outCertificate);
 #endif
 
 _UA_END_DECLS

--- a/plugins/include/open62541/plugin/create_certificate.h
+++ b/plugins/include/open62541/plugin/create_certificate.h
@@ -29,13 +29,14 @@ typedef enum {
  *                  e.g. ["C=DE", "O=SampleOrganization", "CN=Open62541Server@localhost"]
  * \param subjectAltName Elements for SubjectAltName,
  *                  e.g. ["DNS:localhost", "URI:urn:open62541.server.application"]
+ * \param expiresInDays after these the cert expires
  * \param keySizeBits Size of the generated key in bits. If set to 0, the maximum key
  *                  size is used. Possible values are: [0, 1024 (deprecated), 2048, 4096]
  */
 UA_StatusCode UA_EXPORT
-UA_CreateCertificate(const UA_Logger *logger,
-                     const UA_String *subject, size_t subjectSize,
-                     const UA_String *subjectAltName, size_t subjectAltNameSize,
+UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
+                     size_t subjectSize, const UA_String *subjectAltName,
+                     size_t subjectAltNameSize, UA_UInt32 expiresInDays,
                      size_t keySizeBits, UA_CertificateFormat certFormat,
                      UA_ByteString *outPrivateKey, UA_ByteString *outCertificate);
 #endif

--- a/plugins/include/open62541/plugin/create_certificate.h
+++ b/plugins/include/open62541/plugin/create_certificate.h
@@ -20,21 +20,6 @@ typedef enum {
     UA_CERTIFICATEFORMAT_PEM
 } UA_CertificateFormat;
 
-typedef struct {
-    const UA_QualifiedName name;
-    const UA_DataType *type;
-} UA_CreateCertificateParams;
-
-/* Configuration parameters */
-#define CREATECERTIFICATEPARAMSSIZE 2
-#define CERT_EXPIRES_IN_DAYS 0
-#define CERT_KEY_SIZE_BITS 1
-
-static const UA_CreateCertificateParams
-    CreateCertificateParams[CREATECERTIFICATEPARAMSSIZE] = {
-        {{0, UA_STRING_STATIC("expiresInDays")}, &UA_TYPES[UA_TYPES_UINT16]},
-        {{0, UA_STRING_STATIC("keySizeBits")}, &UA_TYPES[UA_TYPES_UINT16]}};
-
 /**
  * Create a self-signed certificate
  *
@@ -46,8 +31,8 @@ static const UA_CreateCertificateParams
  * \param subjectAltName Elements for SubjectAltName,
  *                  e.g. ["DNS:localhost", "URI:urn:open62541.server.application"]
  * \param params key value map with optional parameters:
- *                  - expiresInDays after these the cert expires default: 365
- *                  - keySizeBits Size of the generated key in bits. Possible values are:
+ *                  - expires-in-days after these the cert expires default: 365
+ *                  - key-size-bits Size of the generated key in bits. Possible values are:
  *                    [0, 1024 (deprecated), 2048, 4096] default: 4096
  */
 UA_StatusCode UA_EXPORT

--- a/tests/encryption/check_cert_generation.c
+++ b/tests/encryption/check_cert_generation.c
@@ -34,12 +34,19 @@ START_TEST(certificate_generation) {
         UA_STRING_STATIC("URI:urn:open62541.server.application")
     };
     UA_UInt32 lenSubjectAltName = 2;
-    UA_StatusCode status =
-        UA_CreateCertificate(UA_Log_Stdout,
-                             subject, lenSubject,
-                             subjectAltName, lenSubjectAltName,
-                             365, 0, UA_CERTIFICATEFORMAT_DER,
-                             &derPrivKey, &derCert);
+    UA_KeyValueMap *kvm = UA_KeyValueMap_new();
+    UA_UInt16 expiresIn = 14;
+    UA_KeyValueMap_setScalar(kvm, CreateCertificateParams[CERT_EXPIRES_IN_DAYS].name,
+                             (void *)&expiresIn,
+                             CreateCertificateParams[CERT_EXPIRES_IN_DAYS].type);
+    UA_UInt16 keyLength = 2048;
+    UA_KeyValueMap_setScalar(kvm, CreateCertificateParams[CERT_KEY_SIZE_BITS].name,
+                             (void *)&keyLength,
+                             CreateCertificateParams[CERT_KEY_SIZE_BITS].type);
+    UA_StatusCode status = UA_CreateCertificate(
+        UA_Log_Stdout, subject, lenSubject, subjectAltName, lenSubjectAltName,
+        UA_CERTIFICATEFORMAT_DER, kvm, &derPrivKey, &derCert);
+    UA_KeyValueMap_delete(kvm);
     ck_assert(status == UA_STATUSCODE_GOOD);
     ck_assert(derPrivKey.length > 0);
     ck_assert(derCert.length > 0);

--- a/tests/encryption/check_cert_generation.c
+++ b/tests/encryption/check_cert_generation.c
@@ -38,7 +38,7 @@ START_TEST(certificate_generation) {
         UA_CreateCertificate(UA_Log_Stdout,
                              subject, lenSubject,
                              subjectAltName, lenSubjectAltName,
-                             0, UA_CERTIFICATEFORMAT_DER,
+                             365, 0, UA_CERTIFICATEFORMAT_DER,
                              &derPrivKey, &derCert);
     ck_assert(status == UA_STATUSCODE_GOOD);
     ck_assert(derPrivKey.length > 0);

--- a/tests/encryption/check_cert_generation.c
+++ b/tests/encryption/check_cert_generation.c
@@ -36,13 +36,11 @@ START_TEST(certificate_generation) {
     UA_UInt32 lenSubjectAltName = 2;
     UA_KeyValueMap *kvm = UA_KeyValueMap_new();
     UA_UInt16 expiresIn = 14;
-    UA_KeyValueMap_setScalar(kvm, CreateCertificateParams[CERT_EXPIRES_IN_DAYS].name,
-                             (void *)&expiresIn,
-                             CreateCertificateParams[CERT_EXPIRES_IN_DAYS].type);
+    UA_KeyValueMap_setScalar(kvm, UA_QUALIFIEDNAME(0, "expires-in-days"),
+                             (void *)&expiresIn, &UA_TYPES[UA_TYPES_UINT16]);
     UA_UInt16 keyLength = 2048;
-    UA_KeyValueMap_setScalar(kvm, CreateCertificateParams[CERT_KEY_SIZE_BITS].name,
-                             (void *)&keyLength,
-                             CreateCertificateParams[CERT_KEY_SIZE_BITS].type);
+    UA_KeyValueMap_setScalar(kvm, UA_QUALIFIEDNAME(0, "key-size-bits"),
+                             (void *)&keyLength, &UA_TYPES[UA_TYPES_UINT16]);
     UA_StatusCode status = UA_CreateCertificate(
         UA_Log_Stdout, subject, lenSubject, subjectAltName, lenSubjectAltName,
         UA_CERTIFICATEFORMAT_DER, kvm, &derPrivKey, &derCert);


### PR DESCRIPTION
The expiration time for certificates generated by the UA_CreateCertificate function where hard coded to 1 year. For more flexability I added the ExpirationInDays as a function argument. This is a public API breaking change.