### PR TITLE
fix(core): Fix the order of parameters for MSVC

### DIFF
--- a/include/open62541/architecture_definitions.h
+++ b/include/open62541/architecture_definitions.h
@@ -434,7 +434,7 @@ static UA_INLINE void *
 UA_atomic_cmpxchg(void * volatile * addr, void *expected, void *newptr) {
 #if UA_MULTITHREADING >= 100
 #ifdef _MSC_VER /* Visual Studio */
-    return _InterlockedCompareExchangePointer(addr, expected, newptr);
+    return _InterlockedCompareExchangePointer(addr, newptr, expected);
 #else /* GCC/Clang */
     return __sync_val_compare_and_swap(addr, expected, newptr);
 #endif


### PR DESCRIPTION
Written by @anzeskerjancDS.

This fixes a segfault in our application (we did a few more changes which we might make into a PR later, but this is a direct bug fix, others are less straightforward). A separate bug fix is needed for master where this code was heavily refactored, but we would greatly appreciate a fix in the 1.3 branch as well.

The function `_InterlockedCompareExchangePointer`/`InterlockedCompareExchangePointer` expects the parameters in a different order.

* https://learn.microsoft.com/en-us/cpp/intrinsics/interlockedcompareexchangepointer-intrinsic-functions?view=msvc-170
* https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-interlockedcompareexchangepointer

```c
void * _InterlockedCompareExchangePointer (
   void * volatile * Destination,
   void * Exchange,
   void * Comparand
);
```

```c++
PVOID InterlockedCompareExchangePointer(
  [in, out] PVOID volatile *Destination,
  [in]      PVOID          Exchange,
  [in]      PVOID          Comperand
);
```

In addition to this we would be extremely grateful if intrinsic functions could be replaced by their high level counterparts (in the `1.3` branch) as it was done on the master. We are struggling to compile this code and we do some ugly local patching to work around the issue.

@jpfr