### PR TITLE
feat: Add zephyr support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(ANDROID_PLATFORM 24)
 if(UA_BUILD_FUZZING OR UA_BUILD_OSS_FUZZ OR UA_BUILD_FUZZING_CORPUS)
     project(open62541) # We need to have C++ support configured for fuzzing
 else()
-    project(open62541 C) # Do not look for a C++ compiler
+    project(open62541 C) # Do not look for a C++ compiler endif()
 endif()
 
 # set(CMAKE_VERBOSE_MAKEFILE ON)
@@ -59,7 +59,7 @@ MESSAGE(STATUS "open62541 Version: ${OPEN62541_VERSION}")
 # Architecture #
 ################
 
-set(UA_ARCHITECTURES "none" "posix" "win32")
+set(UA_ARCHITECTURES "none" "posix" "win32" "zephyr")
 set(UA_ARCHITECTURE "" CACHE STRING "Architecture to build open62541 for")
 SET_PROPERTY(CACHE UA_ARCHITECTURE PROPERTY STRINGS "" ${UA_ARCHITECTURES})
 
@@ -76,6 +76,8 @@ if("${UA_ARCHITECTURE}" STREQUAL "posix")
     set(UA_ARCHITECTURE_POSIX 1)
 elseif("${UA_ARCHITECTURE}" STREQUAL "win32")
     set(UA_ARCHITECTURE_WIN32 1)
+elseif("${UA_ARCHITECTURE}" STREQUAL "zephyr")
+    set(UA_ARCHITECTURE_ZEPHYR 1)
 endif()
 
 #################
@@ -512,12 +514,14 @@ function(add_cc_flag CC_FLAG)
 endfunction()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    check_add_cc_flag("-std=c99")   # C99 mode
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-std=c99")   # C99 mode
+    endif()
     check_add_cc_flag("-pipe")      # Avoid writing temporary files (for compiler speed)
-    check_add_cc_flag("-Wall")      # Warnings
-    check_add_cc_flag("-Wextra")    # More warnings
-    check_add_cc_flag("-Wpedantic") # Standard compliance
-    if(UA_FORCE_WERROR)
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wall")      # Warnings
+        check_add_cc_flag("-Wextra")    # More warnings
+        check_add_cc_flag("-Wpedantic") # Standard compliance
         check_add_cc_flag("-Werror") # All warnings are errors
         check_add_cc_flag("-Wunused-command-line-argument") # Warning for command line args instead of error
     endif()
@@ -528,7 +532,10 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     check_add_cc_flag("-Wno-maybe-uninitialized") # too many false positives
 
     # Use a strict subset of the C and C++ languages
-    check_add_cc_flag("-Wc++-compat")
+
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wc++-compat")
+    endif()
 
     # Check that format strings (printf/scanf) are sane
     check_add_cc_flag("-Wformat")
@@ -536,19 +543,35 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     check_add_cc_flag("-Wformat-nonliteral")
 
     # Check prototype definitions
-    check_add_cc_flag("-Wmissing-prototypes")
-    check_add_cc_flag("-Wstrict-prototypes")
-    check_add_cc_flag("-Wredundant-decls")
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wmissing-prototypes")
+    endif()
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wstrict-prototypes")
+    endif()
+
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wredundant-decls")
+    endif()
 
     check_add_cc_flag("-Wuninitialized")
     check_add_cc_flag("-Winit-self")
-    check_add_cc_flag("-Wcast-qual")
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wcast-qual")
+    endif()
     check_add_cc_flag("-Wstrict-overflow")
-    check_add_cc_flag("-Wnested-externs")
+
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wnested-externs")
+    endif()
     check_add_cc_flag("-Wmultichar")
-    check_add_cc_flag("-Wundef")
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-Wundef")
+    endif()
     check_add_cc_flag("-fno-strict-aliasing") # fewer compiler assumptions about pointer types
