### PR TITLE
fix(examples,tests): correct Windows define

### DIFF
--- a/examples/tutorial_server_method_async.c
+++ b/examples/tutorial_server_method_async.c
@@ -38,7 +38,7 @@
 #include <malloc.h>
 #include "common.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <pthread.h>
 #define THREAD_HANDLE pthread_t
 #define THREAD_CREATE(handle, callback) do {            \

--- a/tests/server/check_discovery.c
+++ b/tests/server/check_discovery.c
@@ -15,7 +15,7 @@
 
 #include "testing_clock.h"
 #include "thread_wrapper.h"
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/stat.h>
 #endif
 
@@ -32,7 +32,7 @@
 #define checkWait registerTimeout + 11
 
 #ifdef UA_ENABLE_DISCOVERY_SEMAPHORE
-# ifndef WIN32
+# ifndef _WIN32
 #  define SEMAPHORE_PATH "/tmp/open62541-unit-test-semaphore"
 # else
 #  define SEMAPHORE_PATH ".\\open62541-unit-test-semaphore"
@@ -246,7 +246,7 @@ unregisterServer(void) {
 static void
 Server_register_semaphore(void) {
     // create the semaphore
-#ifndef WIN32
+#ifndef _WIN32
     int fd = open(SEMAPHORE_PATH, O_RDWR|O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
     ck_assert_int_ne(fd, -1);
     close(fd);

--- a/tests/testing-plugins/thread_wrapper.h
+++ b/tests/testing-plugins/thread_wrapper.h
@@ -6,7 +6,7 @@
 
 /* Threads */
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <pthread.h>
 #define THREAD_HANDLE pthread_t
 #define THREAD_CREATE(handle, callback) pthread_create(&handle, NULL, callback, NULL)
@@ -31,7 +31,7 @@
 /* Windows returns non-zero on success and pthread returns zero,
  * so compare to zero to achieve consistent return values */
 
-#ifndef WIN32
+#ifndef _WIN32
 #define MUTEX_HANDLE pthread_mutex_t
 
 /* Will return UA_TRUE when zero */


### PR DESCRIPTION
Checking for `WIN32` only works by virtue of CMake defining `WIN32`, by itself. The `_WIN32` define actually comes from the compiler, so use that instead.
    
Since these are examples and tests, don't use `UA_ARCHITECTURE_WIN32`.