### PR TITLE
fix(pubsub): Correct documentation of beforeWrite callback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,19 @@
 This changelog reports changes visible through the public API. Internal refactorings and bug
 fixes are not reported here.
 
+2025-02-18 Andreas Eckerstorfer <estr at keba.com>
+
+ * PubSub beforeWrite callback
+
+   A misleading comment about the content of the variable
+   externalDataValue in the PubSub beforeWrite callback has been
+   removed. Please review your beforeWrite callback implementation.
+   The beforeWrite callback is called with the data pointer
+   containing the data before the update. It may be used for a
+   double buffer implementation.
+   The original code change was done with commit
+   06da5d07bd9a653d32e7a6ed06deae994d29953c.
+
 2023-07-02 Jonas Green <jgr at hms.se>
 
  * Decoding variant with array of structure

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -652,7 +652,7 @@ typedef struct {
     /* If realtime-handling is required, set this pointer non-NULL and it will be used
      * to memcpy the value instead of using the Write service.
      * If the beforeWrite method pointer is set, it will be called before a memcpy update
-     * to the value. But param externalDataValue already contains the new value.
+     * to the value.
      * If the afterWrite method pointer is set, it will be called after a memcpy update
      * to the value. */
     UA_DataValue **externalDataValue;


### PR DESCRIPTION
Remove a misleading comment about the content of the variable
externalDataValue in the PubSub beforeWrite callback.
The beforeWrite callback is called with the data pointer containing the
data before the update. It may be used for a double buffer
implementation.
The original code change that changed the usage of the beforeWrite
callback was done with commit
06da5d07bd9a653d32e7a6ed06deae994d29953c.