### PR TITLE
[REVIEW] CI: Added support for arguments in the examples workflow

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -154,6 +154,8 @@ endif()
 # Feature Examples #
 ####################
 
+add_example(ci_server ci_server.c)
+
 add_example(server_mainloop server_mainloop.c)
 
 add_example(server_instantiation server_instantiation.c)

--- a/examples/access_control_encrypt/client_access_control_encrypt.c
+++ b/examples/access_control_encrypt/client_access_control_encrypt.c
@@ -45,6 +45,8 @@ int main(int argc, char* argv[]) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig *config = UA_Client_getConfig(client);
     config->securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
+    UA_String_clear(&config->clientDescription.applicationUri);
+    config->clientDescription.applicationUri = UA_STRING_ALLOC("urn:open62541.server.application");
     UA_ClientConfig_setDefaultEncryption(config, certificate, privateKey,
                                          trustList, trustListSize,
                                          revocationList, revocationListSize);

--- a/examples/ci_server.c
+++ b/examples/ci_server.c
@@ -1,0 +1,202 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/accesscontrol_default.h>
+#include <open62541/client_highlevel.h>
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/plugin/securitypolicy.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+
+#include <stdlib.h>
+
+#include "common.h"
+
+/* This is a test server to the ci script. It can be used for some of the examples that need a server to connect.
+* It allows to connect with the username "peter" and "paula" and the password "peter123" and "paula123" or "user1" and "password". Anonymus login is also allowed.
+* The server has a method "hello world" and a variable "the answer" that can be written to.
+* The server certificate and private key are loaded from the command line arguments.
+*/
+
+#define MIN_ARGS 4
+
+static UA_UsernamePasswordLogin logins[3] = {
+    {UA_STRING_STATIC("peter"), UA_STRING_STATIC("peter123")},
+    {UA_STRING_STATIC("paula"), UA_STRING_STATIC("paula123")},
+    {UA_STRING_STATIC("user1"), UA_STRING_STATIC("password")}
+};
+
+static UA_StatusCode
+helloWorldMethodCallback(UA_Server *server,
+                         const UA_NodeId *sessionId, void *sessionHandle,
+                         const UA_NodeId *methodId, void *methodContext,
+                         const UA_NodeId *objectId, void *objectContext,
+                         size_t inputSize, const UA_Variant *input,
+                         size_t outputSize, UA_Variant *output) {
+    UA_String *inputStr = (UA_String*)input->data;
+    UA_String tmp = UA_STRING_ALLOC("Hello ");
+    if(inputStr->length > 0) {
+        tmp.data = (UA_Byte *)UA_realloc(tmp.data, tmp.length + inputStr->length);
+        memcpy(&tmp.data[tmp.length], inputStr->data, inputStr->length);
+        tmp.length += inputStr->length;
+    }
+    UA_Variant_setScalarCopy(output, &tmp, &UA_TYPES[UA_TYPES_STRING]);
+    UA_String_clear(&tmp);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Hello World was called");
+    return UA_STATUSCODE_GOOD;
+}
+
+static void
+addHelloWorldMethod(UA_Server *server) {
+    UA_Argument inputArgument;
+    UA_Argument_init(&inputArgument);
+    inputArgument.description = UA_LOCALIZEDTEXT("en-US", "A String");
+    inputArgument.name = UA_STRING("MyInput");
+    inputArgument.dataType = UA_TYPES[UA_TYPES_STRING].typeId;
+    inputArgument.valueRank = UA_VALUERANK_SCALAR;
+
+    UA_Argument outputArgument;
+    UA_Argument_init(&outputArgument);
+    outputArgument.description = UA_LOCALIZEDTEXT("en-US", "A String");
+    outputArgument.name = UA_STRING("MyOutput");
+    outputArgument.dataType = UA_TYPES[UA_TYPES_STRING].typeId;
+    outputArgument.valueRank = UA_VALUERANK_SCALAR;
+
+    UA_MethodAttributes helloAttr = UA_MethodAttributes_default;
+    helloAttr.description = UA_LOCALIZEDTEXT("en-US","Say `Hello World`");
+    helloAttr.displayName = UA_LOCALIZEDTEXT("en-US","Hello World");
+    helloAttr.executable = true;
+    helloAttr.userExecutable = true;
+    UA_Server_addMethodNode(server, UA_NODEID_NUMERIC(1,62541),
+                            UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                            UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                            UA_QUALIFIEDNAME(1, "hello world"),
+                            helloAttr, &helloWorldMethodCallback,
+                            1, &inputArgument, 1, &outputArgument, NULL, NULL);
+}
+
+static void
+addVariable(UA_Server *server) {
+    /* Define the attribute of the myInteger variable node */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    UA_Int32 myInteger = 42;
+    UA_Variant_setScalar(&attr.value, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
+    attr.description = UA_LOCALIZEDTEXT("en-US","the answer");
+    attr.displayName = UA_LOCALIZEDTEXT("en-US","the answer");
+    attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
+    attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+
+    /* Add the variable node to the information model */
+    UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
+    UA_QualifiedName myIntegerName = UA_QUALIFIEDNAME(1, "the answer");
+    UA_NodeId parentNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    UA_NodeId parentReferenceNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    UA_Server_addVariableNode(server, myIntegerNodeId, parentNodeId,
+                              parentReferenceNodeId, myIntegerName,
+                              UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE), attr, NULL, NULL);
+}
+
+static void
+writeVariable(UA_Server *server) {
+    UA_NodeId myIntegerNodeId = UA_NODEID_STRING(1, "the.answer");
+
+    /* Write a different integer value */
+    UA_Int32 myInteger = 43;
+    UA_Variant myVar;
+    UA_Variant_init(&myVar);
+    UA_Variant_setScalar(&myVar, &myInteger, &UA_TYPES[UA_TYPES_INT32]);
+    UA_Server_writeValue(server, myIntegerNodeId, myVar);
+
+    /* Set the status code of the value to an error code. The function
+     * UA_Server_write provides access to the raw service. The above
+     * UA_Server_writeValue is syntactic sugar for writing a specific node
+     * attribute with the write service. */
+    UA_WriteValue wv;
+    UA_WriteValue_init(&wv);
+    wv.nodeId = myIntegerNodeId;
+    wv.attributeId = UA_ATTRIBUTEID_VALUE;
+    wv.value.status = UA_STATUSCODE_BADNOTCONNECTED;
+    wv.value.hasStatus = true;
+    UA_Server_write(server, &wv);
+
+    /* Reset the variable to a good statuscode with a value */
+    wv.value.hasStatus = false;
+    wv.value.value = myVar;
+    wv.value.hasValue = true;
+    UA_Server_write(server, &wv);
+}
+
+int main(int argc, char* argv[]) {
+    UA_StatusCode retval = 0;
+
+    UA_Server *server = UA_Server_new();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+
+#ifdef UA_ENABLE_ENCRYPTION
+    UA_ByteString certificate = UA_BYTESTRING_NULL;
+    UA_ByteString privateKey = UA_BYTESTRING_NULL;
+    UA_UInt16 port = 0;
+    if(argc >= 4) {
+        /* Load port, certificate and private key */
+        port = (UA_UInt16) atoi(argv[1]);
+        certificate = loadFile(argv[2]);
+        privateKey = loadFile(argv[3]);
+        // print the certificat and private key
+        printf("certificate: %.*s\n", (int)certificate.length, certificate.data);
+    } else {
+        UA_LOG_FATAL(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                     "Missing arguments. Arguments are "
+                     "<port> <server-certificate.der> <private-key.der> "
+                     "[<trustlist1.crl>, ...]");
+
+        return EXIT_SUCCESS;
+    }
+
+    /* Load the trustlist */
+    size_t trustListSize = 0;
+    if(argc > 4)
+        trustListSize = (size_t)argc-4;
+    UA_STACKARRAY(UA_ByteString, trustList, trustListSize+1);
+    for(size_t i = 0; i < trustListSize; i++)
+        trustList[i] = loadFile(argv[i+4]);
+
+    /* Loading of an issuer list, not used in this application */
+    size_t issuerListSize = 0;
+    UA_ByteString *issuerList = NULL;
+
+    /* Loading of a revocation list currently unsupported */
+    UA_ByteString *revocationList = NULL;
+    size_t revocationListSize = 0;
+
+
+     retval = UA_ServerConfig_setDefaultWithSecurityPolicies(config, port,
+                                                       &certificate, &privateKey,
+                                                       trustList, trustListSize,
+                                                       issuerList, issuerListSize,
+                                                       revocationList, revocationListSize);
+                                                           UA_ByteString_clear(&certificate);
+    UA_ByteString_clear(&privateKey);
+    for(size_t i = 0; i < trustListSize; i++)
+        UA_ByteString_clear(&trustList[i]);
+    if(retval != UA_STATUSCODE_GOOD)
+        goto cleanup;   
+
+#endif
+    retval = UA_AccessControl_default(config, true, NULL,
+             &config->securityPolicies[config->securityPoliciesSize-1].policyUri, 3, logins);
+    if(retval != UA_STATUSCODE_GOOD)
+        goto cleanup;
+        
+    addHelloWorldMethod(server);
+    addVariable(server);
+    writeVariable(server);
+
+    retval = UA_Server_runUntilInterrupt(server);
+
+    if(retval != UA_STATUSCODE_GOOD)
+        goto cleanup;
+ cleanup:
+    UA_Server_delete(server);
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/client.c
+++ b/examples/client.c
@@ -50,7 +50,8 @@ int main(int argc, char *argv[]) {
                endpointArray[i].endpointUrl.data);
     }
     UA_Array_delete(endpointArray,endpointArraySize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-
+    UA_Client_delete(client);
+    
     /* Create a client and connect */
     client = UA_Client_new();
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));

