### PR TITLE
fix(PubSub): Check DataSetReader before using saved NetworkMessage

### DIFF
--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -772,6 +772,26 @@ UA_NetworkMessage_decodeHeaders(const UA_ByteString *src, size_t *offset, UA_Net
 }
 
 UA_StatusCode
+UA_NetworkMessage_decodeHeadersRT(const UA_ByteString *src, UA_NetworkMessage *dst) {
+
+    size_t offset = 0;
+    UA_StatusCode rv = UA_NetworkMessageHeader_decodeBinary(src, &offset, dst);
+    UA_CHECK_STATUS(rv, return rv);
+
+    if(dst->groupHeaderEnabled) {
+        rv = UA_GroupHeader_decodeBinary(src, &offset, dst);
+        UA_CHECK_STATUS(rv, return rv);
+    }
+
+    if(dst->payloadHeaderEnabled) {
+        rv = UA_PayloadHeader_decodeBinary(src, &offset, dst);
+        UA_CHECK_STATUS(rv, return rv);
+    }
+
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
 UA_NetworkMessage_decodePayload(const UA_ByteString *src, size_t *offset, UA_NetworkMessage *dst, const UA_DataTypeArray *customTypes, UA_DataSetMetaDataType *dsm) {
 
     // Payload

--- a/src/pubsub/ua_pubsub_networkmessage.h
+++ b/src/pubsub/ua_pubsub_networkmessage.h
@@ -290,6 +290,9 @@ UA_NetworkMessage_decodeHeaders(const UA_ByteString *src, size_t *offset,
                                 UA_NetworkMessage *dst);
 
 UA_StatusCode
+UA_NetworkMessage_decodeHeadersRT(const UA_ByteString *src, UA_NetworkMessage *dst);
+
+UA_StatusCode
 UA_NetworkMessage_decodePayload(const UA_ByteString *src, size_t *offset,
                                 UA_NetworkMessage *dst, const UA_DataTypeArray *customTypes,
                                 UA_DataSetMetaDataType *dsm);


### PR DESCRIPTION
If a received message is not intended for a DataSetReader, the saved
NetworkMessage must not be used.