-    check_add_cc_flag("-fexceptions") # recommended for multi-threaded C code, also in combination with C++ code
+    if(NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
+        check_add_cc_flag("-fexceptions") # recommended for multi-threaded C code, also in combination with C++ code
+    endif()
 
     # Generate position-independent code for shared libraries (adds a performance penalty)
     if(BUILD_SHARED_LIBS)
@@ -581,7 +604,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
             check_add_cc_flag("-fstack-protector-strong") # more performant stack protector, available since gcc 4.9
             check_add_cc_flag("-fstack-clash-protection") # increased reliability of stack overflow detection, available since gcc 8
             # future use (control flow integrity protection)
-            if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+            if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD" AND NOT ${UA_ARCHITECTURE} STREQUAL "zephyr")
                 check_add_cc_flag("-mcet")
                 check_add_cc_flag("-fcf-protection")
             endif()
@@ -917,6 +940,9 @@ list(APPEND plugin_sources
      ${PROJECT_SOURCE_DIR}/arch/eventloop_posix/eventloop_posix_udp.c
      ${PROJECT_SOURCE_DIR}/arch/eventloop_posix/eventloop_posix_eth.c
      ${PROJECT_SOURCE_DIR}/arch/eventloop_posix/eventloop_posix_interrupt.c
+     ${PROJECT_SOURCE_DIR}/arch/eventloop_zephyr/eventloop_zephyr.h
+     ${PROJECT_SOURCE_DIR}/arch/eventloop_zephyr/eventloop_zephyr.c
+     ${PROJECT_SOURCE_DIR}/arch/eventloop_zephyr/eventloop_zephyr_tcp.c
      ${PROJECT_SOURCE_DIR}/arch/eventloop_common/eventloop_mqtt.c)
 
 # For file based server configuration
@@ -1206,8 +1232,15 @@ assign_source_group(${lib_headers} ${lib_sources})
 assign_source_group(${plugin_headers} ${plugin_sources})
 
 # Define the target libraries
-add_library(open62541-object OBJECT ${lib_sources} ${lib_headers} ${exported_headers})
-add_library(open62541-plugins OBJECT ${plugin_sources} ${plugin_headers})
+if(${UA_ARCHITECTURE} STREQUAL "zephyr")
+    zephyr_library_named(open62541-object)
+    zephyr_library_named(open62541-plugins)
+    target_sources(open62541-object PRIVATE ${lib_sources} ${lib_headers} ${exported_headers})
+    target_sources(open62541-plugins PRIVATE ${plugin_sources} ${plugin_headers})
+else()
+    add_library(open62541-object OBJECT ${lib_sources} ${lib_headers} ${exported_headers})
+    add_library(open62541-plugins OBJECT ${plugin_sources} ${plugin_headers})
+endif()
 add_library(open62541 $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-plugins>)
 
 add_dependencies(open62541-object open62541-code-generation)

--- a/arch/clock.c
+++ b/arch/clock.c
@@ -16,36 +16,71 @@
  * source should be through the EventLoop. The below is therefore for developer
  * convenience to just use UA_DateTime_now. */
 
-#ifdef UA_ARCHITECTURE_POSIX
+#if defined(UA_ARCHITECTURE_ZEPHYR)
+#include <time.h>
+
+#include <sys/time.h>
+#include <zephyr/kernel.h>
+
+UA_DateTime
+UA_DateTime_now(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (tv.tv_sec * UA_DATETIME_SEC) + (tv.tv_usec * UA_DATETIME_USEC) +
+           UA_DATETIME_UNIX_EPOCH;
+}
+
+/* Credit to
+ * https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
+UA_Int64
+UA_DateTime_localTimeUtcOffset(void) {
+    time_t rawtime = time(NULL);
+    struct tm *ptm = gmtime(&rawtime);
+    /* Request mktime() to look up dst in timezone database */
+    ptm->tm_isdst = -1;
+    time_t gmt = mktime(ptm);
+    return (UA_Int64)(difftime(rawtime, gmt) * UA_DATETIME_SEC);
+}
+
+UA_DateTime
+UA_DateTime_nowMonotonic(void) {
+    return k_uptime_get();
+}
+
+#elif defined(UA_ARCHITECTURE_POSIX)
 
 #include <time.h>
+
 #include <sys/time.h>
 
 #if defined(__APPLE__) || defined(__MACH__)
-# include <mach/clock.h>
-# include <mach/mach.h>
+#include <mach/clock.h>
+#include <mach/mach.h>
 #endif
 
-UA_DateTime UA_DateTime_now(void) {
+UA_DateTime
+UA_DateTime_now(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    return (tv.tv_sec * UA_DATETIME_SEC) +
-        (tv.tv_usec * UA_DATETIME_USEC) +
-        UA_DATETIME_UNIX_EPOCH;
+    return (tv.tv_sec * UA_DATETIME_SEC) + (tv.tv_usec * UA_DATETIME_USEC) +
+           UA_DATETIME_UNIX_EPOCH;
 }
 
-/* Credit to https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
-UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
+/* Credit to
+ * https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
+UA_Int64
+UA_DateTime_localTimeUtcOffset(void) {
     time_t rawtime = time(NULL);
     struct tm gbuf;
     struct tm *ptm = gmtime_r(&rawtime, &gbuf);
     /* Request mktime() to look up dst in timezone database */
     ptm->tm_isdst = -1;
     time_t gmt = mktime(ptm);
-    return (UA_Int64) (difftime(rawtime, gmt) * UA_DATETIME_SEC);
+    return (UA_Int64)(difftime(rawtime, gmt) * UA_DATETIME_SEC);
 }
 
