### PR TITLE
fix(plugin,cmake): Failure when build in MacOSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -905,8 +905,14 @@ configure_file(tools/open62541.pc.in ${PROJECT_BINARY_DIR}/src_generated/open625
 if(UA_ENABLE_DISCOVERY_MULTICAST)
   include(GenerateExportHeader)
     set(MDNSD_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported" FORCE)
+    
     # create a "fake" empty library to generate the export header macros
-    add_library(libmdnsd ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
+    if (APPLE)
+    	add_library(libmdnsd INTERFACE ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
+    else()
+    	add_library(libmdnsd ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
+    endif()
+    
     if (UA_FORCE_CPP)
         set_property(TARGET libmdnsd PROPERTY LINKER_LANGUAGE CXX)
     else()

--- a/plugins/ua_pubsub_udp_multicast.c
+++ b/plugins/ua_pubsub_udp_multicast.c
@@ -24,6 +24,18 @@
 #   define UA_IPV6_MULTICAST_PREFIX 0xFF
 #endif
 
+#if defined(__APPLE__)
+
+# ifndef IPV6_ADD_MEMBERSHIP
+#define IPV6_ADD_MEMBERSHIP  IPV6_JOIN_GROUP
+# endif
+
+# ifndef IPV6_DROP_MEMBERSHIP
+#define IPV6_DROP_MEMBERSHIP IPV6_LEAVE_GROUP
+# endif
+
+#endif
+
 static UA_THREAD_LOCAL UA_Byte ReceiveMsgBufferUDP[UA_RECEIVE_MSG_BUFFER_SIZE];
 
 typedef union {


### PR DESCRIPTION
Included fixes for:
• Incorrect way of creation an empty library for macOS. 
• Incorrect macros for macOS.
