### PR TITLE
fix(plugin): Declare log constants static

### DIFF
--- a/plugins/ua_log_stdout.c
+++ b/plugins/ua_log_stdout.c
@@ -31,11 +31,13 @@
 # define ANSI_COLOR_RESET   ""
 #endif
 
+static
 const char *logLevelNames[6] = {"trace", "debug",
                                 ANSI_COLOR_GREEN "info",
                                 ANSI_COLOR_YELLOW "warn",
                                 ANSI_COLOR_RED "error",
                                 ANSI_COLOR_MAGENTA "fatal"};
+static
 const char *logCategoryNames[7] = {"network", "channel", "session", "server",
                                    "client", "userland", "securitypolicy"};
 


### PR DESCRIPTION
The constant string arrays logLevelNames and logCategoryNames are not exported neither in header include nor in dynamic library.  But they appear in static libopen62541.a library and my create conflicts. Declare these symbols static to keep them local in ua_log_stdout.c .