--- a/examples/client.c
+++ b/examples/client.c
@@ -50,7 +50,11 @@ int main(int argc, char *argv[]) {
                endpointArray[i].endpointUrl.data);
     }
     UA_Array_delete(endpointArray,endpointArraySize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
+    UA_Client_delete(client);
 
+    /* Create a client and connect */
+    client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
     /* Connect to a server */
     /* anonymous connect would be: retval = UA_Client_connect(client, "opc.tcp://localhost:4840"); */
     retval = UA_Client_connectUsername(client, "opc.tcp://localhost:4840", "user1", "password");

--- a/examples/client.c
+++ b/examples/client.c
@@ -50,7 +50,6 @@ int main(int argc, char *argv[]) {
                endpointArray[i].endpointUrl.data);
     }
     UA_Array_delete(endpointArray,endpointArraySize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-    UA_Client_delete(client);
 
     /* Create a client and connect */
     client = UA_Client_new();

--- a/examples/client_async.c
+++ b/examples/client_async.c
@@ -69,22 +69,18 @@ methodCalled(UA_Client *client, void *userdata, UA_UInt32 requestId,
     }
     if(retval != UA_STATUSCODE_GOOD) {
         UA_CallResponse_clear(response);
-    }
-
-    /* Move the output arguments */
-    output = response->results[0].outputArguments;
-    outputSize = response->results[0].outputArgumentsSize;
-    response->results[0].outputArguments = NULL;
-    response->results[0].outputArgumentsSize = 0;
-
-    if(retval == UA_STATUSCODE_GOOD) {
-        printf("---Method call was successful, returned %lu values.\n",
-               (unsigned long) outputSize);
-        UA_Array_delete(output, outputSize, &UA_TYPES[UA_TYPES_VARIANT]);
+        printf("---Method call was unsuccessful, returned %x values.\n", retval);
     } else {
-        printf("---Method call was unsuccessful, returned %x values.\n",
-                retval);
+        /* Move the output arguments */
+        output = response->results[0].outputArguments;
+        outputSize = response->results[0].outputArgumentsSize;
+        response->results[0].outputArguments = NULL;
+        response->results[0].outputArgumentsSize = 0;
+        printf("---Method call was successful, returned %lu values.\n",
+               (unsigned long)outputSize);
+        UA_Array_delete(output, outputSize, &UA_TYPES[UA_TYPES_VARIANT]);
     }
+
     UA_CallResponse_clear(response);
 }
 

