### PR TITLE
[WIP] fix(nc): Fix generated namespaceIndex of datatypes

### DIFF
--- a/tools/nodeset_compiler/backend_open62541_typedefinitions.py
+++ b/tools/nodeset_compiler/backend_open62541_typedefinitions.py
@@ -129,8 +129,8 @@ class CGenerator(object):
         raise RuntimeError("Unknown datatype")
 
     def print_datatype(self, datatype, namespaceMap):
-        typeid = "{%s, %s}" % ("0", getNodeidTypeAndId(datatype.nodeId))
-        binaryEncodingId = "{%s, %s}" % ("0",
+        typeid = "{%s, %s}" % (namespaceMap[datatype.namespaceUri], getNodeidTypeAndId(datatype.nodeId))
+        binaryEncodingId = "{%s, %s}" % (namespaceMap[datatype.namespaceUri],
                                          getNodeidTypeAndId(datatype.binaryEncodingId))
         idName = makeCIdentifier(datatype.name)
         pointerfree = "true" if datatype.pointerfree else "false"


### PR DESCRIPTION
Resolve #6143 using a partly revert of changes in tools/nodeset_compiler/backend_open62541_typedefinitions.py
from commit 8e985d20341d2aaa0383fe96e433265acd470e48

With typeid and binaryEncodingId set to "0" in print_datatypes, the generated datatypes (in src_generated/tests) have a typeId with namespaceIndex 0 instead of 2 as specified in NAMESPACE_MAP of CMakeLists.
Changing it back to namespaceMap[datatype.namespaceUri] ensures that the right index is used.

Unfortunately, it is not immediately clear to me why the change was perhaps necessary for something else.
@andreasebner and @NoelGraf can you please look over whether that is okay?