-UA_DateTime UA_DateTime_nowMonotonic(void) {
+UA_DateTime
+UA_DateTime_nowMonotonic(void) {
 #if defined(__APPLE__) || defined(__MACH__)
     /* OS X does not have clock_gettime, use clock_get_time */
     clock_serv_t cclock;
@@ -65,24 +100,22 @@ UA_DateTime UA_DateTime_nowMonotonic(void) {
 #endif
 }
 
-#endif /* UA_ARCHITECTURE_POSIX */
-
-#ifdef UA_ARCHITECTURE_WIN32
+#elif defined(UA_ARCHITECTURE_WIN32)
 
 #include <time.h>
 /* Backup definition of SLIST_ENTRY on mingw winnt.h */
-# ifdef SLIST_ENTRY
-#  pragma push_macro("SLIST_ENTRY")
-#  undef SLIST_ENTRY
-#  define POP_SLIST_ENTRY
-# endif
-# include <windows.h>
+#ifdef SLIST_ENTRY
+#pragma push_macro("SLIST_ENTRY")
+#undef SLIST_ENTRY
+#define POP_SLIST_ENTRY
+#endif
+#include <windows.h>
 /* restore definition */
-# ifdef POP_SLIST_ENTRY
-#  undef SLIST_ENTRY
-#  undef POP_SLIST_ENTRY
-#  pragma pop_macro("SLIST_ENTRY")
-# endif
+#ifdef POP_SLIST_ENTRY
+#undef SLIST_ENTRY
+#undef POP_SLIST_ENTRY
+#pragma pop_macro("SLIST_ENTRY")
+#endif
 
 /* Windows filetime has the same definition as UA_DateTime */
 UA_DateTime
@@ -97,7 +130,8 @@ UA_DateTime_now(void) {
     return (UA_DateTime)ul.QuadPart;
 }
 
-/* Credit to https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
+/* Credit to
+ * https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
 UA_Int64
 UA_DateTime_localTimeUtcOffset(void) {
     time_t rawtime = time(NULL);
@@ -112,7 +146,7 @@ UA_DateTime_localTimeUtcOffset(void) {
     ptm.tm_isdst = -1;
     time_t gmt = mktime(&ptm);
 
-    return (UA_Int64) (difftime(rawtime, gmt) * UA_DATETIME_SEC);
+    return (UA_Int64)(difftime(rawtime, gmt) * UA_DATETIME_SEC);
 }
 
 UA_DateTime
@@ -124,4 +158,4 @@ UA_DateTime_nowMonotonic(void) {
     return (UA_DateTime)(ticks.QuadPart * ticks2dt);
 }
 
-#endif /* UA_ARCHITECTURE_WIN32 */
+#endif

--- a/arch/eventloop_posix/eventloop_posix.c
+++ b/arch/eventloop_posix/eventloop_posix.c
@@ -9,6 +9,8 @@
 #include "eventloop_posix.h"
 #include "open62541/plugin/eventloop.h"
 
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
+
 #if defined(UA_ARCHITECTURE_POSIX) && !defined(__APPLE__) && !defined(__MACH__)
 #include <time.h>
 #endif
@@ -1079,3 +1081,5 @@ UA_EventLoopPOSIX_cancel(UA_EventLoopPOSIX *el) {
                            "Eventloop\t| Error signaling self-pipe (%s)", errno_str));
     }
 }
+
+#endif

--- a/arch/eventloop_posix/eventloop_posix_interrupt.c
+++ b/arch/eventloop_posix/eventloop_posix_interrupt.c
@@ -8,6 +8,7 @@
 #include "eventloop_posix.h"
 #include <signal.h>
 
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
 /* Different implementation approaches:
  * - Linux: Use signalfd
  * - Other: Use the self-pipe trick (http://cr.yp.to/docs/selfpipe.html) */
@@ -441,3 +442,5 @@ UA_InterruptManager_new_POSIX(const UA_String eventSourceName) {
     im->deregisterInterrupt = deregisterPOSIXInterrupt;
     return im;
 }
