### PR TITLE
fix(server) copy mbedtls find cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1523,6 +1523,11 @@ export(TARGETS open62541
        NAMESPACE open62541::
        FILE ${CMAKE_CURRENT_BINARY_DIR}/open62541Targets.cmake)
 
+if(UA_ENABLE_ENCRYPTION STREQUAL "MBEDTLS")
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/FindMbedTLS.cmake"
+            DESTINATION "${cmake_configfile_install}")
+endif()
+
 # Generate and install open62541.pc
 if(UA_ENABLE_AMALGAMATION)
     set(PC_EXTRA_CFLAGS "-DUA_ENABLE_AMALGAMATION")


### PR DESCRIPTION
For MbedTLS Version (<3) e.g. delivered with Ubuntu 20LTS, we need a dedicated cmake-find file (see Mbedtls 3.0 release notes "Add CMake package config generation for CMake projects consuming Mbed TLS." https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.0.0). Therefore we have to copy the file during the make install.