### PR TITLE
refactor(tests): fix compilation on windows by removing unused include unistd.h

### DIFF
--- a/tests/nodeset-compiler/check_nodeset_compiler_autoid.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_autoid.c
@@ -11,7 +11,6 @@
 #include "test_helpers.h"
 #include "tests/namespace_tests_di_generated.h"
 #include "tests/namespace_tests_autoid_generated.h"
-#include "unistd.h"
 #include <stdlib.h>
 
 UA_Server *server = NULL;

--- a/tests/nodeset-compiler/check_nodeset_compiler_plc.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_plc.c
@@ -11,7 +11,6 @@
 #include "test_helpers.h"
 #include "tests/namespace_tests_di_generated.h"
 #include "tests/namespace_tests_plc_generated.h"
-#include "unistd.h"
 #include <stdlib.h>
 
 UA_Server *server = NULL;

--- a/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_testnodeset.c
@@ -12,7 +12,6 @@
 #include "tests/namespace_tests_testnodeset_generated.h"
 #include "namespace_tests_di_generated.h"
 #include <limits.h>
-#include "unistd.h"
 #include <stdlib.h>
 
 UA_Server *server = NULL;


### PR DESCRIPTION
unistd.h does not seem to be used in these tests, but breaks compilation on Windows.