### PR TITLE
[REVIEW] Fix SecurityLevel in the EndpointDescription

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -222,7 +222,21 @@ addEndpoint(UA_ServerConfig *conf,
     endpoint->transportProfileUri =
         UA_STRING_ALLOC("http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary");
     endpoint->securityMode = securityMode;
-    endpoint->securityLevel = (UA_Byte)securityMode;
+
+    /* A numeric value that indicates how secure the EndpointDescription is compared to other EndpointDescriptions
+     * for the same Server. A value of 0 indicates that the EndpointDescription is not recommended and is only
+     * supported for backward compatibility. A higher value indicates better security. */
+    UA_String noneuri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#None");
+    UA_String basic128uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+    UA_String basic256uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
+    if(UA_String_equal(&securityPolicy->policyUri, &noneuri) ||
+       UA_String_equal(&securityPolicy->policyUri, &basic128uri) ||
+       UA_String_equal(&securityPolicy->policyUri, &basic256uri)) {
+        endpoint->securityLevel = 0;
+    } else {
+        endpoint->securityLevel = 1;
+    }
+
     UA_StatusCode retval = UA_String_copy(&securityPolicy->policyUri,
                                           &endpoint->securityPolicyUri);
 

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -1023,7 +1023,7 @@ initNS0(UA_Server *server) {
     UA_String profileArray[3];
     UA_UInt16 profileArraySize = 0;
 #define ADDPROFILEARRAY(x) profileArray[profileArraySize++] = UA_STRING(x)
-    ADDPROFILEARRAY("http://opcfoundation.org/UA-Profile/Server/MicroEmbeddedDevice");
+    ADDPROFILEARRAY("http://opcfoundation.org/UA-Profile/Server/StandardUA2017");
 #ifdef UA_ENABLE_NODEMANAGEMENT
     ADDPROFILEARRAY("http://opcfoundation.org/UA-Profile/Server/NodeManagement");
 #endif


### PR DESCRIPTION
The SecurityLevel in the EndpointsDescriptions is an indicator for the security of this endpoint. The value 0 represents a special feature and should be used for endpoints that are not recommended and, for example, are now only supported for backwards compatibility.

The ServerProfileArray still contains the values of the last certification. The URL of the Micro Embedded Device Profile must be adapted to that of the standard 2017 UA Server Profile.