### PR TITLE
Don't force UA_MESSAGESECURITYMODE_SIGNANDENCRYPT if encryption is disabled.

### DIFF
--- a/src/server/ua_discovery.c
+++ b/src/server/ua_discovery.c
@@ -374,8 +374,10 @@ discoveryClientStateCallback(UA_Client *client,
     UA_Client_getConnectionAttribute_scalar(client, UA_QUALIFIEDNAME(0, "securityMode"),
                                             &UA_TYPES[UA_TYPES_MESSAGESECURITYMODE],
                                             &msm);
+#ifdef UA_ENABLE_ENCRYPTION 
     if(msm != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
         return;
+#endif
 
     const UA_DataType *reqType;
     const UA_DataType *respType;


### PR DESCRIPTION
Added static check for enabled encryption.
The discovery example fails (server_register can't register with the LDS) if encryption is disabled and this check is missing. It corresponds to UA_Server_register, line 475.