### PR TITLE
[Review] fix(core): Include limits.h for PATH_MAX

### DIFF
--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -21,6 +21,8 @@
 #include "ua_openssl_version_abstraction.h"
 #include "libc_time.h"
 
+#include <limits.h>
+
 /* Find binary substring. Taken and adjusted from
  * http://tungchingkai.blogspot.com/2011/07/binary-strstr.html */
 


### PR DESCRIPTION
Compiling on `alpine-3.18` fails if this is not included explicitly.

Thanks @ccvca for preparation.

```
#11 279.1 [ 73%] Building C object CMakeFiles/open62541-plugins.dir/plugins/crypto/openssl/ua_pki_openssl.c.o
#11 279.3 /src/Sample-Server/deps/open62541/plugins/crypto/openssl/ua_pki_openssl.c: In function 'UA_ReloadCertFromFolder':
#11 279.3 /src/Sample-Server/deps/open62541/plugins/crypto/openssl/ua_pki_openssl.c:288:31: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'UA_MAX'?
#11 279.3   288 |     char             certFile[PATH_MAX];
#11 279.3       |                               ^~~~~~~~
#11 279.3       |                               UA_MAX
#11 279.3 /src/Sample-Server/deps/open62541/plugins/crypto/openssl/ua_pki_openssl.c:288:31: note: each undeclared identifier is reported only once for each function it appears in
#11 279.3 /src/Sample-Server/deps/open62541/plugins/crypto/openssl/ua_pki_openssl.c:290:22: warning: unused variable 'folderPath' [-Wunused-variable]
#11 279.3   290 |     char             folderPath[PATH_MAX];
#11 279.3       |                      ^~~~~~~~~~
#11 279.3 /src/Sample-Server/deps/open62541/plugins/crypto/openssl/ua_pki_openssl.c:288:22: warning: unused variable 'certFile' [-Wunused-variable]
#11 279.3   288 |     char             certFile[PATH_MAX];
#11 279.3       |                      ^~~~~~~~
#11 279.3 At top level:
#11 279.3 cc1: note: unrecognized command-line option '-Wno-static-in-inline' may have been intended to silence earlier diagnostics
```