### PR TITLE
feat(plugin): use callback for password validation

### DIFF
--- a/plugins/include/open62541/plugin/accesscontrol_default.h
+++ b/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -18,6 +18,10 @@ typedef struct {
     UA_String password;
 } UA_UsernamePasswordLogin;
 
+typedef UA_StatusCode (*UA_LoginCallback)
+    (const UA_String *userName, const UA_ByteString *password,
+    void *loginContext);
+
 /* Default access control. The log-in can be anonymous or username-password. A
  * logged-in user has all access rights.
  *
@@ -28,8 +32,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
                          UA_Boolean allowAnonymous,
                          UA_CertificateVerification *verifyX509,
                          const UA_ByteString *userTokenPolicyUri,
-                         size_t usernamePasswordLoginSize,
-                         const UA_UsernamePasswordLogin *usernamePasswordLogin);
+                         UA_LoginCallback loginCallback, void *loginContext);
 
 _UA_END_DECLS
 

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -115,11 +115,6 @@ createEndpoint(UA_ServerConfig *conf, UA_EndpointDescription *endpoint,
     return UA_STATUSCODE_GOOD;
 }
 
-static const size_t usernamePasswordsSize = 2;
-static UA_UsernamePasswordLogin usernamePasswords[2] = {
-    {UA_STRING_STATIC("user1"), UA_STRING_STATIC("password")},
-    {UA_STRING_STATIC("user2"), UA_STRING_STATIC("password1")}};
-
 static UA_StatusCode
 setDefaultConfig(UA_ServerConfig *conf) {
     if(!conf)
@@ -458,7 +453,7 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     /* Initialize the Access Control plugin */
     retval = UA_AccessControl_default(config, true, NULL,
                                       &config->securityPolicies[config->securityPoliciesSize-1].policyUri,
-                                      usernamePasswordsSize, usernamePasswords);
+                                      NULL, NULL);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(config);
         return retval;
@@ -711,7 +706,7 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
                                                   revocationList, revocationListSize);
     retval |= UA_AccessControl_default(conf, true, &accessControlVerification,
                 &conf->securityPolicies[conf->securityPoliciesSize-1].policyUri,
-                usernamePasswordsSize, usernamePasswords);
+                NULL, NULL);
     if(retval != UA_STATUSCODE_GOOD) {
         UA_ServerConfig_clean(conf);
         return retval;


### PR DESCRIPTION
Username password validation in access control plugin allows only passwords stored in plaintext.  Use a callback to implement custom validation.  This allows salted password hashes and timing safe comparison in the server.  Furthermore remote validation could be implemented.  The function UA_AccessControl_default() is changed to a callback parameter, username password arrays are not accepted anymore.

This is a API break.  I doubt it should be merged.  I just want to show how a clean interface would look like instead of PR #5935 .