### PR TITLE
Cleanup

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -397,7 +397,12 @@ struct UA_ServerConfig {
 };
 
 void UA_EXPORT
-UA_ServerConfig_clean(UA_ServerConfig *config);
+UA_ServerConfig_clear(UA_ServerConfig *config);
+
+UA_DEPRECATED static UA_INLINE void
+UA_ServerConfig_clean(UA_ServerConfig *config) {
+	UA_ServerConfig_clear(config);
+}
 
 /**
  * .. _server-lifecycle:

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1154,10 +1154,9 @@ UA_INLINABLE(void
 UA_StatusCode UA_EXPORT
 UA_copy(const void *src, void *dst, const UA_DataType *type);
 
-/* Deletes the dynamically allocated content of a variable (e.g. resets all
- * arrays to undefined arrays). Afterwards, the variable can be safely deleted
- * without causing memory leaks. But the variable is not initialized and may
- * contain old data that is not memory-relevant.
+/* Deletes the dynamically allocated content of a variable (e.g. deallocates all
+ * arrays in the variable). Also initializes the variable to default values.
+ * Afterwards, the variable can be safely deleted without causing memory leaks.
  *
  * @param p The memory location of the variable
  * @param type The datatype description of the variable */

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -628,7 +628,7 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
 
     UA_StatusCode retval = setDefaultConfig(config, portNumber);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
@@ -638,14 +638,14 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     /* Allocate the SecurityPolicies */
     retval = UA_ServerConfig_addSecurityPolicyNone(config, certificate);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
     /* Initialize the Access Control plugin */
     retval = UA_AccessControl_default(config, true, NULL, 0, NULL);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
@@ -653,7 +653,7 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     retval = UA_ServerConfig_addEndpoint(config, UA_SECURITY_POLICY_NONE_URI,
                                          UA_MESSAGESECURITYMODE_NONE);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
@@ -965,7 +965,7 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
                                                size_t revocationListSize) {
     UA_StatusCode retval = setDefaultConfig(conf, portNumber);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
@@ -989,13 +989,13 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
         retval = UA_AccessControl_default(conf, true, NULL, 0, NULL);
     }
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
     retval = UA_ServerConfig_addAllEndpoints(conf);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
@@ -1015,7 +1015,7 @@ UA_ServerConfig_setDefaultWithSecureSecurityPolicies(UA_ServerConfig *conf,
                                                size_t revocationListSize) {
     UA_StatusCode retval = setDefaultConfig(conf, portNumber);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
@@ -1039,13 +1039,13 @@ UA_ServerConfig_setDefaultWithSecureSecurityPolicies(UA_ServerConfig *conf,
         retval = UA_AccessControl_default(conf, false, NULL, 0, NULL);
     }
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
     retval = UA_ServerConfig_addAllSecureEndpoints(conf);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
     conf->securityPolicyNoneDiscoveryOnly = true;

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -219,7 +219,7 @@ UA_Client_clear(UA_Client *client) {
 
     /* Delete the subscriptions */
 #ifdef UA_ENABLE_SUBSCRIPTIONS
-    __Client_Subscriptions_clean(client);
+    __Client_Subscriptions_clear(client);
 #endif
 
     /* Remove the internal regular callback */

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -2181,7 +2181,7 @@ cleanupSession(UA_Client *client) {
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /* We need to clean up the subscriptions */
-    __Client_Subscriptions_clean(client);
+    __Client_Subscriptions_clear(client);
 #endif
 
     /* Delete outstanding async services */

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -64,7 +64,7 @@ typedef struct UA_Client_Subscription {
 } UA_Client_Subscription;
 
 void
-__Client_Subscriptions_clean(UA_Client *client);
+__Client_Subscriptions_clear(UA_Client *client);
 
 /* Exposed for fuzzing */
 UA_StatusCode

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -1325,7 +1325,7 @@ processPublishResponseAsync(UA_Client *client, void *userdata,
 }
 
 void
-__Client_Subscriptions_clean(UA_Client *client) {
+__Client_Subscriptions_clear(UA_Client *client) {
     UA_Client_NotificationsAckNumber *n;
     UA_Client_NotificationsAckNumber *tmp;
     LIST_FOREACH_SAFE(n, &client->pendingNotificationsAcks, listEntry, tmp) {

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -297,7 +297,7 @@ UA_Server_delete(UA_Server *server) {
     UA_UNLOCK(&server->serviceMutex); /* The timer has its own mutex */
 
     /* Clean up the config */
-    UA_ServerConfig_clean(&server->config);
+    UA_ServerConfig_clear(&server->config);
 
 #if UA_MULTITHREADING >= 100
     UA_LOCK_DESTROY(&server->serviceMutex);
@@ -430,7 +430,7 @@ UA_Server_newWithConfig(UA_ServerConfig *config) {
                  config->logging, UA_LOGCATEGORY_SERVER, "No EventLoop configured");
 
     UA_Server *server = (UA_Server *)UA_calloc(1, sizeof(UA_Server));
-    UA_CHECK_MEM(server, UA_ServerConfig_clean(config); return NULL);
+    UA_CHECK_MEM(server, UA_ServerConfig_clear(config); return NULL);
 
     server->config = *config;
 

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -11,7 +11,7 @@
 #include "ua_server_internal.h"
 
 void
-UA_ServerConfig_clean(UA_ServerConfig *config) {
+UA_ServerConfig_clear(UA_ServerConfig *config) {
     if(!config)
         return;
 


### PR DESCRIPTION
- Fix comment to explain that the UA_clear() function also initializes the content after deallocating any contained dynamic memory.
- Rename two functions postfixes from _clean() to _clear() to match the naming conventions used for the datatype delete functions.