### PR TITLE
[REVIEW] Disable the reuseaddr socket option by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,9 @@ endif()
 set(UA_MULTITHREADING ${MULTITHREADING_DEFAULT} CACHE STRING
     "Multithreading support (<100: No multithreading support, >=100: Thread-safety enabled (internal mutexes)")
 
+option(UA_ENABLE_ALLOW_REUSEADDR "Enable reuseaddr (only for tests)" OFF)
+mark_as_advanced(UA_ENABLE_ALLOW_REUSEADDR)
+
 option(UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS "Enable the use of A&C. (EXPERIMENTAL)" OFF)
 mark_as_advanced(UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS)
 

--- a/arch/eventloop_posix.c
+++ b/arch/eventloop_posix.c
@@ -545,7 +545,15 @@ UA_EventLoopPOSIX_setNoSigPipe(UA_FD sockfd) {
 UA_StatusCode
 UA_EventLoopPOSIX_setReusable(UA_FD sockfd) {
     int enableReuseVal = 1;
+#ifndef _WIN32
+    int res = UA_setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR,
+                            (const char*)&enableReuseVal, sizeof(enableReuseVal));
+    res |= UA_setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT,
+                            (const char*)&enableReuseVal, sizeof(enableReuseVal));
+    return (res == 0) ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADINTERNALERROR;
+#else
     int res = UA_setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR,
                             (const char*)&enableReuseVal, sizeof(enableReuseVal));
     return (res == 0) ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADINTERNALERROR;
+#endif
 }

--- a/arch/eventloop_posix_tcp.c
+++ b/arch/eventloop_posix_tcp.c
@@ -11,19 +11,21 @@
 #include "eventloop_common.h"
 
 /* Configuration parameters */
-#define TCP_PARAMETERSSIZE 5
+#define TCP_PARAMETERSSIZE 6
 #define TCP_PARAMINDEX_RECVBUF 0
 #define TCP_PARAMINDEX_ADDR 1
 #define TCP_PARAMINDEX_PORT 2
 #define TCP_PARAMINDEX_LISTEN 3
 #define TCP_PARAMINDEX_VALIDATE 4
+#define TCP_PARAMINDEX_REUSE 5
 
 static UA_KeyValueRestriction TCPConfigParameters[TCP_PARAMETERSSIZE] = {
     {{0, UA_STRING_STATIC("recv-bufsize")}, &UA_TYPES[UA_TYPES_UINT32], false, true, false},
     {{0, UA_STRING_STATIC("address")}, &UA_TYPES[UA_TYPES_STRING], false, true, true},
     {{0, UA_STRING_STATIC("port")}, &UA_TYPES[UA_TYPES_UINT16], true, true, false},
     {{0, UA_STRING_STATIC("listen")}, &UA_TYPES[UA_TYPES_BOOLEAN], false, true, false},
-    {{0, UA_STRING_STATIC("validate")}, &UA_TYPES[UA_TYPES_BOOLEAN], false, true, false}
+    {{0, UA_STRING_STATIC("validate")}, &UA_TYPES[UA_TYPES_BOOLEAN], false, true, false},
+    {{0, UA_STRING_STATIC("reuse")}, &UA_TYPES[UA_TYPES_BOOLEAN], false, true, false}
 };
 
 typedef struct {
@@ -340,7 +342,7 @@ static UA_StatusCode
 TCP_registerListenSocket(UA_POSIXConnectionManager *pcm, struct addrinfo *ai,
                          UA_UInt16 port, void *application, void *context,
                          UA_ConnectionManager_connectionCallback connectionCallback,
-                         UA_Boolean validate) {
+                         UA_Boolean validate, UA_Boolean reuseaddr) {
     UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)pcm->cm.eventSource.eventLoop;
     UA_LOCK_ASSERT(&el->elMutex, 1);
 
@@ -387,26 +389,17 @@ TCP_registerListenSocket(UA_POSIXConnectionManager *pcm, struct addrinfo *ai,
     }
 #endif
 
-    /* Allow rebinding to the IP/port combination. Eg. to restart the server. */
-    if(UA_setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR,
-                     (const char *)&optval, sizeof(optval)) == -1) {
-        UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
-                       "TCP %u\t| Could not make the socket addr reusable",
-                       (unsigned)listenSocket);
-        UA_close(listenSocket);
-        return UA_STATUSCODE_BADINTERNALERROR;
+    if(reuseaddr) {
+        /* Allow rebinding to the IP/port combination. Eg. to restart the server. */
+        if(UA_EventLoopPOSIX_setReusable(listenSocket) != UA_STATUSCODE_GOOD) {
+            UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                           "TCP %u\t| Could not make the socket addr reusable",
+                           (unsigned)listenSocket);
+            UA_close(listenSocket);
+            return UA_STATUSCODE_BADINTERNALERROR;
+        }
     }
