### PR TITLE
fix(build): Add libopen62541.so to libopen62541-dev package

### DIFF
--- a/tools/packaging/debian/libopen62541-dev.install-template
+++ b/tools/packaging/debian/libopen62541-dev.install-template
@@ -1,2 +1,3 @@
 usr/include
+usr/lib/*/*.so
 usr/lib/*/pkgconfig/open62541.pc


### PR DESCRIPTION
Has been removed with commit 9e0b766fbba73be8d703b6ccbfdeec5bfd200b48. The so file is needed for linking.