### PR TITLE
[REVIEW] build(deps): bump deps/ua-nodeset from `d1bb6a2` to `19d7d52`

### DIFF
--- a/tests/nodeset-loader/check_memory.sh
+++ b/tests/nodeset-loader/check_memory.sh
@@ -167,19 +167,6 @@ memory_usage $NODESETLOADER_TESTS_PATH/$NODESETLOADER_TEST_APP \
              $UA_NODESET_PATH/IA/Opc.Ua.IA.NodeSet2.xml \
              $UA_NODESET_PATH/IA/Opc.Ua.IA.NodeSet2.examples.xml
 
-echo "... IEC61850-6 ..."
-memory_usage $NODESETLOADER_TESTS_PATH/$NODESETLOADER_TEST_APP \
-             $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml \
-             $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-6.NodeSet2.xml
-echo "... IEC61850-7-3 ..."
-memory_usage $NODESETLOADER_TESTS_PATH/$NODESETLOADER_TEST_APP \
-             $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml
-
-echo "... IEC61850-7-4 ..."
-memory_usage $NODESETLOADER_TESTS_PATH/$NODESETLOADER_TEST_APP \
-             $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml \
-             $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-4.NodeSet2.xml
-
 echo "... IOLinkIODD ..."
 memory_usage $NODESETLOADER_TESTS_PATH/$NODESETLOADER_TEST_APP \
              $UA_NODESET_PATH/IOLink/Opc.Ua.IOLinkIODD.NodeSet2.xml

--- a/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
@@ -195,27 +195,6 @@ START_TEST(Server_loadIAExamplesNodeset) {
 }
 END_TEST
 
