### PR TITLE
fix (tools): Make ua2json compile under Windows

### DIFF
--- a/tools/ua2json/ua2json.c
+++ b/tools/ua2json/ua2json.c
@@ -10,7 +10,12 @@
 #include <open62541/types_generated_handling.h>
 
 #include <stdio.h>
+#if defined(_MSC_VER)
+# include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
 #include <unistd.h>
+#endif
 
 /* Internal headers */
 #include "ua_pubsub_networkmessage.h"


### PR DESCRIPTION
With this addition the UA_BUILD_TOOLS option in CMake can be enabled