### PR TITLE
(#6414) Fix compilation failures on FreeBSD

### DIFF
--- a/arch/posix/ua_architecture.h
+++ b/arch/posix/ua_architecture.h
@@ -14,6 +14,7 @@
 
 #include <errno.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netdb.h>
 #include <sys/ioctl.h>

--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -127,9 +127,14 @@
  * POSIX Feature Flags
  * -------------------
  * These feature flags have to be set before including the first POSIX
- * header. */
+ * header.
+ *
+ * Special note for FreeBSD: Defining _XOPEN_SOURCE will hide lots of socket
+ * definitions as they are not defined by POSIX. Defining _BSD_SOURCE will
+ * not help as the symbols undergo a consistency check and get adjusted in
+ * the headers. */
 #ifdef UA_ARCHITECTURE_POSIX
-# if !defined(_XOPEN_SOURCE)
+# if !defined(_XOPEN_SOURCE) && !defined(__FreeBSD__)
 #  define _XOPEN_SOURCE 600
 # endif
 # ifndef _DEFAULT_SOURCE


### PR DESCRIPTION
Please refer to the commit message and the referenced issue for details.

As a minor note: Defining `_XOPEN_SOURCE` to 600 should lock down the compilation environment to a strict POSIX compliant environment.
This means that BSD socket features are unavailable. Presumably this is fine on glibc Linux systems however a lot of other Unix Systems won't allow this (and so does FreeBSD).

Probably a better solution to this problem is to check whether it is safe to define `_XOPEN_SOURCE` during the configure stage.