-#ifndef _WIN32
-    /* Allow rebinding to the IP/port combination. Eg. to restart the server. */
-    if(UA_setsockopt(listenSocket, SOL_SOCKET, SO_REUSEPORT,
-                     (const char *)&optval, sizeof(optval)) == -1) {
-        UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
-                       "TCP %u\t| Could not make the socket port reusable",
-                       (unsigned)listenSocket);
-        UA_close(listenSocket);
-        return UA_STATUSCODE_BADINTERNALERROR;
-    }
-#endif
+
     /* Set the socket non-blocking */
     if(UA_EventLoopPOSIX_setNonBlocking(listenSocket) != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
@@ -515,7 +508,7 @@ static UA_StatusCode
 TCP_registerListenSockets(UA_POSIXConnectionManager *pcm, const char *hostname,
                           UA_UInt16 port, void *application, void *context,
                           UA_ConnectionManager_connectionCallback connectionCallback,
-                          UA_Boolean validate) {
+                          UA_Boolean validate, UA_Boolean reuseaddr) {
     UA_LOCK_ASSERT(&((UA_EventLoopPOSIX*)pcm->cm.eventSource.eventLoop)->elMutex, 1);
 
     /* Create a string for the port */
@@ -555,7 +548,7 @@ TCP_registerListenSockets(UA_POSIXConnectionManager *pcm, const char *hostname,
     struct addrinfo *ai = res;
     while(ai) {
         total_result &= TCP_registerListenSocket(pcm, ai, port, application, context,
-                                                 connectionCallback, validate);
+                                                 connectionCallback, validate, reuseaddr);
         ai = ai->ai_next;
     }
     freeaddrinfo(res);
@@ -703,27 +696,40 @@ TCP_openPassiveConnection(UA_POSIXConnectionManager *pcm, const UA_KeyValueMap *
             addrsSize = addrs->arrayLength;
     }
 
+    /* Get the reuseaddr parameter */
+    UA_Boolean reuseaddr = false;
+    const UA_Boolean *reuseaddrTmp = (const UA_Boolean*)
+        UA_KeyValueMap_getScalar(params, TCPConfigParameters[TCP_PARAMINDEX_REUSE].name,
+                                 &UA_TYPES[UA_TYPES_BOOLEAN]);
+    if(reuseaddrTmp)
+        reuseaddr = *reuseaddrTmp;
+
+#ifdef UA_ENABLE_ALLOW_REUSEADDR
+    reuseaddr = true;
+#endif
+
     /* Undefined or empty addresses array -> listen on all interfaces */
     if(addrsSize == 0) {
         UA_LOG_INFO(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
                     "TCP\t| Listening on all interfaces");
         return TCP_registerListenSockets(pcm, NULL, *port, application,
-                                         context, connectionCallback, validate);
+                                         context, connectionCallback, validate, reuseaddr);
     }
 
     /* Iterate over the configured hostnames */
     UA_String *hostStrings = (UA_String*)addrs->data;
+    UA_StatusCode retval = UA_STATUSCODE_BADINTERNALERROR;
     for(size_t i = 0; i < addrsSize; i++) {
         char hostname[512];
         if(hostStrings[i].length >= sizeof(hostname))
             continue;
         memcpy(hostname, hostStrings[i].data, hostStrings->length);
         hostname[hostStrings->length] = '\0';
-        TCP_registerListenSockets(pcm, hostname, *port, application,
-                                  context, connectionCallback, validate);
+        if(TCP_registerListenSockets(pcm, hostname, *port, application,
+                                     context, connectionCallback, validate, reuseaddr) == UA_STATUSCODE_GOOD)
+            retval = UA_STATUSCODE_GOOD;
     }
-
-    return UA_STATUSCODE_GOOD;
+    return retval;
 }
 
 /* Open a TCP connection to a remote host */

--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -96,6 +96,9 @@
 #cmakedefine UA_DEBUG_DUMP_PKGS
 #cmakedefine UA_DEBUG_FILE_LINE_INFO
 
+/* Options for Tests */
+#cmakedefine UA_ENABLE_ALLOW_REUSEADDR
+
 /**
  * Function Export
  * ---------------

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -176,6 +176,7 @@ struct UA_ServerConfig {
                               * (default: 0 -> unbounded) */
     UA_UInt32 tcpMaxChunks;  /* Max number of chunks per message
                               * (default: 0 -> unbounded) */
+    UA_Boolean tcpReuseAddr;
 
     /**
      * Security and Encryption

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -347,6 +347,8 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
         }
     }
 
+    conf->tcpReuseAddr = false;
+
     /* --> Start setting the default static config <-- */
 
     conf->shutdownDelay = 0.0;
@@ -393,10 +395,9 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
     /* Networking */
     /* Set up the local ServerUrls. They are used during startup to initialize
      * the server sockets. */
-    UA_String serverUrls[2];
+    UA_String serverUrls[1];
     size_t serverUrlsSize = 0;
