### PR TITLE
Fix architecture independent amalgamation (#6110)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,12 +75,14 @@ if("${UA_ARCHITECTURE}" STREQUAL "")
     endif(UNIX)
 endif()
 
-message(STATUS "The selected architecture is: ${UA_ARCHITECTURE}")
+if (NOT UA_ENABLE_AMALGAMATION OR (UA_ENABLE_AMALGAMATION AND NOT UA_AMALGAMATION_MULTIARCH))
+    message(STATUS "The selected architecture is: ${UA_ARCHITECTURE}")
 
-if("${UA_ARCHITECTURE}" STREQUAL "posix")
-    set(UA_ARCHITECTURE_POSIX 1)
-elseif("${UA_ARCHITECTURE}" STREQUAL "win32")
-    set(UA_ARCHITECTURE_WIN32 1)
+    if("${UA_ARCHITECTURE}" STREQUAL "posix")
+        set(UA_ARCHITECTURE_POSIX 1)
+    elseif("${UA_ARCHITECTURE}" STREQUAL "win32")
+        set(UA_ARCHITECTURE_WIN32 1)
+    endif()
 endif()
 
 #################
@@ -94,6 +96,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 option(UA_ENABLE_AMALGAMATION "Concatenate the library to a single file open62541.h/.c" OFF)
+option(UA_AMALGAMATION_MULTIARCH "Create an architecture-independent amalgamation if UA_ENABLE_AMALGAMATION is ON" OFF)
 option(BUILD_SHARED_LIBS "Enable building of shared libraries (dll/so)" OFF)
 set(UA_LOGLEVEL 300 CACHE STRING "Minimal level at which logs shall be reported (100=TRACE, 200=DEBUG, 300=INFO, 400=WARNING, 500=ERROR, 600=FATAL)")
 option(UA_ENABLE_DIAGNOSTICS "Enable diagnostics information exposed by the server" ON)
@@ -969,7 +972,7 @@ if(NOT "${UA_ARCHITECTURE}" STREQUAL "none")
          ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_udp.c
          ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_interrupt.c)
 
-    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+     if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR UA_ENABLE_AMALGAMATION)
         list(APPEND architecture_sources ${PROJECT_SOURCE_DIR}/arch/eventloop_posix_eth.c)
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,6 +784,7 @@ set(exported_headers ${PROJECT_BINARY_DIR}/src_generated/open62541/config.h
                      ${PROJECT_SOURCE_DIR}/include/open62541/client_highlevel_async.h)
 
 # Main Library
+
 set(lib_headers ${PROJECT_SOURCE_DIR}/deps/open62541_queue.h
                 ${PROJECT_SOURCE_DIR}/deps/pcg_basic.h
                 ${PROJECT_SOURCE_DIR}/deps/libc_time.h
@@ -867,6 +868,10 @@ set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c
 if(UA_GENERATED_NAMESPACE_ZERO)
     list(APPEND lib_headers ${PROJECT_BINARY_DIR}/src_generated/open62541/namespace0_generated.h)
     list(APPEND lib_sources ${PROJECT_BINARY_DIR}/src_generated/open62541/namespace0_generated.c)
+endif()
+
+if (NOT "${UA_ARCHITECTURE}" STREQUAL "none")
+    list(PREPEND lib_headers ${PROJECT_SOURCE_DIR}/arch/posix/ua_architecture.h)
 endif()
 
 if(UA_ENABLE_PARSING)
@@ -954,7 +959,6 @@ set(architecture_sources)
 
 if(NOT "${UA_ARCHITECTURE}" STREQUAL "none")
     list(APPEND architecture_headers
-         ${PROJECT_SOURCE_DIR}/arch/posix/ua_architecture.h
          ${PROJECT_SOURCE_DIR}/arch/win32/ua_architecture.h
          ${PROJECT_SOURCE_DIR}/arch/common/ua_timer.h
          ${PROJECT_SOURCE_DIR}/arch/eventloop_common.h

--- a/arch/eventloop_posix_eth.c
+++ b/arch/eventloop_posix_eth.c
@@ -11,7 +11,7 @@
 #include "eventloop_posix.h"
 #include "eventloop_common.h"
 
-#ifdef UA_ARCHITECTURE_POSIX
+#if defined(UA_ARCHITECTURE_POSIX) && defined(__linux__)
 
 #include <arpa/inet.h> /* htons */
 #include <net/ethernet.h> /* ETH_P_*/
@@ -930,4 +930,5 @@ UA_ConnectionManager_new_POSIX_Ethernet(const UA_String eventSourceName) {
     return &cm->cm;
 }
 
-#endif /* defined(UA_ARCHITECTURE_POSIX) */
+#endif /* defined(UA_ARCHITECTURE_POSIX) && defined(__linux__) */
+


### PR DESCRIPTION
- Don't set an architecture define in config.h.in when amalgamating
- Disable eventloop_posix_eth if __linux__ is not defined