### PR TITLE
[Review] feat(server): add ability to purge TCP connections

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -243,6 +243,8 @@ struct UA_ServerConfig {
     UA_UInt16 maxSessions;
     UA_Double maxSessionTimeout; /* in ms */
 
+    UA_UInt16 maxConnections;
+
     /* Operation limits */
     UA_UInt32 maxNodesPerRead;
     UA_UInt32 maxNodesPerWrite;


### PR DESCRIPTION
Purge when trying to establish a new connection and the maximum
number of connections has already been reached. Disabled by
default. Enable by setting maxConnections to >0