### PR TITLE
[Review] fix(build): fix OpenSSL link flags in build output files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,9 +528,9 @@ endif()
 
 if(UA_ENABLE_ENCRYPTION_OPENSSL)
     # use the OpenSSL encryption library
-    # https://cmake.org/cmake/help/v3.0/module/FindOpenSSL.html
+    # https://cmake.org/cmake/help/v3.13/module/FindOpenSSL.html
     find_package(OpenSSL REQUIRED)
-    list(APPEND open62541_LIBRARIES OpenSSL::Crypto OpenSSL::SSL)
+    list(APPEND open62541_LIBRARIES "${OPENSSL_LIBRARIES}")
 endif()
 
 if(UA_ENABLE_ENCRYPTION_LIBRESSL)


### PR DESCRIPTION
Fixed CMake imported targets `OpenSSL::Crypto` and `OpenSSL::SSL` being written literally (without being expanded) to output files `open62541Targets.cmake` and `open62541.pc`.