### PR TITLE
ci: comment out azure-pipeline-dist.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,4 +9,4 @@ trigger:
 
 jobs:
     - template: ./tools/azure-devops/azure-pipelines-win.yml
-    - template: ./tools/azure-devops/azure-pipelines-dist.yml
+    # - template: ./tools/azure-devops/azure-pipelines-dist.yml


### PR DESCRIPTION
Looks like some remnants of Debian build, now doing nothing except producing fake test ".deb" files for artifact and wasting ~2-3min of azure servers time.

I know almost nothing about this project and its history to attempt to modify this toward functional Azure Debian build (I don't even know if that would be desired), but jpfr agreed about removing it - I can do *that*.