### PR TITLE
Updated Visual Studio build instructions on Windows

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,117 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x86-RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x86_x64" ],
+      "buildRoot": "${projectDir}\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "UA_ENABLE_ENCRYPTION",
+          "value": "MBEDTLS",
+          "type": "STRING"
+        },
+        {
+          "name": "MBEDTLS_INCLUDE_DIRS",
+          "value": "D:/UaComAutomation2/deps/Mbed TLS/include",
+          "type": "PATH"
+        },
+        {
+          "name": "MBEDTLS_LIBRARY",
+          "value": "D:/UaComAutomation2/deps/Mbed TLS/lib/mbedtls.lib",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "MBEDX509_LIBRARY",
+          "value": "D:/UaComAutomation2/deps/Mbed TLS/lib/mbedx509.lib",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "MBEDCRYPTO_LIBRARY",
+          "value": "D:/UaComAutomation2/deps/Mbed TLS/lib/mbedcrypto.lib",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "CMAKE_INSTALL_PREFIX",
+          "value": "D:\\UaComAutomation2\\deps\\open62541",
+          "type": "PATH"
+        },
+        {
+          "name": "UA_ENABLE_DISCOVERY",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ENABLE_DIAGNOSTICS",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ENABLE_HISTORIZING",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ENABLE_PUBSUB",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ENABLE_PUBSUB_INFORMATIONMODEL",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_ENABLE_NODESETLOADER",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "LIBXML2_INCLUDE_DIR",
+          "value": "D:/UaComAutomation2/deps/libxml2/x86-Release/include/libxml2",
+          "type": "PATH"
+        },
+        {
+          "name": "LIBXML2_LIBRARY",
+          "value": "D:/UaComAutomation2/deps/libxml2/x86-Release/lib/libxml2.lib",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "LIBXML2_XMLLINT_EXECUTABLE",
+          "value": "D:/UaComAutomation2/deps/libxml2/x86-Release/bin/xmllint.exe",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "UA_ENABLE_JSON_ENCODING",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "UA_LOGLEVEL",
+          "value": "0",
+          "type": "STRING"
+        },
+        {
+          "name": "UA_NAMESPACE_ZERO",
+          "value": "FULL",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_BUILD_TYPE",
+          "value": "RelWithDebInfo",
+          "type": "STRING"
+        },
+        {
+          "name": "UA_BUILD_EXAMPLES",
+          "value": "True",
+          "type": "BOOL"
+        }
+      ]
+    }
+  ]
+}

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -79,7 +79,7 @@ Here we explain the build process for Visual Studio 2022 Community.
 - Download and install
     - Python 3.x: https://python.org/downloads
     - Visual Studio 2022: https://visualstudio.microsoft.com
-    - When installing Visual Studio select the workload "Desktop development with C++"
+        - When installing Visual Studio select the workload "Desktop development with C++"
 
 - Open Visual Studio and from the Get started window select "Clone a repository"
     - Repository location: https://github.com/open62541/open62541.git
@@ -90,7 +90,7 @@ Here we explain the build process for Visual Studio 2022 Community.
 - Build / Build All
 - Build / Install open62541
 
-Note: the solution generated with cmake can be compiled in parallel with the command
+Note: the solution generated with cmake can also be compiled in parallel with the command
 
 .. code-block:: bash
 

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -77,8 +77,8 @@ Building with Visual Studio on Windows
 Here we explain the build process for Visual Studio 2022 Community.
 
 - Download and install
-  - Python 3.x: https://python.org/downloads
-  - Visual Studio 2022: https://visualstudio.microsoft.com
+    - Python 3.x: https://python.org/downloads
+    - Visual Studio 2022: https://visualstudio.microsoft.com
     - When installing Visual Studio select the workload "Desktop development with C++"
 
 - Open Visual Studio and from the Get started window select "Clone a repository"
@@ -94,7 +94,7 @@ Note: the solution generated with cmake can be compiled in parallel with the com
 
 .. code-block:: bash
 
-msbuild open62541.sln /v:n -t:rebuild -m
+    msbuild open62541.sln /v:n -t:rebuild -m
 
 Building on OS X
 ^^^^^^^^^^^^^^^^

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -108,9 +108,9 @@ Building with CMake/MinGW on Windows
 To build with MinGW, just replace the compiler selection in the call to CMake.
 
 - Download and install
