### PR TITLE
fix(server): Bug fixes in the subscription transfer service.

### DIFF
--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -224,6 +224,8 @@ static UA_Boolean
 allowTransferSubscription_default(UA_Server *server, UA_AccessControl *ac,
                                   const UA_NodeId *oldSessionId, void *oldSessionContext,
                                   const UA_NodeId *newSessionId, void *newSessionContext) {
+    if(!oldSessionId)
+        return true;
     /* Allow the transfer if the same user-id was used to activate both sessions */
     UA_Variant session1UserId;
     UA_Variant_init(&session1UserId);

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -516,6 +516,7 @@ Operation_TransferSubscription(UA_Server *server, UA_Session *session,
     memcpy(newSub, sub, sizeof(UA_Subscription));
 
     /* Set to the same state as the original subscription */
+    newSub->publishCallbackId = 0;
     result->statusCode = Subscription_setState(server, newSub, sub->state);
     if(result->statusCode != UA_STATUSCODE_GOOD) {
         UA_Array_delete(result->availableSequenceNumbers,
@@ -576,9 +577,6 @@ Operation_TransferSubscription(UA_Server *server, UA_Session *session,
      * queued to send a StatusChangeNotification. */
     sub->statusChange = UA_STATUSCODE_GOODSUBSCRIPTIONTRANSFERRED;
     UA_Subscription_publish(server, sub);
-
-    /* The original subscription has been deactivated */
-    UA_assert(sub->publishCallbackId == 0);
 
     /* Re-create notifications with the current values for the new subscription */
     if(*sendInitialValues) {

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -384,12 +384,14 @@ static void
 sendStatusChangeDelete(UA_Server *server, UA_Subscription *sub,
                        UA_PublishResponseEntry *pre) {
     /* Cannot send out the StatusChange because no response is queued.
-     * Delete the Subscription without sending the StatusChange. */
+     * Delete the Subscription without sending the StatusChange, if the statusChange is Bad*/
     if(!pre) {
         UA_LOG_DEBUG_SUBSCRIPTION(&server->config.logger, sub,
-                                  "Cannot send the StatusChange notification. "
-                                  "Removing the subscription.");
-        UA_Subscription_delete(server, sub);
+                                  "Cannot send the StatusChange notification because no response is queued.");
+        if(UA_StatusCode_isBad(sub->statusChange)) {
+            UA_LOG_DEBUG_SUBSCRIPTION(&server->config.logger, sub, "Removing the subscription.");
+            UA_Subscription_delete(server, sub);
+        }
         return;
     }
 


### PR DESCRIPTION
* [x] Fixed a bug where after transferring a subscription and deleting the old session, the publish callback was no longer called.
* [x] Subscriptions that were transferred to another Session must be deleted by the Client that owns the Session.
* [x] Implementation of the allowTransferSubscription function. The function must check if a transfer is allowed. Currently it always returns true.