### PR TITLE
fix(PubSub): fix order of SecurityHeader and ExtendedNetworkMessageHe…

### DIFF
--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -803,13 +803,13 @@ UA_NetworkMessage_decodeHeaders(const UA_ByteString *src, size_t *offset, UA_Net
         UA_CHECK_STATUS(rv, return rv);
     }
 
+    rv = UA_ExtendedNetworkMessageHeader_decodeBinary(src, offset, dst);
+    UA_CHECK_STATUS(rv, return rv);
+
     if (dst->securityEnabled) {
         rv = UA_SecurityHeader_decodeBinary(src, offset, dst);
         UA_CHECK_STATUS(rv, return rv);
     }
-
-    rv = UA_ExtendedNetworkMessageHeader_decodeBinary(src, offset, dst);
-    UA_CHECK_STATUS(rv, return rv);
 
     return UA_STATUSCODE_GOOD;
 }


### PR DESCRIPTION
…ader

In the PubSub specification the SecurityHeader is before the ExtendedNetworkMessageHeader, thus the headers must be decoded in this order.