### PR TITLE
fix(sec): avoid memmory  read access errors

### DIFF
--- a/plugins/crypto/openssl/certificategroup.c
+++ b/plugins/crypto/openssl/certificategroup.c
@@ -433,11 +433,13 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
                 /* Fetch the Subject key identifier of the remote certificate */
                 remote_cert_keyid = X509_get0_subject_key_id(certificateX509);
 
-                /* Check remote certificate is present in the trust list */
-                cmpVal = ASN1_OCTET_STRING_cmp(trusted_cert_keyid, remote_cert_keyid);
-                if(cmpVal == 0) {
-                    ret = UA_STATUSCODE_GOOD;
-                    goto cleanup;
+                if(trusted_cert_keyid && remote_cert_keyid) {
+                    /* Check remote certificate is present in the trust list */
+                    cmpVal = ASN1_OCTET_STRING_cmp(trusted_cert_keyid, remote_cert_keyid);
+                    if(cmpVal == 0) {
+                        ret = UA_STATUSCODE_GOOD;
+                        goto cleanup;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Check for null pointer befor passing then into a openssl function.

See https://github.com/open62541/open62541/pull/6688 for 1.3 branch.