### PR TITLE
[REVIEW] Fix a memory leak for the PKI CertContext

### DIFF
--- a/plugins/crypto/mbedtls/ua_pki_mbedtls.c
+++ b/plugins/crypto/mbedtls/ua_pki_mbedtls.c
@@ -691,6 +691,7 @@ UA_CertificateVerification_CertFolders(UA_CertificateVerification *cv,
                                        const char *issuerListFolder,
                                        const char *revocationListFolder) {
 #endif
+    UA_StatusCode ret;
     if(cv == NULL) {
         return UA_STATUSCODE_BADINTERNALERROR;
     }
@@ -719,14 +720,14 @@ UA_CertificateVerification_CertFolders(UA_CertificateVerification *cv,
     ci->rejectedListFolder = UA_STRING_ALLOC(rejectedListFolder);
 #endif
 
-    reloadCertificates(cv, ci);
-
     cv->context = (void*)ci;
     cv->verifyCertificate = certificateVerification_verify;
     cv->clear = certificateVerification_clear;
     cv->verifyApplicationURI = certificateVerification_verifyApplicationURI;
 
-    return UA_STATUSCODE_GOOD;
+    ret = reloadCertificates(cv, ci);
+
+    return ret;
 }
 
 #endif

--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -747,10 +747,6 @@ UA_CertificateVerification_Trustlist(UA_CertificateVerification * cv,
     if (context == NULL) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    ret = UA_CertContext_Init (context, cv);
-    if (ret != UA_STATUSCODE_GOOD) {
-        return ret;
-    }
 
     cv->verifyApplicationURI = UA_CertificateVerification_VerifyApplicationURI;
     cv->clear = UA_CertificateVerification_clear;
@@ -760,6 +756,11 @@ UA_CertificateVerification_Trustlist(UA_CertificateVerification * cv,
     cv->getExpirationDate     = UA_GetCertificate_ExpirationDate;
 #endif
     cv->getSubjectName = UA_GetCertificate_SubjectName;
+
+    ret = UA_CertContext_Init (context, cv);
+    if (ret != UA_STATUSCODE_GOOD) {
+        return ret;
+    }
     
     if (certificateTrustListSize > 0) {
         if (UA_skTrusted_Cert2X509 (certificateTrustList, certificateTrustListSize,
@@ -814,15 +815,16 @@ UA_CertificateVerification_CertFolders(UA_CertificateVerification * cv,
     if (context == NULL) {
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    ret = UA_CertContext_Init (context, cv);
-    if (ret != UA_STATUSCODE_GOOD) {
-        return ret;
-    }
 
     cv->verifyApplicationURI = UA_CertificateVerification_VerifyApplicationURI;
     cv->clear = UA_CertificateVerification_clear;
     cv->context = context;
     cv->verifyCertificate = UA_CertificateVerification_Verify;
+
+    ret = UA_CertContext_Init (context, cv);
+    if (ret != UA_STATUSCODE_GOOD) {
+        return ret;
+    }
 
     /* Only set the folder paths. They will be reloaded during runtime. */
 


### PR DESCRIPTION
If an error occurs in the UA_CertContext_Init function, the allocated memory is not released because the context and clear function in the UA_CertificateVerification structure are not set before the function returns.