### PR TITLE
fix(arch): Decrease log level for processing delayed callbacks

### DIFF
--- a/arch/eventloop_posix.c
+++ b/arch/eventloop_posix.c
@@ -93,7 +93,7 @@ UA_EventLoopPOSIX_removeDelayedCallback(UA_EventLoop *public_el,
 /* Process and then free registered delayed callbacks */
 static void
 processDelayed(UA_EventLoopPOSIX *el) {
-    UA_LOG_DEBUG(el->eventLoop.logger, UA_LOGCATEGORY_EVENTLOOP,
+    UA_LOG_TRACE(el->eventLoop.logger, UA_LOGCATEGORY_EVENTLOOP,
                  "Process delayed callbacks");
 
     UA_LOCK_ASSERT(&el->elMutex, 1);


### PR DESCRIPTION
The log "Process delayed callbacks" is called as often as the log "Iterate the EventLoop", so the log level should also be UA_LOGLEVEL_TRACE, not UA_LOGLEVEL_DEBUG.