### PR TITLE
fix(server): memory handling in the server mdns implementation.

### DIFF
--- a/src/server/ua_discovery_mdns.c
+++ b/src/server/ua_discovery_mdns.c
@@ -269,7 +269,7 @@ setTxt(UA_DiscoveryManager *dm, const struct resource *r,
                                  "Cannot alloc memory for mDNS srv path");
                     return;
                 }
-                memcpy(&entry->pathTmp, path, pathLen);
+                memcpy(entry->pathTmp, path, pathLen);
                 entry->pathTmp[pathLen] = '\0';
             }
         } else {


### PR DESCRIPTION
Fix memcpy issue (maybe "copy&paste" error from fix in 1.3 ->  47239db132de3db30b975d65853a5a2ee295124c).