### PR TITLE
refactor(server): add local hostname if none given for LDS-ME.

### DIFF
--- a/src/server/ua_discovery_mdns.c
+++ b/src/server/ua_discovery_mdns.c
@@ -821,6 +821,7 @@ static UA_StatusCode
 addMdnsRecordForNetworkLayer(UA_DiscoveryManager *dm, const UA_String *appName,
                              const UA_String *discoveryUrl) {
     UA_String hostname = UA_STRING_NULL;
+    char hoststr[256]; /* check with UA_MAXHOSTNAME_LENGTH */
     UA_UInt16 port = 4840;
     UA_String path = UA_STRING_NULL;
     UA_StatusCode retval =
@@ -832,6 +833,12 @@ addMdnsRecordForNetworkLayer(UA_DiscoveryManager *dm, const UA_String *appName,
         return retval;
     }
 
+    if (hostname.length == 0) {
+	gethostname(hoststr, sizeof(hoststr)-1);
+	hoststr[sizeof(hoststr)-1] = '\0';
+	hostname.data = (unsigned char *) hoststr;
+	hostname.length = strlen(hoststr);
+    }
     retval = UA_Discovery_addRecord(dm, appName, &hostname, port,
                                     &path, UA_DISCOVERY_TCP, true,
                                     dm->serverConfig->mdnsConfig.serverCapabilities,


### PR DESCRIPTION
In src/server/ua_discovery_mdns.c if no local hostname is given and thus INADDR_ANY/0.0.0.0 should be used, use gethostname() as local hostname.
Until now an error is returned from UA_Discovery_addRecord().