### PR TITLE
Fix binary encoding and decoding for DiagnosticInfo

### DIFF
--- a/deps/base64.c
+++ b/deps/base64.c
@@ -98,9 +98,9 @@ UA_unbase64(const unsigned char *src, size_t len, size_t *out_len) {
 		block[count] = tmp;
 		count++;
 		if(count == 4) {
-			*pos++ = (block[0] << 2) | (block[1] >> 4);
-			*pos++ = (block[1] << 4) | (block[2] >> 2);
-			*pos++ = (block[2] << 6) | block[3];
+			*pos++ = (unsigned char)((block[0] << 2) | (block[1] >> 4));
+			*pos++ = (unsigned char)((block[1] << 4) | (block[2] >> 2));
+			*pos++ = (unsigned char)((block[2] << 6) | block[3]);
 			if(pad) {
                 if(pad == 1)
                     pos--;

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1834,8 +1834,8 @@ Service_HistoryRead(UA_Server *server, UA_Session *session,
     }
 
     /* Check if the configured History-Backend supports the requested history type */
-    if(!readHistory){
-        UA_LOG_INFO_SESSION(server->config.logging, session,
+    if(!readHistory) {
+        UA_LOG_INFO_SESSION(&server->config.logger, session,
                             "The configured HistoryBackend does not support the selected history-type.");
         response->responseHeader.serviceResult = UA_STATUSCODE_BADNOTSUPPORTED;
         return;

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -1199,10 +1199,10 @@ ENCODE_BINARY(DiagnosticInfo) {
         ret |= ENCODE_DIRECT(&src->symbolicId, UInt32); /* Int32 */
     if(src->hasNamespaceUri)
         ret |= ENCODE_DIRECT(&src->namespaceUri, UInt32); /* Int32 */
-    if(src->hasLocalizedText)
-        ret |= ENCODE_DIRECT(&src->localizedText, UInt32); /* Int32 */
     if(src->hasLocale)
         ret |= ENCODE_DIRECT(&src->locale, UInt32); /* Int32 */
+    if(src->hasLocalizedText)
+        ret |= ENCODE_DIRECT(&src->localizedText, UInt32); /* Int32 */
     if(ret != UA_STATUSCODE_GOOD)
         return ret;
 
@@ -1245,13 +1245,13 @@ DECODE_BINARY(DiagnosticInfo) {
         dst->hasNamespaceUri = true;
         ret |= DECODE_DIRECT(&dst->namespaceUri, UInt32); /* Int32 */
     }
-    if(encodingMask & 0x04u) {
-        dst->hasLocalizedText = true;
-        ret |= DECODE_DIRECT(&dst->localizedText, UInt32); /* Int32 */
-    }
     if(encodingMask & 0x08u) {
         dst->hasLocale = true;
         ret |= DECODE_DIRECT(&dst->locale, UInt32); /* Int32 */
+    }
+    if(encodingMask & 0x04u) {
+        dst->hasLocalizedText = true;
+        ret |= DECODE_DIRECT(&dst->localizedText, UInt32); /* Int32 */
     }
     if(encodingMask & 0x10u) {
         dst->hasAdditionalInfo = true;


### PR DESCRIPTION
The order of the `locale` and `localizedText` fields is different between the encoding mask and the encoded values in the body: https://reference.opcfoundation.org/Core/Part6/v105/docs/5.2.2.12

The two fields have been in the wrong order since v0.1 of open62541.