### PR TITLE
refactor(pubsub): Rename ua_pubsub.h into ua_pubsub_internal.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -752,7 +752,7 @@ set(lib_headers ${PROJECT_SOURCE_DIR}/deps/open62541_queue.h
                 ${PROJECT_SOURCE_DIR}/src/server/ua_server_internal.h
                 ${PROJECT_SOURCE_DIR}/src/client/ua_client_internal.h
                 ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_networkmessage.h
-                ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub.h
+                ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_internal.h
                 ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_keystorage.h)
 
 set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c

--- a/examples/pubsub/server_pubsub_file_configuration.c
+++ b/examples/pubsub/server_pubsub_file_configuration.c
@@ -6,7 +6,7 @@
 #include <open62541/server_pubsub.h>
 #include <open62541/server_config_default.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 #include "common.h"
 

--- a/src/pubsub/ua_pubsub_config.c
+++ b/src/pubsub/ua_pubsub_config.c
@@ -9,7 +9,8 @@
 #include <open62541/server_pubsub.h>
 
 #if defined(UA_ENABLE_PUBSUB) && defined(UA_ENABLE_PUBSUB_FILE_CONFIG)
-#include "../pubsub/ua_pubsub.h"
+
+#include "ua_pubsub_internal.h"
 
 static UA_StatusCode
 createPubSubConnection(UA_PubSubManager *psm,

--- a/src/pubsub/ua_pubsub_connection.c
+++ b/src/pubsub/ua_pubsub_connection.c
@@ -10,8 +10,7 @@
  * Copyright (c) 2022 Fraunhofer IOSB (Author: Noel Graf)
  */
 
-#include "ua_pubsub.h"
-#include "../server/ua_server_internal.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 

--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -11,8 +11,7 @@
  */
 
 #include <open62541/server_pubsub.h>
-#include "ua_pubsub.h"
-#include "../server/ua_server_internal.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 

--- a/src/pubsub/ua_pubsub_internal.h
+++ b/src/pubsub/ua_pubsub_internal.h
@@ -12,8 +12,8 @@
  * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
  */
 
-#ifndef UA_PUBSUB_H_
-#define UA_PUBSUB_H_
+#ifndef UA_PUBSUB_INTERNAL_H_
+#define UA_PUBSUB_INTERNAL_H_
 
 #define UA_INTERNAL
 #include <open62541/server.h>
@@ -772,4 +772,4 @@ addSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGrou
 
 _UA_END_DECLS
 
-#endif /* UA_PUBSUB_H_ */
+#endif /* UA_PUBSUB_INTERNAL_H_ */

--- a/src/pubsub/ua_pubsub_keystorage.c
+++ b/src/pubsub/ua_pubsub_keystorage.c
@@ -7,7 +7,6 @@
  */
 
 #include "ua_pubsub_keystorage.h"
-#include "ua_pubsub.h"
 
 #ifdef UA_ENABLE_PUBSUB_SKS /* conditional compilation */
 

--- a/src/pubsub/ua_pubsub_keystorage.h
+++ b/src/pubsub/ua_pubsub_keystorage.h
@@ -20,7 +20,7 @@ _UA_BEGIN_DECLS
 #ifdef UA_ENABLE_PUBSUB_SKS
 
 #include "open62541_queue.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 /**
  * PubSubKeyStorage

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -10,8 +10,7 @@
  * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
  */
 
-#include <open62541/types.h>
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -9,7 +9,7 @@
  * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
  */
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB_SKS
 #include "ua_pubsub_keystorage.h"

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2022 Fraunhofer IOSB (Author: Noel Graf)
  */
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -10,8 +10,7 @@
  */
 
 #include <open62541/server_pubsub.h>
-#include "ua_pubsub.h"
-#include "../server/ua_server_internal.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 

--- a/src/pubsub/ua_pubsub_securitygroup.c
+++ b/src/pubsub/ua_pubsub_securitygroup.c
@@ -10,9 +10,8 @@
 
 #ifdef UA_ENABLE_PUBSUB_SKS /* conditional compilation */
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_keystorage.h"
-#include "../server/ua_server_internal.h"
 
 #define UA_PUBSUB_KEYMATERIAL_NONCELENGTH 32
 

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2021 Fraunhofer IOSB (Author: Jan Hermes)
  */
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -11,8 +11,7 @@
  * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
  */
 
-#include "ua_pubsub.h"
-#include "../server/ua_server_internal.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 

--- a/tests/pubsub/check_pubsub_config_freeze.c
+++ b/tests/pubsub/check_pubsub_config_freeze.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "ua_server_internal.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "test_helpers.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_configuration.c
+++ b/tests/pubsub/check_pubsub_configuration.c
@@ -10,7 +10,7 @@
 #include "../common.h"
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_connection_ethernet.c
+++ b/tests/pubsub/check_pubsub_connection_ethernet.c
@@ -13,8 +13,7 @@
 #include <open62541/types_generated.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_connection_mqtt.c
+++ b/tests/pubsub/check_pubsub_connection_mqtt.c
@@ -11,7 +11,7 @@
 #include <open62541/server_config_default.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_connection_udp.c
+++ b/tests/pubsub/check_pubsub_connection_udp.c
@@ -10,7 +10,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "ua_server_internal.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "test_helpers.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_decryption.c
+++ b/tests/pubsub/check_pubsub_decryption.c
@@ -9,7 +9,7 @@
 #include <open62541/server_config_default.h>
 #include <open62541/server_pubsub.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 #include "test_helpers.h"
 

--- a/tests/pubsub/check_pubsub_encoding_custom.c
+++ b/tests/pubsub/check_pubsub_encoding_custom.c
@@ -7,7 +7,7 @@
 
 #include <open62541/types.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_networkmessage.h"
 
 #include "math.h"

--- a/tests/pubsub/check_pubsub_encrypted_rt_levels.c
+++ b/tests/pubsub/check_pubsub_encrypted_rt_levels.c
@@ -10,7 +10,7 @@
 #include "open62541/server_pubsub.h"
 #include <open62541/plugin/securitypolicy_default.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_networkmessage.h"
 #include "testing_clock.h"
 #include "test_helpers.h"

--- a/tests/pubsub/check_pubsub_encryption.c
+++ b/tests/pubsub/check_pubsub_encryption.c
@@ -10,7 +10,7 @@
 #include <open62541/plugin/securitypolicy_default.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_encryption_aes256.c
+++ b/tests/pubsub/check_pubsub_encryption_aes256.c
@@ -10,7 +10,7 @@
 #include <open62541/plugin/securitypolicy_default.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_get_state.c
+++ b/tests/pubsub/check_pubsub_get_state.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 #include <open62541/plugin/log_stdout.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include "../arch/eventloop_posix/eventloop_posix.h"

--- a/tests/pubsub/check_pubsub_informationmodel.c
+++ b/tests/pubsub/check_pubsub_informationmodel.c
@@ -12,7 +12,7 @@
 #include <open62541/types_generated.h>
 
 #include "ua_server_internal.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "test_helpers.h"
 
 #include <math.h>

--- a/tests/pubsub/check_pubsub_mqtt.c
+++ b/tests/pubsub/check_pubsub_mqtt.c
@@ -10,7 +10,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_multiple_subscribe_rt_levels.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 #include <open62541/server_config_default.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_networkmessage.h"
 #include "testing_clock.h"
 #include "test_helpers.h"

--- a/tests/pubsub/check_pubsub_pds.c
+++ b/tests/pubsub/check_pubsub_pds.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "ua_server_internal.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "test_helpers.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_publish_ethernet.c
+++ b/tests/pubsub/check_pubsub_publish_ethernet.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 #include "ua_pubsub_networkmessage.h"
 

--- a/tests/pubsub/check_pubsub_publish_json.c
+++ b/tests/pubsub/check_pubsub_publish_json.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 #include <open62541/types.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "test_helpers.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_publish_rt_levels.c
+++ b/tests/pubsub/check_pubsub_publish_rt_levels.c
@@ -10,7 +10,7 @@
 #include <open62541/server_config_default.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_networkmessage.h"
 #include <server/ua_server_internal.h>
 

--- a/tests/pubsub/check_pubsub_publisherid.c
+++ b/tests/pubsub/check_pubsub_publisherid.c
@@ -6,7 +6,7 @@
 #include "test_helpers.h"
 #include "testing_clock.h"
 #include "ua_server_internal.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
 #include "util/ua_util_internal.h"

--- a/tests/pubsub/check_pubsub_publishspeed.c
+++ b/tests/pubsub/check_pubsub_publishspeed.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_sks_client.c
+++ b/tests/pubsub/check_pubsub_sks_client.c
@@ -14,7 +14,7 @@
 #include <open62541/plugin/certificategroup_default.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_keystorage.h"
 #include "ua_server_internal.h"
 

--- a/tests/pubsub/check_pubsub_sks_keystorage.c
+++ b/tests/pubsub/check_pubsub_sks_keystorage.c
@@ -9,7 +9,7 @@
 #include <open62541/server_config_default.h>
 #include <open62541/server_pubsub.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_keystorage.h"
 #include "ua_server_internal.h"
 

--- a/tests/pubsub/check_pubsub_sks_pull.c
+++ b/tests/pubsub/check_pubsub_sks_pull.c
@@ -14,8 +14,8 @@
 #include <open62541/plugin/certificategroup_default.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
 #include "ua_pubsub_keystorage.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_sks_push.c
+++ b/tests/pubsub/check_pubsub_sks_push.c
@@ -17,7 +17,7 @@
 
 #include "test_helpers.h"
 #include "../encryption/certificates.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_keystorage.h"
 #include "ua_server_internal.h"
 

--- a/tests/pubsub/check_pubsub_sks_securitygroups.c
+++ b/tests/pubsub/check_pubsub_sks_securitygroups.c
@@ -13,8 +13,8 @@
 #include <open62541/server_pubsub.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
 #include "ua_pubsub_keystorage.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -14,7 +14,7 @@
 
 #include "test_helpers.h"
 #include "testing_clock.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #define MULTICAST_URL "opc.udp://224.0.0.22:4801/"

--- a/tests/pubsub/check_pubsub_subscribe_config_freeze.c
+++ b/tests/pubsub/check_pubsub_subscribe_config_freeze.c
@@ -9,7 +9,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "ua_server_internal.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "test_helpers.h"
 
 #include <check.h>

--- a/tests/pubsub/check_pubsub_subscribe_encrypted.c
+++ b/tests/pubsub/check_pubsub_subscribe_encrypted.c
@@ -10,7 +10,7 @@
 #include <open62541/server_pubsub.h>
 
 #include "test_helpers.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 #include "testing_clock.h"
 

--- a/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
+++ b/tests/pubsub/check_pubsub_subscribe_msgrcvtimeout.c
@@ -6,7 +6,7 @@
 #include "testing_clock.h"
 #include "test_helpers.h"
 #include "ua_server_internal.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 
 #include <check.h>
 #include <stdlib.h>

--- a/tests/pubsub/check_pubsub_subscribe_rt_levels.c
+++ b/tests/pubsub/check_pubsub_subscribe_rt_levels.c
@@ -10,7 +10,7 @@
 #include <open62541/server_config_default.h>
 #include <open62541/plugin/log_stdout.h>
 
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_pubsub_networkmessage.h"
 #include "testing_clock.h"
 #include "test_helpers.h"

--- a/tests/pubsub/check_pubsub_udp_unicast.c
+++ b/tests/pubsub/check_pubsub_udp_unicast.c
@@ -13,7 +13,7 @@
 
 #include "../../deps/mp_printf.h"
 #include "testing_clock.h"
-#include "ua_pubsub.h"
+#include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
 #define STR_BUFSIZE             1024


### PR DESCRIPTION
This way all subsystems (client/server/pubsub) follow the same nomenclature.