### PR TITLE
fix(pubsub): Fix invalid DataType comparison on creation of DSR

### DIFF
--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -239,8 +239,8 @@ UA_DataSetReader_create(UA_PubSubManager *psm, UA_NodeId readerGroupIdentifier,
             fieldIdx < dsr->config.dataSetMetaData.fieldsSize; fieldIdx++) {
             const UA_FieldMetaData *field =
                 &dsr->config.dataSetMetaData.fields[fieldIdx];
-            if((field->builtInType == UA_TYPES_STRING ||
-                field->builtInType == UA_TYPES_BYTESTRING) &&
+            if((field->builtInType == UA_NS0ID_STRING ||
+                field->builtInType == UA_NS0ID_BYTESTRING) &&
                field->maxStringLength == 0) {
                 /* Fields of type String or ByteString need to have defined
                  * MaxStringLength*/


### PR DESCRIPTION
UA_TYPES_* are indexes of the types in the type array (they are starting from 0).
We need to compare the builtInType to the well-known numeric identifier of the type (they are starting from 1).