### PR TITLE
added include stdlib.h to examples/file_based_server/server_file_base…

### DIFF
--- a/examples/file_based_server/server_file_based_config.c
+++ b/examples/file_based_server/server_file_based_config.c
@@ -1,6 +1,7 @@
 /* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
 
+#include <stdlib.h>
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
 #include <open62541/plugin/log_stdout.h>


### PR DESCRIPTION
when building with UA_ENABLE_MALLOC_SINGLETON=ON, the bild was failing with:

open62541/examples/file_based_server/server_file_based_config.c:22:16: error: ‘EXIT_FAILURE’ undeclared (first use in this function)
   22 |         return EXIT_FAILURE;
      |                ^~~~~~~~~~~~

This was fixed by including stdlib.h in that file.
