### PR TITLE
fix(plugin): free old thumbprint befor creating the new one

### DIFF
--- a/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
+++ b/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
@@ -135,6 +135,8 @@ updateCertificateAndPrivateKey_sp_aes128sha256rsaoaep(UA_SecurityPolicy *securit
         goto error;
     }
 
+    UA_ByteString_clear(&pc->localCertThumbprint);
+
     retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
                                                       &pc->localCertThumbprint, true);
     if(retval != UA_STATUSCODE_GOOD) {

--- a/plugins/crypto/openssl/ua_openssl_basic128rsa15.c
+++ b/plugins/crypto/openssl/ua_openssl_basic128rsa15.c
@@ -128,6 +128,8 @@ updateCertificateAndPrivateKey_sp_basic128rsa15(UA_SecurityPolicy *securityPolic
         goto error;
     }
 
+    UA_ByteString_clear(&pc->localCertThumbprint);
+
     retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
                                                       &pc->localCertThumbprint, true);
     if(retval != UA_STATUSCODE_GOOD) {

--- a/plugins/crypto/openssl/ua_openssl_basic256.c
+++ b/plugins/crypto/openssl/ua_openssl_basic256.c
@@ -126,6 +126,8 @@ updateCertificateAndPrivateKey_sp_basic256(UA_SecurityPolicy *securityPolicy,
         goto error;
     }
 
+    UA_ByteString_clear(&pc->localCertThumbprint);
+
     retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
                                                       &pc->localCertThumbprint, true);
     if(retval != UA_STATUSCODE_GOOD) {

--- a/plugins/crypto/openssl/ua_openssl_basic256sha256.c
+++ b/plugins/crypto/openssl/ua_openssl_basic256sha256.c
@@ -127,6 +127,8 @@ updateCertificateAndPrivateKey_sp_basic256sha256(UA_SecurityPolicy *securityPoli
         goto error;
     }
 
+    UA_ByteString_clear(&pc->localCertThumbprint);
+
     retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
                                                       &pc->localCertThumbprint, true);
     if(retval != UA_STATUSCODE_GOOD) {


### PR DESCRIPTION
Recently I added the update server cert at runtime function for the openssl builds with this PR https://github.com/open62541/open62541/pull/5712 .

I forgot to clear the thumbprint befor creating the new one so there is a memory leak. This PR should fix that.