### PR TITLE
feat(pubsub): Make DataSetFieldId and field Description configurable.

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -349,6 +349,10 @@ typedef struct {
         UA_DataValue ** staticValueSource;
     } rtValueSource;
     UA_UInt32 maxStringLength;
+    UA_LocalizedText description;
+    /* If dataSetFieldId is not set, the GUID will be generated on adding the
+    *  field*/
+    UA_Guid dataSetFieldId;
 } UA_DataSetVariableConfig;
 
 typedef enum {


### PR DESCRIPTION
In some use cases it's necessary to configure them. There is no reason why they should not be part of the configuration.