### PR TITLE
Fix for issue open62541/open62541#6205: Different data types for namespace indexes used.

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1831,11 +1831,11 @@ UA_Server_addNamespace(UA_Server *server, const char* name);
 /* Get namespace by name from the server. */
 UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
-                             size_t* foundIndex);
+                             UA_UInt16* foundIndex);
 
 /* Get namespace by id from the server. */
 UA_StatusCode UA_EXPORT UA_THREADSAFE
-UA_Server_getNamespaceByIndex(UA_Server *server, const size_t namespaceIndex,
+UA_Server_getNamespaceByIndex(UA_Server *server, const UA_UInt16 namespaceIndex,
                               UA_String *foundUri);
 
 /**

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -129,18 +129,21 @@ getNamespaceByIndex(UA_Server *server, const size_t namespaceIndex,
 
 UA_StatusCode
 UA_Server_getNamespaceByName(UA_Server *server, const UA_String namespaceUri,
-                             size_t *foundIndex) {
+                             UA_UInt16 *foundIndex) {
+    size_t tempIndex = 0;
     UA_LOCK(&server->serviceMutex);
-    UA_StatusCode res = getNamespaceByName(server, namespaceUri, foundIndex);
+    UA_StatusCode res = getNamespaceByName(server, namespaceUri, &tempIndex);
     UA_UNLOCK(&server->serviceMutex);
+    UA_CHECK_STATUS(res, return res);
+    *foundIndex = (UA_UInt16)tempIndex;
     return res;
 }
 
 UA_StatusCode
-UA_Server_getNamespaceByIndex(UA_Server *server, const size_t namespaceIndex,
+UA_Server_getNamespaceByIndex(UA_Server *server, const UA_UInt16 namespaceIndex,
                               UA_String *foundUri) {
     UA_LOCK(&server->serviceMutex);
-    UA_StatusCode res = getNamespaceByIndex(server, namespaceIndex, foundUri);
+    UA_StatusCode res = getNamespaceByIndex(server, (size_t)namespaceIndex, foundUri);
     UA_UNLOCK(&server->serviceMutex);
     return res;
 }

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -38,7 +38,7 @@ START_TEST(Server_addTestNodeset) {
     UA_UInt16 nsIndex = UINT_MAX;
     retval = UA_Server_getNamespaceByName(server, UA_STRING("http://yourorganisation.org/test/"), &nsIndex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    testNamespaceIndex = (UA_UInt16) nsIndex;
+    testNamespaceIndex = nsIndex;
 }
 END_TEST
 

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -35,7 +35,7 @@ static void teardown(void) {
 START_TEST(Server_addTestNodeset) {
     UA_StatusCode retval = namespace_tests_testnodeset_generated(server);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    size_t nsIndex = LONG_MAX;
+    UA_UInt16 nsIndex = UINT_MAX;
     retval = UA_Server_getNamespaceByName(server, UA_STRING("http://yourorganisation.org/test/"), &nsIndex);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     testNamespaceIndex = (UA_UInt16) nsIndex;

--- a/tests/nodeset-loader/check_nodeset_loader_testnodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_testnodeset.c
@@ -65,7 +65,7 @@ START_TEST(Server_loadTestNodeset) {
     UA_UInt16 nsIndex = UINT_MAX;
     retVal = UA_Server_getNamespaceByName(server, UA_STRING("http://yourorganisation.org/test/"), &nsIndex);
     ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
-    testNamespaceIndex = (UA_UInt16) nsIndex;
+    testNamespaceIndex = nsIndex;
 }
 END_TEST
 

--- a/tests/nodeset-loader/check_nodeset_loader_testnodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_testnodeset.c
@@ -62,7 +62,7 @@ START_TEST(Server_loadTestNodeset) {
     UA_StatusCode retVal = UA_Server_loadNodeset(server,
         OPEN62541_TESTNODESET_DIR "testnodeset.xml", NULL);
     ck_assert(UA_StatusCode_isGood(retVal));
-    size_t nsIndex = LONG_MAX;
+    UA_UInt16 nsIndex = UINT_MAX;
     retVal = UA_Server_getNamespaceByName(server, UA_STRING("http://yourorganisation.org/test/"), &nsIndex);
     ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
     testNamespaceIndex = (UA_UInt16) nsIndex;

--- a/tests/server/check_server.c
+++ b/tests/server/check_server.c
@@ -36,12 +36,12 @@ START_TEST(checkGetConfig) {
 } END_TEST
 
 START_TEST(checkGetNamespaceByName) {
-    size_t notFoundIndex = 62541;
+    UA_UInt16 notFoundIndex = 62541;
     UA_StatusCode notFound = UA_Server_getNamespaceByName(server, UA_STRING("http://opcfoundation.org/UA/invalid"), &notFoundIndex);
     ck_assert_uint_eq(notFoundIndex, 62541); // not changed
     ck_assert_uint_eq(notFound, UA_STATUSCODE_BADNOTFOUND);
 
-    size_t foundIndex = 62541;
+    UA_UInt16 foundIndex = 62541;
     UA_StatusCode found = UA_Server_getNamespaceByName(server, UA_STRING("http://opcfoundation.org/UA/"), &foundIndex);
     ck_assert_uint_eq(foundIndex, 0); // this namespace always has index 0 (defined by the standard)
     ck_assert_uint_eq(found, UA_STATUSCODE_GOOD);


### PR DESCRIPTION
Fix for issue open62541/open62541#6205 Different data types for namespace indexes used.
Changed prototypes and functions for namespace methods from `size_t` to `UA_UInt16`. Also updated the affected tests.