### PR TITLE
fix(core): Do not reset tools directory when installed

### DIFF
--- a/tools/cmake/macros_public.cmake
+++ b/tools/cmake/macros_public.cmake
@@ -1,4 +1,6 @@
-set(open62541_TOOLS_DIR "${PROJECT_SOURCE_DIR}/tools")
+if(NOT open62541_TOOLS_DIR OR "${open62541_TOOLS_DIR}" STREQUAL "")
+    set(open62541_TOOLS_DIR "${PROJECT_SOURCE_DIR}/tools")
+endif()
 
 # --------------- Generate NodeIDs header ---------------------
 #


### PR DESCRIPTION
Fix: #5956 