### PR TITLE
fix(tools): ua2json compilation issue when <unistd.h> is not available

### DIFF
--- a/tools/ua2json/ua2json.c
+++ b/tools/ua2json/ua2json.c
@@ -10,7 +10,6 @@
 #include <open62541/types_generated_handling.h>
 
 #include <stdio.h>
-#include <unistd.h>
 
 /* Internal headers */
 #include "ua_pubsub_networkmessage.h"
@@ -250,7 +249,7 @@ int main(int argc, char **argv) {
             buf.data = r;
         }
 
-        ssize_t c = read(fileno(in), &buf.data[pos], length - pos);
+        int c = read(fileno(in), &buf.data[pos], length - pos);
         if(c == 0)
             break;
         if(c < 0) {


### PR DESCRIPTION
<unistd.h> is not available in Visual Studio, but it's not really required because can be removed and ssize_t can be replaced by int