### PR TITLE
Fix discoveryUrl initialisation

### DIFF
--- a/src/server/ua_discovery_mdns.c
+++ b/src/server/ua_discovery_mdns.c
@@ -1268,11 +1268,16 @@ UA_Discovery_addRecord(UA_DiscoveryManager *dm, const UA_String *servername,
 
         listEntry->txtSet = true;
 
-        UA_STACKARRAY(char, newUrl, 10 + hostnameLen + 8 + path->length + 1);
-        mp_snprintf(newUrl, 10 + hostnameLen + 8 + path->length + 1,
-                    "opc.tcp://%.*s:%d%s%.*s", (int) hostnameLen,
-                    hostname->data, port, path->length > 0 ? "/" : "",
-                    (int) path->length, path->data);
+        const size_t newUrlSize = 10 + hostnameLen + 8 + path->length + 1;
+        UA_STACKARRAY(char, newUrl, newUrlSize);
+        memset(newUrl, 0, newUrlSize);
+        if(path->length > 0) {
+            mp_snprintf(newUrl, newUrlSize, "opc.tcp://%.*s:%d%s%.*s", (int)hostnameLen,
+                        hostname->data, port, "/", (int)path->length, path->data);
+        } else {
+            mp_snprintf(newUrl, newUrlSize, "opc.tcp://%.*s:%d", (int)hostnameLen,
+                        hostname->data, port);
+        }
         listEntry->serverOnNetwork.discoveryUrl = UA_String_fromChars(newUrl);
         listEntry->srvSet = true;
     }


### PR DESCRIPTION
initialize newUrl
do not add path to discoveryUrl if empty, otherwise (null) will be added to the discoveryUrl