### PR TITLE
docs(plugins): build docs without obsolete headers

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -44,10 +44,8 @@ generate_rst(${PROJECT_SOURCE_DIR}/src/server/ua_services.h ${DOC_SRC_DIR}/servi
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/server_pubsub.h ${DOC_SRC_DIR}/pubsub.rst)
 
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/accesscontrol.h ${DOC_SRC_DIR}/plugin_accesscontrol.rst)
-generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/network.h ${DOC_SRC_DIR}/plugin_network.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/log.h ${DOC_SRC_DIR}/plugin_log.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/nodestore.h ${DOC_SRC_DIR}/plugin_nodestore.rst)
-generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/pubsub.h ${DOC_SRC_DIR}/plugin_pubsub.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/eventloop.h ${DOC_SRC_DIR}/plugin_eventloop.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/pki.h ${DOC_SRC_DIR}/plugin_pki.rst)
 generate_rst(${PROJECT_SOURCE_DIR}/include/open62541/plugin/securitypolicy.h ${DOC_SRC_DIR}/plugin_securitypolicy.rst)


### PR DESCRIPTION
The header include files plugin/network.h and plugin/pubsub.h have been deleted.  They must also be removed from the dependencies of the documentation build.