### PR TITLE
fix(server): Transfer subscription - fix queued subscription notifica…

### DIFF
--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -547,8 +547,8 @@ Operation_TransferSubscription(UA_Server *server, UA_Session *session,
 
     /* Move over the notification queue */
     TAILQ_INIT(&newSub->notificationQueue);
-    UA_Notification *nn;
-    TAILQ_FOREACH(nn, &sub->notificationQueue, globalEntry) {
+    UA_Notification *nn, *nn_tmp;
+    TAILQ_FOREACH_SAFE(nn, &sub->notificationQueue, globalEntry, nn_tmp) {
         TAILQ_REMOVE(&sub->notificationQueue, nn, globalEntry);
         TAILQ_INSERT_TAIL(&newSub->notificationQueue, nn, globalEntry);
     }

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -1526,11 +1526,15 @@ START_TEST(Client_subscription_transfer) {
     UA_MonitoredItemCreateRequest monRequest =
         UA_MonitoredItemCreateRequest_default(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME));
 
+    for(size_t i = 0; i < 5; i++) {
     UA_MonitoredItemCreateResult monResponse =
         UA_Client_MonitoredItems_createDataChange(client, response.subscriptionId,
                                                   UA_TIMESTAMPSTORETURN_BOTH,
                                                   monRequest, NULL, dataChangeHandler, NULL);
     ck_assert_uint_eq(monResponse.statusCode, UA_STATUSCODE_GOOD);
+    }
+
+    UA_sleep_ms(1000);
 
     /* Create a second client */
     UA_Client *client2 = UA_Client_new();
@@ -1553,11 +1557,12 @@ START_TEST(Client_subscription_transfer) {
     UA_TransferSubscriptionsResponse_clear(&tresponse);
 
     /* Iterate the clients some more to see what happens */
-    UA_Client_run_iterate(client, 1);
-    UA_Client_run_iterate(client2, 1);
+    for(size_t i = 0; i < 10; i++) {
+        UA_Client_run_iterate(client, 1);
+        UA_Client_run_iterate(client2, 1);
 
-    UA_Client_run_iterate(client, 1);
-    UA_Client_run_iterate(client2, 1);
+        UA_sleep_ms(100);
+    }
 
     /* Delete */
     UA_Client_disconnect(client);


### PR DESCRIPTION
…tions

When transferring a subscription, TAILQ_FOREACH_SAFE must be used for queued subscription notifications.

Unit test updated.

Fix #5774