### PR TITLE
fix(pubsub): Fix double free of writer group for unicast connection

### DIFF
--- a/src/pubsub/ua_pubsub_eventloop.c
+++ b/src/pubsub/ua_pubsub_eventloop.c
@@ -521,14 +521,16 @@ WriterGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     /* The connection is closing in the EventLoop. This is the last callback
      * from that connection. Clean up the SecureChannel in the client. */
     if(state == UA_CONNECTIONSTATE_CLOSING) {
-        /* Reset the connection channel */
-        wg->sendChannel = 0;
+        if(wg->sendChannel == connectionId) {
+            /* Reset the connection channel */
+            wg->sendChannel = 0;
 
-        /* PSC marked for deletion and the last EventLoop connection has closed */
-        if(wg->deleteFlag) {
-            UA_WriterGroup_remove(server, wg);
-            UA_UNLOCK(&server->serviceMutex);
-            return;
+            /* PSC marked for deletion and the last EventLoop connection has closed */
+            if(wg->deleteFlag) {
+                UA_WriterGroup_remove(server, wg);
+                UA_UNLOCK(&server->serviceMutex);
+                return;
+            }
         }
 
         /* Reconnect automatically if the connection was operational. This sets


### PR DESCRIPTION
If a socket is closed without data transfered, the sendChannel has not been set yet and the writer group is freed with the connection.