### PR TITLE
[Review] fix(pubsub): Fix mqtt reader group shutdown

### DIFF
--- a/src/pubsub/ua_pubsub_connection.c
+++ b/src/pubsub/ua_pubsub_connection.c
@@ -314,7 +314,7 @@ UA_PubSubConnection_setPubSubState(UA_Server *server, UA_PubSubConnection *c,
 
             /* Disable Reader and WriterGroups */
             LIST_FOREACH(readerGroup, &c->readerGroups, listEntry) {
-                UA_ReaderGroup_setPubSubState(server, readerGroup, state);
+                UA_ReaderGroup_setPubSubState(server, readerGroup, readerGroup->state);
             }
             LIST_FOREACH(writerGroup, &c->writerGroups, listEntry) {
                 UA_WriterGroup_setPubSubState(server, writerGroup, writerGroup->state);


### PR DESCRIPTION
Resolve #6130 with a correct pubsub reader group status when the pubsub connection is disabled.

Using the current connection state leads to multiple calls of UA_ReaderGroup_disconnect which also adds multiple deleteTopicConnection (eventloop_mqtt.c) as delayed callbacks. After a longer callstack this ends with the second call of UA_free(tc).
This is actually a double free error which is now displayed as invalid read on later memory access by valgrind test. Changing state to readerGroup->state _(in this case UA_PUBSUBSTATE_PREOPERATIONAL -> UA_PUBSUBSTATE_PREOPERATIONAL)_ avoids the earlier call of UA_ReaderGroup_disconnect and deleteTopicConnection is called only once.

The new pattern is similar with writerGroup->state for publisher a few lines later.

To be honest, I still don't understand the code at this point for untouched UA_WriterGroup_setPubSubState(server, writerGroup, writerGroup->state); and changed UA_ReaderGroup_setPubSubState(server, readerGroup, readerGroup->state);
If I see it right, UA_WriterGroup_setPubSubState and UA_ReaderGroup_setPubSubState will both do wg->state = targetState; what is actually not a new targetState.
@jpfr Could you please look over it. Is this intentional, or is there something else wrong? I would prefer to call both xyGroup_setPubSubState with UA_PUBSUBSTATE_PAUSED while disabling the connection.