### PR TITLE
fix(client) UA_Client_connectSecureChannel_async not async.

### DIFF
--- a/include/open62541/client.h
+++ b/include/open62541/client.h
@@ -442,7 +442,7 @@ UA_Client_connectSecureChannelAsync(UA_Client *client, const char *endpointUrl) 
     cc->endpointUrl = UA_STRING_ALLOC(endpointUrl);
 
     /* Connect */
-    return __UA_Client_connect(client, false);
+    return __UA_Client_connect(client, true);
 })
 
 /* Connect to the server and create+activate a Session with the given username


### PR DESCRIPTION
It seems that UA_Client_connectSecureChannel_async should connect asynchronously as the name suggests.

Problem introduced in: https://github.com/open62541/open62541/pull/5789