### PR TITLE
fix(tests): Correct type of publisherId in tests

### DIFF
--- a/tests/pubsub/check_pubsub_get_state.c
+++ b/tests/pubsub/check_pubsub_get_state.c
@@ -190,7 +190,7 @@ static void AddDataSetReader(
     UA_DataSetReaderConfig readerConfig;
     memset (&readerConfig, 0, sizeof(UA_DataSetReaderConfig));
     readerConfig.name = UA_STRING(pName);
-    UA_Variant_setScalar(&readerConfig.publisherId, (UA_UInt16*) &PublisherId, &UA_TYPES[UA_TYPES_UINT16]);
+    UA_Variant_setScalar(&readerConfig.publisherId, (UA_UInt32*) &PublisherId, &UA_TYPES[UA_TYPES_UINT32]);
     readerConfig.writerGroupId    = (UA_UInt16) WriterGroupId;
     readerConfig.dataSetWriterId  = (UA_UInt16) DataSetWriterId;
     readerConfig.messageReceiveTimeout = MessageReceiveTimeout;

--- a/tests/pubsub/check_pubsub_mqtt.c
+++ b/tests/pubsub/check_pubsub_mqtt.c
@@ -250,8 +250,8 @@ START_TEST(SinglePublishSubscribeDateTime){
         // add DataSetReader
         memset (&readerConfig, 0, sizeof(UA_DataSetReaderConfig));
         readerConfig.name = UA_STRING("DataSet Reader 1");
-        UA_UInt32 publisherIdentifier = 2234;
-        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT32];
+        UA_UInt16 publisherIdentifier = 2234;
+        readerConfig.publisherId.type = &UA_TYPES[UA_TYPES_UINT16];
         readerConfig.publisherId.data = &publisherIdentifier;
         readerConfig.writerGroupId    = 100;
         readerConfig.dataSetWriterId  = 62541;


### PR DESCRIPTION
Correct type of publisherId in tests to match publisherId type in connection and readergroup configuration.