### PR TITLE
fix(pubsub): Allow interface name for multicast

### DIFF
--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -22,6 +22,7 @@
 #include <poll.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <ifaddrs.h>
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 # include <sys/param.h>

--- a/include/open62541/plugin/eventloop.h
+++ b/include/open62541/plugin/eventloop.h
@@ -516,7 +516,8 @@ UA_ConnectionManager_new_POSIX_TCP(const UA_String eventSourceName);
  *
  * 0:interface [string]
  *    Network interface for listening or sending (e.g. when using multicast
- *    addresses)
+ *    addresses). Can be either the IP address of the network interface
+ *    or the interface name (e.g. 'eth0').
  *
  * 0:ttl [uint32]
  *    Multicast time to live, (optional, default: 1 - meaning multicast is
@@ -541,7 +542,7 @@ UA_ConnectionManager_new_POSIX_TCP(const UA_String eventSourceName);
  *    creating any connection but solely validating the provided parameters
  *    (default: false)
  *
- * **Connection Callback Paramters:**
+ * **Connection Callback Parameters:**
  *
  * 0:remote-address [string]
  *    Contains the remote IP address.


### PR DESCRIPTION
In case of multicast configuration only an IP address was allowed
for the network interface. Now also network interface names can be
used.