### PR TITLE
fix(arch): Fix setting the source address in the Ethernet frame

### DIFF
--- a/arch/eventloop_posix_eth.c
+++ b/arch/eventloop_posix_eth.c
@@ -162,7 +162,7 @@ setETHHeader(unsigned char *buf,
     size_t pos = 0;
     memcpy(buf, destAddr, ETHER_ADDR_LEN);
     pos += ETHER_ADDR_LEN;
-    memcpy(&buf[pos], destAddr, ETHER_ADDR_LEN);
+    memcpy(&buf[pos], sourceAddr, ETHER_ADDR_LEN);
     pos += ETHER_ADDR_LEN;
 
     /* Set the 802.1Q VLAN header */


### PR DESCRIPTION
This fixes #6623 reported by @Bubeck-ISW.