### PR TITLE
Fix dead link to certified SDK page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,7 +22,7 @@ the 'Micro Embedded Device Server' Profile of OPC Foundation supporting OPC UA
 client/server communication, subscriptions, method calls and security
 (encryption) with the security policies 'Basic128Rsa15', 'Basic256' and
 'Basic256Sha256' and the facets 'method server' and 'node management'. See
-https://open62541.org/certified-sdk for more details.
+https://open62541.org/certification for more details.
 
 OPC Unified Architecture
 ------------------------


### PR DESCRIPTION
The documentation page https://www.open62541.org/doc/master/ contains a dead link in the introduction:

> [...] See https://open62541.org/certified-sdk for more details.

Opening the link https://open62541.org/certified-sdk returns 404 Page not found.

I assume the proper link is https://open62541.org/certification which returns a page with the title "Certified SDK", which matches the dead link path name.