### PR TITLE
fix(ci): Fix git version matching

### DIFF
--- a/tools/prepare_packaging.py
+++ b/tools/prepare_packaging.py
@@ -29,7 +29,7 @@ git_describe_version = subprocess.check_output(["git", "describe", "--tags", "--
 # v1.2.3-5-g4538abcd-dirty
 # git_describe_version = "v1.2.3"
 
-m = re.match(r"^v([0-9]{1,4})(\.[0-9]{1,4}){0,2}(-(.*){1,100})?$", git_describe_version)
+m = re.match(r"^v([0-9]{1,4})(\.[0-9]{1,4})?(\.[0-9]{1,4})?(-(.*){1,100})?$", git_describe_version)
 version_major = m.group(1) if m.group(1) is not None else "0"
 version_minor = m.group(2).replace(".", "") if m.group(2) is not None else "0"
 version_patch = m.group(3).replace(".", "") if m.group(3) is not None else "0"


### PR DESCRIPTION
Fix parsing of version_minor and version_patch from git description.

For version v1.3.5-... the version_minor was set to 5 and version_patch
was empty with the old regex.

Error was introduced in PR #4854.