### PR TITLE
fix(tools): ua2json initialize options struct

### DIFF
--- a/tools/ua2json/ua2json.c
+++ b/tools/ua2json/ua2json.c
@@ -44,7 +44,7 @@ decode(const UA_ByteString *buf, UA_ByteString *out, const UA_DataType *type) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
     /* Decode JSON */
-    const UA_DecodeJsonOptions opt = {NULL};
+    static const UA_DecodeJsonOptions opt;
     UA_StatusCode retval = UA_decodeJson(buf, data, type, &opt);
     if(retval != UA_STATUSCODE_GOOD) {
         free(data);


### PR DESCRIPTION
The initializer for UA_DecodeJsonOptions does not contain all fields and emits warning: missing field 'namespacesSize' initializer [-Wmissing-field-initializers].  As variable opt is constant, it can also be declared static.  Then it is allocated in BSS and zero initialized if there is no initializer.