### PR TITLE
fix(CI): Enable alarm conditions example in CI

### DIFF
--- a/examples/nodeset/server_testnodeset.c
+++ b/examples/nodeset/server_testnodeset.c
@@ -48,6 +48,7 @@ int main(int argc, char **argv)
         UA_Point *p = (UA_Point *)out.data;
         printf("point 2d x: %f y: %f \n", p->x, p->y);
         retval = UA_Server_run(server, &running);
+        UA_free(p);
     }
 
     UA_Server_delete(server);

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -388,6 +388,7 @@ function examples_valgrind {
           -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
           -DUA_ENABLE_ENCRYPTION=$1 \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+          -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON \
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_PUBSUB=ON \
@@ -397,6 +398,7 @@ function examples_valgrind {
           -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
           -DUA_ENABLE_PUBSUB_MQTT=ON \
           -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
+          -DUA_NAMESPACE_ZERO=FULL \
           ..
     make ${MAKEOPTS}
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -410,9 +410,13 @@ function examples_valgrind {
     do
 	    echo "Processing $f"
 	    valgrind --errors-for-leak-kinds=all --leak-check=full --error-exitcode=1 $f &
+        pid=$!
 	    sleep 10
-	    kill -INT %1
-	    wait $!; EXIT_CODE=$?
+        # || true to ignore the error if the process is already dead
+	    kill -INT $pid || true
+
+        # using a 20 second timeout with SIGTERM to kill the process if it is still running
+	    timeout 20s bash -c 'wait $pid || kill -TERM $pid' ; EXIT_CODE=$?
 	    if [[ $EXIT_CODE -ne 0 ]]; then
 		   echo "Processing $f failed with exit code $EXIT_CODE "
 		   exit $EXIT_CODE	


### PR DESCRIPTION
This enables the `tutorial_server_alarms_conditions` example in the CI.

This also fixes a small memory leak in the `server_testnodeset` example that is also enabled by the full ns0. 

PR #5650 and #5747 will also fix the memory leak in the `server_testnodeset` example.