### PR TITLE
[REVIEW] Add missing function in the rsapss security policy for openssl

### DIFF
--- a/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
+++ b/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
@@ -104,6 +104,54 @@ UA_Policy_Aes256Sha256RsaPss_Clear_Context(UA_SecurityPolicy *policy) {
     return;
 }
 
+static UA_StatusCode
+updateCertificateAndPrivateKey_sp_aes128sha256rsapss(UA_SecurityPolicy *securityPolicy,
+                                                      const UA_ByteString newCertificate,
+                                                      const UA_ByteString newPrivateKey) {
+    if(securityPolicy == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    if(securityPolicy->policyContext == NULL)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    Policy_Context_Aes256Sha256RsaPss *pc =
+        (Policy_Context_Aes256Sha256RsaPss *)securityPolicy->policyContext;
+
+    UA_ByteString_clear(&securityPolicy->localCertificate);
+
+    UA_StatusCode retval = UA_OpenSSL_LoadLocalCertificate(
+        &newCertificate, &securityPolicy->localCertificate);
+
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* Set the new private key */
+    EVP_PKEY_free(pc->localPrivateKey);
+
+    pc->localPrivateKey = UA_OpenSSL_LoadPrivateKey(&newPrivateKey);
+    if(!pc->localPrivateKey) {
+        retval = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+        goto error;
+    }
+
+    UA_ByteString_clear(&pc->localCertThumbprint);
+
+    retval = UA_Openssl_X509_GetCertificateThumbprint(&securityPolicy->localCertificate,
+                                                      &pc->localCertThumbprint, true);
+    if(retval != UA_STATUSCODE_GOOD) {
+        goto error;
+    }
+
+    return retval;
+
+error:
+    UA_LOG_ERROR(securityPolicy->logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                 "Could not update certificate and private key");
+    if(securityPolicy->policyContext != NULL)
+        UA_Policy_Aes256Sha256RsaPss_Clear_Context(securityPolicy);
+    return retval;
+}
+
 /* create the channel context */
 
 static UA_StatusCode
@@ -670,6 +718,7 @@ UA_SecurityPolicy_Aes256Sha256RsaPss(UA_SecurityPolicy *policy,
         UA_ByteString_clear(&policy->localCertificate);
         return retval;
     }
+    policy->updateCertificateAndPrivateKey = updateCertificateAndPrivateKey_sp_aes128sha256rsapss;
     policy->clear = UA_Policy_Aes256Sha256RsaPss_Clear_Context;
 
     /* Certificate Signing Algorithm */


### PR DESCRIPTION
Add the missing function 'updateCertificateAndPrivateKey' in the rsapss security policy for the openssl implementation.