### PR TITLE
fix(HDA): Replace HDA dataEncoding with empty string

### DIFF
--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -474,7 +474,7 @@ __UA_Client_HistoryRead(UA_Client *client, const UA_NodeId *nodeId,
     item.nodeId = *nodeId;
     item.indexRange = indexRange;
     item.continuationPoint = continuationPoint;
-    item.dataEncoding = UA_QUALIFIEDNAME(0, "Default Binary");
+    item.dataEncoding = UA_QUALIFIEDNAME(0, "");
 
     UA_HistoryReadRequest request;
     UA_HistoryReadRequest_init(&request);


### PR DESCRIPTION
Fetching HDA did not work while UAExpert did. Used Wireshark to analyze the difference.