### PR TITLE
[Review] fix(pubsub): fix MQTT subscribe

### DIFF
--- a/examples/pubsub/tutorial_pubsub_mqtt_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_mqtt_subscribe.c
@@ -111,8 +111,8 @@ addReaderGroup(UA_Server *server) {
         readerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_JSON;
 
     /* configure the mqtt publish topic */
-    UA_BrokerWriterGroupTransportDataType brokerTransportSettings;
-    memset(&brokerTransportSettings, 0, sizeof(UA_BrokerWriterGroupTransportDataType));
+    UA_BrokerDataSetReaderTransportDataType brokerTransportSettings;
+    memset(&brokerTransportSettings, 0, sizeof(UA_BrokerDataSetReaderTransportDataType));
     /* Assign the Topic at which MQTT publish should happen */
     /*ToDo: Pass the topic as argument from the reader group */
     brokerTransportSettings.queueName = UA_STRING(SUBSCRIBER_TOPIC);

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -76,6 +76,7 @@ void
 UA_ReaderGroupConfig_clear(UA_ReaderGroupConfig *readerGroupConfig) {
     UA_String_clear(&readerGroupConfig->name);
     UA_KeyValueMap_clear(&readerGroupConfig->groupProperties);
+    UA_ExtensionObject_clear(&readerGroupConfig->transportSettings);
     UA_String_clear(&readerGroupConfig->securityGroupId);
 }
 

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -65,6 +65,7 @@ UA_ReaderGroupConfig_copy(const UA_ReaderGroupConfig *src,
     UA_StatusCode res = UA_STATUSCODE_GOOD;
     res |= UA_String_copy(&src->name, &dst->name);
     res |= UA_KeyValueMap_copy(&src->groupProperties, &dst->groupProperties);
+    res |= UA_ExtensionObject_copy(&src->transportSettings, &dst->transportSettings);
     res |= UA_String_copy(&src->securityGroupId, &dst->securityGroupId);
     if(res != UA_STATUSCODE_GOOD)
         UA_ReaderGroupConfig_clear(dst);

--- a/tests/pubsub/check_pubsub_mqtt.c
+++ b/tests/pubsub/check_pubsub_mqtt.c
@@ -6,7 +6,6 @@
  */
 
 #include <open62541/server.h>
-#include <open62541/server_config_default.h>
 #include <open62541/server_pubsub.h>
 
 #include "test_helpers.h"
@@ -58,9 +57,7 @@ static void setup(void) {
     connectionConfig.publisherId.id.uint16 = 2234;
 
     /* configure options, set mqtt client id */
-    const int connectionOptionsCount = 1;
-
-    UA_KeyValuePair connectionOptions[connectionOptionsCount];
+    UA_KeyValuePair connectionOptions[1];
 
     size_t connectionOptionIndex = 0;
     connectionOptions[connectionOptionIndex].key = UA_QUALIFIEDNAME(0, CONNECTIONOPTION_NAME);
@@ -224,8 +221,8 @@ START_TEST(SinglePublishSubscribeDateTime){
         readerGroupConfig.name = UA_STRING("ReaderGroup1");
 
         /* configure the mqtt publish topic */
-        UA_BrokerWriterGroupTransportDataType brokerTransportSettingsSubscriber;
-        memset(&brokerTransportSettingsSubscriber, 0, sizeof(UA_BrokerWriterGroupTransportDataType));
+        UA_BrokerDataSetReaderTransportDataType brokerTransportSettingsSubscriber;
+        memset(&brokerTransportSettingsSubscriber, 0, sizeof(UA_BrokerDataSetReaderTransportDataType));
 
         brokerTransportSettingsSubscriber.queueName = UA_STRING(SUBSCRIBE_TOPIC);
         brokerTransportSettingsSubscriber.resourceUri = UA_STRING_NULL;


### PR DESCRIPTION
- fix` UA_ReaderGroupConfig` copy function
- use correct data type in example

BTW, why `UA_BrokerDataSetReaderTransportDataType ` is used for transport settings in ReaderGroup while specifications says that subtypes of ReaderGroupTransportDataType should be used?

### 6.2.8.2 ReaderGroup structures
### 6.2.8.2.1 ReaderGroupDataType
This Structure DataType is used to represent the configuration parameters for ReaderGroups.
The ReaderGroupDataType is formally defined in Table 46.
Table 46 – ReaderGroupDataType structure
|Name|Type|Description|Allow Subtypes|
|-------------------------|----------|-------------------------------------|----------------------|
|ReaderGroupDataType|Structure|Subtype of PubSubGroupDataType defined in 6.2.5.7.||
|TransportSettings|ReaderGroupTransportDataType|Transport mapping specific ReaderGroup parameters. The abstract base type is defined in 6.2.8.2.2. The concrete subtypes are defined in the subclauses for transport mapping specific parameters. If no concrete subtype is defined for the transport mapping, the field shall be null.|True|