### PR TITLE
fix(test): use correct name for sks callback

### DIFF
--- a/tests/pubsub/check_pubsub_sks_client.c
+++ b/tests/pubsub/check_pubsub_sks_client.c
@@ -580,7 +580,7 @@ START_TEST(SetInvalidSKSClient) {
     UA_Client *client = UA_Client_newForUnitTest();
     UA_ClientConfig *config = UA_Client_getConfig(client);
     int retryCnt = 0;
-    UA_Server_setSksClient(publisherApp, securityGroupId, config, testingSKSEndpointUrl, sksPullRequestCallback, NULL);
+    UA_Server_setSksClient(publisherApp, securityGroupId, config, testingSKSEndpointUrl, sksPullRequestCallback_pubsub, NULL);
     sksPullStatus = UA_STATUSCODE_GOOD;
     while(UA_StatusCode_isGood(sksPullStatus) && (retryCnt++ < MAX_RETRIES)) {
         UA_Server_run_iterate(publisherApp, false);


### PR DESCRIPTION
This was forgotten in 5c979cd8c5d2624d5837a71da463db7d0b34919f:
```
/open62541/tests/pubsub/check_pubsub_sks_client.c:583:90: error: use of undeclared identifier 'sksPullRequestCallback'; did you mean 'sksPullRequestCallback_pubsub'?
  583 |     UA_Server_setSksClient(publisherApp, securityGroupId, config, testingSKSEndpointUrl, sksPullRequestCallback, NULL);
      |                                                                                          ^~~~~~~~~~~~~~~~~~~~~~
      |                                                                                          sksPullRequestCallback_pubsub
```