### PR TITLE
feat(core): Add a consistency check to UA_Array_copy

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1752,7 +1752,9 @@ UA_Array_copy(const void *src, size_t size,
         return UA_STATUSCODE_GOOD;
     }
 
-    if(!type)
+    /* Check the array consistency -- defensive programming in case the user
+     * manually created an inconsistent array */
+    if(UA_UNLIKELY(!type || !src))
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* calloc, so we don't have to check retval in every iteration of copying */


### PR DESCRIPTION
Users might have manually created an inconsistent array. Defensive programming is good practice.