### PR TITLE
fix(pubsub): Make function definition match the data types from the function declaration

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -443,7 +443,7 @@ DataSetReader_updateConfig(UA_Server *server, UA_ReaderGroup *rg, UA_DataSetRead
 }
 
 UA_StatusCode
-UA_Server_DataSetReader_updateConfig(UA_Server *server, UA_NodeId dataSetReaderIdentifier,
+UA_Server_DataSetReader_updateConfig(UA_Server *server, const UA_NodeId dataSetReaderIdentifier,
                                      UA_NodeId readerGroupIdentifier,
                                      const UA_DataSetReaderConfig *config) {
     if(config == NULL)
@@ -462,7 +462,7 @@ UA_Server_DataSetReader_updateConfig(UA_Server *server, UA_NodeId dataSetReaderI
 }
 
 UA_StatusCode
-UA_Server_DataSetReader_getConfig(UA_Server *server, UA_NodeId dataSetReaderIdentifier,
+UA_Server_DataSetReader_getConfig(UA_Server *server, const UA_NodeId dataSetReaderIdentifier,
                                  UA_DataSetReaderConfig *config) {
     if(!config)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -690,7 +690,7 @@ DataSetReader_createTargetVariables(UA_Server *server, UA_DataSetReader *dsr,
 
 UA_StatusCode
 UA_Server_DataSetReader_createTargetVariables(UA_Server *server,
-                                              UA_NodeId dataSetReaderIdentifier,
+                                              const UA_NodeId dataSetReaderIdentifier,
                                               size_t targetVariablesSize,
                                               const UA_FieldTargetVariable *targetVariables) {
     UA_LOCK(&server->serviceMutex);

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -191,7 +191,7 @@ UA_ReaderGroup_create(UA_Server *server, UA_NodeId connectionId,
 }
 
 UA_StatusCode
-UA_Server_addReaderGroup(UA_Server *server, UA_NodeId connectionIdentifier,
+UA_Server_addReaderGroup(UA_Server *server, const UA_NodeId connectionIdentifier,
                          const UA_ReaderGroupConfig *readerGroupConfig,
                          UA_NodeId *readerGroupIdentifier) {
     UA_LOCK(&server->serviceMutex);
@@ -273,7 +273,7 @@ UA_ReaderGroup_remove(UA_Server *server, UA_ReaderGroup *rg) {
 }
 
 UA_StatusCode
-UA_Server_removeReaderGroup(UA_Server *server, UA_NodeId groupIdentifier) {
+UA_Server_removeReaderGroup(UA_Server *server, const UA_NodeId groupIdentifier) {
     UA_LOCK(&server->serviceMutex);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, groupIdentifier);
@@ -284,7 +284,7 @@ UA_Server_removeReaderGroup(UA_Server *server, UA_NodeId groupIdentifier) {
 }
 
 UA_StatusCode
-UA_Server_ReaderGroup_getConfig(UA_Server *server, UA_NodeId readerGroupIdentifier,
+UA_Server_ReaderGroup_getConfig(UA_Server *server, const UA_NodeId readerGroupIdentifier,
                                 UA_ReaderGroupConfig *config) {
     if(!config)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -307,7 +307,7 @@ UA_Server_ReaderGroup_getConfig(UA_Server *server, UA_NodeId readerGroupIdentifi
 }
 
 UA_StatusCode
-UA_Server_ReaderGroup_getState(UA_Server *server, UA_NodeId readerGroupIdentifier,
+UA_Server_ReaderGroup_getState(UA_Server *server, const UA_NodeId readerGroupIdentifier,
                                UA_PubSubState *state) {
     if((server == NULL) || (state == NULL))
         return UA_STATUSCODE_BADINVALIDARGUMENT;

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -52,7 +52,7 @@ UA_Server_getDataSetWriterConfig(UA_Server *server, const UA_NodeId dsw,
 }
 
 UA_StatusCode
-UA_Server_DataSetWriter_getState(UA_Server *server, UA_NodeId dataSetWriterIdentifier,
+UA_Server_DataSetWriter_getState(UA_Server *server, const UA_NodeId dataSetWriterIdentifier,
                                UA_PubSubState *state) {
     if((server == NULL) || (state == NULL))
         return UA_STATUSCODE_BADINVALIDARGUMENT;

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -641,7 +641,7 @@ UA_WriterGroup_updateConfig(UA_Server *server, UA_WriterGroup *wg,
 }
 
 UA_StatusCode
-UA_Server_updateWriterGroupConfig(UA_Server *server, UA_NodeId writerGroupIdentifier,
+UA_Server_updateWriterGroupConfig(UA_Server *server, const UA_NodeId writerGroupIdentifier,
                                   const UA_WriterGroupConfig *config) {
     UA_LOCK(&server->serviceMutex);
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroupIdentifier);
@@ -656,7 +656,7 @@ UA_Server_updateWriterGroupConfig(UA_Server *server, UA_NodeId writerGroupIdenti
 }
 
 UA_StatusCode
-UA_Server_WriterGroup_getState(UA_Server *server, UA_NodeId writerGroupIdentifier,
+UA_Server_WriterGroup_getState(UA_Server *server, const UA_NodeId writerGroupIdentifier,
                                UA_PubSubState *state) {
     if((server == NULL) || (state == NULL))
         return UA_STATUSCODE_BADINVALIDARGUMENT;


### PR DESCRIPTION
The const qualifier is missing from the function definition compared to the function declaration. And these parameters can be constant. This gives compiler warnings in Visual C.