### PR TITLE
fix(server): Problems with event subscription in reduced namespace

### DIFF
--- a/src/server/ua_subscription_events_filter.c
+++ b/src/server/ua_subscription_events_filter.c
@@ -1125,6 +1125,11 @@ UA_SimpleAttributeOperandValidation(UA_Server *server,
     if(UA_NodeId_isNull(&sao->typeDefinitionId))
         return UA_STATUSCODE_BADTYPEDEFINITIONINVALID;
 
+    /* If the BrowsePath is empty, the Node is the instance of the
+     * TypeDefinition. (Part 4, 7.4.4.5) */
+    if(sao->browsePathSize == 0)
+        return UA_STATUSCODE_GOOD;
+
     /* EventType is a subtype of BaseEventType? */
     UA_NodeId baseEventTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
     if(!isNodeInTree_singleRef(server, &sao->typeDefinitionId,
@@ -1134,11 +1139,6 @@ UA_SimpleAttributeOperandValidation(UA_Server *server,
     /* AttributeId is valid ? */
     if(sao->attributeId == 0 || sao->attributeId >= 28)
         return UA_STATUSCODE_BADATTRIBUTEIDINVALID;
-
-    /* If the BrowsePath is empty, the Node is the instance of the
-     * TypeDefinition. (Part 4, 7.4.4.5) */
-    if(sao->browsePathSize == 0)
-        return UA_STATUSCODE_GOOD;
 
     /* BrowsePath contains empty BrowseNames? */
     for(size_t j = 0; j < sao->browsePathSize; ++j) {


### PR DESCRIPTION
Hi,

we are currently trying to integrate version 1.4.0-rc2 (from 1.3.6). If we subscribe to the EventSource in the UAExpert (v1.7.1) now, the Tool returns an error "Item 0 failed with error BadTypeDefinitionInvalid." and cancel the event subscription.
This also happens in the example project (tutorial_server_events). 
We use the REDUCED namespace, if we switch to the FULL namespace the event subscription works but this is not an option for us.

If we adjust the order of the clause validation in the ua_subscription_events_filter.c (like in 1.3.6) the event subscription works again.
