### PR TITLE
refactor(build): CMakeLists.txt: define UA_HAS_GETIFADDR on UNIX

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -145,11 +145,13 @@
 #  define _BSD_SOURCE
 # endif
 
-/* Define _GNU_SOURCE to get functions like ppoll. Comment this out to
+/* Define _GNU_SOURCE to get functions like poll. Comment this out to
  * only use standard POSIX definitions. */
 # ifndef _GNU_SOURCE
 #  define _GNU_SOURCE
 # endif
+
+#define UA_HAS_GETIFADDR 1
 #endif
 
 /**


### PR DESCRIPTION
For building on UNIX, always define UA_HAS_GETIFADDR.