### PR TITLE
fix(client): channel state set to CLOSING without closing underlying connection

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -396,8 +396,6 @@ checkCreateSessionSignature(UA_Client *client, const UA_SecureChannel *channel,
 
 void
 processERRResponse(UA_Client *client, const UA_ByteString *chunk) {
-    client->channel.state = UA_SECURECHANNELSTATE_CLOSING;
-
     size_t offset = 0;
     UA_TcpErrorMessage errMessage;
     client->connectStatus =

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -440,6 +440,28 @@ START_TEST(Client_activateSessionLocaleIds) {
 }
 END_TEST
 
+START_TEST(Client_closes_on_server_error) {
+    UA_Client *client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(server->sessionCount, 1);
+    UA_SecureChannel *channel = server->sessions.lh_first->session.header.channel;
+
+    // send error message from server to client
+    UA_TcpErrorMessage errMsg = {.error = UA_STATUSCODE_BADSECURITYCHECKSFAILED,
+                                 .reason = UA_STRING_NULL};
+    UA_SecureChannel_sendError(channel, &errMsg);
+
+    // client should disconnect and close TCP connections, although err was received
+    // note: if it fails to do so the tests might hang here
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Client");
     TCase *tc_client = tcase_create("Client Basic");
@@ -451,6 +473,7 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_client, Client_endpoints);
     tcase_add_test(tc_client, Client_endpoints_empty);
     tcase_add_test(tc_client, Client_read);
+    tcase_add_test(tc_client, Client_closes_on_server_error);
     suite_add_tcase(s,tc_client);
     TCase *tc_client_reconnect = tcase_create("Client Reconnect");
     tcase_add_checked_fixture(tc_client_reconnect, setup, teardown);


### PR DESCRIPTION
Thanks to @Alexk12 for the analysis and suggested fix (see issue #5783).

If the connection is denied by the OPC UA server with e.g. `BadSecurityChecksFailed` the subsequent call to `UA_Client_delete` / `UA_Client_disconnect` hangs, because the exit condition for the while loop in `disconnectSecureChannel` is never reached: 

https://github.com/open62541/open62541/blob/3888af3410b53be0c5fa15b9d762dbab5b84902e/src/client/ua_client_connect.c#L2212

It was probably caused by the added "recursion check" in closeSecureChannel (commit 4bd6f4023ab59fa8ba1f17f5d82dd89636fc9995) that was added in v1.4.0-rc1

`UA_SecureChannel_shutdown` (correctly) sets `UA_SECURECHANNELSTATE_CLOSING` when actually closing the TCP connection, but is never called when the state is already set to `UA_SECURECHANNELSTATE_CLOSING` before.

