### PR TITLE
fix(docs): Fix rendering of the UA_ENABLE_ENCRYPTION options

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -272,6 +272,7 @@ Detailed SDK Features
 **UA_ENABLE_ENCRYPTION**
    Enable encryption support and specify the used encryption backend. The possible
    options are:
+
    - ``OFF`` No encryption support. (default)
    - ``MBEDTLS`` Encryption support using mbed TLS
    - ``OPENSSL`` Encryption support using OpenSSL


### PR DESCRIPTION
The list didn't render correctly in Sphinx, nor Github because it was missing a newline. Now it should look correct!