### PR TITLE
build(arch): disable compiler error unused variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,9 +298,6 @@ option(UA_FORCE_32BIT "Force compilation as 32-bit executable" OFF)
 mark_as_advanced(UA_FORCE_32BIT)
 
 option(UA_FORCE_WERROR "Force compilation with -Werror (or /WX on MSVC)" OFF)
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(UA_FORCE_WERROR ON)
-endif()
 
 option(UA_ENABLE_DEBUG_SANITIZER "Use sanitizer in debug mode" ON)
 mark_as_advanced(UA_ENABLE_DEBUG_SANITIZER)

--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -790,6 +790,7 @@ PARSE_JSON(SecurityPkiField) {
     }
 #ifndef __linux__
     /* Currently not supported! */
+    (void)field;
     return UA_STATUSCODE_GOOD;
 #else
     /* set server config field */

--- a/tools/azure-devops/win/build.ps1
+++ b/tools/azure-devops/win/build.ps1
@@ -66,7 +66,9 @@ try {
                 -DUA_ENABLE_PUBSUB:BOOL=ON `
                 -DUA_ENABLE_PUBSUB_INFORMATIONMODEL:BOOL=ON `
                 -DUA_ENABLE_PUBSUB_MONITORING:BOOL=ON `
-                -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON ..
+                -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON `
+                -DUA_FORCE_WERROR=ON `
+                ..
         & cmake --build . --config Debug
         if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
             Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
@@ -90,7 +92,9 @@ try {
             -DUA_BUILD_EXAMPLES:BOOL=OFF  `
             -DUA_ENABLE_AMALGAMATION:BOOL=ON `
             -DUA_ENABLE_SUBSCRIPTIONS_EVENTS:BOOL=ON `
-            -DUA_ENABLE_ENCRYPTION:STRING=$build_encryption ..
+            -DUA_ENABLE_ENCRYPTION:STRING=$build_encryption `
+            -DUA_FORCE_WERROR=ON `
+            ..
     & cmake --build . --config RelWithDebInfo
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
@@ -113,7 +117,9 @@ try {
             -DUA_ENABLE_PUBSUB:BOOL=ON `
             -DUA_ENABLE_PUBSUB_INFORMATIONMODEL:BOOL=ON `
             -DUA_ENABLE_SUBSCRIPTIONS_EVENTS:BOOL=ON `
-            -DUA_NAMESPACE_ZERO:STRING=FULL ..
+            -DUA_FORCE_WERROR=ON `
+            -DUA_NAMESPACE_ZERO:STRING=FULL `
+            ..
     & cmake --build . --config Debug
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         Write-Host -ForegroundColor Red "`n`n*** Make failed. Exiting ... ***"
@@ -131,7 +137,9 @@ try {
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DCMAKE_INSTALL_PREFIX="$env:Build_Repository_LocalPath-$env:CC_SHORTNAME-static" `
             -DUA_BUILD_EXAMPLES:BOOL=ON `
-            -DUA_ENABLE_AMALGAMATION:BOOL=OFF ..
+            -DUA_ENABLE_AMALGAMATION:BOOL=OFF `
+            -DUA_FORCE_WERROR=ON `
+            ..
     & cmake --build . --target install --config RelWithDebInfo
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0)
     {
@@ -156,7 +164,9 @@ try {
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DCMAKE_INSTALL_PREFIX="$env:Build_Repository_LocalPath-$env:CC_SHORTNAME-dynamic" `
             -DUA_BUILD_EXAMPLES:BOOL=ON `
-            -DUA_ENABLE_AMALGAMATION:BOOL=OFF ..
+            -DUA_ENABLE_AMALGAMATION:BOOL=OFF `
+            -DUA_FORCE_WERROR=ON `
+            ..
     & cmake --build . --target install --config RelWithDebInfo
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0)
     {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -22,7 +22,8 @@ fi
 
 function cpplint {
     mkdir -p build; cd build; rm -rf *
-    cmake ..
+    cmake -DUA_FORCE_WERROR=ON \
+          ..
     make ${MAKEOPTS} cpplint
 }
 
@@ -34,6 +35,7 @@ function build_docs {
     mkdir -p build; cd build; rm -rf *
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DUA_BUILD_EXAMPLES=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make doc
 }
@@ -46,6 +48,7 @@ function build_docs_pdf {
     mkdir -p build; cd build; rm -rf *
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DUA_BUILD_EXAMPLES=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make doc doc_pdf
 }
@@ -62,6 +65,7 @@ function build_tpm_tool {
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
 }
@@ -77,6 +81,7 @@ function build_release {
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DUA_BUILD_EXAMPLES=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
 }
@@ -97,6 +102,7 @@ function build_amalgamation {
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
 }
@@ -113,6 +119,7 @@ function build_amalgamation_mt {
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_FORCE_WERROR=ON \
           -DUA_MULTITHREADING=100 \
           ..
     make ${MAKEOPTS}
@@ -143,6 +150,7 @@ function unit_tests {
           -DUA_ENABLE_MQTT=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -163,6 +171,7 @@ function unit_tests_32 {
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_FORCE_32BIT=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
           #-DUA_ENABLE_PUBSUB_ETH_UADP=ON \ # TODO: Enable this
     make ${MAKEOPTS}
@@ -177,6 +186,7 @@ function unit_tests_nosub {
           -DUA_BUILD_UNIT_TESTS=ON \
           -DUA_ENABLE_HISTORIZING=OFF \
           -DUA_ENABLE_SUBSCRIPTIONS=OFF \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -198,6 +208,7 @@ function unit_tests_diag {
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -212,6 +223,7 @@ function unit_tests_mt {
           -DUA_BUILD_UNIT_TESTS=ON \
           -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -227,7 +239,8 @@ function unit_tests_alarms {
           -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
-	      -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON \
+              -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON \
+          -DUA_FORCE_WERROR=ON \
           -DUA_NAMESPACE_ZERO=FULL \
           ..
     make ${MAKEOPTS}
@@ -242,6 +255,7 @@ function unit_tests_encryption {
           -DUA_BUILD_UNIT_TESTS=ON \
           -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
           -DUA_ENABLE_ENCRYPTION=$1 \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -260,6 +274,7 @@ function unit_tests_encryption_mbedtls_pubsub {
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -280,6 +295,7 @@ function unit_tests_pubsub_sks {
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
           -DUA_ENABLE_PUBSUB_SKS=ON \
           -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     # set_capabilities not possible with valgrind
@@ -307,6 +323,7 @@ function unit_tests_with_coverage {
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_ENABLE_ENCRYPTION=MBEDTLS \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     set_capabilities
@@ -333,6 +350,7 @@ function unit_tests_valgrind {
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
           -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
     # set_capabilities not possible with valgrind
@@ -371,6 +389,7 @@ function examples_valgrind {
           -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_SKS=ON \
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
 
@@ -402,6 +421,7 @@ function build_clang_analyzer {
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \
+          -DUA_FORCE_WERROR=ON \
           ..
     scan-build-11 --status-bugs make ${MAKEOPTS}
 }
@@ -415,6 +435,7 @@ function build_all_companion_specs {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_FORCE_WERROR=ON \
           -DUA_INFORMATION_MODEL_AUTOLOAD=DI\;ISA95-JOBCONTROL\;OpenSCS\;DEXPI\;AMB\;AutoID\;POWERLINK\;IA\;Machinery\;PackML\;PNEM\;PLCopen\;MachineTool\;PROFINET\;MachineVision\;FDT\;CommercialKitchenEquipment\;Scales\;Weihenstephan\;Pumps\;CAS\;TMC \
           -DUA_NAMESPACE_ZERO=FULL \
           ..


### PR DESCRIPTION
If the macro UA_LOCK_ASSERT() is not generating code, the variable UA_EventLoopPOSIX *el is not used.  OpenBSD 7.4 clang version 13.0.0 generates a warning in this case which aborts the build due to -Werror.  Compile with -Wno-unused-variable instead.