### PR TITLE
[REVIEW] Add server option to allow password with None policy

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -205,6 +205,12 @@ struct UA_ServerConfig {
      * securityPolicies list. */
     UA_Boolean securityPolicyNoneDiscoveryOnly;
 
+    /* Allow clients without encryption support to connect with username and password.
+     * This requires to transmit the password in plain text over the network which is
+     * why this option is disabled by default.
+     * Make sure you really need this before enabling plain text passwords. */
+    UA_Boolean allowNonePolicyPassword;
+
     /* Different sets of certificates are trusted for SecureChannel / Session */
     UA_CertificateVerification secureChannelPKI;
     UA_CertificateVerification sessionPKI;

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -341,7 +341,8 @@ updateEndpointUserIdentityToken(UA_Server *server, UA_EndpointDescription *ed) {
          * SecureChannel is unencrypted and there is a non-anonymous token. */
         UA_UserTokenPolicy *utp = &ed->userIdentityTokens[i];
         UA_String_clear(&utp->securityPolicyUri);
-        if(UA_String_equal(&ed->securityPolicyUri, &UA_SECURITY_POLICY_NONE_URI) &&
+        if((!server->config.allowNonePolicyPassword || ed->userIdentityTokens[i].tokenType != UA_USERTOKENTYPE_USERNAME) &&
+           UA_String_equal(&ed->securityPolicyUri, &UA_SECURITY_POLICY_NONE_URI) &&
            utp->tokenType != UA_USERTOKENTYPE_ANONYMOUS) {
             UA_SecurityPolicy *encSP = getDefaultEncryptedSecurityPolicy(server);
             if(encSP)

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -519,9 +519,11 @@ selectEndpointAndTokenPolicy(UA_Server *server, UA_SecureChannel *channel,
             *tokenSp = channel->securityPolicy;
             if(pol->securityPolicyUri.length > 0)
                 *tokenSp = getSecurityPolicyByUri(server, &pol->securityPolicyUri);
+
 #ifdef UA_ENABLE_ENCRYPTION
-            if(!*tokenSp || (*tokenSp)->localCertificate.length == 0 ||
-               UA_String_equal(&UA_SECURITY_POLICY_NONE_URI, &(*tokenSp)->policyUri))
+            if(!*tokenSp || (!server->config.allowNonePolicyPassword &&
+               ((*tokenSp)->localCertificate.length == 0 ||
+               UA_String_equal(&UA_SECURITY_POLICY_NONE_URI, &(*tokenSp)->policyUri))))
                 *tokenSp = getDefaultEncryptedSecurityPolicy(server);
 #endif
             return;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -434,6 +434,7 @@ if(UA_ENABLE_ENCRYPTION_MBEDTLS)
     ua_add_test(encryption/check_encryption_basic256sha256.c)
     ua_add_test(encryption/check_encryption_aes128sha256rsaoaep.c)
     ua_add_test(encryption/check_encryption_aes256sha256rsapss.c)
+    ua_add_test(encryption/check_username_connect_none.c)
 endif()
 
 if(UA_ENABLE_ENCRYPTION_MBEDTLS AND UA_ENABLE_CERT_REJECTED_DIR)
@@ -447,6 +448,7 @@ if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_ENCRYPTION_LIBRESSL)
     ua_add_test(encryption/check_encryption_aes128sha256rsaoaep.c)
     ua_add_test(encryption/check_encryption_aes256sha256rsapss.c)
     ua_add_test(encryption/check_cert_generation.c)
+    ua_add_test(encryption/check_username_connect_none.c)
 endif()
 
 # Tests for Nodeset Compiler

--- a/tests/encryption/check_username_connect_none.c
+++ b/tests/encryption/check_username_connect_none.c
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <open62541/client_config_default.h>
+#include <open62541/plugin/securitypolicy_default.h>
+#include <open62541/plugin/pki_default.h>
+#include <open62541/plugin/accesscontrol_default.h>
+#include <open62541/server_config_default.h>
+
+#include "ua_server_internal.h"
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "certificates.h"
+#include "thread_wrapper.h"
+
+UA_Server *server;
+UA_Boolean running;
+THREAD_HANDLE server_thread;
+
+static const size_t usernamePasswordsSize = 2;
+static UA_UsernamePasswordLogin usernamePasswords[2] = {
+    {UA_STRING_STATIC("user1"), UA_STRING_STATIC("password")},
+    {UA_STRING_STATIC("user2"), UA_STRING_STATIC("password1")}};
+
+THREAD_CALLBACK(serverloop) {
+    while(running)
+        UA_Server_run_iterate(server, true);
+    return 0;
+}
+
+static void setup(void) {
+    running = true;
+
+    UA_ByteString certificate;
+    certificate.length = CERT_DER_LENGTH;
+    certificate.data = CERT_DER_DATA;
+
+    UA_ByteString privateKey;
+    privateKey.length = KEY_DER_LENGTH;
+    privateKey.data = KEY_DER_DATA;
+
+    server = UA_Server_new();
+    ck_assert(server != NULL);
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
+                                                   NULL, 0, NULL, 0, NULL, 0);
+
+    UA_CertificateVerification_AcceptAll(&config->secureChannelPKI);
+    UA_AccessControl_default(config, false, NULL, usernamePasswordsSize, usernamePasswords);
+
+    UA_String_clear(&config->applicationDescription.applicationUri);
+    config->applicationDescription.applicationUri =
+        UA_STRING_ALLOC("urn:unconfigured:application");
+
+    UA_Server_run_startup(server);
+    THREAD_CREATE(server_thread, serverloop);
+}
+
+static void teardown(void) {
+    running = false;
+    THREAD_JOIN(server_thread);
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(none_policy_connect) {
+    server->config.allowNonePolicyPassword = true;
+    UA_Client *client = UA_Client_new();
+    UA_StatusCode retval =
+        UA_Client_connectUsername(client, "opc.tcp://localhost:4840", "user1", "password");
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(none_policy_connect_fail) {
+    server->config.allowNonePolicyPassword = false;
+
+    UA_Client *client = UA_Client_new();
+    UA_StatusCode retval =
+        UA_Client_connectUsername(client, "opc.tcp://localhost:4840", "user1", "password");
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADIDENTITYTOKENINVALID);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static Suite* testSuite_encryption(void) {
+    Suite *s = suite_create("NoneClientWithEncryptionServer");
+    TCase *tc_encryption = tcase_create("Client without certificate and server with certificate");
+    tcase_add_checked_fixture(tc_encryption, setup, teardown);
+    tcase_add_test(tc_encryption, none_policy_connect);
+    tcase_add_test(tc_encryption, none_policy_connect_fail);
+    suite_add_tcase(s,tc_encryption);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_encryption();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr,CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
If the server is built with security support, plain text passwords are currently rejected and no corresponding token is offered in the None policy endpoint.
A client without encryption support is unable to authenticate using username and password, even if a None policy endpoint is offered.

This commit adds the "allowNonePolicyPassword" option to the server config to enable access for clients with no encryption support.