### PR TITLE
feat(client): add UA_Client_sendAsyncBrowseNextRequest

### DIFF
--- a/include/open62541/client_highlevel_async.h
+++ b/include/open62541/client_highlevel_async.h
@@ -56,6 +56,18 @@ UA_Client_sendAsyncBrowseRequest(UA_Client *client, UA_BrowseRequest *request,
                                       reqId);
 }
 
+typedef void (*UA_ClientAsyncBrowseNextCallback)(UA_Client *client, void *userdata,
+                                                 UA_UInt32 requestId, UA_BrowseNextResponse *wr);
+static UA_INLINE UA_THREADSAFE UA_StatusCode
+UA_Client_sendAsyncBrowseNextRequest(UA_Client *client, UA_BrowseNextRequest *request,
+                                     UA_ClientAsyncBrowseNextCallback browseNextCallback,
+                                     void *userdata, UA_UInt32 *reqId) {
+    return __UA_Client_AsyncService(client, request, &UA_TYPES[UA_TYPES_BROWSENEXTREQUEST],
+                                      (UA_ClientAsyncServiceCallback)browseNextCallback,
+                                      &UA_TYPES[UA_TYPES_BROWSENEXTRESPONSE], userdata,
+                                      reqId);
+}
+
 /**
  * Asynchronous Operations
  * ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The function UA_Client_sendAsyncBrowseNextRequest() was missing in the API.  In older open62541 versions the user of the library could implement it using UA_Client_sendAsyncRequest().  But as this function is gone in version 1.4 the client highlevel async API should be complete.