### PR TITLE
Fix double decrement in UA_KeyValueMap_remove()

### DIFF
--- a/src/ua_util.c
+++ b/src/ua_util.c
@@ -420,15 +420,16 @@ UA_KeyValueMap_remove(UA_KeyValueMap *map,
         m[i] = m[s-1];
         UA_KeyValuePair_init(&m[s-1]);
     }
-    
+
     /* Ignore the result. In case resize fails, keep the longer original array
-     * around. Resize never fails when reducing the size to zero. Reduce the
-     * size integer in any case. */
+     * around. Resize never fails when reducing the size to zero. */
     UA_StatusCode res =
         UA_Array_resize((void**)&map->map, &map->mapSize, map->mapSize - 1,
                           &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-    (void)res;
-    map->mapSize--;
+    /* Adjust map->mapSize only when UA_Array_resize() failed. On success, the
+     * value has already been decremented by UA_Array_resize(). */
+    if(res != UA_STATUSCODE_GOOD)
+        map->mapSize--;
     return UA_STATUSCODE_GOOD;
 }
 

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -567,6 +567,22 @@ START_TEST(idOrderString) {
     ck_assert(UA_NodeId_order(&id_str_d, &id_str_c) == UA_ORDER_MORE);
 } END_TEST
 
+START_TEST(kvmRemove) {
+    UA_KeyValueMap *kvm = UA_KeyValueMap_new();
+
+    UA_UInt16 value_1 = 1;
+    UA_KeyValueMap_setScalar(kvm, UA_QUALIFIEDNAME(0, "value-1"), (void *)&value_1,
+                             &UA_TYPES[UA_TYPES_UINT16]);
+    UA_UInt16 value_2 = 2;
+    UA_KeyValueMap_setScalar(kvm, UA_QUALIFIEDNAME(0, "value-2"), (void *)&value_2,
+                             &UA_TYPES[UA_TYPES_UINT16]);
+
+    UA_KeyValueMap_remove(kvm, UA_QUALIFIEDNAME(0, "value-1"));
+    ck_assert(UA_KeyValueMap_contains(kvm, UA_QUALIFIEDNAME(0, "value-2")));
+
+    UA_KeyValueMap_delete(kvm);
+} END_TEST
+
 static Suite* testSuite_Utils(void) {
     Suite *s = suite_create("Utils");
     TCase *tc_endpointUrl_split = tcase_create("EndpointUrl_split");
@@ -597,6 +613,10 @@ static Suite* testSuite_Utils(void) {
     tcase_add_test(tc1, idOrderGuid);
     tcase_add_test(tc1, idOrderString);
     suite_add_tcase(s, tc2);
+
+    TCase *tc3 = tcase_create("test keyvaluemap");
+    tcase_add_test(tc3, kvmRemove);
+    suite_add_tcase(s, tc3);
 
     return s;
 }


### PR DESCRIPTION
This fixes #6905. The branch on the return value of `UA_Array_resize()` is necessary:

- On success, we must not decrement the internal map size again—`UA_Array_resize()` already did that for us.
- On failure, the underlying array storage is left as-is, leaving a null element in the last position. We must decrement the map size anyway to avoid accessing this null element in the other operations.