### PR TITLE
Change in nodemanagement to fix problem with structures which are not

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -410,9 +410,11 @@ useVariableTypeAttributes(UA_Server *server, UA_Session *session,
         UA_DataValue_init(&v);
         retval = readValueAttribute(server, session, (const UA_VariableNode*)vt, &v);
         if(retval == UA_STATUSCODE_GOOD && v.hasValue) {
-            retval = writeAttribute(server, session, &node->head.nodeId,
-                                    UA_ATTRIBUTEID_VALUE, &v.value,
-                                    &UA_TYPES[UA_TYPES_VARIANT]);
+            if (v.value.type->typeKind != UA_DATATYPEKIND_EXTENSIONOBJECT) {
+                retval = writeAttribute(server, session, &node->head.nodeId,
+                                        UA_ATTRIBUTEID_VALUE, &v.value,
+                                        &UA_TYPES[UA_TYPES_VARIANT]);
+            }
         }
         UA_DataValue_clear(&v);
 


### PR DESCRIPTION
created with Variable Type BaseDataVariableType.

If creating a structure with BaseDataVariableType as type definition, the attribute read before has no value. Because of this writeAttribute() is not called.

If creating a structure with another variable type as type definition, the attribute has a value. Strange it tells, that it is an extension object and not a structure anymore.
Afterwards writeAttribute() in the NodeSet changes the structre to an extension object.

This leads to the problem that we can not describe and handle the node properly after construction.

Here we fix the problem by not overwriting the attribute if it of type extension object.



