### PR TITLE
fix(core): ret is already defined, so reuse var

### DIFF
--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -2233,7 +2233,7 @@ getArrayUnwrapType(ParseCtx *ctx, size_t arrayIndex) {
 
         /* Check for non-JSON encoding */
         size_t encIndex = 0;
-        UA_StatusCode ret = lookAheadForKey(ctx, UA_JSONKEY_ENCODING, &encIndex);
+        ret = lookAheadForKey(ctx, UA_JSONKEY_ENCODING, &encIndex);
         if(ret == UA_STATUSCODE_GOOD) {
             ctx->index = oldIndex; /* Restore the index */
             return NULL;


### PR DESCRIPTION
If src/ua_types_encoding_json.c is compiled with "gcc -Wshadow", a warning is output for an already defined var. This change fixes this.