### PR TITLE
fix(pubsub): Set reader group to operational

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -1099,9 +1099,12 @@ UA_ReaderGroup_process(UA_Server *server, UA_ReaderGroup *readerGroup,
     /* Received a (first) message for the ReaderGroup.
      * Transition from PreOperational to Operational. */
     if(readerGroup->state == UA_PUBSUBSTATE_PREOPERATIONAL) {
-        UA_ReaderGroup_setPubSubState(server, readerGroup,
-                                      UA_PUBSUBSTATE_OPERATIONAL,
-                                      UA_STATUSCODE_GOOD);
+        readerGroup->state = UA_PUBSUBSTATE_OPERATIONAL;
+        UA_ServerConfig *config = &server->config;
+        if(config->pubSubConfig.stateChangeCallback != 0) {
+            config->pubSubConfig.stateChangeCallback(server, &readerGroup->identifier,
+                                                     readerGroup->state, UA_STATUSCODE_GOOD);
+        }
     }
     LIST_FOREACH(reader, &readerGroup->readers, listEntry) {
         UA_StatusCode res =
@@ -1160,9 +1163,12 @@ prepareOffsetBuffer(UA_Server *server, UA_ReaderGroup *rg, UA_DataSetReader *rea
     /* If pre-operational, set to operational after the first message was
      * processed */
     if(rg->state == UA_PUBSUBSTATE_PREOPERATIONAL) {
-        rv = UA_ReaderGroup_setPubSubState(server, rg,
-                                           UA_PUBSUBSTATE_OPERATIONAL,
-                                           UA_STATUSCODE_GOOD);
+        rg->state = UA_PUBSUBSTATE_OPERATIONAL;
+        UA_ServerConfig *config = &server->config;
+        if(config->pubSubConfig.stateChangeCallback != 0) {
+            config->pubSubConfig.stateChangeCallback(server, &rg->identifier,
+                                                     rg->state, UA_STATUSCODE_GOOD);
+        }
     }
 
     return rv;

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -902,6 +902,8 @@ START_TEST(Test_different_timeouts) {
     /* check that callback has been called for writer and reader groups and datasets */
     ck_assert_int_eq(ExpectedCallbackCnt, CallbackCnt);
     CallbackCnt = 0;
+    /* disable callback cnt check */
+    ExpectedCallbackCnt = 0;
 
     /* check that all dataset writers- and readers are operational */
     UA_PubSubState state = UA_PUBSUBSTATE_DISABLED;
@@ -927,6 +929,7 @@ START_TEST(Test_different_timeouts) {
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "disable writergroup");
     ExpectedCallbackCnt = 2;
+    CallbackCnt = 0;
     pExpectedComponentCallbackIds[0] = DsWId_Conn1_WG1_DS1;
     pExpectedComponentCallbackIds[1] = WGId_Conn1_WG1;
     ExpectedCallbackStatus = UA_STATUSCODE_BADRESOURCEUNAVAILABLE;

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -540,7 +540,7 @@ START_TEST(Test_basic) {
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
     ck_assert(state == UA_PUBSUBSTATE_DISABLED);
 
-    /* state change to operational of WriterGroup */
+    /* state change to operational of ReaderGroup */
     ExpectedCallbackCnt = 2;
     pExpectedComponentCallbackIds[0] = DSRId_Conn2_RG1_DSR1;
     pExpectedComponentCallbackIds[1] = RGId_Conn2_RG1;
@@ -567,11 +567,14 @@ START_TEST(Test_basic) {
 
     ValidatePublishSubscribe(VarId_Conn1_WG1, VarId_Conn2_RG1_DSR1, 44, (UA_UInt32) PublishingInterval_Conn1WG1, 3);
 
+    ck_assert(UA_Server_ReaderGroup_getState(server, RGId_Conn2_RG1, &state) == UA_STATUSCODE_GOOD);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
     ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
 
-    /* there should not be a callback notification for MessageReceiveTimeout */
-    ck_assert(CallbackCnt == 0);
+    /* check that callback has been called for reader group */
+    ck_assert_int_eq(1, CallbackCnt);
+    CallbackCnt = 0;
 
     /* now we disable the publisher WriterGroup and check if a MessageReceiveTimeout occurs at Subscriber */
     ExpectedCallbackCnt = 2;
@@ -604,7 +607,7 @@ START_TEST(Test_basic) {
 
     /* state of ReaderGroup should still be ok */
     ck_assert(UA_Server_ReaderGroup_getState(server, RGId_Conn2_RG1, &state) == UA_STATUSCODE_GOOD);
-    ck_assert(state == UA_PUBSUBSTATE_PREOPERATIONAL);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
      /* but DataSetReader state shall be error */
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
     ck_assert(state == UA_PUBSUBSTATE_ERROR);
@@ -2003,7 +2006,7 @@ START_TEST(Test_fast_path) {
 
     /* state of ReaderGroup should still be ok */
     ck_assert(UA_Server_ReaderGroup_getState(server, RGId_Conn2_RG1, &state) == UA_STATUSCODE_GOOD);
-    ck_assert(state == UA_PUBSUBSTATE_PREOPERATIONAL);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
      /* but DataSetReader state shall be error */
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn2_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
     ck_assert(state == UA_PUBSUBSTATE_ERROR);


### PR DESCRIPTION
If the function UA_PubSubConnection_setPubSubState is used with UA_PUBSUBSTATE_OPERATIONAL in state UA_PUBSUBSTATE_PREOPERATIONAL, The state is reset to UA_PUBSUBSTATE_PREOPERATIONAL internally. Thus the state has to be set manually (like in ua_pubsub_eventloop.c) and the user callback has to be called.

fix(tests): Unlock mutex in state callbacks before throwing assert

fix(tests): Reset expected cb counter in check_pubsub_subscribe_msgrcvtimeoout