### PR TITLE
[REVIEW] fix(build): Correct path for schema files of external build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,7 +1124,6 @@ endif()
 # Nodeset files combined into NS0 generated file
 set(UA_FILE_NODESETS) # List of nodeset-xml files to be considered in the generated information model
 set(UA_NODESET_DIR ${PROJECT_SOURCE_DIR}/deps/ua-nodeset CACHE STRING "The path to the node-set directory (e.g. from https://github.com/OPCFoundation/UA-Nodeset)")
-set(UA_SCHEMA_DIR ${PROJECT_SOURCE_DIR}/tools/schema) # Directory with the schema files for installation
 
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     # Use the "full" schema files also for datatypes and statuscodes
@@ -1145,6 +1144,9 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
         endif()
     endif()
 else()
+    # Directory with the schema files for installation
+    set(UA_SCHEMA_DIR ${PROJECT_SOURCE_DIR}/tools/schema)
+
     # Set the reduced Nodeset for NS0
     if(NOT UA_FILE_NS0)
         set(UA_FILE_NS0 ${UA_SCHEMA_DIR}/Opc.Ua.NodeSet2.Reduced.xml)
@@ -1507,7 +1509,7 @@ install(TARGETS ${OPEN62541-LIB}
         INCLUDES DESTINATION include)
 
 set(open62541_install_tools_dir share/open62541)
-set(open62541_install_nodeset_dir share/open62541/schema)
+set(open62541_install_schema_dir share/open62541/schema)
 set(open62541_crypto_plugin ${UA_ENABLE_ENCRYPTION})
 
 # Create open62541Config.cmake
@@ -1517,7 +1519,7 @@ configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/open62541
                               "${CMAKE_CURRENT_BINARY_DIR}/open62541Config.cmake"
                               INSTALL_DESTINATION "${cmake_configfile_install}"
                               PATH_VARS open62541_install_tools_dir
-                                        open62541_install_nodeset_dir
+                                        open62541_install_schema_dir
                                         open62541_crypto_plugin)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/open62541Config.cmake"
               "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/open62541Macros.cmake"
@@ -1566,7 +1568,7 @@ install(DIRECTORY "tools/certs" "tools/nodeset_compiler"
 
 # Trailing slash to prevent "schema/schema" nesting
 install(DIRECTORY ${UA_SCHEMA_DIR}/
-        DESTINATION ${open62541_install_nodeset_dir}
+        DESTINATION ${open62541_install_schema_dir}
         FILES_MATCHING
         PATTERN "*.xml"
         PATTERN "*Types.bsd"

--- a/tools/cmake/open62541Config.cmake.in
+++ b/tools/cmake/open62541Config.cmake.in
@@ -2,7 +2,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/open62541Targets.cmake")
 
 set_and_check(open62541_TOOLS_DIR @PACKAGE_open62541_install_tools_dir@ CACHE PATH "Path to the directory that contains the tooling of the stack")
-set_and_check(UA_NODESET_DIR @PACKAGE_open62541_install_nodeset_dir@ CACHE PATH "Path to the directory that contains the schema files")
+set_and_check(UA_SCHEMA_DIR @PACKAGE_open62541_install_schema_dir@ CACHE PATH "Path to the directory that contains the schema files")
 set(open62541_crypto_plugin @open62541_crypto_plugin@)
 
 # Macros for datatype generation, nodeset compiler, etc.

--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -112,7 +112,7 @@ endfunction()
 #                   passed which will all combined to one resulting code.
 #   IMPORT_BSD      Combination of types array and path to the .bsd file containing additional type definitions referenced by
 #                   the FILES_BSD files. The value is separated with a hash sign, i.e.
-#                   'UA_TYPES#${UA_NODESET_DIR}/Schema/Opc.Ua.Types.bsd'
+#                   'UA_TYPES#${UA_SCHEMA_DIR}/Opc.Ua.Types.bsd'
 #                   Multiple files can be passed which will all be imported.
 #   [FILES_SELECTED] Optional path to a simple text file which contains a list of types which should be included in the generation.
 #                   The file should contain one type per line. Multiple files can be passed to this argument.
@@ -551,8 +551,8 @@ function(ua_generate_nodeset_and_datatypes)
         message(FATAL_ERROR "open62541_TOOLS_DIR must point to the open62541 tools directory")
     endif()
 
-    if(NOT DEFINED UA_NODESET_DIR)
-        message(FATAL_ERROR "UA_NODESET_DIR must point to the open62541/deps/ua-nodeset directory")
+    if(NOT DEFINED UA_SCHEMA_DIR)
+        message(FATAL_ERROR "UA_SCHEMA_DIR must point to the directory that contains the schema files")
     endif()
 
     # ------ Argument checking -----
@@ -669,7 +669,7 @@ function(ua_generate_nodeset_and_datatypes)
     # Create a list of nodesets on which this nodeset depends on
     if (NOT UA_GEN_DEPENDS OR "${UA_GEN_DEPENDS}" STREQUAL "" )
         if(NOT UA_FILE_NS0)
-            set(NODESET_DEPENDS "${UA_NODESET_DIR}/Schema/Opc.Ua.NodeSet2.xml")
+            set(NODESET_DEPENDS "${UA_SCHEMA_DIR}/Opc.Ua.NodeSet2.xml")
         else()
             set(NODESET_DEPENDS "${UA_FILE_NS0}")
         endif()


### PR DESCRIPTION
Use UA_SCHEMA_DIR for path to schema file to be independent from the different case of the 'schema' and 'Schema' folder.
Resolves #6508 