### PR TITLE
fix(plugins): remove dead code.

### DIFF
--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
@@ -84,8 +84,6 @@ mbedtls_generateKey(mbedtls_md_context_t *context,
         mbedtls_hmac(context, secret, &A, ANext.data);
 
         if(retval != UA_STATUSCODE_GOOD) {
-            if(bufferAllocated)
-                UA_ByteString_clear(&outSegment);
             UA_ByteString_clear(&A_and_seed);
             UA_ByteString_clear(&ANext_and_seed);
             return retval;


### PR DESCRIPTION
The UA_ByteString_clear(&outSegment) call will never happen. bufferAllocated is decleard to false and will only be true if retval equals UA_STATUSCODE_GOOD. Retval don't change between the the two if statements so retval will still be in the same state (UA_STATUSCODE_GOOD) and it will not reach the if(bufferAllocated) check. If retval don't equals UA_STATUSCODE_GOOD the retavl will be return in the previous check and bufferAllocated will never be true.