### PR TITLE
[Review] feat(ex): add interface argument usage for udp pubsub

### DIFF
--- a/examples/pubsub/pubsub_publish_encrypted.c
+++ b/examples/pubsub/pubsub_publish_encrypted.c
@@ -168,12 +168,14 @@ int main(int argc, char **argv) {
                 printf("Error: UADP/ETH needs an interface name\n");
                 return EXIT_FAILURE;
             }
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
     return run(&transportProfile, &networkAddressUrl);

--- a/examples/pubsub/pubsub_subscribe_encrypted.c
+++ b/examples/pubsub/pubsub_subscribe_encrypted.c
@@ -345,12 +345,14 @@ int main(int argc, char **argv) {
                 printf("Error: UADP/ETH needs an interface name\n");
                 return EXIT_FAILURE;
             }
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
     return run(&transportProfile, &networkAddressUrl);

--- a/examples/pubsub/pubsub_subscribe_standalone_dataset.c
+++ b/examples/pubsub/pubsub_subscribe_standalone_dataset.c
@@ -206,12 +206,14 @@ main(int argc, char **argv) {
                 return EXIT_FAILURE;
             }
 
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
     return run(&transportProfile, &networkAddressUrl);

--- a/examples/pubsub/server_pubsub_publisher_iop.c
+++ b/examples/pubsub/server_pubsub_publisher_iop.c
@@ -846,13 +846,15 @@ int main(int argc, char **argv) {
                 printf("Error: UADP/ETH needs an interface name\n");
                 return EXIT_FAILURE;
             }
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         }
         else {
             printf("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
     return run(&transportProfile, &networkAddressUrl);

--- a/examples/pubsub/server_pubsub_publisher_on_demand.c
+++ b/examples/pubsub/server_pubsub_publisher_on_demand.c
@@ -224,12 +224,14 @@ int main(int argc, char **argv) {
                 printf("Error: UADP/ETH needs an interface name\n");
                 return EXIT_FAILURE;
             }
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
 

--- a/examples/pubsub/server_pubsub_subscribe_custom_monitoring.c
+++ b/examples/pubsub/server_pubsub_subscribe_custom_monitoring.c
@@ -505,7 +505,6 @@ int main(int argc, char **argv) {
                 printf("Error: UADP/ETH needs an interface name\n");
                 return EXIT_FAILURE;
             }
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf ("Error: unknown URI\n");
@@ -515,6 +514,9 @@ int main(int argc, char **argv) {
         if (strcmp(argv[argc-1], "-UseCustomMonitoring") == 0) {
             useCustomMonitoring = UA_TRUE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
     return run(&transportProfile, &networkAddressUrl, &useCustomMonitoring);
 }

--- a/examples/pubsub/server_pubsub_subscriber_rt_level.c
+++ b/examples/pubsub/server_pubsub_subscriber_rt_level.c
@@ -400,12 +400,14 @@ int main(int argc, char **argv) {
                 return EXIT_FAILURE;
             }
 
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf ("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
     return run(&transportProfile, &networkAddressUrl);

--- a/examples/pubsub/tutorial_pubsub_publish.c
+++ b/examples/pubsub/tutorial_pubsub_publish.c
@@ -204,12 +204,14 @@ int main(int argc, char **argv) {
                 printf("Error: UADP/ETH needs an interface name\n");
                 return EXIT_FAILURE;
             }
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
     return run(&transportProfile, &networkAddressUrl);

--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -308,12 +308,14 @@ int main(int argc, char **argv) {
                 return EXIT_FAILURE;
             }
 
-            networkAddressUrl.networkInterface = UA_STRING(argv[2]);
             networkAddressUrl.url = UA_STRING(argv[1]);
         } else {
             printf ("Error: unknown URI\n");
             return EXIT_FAILURE;
         }
+    }
+    if (argc > 2) {
+        networkAddressUrl.networkInterface = UA_STRING(argv[2]);
     }
 
     return run(&transportProfile, &networkAddressUrl);


### PR DESCRIPTION
Without defined key value for interface only the default interface will join the multicast group due to INADDR_ANY address in setsockopt. The additional argument makes it easier to use other interfaces.