### PR TITLE
feat(client): Add new function to retrieve the user supplied subscription and monitored item contexts

### DIFF
--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -102,6 +102,10 @@ UA_Client_Subscriptions_delete_async(UA_Client *client,
 UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Client_Subscriptions_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId);
 
+/* Retrieve the user supplied subscription contexts */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Client_Subscriptions_getUserContexts(UA_Client *client, UA_UInt32 subscriptionId, void **subContext, UA_UInt32 monitorId, void **monitorContext);
+
 static UA_INLINE UA_THREADSAFE UA_SetPublishingModeResponse
 UA_Client_Subscriptions_setPublishingMode(UA_Client *client,
     const UA_SetPublishingModeRequest request) {

--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -102,9 +102,12 @@ UA_Client_Subscriptions_delete_async(UA_Client *client,
 UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Client_Subscriptions_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId);
 
-/* Retrieve the user supplied subscription contexts */
+/* Retrieve or change the user supplied subscription contexts */
 UA_StatusCode UA_EXPORT UA_THREADSAFE
-UA_Client_Subscriptions_getUserContexts(UA_Client *client, UA_UInt32 subscriptionId, void **subContext, UA_UInt32 monitorId, void **monitorContext);
+UA_Client_Subscriptions_getContext(UA_Client *client, UA_UInt32 subscriptionId, void **subContext);
+
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Client_Subscriptions_setContext(UA_Client *client, UA_UInt32 subscriptionId, void *subContext);
 
 static UA_INLINE UA_THREADSAFE UA_SetPublishingModeResponse
 UA_Client_Subscriptions_setPublishingMode(UA_Client *client,
@@ -280,6 +283,13 @@ UA_Client_MonitoredItems_setTriggering_async(UA_Client *client,
         &UA_TYPES[UA_TYPES_SETTRIGGERINGRESPONSE],
         userdata, requestId);
 }
+
+/* Retrieve or change the user supplied monitored item context */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Client_MonitoredItem_getContext(UA_Client *client, UA_UInt32 subscriptionId, UA_UInt32 monitoredItemId, void **monContext);
+
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Client_MonitoredItem_setContext(UA_Client *client, UA_UInt32 subscriptionId, UA_UInt32 monitoredItemId, void *monContext);
 
 _UA_END_DECLS
 

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -1007,6 +1007,36 @@ UA_Client_MonitoredItems_modify_async(UA_Client *client,
     return statusCode;
 }
 
+static void *
+UA_MonitoredItem_findByID(void *data, UA_Client_MonitoredItem *mon) {
+	UA_UInt32 monitorId = *(UA_UInt32*)data;
+	if (monitorId && (mon->monitoredItemId != monitorId)) {
+		return mon;
+	}
+	return NULL;
+}
+
+UA_StatusCode
+UA_Client_Subscriptions_getUserContexts(UA_Client *client, UA_UInt32 subscriptionId, void **subContext, UA_UInt32 monitorId, void **monContext)
+{
+	UA_LOCK(&client->clientMutex);
+	UA_Client_Subscription *sub = findSubscription(client, subscriptionId);
+	if (!sub) {
+		UA_UNLOCK(&client->clientMutex);
+		return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
+	}
+	if (subContext)
+		*subContext = sub->context;
+
+	if (monitorId && monContext)
+	{
+		UA_Client_MonitoredItem *mon = ZIP_ITER(MonitorItemsTree, &sub->monitoredItems, UA_MonitoredItem_findByID, &monitorId);
+		*monContext = mon ? mon->context : NULL;
+	}
+	UA_UNLOCK(&client->clientMutex);
+	return UA_STATUSCODE_GOOD;
+}
+
 /*************************************/
 /* Async Processing of Notifications */
 /*************************************/

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -1046,7 +1046,7 @@ UA_Client_MonitoredItems_modify_async(UA_Client *client,
 static void *
 ua_MonitoredItem_findByID(void *data, UA_Client_MonitoredItem *mon) {
 	UA_UInt32 monitorId = *(UA_UInt32*)data;
-	if (monitorId && (mon->monitoredItemId != monitorId)) {
+	if (monitorId && (mon->monitoredItemId == monitorId)) {
 		return mon;
 	}
 	return NULL;

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -1030,7 +1030,8 @@ UA_Client_Subscriptions_getUserContexts(UA_Client *client, UA_UInt32 subscriptio
 
 	if (monitorId && monContext)
 	{
-		UA_Client_MonitoredItem *mon = ZIP_ITER(MonitorItemsTree, &sub->monitoredItems, UA_MonitoredItem_findByID, &monitorId);
+		UA_Client_MonitoredItem *mon = (UA_Client_MonitoredItem *)
+				ZIP_ITER(MonitorItemsTree, &sub->monitoredItems, UA_MonitoredItem_findByID, &monitorId);
 		*monContext = mon ? mon->context : NULL;
 	}
 	UA_UNLOCK(&client->clientMutex);

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -211,7 +211,7 @@ UA_Client_Subscriptions_getContext(UA_Client *client, UA_UInt32 subscriptionId, 
 		return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
 	}
 
-	subContext = sub->context;
+	*subContext = sub->context;
 	UA_UNLOCK(&client->clientMutex);
 	return UA_STATUSCODE_GOOD;
 }

--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -456,7 +456,7 @@ UA_DataSetFieldConfig_copy(const UA_DataSetFieldConfig *src,
 }
 
 UA_DataSetField *
-UA_DataSetField_find(UA_PubSubManager *psm, UA_NodeId id) {
+UA_DataSetField_find(UA_PubSubManager *psm, const UA_NodeId id) {
     if(!psm)
         return NULL;
     UA_PublishedDataSet *tmpPDS;


### PR DESCRIPTION
I need this when trying to integrate open62541 into an environment (LabVIEW from National Instruments) that is considerably different than most programming environments. It offers a possibility to interface to shared libraries but requires event resources that must be allocated and deallocated in the LabVIEW environment itself and from the shared library side can't be managed, only used. So I store that resource in the subscription user context.
While there is a delete callback to manage that user context, I can not call any C function from that callback to deallocate the event resource when the subscription is deleted. Instead I have to retrieve that event resource and pass it back into the environment to close it there.
Without this function I would have to somehow post the event resource from the delete callback to some queue or something to retrieve then retrieve it after the UA_Client_Subscriptions_delete() call. Rather than adding yet another asynchronous operation it would be much easier to simply retrieve the user context directly as it is already stored in the client handle.

