### PR TITLE
fix(ci): fix allow reuse of TIME-WAIT sockets

### DIFF
--- a/tools/ci/ci.sh
+++ b/tools/ci/ci.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Allow to reuse TIME-WAIT sockets for new connections
-sudo echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
+sudo sysctl -w net.ipv4.tcp_tw_reuse=1
 
 ###########
 # cpplint #


### PR DESCRIPTION
* `sudo echo 1 >  /proc/sys/net/ipv4/tcp_tw_reuse` not allowed in CI (permission denied)