### PR TITLE
fix(core): LibreSSL build on win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,8 +514,8 @@ if(UA_ENABLE_ENCRYPTION_LIBRESSL)
     find_package(LibreSSL REQUIRED)
     list(APPEND open62541_LIBRARIES ${LIBRESSL_LIBRARIES})
     if(WIN32)
-        # Add bestcrypt for random generator
-        list(APPEND open62541_LIBRARIES bcrypt)
+        # Add bestcrypt for random generator and ws2_32 for crypto
+        list(APPEND open62541_LIBRARIES ws2_32 bcrypt)
     endif()
 endif()
 

--- a/arch/win32/ua_architecture.h
+++ b/arch/win32/ua_architecture.h
@@ -61,17 +61,8 @@ typedef SSIZE_T ssize_t;
 #if UA_IPV6
 # define UA_if_nametoindex if_nametoindex
 
-# if defined(__WINCRYPT_H__) && defined(UA_ENABLE_ENCRYPTION_LIBRESSL)
-#  error "Wincrypt is not compatible with LibreSSL"
-# endif
-/* Hack: Prevent Wincrypt-Includes */
-# ifdef UA_ENABLE_ENCRYPTION_LIBRESSL
-#  define __WINCRYPT_H__
-# endif
 # include <iphlpapi.h>
-# ifdef UA_ENABLE_ENCRYPTION_LIBRESSL
-#  undef __WINCRYPT_H__
-# endif
+
 #endif
 
 #ifdef maxStringLength //defined in mingw64


### PR DESCRIPTION
As a recent mingw version is required for the build, the libressl hack will cause problems and is no longer required for recent libressl and mingw version. (MinGW with gcc 8 was not able to build open62541 anymore, upgrade to recent mingw with gcc 13 requires these fixes)