### PR TITLE
fix(nc): Improve handling of QualifiedName

### DIFF
--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -798,6 +798,8 @@ class QualifiedName(Value):
             self.parseXML(xmlelement)
 
     def parseXML(self, xmlvalue):
+        global namespaceMapping
+
         # Expect <QualifiedName> or <AliasName>
         #           <NamespaceIndex>Int16<NamespaceIndex>
         #           <Name>SomeString<Name>
@@ -815,9 +817,15 @@ class QualifiedName(Value):
         # Is a namespace index passed?
         if len(xmlvalue.getElementsByTagName("NamespaceIndex")) != 0:
             self.ns = int(xmlvalue.getElementsByTagName("NamespaceIndex")[0].firstChild.data)
-        if len(xmlvalue.getElementsByTagName("Name")) != 0:
-            self.name = xmlvalue.getElementsByTagName("Name")[0].firstChild.data
+            if len(namespaceMapping.values()) > 0:
+                self.ns = namespaceMapping[self.ns]
 
+        nameElements = xmlvalue.getElementsByTagName("Name")
+        if len(nameElements) != 0:
+            if nameElements[0].firstChild is None or nameElements[0].firstChild.data is None:
+                self.name = ""
+            else:
+                self.name = nameElements[0].firstChild.data
 
     def __str__(self):
         return "ns=" + str(self.ns) + ";" + str(self.name)


### PR DESCRIPTION
1) NodesetCompiler run into an error parsing the QualfiedName Value, if the Name element was empty.
We got a NodeSet with such code to compile. It's questionable whether such QualifiedName makes sense at all, but at least it's a valid XML, produced by one of the modelling tools.
![image](https://github.com/user-attachments/assets/34621751-156f-4801-9273-9f07bf6de930)

2) NamespeceIdx of the QualifiedName was not remapped to the target scope.
I used the same pattern to remap the index as in the NodeId related function.