### PR TITLE
[Review] style: fix shadow var found from "gcc -Wshadow"

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -22,14 +22,14 @@
 static UA_StatusCode
 setApplicationDescriptionFromRegisteredServer(const UA_FindServersRequest *request,
                                               UA_ApplicationDescription *target,
-                                              const UA_RegisteredServer *registeredServer) {
+                                              const UA_RegisteredServer *rs) {
     UA_ApplicationDescription_init(target);
     UA_StatusCode retval =
-        UA_String_copy(&registeredServer->serverUri, &target->applicationUri);
+        UA_String_copy(&rs->serverUri, &target->applicationUri);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
-    retval = UA_String_copy(&registeredServer->productUri, &target->productUri);
+    retval = UA_String_copy(&rs->productUri, &target->productUri);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
@@ -37,10 +37,10 @@ setApplicationDescriptionFromRegisteredServer(const UA_FindServersRequest *reque
     if(request->localeIdsSize) {
         UA_Boolean appNameFound = false;
         for(size_t i =0; i<request->localeIdsSize && !appNameFound; i++) {
-            for(size_t j =0; j<registeredServer->serverNamesSize; j++) {
+            for(size_t j =0; j<rs->serverNamesSize; j++) {
                 if(UA_String_equal(&request->localeIds[i],
-                                   &registeredServer->serverNames[j].locale)) {
-                    retval = UA_LocalizedText_copy(&registeredServer->serverNames[j],
+                                   &rs->serverNames[j].locale)) {
+                    retval = UA_LocalizedText_copy(&rs->serverNames[j],
                                                    &target->applicationName);
                     if(retval != UA_STATUSCODE_GOOD)
                         return retval;
@@ -52,34 +52,34 @@ setApplicationDescriptionFromRegisteredServer(const UA_FindServersRequest *reque
 
         // server does not have the requested local, therefore we can select the
         // most suitable one
-        if(!appNameFound && registeredServer->serverNamesSize) {
-            retval = UA_LocalizedText_copy(&registeredServer->serverNames[0],
+        if(!appNameFound && rs->serverNamesSize) {
+            retval = UA_LocalizedText_copy(&rs->serverNames[0],
                                            &target->applicationName);
             if(retval != UA_STATUSCODE_GOOD)
                 return retval;
         }
-    } else if(registeredServer->serverNamesSize) {
+    } else if(rs->serverNamesSize) {
         // just take the first name
-        retval = UA_LocalizedText_copy(&registeredServer->serverNames[0],
+        retval = UA_LocalizedText_copy(&rs->serverNames[0],
                                        &target->applicationName);
         if(retval != UA_STATUSCODE_GOOD)
             return retval;
     }
 
-    target->applicationType = registeredServer->serverType;
-    retval = UA_String_copy(&registeredServer->gatewayServerUri, &target->gatewayServerUri);
+    target->applicationType = rs->serverType;
+    retval = UA_String_copy(&rs->gatewayServerUri, &target->gatewayServerUri);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
     // TODO where do we get the discoveryProfileUri for application data?
 
-    target->discoveryUrlsSize = registeredServer->discoveryUrlsSize;
-    if(registeredServer->discoveryUrlsSize) {
-        size_t duSize = sizeof(UA_String) * registeredServer->discoveryUrlsSize;
+    target->discoveryUrlsSize = rs->discoveryUrlsSize;
+    if(rs->discoveryUrlsSize) {
+        size_t duSize = sizeof(UA_String) * rs->discoveryUrlsSize;
         target->discoveryUrls = (UA_String *)UA_malloc(duSize);
         if(!target->discoveryUrls)
             return UA_STATUSCODE_BADOUTOFMEMORY;
-        for(size_t i = 0; i < registeredServer->discoveryUrlsSize; i++) {
-            retval = UA_String_copy(&registeredServer->discoveryUrls[i],
+        for(size_t i = 0; i < rs->discoveryUrlsSize; i++) {
+            retval = UA_String_copy(&rs->discoveryUrls[i],
                                     &target->discoveryUrls[i]);
             if(retval != UA_STATUSCODE_GOOD)
                 return retval;

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -704,7 +704,7 @@ UA_Subscription_publish(UA_Server *server, UA_Subscription *sub) {
         sub->delayedMoreNotifications.application = server;
         sub->delayedMoreNotifications.context = sub;
 
-        UA_EventLoop *el = server->config.eventLoop;
+        el = server->config.eventLoop;
         el->addDelayedCallback(el, &sub->delayedMoreNotifications);
     }
 }

--- a/src/server/ua_subscription_monitoreditem.c
+++ b/src/server/ua_subscription_monitoreditem.c
@@ -329,7 +329,7 @@ UA_Notification_enqueueAndTrigger(UA_Server *server, UA_Notification *n) {
         sub->delayedMoreNotifications.application = server;
         sub->delayedMoreNotifications.context = sub;
 
-        UA_EventLoop *el = server->config.eventLoop;
+        el = server->config.eventLoop;
         el->addDelayedCallback(el, &sub->delayedMoreNotifications);
     }
 }

--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -2244,7 +2244,7 @@ getArrayUnwrapType(ParseCtx *ctx, size_t arrayIndex) {
 
         /* Check for non-JSON encoding */
         size_t encIndex = 0;
-        UA_StatusCode ret = lookAheadForKey(ctx, UA_JSONKEY_ENCODING, &encIndex);
+        ret = lookAheadForKey(ctx, UA_JSONKEY_ENCODING, &encIndex);
         if(ret == UA_STATUSCODE_GOOD) {
             ctx->index = oldIndex; /* Restore the index */
             return NULL;


### PR DESCRIPTION
Compiling with "gcc -Wshadow" shows a few shadow vars, this patch is fixing them.


I am very new to open62541, so please forgive if something is not fully complient with
how patch requests should be sent in.

open62541 compile flags are already very strict, but it seems that "-Wshadow" is still missing
and might be a good addition to the default flags. Also I have just done a standard compile,
but not looked at tests or all possible compile targets.

Comments?

best regards and thanks for open62541,

Florian La Roche
