### PR TITLE
[WIP] Removing typedef of ByteString and XmlElement to String

### DIFF
--- a/include/open62541/client.h
+++ b/include/open62541/client.h
@@ -262,7 +262,7 @@ UA_ClientConfig_setAuthenticationUsername(UA_ClientConfig *config,
     if(!identityToken)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     identityToken->userName = UA_STRING_ALLOC(username);
-    identityToken->password = UA_STRING_ALLOC(password);
+    identityToken->password = UA_BYTESTRING_ALLOC(password, strlen(password));
 
     UA_ExtensionObject_clear(&config->userIdentityToken);
     UA_ExtensionObject_setValue(&config->userIdentityToken, identityToken,

--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -659,7 +659,7 @@ UA_CertificateUtils_getExpirationDate(UA_ByteString *certificate,
 
 UA_StatusCode
 UA_CertificateUtils_getSubjectName(UA_ByteString *certificate,
-                                   UA_String *subjectName) {
+                                   UA_ByteString *subjectName) {
     mbedtls_x509_crt publicKey;
     mbedtls_x509_crt_init(&publicKey);
     int mbedErr = mbedtls_x509_crt_parse(&publicKey, certificate->data, certificate->length);
@@ -671,7 +671,7 @@ UA_CertificateUtils_getSubjectName(UA_ByteString *certificate,
     if(res < 0)
         return UA_STATUSCODE_BADINTERNALERROR;
     UA_String tmp = {(size_t)res, (UA_Byte*)buf};
-    return UA_String_copy(&tmp, subjectName);
+    return UA_ByteString_copy(&tmp, subjectName);
 }
 
 UA_StatusCode

--- a/plugins/include/open62541/plugin/accesscontrol_default.h
+++ b/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -15,7 +15,7 @@ _UA_BEGIN_DECLS
 
 typedef struct {
     UA_String username;
-    UA_String password;
+    UA_ByteString password;
 } UA_UsernamePasswordLogin;
 
 typedef UA_StatusCode (*UA_UsernamePasswordLoginCallback)
@@ -34,14 +34,14 @@ typedef UA_StatusCode (*UA_UsernamePasswordLoginCallback)
 UA_EXPORT UA_StatusCode
 UA_AccessControl_default(UA_ServerConfig *config,
                          UA_Boolean allowAnonymous,
-                         const UA_ByteString *userTokenPolicyUri,
+                         const UA_String *userTokenPolicyUri,
                          size_t usernamePasswordLoginSize,
                          const UA_UsernamePasswordLogin *usernamePasswordLogin);
 
 UA_EXPORT UA_StatusCode
 UA_AccessControl_defaultWithLoginCallback(UA_ServerConfig *config,
                                           UA_Boolean allowAnonymous,
-                                          const UA_ByteString *userTokenPolicyUri,
+                                          const UA_String *userTokenPolicyUri,
                                           size_t usernamePasswordLoginSize,
                                           const UA_UsernamePasswordLogin *usernamePasswordLogin,
                                           UA_UsernamePasswordLoginCallback loginCallback,

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -114,7 +114,7 @@ activateSession_default(UA_Server *server, UA_AccessControl *ac,
         } else {
             for(size_t i = 0; i < context->usernamePasswordLoginSize; i++) {
                 if(UA_String_equal(&userToken->userName, &context->usernamePasswordLogin[i].username) &&
-                   UA_String_equal(&userToken->password, &context->usernamePasswordLogin[i].password)) {
+                   UA_ByteString_equal(&userToken->password, &context->usernamePasswordLogin[i].password)) {
                     match = true;
                     break;
                 }
@@ -280,7 +280,7 @@ static void clear_default(UA_AccessControl *ac) {
     if (context) {
         for(size_t i = 0; i < context->usernamePasswordLoginSize; i++) {
             UA_String_clear(&context->usernamePasswordLogin[i].username);
-            UA_String_clear(&context->usernamePasswordLogin[i].password);
+            UA_ByteString_clear(&context->usernamePasswordLogin[i].password);
         }
         if(context->usernamePasswordLoginSize > 0)
             UA_free(context->usernamePasswordLogin);
@@ -293,7 +293,7 @@ static void clear_default(UA_AccessControl *ac) {
 UA_StatusCode
 UA_AccessControl_default(UA_ServerConfig *config,
                          UA_Boolean allowAnonymous,
-                         const UA_ByteString *userTokenPolicyUri,
+                         const UA_String *userTokenPolicyUri,
                          size_t usernamePasswordLoginSize,
                          const UA_UsernamePasswordLogin *usernamePasswordLogin) {
     UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_SERVER,
@@ -350,7 +350,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
         for(size_t i = 0; i < usernamePasswordLoginSize; i++) {
             UA_String_copy(&usernamePasswordLogin[i].username,
                            &context->usernamePasswordLogin[i].username);
-            UA_String_copy(&usernamePasswordLogin[i].password,
+            UA_ByteString_copy(&usernamePasswordLogin[i].password,
                            &context->usernamePasswordLogin[i].password);
         }
     }
@@ -387,7 +387,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
         return UA_STATUSCODE_GOOD;
     }
 
-    const UA_ByteString *utpUri = NULL;
+    const UA_String *utpUri = NULL;
     policies = 0;
     for(size_t i = 0; i < numOfPolcies; i++) {
         if(userTokenPolicyUri) {
@@ -398,7 +398,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
         if(allowAnonymous) {
             ac->userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_ANONYMOUS;
             ac->userTokenPolicies[policies].policyId = UA_STRING_ALLOC(ANONYMOUS_POLICY);
-            UA_ByteString_copy(utpUri,
+            UA_String_copy(utpUri,
                                &ac->userTokenPolicies[policies].securityPolicyUri);
             policies++;
         }
@@ -407,14 +407,14 @@ UA_AccessControl_default(UA_ServerConfig *config,
             ac->userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_CERTIFICATE;
             ac->userTokenPolicies[policies].policyId = UA_STRING_ALLOC(CERTIFICATE_POLICY);
 #if UA_LOGLEVEL <= 400
-            if(UA_ByteString_equal(utpUri, &UA_SECURITY_POLICY_NONE_URI)) {
+            if(UA_String_equal(utpUri, &UA_SECURITY_POLICY_NONE_URI)) {
                 UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_SERVER,
                                "x509 Certificate Authentication configured, "
                                "but no encrypting SecurityPolicy. "
                                "This can leak credentials on the network.");
             }
 #endif
-            UA_ByteString_copy(utpUri,
+            UA_String_copy(utpUri,
                                &ac->userTokenPolicies[policies].securityPolicyUri);
             policies++;
         }
@@ -423,14 +423,14 @@ UA_AccessControl_default(UA_ServerConfig *config,
             ac->userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_USERNAME;
             ac->userTokenPolicies[policies].policyId = UA_STRING_ALLOC(USERNAME_POLICY);
 #if UA_LOGLEVEL <= 400
-            if(UA_ByteString_equal(utpUri, &UA_SECURITY_POLICY_NONE_URI)) {
+            if(UA_String_equal(utpUri, &UA_SECURITY_POLICY_NONE_URI)) {
                 UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_SERVER,
                                "Username/Password Authentication configured, "
                                "but no encrypting SecurityPolicy. "
                                "This can leak credentials on the network.");
             }
 #endif
-            UA_ByteString_copy(utpUri,
+            UA_String_copy(utpUri,
                                &ac->userTokenPolicies[policies].securityPolicyUri);
             policies++;
         }
@@ -441,7 +441,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
 UA_StatusCode
 UA_AccessControl_defaultWithLoginCallback(UA_ServerConfig *config,
                                           UA_Boolean allowAnonymous,
-                                          const UA_ByteString *userTokenPolicyUri,
+                                          const UA_String *userTokenPolicyUri,
                                           size_t usernamePasswordLoginSize,
                                           const UA_UsernamePasswordLogin *usernamePasswordLogin,
                                           UA_UsernamePasswordLoginCallback loginCallback,

--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -213,8 +213,8 @@ PARSE_JSON(BooleanField) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Value of type bool expected.");
         return UA_STATUSCODE_BADTYPEMISMATCH;
     }
-    UA_String val = UA_STRING("true");
-    if(UA_String_equal(&val, &buf)) {
+    UA_ByteString val = UA_BYTESTRING("true", sizeof("true"));
+    if(UA_ByteString_equal(&val, &buf)) {
         out = true;
     }else {
         out = false;

--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -214,8 +214,8 @@ UA_Client_clear(UA_Client *client) {
     UA_String_clear(&client->discoveryUrl);
     UA_EndpointDescription_clear(&client->endpoint);
 
-    UA_String_clear(&client->serverSessionNonce);
-    UA_String_clear(&client->clientSessionNonce);
+    UA_ByteString_clear(&client->serverSessionNonce);
+    UA_ByteString_clear(&client->clientSessionNonce);
 
     /* Delete the subscriptions */
 #ifdef UA_ENABLE_SUBSCRIPTIONS

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1452,7 +1452,7 @@ verifyClientSecureChannelHeader(void *application, UA_SecureChannel *channel,
      * endpoint is used for the SecureChannel */
     UA_ByteString serverCert = getLeafCertificate(asymHeader->senderCertificate);
     if(client->endpoint.serverCertificate.length > 0 &&
-       !UA_String_equal(&client->endpoint.serverCertificate, &serverCert)) {
+       !UA_ByteString_equal(&client->endpoint.serverCertificate, &serverCert)) {
         UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                      "The server certificate is different from the EndpointDescription");
         return UA_STATUSCODE_BADSECURITYCHECKSFAILED;

--- a/src/pubsub/ua_pubsub_networkmessage_json.c
+++ b/src/pubsub/ua_pubsub_networkmessage_json.c
@@ -259,7 +259,7 @@ UA_NetworkMessage_encodeJson(const UA_NetworkMessage *src,
         outBuf->length = (size_t)((uintptr_t)ctx.pos - (uintptr_t)outBuf->data);
 
     if(alloced && ret != UA_STATUSCODE_GOOD)
-        UA_String_clear(outBuf);
+        UA_ByteString_clear(outBuf);
     return ret;
 }
 

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -757,8 +757,8 @@ UA_Server_updateCertificate(UA_Server *server,
         if(retval != UA_STATUSCODE_GOOD)
             return retval;
 
-        UA_String_clear(&ed->serverCertificate);
-        UA_String_copy(&certificate, &ed->serverCertificate);
+        UA_ByteString_clear(&ed->serverCertificate);
+        UA_ByteString_copy(&certificate, &ed->serverCertificate);
     }
 
     UA_DelayedCallback *dc = (UA_DelayedCallback*)UA_calloc(1, sizeof(UA_DelayedCallback));
@@ -808,9 +808,9 @@ UA_Server_createSigningRequest(UA_Server *server,
     if(!UA_NodeId_equal(&certGroup.certificateGroupId, &defaultApplicationGroup))
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    UA_String *newPrivateKey = NULL;
+    UA_ByteString *newPrivateKey = NULL;
     if(regenerateKey && *regenerateKey == true) {
-        newPrivateKey = UA_String_new();
+        newPrivateKey = UA_ByteString_new();
     }
 
     const UA_String securityPolicyNoneUri =
@@ -849,10 +849,10 @@ cleanup:
 /***************************/
 
 UA_SecurityPolicy *
-getSecurityPolicyByUri(const UA_Server *server, const UA_ByteString *securityPolicyUri) {
+getSecurityPolicyByUri(const UA_Server *server, const UA_String *securityPolicyUri) {
     for(size_t i = 0; i < server->config.securityPoliciesSize; i++) {
         UA_SecurityPolicy *securityPolicyCandidate = &server->config.securityPolicies[i];
-        if(UA_ByteString_equal(securityPolicyUri, &securityPolicyCandidate->policyUri))
+        if(UA_String_equal(securityPolicyUri, &securityPolicyCandidate->policyUri))
             return securityPolicyCandidate;
     }
     return NULL;
@@ -1187,4 +1187,3 @@ UA_Server_run(UA_Server *server, const volatile UA_Boolean *running) {
     }
     return UA_Server_run_shutdown(server);
 }
-

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -577,7 +577,7 @@ configServerSecureChannel(void *application, UA_SecureChannel *channel,
     UA_Server *const server = (UA_Server *const) application;
     for(size_t i = 0; i < server->config.securityPoliciesSize; ++i) {
         UA_SecurityPolicy *policy = &server->config.securityPolicies[i];
-        if(!UA_ByteString_equal(&asymHeader->securityPolicyUri, &policy->policyUri))
+        if(!UA_String_equal(&asymHeader->securityPolicyUri, &policy->policyUri))
             continue;
 
         UA_StatusCode res = policy->asymmetricModule.

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -282,7 +282,7 @@ sendServiceFault(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 request
  * server matched by the security policy uri. */
 UA_SecurityPolicy *
 getSecurityPolicyByUri(const UA_Server *server,
-                       const UA_ByteString *securityPolicyUri);
+                       const UA_String *securityPolicyUri);
 
 /********************/
 /* Session Handling */

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -420,7 +420,7 @@ setCurrentEndPointsArray(UA_Server *server, const UA_String endpointUrl,
                 sp = getDefaultEncryptedSecurityPolicy(server);
             if(sp) {
                 UA_ByteString_clear(&ed->serverCertificate);
-                retval |= UA_String_copy(&sp->localCertificate, &ed->serverCertificate);
+                retval |= UA_ByteString_copy(&sp->localCertificate, &ed->serverCertificate);
             }
 
             /* Set the User Identity Token list fromt the AccessControl plugin */

--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -36,7 +36,7 @@ Service_OpenSecureChannel(UA_Server *server, UA_SecureChannel *channel,
 
         /* Set the SecurityMode */
         if(request->securityMode != UA_MESSAGESECURITYMODE_NONE &&
-           UA_ByteString_equal(&sp->policyUri, &UA_SECURITY_POLICY_NONE_URI)) {
+           UA_String_equal(&sp->policyUri, &UA_SECURITY_POLICY_NONE_URI)) {
             response->responseHeader.serviceResult = UA_STATUSCODE_BADSECURITYMODEREJECTED;
             goto error;
         }

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -297,7 +297,7 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
 
     UA_assert(channel->securityToken.channelId != 0);
 
-    if(!UA_ByteString_equal(&channel->securityPolicy->policyUri,
+    if(!UA_String_equal(&channel->securityPolicy->policyUri,
                             &UA_SECURITY_POLICY_NONE_URI) &&
        request->clientNonce.length < 32) {
         response->responseHeader.serviceResult = UA_STATUSCODE_BADNONCEINVALID;
@@ -548,7 +548,7 @@ selectEndpointAndTokenPolicy(UA_Server *server, UA_SecureChannel *channel,
 static UA_StatusCode
 decryptUserToken(UA_Server *server, UA_Session *session,
                  UA_SecureChannel *channel, const UA_SecurityPolicy *sp,
-                 const UA_String encryptionAlgorithm, UA_String *encrypted) {
+                 const UA_String encryptionAlgorithm, UA_ByteString *encrypted) {
     /* If SecurityPolicy is None there shall be no EncryptionAlgorithm  */
     if(UA_String_equal(&sp->policyUri, &UA_SECURITY_POLICY_NONE_URI)) {
         if(encryptionAlgorithm.length > 0)
@@ -873,8 +873,8 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
     } else if(tokenType == &UA_TYPES[UA_TYPES_X509IDENTITYTOKEN]) {
         UA_X509IdentityToken* userCertToken = (UA_X509IdentityToken*)
             req->userIdentityToken.content.decoded.data;
-        UA_CertificateUtils_getSubjectName(&session->clientUserIdOfSession,
-                                           &userCertToken->certificateData);
+        UA_CertificateUtils_getSubjectName(&userCertToken->certificateData,
+                                           &session->clientUserIdOfSession);
     } else {
         /* TODO: Handle issued token */
     }

--- a/src/ua_securechannel_crypto.c
+++ b/src/ua_securechannel_crypto.c
@@ -481,7 +481,7 @@ UA_StatusCode
 checkAsymHeader(UA_SecureChannel *channel,
                 const UA_AsymmetricAlgorithmSecurityHeader *asymHeader) {
     const UA_SecurityPolicy *sp = channel->securityPolicy;
-    if(!UA_ByteString_equal(&sp->policyUri, &asymHeader->securityPolicyUri))
+    if(!UA_String_equal(&sp->policyUri, &asymHeader->securityPolicyUri))
         return UA_STATUSCODE_BADSECURITYPOLICYREJECTED;
 
     return sp->asymmetricModule.

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -561,6 +561,22 @@ FUNC_DECODE_BINARY(String) {
     return Array_decodeBinary(ctx, (void**)&dst->data, &dst->length, &UA_TYPES[UA_TYPES_BYTE]);
 }
 
+FUNC_ENCODE_BINARY(ByteString) {
+    return Array_encodeBinary(ctx, src->data, src->length, &UA_TYPES[UA_TYPES_BYTE]);
+}
+
+FUNC_DECODE_BINARY(ByteString) {
+    return Array_decodeBinary(ctx, (void**)&dst->data, &dst->length, &UA_TYPES[UA_TYPES_BYTE]);
+}
+
+FUNC_ENCODE_BINARY(XmlElement) {
+    return Array_encodeBinary(ctx, src->data, src->length, &UA_TYPES[UA_TYPES_BYTE]);
+}
+
+FUNC_DECODE_BINARY(XmlElement) {
+    return Array_decodeBinary(ctx, (void**)&dst->data, &dst->length, &UA_TYPES[UA_TYPES_BYTE]);
+}
+
 /* Guid */
 FUNC_ENCODE_BINARY(Guid) {
     status ret = UA_STATUSCODE_GOOD;
@@ -640,7 +656,7 @@ NodeId_encodeBinaryWithEncodingMask(Ctx *ctx, UA_NodeId const *src, u8 encoding)
         ret |= ENCODE_DIRECT(&src->namespaceIndex, UInt16);
         UA_CHECK_STATUS(ret, return ret);
         /* Can exchange the buffer */
-        ret = ENCODE_DIRECT(&src->identifier.byteString, String); /* ByteString */
+        ret = ENCODE_DIRECT(&src->identifier.byteString, ByteString); /* ByteString */
         UA_assert(ret != UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
         break;
     default:
@@ -698,7 +714,7 @@ FUNC_DECODE_BINARY(NodeId) {
     case UA_NODEIDTYPE_BYTESTRING:
         dst->identifierType = UA_NODEIDTYPE_BYTESTRING;
         ret |= DECODE_DIRECT(&dst->namespaceIndex, UInt16);
-        ret |= DECODE_DIRECT(&dst->identifier.byteString, String); /* ByteString */
+        ret |= DECODE_DIRECT(&dst->identifier.byteString, ByteString); /* ByteString */
         break;
     default:
         ret |= UA_STATUSCODE_BADINTERNALERROR;
@@ -862,7 +878,7 @@ FUNC_ENCODE_BINARY(ExtensionObject) {
         case UA_EXTENSIONOBJECT_ENCODED_BYTESTRING:
         case UA_EXTENSIONOBJECT_ENCODED_XML:
             /* ByteString in disguise. Array encoding can exchange the buffer */
-            ret = ENCODE_DIRECT(&src->content.encoded.body, String);
+            ret = ENCODE_DIRECT(&src->content.encoded.body, ByteString);
             break;
         default:
             ret = UA_STATUSCODE_BADINTERNALERROR;
@@ -916,7 +932,7 @@ ExtensionObject_decodeBinaryContent(Ctx *ctx, UA_ExtensionObject *dst,
     if(!type) {
         dst->encoding = UA_EXTENSIONOBJECT_ENCODED_BYTESTRING;
         UA_NodeId_copy(typeId, &dst->content.encoded.typeId);
-        return DECODE_DIRECT(&dst->content.encoded.body, String); /* ByteString */
+        return DECODE_DIRECT(&dst->content.encoded.body, ByteString); /* ByteString */
     }
 
     /* Allocate memory */
@@ -955,7 +971,7 @@ FUNC_DECODE_BINARY(ExtensionObject) {
     case UA_EXTENSIONOBJECT_ENCODED_XML:
         dst->encoding = (UA_ExtensionObjectEncoding)encoding;
         dst->content.encoded.typeId = binTypeId; /* move to dst */
-        ret = DECODE_DIRECT(&dst->content.encoded.body, String); /* ByteString */
+        ret = DECODE_DIRECT(&dst->content.encoded.body, ByteString); /* ByteString */
         UA_CHECK_STATUS(ret, ctxClearNodeId(ctx, &dst->content.encoded.typeId));
         break;
     default:
@@ -1612,8 +1628,8 @@ const encodeBinarySignature encodeBinaryJumpTable[UA_DATATYPEKINDS] = {
     (encodeBinarySignature)String_encodeBinary,
     (encodeBinarySignature)UInt64_encodeBinary, /* DateTime */
     (encodeBinarySignature)Guid_encodeBinary,
-    (encodeBinarySignature)String_encodeBinary, /* ByteString */
-    (encodeBinarySignature)String_encodeBinary, /* XmlElement */
+    (encodeBinarySignature)ByteString_encodeBinary, /* ByteString */
+    (encodeBinarySignature)XmlElement_encodeBinary, /* XmlElement */
     (encodeBinarySignature)NodeId_encodeBinary,
     (encodeBinarySignature)ExpandedNodeId_encodeBinary,
     (encodeBinarySignature)UInt32_encodeBinary, /* StatusCode */
@@ -1832,8 +1848,8 @@ const decodeBinarySignature decodeBinaryJumpTable[UA_DATATYPEKINDS] = {
     (decodeBinarySignature)String_decodeBinary,
     (decodeBinarySignature)UInt64_decodeBinary, /* DateTime */
     (decodeBinarySignature)Guid_decodeBinary,
-    (decodeBinarySignature)String_decodeBinary, /* ByteString */
-    (decodeBinarySignature)String_decodeBinary, /* XmlElement */
+    (decodeBinarySignature)ByteString_decodeBinary, /* ByteString */
+    (decodeBinarySignature)XmlElement_decodeBinary, /* XmlElement */
     (decodeBinarySignature)NodeId_decodeBinary,
     (decodeBinarySignature)ExpandedNodeId_decodeBinary,
     (decodeBinarySignature)UInt32_decodeBinary, /* StatusCode */

--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -1280,7 +1280,7 @@ const encodeJsonSignature encodeJsonJumpTable[UA_DATATYPEKINDS] = {
 };
 
 UA_StatusCode
-UA_encodeJson(const void *src, const UA_DataType *type, UA_ByteString *outBuf,
+UA_encodeJson(const void *src, const UA_DataType *type, UA_String *outBuf,
               const UA_EncodeJsonOptions *options) {
     if(!src || !type)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -1290,7 +1290,7 @@ UA_encodeJson(const void *src, const UA_DataType *type, UA_ByteString *outBuf,
     status res = UA_STATUSCODE_GOOD;
     if(outBuf->length == 0) {
         size_t len = UA_calcSizeJson(src, type, options);
-        res = UA_ByteString_allocBuffer(outBuf, len);
+        res = UA_String_allocBuffer(outBuf, len);
         if(res != UA_STATUSCODE_GOOD)
             return res;
         allocated = true;
@@ -1322,7 +1322,7 @@ UA_encodeJson(const void *src, const UA_DataType *type, UA_ByteString *outBuf,
     if(res == UA_STATUSCODE_GOOD)
         outBuf->length = (size_t)((uintptr_t)ctx.pos - (uintptr_t)outBuf->data);
     else if(allocated)
-        UA_ByteString_clear(outBuf);
+        UA_String_clear(outBuf);
     return res;
 }
 

--- a/src/util/ua_eventfilter_lex.c
+++ b/src/util/ua_eventfilter_lex.c
@@ -8487,12 +8487,13 @@ lit:
     *token = create_operand(ctx, OT_LITERAL);
     (*token)->operand.literal.data = UA_new(lt);
     (*token)->operand.literal.type = lt;
+    UA_String nodeIdStr = { match.length, match.data };
     if(lt == &UA_TYPES[UA_TYPES_NODEID]) {
-        res = UA_NodeId_parse((UA_NodeId*)(*token)->operand.literal.data, match);
+        res = UA_NodeId_parse((UA_NodeId*)(*token)->operand.literal.data, nodeIdStr);
     } else if(lt == &UA_TYPES[UA_TYPES_EXPANDEDNODEID]) {
-        res = UA_ExpandedNodeId_parse((UA_ExpandedNodeId*)(*token)->operand.literal.data, match);
+        res = UA_ExpandedNodeId_parse((UA_ExpandedNodeId*)(*token)->operand.literal.data, nodeIdStr);
     } else if(lt == &UA_TYPES[UA_TYPES_GUID]) {
-        res = UA_Guid_parse((UA_Guid*)(*token)->operand.literal.data, match);
+        res = UA_Guid_parse((UA_Guid*)(*token)->operand.literal.data, nodeIdStr);
     } else {
         res = UA_decodeJson(&match, (*token)->operand.literal.data, lt, NULL);
     }
@@ -8504,7 +8505,8 @@ sao:
     match.length = (uintptr_t)(pos-b);
     match.data = (UA_Byte*)(uintptr_t)b;
     *token = create_operand(ctx, OT_SAO);
-    res = UA_SimpleAttributeOperand_parse(&(*token)->operand.sao, match);
+    UA_String saoStr = { match.length, match.data };
+    res = UA_SimpleAttributeOperand_parse(&(*token)->operand.sao, saoStr);
     tokenId = (res == UA_STATUSCODE_GOOD) ? EF_TOK_SAO : 0;
 
 finish:

--- a/tools/schema/Custom.Opc.Ua.Transport.bsd
+++ b/tools/schema/Custom.Opc.Ua.Transport.bsd
@@ -68,7 +68,7 @@
   
   <opc:StructuredType Name="AsymmetricAlgorithmSecurityHeader">
     <opc:Documentation>Asymmetric Security Header</opc:Documentation>
-    <opc:Field Name="SecurityPolicyUri" TypeName="opc:ByteString" />
+    <opc:Field Name="SecurityPolicyUri" TypeName="opc:String" />
     <opc:Field Name="SenderCertificate" TypeName="opc:ByteString" />
     <opc:Field Name="ReceiverCertificateThumbprint" TypeName="opc:ByteString" />
   </opc:StructuredType>


### PR DESCRIPTION
The idea behind this PR is to increase the type safety by removing the typedef of ByteString and XmlElement to String.
This on the other side unfortunately leads to some duplicated code.
Imho this is fine for the greater purpose to increase the type safety.

A few parts in the code are adjusted in a hacky way, the maintainers with more knowledge about the code should take a further look on this.

Please see this PR more as a suggestions.
The unit tests are not adjusted at all.