### PR TITLE
fix(build): Fix path to schema files in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1483,7 +1483,7 @@ install(TARGETS open62541
         INCLUDES DESTINATION include)
 
 set(open62541_install_tools_dir share/open62541)
-set(open62541_install_nodeset_dir share/open62541/ua-nodeset)
+set(open62541_install_nodeset_dir share/open62541/schema)
 
 # Create open62541Config.cmake
 include(CMakePackageConfigHelpers)

--- a/tools/cmake/open62541Config.cmake.in
+++ b/tools/cmake/open62541Config.cmake.in
@@ -2,7 +2,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/open62541Targets.cmake")
 
 set_and_check(open62541_TOOLS_DIR @PACKAGE_open62541_install_tools_dir@ CACHE PATH "Path to the directory that contains the tooling of the stack")
-set_and_check(UA_NODESET_DIR @PACKAGE_open62541_install_nodeset_dir@ CACHE PATH "Path to the directory that contains the OPC UA schema repository")
+set_and_check(UA_NODESET_DIR @PACKAGE_open62541_install_nodeset_dir@ CACHE PATH "Path to the directory that contains the schema files")
 
 # Macros for datatype generation, nodeset compiler, etc.
 include("${CMAKE_CURRENT_LIST_DIR}/open62541Macros.cmake")


### PR DESCRIPTION
The directory ua-nodeset does not exist any more, the schema files can be found below the schema directory.