### PR TITLE
fix(ci): use correct path to ci.sh for doc_upload workflow

### DIFF
--- a/.github/workflows/doc_upload.yml
+++ b/.github/workflows/doc_upload.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install -y -qq python3-sphinx graphviz python-six texlive-fonts-recommended texlive-latex-extra texlive-plain-generic texlive-latex-recommended latexmk texlive-fonts-extra
           pip install sphinx-rtd-theme
       - name: Build Documentation
-        run: source tools/ci.sh && build_docs_pdf
+        run: source tools/ci/ci.sh && build_docs_pdf
       - name: Checkout Website Repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This was apparently missed when moving the file in https://github.com/open62541/open62541/pull/6766 and the workflow has been broken on master since.

Note: The contributing guidelines list `ci` as a semantic commit type not a scope, but the actual commits over the last three years use it as a scope, so I followed that.