-  - MinGW http://sourceforge.net/projects/mingw
-  - Python 3.x: https://python.org/downloads
-  - CMake: http://www.cmake.org/cmake/resources/software.html
+    - MinGW http://sourceforge.net/projects/mingw
+    - Python 3.x: https://python.org/downloads
+    - CMake: http://www.cmake.org/cmake/resources/software.html
 
 - Download the open62541 sources (using git or as a zipfile from github)
 - Open a command shell (cmd) and run

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -24,7 +24,9 @@ Building with CMake on Ubuntu or Debian
    sudo apt-get install python3-sphinx graphviz  # for documentation generation
    sudo apt-get install python3-sphinx-rtd-theme # documentation style
 
+   git clone https://github.com/open62541/open62541.git
    cd open62541
+   git submodule update --init --recursive
    mkdir build
    cd build
    cmake ..
@@ -69,30 +71,30 @@ CMake project definition looks as follows:
     #   find_package(open62541 REQUIRED)
     #   target_link_libraries(main open62541::open62541)
 
-Building with CMake on Windows
+Building with Visual Studio on Windows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Here we explain the build process for Visual Studio (2013 or newer). To build
-with MinGW, just replace the compiler selection in the call to CMake.
+Here we explain the build process for Visual Studio 2022 Community.
 
 - Download and install
-
   - Python 3.x: https://python.org/downloads
-  - CMake: http://www.cmake.org/cmake/resources/software.html
-  - Microsoft Visual Studio: https://www.visualstudio.com/products/visual-studio-community-vs
+  - Visual Studio 2022: https://visualstudio.microsoft.com
+    - When installing Visual Studio select the workload "Desktop development with C++"
 
-- Download the open62541 sources (using git or as a zipfile from github)
-- Open a command shell (cmd) and run
+- Open Visual Studio and from the Get started window select "Clone a repository"
+    - Repository location: https://github.com/open62541/open62541.git
+    - Select a local path where to download the project and press Clone
+- Switch to Folder View from the Solution Explorer
+- Project / CMake Settings for open62541
+        - Customize CMake variables as wanted and save
+- Build / Build All
+- Build / Install open62541
 
-.. code-block:: bat
+Note: the solution generated with cmake can be compiled in parallel with the command
 
-   cd <path-to>\open62541
-   mkdir build
-   cd build
-   <path-to>\cmake.exe .. -G "Visual Studio 14 2015"
-   :: You can use use cmake-gui for a graphical user-interface to select features
+.. code-block:: bash
 
-- Then open :file:`build\open62541.sln` in Visual Studio 2015 and build as usual
+msbuild open62541.sln /v:n -t:rebuild -m
 
 Building on OS X
 ^^^^^^^^^^^^^^^^
@@ -181,7 +183,7 @@ Main Build Options
   - ``MinSizeRel`` -Os optimization without debug symbols
 
 **BUILD_SHARED_LIBS**
-   Build a shared library (dll/so) or (an archive of) object files for linking
+   Build a shared library (.dll/.so) or (an archive of) object files for linking
    into a static binary. Shared libraries are recommended for a system-wide
    install. Note that this option modifies the :file:`ua_config.h` file that is
    also included in :file:`open62541.h` for the single-file distribution.

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -40,6 +40,12 @@ Building with CMake on Ubuntu or Debian
    make doc # html documentation
    make doc_pdf # pdf documentation (requires LaTeX)
 
+Note: parallel compilation can be enable by using 
+
+.. code-block:: bash
+
+    make -j$(nproc)
+
 You can install open62541 using the well known `make install` command. This
 allows you to use pre-built libraries and headers for your own project. In order
 to use open62541 as a shared library (.dll or .so) make sure to activate the
@@ -95,6 +101,28 @@ Note: the solution generated with cmake can also be compiled in parallel with th
 .. code-block:: bash
 
     msbuild open62541.sln /v:n -t:rebuild -m
+
+Building with CMake/MinGW on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To build with MinGW, just replace the compiler selection in the call to CMake.
+
+- Download and install
+  - MinGW http://sourceforge.net/projects/mingw
+  - Python 3.x: https://python.org/downloads
+  - CMake: http://www.cmake.org/cmake/resources/software.html
+
+- Download the open62541 sources (using git or as a zipfile from github)
+- Open a command shell (cmd) and run
+
+.. code-block:: bat
+
+   cd <path-to>\open62541
+   mkdir build
+   cd build
+   <path-to>\cmake.exe .. -G "MinGW Makefiles"
+   :: You can use use cmake-gui for a graphical user-interface to select features
+   make
 
 Building on OS X
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Updated Visual Studio 2022 build instructions on Windows. Now CMake is integrated and a separate download is not required anymore.

Note: are Debian packages link still updated? 
For example the last daily build is from 2022: https://launchpad.net/~open62541-team/+archive/ubuntu/daily