### PR TITLE
fix(build): Declare tools package architecture-specific

### DIFF
--- a/tools/packaging/debian/control-template
+++ b/tools/packaging/debian/control-template
@@ -35,7 +35,8 @@ Description: open62541 (<http://open62541.org>) is an open source implementation
 
 Package: libopen62541-<soname>-tools
 Section: libdevel
-Architecture: all
+Architecture: any
+Multi-Arch: same
 Depends: ${misc:Depends}, python3
 Recommends: libopen62541-<soname>-dev
 Description: open62541 (<http://open62541.org>) is an open source implementation


### PR DESCRIPTION
Due to commit 6091b1865f87acf3285b45b06c38d740cab40cd5 the tools package now contains architecture-specific
content (usr/lib/*/cmake/open62541/*).
Thus the package must be declared with Architecture 'any' instead of
'all'.