### PR TITLE
fix(eventloop): only attempt to call the UA_ConnectionManager_new_POSIX_Ethernet() when compiling for Linux

### DIFF
--- a/include/open62541/plugin/eventloop.h
+++ b/include/open62541/plugin/eventloop.h
@@ -602,6 +602,7 @@ UA_ConnectionManager_new_POSIX_TCP(const UA_String eventSourceName);
 UA_EXPORT UA_ConnectionManager *
 UA_ConnectionManager_new_POSIX_UDP(const UA_String eventSourceName);
 
+#if defined(__linux__) /* Linux only so far */
 /**
  * Ethernet Connection Manager
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -685,7 +686,7 @@ UA_ConnectionManager_new_POSIX_UDP(const UA_String eventSourceName);
  *    Drop message if it cannot be sent in time (default: true). */
 UA_EXPORT UA_ConnectionManager *
 UA_ConnectionManager_new_POSIX_Ethernet(const UA_String eventSourceName);
-
+#endif
 /**
  * MQTT Connection Manager
  * ~~~~~~~~~~~~~~~~~~~~~~~

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -313,7 +313,7 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
 #endif
 
         /* Add the Ethernet connection manager */
-#if defined(UA_ARCHITECTURE_POSIX)
+#if defined(UA_ARCHITECTURE_POSIX) && (defined(__linux__))
         UA_ConnectionManager *ethCM =
             UA_ConnectionManager_new_POSIX_Ethernet(UA_STRING("eth connection manager"));
         if(ethCM)


### PR DESCRIPTION
 This function is only generated for Linux and should not be attempted to call for other Posix platforms. As this connection manager uses raw ethernet frames it can't be implemented easily on other platforms without using entirely different APIs such as pcap/Npcap. This fixes Issue #6883