-    char hostnamestr[256];
-    char serverUrlBuffer[2][512];
+    char serverUrlBuffer[1][512];
 
     if(portNumber == 0) {
         UA_LOG_WARNING(conf->logging, UA_LOGCATEGORY_USERLAND,
@@ -411,7 +412,7 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
             conf->serverUrlsSize = 0;
         }
 
-        /* 1) Listen on all interfaces (also external). This must be the first
+        /* Listen on all interfaces (also external). This must be the first
          * entry if this is desired. Otherwise some interfaces may be blocked
          * (already in use) with a hostname that is only locally reachable.*/
         mp_snprintf(serverUrlBuffer[0], sizeof(serverUrlBuffer[0]),
@@ -419,25 +420,7 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
         serverUrls[serverUrlsSize] = UA_STRING(serverUrlBuffer[0]);
         serverUrlsSize++;
 
-        /* 2) Use gethostname to get the local hostname. For that temporarily
-         * initialize the Winsock API on Win32. */
-#ifdef _WIN32
-        WSADATA wsaData;
-        WSAStartup(MAKEWORD(2, 2), &wsaData);
-#endif
-        int err = gethostname(hostnamestr, sizeof(hostnamestr));
-#ifdef _WIN32
-        WSACleanup();
-#endif
-
-        if(err == 0) {
-            mp_snprintf(serverUrlBuffer[1], sizeof(serverUrlBuffer[1]),
-                        "opc.tcp://%s:%u", hostnamestr, portNumber);
-            serverUrls[serverUrlsSize] = UA_STRING(serverUrlBuffer[1]);
-            serverUrlsSize++;
-        }
-
-        /* 3) Add to the config */
+        /* Add to the config */
         UA_StatusCode retval =
             UA_Array_copy(serverUrls, serverUrlsSize,
                           (void**)&conf->serverUrls, &UA_TYPES[UA_TYPES_STRING]);

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -195,6 +195,9 @@ UA_SecureChannel_clear(UA_SecureChannel *channel) {
     UA_ByteString_clear(&channel->localNonce);
     UA_ByteString_clear(&channel->remoteNonce);
 
+    /* Clean up endpointUrl */
+    UA_String_clear(&channel->endpointUrl);
+
     /* Delete remaining chunks */
     UA_SecureChannel_deleteBuffered(channel);
 

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -105,6 +105,8 @@ struct UA_SecureChannel {
     UA_ShutdownReason shutdownReason;
     UA_ConnectionConfig config;
 
+    UA_String endpointUrl;
+
     /* Connection handling in the EventLoop */
     UA_ConnectionManager *connectionManager;
     uintptr_t connectionId;

--- a/tools/azure-devops/win/build.ps1
+++ b/tools/azure-devops/win/build.ps1
@@ -43,6 +43,7 @@ cd build
         -DCMAKE_BUILD_TYPE=Debug `
         -DUA_BUILD_EXAMPLES=OFF `
         -DUA_BUILD_UNIT_TESTS=ON `
+        -DUA_ENABLE_ALLOW_REUSEADDR=ON `
         -DUA_ENABLE_DA=ON `
         -DUA_ENABLE_DISCOVERY=ON `
         -DUA_ENABLE_ENCRYPTION:STRING=$build_encryption `

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -137,6 +137,7 @@ function unit_tests {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
@@ -157,6 +158,7 @@ function unit_tests_32 {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
@@ -177,6 +179,7 @@ function unit_tests_nosub {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_HISTORIZING=OFF \
           -DUA_ENABLE_SUBSCRIPTIONS=OFF \
           -DUA_FORCE_WERROR=ON \
@@ -191,6 +194,7 @@ function unit_tests_diag {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_DIAGNOSTICS=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
@@ -212,6 +216,7 @@ function unit_tests_mt {
           -DUA_MULTITHREADING=200 \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_FORCE_WERROR=ON \
           ..
@@ -225,6 +230,7 @@ function unit_tests_alarms {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_DA=ON \
           -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_XML_ENCODING=ON \
@@ -243,6 +249,7 @@ function unit_tests_encryption {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_ENCRYPTION=$1 \
           -DUA_FORCE_WERROR=ON \
           ..
@@ -256,6 +263,7 @@ function unit_tests_encryption_mbedtls_pubsub {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_ENCRYPTION=MBEDTLS \
           -DUA_ENABLE_CERT_REJECTED_DIR=ON \
           -DUA_ENABLE_PUBSUB=ON \
@@ -275,6 +283,7 @@ function unit_tests_pubsub_sks {
           -DUA_NAMESPACE_ZERO=FULL \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_ENCRYPTION=MBEDTLS \
           -DUA_ENABLE_PUBSUB=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
@@ -297,6 +306,7 @@ function unit_tests_with_coverage {
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_COVERAGE=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
@@ -323,6 +333,7 @@ function unit_tests_valgrind {
     mkdir -p build; cd build; rm -rf *
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_ENCRYPTION=$1 \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
@@ -356,6 +367,7 @@ function examples_valgrind {
 
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
+          -DUA_ENABLE_ALLOW_REUSEADDR=ON \
           -DUA_ENABLE_ENCRYPTION=$1 \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON \


### PR DESCRIPTION
The reuseaddr socket option is now disabled by default.
Server does not start if Binary Protocol Manager fails to start.