### PR TITLE
refactor(server): do not set mdns IP address

### DIFF
--- a/src/server/ua_discovery_mdns.c
+++ b/src/server/ua_discovery_mdns.c
@@ -886,7 +886,11 @@ discovery_createMulticastSocket(UA_Server* server, UA_DiscoveryManager *dm) {
     size_t paramsSize = 5;
 
     UA_UInt16 port = 5353;
+#ifdef UA_ARCHITECTURE_POSIX
+    UA_String address = UA_STRING("0.0.0.0");
+#else
     UA_String address = UA_STRING("224.0.0.251");
+#endif
     UA_UInt32 ttl = 255;
     UA_Boolean reuse = true;
     UA_Boolean listen = true;


### PR DESCRIPTION
Starting LDS-ME with Linux I only get some data if changing from the mDNS IP 224.0.0.251 to 0.0.0.0.

With version 1.3 this was working ok and from the source it looks like multicast setup is now not done at all. Should this be re-added again for 1.4 to work properly on Linux?