### PR TITLE
[REVIEW] docs(nc): update link to tutorials

### DIFF
--- a/doc/nodeset_compiler.rst
+++ b/doc/nodeset_compiler.rst
@@ -8,7 +8,7 @@ Note that the nodeset compiler you can find in the *tools/nodeset_compiler* subf
 Getting started
 ...............
 
-We take the following information model snippet as the starting point of the following tutorial. A more detailed tutorial on how to create your own information model and NodeSet2.xml can be found in this blog post: https://opcua.rocks/custom-information-models/
+We take the following information model snippet as the starting point of the following tutorial. A more detailed tutorial on how to create your own information model and NodeSet2.xml can be found in this blog post: https://profanter.medium.com/how-to-create-custom-opc-ua-information-models-1e9a461f5b58
 
 .. code-block:: xml
 


### PR DESCRIPTION
The nodeset compiler has been migrated from opcua.rocks to medium.com. The old link does not work anymore.