### PR TITLE
fix(sec): avoid memmory read access errors

### DIFF
--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -556,11 +556,13 @@ UA_CertificateVerification_Verify (void *                verificationContext,
                 /* Fetch the Subject key identifier of the remote certificate */
                 remote_cert_keyid = X509_get0_subject_key_id(certificateX509);
 
-                /* Check remote certificate is present in the trust list */
-                cmpVal = ASN1_OCTET_STRING_cmp(trusted_cert_keyid, remote_cert_keyid);
-                if (cmpVal == 0){
-                    ret = UA_STATUSCODE_GOOD;
-                    goto cleanup;
+                if(trusted_cert_keyid && remote_cert_keyid) {
+                    /* Check remote certificate is present in the trust list */
+                    cmpVal = ASN1_OCTET_STRING_cmp(trusted_cert_keyid, remote_cert_keyid);
+                    if(cmpVal == 0) {
+                        ret = UA_STATUSCODE_GOOD;
+                        goto cleanup;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Check for null pointer befor passing then into a openssl function.