### PR TITLE
fix(core): Fix issue with invalid signature on the generated CSR

### DIFF
--- a/plugins/crypto/mbedtls/securitypolicy_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_common.c
@@ -523,6 +523,17 @@ mbedtls_createSigningRequest(mbedtls_pk_context *localPrivateKey,
         mbedtls_x509write_csr_set_key(&request, localPrivateKey);
     }
 
+    /* The private key associated with the request will be used for signing the
+     * created CSR. Enforce using RSASSA-PKCS1-v1_5 scheme. The hash_id
+     * argument is ignored when padding is set to MBEDTLS_RSA_PKCS_V15, so just
+     * set it to MBEDTLS_MD_NONE. */
+    mbedtls_rsa_context *rsaContext = mbedtls_pk_rsa(
+#if MBEDTLS_VERSION_NUMBER < 0x03000000
+        *request.key);
+#else
+        *request.private_key);
+#endif
+    mbedtls_rsa_set_padding(rsaContext, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
 
     unsigned char requestBuf[CSR_BUFFER_SIZE];
     memset(requestBuf, 0, sizeof(requestBuf));


### PR DESCRIPTION
Private key associated with a security policy is used for multipule purposes:
- asymmetric encryption/decryption
- asymmetric signing/verification
- certificate/CSR signing

The schemes used for each of the above operations differ in various policies. However, for certificate/CSR signing, for all RSA-based policies, the used scheme is always RSASSA-PKCS1-v1_5 (MBEDTLS_RSA_PKCS_V15).

Before generating a CSR, enforce using the RSASSA-PKCS1-v1_5 by setting the corresponding private key context.

This fixes a bug that in some edge cases, the private key context left after the previous usage of RSA module (e.g. if the last usage was to decrypt the user password) had the scheme set to RSAES-OAEP (MBEDTLS_RSA_PKCS_V21). This resulted in an invalid signature over the CSR.