### PR TITLE
Support defining UA_LOGLEVEL in an external CMakefile

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -37,7 +37,9 @@
  * ---------------
  * Changing the feature options has no effect on a pre-compiled library. */
 
+#ifndef UA_LOGLEVEL
 #define UA_LOGLEVEL ${UA_LOGLEVEL}
+#endif
 #ifndef UA_ENABLE_AMALGAMATION
 #cmakedefine UA_ENABLE_AMALGAMATION
 #endif


### PR DESCRIPTION
Allows to compile the library as a amalgamated, and then change the UA_LOGLEVEL in the CMakefile of the project that's using the amalgamated files.