### PR TITLE
feat(server) enable automatic datatype adjust logic

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1443,14 +1443,11 @@ writeNodeValueAttribute(UA_Server *server, UA_Session *session,
 
     /* Type checking. May change the type of editableValue */
     const char *reason;
-    if(value->hasValue && value->value.type &&
-       !compatibleValue(server, session, &node->dataType, node->valueRank,
-                        node->arrayDimensionsSize, node->arrayDimensions,
-                        &adjustedValue.value, rangeptr, &reason)) {
+    if(value->hasValue && value->value.type) {
         /* Try to correct the type */
         adjustValueType(server, &adjustedValue.value, &node->dataType);
 
-        /* Recheck the type */
+        /* Check the type */
         if(!compatibleValue(server, session, &node->dataType, node->valueRank,
                             node->arrayDimensionsSize, node->arrayDimensions,
                             &adjustedValue.value, rangeptr, &reason)) {

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -92,15 +92,10 @@ checkAdjustArguments(UA_Server *server, UA_Session *session,
     UA_Argument *argReqs = (UA_Argument*)argRequirements->value.data.value.value.data;
     const char *reason;
     for(size_t i = 0; i < argReqsSize; ++i) {
-        if(compatibleValue(server, session, &argReqs[i].dataType, argReqs[i].valueRank,
-                           argReqs[i].arrayDimensionsSize, argReqs[i].arrayDimensions,
-                           &args[i], NULL, &reason))
-            continue;
-
         /* Incompatible value. Try to correct the type if possible. */
         adjustValueType(server, &args[i], &argReqs[i].dataType);
 
-        /* Recheck */
+        /* Check */
         if(!compatibleValue(server, session, &argReqs[i].dataType, argReqs[i].valueRank,
                             argReqs[i].arrayDimensionsSize, argReqs[i].arrayDimensions,
                             &args[i], NULL, &reason)) {


### PR DESCRIPTION
This PR solves an issue with compatible value types. Currently, the server checks if a value type is compatible and tries afterwards to adjust the type if needed. For example, the types duration and double are seen as equal. This results in an unexpected behavior because the adjust logic is not executed in some cases.

Scenario: 
Server with a method containing a duration array as input argument. 
A client calls the method. -> The Method-callback receives a double-array since the adjust logic is not called and the type is transmitted as a double-array.

This PR solves the issue by changing the default behavior to an automatic type adjust and a single compatible check afterwards.