+
+#endif

--- a/arch/eventloop_posix/eventloop_posix_tcp.c
+++ b/arch/eventloop_posix/eventloop_posix_tcp.c
@@ -9,6 +9,8 @@
 #include "open62541/types.h"
 #include "eventloop_posix.h"
 
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
+
 /* Configuration parameters */
 #define TCP_MANAGERPARAMS 2
 
@@ -1080,3 +1082,5 @@ UA_ConnectionManager_new_POSIX_TCP(const UA_String eventSourceName) {
     cm->cm.closeConnection = TCP_shutdownConnection;
     return &cm->cm;
 }
+
+#endif

--- a/arch/eventloop_posix/eventloop_posix_udp.c
+++ b/arch/eventloop_posix/eventloop_posix_udp.c
@@ -8,6 +8,8 @@
 
 #include "eventloop_posix.h"
 
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
+
 #define IPV4_PREFIX_MASK 0xF0
 #define IPV4_MULTICAST_PREFIX 0xE0
 #if UA_IPV6
@@ -1436,3 +1438,5 @@ UA_ConnectionManager_new_POSIX_UDP(const UA_String eventSourceName) {
     cm->cm.closeConnection = UDP_shutdownConnection;
     return &cm->cm;
 }
+
+#endif

--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -22,9 +22,11 @@
 
 #cmakedefine UA_ARCHITECTURE_WIN32
 #cmakedefine UA_ARCHITECTURE_POSIX
+#cmakedefine UA_ARCHITECTURE_ZEPHYR
 
 /* Select default architecture if none is selected */
-#if !defined(UA_ARCHITECTURE_WIN32) && !defined(UA_ARCHITECTURE_POSIX)
+#if !defined(UA_ARCHITECTURE_WIN32) && !defined(UA_ARCHITECTURE_POSIX) &&      \
+    !defined(UA_ARCHITECTURE_ZEPHYR)
 # ifdef _WIN32
 #  define UA_ARCHITECTURE_WIN32
 # else

--- a/include/open62541/plugin/eventloop.h
+++ b/include/open62541/plugin/eventloop.h
@@ -750,6 +750,13 @@ UA_ConnectionManager_new_MQTT(const UA_String eventSourceName);
 UA_EXPORT UA_InterruptManager *
 UA_InterruptManager_new_POSIX(const UA_String eventSourceName);
 
+#elif defined(UA_ARCHITECTURE_ZEPHYR)
+
+UA_EXPORT UA_EventLoop *
+UA_EventLoop_new_Zephyr(const UA_Logger *logger);
+UA_EXPORT UA_ConnectionManager *
+UA_ConnectionManager_new_Zephyr_TCP(const UA_String eventSourceName);
+
 #endif /* defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32) */
 
 _UA_END_DECLS


### PR DESCRIPTION
Just a little side note for anyone trying to make this library run on small embedded devices. With the following open62541 CMake options:
```
set(UA_ENABLE_DISCOVERY_SEMAPHORE OFF CACHE STRING "" FORCE)
set(UA_ARCHITECTURE "zephyr" CACHE STRING "" FORCE)
set(UA_MULTITHREADING 0 CACHE STRING "" FORCE)
set(UA_NAMESPACE_ZERO "MINIMAL" CACHE STRING "" FORCE)
set(UA_ENABLE_PUBSUB OFF CACHE STRING "" FORCE)
set(UA_ENABLE_PUBSUB_INFORMATIONMODEL OFF CACHE STRING "" FORCE)
set(UA_ENABLE_SUBSCRIPTIONS_EVENTS OFF CACHE STRING "" FORCE)
set(UA_ENABLE_SUBSCRIPTIONS OFF CACHE STRING "" FORCE)
set(UA_ENABLE_HISTORIZING OFF CACHE STRING "" FORCE)
set(UA_ENABLE_JSON_ENCODING OFF CACHE STRING "" FORCE)
```
The foot print of the zephyr.elf is:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      671980 B         1 MB     64.09%
```

# What is included?
* Implemented TCP event loop support for Zephyr.
* Ensured consistent usage of abstraction layer macros such as `UA_getaddrinfo` and `UA_fd`.
* Standardized the use of the `UA_ARCHITECTURE_*` macros across the event loop abstraction layer. Introduced type aliases for common structures (e.g., using `UA_addrinfo` instead of `struct addrinfo`).
* Updated the top-level CMakeLists.txt to add compile options to the target instead of directly modifying `CMAKE_C_FLAGS`.