### PR TITLE
[REVIEW] Correct setting of the namespaceIndex

### DIFF
--- a/tools/generate_bsd.py
+++ b/tools/generate_bsd.py
@@ -50,7 +50,13 @@ variableNodes = nodeset.getElementsByTagName("UAVariable")
 for nd in variableNodes:
     if (nd.hasAttribute("SymbolicName") and (re.match(r".*_BinarySchema", nd.attributes["SymbolicName"].nodeValue) or nd.attributes["SymbolicName"].nodeValue == "TypeDictionary_BinarySchema")) or (nd.hasAttribute("ParentNodeId") and not nd.hasAttribute("SymbolicName") and re.fullmatch(r"i=93", nd.attributes["ParentNodeId"].nodeValue)):
         type_content = nd.getElementsByTagName("Value")[0].getElementsByTagName("ByteString")[0]
-        f = open(args.outputFile, 'w')
-        f.write(base64.b64decode(type_content.firstChild.nodeValue).decode("utf-8"))
-        f.flush()
-        f.close()
+        with open(args.outputFile, 'w') as f:
+            f.write(base64.b64decode(type_content.firstChild.nodeValue).decode("utf-8"))
+    elif nd.hasAttribute("BrowseName") and nd.getAttribute("BrowseName").endswith("TypeDictionary"):
+        references = nd.getElementsByTagName("Reference")
+        for ref in references:
+            if ref.getAttribute("ReferenceType") == "HasComponent" and ref.firstChild.nodeValue == "i=93":
+                type_content = nd.getElementsByTagName("Value")[0].getElementsByTagName("ByteString")[0]
+                with open(args.outputFile, 'w') as f:
+                    f.write(base64.b64decode(type_content.firstChild.nodeValue).decode("utf-8"))
+                break

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -310,12 +310,14 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
     # but only if it defines its own data types, otherwise it is not necessary.
     if len(typesArray) > 0:
         typeArr = typesArray[-1]
-        if typeArr != "UA_TYPES" and typeArr != "ns0":
+        # Build the name of the TypeArray to compare if the current nodeset defines data types.
+        currentTypeArr = '_'.join(outfilebase.upper().split('_')[1:-1])
+        if typeArr != "UA_TYPES" and typeArr != "ns0" and typeArr == "UA_TYPES_"+currentTypeArr:
             writec("/* Change namespaceIndex from current namespace */")
             writec("#if " + typeArr + "_COUNT" + " > 0")
             writec("for(int i = 0; i < " + typeArr + "_COUNT" + "; i++) {")
-            writec(typeArr + "[i]" + ".typeId.namespaceIndex = ns[" + str(nodeset.namespaceMapping[1]) + "];")
-            writec(typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = ns[" + str(nodeset.namespaceMapping[1]) + "];")
+            writec(typeArr + "[i]" + ".typeId.namespaceIndex = ns[" + str(len(nodeset.namespaces)-1) + "];")
+            writec(typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = ns[" + str(len(nodeset.namespaces)-1) + "];")
             writec("}")
             writec("#endif")
 


### PR DESCRIPTION
When generating the namespace code, the namespaceIndex may not be set correctly if the nodeset is based on multiple nodesets.

The code for extracting the bsd file from the nodeset has been adjusted. The check that the variable node is the node containing the bsd as a base64-encoded byte string has been extended. 