### PR TITLE
fix(plugin): Proper error handling when checking all CRLs

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1067,7 +1067,7 @@ typedef struct UA_DataTypeArray {
  * If the member is an array, the offset points to the (size_t) length field.
  * (The array pointer comes after the length field without any padding.) */
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-UA_Boolean
+UA_Boolean UA_EXPORT
 UA_DataType_getStructMember(const UA_DataType *type,
                             const char *memberName,
                             size_t *outOffset,
@@ -1078,12 +1078,12 @@ UA_DataType_getStructMember(const UA_DataType *type,
 /* Test if the data type is a numeric builtin data type (via the typeKind field
  * of UA_DataType). This includes integers and floating point numbers. Not
  * included are Boolean, DateTime, StatusCode and Enums. */
-UA_Boolean
+UA_Boolean UA_EXPORT
 UA_DataType_isNumeric(const UA_DataType *type);
 
 /* Return the Data Type Precedence-Rank defined in Part 4.
  * If there is no Precedence-Rank assigned with the type -1 is returned.*/
-UA_Int16
+UA_Int16 UA_EXPORT
 UA_DataType_getPrecedence(const UA_DataType *type);
 
 /**

--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -532,6 +532,8 @@ UA_CertificateVerification_Verify (void *                verificationContext,
                 opensslRet = X509_STORE_CTX_get_error (storeCtx);
                 if (opensslRet == X509_V_ERR_UNABLE_TO_GET_CRL) {
                     ret = UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN;
+                } else {
+                    ret = UA_X509_Store_CTX_Error_To_UAError (opensslRet);
                 }
             }
         }

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -1850,7 +1850,7 @@ UA_Array_append(void **p, size_t *size, void *newElem,
     return UA_STATUSCODE_GOOD;
 }
 
-UA_StatusCode UA_EXPORT
+UA_StatusCode
 UA_Array_appendCopy(void **p, size_t *size, const void *newElem,
                     const UA_DataType *type) {
     char scratch[512];
@@ -1882,7 +1882,7 @@ UA_Array_delete(void *p, size_t size, const UA_DataType *type) {
 }
 
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-UA_Boolean UA_EXPORT
+UA_Boolean
 UA_DataType_getStructMember(const UA_DataType *type, const char *memberName,
                             size_t *outOffset, const UA_DataType **outMemberType,
                             UA_Boolean *outIsArray) {


### PR DESCRIPTION
If a chain of Certificate Authorities (CAs) longer than one is present, all CRL checks on the additional CAs were bypassed. This resulted in the potential acceptance of certificates that have been revoked or have expired CRLs.