### PR TITLE
fix(plugin): return status code from mbedtls_hmac.

### DIFF
--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.c
@@ -22,12 +22,23 @@ swapBuffers(UA_ByteString *const bufA, UA_ByteString *const bufB) {
     *bufB = tmp;
 }
 
-void
+UA_StatusCode
 mbedtls_hmac(mbedtls_md_context_t *context, const UA_ByteString *key,
              const UA_ByteString *in, unsigned char *out) {
-    mbedtls_md_hmac_starts(context, key->data, key->length);
-    mbedtls_md_hmac_update(context, in->data, in->length);
-    mbedtls_md_hmac_finish(context, out);
+    UA_StatusCode retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
+    if(mbedtls_md_hmac_starts(context, key->data, key->length) == 0)
+    {
+        if(mbedtls_md_hmac_update(context, in->data, in->length) == 0)
+        {
+            if(mbedtls_md_hmac_finish(context, out) != 0)
+            {
+                retval = UA_STATUSCODE_GOOD;
+            }
+        }
+    }
+
+    return retval;
 }
 
 UA_StatusCode
@@ -58,7 +69,13 @@ mbedtls_generateKey(mbedtls_md_context_t *context,
         ANext_and_seed.data
     };
 
-    mbedtls_hmac(context, secret, seed, A.data);
+    UA_StatusCode retval = mbedtls_hmac(context, secret, seed, A.data);
+
+    if(retval != UA_STATUSCODE_GOOD){
+        UA_ByteString_clear(&A_and_seed);
+        UA_ByteString_clear(&ANext_and_seed);
+        return retval;
+    }
 
     for(size_t offset = 0; offset < out->length; offset += hashLen) {
         UA_ByteString outSegment = {
@@ -66,7 +83,6 @@ mbedtls_generateKey(mbedtls_md_context_t *context,
             out->data + offset
         };
         UA_Boolean bufferAllocated = UA_FALSE;
-        UA_StatusCode retval = 0;
         // Not enough room in out buffer to write the hash.
         if(offset + hashLen > out->length) {
             outSegment.data = NULL;
@@ -80,8 +96,18 @@ mbedtls_generateKey(mbedtls_md_context_t *context,
             bufferAllocated = UA_TRUE;
         }
 
-        mbedtls_hmac(context, secret, &A_and_seed, outSegment.data);
-        mbedtls_hmac(context, secret, &A, ANext.data);
+        retval = mbedtls_hmac(context, secret, &A_and_seed, outSegment.data);
+        if(retval != UA_STATUSCODE_GOOD){
+            UA_ByteString_clear(&A_and_seed);
+            UA_ByteString_clear(&ANext_and_seed);
+            return retval;
+        }
+        retval = mbedtls_hmac(context, secret, &A, ANext.data);
+        if(retval != UA_STATUSCODE_GOOD){
+            UA_ByteString_clear(&A_and_seed);
+            UA_ByteString_clear(&ANext_and_seed);
+            return retval;
+        }
 
         if(bufferAllocated) {
             memcpy(out->data + offset, outSegment.data, out->length - offset);

--- a/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
+++ b/plugins/crypto/mbedtls/securitypolicy_mbedtls_common.h
@@ -24,7 +24,7 @@ _UA_BEGIN_DECLS
 void
 swapBuffers(UA_ByteString *const bufA, UA_ByteString *const bufB);
 
-void
+UA_StatusCode
 mbedtls_hmac(mbedtls_md_context_t *context, const UA_ByteString *key,
              const UA_ByteString *in, unsigned char *out);
 

--- a/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_aes128sha256rsaoaep.c
@@ -261,7 +261,8 @@ sym_verify_sp_aes128sha256rsaoaep(Aes128Sha256PsaOaep_ChannelContext *cc,
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
     Aes128Sha256PsaOaep_PolicyContext *pc = cc->policyContext;
     unsigned char mac[UA_SHA256_LENGTH];
-    mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
+    if(!mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA256_LENGTH))
@@ -276,8 +277,10 @@ sym_sign_sp_aes128sha256rsaoaep(const Aes128Sha256PsaOaep_ChannelContext *cc,
     if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
-                 message, signature->data);
+    if(!mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
+                     message, signature->data))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
     return UA_STATUSCODE_GOOD;
 }
 

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic128rsa15.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic128rsa15.c
@@ -284,7 +284,8 @@ sym_verify_sp_basic128rsa15(Basic128Rsa15_ChannelContext *cc,
     Basic128Rsa15_PolicyContext *pc = cc->policyContext;
 
     unsigned char mac[UA_SHA1_LENGTH];
-    mbedtls_hmac(&pc->sha1MdContext, &cc->remoteSymSigningKey, message, mac);
+    if(!mbedtls_hmac(&pc->sha1MdContext, &cc->remoteSymSigningKey, message, mac))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA1_LENGTH))
@@ -299,8 +300,10 @@ sym_sign_sp_basic128rsa15(const Basic128Rsa15_ChannelContext *cc,
     if(signature->length != UA_SHA1_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    mbedtls_hmac(&cc->policyContext->sha1MdContext, &cc->localSymSigningKey,
-                 message, signature->data);
+    if(!mbedtls_hmac(&cc->policyContext->sha1MdContext, &cc->localSymSigningKey,
+                     message, signature->data))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
     return UA_STATUSCODE_GOOD;
 }
 

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256.c
@@ -214,7 +214,8 @@ sym_verify_sp_basic256(Basic256_ChannelContext *cc,
     Basic256_PolicyContext *pc = cc->policyContext;
 
     unsigned char mac[UA_SHA1_LENGTH];
-    mbedtls_hmac(&pc->sha1MdContext, &cc->remoteSymSigningKey, message, mac);
+    if(!mbedtls_hmac(&pc->sha1MdContext, &cc->remoteSymSigningKey, message, mac))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA1_LENGTH))
@@ -228,8 +229,10 @@ sym_sign_sp_basic256(const Basic256_ChannelContext *cc,
     if(signature->length != UA_SHA1_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    mbedtls_hmac(&cc->policyContext->sha1MdContext, &cc->localSymSigningKey,
-                 message, signature->data);
+    if(!mbedtls_hmac(&cc->policyContext->sha1MdContext, &cc->localSymSigningKey,
+                     message, signature->data))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
     return UA_STATUSCODE_GOOD;
 }
 

--- a/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
+++ b/plugins/crypto/mbedtls/ua_securitypolicy_basic256sha256.c
@@ -264,7 +264,8 @@ sym_verify_sp_basic256sha256(Basic256Sha256_ChannelContext *cc,
 
     Basic256Sha256_PolicyContext *pc = cc->policyContext;
     unsigned char mac[UA_SHA256_LENGTH];
-    mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac);
+    if(!mbedtls_hmac(&pc->sha256MdContext, &cc->remoteSymSigningKey, message, mac))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
 
     /* Compare with Signature */
     if(!UA_constantTimeEqual(signature->data, mac, UA_SHA256_LENGTH))
@@ -279,8 +280,10 @@ sym_sign_sp_basic256sha256(const Basic256Sha256_ChannelContext *cc,
     if(signature->length != UA_SHA256_LENGTH)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
-                 message, signature->data);
+    if(!mbedtls_hmac(&cc->policyContext->sha256MdContext, &cc->localSymSigningKey,
+                     message, signature->data))
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+
     return UA_STATUSCODE_GOOD;
 }
 


### PR DESCRIPTION
mbedtls_md_hmac_starts, mbedtls_md_hmac_update and mbedtls_md_hmac_finish is function calls in mbedtls_hmac which returns (int) status code. In current implementation the status is ignored which could cause different problems.
In this PR mbedtls_hmac returns status codes instead of void, UA_STATUSCODE_GOOD (0x0) on success and
UA_STATUSCODE_BADSECURITYCHECKSFAILED (0x8013) if something went wrong. This way we can return faster when a error occur. This update may also help remove static code analysis errors like "Unchecked return value"