### PR TITLE
[Review] Fix zero sampling interval handling

### DIFF
--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -249,7 +249,7 @@ checkAdjustMonitoredItemParams(UA_Server *server, UA_Session *session,
                 params->samplingInterval = -1.0;
             }
         }
-    } else {
+    } else if (params->samplingInterval > 0.0) {
         /* Adjust positive sampling interval to lie within the limits */
         UA_BOUNDEDVALUE_SETWBOUNDS(server->config.samplingIntervalLimits,
                                    params->samplingInterval, params->samplingInterval);


### PR DESCRIPTION
Solves sampling interval zero handled as positive sampling interval.

Zero sampling interval was introduced in 46a12f16a6357dc692a30e07c7e16611fa3e99a7 and negative sampling interval was introduced later in 05951d59732238414fd9ddbb6d44e0c84fd7ab3e. Second commit breaks zero sampling interval.