-START_TEST(Server_loadIEC61850_6_Nodeset) {
-    UA_StatusCode retVal = UA_Server_loadNodeset(server,
-        OPEN62541_NODESET_DIR "IEC61850/Opc.Ua.IEC61850-6.NodeSet2.xml", NULL);
-    ck_assert(UA_StatusCode_isGood(retVal));
-}
-END_TEST
-
-START_TEST(Server_loadIEC61850_7_3_Nodeset) {
-    UA_StatusCode retVal = UA_Server_loadNodeset(server,
-        OPEN62541_NODESET_DIR "IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml", NULL);
-    ck_assert(UA_StatusCode_isGood(retVal));
-}
-END_TEST
-
-START_TEST(Server_loadIEC61850_7_4_Nodeset) {
-    UA_StatusCode retVal = UA_Server_loadNodeset(server,
-        OPEN62541_NODESET_DIR "IEC61850/Opc.Ua.IEC61850-7-4.NodeSet2.xml", NULL);
-    ck_assert(UA_StatusCode_isGood(retVal));
-}
-END_TEST
-
 START_TEST(Server_loadIOLinkIODDNodeset) {
     UA_StatusCode retVal = UA_Server_loadNodeset(server,
         OPEN62541_NODESET_DIR "IOLink/Opc.Ua.IOLinkIODD.NodeSet2.xml", NULL);
@@ -765,26 +744,6 @@ static Suite* testSuite_Client(void) {
         tcase_add_test(tc_server, Server_loadDINodeset);
         tcase_add_test(tc_server, Server_loadIANodeset);
         tcase_add_test(tc_server, Server_loadIAExamplesNodeset);
-        suite_add_tcase(s, tc_server);
-    }
-    {
-        TCase *tc_server = tcase_create("Server load IEC61850-6 nodeset");
-        tcase_add_unchecked_fixture(tc_server, setup, teardown);
-        tcase_add_test(tc_server, Server_loadIEC61850_7_3_Nodeset);
-        tcase_add_test(tc_server, Server_loadIEC61850_6_Nodeset);
-        suite_add_tcase(s, tc_server);
-    }
-    {
-        TCase *tc_server = tcase_create("Server load IEC61850-7-3 nodeset");
-        tcase_add_unchecked_fixture(tc_server, setup, teardown);
-        tcase_add_test(tc_server, Server_loadIEC61850_7_3_Nodeset);
-        suite_add_tcase(s, tc_server);
-    }
-    {
-        TCase *tc_server = tcase_create("Server load IEC61850-7-4 nodeset");
-        tcase_add_unchecked_fixture(tc_server, setup, teardown);
-        tcase_add_test(tc_server, Server_loadIEC61850_7_3_Nodeset);
-        tcase_add_test(tc_server, Server_loadIEC61850_7_4_Nodeset);
         suite_add_tcase(s, tc_server);
     }
     {

--- a/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
@@ -237,12 +237,12 @@ START_TEST(Server_loadMachineToolNodeset) {
 }
 END_TEST
 
-START_TEST(Server_loadMDISNodeset) {
-    UA_StatusCode retVal = UA_Server_loadNodeset(server,
-        OPEN62541_NODESET_DIR "MDIS/Opc.MDIS.NodeSet2.xml", NULL);
-    ck_assert(UA_StatusCode_isGood(retVal));
-}
-END_TEST
+// START_TEST(Server_loadMDISNodeset) {
+//     UA_StatusCode retVal = UA_Server_loadNodeset(server,
+//         OPEN62541_NODESET_DIR "MDIS/Opc.MDIS.NodeSet2.xml", NULL);
+//     ck_assert(UA_StatusCode_isGood(retVal));
+// }
+// END_TEST
 
 START_TEST(Server_loadMiningDevelopmentSupportGeneralNodeset) {
     UA_StatusCode retVal = UA_Server_loadNodeset(server,
@@ -789,12 +789,12 @@ static Suite* testSuite_Client(void) {
         tcase_add_test(tc_server, Server_loadMachineToolNodeset);
         suite_add_tcase(s, tc_server);
     }
-    {
-        TCase *tc_server = tcase_create("Server load MDIS nodeset");
-        tcase_add_unchecked_fixture(tc_server, setup, teardown);
-        tcase_add_test(tc_server, Server_loadMDISNodeset);
-        suite_add_tcase(s, tc_server);
-    }
+    // {
+    //     TCase *tc_server = tcase_create("Server load MDIS nodeset");
+    //     tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    //     tcase_add_test(tc_server, Server_loadMDISNodeset);
+    //     suite_add_tcase(s, tc_server);
+    // }
     {
         TCase *tc_server = tcase_create("Server load MiningDevelopmentSupportGeneral nodeset");
         tcase_add_unchecked_fixture(tc_server, setup, teardown);

--- a/tests/nodeset-loader/run_test.sh
+++ b/tests/nodeset-loader/run_test.sh
@@ -22,7 +22,6 @@
 #      - ${OPEN62541_NODESET_DIR}CSPPlusForMachine/Opc.Ua.CSPPlusForMachine.NodeSet2.xml
 #      - ${OPEN62541_NODESET_DIR}FDI/Opc.Ua.Fdi5.NodeSet2.xml
 #      - ${OPEN62541_NODESET_DIR}FDI/Opc.Ua.Fdi7.NodeSet2.xml
-#      - ${OPEN62541_NODESET_DIR}IEC61850/Opc.Ua.IEC61850-6.NodeSet2.xml
 #      - ${OPEN62541_NODESET_DIR}ISA-95/Opc.ISA95.NodeSet2.xml
 #      - ${OPEN62541_NODESET_DIR}POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml
 #
@@ -66,7 +65,7 @@ function prepare_nodeids() {
                                     $nodeset | awk '{ sub(/.*\ NodeId="/, ""); sub(/".*/, ""); print $1}' >> $nodesetIdPath
         fi
         
-        if [[ $nodesetIdPath == *"IEC61850"* ]] || [[ $nodesetIdPath == *"PLCopen"* ]]; then
+        if [[ $nodesetIdPath == *"PLCopen"* ]]; then
             sed -i "s/ns=2;/ns=$CustomNsStartNum;/gI" $nodesetIdPath
             sed -i "s/ns=1;/ns=2;/gI" $nodesetIdPath
         elif [[ $nodesetIdPath == *"PADIM"* ]]; then
@@ -174,13 +173,6 @@ add_node_integration_test "IA.examples" \
     $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \
     $UA_NODESET_PATH/IA/Opc.Ua.IA.NodeSet2.xml \
     $UA_NODESET_PATH/IA/Opc.Ua.IA.NodeSet2.examples.xml
-
-add_node_integration_test "IEC61850-7-3" \
-    $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml
-
-add_node_integration_test "IEC61850-7-4" \
-    $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-3.NodeSet2.xml \
-    $UA_NODESET_PATH/IEC61850/Opc.Ua.IEC61850-7-4.NodeSet2.xml
 
 add_node_integration_test "IOLinkIODD" \
     $UA_NODESET_PATH/IOLink/Opc.Ua.IOLinkIODD.NodeSet2.xml

--- a/tests/nodeset-loader/run_test.sh
+++ b/tests/nodeset-loader/run_test.sh
@@ -196,8 +196,8 @@ add_node_integration_test "MachineTool" \
     $UA_NODESET_PATH/IA/Opc.Ua.IA.NodeSet2.xml \
     $UA_NODESET_PATH/MachineTool/Opc.Ua.MachineTool.NodeSet2.xml
 
-add_node_integration_test "MDIS" \
-    $UA_NODESET_PATH/MDIS/Opc.MDIS.NodeSet2.xml
+# add_node_integration_test "MDIS" \
+#     $UA_NODESET_PATH/MDIS/Opc.MDIS.NodeSet2.xml
 
 add_node_integration_test "Mining.DevelopmentSupport.Dozer" \
     $UA_NODESET_PATH/DI/Opc.Ua.Di.NodeSet2.xml \


### PR DESCRIPTION
Removes IEC 61850 tests, as NodeSet was removed from `deps/UA-NodeSet`
Disables MDIS tests, as v1.3 NodeSet contains unreferenced nodes. Issue with OPCF raised.
Superseeds #6035 