### PR TITLE
fix(cmake): Add missing compile definitions to open62541-object/plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1520,6 +1520,11 @@ GET_PROPERTY(ua_architecture_append_to_library GLOBAL PROPERTY UA_ARCHITECTURE_A
 list(APPEND open62541_LIBRARIES ${ua_architecture_append_to_library})
 
 target_compile_definitions(open62541 PUBLIC UA_ARCHITECTURE_${UA_ARCHITECTURE_UPPER})
+target_compile_definitions(open62541-object PUBLIC UA_ARCHITECTURE_${UA_ARCHITECTURE_UPPER})
+
+if(NOT UA_ENABLE_AMALGAMATION)
+    target_compile_definitions(open62541-plugins PUBLIC UA_ARCHITECTURE_${UA_ARCHITECTURE_UPPER})
+endif()
 
 # DLL requires linking to dependencies
 target_link_libraries(open62541 ${open62541_LIBRARIES})


### PR DESCRIPTION
UA_ARCHITECTURE_* compile definition was added only to open62541 target, but it should be also added to open62541-plugins and open62541-object targets.

An additional somewhat related question: why do we have a standalone
```cmake
add_definitions(-DUA_ARCHITECTURE_${UA_ARCHITECTURE_UPPER})
```
that is not bound to any target? @Pro 

@janm-dw / @ja4nm