### PR TITLE
fix(CI): Enable file config example

### DIFF
--- a/examples/pubsub/server_pubsub_file_configuration.c
+++ b/examples/pubsub/server_pubsub_file_configuration.c
@@ -7,7 +7,7 @@
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
 
-#include "ua_pubsub_config.h"
+#include "ua_pubsub.h"
 
 #include <signal.h>
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -396,6 +396,7 @@ function examples_valgrind {
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
           -DUA_ENABLE_PUBSUB_MQTT=ON \
+          -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           ..
     make ${MAKEOPTS}
 


### PR DESCRIPTION
This enables the `server_pubsub_file_configuration` example and fixes an include error. 