### PR TITLE
fix(pubsub): Fixed DSR not coming back from error state after communication resumes

### DIFF
--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -616,7 +616,11 @@ UA_ReaderGroup_process(UA_Server *server, UA_ReaderGroup *readerGroup,
 
         /* Check if the reader is enabled */
         if(reader->state != UA_PUBSUBSTATE_OPERATIONAL &&
-           reader->state != UA_PUBSUBSTATE_PREOPERATIONAL)
+           reader->state != UA_PUBSUBSTATE_PREOPERATIONAL
+#ifdef UA_ENABLE_PUBSUB_MONITORING
+           && reader->state != UA_PUBSUBSTATE_ERROR
+#endif
+        )
             continue;
 
         /* Update the ReaderGroup state if this is the first received message */

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -973,21 +973,13 @@ START_TEST(Test_wrong_timeout) {
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
     ck_assert(state == UA_PUBSUBSTATE_ERROR);
 
+    expectedState = UA_PUBSUBSTATE_OPERATIONAL;
     ServerDoProcess("2", (UA_UInt32) PublishingInterval_Conn1_WG1, 1);
     ServerDoProcess("2", (UA_UInt32) 100, 1);
 
     /* now the reader should have received something and the state changes to operational */
     ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-    ck_assert(state == UA_PUBSUBSTATE_ERROR);
-
-    ServerDoProcess("3", 300, 1);
-
-    /* then there should have happened another timeout */
-    ck_assert_int_eq(CallbackCnt, 11);
-
-    /* DataSetReader state toggles from error to operational, because it receives messages but always too late */
-    ck_assert(UA_Server_DataSetReader_getState(server, DSRId_Conn1_RG1_DSR1, &state) == UA_STATUSCODE_GOOD);
-    ck_assert(state == UA_PUBSUBSTATE_ERROR);
+    ck_assert(state == UA_PUBSUBSTATE_OPERATIONAL);
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "END: Test_wrong_timeout\n\n");
 } END_TEST


### PR DESCRIPTION
Reader which MessgaeReceiveTimeout elapsed was ignored when parsing incoming messages, so it couldn't get back to 'operational' state even after communication resumed.