### PR TITLE
fix(build): CMakeLists.txt: set BUILD_TYPE_LOWER_CASE after CMAKE_BUILD_TYPE is final

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ endif()
 
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
-string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER_CASE)
-
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/tools/cmake")
 
 find_package(Python3 REQUIRED)
@@ -86,6 +84,8 @@ if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "CMAKE_BUILD_TYPE not given; setting to 'Debug'")
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build" FORCE)
 endif()
+
+string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER_CASE)
 
 option(UA_ENABLE_AMALGAMATION "Concatenate the library to a single file open62541.h/.c" OFF)
 option(BUILD_SHARED_LIBS "Enable building of shared libraries (dll/so)" OFF)


### PR DESCRIPTION
In case CMAKE_BUILD_TYPE is not set, it defaults to "Debug", but BUILD_TYPE_LOWER_CASE was left unset.