### PR TITLE
problem to add values with status other than good

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -658,7 +658,8 @@ readWithReadValue(UA_Server *server, const UA_NodeId *nodeId,
 
     /* Check the return value */
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    if(dv.hasStatus)
+    /* The status may be uncertain */
+    if(dv.hasStatus && dv.status >= UA_STATUSCODE_BAD)
         retval = dv.status;
     else if(!dv.hasValue)
         retval = UA_STATUSCODE_BADUNEXPECTEDERROR;


### PR DESCRIPTION
If the status of a variable node is other than "good" you are not able to add the value to the datastore.

This is only a workaround to allow add variable with "uncertain" status.

Normaly you can allso have variable with "BADCOMMUNICATIONERROR" or other.
may be we have to change:

```
UA_DataValue
UA_Server_readWithSession(UA_Server *server, UA_Session *session,
                          const UA_ReadValueId *item,
                          UA_TimestampsToReturn timestampsToReturn);

```
to:
```
UA_StatusCode
UA_Server_readWithSession(UA_Server *server, UA_Session *session,
                          const UA_ReadValueId *item,
                          UA_TimestampsToReturn timestampsToReturn, UA_DataValue *dv)

```
to get full information with UA_DataValue and UA_StatusCode

Please check this, if you think it's the right way, i can change th code and make a pull request.