--- a/examples/client_historical.c
+++ b/examples/client_historical.c
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));
 
     /* Connect to the Unified Automation demo server */
-    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:53530/OPCUA/SimulationServer");
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840/");
     if(retval != UA_STATUSCODE_GOOD) {
         printf("Could not connect\n");
         UA_Client_delete(client);

--- a/examples/discovery/client_find_servers.c
+++ b/examples/discovery/client_find_servers.c
@@ -54,6 +54,7 @@ int main(void) {
 
         UA_Array_delete(serverOnNetwork, serverOnNetworkSize,
                         &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
+        UA_Client_delete(client);
     }
 
     /* Example for calling FindServers */

--- a/examples/encryption/client_encryption.c
+++ b/examples/encryption/client_encryption.c
@@ -44,6 +44,7 @@ int main(int argc, char* argv[]) {
     UA_Client *client = UA_Client_new();
     UA_ClientConfig *cc = UA_Client_getConfig(client);
     cc->securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
+    UA_String_clear(&cc->clientDescription.applicationUri);
     cc->clientDescription.applicationUri = UA_STRING_ALLOC("urn:open62541.server.application");
     UA_StatusCode retval = UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
                                          trustList, trustListSize,

--- a/examples/pubsub/sks/pubsub_publish_encrypted_sks.c
+++ b/examples/pubsub/sks/pubsub_publish_encrypted_sks.c
@@ -163,9 +163,9 @@ run(UA_UInt16 port, UA_String *transportProfile,
     addDataSetWriter(server);
 
     UA_StatusCode retval = UA_Server_run(server, &running);
-
-    UA_Server_delete(server);
+    
     UA_ClientConfig_delete(sksClientConfig);
+    UA_Server_delete(server);
     return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 

--- a/examples/pubsub/tutorial_pubsub_mqtt_publish.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt_publish.c
@@ -490,7 +490,8 @@ int main(int argc, char **argv) {
     if(UA_STATUSCODE_GOOD != retval) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                      "Error Name = %s", UA_StatusCode_name(retval));
-        return EXIT_FAILURE;
+        UA_Server_delete(server);
+        return EXIT_SUCCESS;
     }
     addDataSetWriter(server, topic);
 

--- a/examples/pubsub/tutorial_pubsub_mqtt_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt_subscribe.c
@@ -388,24 +388,25 @@ int main(int argc, char **argv) {
     /* Add PubSubConnection */
     UA_StatusCode retval = addPubSubConnection(server, addressUrl);
     if (retval != UA_STATUSCODE_GOOD)
-        return EXIT_FAILURE;
+        goto cleanup;
 
     /* Add ReaderGroup to the created PubSubConnection */
     retval |= addReaderGroup(server, interval);
     if (retval != UA_STATUSCODE_GOOD)
-        return EXIT_FAILURE;
+        goto cleanup;
 
     /* Add DataSetReader to the created ReaderGroup */
     retval |= addDataSetReader(server);
     if (retval != UA_STATUSCODE_GOOD)
-        return EXIT_FAILURE;
+        goto cleanup;
 
     /* Add SubscribedVariables to the created DataSetReader */
     retval |= addSubscribedVariables(server, subscribedDataSetIdent);
     if (retval != UA_STATUSCODE_GOOD)
-        return EXIT_FAILURE;
+        goto cleanup;
 
     retval = UA_Server_runUntilInterrupt(server);
+cleanup:
     UA_Server_delete(server);
-    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
+    return EXIT_SUCCESS;
 }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -405,14 +405,19 @@ function examples_valgrind {
           ..
     make ${MAKEOPTS}
 
+    # Arguments for the examples. The key is the example name and the value is the arguments.
+    declare -A example_args
+    example_args=( ["client_connect"]="opc.tcp://0.0.0.0:4840")
     # Run each example with valgrind. Wait 10 seconds and send the SIGINT
     # signal. Wait for the process to terminate and collect the exit status.
     # Abort when the exit status is non-null.
     FILES="./bin/examples/*"
     for f in $FILES
     do
+        example_name=$(basename $f)
+        args=${example_args[$example_name]:-}
 	    echo "Processing $f"
-	    valgrind --errors-for-leak-kinds=all --leak-check=full --error-exitcode=1 $f &
+	    valgrind --errors-for-leak-kinds=all --leak-check=full --error-exitcode=1 $f $args &
         pid=$!
 	    sleep 10
         # || true to ignore the error if the process is already dead

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Exit immediately if a command exits with a non-zero status
-#set -e
+set -e
 
 # Use the error status of the first failure in a pipeline
 set -o pipefail
@@ -380,106 +380,9 @@ function unit_tests_valgrind {
 ########################################
 
 function examples_valgrind {
-
-    declare -A example_args
-    example_args=(["client_encryption"]="opc.tcp://localhost:4840 client_cert.der client_key.der server_cert.der"
-        ["access_control_client_encrypt"]="opc.tcp://localhost:4840 client_cert.der client_key.der server_cert.der"
-        ["client_event_filter"]="opc.tcp://localhost:4840"
-        ["client_connect"]="-username user1 -password password -cert client_cert.der -key client_key.der opc.tcp://localhost:4840"
-        ["pubsub_nodeset_rt_publisher"]="-i lo"
-        ["pubsub_nodeset_rt_subscriber"]="-i lo"
-        ["pubsub_TSN_loopback"]="-i lo"
-        ["pubsub_TSN_loopback_single_thread"]="-i lo"
-        ["pubsub_TSN_publisher"]="-i lo"
-        ["pubsub_TSN_publisher_multiple_thread"]="-i lo"
-        ["server_encryption"]="server_cert.der server_key.der client_cert.der"
-        ["server_loglevel"]="--loglevel=1"
-        ["ci_server"]="4840 server_cert.der server_key.der client_cert.der"
-    )
-
-    ciServer="ci_server 4840 server_cert.der server_key.der client_cert.der"
-
-    declare -A server_needed_examples
-    server_needed_examples=(["access_control_client"]=$ciServer
-        ["access_control_client_encrypt"]=$ciServer
-        ["client"]=$ciServer
-        ["client_async"]=$ciServer
-        ["client_connect"]=$ciServer
-        ["client_connect_loop"]=$ciServer
-        ["client_encryption"]="server_encryption server_cert.der server_key.der client_cert.der"
-        ["client_event_filter"]=$ciServer
-        ["client_historical"]="tutorial_server_historicaldata"
-        ["client_method_async"]=$ciServer
-        ["client_subscription_loop"]=$ciServer
-        ["custom_datatype_client"]="custom_datatype_server"
-        ["discovery_client_find_servers"]="discovery_server_lds"
-        ["discovery_server_register"]="discovery_server_lds"
-        ["pubsub_publish_encrypted"]="pubsub_subscribe_encrypted"
-        ["pubsub_publish_encrypted_sks"]="server_pubsub_central_sks server_cert.der server_key.der --enableUnencrypted --enableAnonymous"
-        ["pubsub_subscribe_encrypted"]="pubsub_publish_encrypted"
-        ["pubsub_subscribe_encrypted_sks"]="server_pubsub_central_sks server_cert.der server_key.der --enableUnencrypted --enableAnonymous"
-        ["pubsub_subscribe_standalone_dataset"]="tutorial_pubsub_publish"
-        ["server_pubsub_publish_rt_level"]="server_pubsub_subscribe_rt_level"
-        ["server_pubsub_publish_rt_level_raw"]="server_pubsub_subscribe_rt_level"
-        ["server_pubsub_rt_information_model"]="server_pubsub_subscribe_rt_level"
-        ["server_pubsub_subscribe_custom_monitoring"]="tutorial_pubsub_publish_raw"
-        ["server_pubsub_subscribe_rt_level"]="server_pubsub_publish_rt_level"
-        ["tutorial_client_events"]="tutorial_server_events"
-        ["tutorial_client_firststeps"]="tutorial_server_firststeps"
-        ["tutorial_pubsub_connection"]="tutorial_pubsub_subscribe_raw"
-        ["tutorial_pubsub_mqtt_subscrib"]="tutorial_pubsub_mqtt_publish"
-        ["tutorial_pubsub_publish"]="tutorial_pubsub_subscribe"
-        ["tutorial_pubsub_publish_raw"]="tutorial_pubsub_subscribe_raw"
-        ["tutorial_pubsub_subscribe"]="tutorial_pubsub_publish"
-        ["tutorial_pubsub_subscribe_raw"]="tutorial_pubsub_publish_raw"
-        ["tutorial_server_reverseconnect"]="ci_server 4841 client_cert.der client_key.der server_cert.der")
-
-    declare -A client_needed_examples
-    client_needed_examples=(["ci_server"]="client"
-        ["server_ctt"]="client"
-        ["server_inheritance"]="client"
-        ["server_instantiation"]="client"
-        ["server_loglevel"]="client"
-        ["server_mainloop"]="client"
-        ["server_nodeset"]="client"
-        ["server_nodeset_loader"]="client"
-        ["server_nodeset_plcopen"]="client"
-        ["server_nodeset_powerlink"]="client"
-        ["server_settimestamp"]="client"
-        ["server_testnodeset"]="client"
-        ["tutorial_server_monitoreditems"]="client"
-        ["tutorial_server_variabletype"]="client"
-        ["tutorial_server_object"]="client"
-        ["tutorial_server_variable"]="client"
-        ["access_control_server"]="access_control_client"
-        ["custom_datatype_server"]="custom_datatype_client"
-        ["discovery_server_lds"]="discovery_client_find_servers"
-        ["server_encryption"]="client_encryption opc.tcp://localhost:4840 client_cert.der client_key.der server_cert.der"
-        ["server_events_random"]="tutorial_client_events opc.tcp://localhost:4840"
-        ["server_pubsub_central_sks"]="pubsub_publish_encrypted_sks"
-        ["tutorial_server_alarms_conditions"]="tutorial_client_events opc.tcp://localhost:4840"
-        ["tutorial_server_datasource"]="tutorial_client_events opc.tcp://localhost:4840"
-        ["tutorial_server_firststeps"]="tutorial_client_firststeps"
-        ["tutorial_server_historicaldata"]="client_historical"
-        ["tutorial_server_historicaldata_circular"]="client_historical"
-        ["tutorial_server_method"]="client_method_async"
-        ["tutorial_server_method_async"]="client_method_async")
-
-    # a blacklist for examples taht cause issues. Mostly because of EXIT_FAILURE...
-    declare -A blacklist
-    blacklist=(
-        ["pubsub_TSN_loopback"]=1
-        ["pubsub_TSN_loopback_single_thread"]=1
-        ["pubsub_TSN_publisher"]=1
-        ["pubsub_TSN_publisher_multiple_thread"]=1
-        ["pubsub_nodeset_rt_publisher"]=1
-        ["pubsub_nodeset_rt_subscriber"]=1
-        ["access_control_client_encrypt"]=1
-        ["client_encryption"]=1
-        ["client_historical"]=1
-    )
     mkdir -p build; cd build; rm -rf *
 
+    # create certificates for the examples
     python3 ../tools/certs/create_self-signed.py -c server 
     python3 ../tools/certs/create_self-signed.py -c client 
 
@@ -510,88 +413,12 @@ function examples_valgrind {
     # Run each example with valgrind. Wait 10 seconds and send the SIGINT
     # signal. Wait for the process to terminate and collect the exit status.
     # Abort when the exit status is non-null.
-    FILES="./bin/examples/*"
-    for f in $FILES
-    do
-        example_name=$(basename $f)
-        args=${example_args[$example_name]:-}
-        
-        #check if examples is in blacklist. If yes, skip it
-        if [[ ${blacklist[$example_name]:-} ]]; then
-            echo "Skipping $example_name"
-            continue
-        fi
-
-        # check if a server/client is needed for the example
-        if [[ ${server_needed_examples[$example_name]:-} ]]; then
-            # Start the server in the background
-            server=${server_needed_examples[$example_name]:-}
-            echo "Starting $server for $example_name"
-            # silence all output of the server
-            
-            eval "./bin/examples/$server" >/dev/null 2>&1 &
-            # Save the PID of the server process
-            server_pid=$!
-            # Give the server some time to start up
-            sleep 10
-        fi
- 
-        eval "valgrind --errors-for-leak-kinds=all --leak-check=full --error-exitcode=1 $f $args" &
-        pid=$!
-
-        # Give the example some time to start up
-        sleep 5
-        # check if a client is needed for the example
-        if [[ ${client_needed_examples[$example_name]:-} ]]; then
-            # Start the client in the background
-            client=${client_needed_examples[$example_name]:-}
-            echo "Starting $client for $example_name"
-            # silence all output of the client
-            eval "./bin/examples/$client" >/dev/null 2>&1 &
-            # Save the PID of the client process
-            client_pid=$!
-        fi
-
-        sleep 10
-        # || true to ignore the error if the process is already dead
-        kill -INT $pid || true
-
-        sleep 5
-
-        # Check if the process is still running.
-        tries=0
-        while ps | grep "$pid" >/dev/null; do
-            tries=$((tries+1))
-            if [[ $tries -gt 5 ]]; then
-                echo "Process $pid is still running after 5 tries. Terminating process."
-                kill -9 $pid || true
-            fi
-            echo "$pid is still in the ps output. Must still be running. Try: $tries"
-            kill -INT $pid || true
-            sleep 10
-        done
-
-        wait $pid
-        EXIT_CODE=$?
-        if [[ $EXIT_CODE -ne 0 ]]; then
-            echo "Processing $f failed with exit code $EXIT_CODE "
-            exit $EXIT_CODE
-        fi
-
-        if [[ ${server_needed_examples[$example_name]:-} ]]; then
-            # Once the client has finished, kill the server
-            echo "Stopping server_encryption with pid $server_pid for $example_name"
-            kill -9 $server_pid || true
-            wait $server_pid
-        fi
-
-        if [[ ${client_needed_examples[$example_name]:-} ]]; then
-            # Once the client has finished, kill the client
-            echo "Stopping client with pid $client_pid for $example_name"
-            kill -9 $client_pid || true
-            wait $client_pid
-        fi
-    done
+    python3 ../tools/examples_with_valgrind.py
+    EXIT_CODE=$?
+    if [[ $EXIT_CODE -ne 0 ]]; then
+        echo "Processing failed with exit code $EXIT_CODE"
+        exit $EXIT_CODE
+    fi
 }
 
 ##############################

--- a/tools/examples_with_valgrind.py
+++ b/tools/examples_with_valgrind.py
@@ -40,18 +40,15 @@ server_needed_examples = {
         "pubsub_subscribe_encrypted_sks":"server_pubsub_central_sks server_cert.der server_key.der --enableUnencrypted --enableAnonymous",
         "pubsub_subscribe_standalone_dataset":"tutorial_pubsub_publish",
         "server_pubsub_publish_rt_level":"server_pubsub_subscribe_rt_level",
-        "server_pubsub_publish_rt_level_raw":"server_pubsub_subscribe_rt_level",
         "server_pubsub_rt_information_model":"server_pubsub_subscribe_rt_level",
-        "server_pubsub_subscribe_custom_monitoring":"tutorial_pubsub_publish_raw",
+        "server_pubsub_subscribe_custom_monitoring":"server_pubsub_publish_on_demand",
         "server_pubsub_subscribe_rt_level":"server_pubsub_publish_rt_level",
         "tutorial_client_events":"tutorial_server_events",
         "tutorial_client_firststeps":"tutorial_server_firststeps",
-        "tutorial_pubsub_connection":"tutorial_pubsub_subscribe_raw",
+        "tutorial_pubsub_connection":"tutorial_pubsub_subscribe",
         "tutorial_pubsub_mqtt_subscrib":"tutorial_pubsub_mqtt_publish",
         "tutorial_pubsub_publish":"tutorial_pubsub_subscribe",
-        "tutorial_pubsub_publish_raw":"tutorial_pubsub_subscribe_raw",
         "tutorial_pubsub_subscribe":"tutorial_pubsub_publish",
-        "tutorial_pubsub_subscribe_raw":"tutorial_pubsub_publish_raw",
         "tutorial_server_reverseconnect":"ci_server 4841 client_cert.der client_key.der server_cert.der"
 }
 

--- a/tools/examples_with_valgrind.py
+++ b/tools/examples_with_valgrind.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import time
 from collections import defaultdict
-import shlex
 
 example_args = {
         "client_encryption":"opc.tcp://localhost:4840 client_cert.der client_key.der server_cert.der",
@@ -120,10 +119,11 @@ for example in examples:
         continue
     
     # get the arguments for the example
-    args = example_args.get(example, "")
+    args = example_args.get(example)
     cmd = ["valgrind", "--errors-for-leak-kinds=all", "--leak-check=full", "--error-exitcode=1", "./bin/examples/"+example]
     if args:
-        cmd += shlex.split(args)
+        args_list = args.split()
+        cmd += args_list
     print(f"Args for {example}: {cmd} ")
 
     # check if the example needs a server or client to be running
@@ -133,7 +133,7 @@ for example in examples:
     #start the server if needed
     server_process = None
     if server_needed:
-        server_cmd = shlex.split(server_needed)
+        server_cmd = server_needed.split()
         server_cmd[0] = "./bin/examples/" + server_cmd[0]
         print(f"Starting server {server_cmd} from {os.getcwd()}")
         server_process = subprocess.Popen(server_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -146,7 +146,7 @@ for example in examples:
     # start the client if needed
     client_process = None
     if client_needed:
-        client_cmd = shlex.split(client_needed)
+        client_cmd = client_needed.split()
         client_cmd[0] = "./bin/examples/" + client_cmd[0]
         print(f"Starting client {client_cmd}")
         client_process = subprocess.Popen(client_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/tools/examples_with_valgrind.py
+++ b/tools/examples_with_valgrind.py
@@ -1,0 +1,183 @@
+import os
+import subprocess
+import time
+from collections import defaultdict
+import shlex
+
+example_args = {
+        "client_encryption":"opc.tcp://localhost:4840 client_cert.der client_key.der server_cert.der",
+        "access_control_client_encrypt":"opc.tcp://localhost:4840 client_cert.der client_key.der server_cert.der",
+        "client_event_filter":"opc.tcp://localhost:4840",
+        "client_connect":"-username user1 -password password -cert client_cert.der -key client_key.der opc.tcp://localhost:4840",
+        "pubsub_nodeset_rt_publisher":"-i lo",
+        "pubsub_nodeset_rt_subscriber":"-i lo",
+        "pubsub_TSN_loopback":"-i lo",
+        "pubsub_TSN_loopback_single_thread":"-i lo",
+        "pubsub_TSN_publisher":"-i lo",
+        "pubsub_TSN_publisher_multiple_thread":"-i lo",
+        "server_encryption":"server_cert.der server_key.der client_cert.der",
+        "server_loglevel":"--loglevel=1",
+        "ci_server":"4840 server_cert.der server_key.der client_cert.der"
+        }
+
+server_needed_examples = {
+        "access_control_client":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "access_control_client_encrypt":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "client":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "client_async":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "client_connect":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "client_connect_loop":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "client_encryption":"server_encryption server_cert.der server_key.der client_cert.der",
+        "client_event_filter":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "client_historical":"tutorial_server_historicaldata",
+        "client_method_async":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "client_subscription_loop":"ci_server 4840 server_cert.der server_key.der client_cert.der",
+        "custom_datatype_client":"custom_datatype_server",
+        "discovery_client_find_servers":"discovery_server_lds",
+        "discovery_server_register":"discovery_server_lds",
+        "pubsub_publish_encrypted":"pubsub_subscribe_encrypted",
+        "pubsub_publish_encrypted_sks":"server_pubsub_central_sks server_cert.der server_key.der --enableUnencrypted --enableAnonymous",
+        "pubsub_subscribe_encrypted":"pubsub_publish_encrypted",
+        "pubsub_subscribe_encrypted_sks":"server_pubsub_central_sks server_cert.der server_key.der --enableUnencrypted --enableAnonymous",
+        "pubsub_subscribe_standalone_dataset":"tutorial_pubsub_publish",
+        "server_pubsub_publish_rt_level":"server_pubsub_subscribe_rt_level",
+        "server_pubsub_publish_rt_level_raw":"server_pubsub_subscribe_rt_level",
+        "server_pubsub_rt_information_model":"server_pubsub_subscribe_rt_level",
+        "server_pubsub_subscribe_custom_monitoring":"tutorial_pubsub_publish_raw",
+        "server_pubsub_subscribe_rt_level":"server_pubsub_publish_rt_level",
+        "tutorial_client_events":"tutorial_server_events",
+        "tutorial_client_firststeps":"tutorial_server_firststeps",
+        "tutorial_pubsub_connection":"tutorial_pubsub_subscribe_raw",
+        "tutorial_pubsub_mqtt_subscrib":"tutorial_pubsub_mqtt_publish",
+        "tutorial_pubsub_publish":"tutorial_pubsub_subscribe",
+        "tutorial_pubsub_publish_raw":"tutorial_pubsub_subscribe_raw",
+        "tutorial_pubsub_subscribe":"tutorial_pubsub_publish",
+        "tutorial_pubsub_subscribe_raw":"tutorial_pubsub_publish_raw",
+        "tutorial_server_reverseconnect":"ci_server 4841 client_cert.der client_key.der server_cert.der"
+}
+
+client_needed_examples = {
+        "ci_server":"client",
+        "server_ctt":"client",
+        "server_inheritance":"client",
+        "server_instantiation":"client",
+        "server_loglevel":"client",
+        "server_mainloop":"client",
+        "server_nodeset":"client",
+        "server_nodeset_loader":"client",
+        "server_nodeset_plcopen":"client",
+        "server_nodeset_powerlink":"client",
+        "server_settimestamp":"client",
+        "server_testnodeset":"client",
+        "tutorial_server_monitoreditems":"client",
+        "tutorial_server_variabletype":"client",
+        "tutorial_server_object":"client",
+        "tutorial_server_variable":"client",
+        "access_control_server":"access_control_client",
+        "custom_datatype_server":"custom_datatype_client",
+        "discovery_server_lds":"discovery_client_find_servers",
+        "server_encryption":"client_encryption opc.tcp://localhost:4840 client_cert.der client_key.der server_cert.der",
+        "server_events_random":"tutorial_client_events opc.tcp://localhost:4840",
+        "server_pubsub_central_sks":"pubsub_publish_encrypted_sks",
+        "tutorial_server_alarms_conditions":"tutorial_client_events opc.tcp://localhost:4840",
+        "tutorial_server_datasource":"tutorial_client_events opc.tcp://localhost:4840",
+        "tutorial_server_firststeps":"tutorial_client_firststeps",
+        "tutorial_server_historicaldata":"client_historical",
+        "tutorial_server_historicaldata_circular":"client_historical",
+        "tutorial_server_method":"client_method_async",
+        "tutorial_server_method_async":"client_method_async"
+}
+
+blacklist = {
+        "pubsub_TSN_loopback":1,
+        "pubsub_TSN_loopback_single_thread":1,
+        "pubsub_TSN_publisher":1,
+        "pubsub_TSN_publisher_multiple_thread":1,
+        "pubsub_nodeset_rt_publisher":1,
+        "pubsub_nodeset_rt_subscriber":1,
+        "access_control_client_encrypt":1,
+        "client_encryption":1,
+        "client_historical":1,
+        "client_subscription_loop":1,
+        "client_method_async":1
+}
+
+# Run each example with valgrind.
+# Wait 10 seconds and send the SIGINT signal.
+# Wait for the process to terminate and collect the exit status.
+# Abort when the exit status is non-null.
+
+os.chdir("../build")
+current_dir = os.getcwd()
+print(f"Current directory: {current_dir}")
+example_dir = os.path.join(current_dir, "bin", "examples")
+examples = os.listdir(example_dir)
+
+# skipping examples that are in the blacklist
+for example in examples:
+    if example in blacklist:
+        print(f"Skipping {example}")
+        continue
+    
+    # get the arguments for the example
+    args = example_args.get(example, "")
+    cmd = ["valgrind", "--errors-for-leak-kinds=all", "--leak-check=full", "--error-exitcode=1", "./bin/examples/"+example]
+    if args:
+        cmd += shlex.split(args)
+    print(f"Args for {example}: {cmd} ")
+
+    # check if the example needs a server or client to be running
+    server_needed = server_needed_examples.get(example)
+    client_needed = client_needed_examples.get(example)
+    
+    #start the server if needed
+    server_process = None
+    if server_needed:
+        server_cmd = shlex.split(server_needed)
+        server_cmd[0] = "./bin/examples/" + server_cmd[0]
+        print(f"Starting server {server_cmd} from {os.getcwd()}")
+        server_process = subprocess.Popen(server_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(10)
+    
+    # start the example
+    process = subprocess.Popen(cmd)
+    time.sleep(10)
+    
+    # start the client if needed
+    client_process = None
+    if client_needed:
+        client_cmd = shlex.split(client_needed)
+        client_cmd[0] = "./bin/examples/" + client_cmd[0]
+        print(f"Starting client {client_cmd}")
+        client_process = subprocess.Popen(client_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    
+    # wait 20 seconds and send the SIGINT signal
+    time.sleep(20)
+    print(f"Sending SIGINT to {process.pid}")
+    process.send_signal(subprocess.signal.SIGINT)
+    
+    tries = 0
+    while process.poll() is None:
+        time.sleep(20)
+        process.send_signal(subprocess.signal.SIGINT)
+        if tries > 5:
+            print(f"Process {process.pid} is still running after 5 tries. Terminating process.")
+            process.kill()
+        tries += 1
+
+    # save the exit code
+    exit_code = process.wait()
+    if exit_code != 0:
+        print(f"Processing {example} failed with exit code {exit_code}")
+        exit(exit_code)
+
+    # terminate the server and client
+    if server_process:
+        print(f"Sending SIGKILL to server {server_process.pid}")
+        server_process.kill()
+        server_process.wait()
+    
+    if client_process:
+        print(f"Sending SIGKILL to client {client_process.pid}")
+        client_process.kill()
+        client_process.wait()


### PR DESCRIPTION
This allows to set arguments for the examples in the CI script.

The execution of the examples is outsourced to a python script since the associative arrays in bash didn't work as expected in the CI environment. 

You can set a client or server that needs to be running for each examples. Servers are started before the example, clients are started 10 seconds afterwards. 

You can also set arguments for the examples like a server address or certificates and keys that will be generated as well.

Some examples just run the client examples as well and might need a better client but this provides an environment where things can be adjusted easily. 
I added another example `ci_server.c` that is used for a lot of examples. 

There is also a blacklist for examples that dont work right now. Its mostly because they exit with a non zero return value. This results in a failing CI workflow.

There are also some memory leak fixes that have been undetected with the old workflow without args/client/server.
