### PR TITLE
[REVIEW] refactor(server): Make first reverse connect attempt also from event loop

### DIFF
--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -1119,11 +1119,13 @@ UA_Server_addReverseConnect(UA_Server *server, UA_String url,
     if(handle)
         *handle = newContext->handle;
 
-    /* Attempt to connect right away */
-    res = attemptReverseConnect(bpm, newContext);
-
     UA_UNLOCK(&server->serviceMutex);
-    return res;
+
+    /* Attempt to connect right away from the event loop */
+    UA_EventLoop *el = bpm->server->config.eventLoop;
+    return UA_Server_addTimedCallback(server, retryReverseConnectCallback, bpm,
+                                      el->dateTime_nowMonotonic(el),
+                                      &bpm->reverseConnectsCheckHandle);
 }
 
 UA_StatusCode


### PR DESCRIPTION
Avoid making operations that possibly take long time (like getaddrinfo doing DNS lookup) from the calling thread when adding reverse connection. Instead of calling attemptReverseConnect directly from UA_Server_addReverseConnect, schedule immediate connect attempt from the event loop.