### PR TITLE
Fix CMake git working directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ if(UA_ENABLE_MQTT)
     if(NOT EXISTS "${UA_FILE_MQTT}")
         message(STATUS "Submodule update")
         execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                         RESULT_VARIABLE GIT_SUBMOD_RESULT)
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")
             message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}")
@@ -1120,6 +1121,7 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     if(NOT EXISTS "${UA_FILE_NS0}")
         message(STATUS "Submodule update")
         execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                         RESULT_VARIABLE GIT_SUBMOD_RESULT)
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")
             message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}")


### PR DESCRIPTION
If CMake is not executed in the source code directory, there is an error because Git cannot find the repository. It is therefore necessary to specify the working directory for Git.