### PR TITLE
Update ua_eventfilter_parser.c: Add missing include stdlib.h

### DIFF
--- a/src/util/ua_eventfilter_parser.c
+++ b/src/util/ua_eventfilter_parser.c
@@ -11,6 +11,8 @@
 #include "cj5.h"
 #include "mp_printf.h"
 
+#include <stdlib.h>
+
 static UA_Parsed_Element_List *
 create_next_operator_element(UA_Element_List *elements) {
     UA_Parsed_Element_List *element = (UA_Parsed_Element_List*)


### PR DESCRIPTION
This fixes clang-18 errors:

```
[ 42%] Building C object CMakeFiles/open62541-object.dir/src/util/ua_eventfilter_parser.c.o
/src/open62541/src/util/ua_eventfilter_parser.c:37:5: error: call to undeclared library function 'free' with type 'void (void *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   37 |     free(ref);
      |     ^
/src/open62541/src/util/ua_eventfilter_parser.c:37:5: note: include the header <stdlib.h> or explicitly provide a declaration for 'free'
/src/open62541/src/util/ua_eventfilter_parser.c:720:31: error: call to undeclared library function 'strtod' with type 'double (const char *, char **)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  720 |     UA_Float val = (UA_Float) strtod(yytext, NULL);
      |                               ^
/src/open62541/src/util/ua_eventfilter_parser.c:720:31: note: include the header <stdlib.h> or explicitly provide a declaration for 'strtod'
/src/open62541/src/util/ua_eventfilter_parser.c:732:31: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  732 |     UA_SByte val = (UA_SByte) atoi(yytext);
      |                               ^
/src/open62541/src/util/ua_eventfilter_parser.c:738:36: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  738 |     UA_StatusCode val = (uint32_t) atoi(yytext);
      |                                    ^
/src/open62541/src/util/ua_eventfilter_parser.c:774:29: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  774 |     UA_Byte val = (UA_Byte) atoi(yytext);
      |                             ^
/src/open62541/src/util/ua_eventfilter_parser.c:811:31: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  811 |     UA_Int64 val = (UA_Int64) atoi(yytext);
      |                               ^
/src/open62541/src/util/ua_eventfilter_parser.c:823:33: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  823 |     UA_UInt16 val = (UA_UInt16) atoi(yytext);
      |                                 ^
/src/open62541/src/util/ua_eventfilter_parser.c:829:33: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  829 |     UA_UInt32 val = (UA_UInt32) atoi(yytext);
      |                                 ^
/src/open62541/src/util/ua_eventfilter_parser.c:835:33: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  835 |     UA_UInt64 val = (UA_UInt64) atoi(yytext);
      |                                 ^
/src/open62541/src/util/ua_eventfilter_parser.c:841:31: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  841 |     UA_Int16 val = (UA_Int16) atoi(yytext);
      |                               ^
/src/open62541/src/util/ua_eventfilter_parser.c:847:31: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  847 |     UA_Int32 val = (UA_Int32) atoi(yytext);
      |                               ^
11 errors generated.
make[2]: *** [CMakeFiles/open62541-object.dir/build.make:898: CMakeFiles/open62541-object.dir/src/util/ua_eventfilter_parser.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:309: CMakeFiles/open62541-object.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
ERROR:__main__:Building fuzzers failed.
