### PR TITLE
build(pkgconfig): export amalgamation flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,6 +732,9 @@ file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src_generated")
 configure_file(include/open62541/config.h.in ${PROJECT_BINARY_DIR}/src_generated/open62541/config.h)
 
 # Generate a .pc file for pkg-config
+if(UA_ENABLE_AMALGAMATION)
+    set(PC_EXTRA_CFLAGS "-DUA_ENABLE_AMALGAMATION")
+endif()
 configure_file(tools/open62541.pc.in ${PROJECT_BINARY_DIR}/src_generated/open62541.pc @ONLY)
 
 if(UA_ENABLE_DISCOVERY_MULTICAST)

--- a/tools/open62541.pc.in
+++ b/tools/open62541.pc.in
@@ -10,4 +10,4 @@ Name: open62541
 Description: open62541 is an open source C (C99) implementation of OPC UA
 Version: @OPEN62541_VER_MAJOR@.@OPEN62541_VER_MINOR@.@OPEN62541_VER_PATCH@@OPEN62541_VER_LABEL@
 Libs: -L${libdir} -lopen62541
-Cflags: -I${includedir}
+Cflags: -I${includedir} @PC_EXTRA_CFLAGS@


### PR DESCRIPTION
While a UA_ENABLE_AMALGAMATION macro is defined in the amalgamated open62541.h file and undefined in the non-amalgamated open62541/config.h file, it is not usable in downstream projects as they would need a priori knowledge which of the header files to include. They may try a test compilation in their build system's configure phase with one of the headers and set UA_ENABLE_AMALGAMATION if amalgamation is detected. However, this causes some code duplication in each downstream project.

Exporting the flag in the pkg-config file enables downstream projects to check for the open62541 dependency as usual and automatically get the necessary flag.

This is slightly related to #3178, although just concerning an import of open62541 via pkg-config.
In case of cmake, it would probably (I'm not very familiar with cmake) be done via `target_compile_definitions(open62541 INTERFACE UA_ENABLE_AMALGAMATION)` ([manual](https://cmake.org/cmake/help/latest/command/target_compile_definitions.html)).

It would also be nice if this patch could be ported to the 1.4 branch, so that the fixed pc file becomes available with the 1.4.0 release.