### PR TITLE
fix(pubsub): Fix exception at PubSub update

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -810,7 +810,7 @@ DataSetReader_processRaw(UA_Server *server, UA_ReaderGroup *rg,
         UA_FieldTargetVariable *tv =
             &dsr->config.subscribedDataSet.subscribedDataSetTarget.targetVariables[i];
 
-        if(tv->beforeWrite || tv->externalDataValue) {
+        if(tv->externalDataValue) {
             if(tv->beforeWrite)
                 tv->beforeWrite(server, &dsr->identifier, &dsr->linkedReaderGroup,
                                 &tv->targetVariable.targetNodeId,


### PR DESCRIPTION
If a beforeWrite callback is used without an externalDataValue pointer, an exception occurred.