### PR TITLE
fix(PubSub) Add StatusCode checks.

### DIFF
--- a/tests/pubsub/check_pubsub_config_freeze.c
+++ b/tests/pubsub/check_pubsub_config_freeze.c
@@ -35,13 +35,14 @@ START_TEST(CreateAndLockConfiguration) {
     //create config
     UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1, dataSetField1;
     UA_PubSubConnectionConfig connectionConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("UADP Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
     &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -49,13 +50,13 @@ START_TEST(CreateAndLockConfiguration) {
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
     writerGroupConfig.rtLevel = UA_PUBSUB_RT_NONE;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet 1");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
 
     UA_DataSetFieldConfig fieldConfig;
     memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -63,7 +64,7 @@ START_TEST(CreateAndLockConfiguration) {
     fieldConfig.field.variable.fieldNameAlias = UA_STRING("field 1");
     fieldConfig.field.variable.publishParameters.publishedVariable =
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
-    UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &dataSetField1);
+    retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &dataSetField1).result;
 
     UA_DataSetField *dataSetField = UA_DataSetField_findDSFbyId(server, dataSetField1);
     ck_assert(dataSetField->configurationFrozen == UA_FALSE);
@@ -90,7 +91,7 @@ START_TEST(CreateAndLockConfiguration) {
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
     UA_DataSetWriter *dataSetWriter = UA_DataSetWriter_findDSWbyId(server, dataSetWriter1);
     ck_assert(dataSetWriter != NULL);
 
@@ -111,20 +112,22 @@ START_TEST(CreateAndLockConfiguration) {
         ck_assert(dsf->configurationFrozen == UA_TRUE);
     }
     //set state to disabled and implicit unlock the configuration
-        UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
+    retVal |= UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 } END_TEST
 
 START_TEST(CreateAndLockConfigurationWithExternalAPI) {
         //create config
         UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1, dataSetField1;
         UA_PubSubConnectionConfig connectionConfig;
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
         memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
         connectionConfig.name = UA_STRING("UADP Connection");
         UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING("opc.udp://224.0.0.22:4840/")};
         UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                              &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
         connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-        UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+        retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -132,13 +135,13 @@ START_TEST(CreateAndLockConfigurationWithExternalAPI) {
         writerGroupConfig.publishingInterval = 10;
         writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
         writerGroupConfig.rtLevel = UA_PUBSUB_RT_NONE;
-        UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+        retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
 
         UA_PublishedDataSetConfig pdsConfig;
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet 1");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
+        retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
 
         UA_DataSetFieldConfig fieldConfig;
         memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -146,7 +149,7 @@ START_TEST(CreateAndLockConfigurationWithExternalAPI) {
         fieldConfig.field.variable.fieldNameAlias = UA_STRING("field 1");
         fieldConfig.field.variable.publishParameters.publishedVariable =
             UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
-        UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &dataSetField1);
+        retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &dataSetField1).result;
 
         UA_DataSetField *dataSetField = UA_DataSetField_findDSFbyId(server, dataSetField1);
         ck_assert(dataSetField->configurationFrozen == UA_FALSE);
@@ -158,7 +161,7 @@ START_TEST(CreateAndLockConfigurationWithExternalAPI) {
         UA_DataSetWriterConfig dataSetWriterConfig;
         memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
         dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-        UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
         UA_DataSetWriter *dataSetWriter = UA_DataSetWriter_findDSWbyId(server, dataSetWriter1);
         ck_assert(dataSetWriter != NULL);
 
@@ -178,20 +181,22 @@ START_TEST(CreateAndLockConfigurationWithExternalAPI) {
             ck_assert(dsf->configurationFrozen == UA_TRUE);
         }
         //set state to disabled and implicit unlock the configuration
-        UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
+        retVal |= UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 START_TEST(CreateAndReleaseMultiplePDSLocks) {
     //create config
     UA_NodeId connection1, writerGroup1, writerGroup2, publishedDataSet1, dataSetWriter1, dataSetWriter2, dataSetWriter3, dataSetField1;
     UA_PubSubConnectionConfig connectionConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("UADP Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
     //Add two writer groups
     UA_WriterGroupConfig writerGroupConfig;
@@ -200,15 +205,15 @@ START_TEST(CreateAndReleaseMultiplePDSLocks) {
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
     writerGroupConfig.rtLevel = UA_PUBSUB_RT_NONE;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
     writerGroupConfig.name = UA_STRING("WriterGroup 2");
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup2);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup2);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet 1");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
 
     UA_DataSetFieldConfig fieldConfig;
     memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -216,18 +221,18 @@ START_TEST(CreateAndReleaseMultiplePDSLocks) {
     fieldConfig.field.variable.fieldNameAlias = UA_STRING("field 1");
     fieldConfig.field.variable.publishParameters.publishedVariable =
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
-    UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &dataSetField1);
+    retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &dataSetField1).result;
 
     UA_DataSetField *dataSetField = UA_DataSetField_findDSFbyId(server, dataSetField1);
 
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 2");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter2);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter2);
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 3");
-    UA_Server_addDataSetWriter(server, writerGroup2, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter3);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup2, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter3);
 
     UA_WriterGroup *writerGroup_1 = UA_WriterGroup_findWGbyId(server, writerGroup1);
     UA_WriterGroup *writerGroup_2 = UA_WriterGroup_findWGbyId(server, writerGroup2);
@@ -238,34 +243,35 @@ START_TEST(CreateAndReleaseMultiplePDSLocks) {
     ck_assert(writerGroup_2->configurationFrozen == UA_FALSE);
     ck_assert(publishedDataSet->configurationFreezeCounter == 0);
     ck_assert(pubSubConnection->configurationFreezeCounter == 0);
-        UA_Server_freezeWriterGroupConfiguration(server, writerGroup1);
-        UA_Server_freezeWriterGroupConfiguration(server, writerGroup2);
+    retVal |= UA_Server_freezeWriterGroupConfiguration(server, writerGroup1);
+    retVal |= UA_Server_freezeWriterGroupConfiguration(server, writerGroup2);
     ck_assert(writerGroup_1->configurationFrozen == UA_TRUE);
     ck_assert(writerGroup_2->configurationFrozen == UA_TRUE);
     ck_assert(publishedDataSet->configurationFreezeCounter > 0);
     ck_assert(pubSubConnection->configurationFreezeCounter > 0);
     //unlock one tree, get sure pds still locked
-        UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
+    retVal |= UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
     ck_assert(writerGroup_1->configurationFrozen == UA_FALSE);
     ck_assert(publishedDataSet->configurationFreezeCounter > 0);
     ck_assert(dataSetField->configurationFrozen == UA_TRUE);
-    UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup2);
+    retVal |= UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup2);
     ck_assert(publishedDataSet->configurationFreezeCounter == 0);
     ck_assert(dataSetField->configurationFrozen == UA_FALSE);
     ck_assert(pubSubConnection->configurationFreezeCounter == 0);
-
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 START_TEST(CreateLockAndEditConfiguration) {
     UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
     UA_PubSubConnectionConfig connectionConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("UADP Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -273,13 +279,13 @@ START_TEST(CreateLockAndEditConfiguration) {
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
     writerGroupConfig.rtLevel = UA_PUBSUB_RT_NONE;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet 1");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
 
     UA_DataSetFieldConfig fieldConfig;
     memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -288,7 +294,7 @@ START_TEST(CreateLockAndEditConfiguration) {
     fieldConfig.field.variable.publishParameters.publishedVariable =
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
     UA_NodeId localDataSetField;
-    UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &localDataSetField);
+    retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &localDataSetField).result;
 
     //get internal WG Pointer
     UA_WriterGroup *writerGroup = UA_WriterGroup_findWGbyId(server, writerGroup1);
@@ -297,7 +303,7 @@ START_TEST(CreateLockAndEditConfiguration) {
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
     UA_DataSetWriter *dataSetWriter = UA_DataSetWriter_findDSWbyId(server, dataSetWriter1);
     ck_assert(dataSetWriter != NULL);
 
@@ -308,21 +314,23 @@ START_TEST(CreateLockAndEditConfiguration) {
     UA_DataSetFieldResult fieldRemoveResult = UA_Server_removeDataSetField(server, localDataSetField);
     ck_assert(fieldRemoveResult.result == UA_STATUSCODE_BADCONFIGURATIONERROR);
     ck_assert(UA_Server_removePublishedDataSet(server, publishedDataSet1) == UA_STATUSCODE_BADCONFIGURATIONERROR);
-        UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
+    retVal |= UA_Server_unfreezeWriterGroupConfiguration(server, writerGroup1);
     fieldRemoveResult = UA_Server_removeDataSetField(server, localDataSetField);
     ck_assert(fieldRemoveResult.result == UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 START_TEST(CreateConfigWithStaticFieldSource) {
     UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
     UA_PubSubConnectionConfig connectionConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("UADP Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl = {UA_STRING_NULL, UA_STRING("opc.udp://224.0.0.22:4840/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -330,13 +338,13 @@ START_TEST(CreateConfigWithStaticFieldSource) {
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
     writerGroupConfig.rtLevel = UA_PUBSUB_RT_FIXED_SIZE;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet 1");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
 
     UA_UInt32 *intValue = UA_UInt32_new();
     UA_DataValue *dataValue = UA_DataValue_new();
@@ -349,13 +357,14 @@ START_TEST(CreateConfigWithStaticFieldSource) {
     fieldConfig.field.variable.rtValueSource.rtFieldSourceEnabled = UA_TRUE;
     fieldConfig.field.variable.rtValueSource.staticValueSource = &dataValue;
     UA_NodeId localDataSetField;
-    UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &localDataSetField);
+    retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &fieldConfig, &localDataSetField).result;
 
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
     UA_DataValue_delete(dataValue);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 int main(void) {

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -52,9 +52,10 @@ UA_Logger *logger = NULL;
 static void
 setup(void) {
     server = UA_Server_new();
+    UA_StatusCode retVal = UA_Server_run_startup(server);
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
 
     config->pubSubConfig.securityPolicies =
         (UA_PubSubSecurityPolicy *)UA_malloc(sizeof(UA_PubSubSecurityPolicy));
@@ -62,7 +63,7 @@ setup(void) {
     UA_PubSubSecurityPolicy_Aes128Ctr(config->pubSubConfig.securityPolicies,
                                       &config->logger);
 
-    UA_Server_run_startup(server);
+    retVal |= UA_Server_run_startup(server);
     // add connection
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
@@ -75,8 +76,8 @@ setup(void) {
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
     connectionConfig.publisherId.uint16 = 2234;
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
-
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     logger = &server->config.logger;
 }
 

--- a/tests/pubsub/check_pubsub_encrypted_rt_levels.c
+++ b/tests/pubsub/check_pubsub_encrypted_rt_levels.c
@@ -204,10 +204,11 @@ START_TEST(SetupInvalidPubSubConfig) {
     memset(&variant, 0, sizeof(UA_Variant));
     UA_Variant_setScalar(&variant, intValue, &UA_TYPES[UA_TYPES_UINT32]);
     attributes.value = variant;
-    UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1,  1000),
+    retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1,  1000),
                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                               UA_QUALIFIEDNAME(1, "variable"), UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
                               attributes, NULL, NULL);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);                          
     dsfConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(1, 1000);
     dsfConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
     /* Not using static value source */
@@ -281,11 +282,12 @@ START_TEST(SetupInvalidPubSubConfig) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
                              UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     /* Variable to subscribe data */
     UA_VariableAttributes vAttr = UA_VariableAttributes_default;
     vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed DateTime");
@@ -442,11 +444,12 @@ START_TEST(PublishAndSubscribeSingleFieldWithFixedOffsets) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
                              UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     /* Variable to subscribe data */
     UA_VariableAttributes vAttr = UA_VariableAttributes_default;
     vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed UInt32");
@@ -532,11 +535,12 @@ START_TEST(PublishPDSWithMultipleFieldsAndSubscribeFixedSize) {
         folderBrowseName1 = UA_QUALIFIEDNAME (1, "Published Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName1, UA_NODEID_NUMERIC (0,
                              UA_NS0ID_BASEOBJECTTYPE), oAttr1, NULL, &folderId1);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_VariableAttributes vAttr = UA_VariableAttributes_default;
     UA_UInt32 value            = 0;
     vAttr.accessLevel           = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
@@ -694,11 +698,12 @@ START_TEST(PublishPDSWithMultipleFieldsAndSubscribeFixedSize) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
                              UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     /* Variable to subscribe data */
     vAttr = UA_VariableAttributes_default;
     vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed UInt32");

--- a/tests/pubsub/check_pubsub_encryption.c
+++ b/tests/pubsub/check_pubsub_encryption.c
@@ -30,9 +30,10 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
 
     config->pubSubConfig.securityPolicies = (UA_PubSubSecurityPolicy*)
         UA_malloc(sizeof(UA_PubSubSecurityPolicy));
@@ -40,7 +41,7 @@ static void setup(void) {
     UA_PubSubSecurityPolicy_Aes128Ctr(config->pubSubConfig.securityPolicies,
                                       &config->logger);
 
-    UA_Server_run_startup(server);
+    retVal |= UA_Server_run_startup(server);
     //add 2 connections
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
@@ -49,8 +50,9 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection2);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection2);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {
@@ -60,19 +62,21 @@ static void teardown(void) {
 
 START_TEST(SinglePublishDataSetField) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
-
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
     writerGroupConfig.name = UA_STRING("WriterGroup 1");
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
-    UA_Server_setWriterGroupOperational(server, writerGroup1);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retVal |= UA_Server_setWriterGroupOperational(server, writerGroup1);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     writerGroupConfig.name = UA_STRING("WriterGroup 2");
     writerGroupConfig.publishingInterval = 50;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
-    UA_Server_setWriterGroupOperational(server, writerGroup2);
+    retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
+    retVal |= UA_Server_setWriterGroupOperational(server, writerGroup2);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     writerGroupConfig.name = UA_STRING("WriterGroup 3");
     writerGroupConfig.publishingInterval = 100;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
@@ -80,30 +84,36 @@ START_TEST(SinglePublishDataSetField) {
     writerGroupConfig.securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
     writerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
 
-    UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
-    UA_Server_setWriterGroupOperational(server, writerGroup3);
+    retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
+    retVal |= UA_Server_setWriterGroupOperational(server, writerGroup3);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet 1");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+    pdsConfig.name = UA_STRING("PublishedDataSet 2");
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2).addResult;
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_DataSetFieldConfig dataSetFieldConfig;
     memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
     dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
     dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
     dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
-    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME);
+    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
     dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-    UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL);
+    retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup3, publishedDataSet1,
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup3, publishedDataSet1,
                                    &dataSetWriterConfig, &dataSetWriter1);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_ByteString sk = {UA_AES128CTR_SIGNING_KEY_LENGTH, signingKey};
     UA_ByteString ek = {UA_AES128CTR_KEY_LENGTH, encryptingKey};
@@ -113,6 +123,7 @@ START_TEST(SinglePublishDataSetField) {
 
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup3);
     UA_WriterGroup_publishCallback(server, wg);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 } END_TEST
 
 int main(void) {

--- a/tests/pubsub/check_pubsub_encryption_aes256.c
+++ b/tests/pubsub/check_pubsub_encryption_aes256.c
@@ -30,9 +30,10 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
 
     config->pubSubConfig.securityPolicies = (UA_PubSubSecurityPolicy*)
         UA_malloc(sizeof(UA_PubSubSecurityPolicy));
@@ -40,7 +41,7 @@ static void setup(void) {
     UA_PubSubSecurityPolicy_Aes256Ctr(config->pubSubConfig.securityPolicies,
                                       &config->logger);
 
-    UA_Server_run_startup(server);
+    retVal |= UA_Server_run_startup(server);
     //add 2 connections
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
@@ -49,8 +50,9 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection2);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection2);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {
@@ -62,16 +64,17 @@ START_TEST(SinglePublishDataSetField) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
     UA_WriterGroupConfig writerGroupConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
     writerGroupConfig.name = UA_STRING("WriterGroup 1");
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
     UA_Server_setWriterGroupOperational(server, writerGroup1);
     writerGroupConfig.name = UA_STRING("WriterGroup 2");
     writerGroupConfig.publishingInterval = 50;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
+    retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
     UA_Server_setWriterGroupOperational(server, writerGroup2);
     writerGroupConfig.name = UA_STRING("WriterGroup 3");
     writerGroupConfig.publishingInterval = 100;
@@ -80,30 +83,35 @@ START_TEST(SinglePublishDataSetField) {
     writerGroupConfig.securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
     writerGroupConfig.securityPolicy = &config->pubSubConfig.securityPolicies[0];
 
-    UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
-    UA_Server_setWriterGroupOperational(server, writerGroup3);
+    retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
+    retVal |= UA_Server_setWriterGroupOperational(server, writerGroup3);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet 1");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
+    pdsConfig.name = UA_STRING("PublishedDataSet 2");
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2).addResult;
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_DataSetFieldConfig dataSetFieldConfig;
     memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
     dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
     dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
     dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
-    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME);
+    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
     dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-    UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL);
+    retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup3, publishedDataSet1,
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup3, publishedDataSet1,
                                &dataSetWriterConfig, &dataSetWriter1);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     UA_ByteString sk = {UA_AES256CTR_SIGNING_KEY_LENGTH, signingKey};
     UA_ByteString ek = {UA_AES256CTR_KEY_LENGTH, encryptingKey};
@@ -113,6 +121,7 @@ START_TEST(SinglePublishDataSetField) {
 
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup3);
     UA_WriterGroup_publishCallback(server, wg);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 } END_TEST
 
 int main(void) {

--- a/tests/pubsub/check_pubsub_informationmodel.c
+++ b/tests/pubsub/check_pubsub_informationmodel.c
@@ -29,10 +29,12 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_Server_run_startup(server);
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
-    UA_Server_run_startup(server);
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
+    retVal |= UA_Server_run_startup(server);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {
@@ -45,7 +47,7 @@ static void addPublishedDataSet(UA_String pdsName, UA_NodeId *assignedId){
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = pdsName;
-    UA_Server_addPublishedDataSet(server, &pdsConfig, assignedId);
+    ck_assert_int_eq(UA_Server_addPublishedDataSet(server, &pdsConfig, assignedId).addResult, UA_STATUSCODE_GOOD);
 }
 
 static void addDataSetField(UA_NodeId publishedDataSetIdent) {
@@ -59,8 +61,8 @@ static void addDataSetField(UA_NodeId publishedDataSetIdent) {
     dataSetFieldConfig.field.variable.publishParameters.publishedVariable =
     UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
     dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-    UA_Server_addDataSetField(server, publishedDataSetIdent,
-                              &dataSetFieldConfig, &dataSetFieldIdent);
+    ck_assert_int_eq(UA_Server_addDataSetField(server, publishedDataSetIdent,
+                              &dataSetFieldConfig, &dataSetFieldIdent).result, UA_STATUSCODE_GOOD);
 }
 
 static void addPubSubConnection(UA_String connectionName, UA_String addressUrl, UA_NodeId *assignedId){
@@ -71,7 +73,7 @@ static void addPubSubConnection(UA_String connectionName, UA_String addressUrl, 
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, assignedId);
+    ck_assert_int_eq(UA_Server_addPubSubConnection(server, &connectionConfig, assignedId), UA_STATUSCODE_GOOD);
 }
 
 static void addWriterGroup(UA_NodeId parentConnection, UA_String name, UA_Duration interval, UA_NodeId *assignedId){
@@ -80,29 +82,29 @@ static void addWriterGroup(UA_NodeId parentConnection, UA_String name, UA_Durati
     writerGroupConfig.name = name;
     writerGroupConfig.publishingInterval = interval;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, parentConnection, &writerGroupConfig, assignedId);
-    UA_Server_setWriterGroupOperational(server, *assignedId);
+    ck_assert_int_eq(UA_Server_addWriterGroup(server, parentConnection, &writerGroupConfig, assignedId), UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(UA_Server_setWriterGroupOperational(server, *assignedId), UA_STATUSCODE_GOOD);
 }
 
 static void addDataSetWriter(UA_NodeId parentWriterGroup, UA_NodeId connectedPDS, UA_String name, UA_NodeId *assignedId){
     UA_DataSetWriterConfig dataSetWriterConfig;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = name;
-    UA_Server_addDataSetWriter(server, parentWriterGroup, connectedPDS, &dataSetWriterConfig, assignedId);
+    ck_assert_int_eq(UA_Server_addDataSetWriter(server, parentWriterGroup, connectedPDS, &dataSetWriterConfig, assignedId), UA_STATUSCODE_GOOD);
 }
 
 static void addReaderGroup(UA_NodeId parentConnection, UA_String name, UA_NodeId *assignedId){
     UA_ReaderGroupConfig readerGroupConfig;
     memset(&readerGroupConfig, 0, sizeof(readerGroupConfig));
     readerGroupConfig.name = name;
-    UA_Server_addReaderGroup(server, parentConnection, &readerGroupConfig, assignedId);
+    ck_assert_int_eq(UA_Server_addReaderGroup(server, parentConnection, &readerGroupConfig, assignedId), UA_STATUSCODE_GOOD);
 }
 
 static void addDataSetReader(UA_NodeId parentReaderGroup, UA_String name, UA_NodeId *assignedId){
     UA_DataSetReaderConfig readerConfig;
     memset(&readerConfig, 0, sizeof(readerConfig));
     readerConfig.name = name;
-    UA_Server_addDataSetReader(server, parentReaderGroup, &readerConfig, assignedId);
+    ck_assert_int_eq(UA_Server_addDataSetReader(server, parentReaderGroup, &readerConfig, assignedId), UA_STATUSCODE_GOOD);
 }
 
 static UA_Boolean doubleEqual(UA_Double a, UA_Double b, UA_Double maxAbsDelta){
@@ -151,8 +153,8 @@ static void setupBasicPubSubConfiguration(void){
     memset(&dataSetWriterConfig, 0, sizeof(UA_DataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("Demo DataSetWriter");
     dataSetWriterConfig.dataSetWriterId = 62541;
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet2,
-                               &dataSetWriterConfig, &dataSetWriter4);
+    ck_assert_int_eq(UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet2,
+                               &dataSetWriterConfig, &dataSetWriter4), UA_STATUSCODE_GOOD);
     addReaderGroup(connection1, UA_STRING("ReaderGroup 1"), &readerGroup1);
     addDataSetReader(readerGroup1, UA_STRING("DataSetReader 1"), &dataSetReader1);
 }

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -33,10 +33,12 @@ static void setup(void) {
     running = true;
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_Server_run_startup(server);
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
-    UA_Server_run_startup(server);
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retVal |= UA_Server_run_startup(server);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     THREAD_CREATE(server_thread, serverloop);
 }
 
@@ -1234,26 +1236,26 @@ START_TEST(ReserveIdsMultipleTimes){
         UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                             &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
         UA_NodeId connectionNodeId, writerGroupNodeId, dataSetWriterNodeId, publishedDataSetNodeId;
-        UA_Server_addPubSubConnection (server, &connectionConfig, &connectionNodeId);
+        retVal |= UA_Server_addPubSubConnection (server, &connectionConfig, &connectionNodeId);
 
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
         writerGroupConfig.name = UA_STRING("TestWriterGroup");
         writerGroupConfig.writerGroupId = ((UA_UInt16 *)regWriterGroupIds.data)[0]; // Here use the reserved WriterGroupId
 
-        UA_Server_addWriterGroup(server, connectionNodeId, &writerGroupConfig, &writerGroupNodeId);
+        retVal |= UA_Server_addWriterGroup(server, connectionNodeId, &writerGroupConfig, &writerGroupNodeId);
 
         UA_PublishedDataSetConfig publishedDataSetConfig;
         memset(&publishedDataSetConfig, 0, sizeof(UA_PublishedDataSetConfig));
         publishedDataSetConfig.name = UA_STRING("TestPublishedDataSet");
-        UA_Server_addPublishedDataSet(server, &publishedDataSetConfig, &publishedDataSetNodeId);
+        retVal |= UA_Server_addPublishedDataSet(server, &publishedDataSetConfig, &publishedDataSetNodeId).addResult;
 
         UA_DataSetWriterConfig dataSetWriterConfig;
         memset(&dataSetWriterConfig, 0, sizeof(UA_DataSetWriterConfig));
         dataSetWriterConfig.name = UA_STRING("TestDataSetWriter");
         dataSetWriterConfig.dataSetWriterId = ((UA_UInt16 *)regDataSetWriterIds.data)[0]; // Here use the reserved DataSetWriterId
-        UA_Server_addDataSetWriter(server, writerGroupNodeId, publishedDataSetNodeId, &dataSetWriterConfig, &dataSetWriterNodeId);
-
+        retVal |= UA_Server_addDataSetWriter(server, writerGroupNodeId, publishedDataSetNodeId, &dataSetWriterConfig, &dataSetWriterNodeId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         UA_Variant_clear(&defaultPublisherId);
         UA_Variant_clear(&regWriterGroupIds);
         UA_Variant_clear(&regDataSetWriterIds);

--- a/tests/pubsub/check_pubsub_mqtt.c
+++ b/tests/pubsub/check_pubsub_mqtt.c
@@ -35,10 +35,11 @@ UA_DataSetReaderConfig readerConfig;
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_Server_run_startup(server);
     config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerMQTT());
-    UA_Server_run_startup(server);
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerMQTT());
+    retVal |= UA_Server_run_startup(server);
 
     //add connection
     UA_PubSubConnectionConfig connectionConfig;
@@ -71,7 +72,8 @@ static void setup(void) {
     connectionConfig.connectionProperties.map = connectionOptions;
     connectionConfig.connectionProperties.mapSize = connectionOptionIndex;
 
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionIdent);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {

--- a/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
@@ -285,7 +285,7 @@ START_TEST(SubscribeMultipleMessagesRT) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal |= UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
@@ -488,7 +488,7 @@ START_TEST(SubscribeMultipleMessagesWithoutRT) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal |= UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
@@ -568,10 +568,11 @@ START_TEST(SetupInvalidPubSubConfig) {
     memset(&variant, 0, sizeof(UA_Variant));
     UA_Variant_setScalar(&variant, intValue, &UA_TYPES[UA_TYPES_UINT32]);
     attributes.value = variant;
-    UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1,  1000),
+    retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1,  1000),
                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                               UA_QUALIFIEDNAME(1, "variable"), UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
                               attributes, NULL, NULL);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     dsfConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(1, 1000);
     dsfConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
     /* Not using static value source */
@@ -636,11 +637,12 @@ START_TEST(SetupInvalidPubSubConfig) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
                              UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     /* Variable to subscribe data */
     UA_VariableAttributes vAttr = UA_VariableAttributes_default;
     vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed DateTime");

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -23,6 +23,7 @@ UA_NodeId connection1, connection2, writerGroup1, writerGroup2, writerGroup3,
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefault(config);
     UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
@@ -36,8 +37,9 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection2);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection2);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {
@@ -72,7 +74,7 @@ START_TEST(AddRemoveAddWriterGroupWithMinimalValidConfiguration){
         writerGroupConfig.publishingInterval = 10;
         UA_NodeId localWriterGroup;
         retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &localWriterGroup);
-        UA_Server_setWriterGroupOperational(server, localWriterGroup);
+        retVal |= UA_Server_setWriterGroupOperational(server, localWriterGroup);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         retVal |= UA_Server_removeWriterGroup(server, localWriterGroup);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
@@ -148,32 +150,36 @@ START_TEST(GetWriterGroupConfigurationAndCompareValues){
 
 static void setupDataSetWriterTestEnvironment(void){
     UA_WriterGroupConfig writerGroupConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
     writerGroupConfig.name = UA_STRING("WriterGroup 1");
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
-    UA_Server_setWriterGroupOperational(server, writerGroup1);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retVal |= UA_Server_setWriterGroupOperational(server, writerGroup1);
     writerGroupConfig.name = UA_STRING("WriterGroup 2");
     writerGroupConfig.publishingInterval = 50;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
-    UA_Server_setWriterGroupOperational(server, writerGroup2);
+    retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
+    retVal |= UA_Server_setWriterGroupOperational(server, writerGroup2);
     writerGroupConfig.name = UA_STRING("WriterGroup 3");
     writerGroupConfig.publishingInterval = 100;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
-    UA_Server_setWriterGroupOperational(server, writerGroup3);
+    retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
+    retVal |= UA_Server_setWriterGroupOperational(server, writerGroup3);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void setupPublishedDataSetTestEnvironment(void){
     UA_PublishedDataSetConfig pdsConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING(publishedDataSet1Name);
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
     pdsConfig.name = UA_STRING(publishedDataSet2Name);
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2);
+    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2).addResult;
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 START_TEST(AddDataSetWriterWithValidConfiguration){
@@ -304,18 +310,20 @@ START_TEST(FindPDS){
 static void setupDataSetFieldTestEnvironment(void){
     setupDataSetWriterTestEnvironment();
     UA_DataSetWriterConfig dataSetWriterConfig;
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 2");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter2);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter2);
     dataSetWriterConfig.name = UA_STRING("DataSetWriter 3");
-    UA_Server_addDataSetWriter(server, writerGroup2, publishedDataSet2, &dataSetWriterConfig, &dataSetWriter3);
+    retVal |= UA_Server_addDataSetWriter(server, writerGroup2, publishedDataSet2, &dataSetWriterConfig, &dataSetWriter3);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 START_TEST(AddDataSetFieldWithValidConfiguration){
-        setupDataSetFieldTestEnvironment();
         setupPublishedDataSetTestEnvironment();
+        setupDataSetFieldTestEnvironment();
         UA_StatusCode retVal;
         UA_DataSetFieldConfig fieldConfig;
         memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -333,8 +341,8 @@ START_TEST(AddDataSetFieldWithValidConfiguration){
     } END_TEST
 
 START_TEST(AddRemoveAddDataSetFieldWithValidConfiguration){
-        setupDataSetFieldTestEnvironment();
         setupPublishedDataSetTestEnvironment();
+        setupDataSetFieldTestEnvironment();
         UA_StatusCode retVal;
         UA_DataSetFieldConfig fieldConfig;
         memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -389,18 +397,17 @@ START_TEST(AddRemoveAddDataSetFieldWithValidConfiguration){
     } END_TEST
 
 START_TEST(AddDataSetFieldWithNullConfig){
-        setupDataSetFieldTestEnvironment();
         UA_StatusCode retVal;
         retVal = UA_Server_addDataSetField(server, publishedDataSet1, NULL, NULL).result;
         ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
         setupPublishedDataSetTestEnvironment();
+        setupDataSetFieldTestEnvironment();
         UA_PublishedDataSet *pds1 = UA_PublishedDataSet_findPDSbyId(server, publishedDataSet1);
         ck_assert_ptr_ne(pds1, NULL);
         ck_assert_uint_eq(pds1->fieldSize, 0);
     } END_TEST
 
 START_TEST(AddDataSetFieldWithInvalidPDSId){
-        setupDataSetFieldTestEnvironment();
         UA_StatusCode retVal;
         UA_DataSetFieldConfig fieldConfig;
         memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -410,6 +417,7 @@ START_TEST(AddDataSetFieldWithInvalidPDSId){
         fieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
         retVal = UA_Server_addDataSetField(server, UA_NODEID_NUMERIC(0, UA_UINT32_MAX), &fieldConfig, NULL).result;
         setupPublishedDataSetTestEnvironment();
+        setupDataSetFieldTestEnvironment();
         ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
         UA_PublishedDataSet *pds1 = UA_PublishedDataSet_findPDSbyId(server, publishedDataSet1);
         ck_assert_ptr_ne(pds1, NULL);
@@ -417,8 +425,8 @@ START_TEST(AddDataSetFieldWithInvalidPDSId){
     } END_TEST
 
 START_TEST(GetDataSetFieldConfigurationAndCompareValues){
-        setupDataSetFieldTestEnvironment();
         setupPublishedDataSetTestEnvironment();
+        setupDataSetFieldTestEnvironment();
         UA_StatusCode retVal;
         UA_DataSetFieldConfig fieldConfig;
         memset(&fieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -440,12 +448,13 @@ START_TEST(GetDataSetFieldConfigurationAndCompareValues){
 
 START_TEST(SinglePublishDataSetFieldAndPublishTimestampTest){
         UA_PublishedDataSetConfig pdsConfig;
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING(publishedDataSet1Name);
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
+        retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
         pdsConfig.name = UA_STRING(publishedDataSet2Name);
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2);
+        retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet2).addResult;
 
         UA_DataSetFieldConfig dataSetFieldConfig;
         memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -454,29 +463,29 @@ START_TEST(SinglePublishDataSetFieldAndPublishTimestampTest){
         dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
         dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL);
+        retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
         writerGroupConfig.name = UA_STRING("WriterGroup 1");
         writerGroupConfig.publishingInterval = 10;
         writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-        UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+        retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
         UA_Server_setWriterGroupOperational(server, writerGroup1);
         writerGroupConfig.name = UA_STRING("WriterGroup 2");
         writerGroupConfig.publishingInterval = 50;
         writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-        UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
+        retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup2);
         UA_Server_setWriterGroupOperational(server, writerGroup2);
         writerGroupConfig.name = UA_STRING("WriterGroup 3");
         writerGroupConfig.publishingInterval = 100;
         writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-        UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
+        retVal |= UA_Server_addWriterGroup(server, connection2, &writerGroupConfig, &writerGroup3);
         UA_Server_setWriterGroupOperational(server, writerGroup3);
 
         UA_DataSetWriterConfig dataSetWriterConfig;
         memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
         dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-        UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
 
         UA_DateTime currentTime = UA_DateTime_now();
         UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup1);
@@ -484,20 +493,22 @@ START_TEST(SinglePublishDataSetFieldAndPublishTimestampTest){
         UA_DateTime publishTime;
         UA_WriterGroup_lastPublishTimestamp(server, writerGroup1, &publishTime);
         ck_assert((publishTime - currentTime) < UA_DATETIME_MSEC * 100);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 START_TEST(PublishDataSetFieldAsDeltaFrame){
         setupPublishedDataSetTestEnvironment();
         UA_DataSetFieldConfig dataSetFieldConfig;
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
         memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
         dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
         dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
         dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
         dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL);
+        retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
         dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime2");
-        UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL);
+        retVal |= UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
         setupDataSetFieldTestEnvironment();
         UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup1);
         wg->config.maxEncapsulatedDataSetMessageCount = 3;
@@ -509,6 +520,7 @@ START_TEST(PublishDataSetFieldAsDeltaFrame){
         UA_WriterGroup_publishCallback(server, wg);
         UA_WriterGroup_publishCallback(server, wg);
         UA_WriterGroup_publishCallback(server, wg);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 int main(void) {

--- a/tests/pubsub/check_pubsub_publish_json.c
+++ b/tests/pubsub/check_pubsub_publish_json.c
@@ -21,12 +21,13 @@ UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_Server_run_startup(server);
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_setDefault(config);
 
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
 
-    UA_Server_run_startup(server);
+    retVal |= UA_Server_run_startup(server);
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("UADP Connection");
@@ -36,7 +37,8 @@ static void setup(void) {
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {

--- a/tests/pubsub/check_pubsub_publish_rt_levels.c
+++ b/tests/pubsub/check_pubsub_publish_rt_levels.c
@@ -511,9 +511,9 @@ START_TEST(PubSubConfigWithInformationModelRTVariable) {
         UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "test node");
         UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
         UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
-        UA_Server_addVariableNode(server, UA_NODEID_NULL, parentNodeId,
+        ck_assert_int_eq(UA_Server_addVariableNode(server, UA_NODEID_NULL, parentNodeId,
                                   parentReferenceNodeId, myIntegerName,
-                                  UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, &variableNodeId);
+                                  UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, &variableNodeId), UA_STATUSCODE_GOOD);
         ck_assert(!UA_NodeId_isNull(&variableNodeId));
         UA_Variant variant;
         UA_Variant_init(&variant);

--- a/tests/pubsub/check_pubsub_publish_uadp.c
+++ b/tests/pubsub/check_pubsub_publish_uadp.c
@@ -19,10 +19,11 @@ UA_NodeId connection1, publishedDataSetIdent, dataSetFieldIdent, writerGroupIden
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
-    UA_Server_run_startup(server);
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retVal |= UA_Server_run_startup(server);
 
     //add connection
     UA_PubSubConnectionConfig connectionConfig;
@@ -34,13 +35,13 @@ static void setup(void) {
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
     connectionConfig.publisherId.uint16 = 62541;
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
 
     UA_PublishedDataSetConfig publishedDataSetConfig;
     memset(&publishedDataSetConfig, 0, sizeof(UA_PublishedDataSetConfig));
     publishedDataSetConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     publishedDataSetConfig.name = UA_STRING("Test PDS");
-    UA_Server_addPublishedDataSet(server, &publishedDataSetConfig, &publishedDataSetIdent);
+    retVal |= UA_Server_addPublishedDataSet(server, &publishedDataSetConfig, &publishedDataSetIdent).addResult;
 
     UA_DataSetFieldConfig dataSetFieldConfig;
     memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
@@ -50,8 +51,9 @@ static void setup(void) {
     dataSetFieldConfig.field.variable.publishParameters.publishedVariable =
             UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
     dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-    UA_Server_addDataSetField(server, publishedDataSetIdent,
-                              &dataSetFieldConfig, &dataSetFieldIdent);
+    retVal |= UA_Server_addDataSetField(server, publishedDataSetIdent,
+                              &dataSetFieldConfig, &dataSetFieldIdent).result;
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {
@@ -137,6 +139,7 @@ static void receiveAvailableMessages(UA_ByteString buffer, UA_PubSubConnection *
 }
 
 START_TEST(CheckNMandDSMcalculation){
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
     writerGroupConfig.name = UA_STRING("Demo WriterGroup");
@@ -154,7 +157,7 @@ START_TEST(CheckNMandDSMcalculation){
 
     //maximum DSM in one NM = 10
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 10;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroupIdent);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroupIdent);
     UA_Server_setWriterGroupOperational(server, writerGroupIdent);
     UA_UadpWriterGroupMessageDataType_delete(wgm);
 
@@ -166,7 +169,7 @@ START_TEST(CheckNMandDSMcalculation){
     //add 10 dataSetWriter
     for(UA_UInt16 i = 0; i < 10; i++){
         dataSetWriterConfig.dataSetWriterId = (UA_UInt16) (dataSetWriterConfig.dataSetWriterId + 1);
-        UA_Server_addDataSetWriter(server, writerGroupIdent, publishedDataSetIdent,
+        retVal |= UA_Server_addDataSetWriter(server, writerGroupIdent, publishedDataSetIdent,
                                    &dataSetWriterConfig, &dataSetWriterIdent);
     }
 
@@ -177,7 +180,7 @@ START_TEST(CheckNMandDSMcalculation){
 
     //change publish interval triggers implicit one publish callback run | alternatively run UA_Server_iterate
     writerGroupConfig.publishingInterval = 100000;
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
 
     UA_ByteString buffer = UA_BYTESTRING("");
     UA_NetworkMessage networkMessage;
@@ -196,7 +199,7 @@ START_TEST(CheckNMandDSMcalculation){
     writerGroupConfig.publishingInterval = 200000;
     //maximum DSM in one NM = 5
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 5;
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
     // UA_NetworkMessage networkMessage1, networkMessage2;
     UA_NetworkMessage networkMessages[2];
     receiveAvailableMessages(buffer, connection, networkMessages);
@@ -215,7 +218,7 @@ START_TEST(CheckNMandDSMcalculation){
     writerGroupConfig.publishingInterval = 300000;
     //maximum DSM in one NM = 20
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 20;
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
     UA_NetworkMessage networkMessage3;
     receiveAvailableMessages(buffer, connection, &networkMessage3);
     ck_assert_uint_eq(networkMessage3.payloadHeader.dataSetPayloadHeader.count, 10);
@@ -229,7 +232,7 @@ START_TEST(CheckNMandDSMcalculation){
     writerGroupConfig.publishingInterval = 400000;
     //maximum DSM in one NM = 1
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 1;
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
     UA_NetworkMessage messageArray[10];
     receiveAvailableMessages(buffer, connection, messageArray);
     for (int j = 0; j < 10; ++j) {
@@ -244,8 +247,8 @@ START_TEST(CheckNMandDSMcalculation){
     writerGroupConfig.publishingInterval = 500000;
     //maximum DSM in one NM = 0 -> should be equal to 1
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 0;
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
 
     receiveAvailableMessages(buffer, connection, messageArray);
     for (int j = 0; j < 10; ++j) {
@@ -255,10 +258,11 @@ START_TEST(CheckNMandDSMcalculation){
         }
         UA_NetworkMessage_clear(&messageArray[j]);
     }
-
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 START_TEST(CheckNMandDSMBufferCalculation){
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
         writerGroupConfig.name = UA_STRING("Demo WriterGroup");
@@ -277,7 +281,7 @@ START_TEST(CheckNMandDSMBufferCalculation){
 
         //maximum DSM in one NM = 10
         writerGroupConfig.maxEncapsulatedDataSetMessageCount = 10;
-        UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroupIdent);
+        retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroupIdent);
         UA_Server_setWriterGroupOperational(server, writerGroupIdent);
         UA_UadpWriterGroupMessageDataType_delete(wgm);
 
@@ -289,17 +293,18 @@ START_TEST(CheckNMandDSMBufferCalculation){
         //add 10 dataSetWriter
         for(UA_UInt16 i = 0; i < 10; i++){
             dataSetWriterConfig.dataSetWriterId = (UA_UInt16) (dataSetWriterConfig.dataSetWriterId + 1);
-            UA_Server_addDataSetWriter(server, writerGroupIdent, publishedDataSetIdent,
+            retVal |= UA_Server_addDataSetWriter(server, writerGroupIdent, publishedDataSetIdent,
                                        &dataSetWriterConfig, &dataSetWriterIdent);
         }
 
         UA_Server_freezeWriterGroupConfiguration(server, writerGroupIdent);
         UA_Server_unfreezeWriterGroupConfiguration(server, writerGroupIdent);
-
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
 START_TEST(CheckSingleDSMRawEncodedMessage){
     //TODO extend test case with raw encoding
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
     writerGroupConfig.name = UA_STRING("Demo WriterGroup");
@@ -317,7 +322,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
 
     //maximum DSM in one NM = 10
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 10;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroupIdent);
+    retVal |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroupIdent);
     UA_Server_setWriterGroupOperational(server, writerGroupIdent);
     UA_UadpWriterGroupMessageDataType_delete(wgm);
 
@@ -332,7 +337,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
     //add 10 dataSetWriter
     for(UA_UInt16 i = 0; i < 10; i++){
         dataSetWriterConfig.dataSetWriterId = (UA_UInt16) (dataSetWriterConfig.dataSetWriterId + 1);
-        UA_Server_addDataSetWriter(server, writerGroupIdent, publishedDataSetIdent,
+        retVal |= UA_Server_addDataSetWriter(server, writerGroupIdent, publishedDataSetIdent,
                                    &dataSetWriterConfig, &dataSetWriterIdent);
     }
 
@@ -343,7 +348,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
 
     //change publish interval triggers implicit one publish callback run | alternatively run UA_Server_iterate
     writerGroupConfig.publishingInterval = 100000;
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
 
     UA_ByteString buffer = UA_BYTESTRING("");
     UA_NetworkMessage networkMessage;
@@ -362,7 +367,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
     writerGroupConfig.publishingInterval = 200000;
     //maximum DSM in one NM = 5
     writerGroupConfig.maxEncapsulatedDataSetMessageCount = 5;
-    UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
+    retVal |= UA_Server_updateWriterGroupConfig(server, writerGroupIdent, &writerGroupConfig);
     UA_NetworkMessage networkMessages[2];
     receiveAvailableMessages(buffer, connection, networkMessages);
     ck_assert_int_eq(networkMessages[0].payloadHeader.dataSetPayloadHeader.count, 5);
@@ -402,6 +407,7 @@ START_TEST(CheckSingleDSMRawEncodedMessage){
     }
     UA_NetworkMessage_clear(&networkMessages[0]);
     UA_NetworkMessage_clear(&networkMessages[1]);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 } END_TEST
 
 int main(void) {

--- a/tests/pubsub/check_pubsub_publishspeed.c
+++ b/tests/pubsub/check_pubsub_publishspeed.c
@@ -21,9 +21,12 @@ UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
 static void setup(void) {
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
+    retval |= UA_ServerConfig_setDefault(config);
+    retval |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
+    retval |= UA_Server_run_startup(server);
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_PubSubConnectionConfig connectionConfig;
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
@@ -32,28 +35,23 @@ static void setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection1);
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
     writerGroupConfig.name = UA_STRING("WriterGroup 1");
     writerGroupConfig.publishingInterval = 10;
     writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-    UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
-    UA_Server_setWriterGroupOperational(server, writerGroup1);
+    retval |= UA_Server_addWriterGroup(server, connection1, &writerGroupConfig, &writerGroup1);
+    retval |= UA_Server_setWriterGroupOperational(server, writerGroup1);
 
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet 1");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1);
-
-    UA_DataSetWriterConfig dataSetWriterConfig;
-    memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
-    dataSetWriterConfig.name = UA_STRING("DataSetWriter 1");
-    UA_Server_addDataSetWriter(server, writerGroup1, publishedDataSet1, &dataSetWriterConfig, &dataSetWriter1);
-
-    UA_Server_run_startup(server);
+    retval |= UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSet1).addResult;
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {
@@ -67,9 +65,10 @@ START_TEST(PublishSpeedTest) {
     dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
     dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
     dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
-    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME);
+    dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
     dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-    UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL);
+    UA_StatusCode retval = UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup1);
 

--- a/tests/pubsub/check_pubsub_sks_keystorage.c
+++ b/tests/pubsub/check_pubsub_sks_keystorage.c
@@ -182,10 +182,11 @@ hexstr_to_char(const char *hexstr) {
 static void
 setup(void) {
     server = UA_Server_new();
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     SecurityGroupId = UA_STRING("TestSecurityGroup");
     UA_ServerConfig *config = UA_Server_getConfig(server);
-    UA_ServerConfig_setDefault(config);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
+    retVal |= UA_ServerConfig_setDefault(config);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDP());
 
     config->pubSubConfig.securityPolicies = (UA_PubSubSecurityPolicy*)
         UA_malloc(sizeof(UA_PubSubSecurityPolicy));
@@ -202,7 +203,8 @@ setup(void) {
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 static void teardown(void) {

--- a/tests/pubsub/check_pubsub_sks_push.c
+++ b/tests/pubsub/check_pubsub_sks_push.c
@@ -202,6 +202,8 @@ setup(void) {
     UA_ByteString *revocationList = NULL;
     size_t revocationListSize = 0;
 
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+
     server = UA_Server_new();
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
@@ -214,7 +216,7 @@ setup(void) {
     config->applicationDescription.applicationUri =
         UA_STRING_ALLOC("urn:unconfigured:application");
 
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
 
     config->pubSubConfig.securityPolicies =
         (UA_PubSubSecurityPolicy *)UA_malloc(sizeof(UA_PubSubSecurityPolicy));
@@ -233,14 +235,15 @@ setup(void) {
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection);
 
     securityGroupId = UA_STRING("TestSecurityGroup");
 
     addTestReaderGroup(securityGroupId);
     addTestWriterGroup(securityGroupId);
 
-    UA_Server_run_startup(server);
+    retVal |= UA_Server_run_startup(server);
+    ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
     THREAD_CREATE(server_thread, serverloop);
 }
 

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -93,10 +93,11 @@ static void setup(void) {
     /*Add setup by creating new server with valid configuration */
     server = UA_Server_new();
     ck_assert(server != NULL);
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
     config = UA_Server_getConfig(server);
-    UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
-    UA_Server_run_startup(server);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retval |= UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
+    retval |= UA_Server_run_startup(server);
+    retval |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
 
     addVariables();
 
@@ -112,7 +113,8 @@ static void setup(void) {
         UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
     connectionConfig.publisherId.uint16 = PUBLISHER_ID;
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
+    retval |= UA_Server_addPubSubConnection(server, &connectionConfig, &connectionId);
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 }
 
 /* teardown() is to delete the environment set for test cases */
@@ -612,7 +614,7 @@ START_TEST(SinglePublishSubscribeDateTime) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Data Set Field */
         UA_NodeId dataSetFieldId;
@@ -621,9 +623,10 @@ START_TEST(SinglePublishSubscribeDateTime) {
         dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
         dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
         dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
-        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME);
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
         dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField(server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldId);
+        retVal = UA_Server_addDataSetField(server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldId).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -700,7 +703,7 @@ START_TEST(SinglePublishSubscribeDateTimeRaw) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Data Set Field */
         UA_NodeId dataSetFieldId;
@@ -709,9 +712,10 @@ START_TEST(SinglePublishSubscribeDateTimeRaw) {
         dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
         dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
         dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
-        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME);
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
         dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField(server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldId);
+        retVal = UA_Server_addDataSetField(server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldId).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -791,7 +795,7 @@ START_TEST(SinglePublishSubscribeInt32) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish integer data */
@@ -819,8 +823,8 @@ START_TEST(SinglePublishSubscribeInt32) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
-
+        retVal = UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -932,7 +936,7 @@ START_TEST(SinglePublishSubscribeInt32StatusCode) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish integer data */
@@ -960,8 +964,8 @@ START_TEST(SinglePublishSubscribeInt32StatusCode) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
-
+        UA_DataSetFieldResult retval = UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
+        ck_assert_int_eq(retval.result, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -1099,7 +1103,7 @@ START_TEST(SinglePublishSubscribeInt64) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish integer data */
@@ -1127,8 +1131,8 @@ START_TEST(SinglePublishSubscribeInt64) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
-
+        UA_DataSetFieldResult retval = UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
+        ck_assert_int_eq(retval.result, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -1244,7 +1248,7 @@ START_TEST(SinglePublishSubscribeBool) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish boolean data */
@@ -1272,8 +1276,8 @@ START_TEST(SinglePublishSubscribeBool) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
-
+        UA_DataSetFieldResult retval = UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
+        ck_assert_int_eq(retval.result, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -1389,7 +1393,7 @@ START_TEST(SinglePublishSubscribewithValidIdentifiers) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish integer data */
@@ -1418,9 +1422,9 @@ START_TEST(SinglePublishSubscribewithValidIdentifiers) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField(server, publishedDataSetId,
+        UA_DataSetFieldResult retval = UA_Server_addDataSetField(server, publishedDataSetId,
                                   &dataSetFieldConfig, &dataSetFieldIdent);
-
+        ck_assert_int_eq(retval.result, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -1619,7 +1623,7 @@ START_TEST(SinglePublishSubscribeWithoutPayloadHeader) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish integer data */
@@ -1647,8 +1651,8 @@ START_TEST(SinglePublishSubscribeWithoutPayloadHeader) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
-
+        UA_DataSetFieldResult retval = UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
+        ck_assert_int_eq(retval.result, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -1759,7 +1763,7 @@ START_TEST(MultiPublishSubscribeInt32) {
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
     pdsConfig.name = UA_STRING("PublishedDataSet Test");
-    UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+    retVal =UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
     /* Create variable to publish integer data */
@@ -1787,8 +1791,8 @@ START_TEST(MultiPublishSubscribeInt32) {
     dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
     dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
     dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-    UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
-
+    UA_DataSetFieldResult retval = UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
+    ck_assert_int_eq(retval.result, UA_STATUSCODE_GOOD);
     /* Writer group */
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -1932,6 +1936,7 @@ START_TEST(MultiPublishSubscribeInt32) {
 
 static void
 addTargetVariable(void) {
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     UA_DateTime dateTime = 0;
     UA_Variant_setScalar(&attr.value, &dateTime, &UA_TYPES[UA_TYPES_DATETIME]);
@@ -1945,9 +1950,10 @@ addTargetVariable(void) {
     UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "subscribedTargetVar");
     UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
     UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
-    UA_Server_addVariableNode(
+    retVal = UA_Server_addVariableNode(
         server, myIntegerNodeId, parentNodeId, parentReferenceNodeId, myIntegerName,
         UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, NULL);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 START_TEST(ValidStandaloneDataSetConfigurationAddAndRemove) {
@@ -2084,7 +2090,7 @@ START_TEST(SinglePublishOnDemand) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetId).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish integer data */
@@ -2112,8 +2118,8 @@ START_TEST(SinglePublishOnDemand) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
-
+        UA_DataSetFieldResult retval = UA_Server_addDataSetField (server, publishedDataSetId, &dataSetFieldConfig, &dataSetFieldIdent);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));

--- a/tests/pubsub/check_pubsub_subscribe_encrypted.c
+++ b/tests/pubsub/check_pubsub_subscribe_encrypted.c
@@ -48,10 +48,11 @@ UA_NodeId publishedDataSetTest;
 /* setup() is to create an environment for test cases */
 static void setup(void) {
     /*Add setup by creating new server with valid configuration */
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     server = UA_Server_new();
     ck_assert(server != NULL);
     config = UA_Server_getConfig(server);
-    UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
+    retVal |= UA_ServerConfig_setMinimal(config, UA_SUBSCRIBER_PORT, NULL);
 
     /* Instantiate the PubSub SecurityPolicy */
     config->pubSubConfig.securityPolicies = (UA_PubSubSecurityPolicy*)
@@ -60,8 +61,8 @@ static void setup(void) {
     UA_PubSubSecurityPolicy_Aes128Ctr(config->pubSubConfig.securityPolicies,
                                       &config->logger);
 
-    UA_Server_run_startup(server);
-    UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
+    retVal |= UA_Server_run_startup(server);
+    retVal |= UA_ServerConfig_addPubSubTransportLayer(config, UA_PubSubTransportLayerUDPMP());
 
     /* Add connection to the server */
     UA_PubSubConnectionConfig connectionConfig;
@@ -73,7 +74,8 @@ static void setup(void) {
     connectionConfig.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
     connectionConfig.publisherIdType = UA_PUBLISHERIDTYPE_UINT16;
     connectionConfig.publisherId.uint16 = PUBLISHER_ID;
-    UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
+    retVal |= UA_Server_addPubSubConnection(server, &connectionConfig, &connection_test);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 }
 
 /* teardown() is to delete the environment set for test cases */
@@ -83,126 +85,127 @@ static void teardown(void) {
     UA_Server_delete(server);
 }
 
-// START_TEST(SinglePublishSubscribeDateTime) {
-//         /* To check status after running both publisher and subscriber */
-//         UA_StatusCode retVal = UA_STATUSCODE_GOOD;
-//         UA_PublishedDataSetConfig pdsConfig;
-//         UA_NodeId dataSetWriter;
-//         UA_NodeId readerIdentifier;
-//         UA_NodeId writerGroup;
-//         UA_DataSetReaderConfig readerConfig;
-//         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
-//         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
-//         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-//         UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetTest);
-//         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-//         /* Data Set Field */
-//         UA_NodeId dataSetFieldId;
-//         UA_DataSetFieldConfig dataSetFieldConfig;
-//         memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
-//         dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
-//         dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
-//         dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
-//         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME);
-//         dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
-//         UA_Server_addDataSetField(server, publishedDataSetTest, &dataSetFieldConfig, &dataSetFieldId);
-//         /* Writer group */
-//         UA_WriterGroupConfig writerGroupConfig;
-//         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
-//         writerGroupConfig.name = UA_STRING("WriterGroup Test");
-//         writerGroupConfig.publishingInterval = PUBLISH_INTERVAL;
-//         writerGroupConfig.enabled = UA_FALSE;
-//         writerGroupConfig.writerGroupId = WRITER_GROUP_ID;
-//         writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-//         retVal |= UA_Server_addWriterGroup(server, connection_test, &writerGroupConfig, &writerGroup);
-//         UA_Server_setWriterGroupOperational(server, writerGroup);
-//         /* DataSetWriter */
-//         UA_DataSetWriterConfig dataSetWriterConfig;
-//         memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
-//         dataSetWriterConfig.name = UA_STRING("DataSetWriter Test");
-//         dataSetWriterConfig.dataSetWriterId = DATASET_WRITER_ID;
-//         dataSetWriterConfig.keyFrameCount = 10;
-//         retVal |= UA_Server_addDataSetWriter(server, writerGroup, publishedDataSetTest, &dataSetWriterConfig, &dataSetWriter);
-//         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-//         /* Reader Group */
-//         UA_ReaderGroupConfig readerGroupConfig;
-//         memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
-//         readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
-//         retVal |=  UA_Server_addReaderGroup (server, connection_test, &readerGroupConfig, &readerGroupTest);
-//         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-//         UA_Server_setReaderGroupOperational(server, readerGroupTest);
-//         /* Data Set Reader */
-//         memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
-//         readerConfig.name = UA_STRING ("DataSetReader Test");
-//         readerConfig.dataSetWriterId = DATASET_WRITER_ID;
-//         /* Setting up Meta data configuration in DataSetReader for DateTime DataType */
-//         UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
-//         /* FilltestMetadata function in subscriber implementation */
-//         UA_DataSetMetaDataType_init (pMetaData);
-//         pMetaData->name = UA_STRING ("DataSet Test");
-//         /* Static definition of number of fields size to 1 to create one
-//         targetVariable */
-//         pMetaData->fieldsSize = 1;
-//         pMetaData->fields = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
-//                              &UA_TYPES[UA_TYPES_FIELDMETADATA]);
-//         /* DateTime DataType */
-//         UA_FieldMetaData_init (&pMetaData->fields[0]);
-//         UA_NodeId_copy (&UA_TYPES[UA_TYPES_DATETIME].typeId,
-//                         &pMetaData->fields[0].dataType);
-//         pMetaData->fields[0].builtInType = UA_NS0ID_DATETIME;
-//         pMetaData->fields[0].valueRank = -1; /* scalar */
-//
-//         /* Add Subscribed Variables */
-//         UA_NodeId folderId;
-//         UA_NodeId newnodeId;
-//         UA_String folderName = readerConfig.dataSetMetaData.name;
-//         UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
-//         UA_QualifiedName folderBrowseName;
-//         if (folderName.length > 0) {
-//             oAttr.displayName.locale = UA_STRING ("en-US");
-//             oAttr.displayName.text = folderName;
-//             folderBrowseName.namespaceIndex = 1;
-//             folderBrowseName.name = folderName;
-//           }
-//         else {
-//             oAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Variables");
-//             folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
-//         }
-//
-//         UA_Server_addObjectNode (server, UA_NODEID_NULL,
-//                                  UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
-//                                  UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
-//                                  folderBrowseName, UA_NODEID_NUMERIC (0,
-//                                  UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
-//
-//         /* Variable to subscribe data */
-//         UA_VariableAttributes vAttr = UA_VariableAttributes_default;
-//         vAttr.description = UA_LOCALIZEDTEXT ("en-US", "DateTime");
-//         vAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "DateTime");
-//         vAttr.dataType    = UA_TYPES[UA_TYPES_DATETIME].typeId;
-//         retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID),
-//                                            folderId,
-//                                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "DateTime"),
-//                                            UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId);
-//         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-//
-//         readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariablesSize = 1;
-//         readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables     = (UA_FieldTargetVariable *)
-//             UA_calloc(readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariablesSize, sizeof(UA_FieldTargetVariable));
-//
-//         /* For creating Targetvariable */
-//         UA_FieldTargetDataType_init(&readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables[0].targetVariable);
-//         readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables[0].targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
-//         readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables[0].targetVariable.targetNodeId = newnodeId;
-//         retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
-//                                              &readerIdentifier);
-//         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-//         UA_free(readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables);
-//         /* run server - publisher and subscriber */
-//         UA_Server_run_iterate(server,true);
-//         UA_Server_run_iterate(server,true);
-//         UA_free(pMetaData->fields);
-// }END_TEST
+START_TEST(SinglePublishSubscribeDateTime) {
+        /* To check status after running both publisher and subscriber */
+        UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+        UA_PublishedDataSetConfig pdsConfig;
+        UA_NodeId dataSetWriter;
+        UA_NodeId readerIdentifier;
+        UA_NodeId writerGroup;
+        UA_DataSetReaderConfig readerConfig;
+        memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
+        pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
+        pdsConfig.name = UA_STRING("PublishedDataSet Test");
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetTest).addResult;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        /* Data Set Field */
+        UA_NodeId dataSetFieldId;
+        UA_DataSetFieldConfig dataSetFieldConfig;
+        memset(&dataSetFieldConfig, 0, sizeof(UA_DataSetFieldConfig));
+        dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("Server localtime");
+        dataSetFieldConfig.field.variable.promotedField = UA_FALSE;
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
+        dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
+        UA_DataSetFieldResult retval = UA_Server_addDataSetField(server, publishedDataSetTest, &dataSetFieldConfig, &dataSetFieldId);
+        ck_assert_int_eq(retval.result, UA_STATUSCODE_GOOD);
+        /* Writer group */
+        UA_WriterGroupConfig writerGroupConfig;
+        memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
+        writerGroupConfig.name = UA_STRING("WriterGroup Test");
+        writerGroupConfig.publishingInterval = PUBLISH_INTERVAL;
+        writerGroupConfig.enabled = UA_FALSE;
+        writerGroupConfig.writerGroupId = WRITER_GROUP_ID;
+        writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
+        retVal |= UA_Server_addWriterGroup(server, connection_test, &writerGroupConfig, &writerGroup);
+        UA_Server_setWriterGroupOperational(server, writerGroup);
+        /* DataSetWriter */
+        UA_DataSetWriterConfig dataSetWriterConfig;
+        memset(&dataSetWriterConfig, 0, sizeof(dataSetWriterConfig));
+        dataSetWriterConfig.name = UA_STRING("DataSetWriter Test");
+        dataSetWriterConfig.dataSetWriterId = DATASET_WRITER_ID;
+        dataSetWriterConfig.keyFrameCount = 10;
+        retVal |= UA_Server_addDataSetWriter(server, writerGroup, publishedDataSetTest, &dataSetWriterConfig, &dataSetWriter);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        /* Reader Group */
+        UA_ReaderGroupConfig readerGroupConfig;
+        memset (&readerGroupConfig, 0, sizeof (UA_ReaderGroupConfig));
+        readerGroupConfig.name = UA_STRING ("ReaderGroup Test");
+        retVal |=  UA_Server_addReaderGroup (server, connection_test, &readerGroupConfig, &readerGroupTest);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        UA_Server_setReaderGroupOperational(server, readerGroupTest);
+        /* Data Set Reader */
+        memset (&readerConfig, 0, sizeof (UA_DataSetReaderConfig));
+        readerConfig.name = UA_STRING ("DataSetReader Test");
+        readerConfig.dataSetWriterId = DATASET_WRITER_ID;
+        /* Setting up Meta data configuration in DataSetReader for DateTime DataType */
+        UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
+        /* FilltestMetadata function in subscriber implementation */
+        UA_DataSetMetaDataType_init (pMetaData);
+        pMetaData->name = UA_STRING ("DataSet Test");
+        /* Static definition of number of fields size to 1 to create one
+        targetVariable */
+        pMetaData->fieldsSize = 1;
+        pMetaData->fields = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
+                             &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+        /* DateTime DataType */
+        UA_FieldMetaData_init (&pMetaData->fields[0]);
+        UA_NodeId_copy (&UA_TYPES[UA_TYPES_DATETIME].typeId,
+                        &pMetaData->fields[0].dataType);
+        pMetaData->fields[0].builtInType = UA_NS0ID_DATETIME;
+        pMetaData->fields[0].valueRank = -1; /* scalar */
+
+        /* Add Subscribed Variables */
+        UA_NodeId folderId;
+        UA_NodeId newnodeId;
+        UA_String folderName = readerConfig.dataSetMetaData.name;
+        UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+        UA_QualifiedName folderBrowseName;
+        if (folderName.length > 0) {
+            oAttr.displayName.locale = UA_STRING ("en-US");
+            oAttr.displayName.text = folderName;
+            folderBrowseName.namespaceIndex = 1;
+            folderBrowseName.name = folderName;
+          }
+        else {
+            oAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "Subscribed Variables");
+            folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
+        }
+
+        retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
+                                 UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
+                                 UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
+                                 folderBrowseName, UA_NODEID_NUMERIC (0,
+                                 UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        /* Variable to subscribe data */
+        UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+        vAttr.description = UA_LOCALIZEDTEXT ("en-US", "DateTime");
+        vAttr.displayName = UA_LOCALIZEDTEXT ("en-US", "DateTime");
+        vAttr.dataType    = UA_TYPES[UA_TYPES_DATETIME].typeId;
+        retVal = UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, SUBSCRIBEVARIABLE_NODEID),
+                                           folderId,
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),  UA_QUALIFIEDNAME(1, "DateTime"),
+                                           UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), vAttr, NULL, &newnodeId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariablesSize = 1;
+        readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables     = (UA_FieldTargetVariable *)
+            UA_calloc(readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariablesSize, sizeof(UA_FieldTargetVariable));
+
+        /* For creating Targetvariable */
+        UA_FieldTargetDataType_init(&readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables[0].targetVariable);
+        readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables[0].targetVariable.attributeId  = UA_ATTRIBUTEID_VALUE;
+        readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables[0].targetVariable.targetNodeId = newnodeId;
+        retVal |= UA_Server_addDataSetReader(server, readerGroupTest, &readerConfig,
+                                             &readerIdentifier);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        UA_free(readerConfig.subscribedDataSet.subscribedDataSetTarget.targetVariables);
+        /* run server - publisher and subscriber */
+        UA_Server_run_iterate(server,true);
+        UA_Server_run_iterate(server,true);
+        UA_free(pMetaData->fields);
+}END_TEST
 
 
 START_TEST(SinglePublishSubscribeInt32) {
@@ -224,7 +227,7 @@ START_TEST(SinglePublishSubscribeInt32) {
         memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
         pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS;
         pdsConfig.name = UA_STRING("PublishedDataSet Test");
-        UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetTest);
+        retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, &publishedDataSetTest).addResult;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         /* Create variable to publish integer data */
@@ -252,8 +255,8 @@ START_TEST(SinglePublishSubscribeInt32) {
         dataSetFieldConfig.field.variable.promotedField  = UA_FALSE;
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = publisherNode;
         dataSetFieldConfig.field.variable.publishParameters.attributeId       = UA_ATTRIBUTEID_VALUE;
-        UA_Server_addDataSetField (server, publishedDataSetTest, &dataSetFieldConfig, &dataSetFieldIdent);
-
+        retVal = UA_Server_addDataSetField (server, publishedDataSetTest, &dataSetFieldConfig, &dataSetFieldIdent).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Writer group */
         UA_WriterGroupConfig writerGroupConfig;
         memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -409,7 +412,7 @@ int main(void) {
     /*Test case to run both publisher and subscriber */
     TCase *tc_pubsub_publish_subscribe = tcase_create("Publisher publishing and Subscriber subscribing");
     tcase_add_checked_fixture(tc_pubsub_publish_subscribe, setup, teardown);
-    // tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeDateTime);
+    tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeDateTime);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeInt32);
 
     Suite *suite = suite_create("PubSub readerGroups/reader/Fields handling and publishing");

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -254,7 +254,7 @@ START_TEST(SubscribeSingleFieldWithFixedOffsets) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal |= UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
@@ -419,11 +419,12 @@ START_TEST(SetupInvalidPubSubConfigReader) {
             folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
         }
 
-        UA_Server_addObjectNode (server, UA_NODEID_NULL,
+        retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
                                  UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                                  UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                                  folderBrowseName, UA_NODEID_NUMERIC (0,
                                                                       UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         /* Variable to subscribe data */
         UA_VariableAttributes vAttr = UA_VariableAttributes_default;
         vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed DateTime");
@@ -504,10 +505,10 @@ START_TEST(SetupInvalidPubSubConfig) {
     memset(&variant, 0, sizeof(UA_Variant));
     UA_Variant_setScalar(&variant, intValue, &UA_TYPES[UA_TYPES_UINT32]);
     attributes.value = variant;
-    UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1,  1000),
+    ck_assert_int_eq(UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1,  1000),
                               UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                               UA_QUALIFIEDNAME(1, "variable"), UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
-                              attributes, NULL, NULL);
+                              attributes, NULL, NULL), UA_STATUSCODE_GOOD);
     dsfConfig.field.variable.publishParameters.publishedVariable = UA_NODEID_NUMERIC(1, 1000);
     dsfConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
     /* Not using static value source */
@@ -568,8 +569,8 @@ static void PublishSubscribeWithWriteCallback_Helper(
     dataSetFieldConfig.field.variable.publishParameters.publishedVariable  = publisherNode;
     dataSetFieldConfig.field.variable.publishParameters.attributeId        = UA_ATTRIBUTEID_VALUE;
     dataSetFieldConfig.field.variable.rtValueSource.rtInformationModelNode = UA_TRUE;
-    UA_Server_addDataSetField (server, publishedDataSetIdent, &dataSetFieldConfig, &dataSetFieldIdent);
-
+    retVal = UA_Server_addDataSetField (server, publishedDataSetIdent, &dataSetFieldConfig, &dataSetFieldIdent).result;
+    ck_assert(retVal == UA_STATUSCODE_GOOD);
     /* Writer group */
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
@@ -763,11 +764,12 @@ START_TEST(PublishSubscribeWithWriteCallback) {
         folderBrowseName = UA_QUALIFIEDNAME (1, "Subscribed Variables");
     }
 
-    UA_Server_addObjectNode (server, UA_NODEID_NULL,
+    retVal = UA_Server_addObjectNode (server, UA_NODEID_NULL,
                              UA_NODEID_NUMERIC (0, UA_NS0ID_OBJECTSFOLDER),
                              UA_NODEID_NUMERIC (0, UA_NS0ID_ORGANIZES),
                              folderBrowseName, UA_NODEID_NUMERIC (0,
                              UA_NS0ID_BASEOBJECTTYPE), oAttr, NULL, &folderId);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     /* Variable to subscribe data */
     UA_VariableAttributes vAttr = UA_VariableAttributes_default;
     vAttr.description = UA_LOCALIZEDTEXT ("en-US", "Subscribed UInt32");


### PR DESCRIPTION
After replacing the optional `UA_NS0ID_SERVER_LOCALTIME` with the `UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME` in #5716, I saw that this was used in some other places without checks for the StatusCode. As a result, some tests didn't do what they intended because the Node is not available and no DataSet is being published.

I removed the LocalTime in all Pubsub tests and added missing StatusChecks all over the tests.

This fixes some issues with the encryption or publishspeed tests that were not detected because of the missing StatusCode checks.
 