### PR TITLE
[Review]refactor(plugin): avoid magic numbers in detection of DER encoding

### DIFF
--- a/plugins/crypto/openssl/certificategroup.c
+++ b/plugins/crypto/openssl/certificategroup.c
@@ -310,19 +310,16 @@ reloadCertificates(UA_CertificateGroup *certGroup) {
         X509_CRL * crl = NULL;
         BIO * bio = NULL;
 
-        /* Try to load DER encoded CRL */
         bio = BIO_new_mem_buf((void *)context->trustList.trustedCrls[i].data,
                               (int)context->trustList.trustedCrls[i].length);
+        /* Try to load DER encoded CRL */
         crl = d2i_X509_CRL_bio(bio, NULL);
-        BIO_free(bio);
-
         if (crl == NULL) {
             /* Try to load PEM encoded CRL */
-            bio = BIO_new_mem_buf((void *)context->trustList.trustedCrls[i].data,
-                                  (int)context->trustList.trustedCrls[i].length);
+            BIO_reset(bio);
             crl = PEM_read_bio_X509_CRL(bio, NULL, NULL, NULL);
-            BIO_free(bio);
         }
+        BIO_free(bio);
 
         if (crl == NULL) {
             return UA_STATUSCODE_BADINTERNALERROR;
@@ -333,19 +330,16 @@ reloadCertificates(UA_CertificateGroup *certGroup) {
         X509_CRL * crl = NULL;
         BIO * bio = NULL;
 
-        /* Try to load DER encoded Issuer CRL */
         bio = BIO_new_mem_buf((void *)context->trustList.issuerCrls[i].data,
                               (int)context->trustList.issuerCrls[i].length);
+        /* Try to load DER encoded Issuer CRL */
         crl = d2i_X509_CRL_bio(bio, NULL);
-        BIO_free(bio);
-
         if (crl == NULL) {
             /* Try to load PEM encoded Issuer CRL */
-            bio = BIO_new_mem_buf((void *)context->trustList.issuerCrls[i].data,
-                                  (int)context->trustList.issuerCrls[i].length);
+            BIO_reset(bio);
             crl = PEM_read_bio_X509_CRL(bio, NULL, NULL, NULL);
-            BIO_free(bio);
         }
+        BIO_free(bio);
 
         if (crl == NULL) {
             return UA_STATUSCODE_BADINTERNALERROR;

--- a/plugins/crypto/openssl/securitypolicy_common.c
+++ b/plugins/crypto/openssl/securitypolicy_common.c
@@ -1314,17 +1314,16 @@ UA_OpenSSL_LoadPrivateKey(const UA_ByteString *privateKey) {
     EVP_PKEY *result = NULL;
     BIO *bio = NULL;
 
-    /* Try to read DER encoded private key */
     bio = BIO_new_mem_buf((void *) privateKey->data, (int) privateKey->length);
+    /* Try to read DER encoded private key */
     result = d2i_PrivateKey_bio(bio, NULL);
-    BIO_free(bio);
 
     if (result == NULL) {
         /* Try to read PEM encoded private key */
-        bio = BIO_new_mem_buf((void *) privateKey->data, (int) privateKey->length);
+        BIO_reset(bio);
         result = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
-        BIO_free(bio);
     }
+    BIO_free(bio);
 
     return result;
 }

--- a/plugins/crypto/openssl/securitypolicy_common.c
+++ b/plugins/crypto/openssl/securitypolicy_common.c
@@ -6,6 +6,7 @@
  *    Copyright 2020 (c) basysKom GmbH
  *    Copyright 2022 (c) Wind River Systems, Inc.
  *    Copyright 2022 (c) Fraunhofer IOSB (Author: Noel Graf)
+ *    Copyright 2024 (c) Siemens AG (Authors: Tin Raic, Thomas Zeschg)
  */
 
 /*
@@ -1307,18 +1308,19 @@ cleanup:
 
 EVP_PKEY *
 UA_OpenSSL_LoadPrivateKey(const UA_ByteString *privateKey) {
-    const unsigned char * pkData = privateKey->data;
-    long len = (long) privateKey->length;
-    if(len == 0)
+    if(privateKey->length == 0)
         return NULL;
 
     EVP_PKEY *result = NULL;
+    BIO *bio = NULL;
 
-    if (len > 1 && pkData[0] == 0x30 && pkData[1] == 0x82) { // Magic number for DER encoded keys
-        result = d2i_PrivateKey(EVP_PKEY_RSA, NULL,
-                                          &pkData, len);
-    } else {
-        BIO *bio = NULL;
+    /* Try to read DER encoded private key */
+    bio = BIO_new_mem_buf((void *) privateKey->data, (int) privateKey->length);
+    result = d2i_PrivateKey_bio(bio, NULL);
+    BIO_free(bio);
+
+    if (result == NULL) {
+        /* Try to read PEM encoded private key */
         bio = BIO_new_mem_buf((void *) privateKey->data, (int) privateKey->length);
         result = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
         BIO_free(bio);
@@ -1330,11 +1332,12 @@ UA_OpenSSL_LoadPrivateKey(const UA_ByteString *privateKey) {
 X509 *
 UA_OpenSSL_LoadCertificate(const UA_ByteString *certificate) {
     X509 * result = NULL;
-    const unsigned char *pData = certificate->data;
 
-    if (certificate->length > 1 && pData[0] == 0x30 && pData[1] == 0x82) { // Magic number for DER encoded files
-        result = UA_OpenSSL_LoadDerCertificate(certificate);
-    } else {
+    /* Try to decode DER encoded certificate */
+    result = UA_OpenSSL_LoadDerCertificate(certificate);
+
+    if (result == NULL) {
+        /* Try to decode PEM encoded certificate */
         result = UA_OpenSSL_LoadPemCertificate(certificate);
     }
 


### PR DESCRIPTION
Replace the detection of DER encoding using magic numbers by OpenSSL functions trying to decode the input as DER first and if not successful as PEM afterwards. This approach is less error prone and more flexible, as it supports Elliptic Curve keys and certificates as well.