### PR TITLE
[REVIEW] fix(el): Unlock EventLoop mutex before wait condition

### DIFF
--- a/arch/eventloop_posix_select.c
+++ b/arch/eventloop_posix_select.c
@@ -123,7 +123,9 @@ UA_EventLoopPOSIX_pollFDs(UA_EventLoopPOSIX *el, UA_DateTime listenTimeout) {
 #endif
     };
 
+    UA_UNLOCK(&el->elMutex);
     int selectStatus = UA_select(highestfd+1, &readset, &writeset, &errset, &tmptv);
+    UA_LOCK(&el->elMutex);
     if(selectStatus < 0) {
         /* We will retry, only log the error */
         UA_LOG_SOCKET_ERRNO_WRAP(


### PR DESCRIPTION
If UA_Server_addPubSubConnection was called in a (real-time) linux system from a task with lower priority than the task that called UA_Server_run, a deadlock occured.