### PR TITLE
fix(core): add UA_EXPORT for UA_DataType_getStructMember

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1882,7 +1882,7 @@ UA_Array_delete(void *p, size_t size, const UA_DataType *type) {
 }
 
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-UA_Boolean
+UA_Boolean UA_EXPORT
 UA_DataType_getStructMember(const UA_DataType *type, const char *memberName,
                             size_t *outOffset, const UA_DataType **outMemberType,
                             UA_Boolean *outIsArray) {


### PR DESCRIPTION
When building under Linux, the function `UA_DataType_getStructMember` is a global (external) symbol when building statically and a local symbol when building a shared library.

This fix makes it a global (external) symbol for both build types.