### PR TITLE
fix(server): Eliminate memcpy() undefined behavior

### DIFF
--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -290,8 +290,10 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
         return;
     }
     UA_Variant mutableInputArgs[UA_MAX_METHOD_ARGUMENTS];
-    memcpy(mutableInputArgs, request->inputArguments,
-           sizeof(UA_Variant) * request->inputArgumentsSize);
+    if(request->inputArgumentsSize > 0) {
+        memcpy(mutableInputArgs, request->inputArguments,
+               sizeof(UA_Variant) * request->inputArgumentsSize);
+    }
 
     /* Allocate the inputArgumentResults array */
     result->inputArgumentResults = (UA_StatusCode*)


### PR DESCRIPTION
Calling memcpy() with a null pointer is undefined behavior even if the length is zero. The source pointer may be null if there are no arguments so check the argument count before calling memcpy().