### PR TITLE
fix(build): lowercase typo in UA_ARCHITECTURE_*

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -24,7 +24,7 @@
 #cmakedefine UA_ARCHITECTURE_POSIX
 
 /* Select default architecture if none is selected */
-#if !defined(UA_ARCHITECtURE_WIN32) && !defined(UA_ARCHITECtURE_POSIX)
+#if !defined(UA_ARCHITECTURE_WIN32) && !defined(UA_ARCHITECTURE_POSIX)
 # ifdef _WIN32
 #  define UA_ARCHITECTURE_WIN32
 # else


### PR DESCRIPTION
Use an uppercase T to match the #cmakedefine's above.

Fixes: 7547a8a9dc0b64eaf7a568305d82a78da6a6a6a1