### PR TITLE
Respect certificate format in `UA_CreateCertificate()` with Mbed TLS

### DIFF
--- a/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
+++ b/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
@@ -390,7 +390,7 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
             return ret;
         }
 
-        len = strlen((char *) output_buf);
+        len = strlen((char *)output_buf);
         break;
     }
     }

--- a/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
+++ b/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
@@ -374,10 +374,10 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
     unsigned char *c = output_buf;
     size_t len = 0;
 
-    memset(output_buf, 0, 16000);
+    memset(output_buf, 0, sizeof(output_buf));
     switch(keyFormat) {
     case UA_CERTIFICATEFORMAT_DER: {
-        if((ret = mbedtls_pk_write_key_der(key, output_buf, 16000)) < 0) {
+        if((ret = mbedtls_pk_write_key_der(key, output_buf, sizeof(output_buf))) < 0) {
             return ret;
         }
 
@@ -386,7 +386,7 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
         break;
     }
     case UA_CERTIFICATEFORMAT_PEM: {
-        if((ret = mbedtls_pk_write_key_pem(key, output_buf, 16000)) != 0) {
+        if((ret = mbedtls_pk_write_key_pem(key, output_buf, sizeof(output_buf))) != 0) {
             return ret;
         }
 
@@ -410,19 +410,19 @@ static int write_certificate(mbedtls_x509write_cert *crt, UA_CertificateFormat c
     unsigned char *c = output_buf;
     size_t len = 0;
 
-    memset(output_buf, 0, 4096);
+    memset(output_buf, 0, sizeof(output_buf));
     switch(certFormat) {
     case UA_CERTIFICATEFORMAT_DER: {
-        if((ret = mbedtls_x509write_crt_der(crt, output_buf, 4096, f_rng, p_rng)) < 0) {
+        if((ret = mbedtls_x509write_crt_der(crt, output_buf, sizeof(output_buf), f_rng, p_rng)) < 0) {
             return ret;
         }
 
         len = ret;
-        c = output_buf + 4096 - len;
+        c = output_buf + sizeof(output_buf) - len;
         break;
     }
     case UA_CERTIFICATEFORMAT_PEM: {
-        if((ret = mbedtls_x509write_crt_pem(crt, output_buf, 4096, f_rng, p_rng)) < 0) {
+        if((ret = mbedtls_x509write_crt_pem(crt, output_buf, sizeof(output_buf), f_rng, p_rng)) < 0) {
             return ret;
         }
 

--- a/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
+++ b/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
@@ -376,7 +376,7 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
 
     memset(output_buf, 0, 16000);
     switch(keyFormat) {
-    case UA_CERTIFICATEFORMAT_DER: {
+    case UA_CERTIFICATEFORMAT_PEM: {
         if((ret = mbedtls_pk_write_key_pem(key, output_buf, 16000)) != 0) {
             return ret;
         }
@@ -384,7 +384,7 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
         len = strlen((char *) output_buf);
         break;
     }
-    case UA_CERTIFICATEFORMAT_PEM: {
+    case UA_CERTIFICATEFORMAT_DER: {
         if((ret = mbedtls_pk_write_key_der(key, output_buf, 16000)) < 0) {
             return ret;
         }

--- a/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
+++ b/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
@@ -376,14 +376,6 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
 
     memset(output_buf, 0, 16000);
     switch(keyFormat) {
-    case UA_CERTIFICATEFORMAT_PEM: {
-        if((ret = mbedtls_pk_write_key_pem(key, output_buf, 16000)) != 0) {
-            return ret;
-        }
-
-        len = strlen((char *) output_buf);
-        break;
-    }
     case UA_CERTIFICATEFORMAT_DER: {
         if((ret = mbedtls_pk_write_key_der(key, output_buf, 16000)) < 0) {
             return ret;
@@ -391,6 +383,14 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
 
         len = ret;
         c = output_buf + sizeof(output_buf) - len;
+        break;
+    }
+    case UA_CERTIFICATEFORMAT_PEM: {
+        if((ret = mbedtls_pk_write_key_pem(key, output_buf, 16000)) != 0) {
+            return ret;
+        }
+
+        len = strlen((char *) output_buf);
         break;
     }
     }


### PR DESCRIPTION
Fixes #6936. The fix itself is simply the swapping of two constants in f840415d9620670fbde8ea6e7d69d079368b1a74. 077695f233d8cc5c952042fff7821a79a8c86a73 makes use of `sizeof()` to avoid duplication and potential mistakes in the future regarding the buffer size (which I noticed while fixing the bug).

The remaining two commits clean up the code to match the surrounding code style.

Technically, this is a breaking change.