### PR TITLE
fix(core): fix default network values in UA_ConnectionConfig_default

### DIFF
--- a/plugins/crypto/mbedtls/ua_pki_mbedtls.c
+++ b/plugins/crypto/mbedtls/ua_pki_mbedtls.c
@@ -776,7 +776,7 @@ UA_PKI_decryptPrivateKey(const UA_ByteString privateKey,
     }
 
     /* Write the DER-encoded key into a local buffer */
-    unsigned char buf[2 << 13];
+    unsigned char buf[1 << 14];
     size_t pos = (size_t)mbedtls_pk_write_key_der(&ctx, buf, sizeof(buf));
 
     /* Allocate memory */

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -191,12 +191,12 @@ UA_Server_runUntilInterrupt(UA_Server *server) {
 
 const UA_ConnectionConfig UA_ConnectionConfig_default = {
     0,       /* .protocolVersion */
-    2 << 16, /* .sendBufferSize, 64k per chunk */
-    2 << 16, /* .recvBufferSize, 64k per chunk */
-    2 << 29, /* .localMaxMessageSize, 512 MB */
-    2 << 29, /* .remoteMaxMessageSize, 512 MB */
-    2 << 14, /* .localMaxChunkCount, 16k */
-    2 << 14  /* .remoteMaxChunkCount, 16k */
+    1 << 16, /* .sendBufferSize, 64k per chunk */
+    1 << 16, /* .recvBufferSize, 64k per chunk */
+    1 << 29, /* .localMaxMessageSize, 512 MB */
+    1 << 29, /* .remoteMaxMessageSize, 512 MB */
+    1 << 14, /* .localMaxChunkCount, 16k */
+    1 << 14  /* .remoteMaxChunkCount, 16k */
 };
 
 /***************************/


### PR DESCRIPTION
Some items use 2<<y instead of 1<<y==2^y.
I've kept the buffer size in ua_pki_mbedtls.c the same, though this could also get reduced.