### PR TITLE
feature: optional types decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ option(UA_ENABLE_XML_ENCODING "Enable XML encoding (EXPERIMENTAL)" OFF)
 option(UA_ENABLE_NODESETLOADER "Enable nodesetLoader public API" OFF)
 option(UA_ENABLE_DATATYPES_ALL "Generate all datatypes for namespace zero (uses more binary space)" ON)
 
+option(UA_ENABLE_TYPES_DECODING "Automatically decode known Extension Objects" ON)
+mark_as_advanced(UA_ENABLE_TYPES_DECODING)
+
 if(UA_INFORMATION_MODEL_AUTOLOAD AND NOT UA_ENABLE_NODESETLOADER AND NOT UA_BUILD_FUZZING)
     set(UA_ENABLE_NODESET_INJECTOR ON)
 endif()


### PR DESCRIPTION
- Add a new UA_ENABLE_TYPES_DECODING advanced option (ON by default)
- Variant types containing Extension Objects can be decoded or not according to the parameter

It's now possible to avoid decoding and retrieve raw Extension Objects bytes when UA_ENABLE_TYPES_DECODING is manually set to OFF