### PR TITLE
fix(pubsub): No WriterGroup address with old transportSettings type

### DIFF
--- a/src/pubsub/ua_pubsub_eventloop.c
+++ b/src/pubsub/ua_pubsub_eventloop.c
@@ -568,6 +568,13 @@ UA_WriterGroup_connectUDPUnicast(UA_Server *server, UA_WriterGroup *wg) {
     if(wg->sendChannel != 0)
         return UA_STATUSCODE_GOOD;
 
+    /* Check if address is available in TransportSettings */
+    if(((wg->config.transportSettings.encoding == UA_EXTENSIONOBJECT_DECODED ||
+         wg->config.transportSettings.encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE) &&
+        wg->config.transportSettings.content.decoded.type ==
+        &UA_TYPES[UA_TYPES_DATAGRAMWRITERGROUPTRANSPORTDATATYPE]))
+        return UA_STATUSCODE_GOOD;
+
     /* Unpack the TransportSettings */
     if((wg->config.transportSettings.encoding != UA_EXTENSIONOBJECT_DECODED &&
         wg->config.transportSettings.encoding != UA_EXTENSIONOBJECT_DECODED_NODELETE) ||


### PR DESCRIPTION
If the old type UA_TYPES_DATAGRAMWRITERGROUPTRANSPORTDATATYPE is used for transportSettings, no address can be used for unicast configuration. Yet a multicast configuration with this type must be possible.