### PR TITLE
fix(build): unit test compilation under MSVC

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,10 @@
 if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W1") # Reduce warnings level
+    add_compile_options(
+        $<$<CONFIG:>:/MD>
+        $<$<CONFIG:Debug>:/MDd>
+        $<$<CONFIG:Release>:/MD>
+    )    
 else()
     add_compile_options(-Wno-unused-variable -Wno-unused-function)
 endif()


### PR DESCRIPTION
This PR fixes Unit Test compilation under Visual Studio 2022.

Notes:
- Firewall pop-up at every test the first time, may be an issue for the CI server
- One test for the branch v1.4 is failing

```
----------------------------------------------------------
1/66 Testing: check_types_builtin
1/66 Test: check_types_builtin
Command: "D:/open62541/build/bin/tests/Release/check_types_builtin.exe"
Directory: D:/open62541/build/tests
"check_types_builtin" start time: Nov 11 14:23 W. Europe Standard Time
Output:
----------------------------------------------------------
Running suite(s): Built-in Data Types 62541-6 Table 1
98%: Checks: 68, Failures: 1, Errors: 0
D:\open62541\tests\check_types_builtin.c:894:F:encode:UA_Float_encodeShallWorkOnExample:0: Assertion 'dst.data[3] == result[i][3]' failed: dst.data[3] == 255, result[i][3] == 127
<end of output>
Test time =   0.02 sec
----------------------------------------------------------
Test Failed.
"check_types_builtin" end time: Nov 11 14:23 W. Europe Standard Time
"check_types_builtin" time elapsed: 00:00:00
--------------------------------------------------
```

Update: Test for v1.4 is failing because below code is not true anymore (tested on VS2022), seems that -NAN is encoded in the same way now

```
#if defined(_MSC_VER)
	/* On Visual Studio, -NAN is encoded differently */
	result[4][3] = 127;
#endif

```

Anyway seems that the test is already fixed in Master