### PR TITLE
fix(hda client) replace dataEncoding with empty string

### DIFF
--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -474,7 +474,7 @@ __UA_Client_HistoryRead(UA_Client *client, const UA_NodeId *nodeId,
     item.nodeId = *nodeId;
     item.indexRange = indexRange;
     item.continuationPoint = continuationPoint;
-    item.dataEncoding = UA_QUALIFIEDNAME(0, "Default Binary");
+    item.dataEncoding = UA_QUALIFIEDNAME(0, "");
 
     UA_HistoryReadRequest request;
     UA_HistoryReadRequest_init(&request);


### PR DESCRIPTION
Connected with an OPC-UA_Server which did not accept the "Default Binary" dataEncoding when fetching HDA.
Removing the string entirely solved the issue.
This server was working with UAExpert so I analyzed the differences with WireShark between UAExpert and open62541