### PR TITLE
fix(pubsub): export two functions used in examples\server_pubsub_file_configuration.exe

### DIFF
--- a/include/open62541/pubsub.h
+++ b/include/open62541/pubsub.h
@@ -17,6 +17,19 @@ _UA_BEGIN_DECLS
 
 #ifdef UA_ENABLE_PUBSUB
 
+#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
+/* Decodes the information from the ByteString. If the decoded content is a
+ * PubSubConfiguration in a UABinaryFileDataType-object. It will overwrite the
+ * current PubSub configuration from the server. */
+UA_EXPORT UA_StatusCode
+UA_PubSubManager_loadPubSubConfigFromByteString(UA_Server *server,
+                                                const UA_ByteString buffer);
+
+/* Saves the current PubSub configuration of a server in a byteString. */
+UA_EXPORT UA_StatusCode
+UA_PubSubManager_getEncodedPubSubConfiguration(UA_Server *server, UA_ByteString *buffer);
+#endif
+
 /**
  * .. _pubsub-messages:
  *

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -870,20 +870,6 @@ void
 UA_PubSubManager_generateUniqueNodeId(UA_PubSubManager *psm, UA_NodeId *nodeId);
 #endif
 
-#ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
-/* Decodes the information from the ByteString. If the decoded content is a
- * PubSubConfiguration in a UABinaryFileDataType-object. It will overwrite the
- * current PubSub configuration from the server. */
-UA_StatusCode
-UA_PubSubManager_loadPubSubConfigFromByteString(UA_Server *server,
-                                                const UA_ByteString buffer);
-
-/* Saves the current PubSub configuration of a server in a byteString. */
-UA_StatusCode
-UA_PubSubManager_getEncodedPubSubConfiguration(UA_Server *server,
-                                               UA_ByteString *buffer);
-#endif
-
 UA_Guid
 UA_PubSubManager_generateUniqueGuid(UA_Server *server);
 


### PR DESCRIPTION
This allows to compile this example under Windows with an open62541 shared library