### PR TITLE
fix(server) find crypto plugin in cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1484,6 +1484,7 @@ install(TARGETS open62541
 
 set(open62541_install_tools_dir share/open62541)
 set(open62541_install_nodeset_dir share/open62541/schema)
+set(open62541_crypto_plugin ${UA_ENABLE_ENCRYPTION})
 
 # Create open62541Config.cmake
 include(CMakePackageConfigHelpers)
@@ -1492,7 +1493,8 @@ configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/open62541
                               "${CMAKE_CURRENT_BINARY_DIR}/open62541Config.cmake"
                               INSTALL_DESTINATION "${cmake_configfile_install}"
                               PATH_VARS open62541_install_tools_dir
-                                        open62541_install_nodeset_dir)
+                                        open62541_install_nodeset_dir
+                                        open62541_crypto_plugin)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/open62541Config.cmake"
               "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/open62541Macros.cmake"
         DESTINATION "${cmake_configfile_install}")

--- a/tools/cmake/open62541Config.cmake.in
+++ b/tools/cmake/open62541Config.cmake.in
@@ -3,8 +3,20 @@ include("${CMAKE_CURRENT_LIST_DIR}/open62541Targets.cmake")
 
 set_and_check(open62541_TOOLS_DIR @PACKAGE_open62541_install_tools_dir@ CACHE PATH "Path to the directory that contains the tooling of the stack")
 set_and_check(UA_NODESET_DIR @PACKAGE_open62541_install_nodeset_dir@ CACHE PATH "Path to the directory that contains the schema files")
+set(open62541_crypto_plugin @open62541_crypto_plugin@)
 
 # Macros for datatype generation, nodeset compiler, etc.
 include("${CMAKE_CURRENT_LIST_DIR}/open62541Macros.cmake")
 
 check_required_components(open62541)
+
+include(CMakeFindDependencyMacro)
+if(open62541_crypto_plugin STREQUAL "mbedtls")
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+  find_dependency(MbedTLS REQUIRED)
+  list(REMOVE_AT CMAKE_MODULE_PATH -1)
+elseif(open62541_crypto_plugin STREQUAL "openssl")
+  find_dependency(OpenSSL REQUIRED)
+elseif(open62541_crypto_plugin STREQUAL "libressl")
+  find_dependency(LibreSSL REQUIRED)
+endif()


### PR DESCRIPTION
Currently the transitive reference to the crypto plugin could not be resolved in environments with an installed open62541 stack.