### PR TITLE
fix(CI): Enabled pubsub realtime examples

### DIFF
--- a/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_publisher.c
+++ b/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_publisher.c
@@ -671,7 +671,8 @@ int main(int argc, char **argv) {
     if (!interface) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Need a network interface to run");
         usage(progname);
-        return -1;
+        UA_Server_delete(server);
+        return 0;
     }
 
     networkAddressUrlPub.networkInterface = UA_STRING(interface);

--- a/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_subscriber.c
+++ b/examples/pubsub_realtime/nodeset/pubsub_nodeset_rt_subscriber.c
@@ -636,7 +636,8 @@ int main(int argc, char **argv) {
     if (!interface) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Need a network interface to run");
         usage(progname);
-        return -1;
+        UA_Server_delete(server);
+        return 0;
     }
     networkAddressUrlSub.networkInterface = UA_STRING(interface);
     networkAddressUrlSub.url              = UA_STRING(SUBSCRIBING_MAC_ADDRESS);

--- a/examples/pubsub_realtime/pubsub_TSN_loopback.c
+++ b/examples/pubsub_realtime/pubsub_TSN_loopback.c
@@ -1595,7 +1595,8 @@ int main(int argc, char **argv) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                      "Need a network interface to run");
         usage(progname);
-        return -1;
+        UA_Server_delete(server);
+        return 0;
     }
 
     if(cycleTimeInMsec < 0.125) {

--- a/examples/pubsub_realtime/pubsub_TSN_publisher.c
+++ b/examples/pubsub_realtime/pubsub_TSN_publisher.c
@@ -1669,7 +1669,8 @@ int main(int argc, char **argv) {
     if(!interface) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Need a network interface to run");
         usage(progname);
-        return -1;
+        UA_Server_delete(server);
+        return 0;
     }
 
     if(cycleTimeInMsec < 0.125) {

--- a/examples/pubsub_realtime/pubsub_interrupt_publish.c
+++ b/examples/pubsub_realtime/pubsub_interrupt_publish.c
@@ -305,7 +305,6 @@ addPubSubConfiguration(UA_Server* server) {
 #endif
     UA_Server_addDataSetField(server, publishedDataSetIdent, &counterValue,
                               &dataSetFieldIdentCounter);
-
     UA_WriterGroupConfig writerGroupConfig;
     memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
     writerGroupConfig.name = UA_STRING("Demo WriterGroup");
@@ -373,6 +372,7 @@ int main(void) {
     UA_StatusCode retval = UA_Server_run(server, &running);
 #if defined(PUBSUB_CONFIG_FASTPATH_FIXED_OFFSETS) || (PUBSUB_CONFIG_FASTPATH_STATIC_VALUES)
     if(staticValueSource != NULL) {
+        UA_DataValue_init(staticValueSource);
         UA_DataValue_delete(staticValueSource);
     }
 #endif

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -398,6 +398,8 @@ function examples_valgrind {
           -DUA_ENABLE_PUBSUB_MQTT=ON \
           -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
+          -DUA_ENABLE_MALLOC_SINGLETON=ON \
+          -DUA_ENABLE_IMMUTABLE_NODES=ON \
           ..
     make ${MAKEOPTS}
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -397,6 +397,7 @@ function examples_valgrind {
           -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
           -DUA_ENABLE_PUBSUB_MQTT=ON \
           -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
+          -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           ..
     make ${MAKEOPTS}
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -398,8 +398,6 @@ function examples_valgrind {
           -DUA_ENABLE_PUBSUB_MQTT=ON \
           -DUA_ENABLE_PUBSUB_FILE_CONFIG=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
-          -DUA_ENABLE_MALLOC_SINGLETON=ON \
-          -DUA_ENABLE_IMMUTABLE_NODES=ON \
           ..
     make ${MAKEOPTS}
 


### PR DESCRIPTION
This enables the realtime examples. 

NOTE: Since the CI just runs the examples without any arguments, I just fixed memory leaks that occur when those examples are just called without any arguments. I also returned 0 instead of -1 since this would break the CI.

How should this be done? Should we provide a way to run the examples with arguments?