### PR TITLE
[WIP] feat(server): Add GetFirstSession, GetNextSession

### DIFF
--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -265,6 +265,12 @@ getSessionByToken(UA_Server *server, const UA_NodeId *token);
 UA_Session *
 getSessionById(UA_Server *server, const UA_NodeId *sessionId);
 
+const UA_Session *
+UA_Server_GetFirstSession(UA_Server *server);
+
+const UA_Session *
+UA_Server_GetNextSession(UA_Server *server, const UA_Session *session);
+
 /*****************/
 /* Node Handling */
 /*****************/

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -178,6 +178,32 @@ getSessionById(UA_Server *server, const UA_NodeId *sessionId) {
     return NULL;
 }
 
+const UA_Session *
+UA_Server_GetFirstSession(UA_Server *server) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+    if (server->sessions.lh_first != NULL) {
+        return &server->sessions.lh_first->session;
+    }
+    return NULL;
+}
+
+const UA_Session *
+UA_Server_GetNextSession(UA_Server *server, const UA_Session *session) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+    session_list_entry * currentSessionListEntry = server->sessions.lh_first;
+
+    while (currentSessionListEntry != NULL) {
+        if (&currentSessionListEntry->session == session) {
+            if (currentSessionListEntry->pointers.le_next != NULL) {
+                return &(LIST_NEXT(currentSessionListEntry, pointers)->session);
+            }
+            return NULL;
+        }
+        currentSessionListEntry = LIST_NEXT(currentSessionListEntry, pointers);
+    }
+    return NULL;
+}
+
 static UA_StatusCode
 signCreateSessionResponse(UA_Server *server, UA_SecureChannel *channel,
                           const UA_CreateSessionRequest *request,


### PR DESCRIPTION
Add two functions to get the sessions that are in the session list. The function GetFirstSession gets the head of the list and GetNextSession returns the next session that is in the list.

This allows to get access to the sessions and their fields. This makes it possible to get the information that are in the clientDescription field of the session.