### PR TITLE
fix(util): Fix "direct" parsing of NodeId/ExpandedNodeId/Guid in Even…

### DIFF
--- a/src/util/ua_eventfilter_parser.c
+++ b/src/util/ua_eventfilter_parser.c
@@ -113,8 +113,19 @@ parse_literal(OperandList *ol, char *yytext, const UA_DataType *type) {
     void *data = UA_new(type);
     if(!data)
         return on;
+
+    UA_StatusCode res;
     UA_String src = UA_STRING(yytext);
-    UA_StatusCode res = UA_decodeJson(&src, data, type, NULL);
+    if(type == &UA_TYPES[UA_TYPES_NODEID]) {
+        res = UA_NodeId_parse((UA_NodeId*)data, src);
+    } else if(type == &UA_TYPES[UA_TYPES_EXPANDEDNODEID]) {
+        res = UA_ExpandedNodeId_parse((UA_ExpandedNodeId*)data, src);
+    } else if(type == &UA_TYPES[UA_TYPES_GUID]) {
+        res = UA_Guid_parse((UA_Guid*)data, src);
+    } else {
+        res = UA_decodeJson(&src, data, type, NULL);
+    }
+
     if(res != UA_STATUSCODE_GOOD) {
         UA_free(data);
         return on;

--- a/tests/server/check_eventfilter_parser.c
+++ b/tests/server/check_eventfilter_parser.c
@@ -21,6 +21,11 @@ START_TEST(Case_1) {
     UA_String case1 = UA_STRING(inp);
     UA_StatusCode res = UA_EventFilter_parse(&filter, &case1);
     ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_NodeId typeId = UA_NODEID_NUMERIC(1, 5001);
+    UA_ContentFilterElement *elm = &filter.whereClause.elements[0];
+    UA_LiteralOperand *op = (UA_LiteralOperand*)elm->filterOperands[0].content.decoded.data;
+    ck_assert(UA_NodeId_equal(&typeId, (UA_NodeId*)op->value.data));
     UA_EventFilter_clear(&filter);
 } END_TEST
 


### PR DESCRIPTION
…tFilter expressions