### PR TITLE
fix(nodesetinjector):  Bug fixing when adjusting the type array.

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -312,10 +312,12 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
         typeArr = typesArray[-1]
         if typeArr != "UA_TYPES" and typeArr != "ns0":
             writec("/* Change namespaceIndex from current namespace */")
+            writec("#if " + typeArr + "_COUNT" + " > 0")
             writec("for(int i = 0; i < " + typeArr + "_COUNT" + "; i++) {")
             writec(typeArr + "[i]" + ".typeId.namespaceIndex = ns[" + str(nodeset.namespaceMapping[1]) + "];")
             writec(typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = ns[" + str(nodeset.namespaceMapping[1]) + "];")
             writec("}")
+            writec("#endif")
 
     # Add generated types to the server
     writec("\n/* Load custom datatype definitions into the server */")

--- a/tools/nodeset_injector/CMakeLists.txt
+++ b/tools/nodeset_injector/CMakeLists.txt
@@ -212,6 +212,26 @@ foreach(MODEL ${UA_INFORMATION_MODEL_AUTOLOAD})
                 AUTOLOAD
                 DEPENDS "di"
         )
+    elseif(MODEL STREQUAL "PADIM")
+        ua_generate_nodeset_and_datatypes(
+                NAME "irdi"
+                FILE_NS "${UA_NODESET_DIR}/${MODEL}/Opc.Ua.IRDI.NodeSet2.xml"
+                INTERNAL
+                AUTOLOAD
+        )
+
+        set(TMP_NSURI "http://opcfoundation.org/UA/${MODEL}/")
+        configure_file(${PROJECT_SOURCE_DIR}/tools/nodeset_injector/empty.bsd.template "${CMAKE_BINARY_DIR}/bsd_files_gen/Opc.Ua.${MODEL}.Types.bsd")
+        ua_generate_nodeset_and_datatypes(
+                NAME "${NODESET_NAME}"
+                FILE_NS "${UA_NODESET_DIR}/${MODEL}/Opc.Ua.${MODEL}.NodeSet2.xml"
+                FILE_CSV "${UA_NODESET_DIR}/${MODEL}/Opc.Ua.${MODEL}.NodeIds.csv"
+                FILE_BSD "${CMAKE_BINARY_DIR}/bsd_files_gen/Opc.Ua.${MODEL}.Types.bsd"
+                INTERNAL
+                AUTOLOAD
+                DEPENDS "di"
+                DEPENDS "irdi"
+        )
     else()
         MESSAGE(WARNING "The specified nodeset '${MODEL}' is not supported or is misspelled.")
     endif()

--- a/tools/nodeset_injector/empty.bsd.template
+++ b/tools/nodeset_injector/empty.bsd.template
@@ -1,0 +1,3 @@
+<opc:TypeDictionary xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="${TMP_NSURI}" DefaultByteOrder="LittleEndian" xmlns:opc="http://opcfoundation.org/BinarySchema/" xmlns:ua="http://opcfoundation.org/UA/" TargetNamespace="${TMP_NSURI}">
+    <opc:Import Namespace="http://opcfoundation.org/UA/"/>
+</opc:TypeDictionary>


### PR DESCRIPTION
The type array of the respective nodeset is not adjusted if an empty bsd file is specified. If no bsd is specified or the xml file does not contain a base64 block, an empty bsd file is automatically generated.
PADIM specification included in the nodesetinjector.
Fix for #5814