### PR TITLE
[Discussion]: Add user context parameter to UA_Server_createCondition Public API

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1623,17 +1623,29 @@ typedef UA_StatusCode
  * @param conditionType The NodeId of the node representation of the ConditionType
  * @param conditionName The name of the condition to be created
  * @param conditionSource The NodeId of the Condition Source (Parent of the Condition)
- * @param hierarchialReferenceType The NodeId of Hierarchical ReferenceType
+ * @param hierarchicalReferenceType The NodeId of Hierarchical ReferenceType
  *                                 between Condition and its source
+ * @param nodeContext An optional pointer to user-defined data, associated
+ *                                 with the node in the nodestore
  * @param outConditionId The NodeId of the created Condition
  * @return The StatusCode of the UA_Server_createCondition method */
+UA_StatusCode UA_EXPORT
+UA_Server_createConditionWithContext(UA_Server *server,
+                          const UA_NodeId conditionId,
+                          const UA_NodeId conditionType,
+                          const UA_QualifiedName conditionName,
+                          const UA_NodeId conditionSource,
+                          const UA_NodeId hierarchicalReferenceType,
+                          void *nodeContext,
+                          UA_NodeId *outConditionId);
+
 UA_StatusCode UA_EXPORT
 UA_Server_createCondition(UA_Server *server,
                           const UA_NodeId conditionId,
                           const UA_NodeId conditionType,
                           const UA_QualifiedName conditionName,
                           const UA_NodeId conditionSource,
-                          const UA_NodeId hierarchialReferenceType,
+                          const UA_NodeId hierarchicalReferenceType,
                           UA_NodeId *outConditionId);
 
 /* The method pair UA_Server_addCondition_begin and _finish splits the
@@ -1652,8 +1664,18 @@ UA_Server_createCondition(UA_Server *server,
  *        E.g. passing UA_NODEID_NULL will result in a NodeId in namespace 0.
  * @param conditionType The NodeId of the node representation of the ConditionType
  * @param conditionName The name of the condition to be added
+ * @param nodeContext @param nodeidContext An optional pointer to user-defined data, 
+ *                                 associated with the node in the nodestore
  * @param outConditionId The NodeId of the added Condition
  * @return The StatusCode of the UA_Server_addCondition_begin method */
+UA_StatusCode UA_EXPORT
+UA_Server_addConditionWithContext_begin(UA_Server *server,
+                             const UA_NodeId conditionId,
+                             const UA_NodeId conditionType,
+                             const UA_QualifiedName conditionName,
+                             void *nodeContext,
+                             UA_NodeId *outConditionId);
+
 UA_StatusCode UA_EXPORT
 UA_Server_addCondition_begin(UA_Server *server,
                              const UA_NodeId conditionId,

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -2521,11 +2521,12 @@ addCondition_finish(UA_Server *server, const UA_NodeId conditionId,
  * ReferenceType should be passed to create the reference to condition source.
  * Otherwise, UA_NODEID_NULL should be passed to make the condition unexposed. */
 UA_StatusCode
-UA_Server_createCondition(UA_Server *server,
+UA_Server_createConditionWithContext(UA_Server *server,
                           const UA_NodeId conditionId, const UA_NodeId conditionType,
                           const UA_QualifiedName conditionName,
                           const UA_NodeId conditionSource,
-                          const UA_NodeId hierarchialReferenceType,
+                          const UA_NodeId hierarchicalReferenceType,
+                          void *nodeContext,
                           UA_NodeId *outNodeId) {
     if(!outNodeId) {
         UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_USERLAND,
@@ -2533,22 +2534,35 @@ UA_Server_createCondition(UA_Server *server,
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    UA_StatusCode retval = UA_Server_addCondition_begin(server, conditionId, conditionType,
-                                                        conditionName, outNodeId);
+    UA_StatusCode retval = UA_Server_addConditionWithContext_begin(server, conditionId, conditionType,
+                                                        conditionName, nodeContext, outNodeId);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
     UA_LOCK(&server->serviceMutex);
     retval = addCondition_finish(server, *outNodeId, conditionType, conditionName,
-                               conditionSource, hierarchialReferenceType);
+                               conditionSource, hierarchicalReferenceType);
     UA_UNLOCK(&server->serviceMutex);
     return retval;
 }
 
 UA_StatusCode
-UA_Server_addCondition_begin(UA_Server *server, const UA_NodeId conditionId,
-                             const UA_NodeId conditionType,
-                             const UA_QualifiedName conditionName, UA_NodeId *outNodeId) {
+UA_Server_createCondition(UA_Server *server,
+                          const UA_NodeId conditionId, const UA_NodeId conditionType,
+                          const UA_QualifiedName conditionName,
+                          const UA_NodeId conditionSource,
+                          const UA_NodeId hierarchicalReferenceType,
+                          UA_NodeId *outNodeId) {
+    return UA_Server_createConditionWithContext(server, conditionId, conditionType,
+                                     conditionName, conditionSource,
+                                     hierarchicalReferenceType,
+                                     NULL, outNodeId);
+}
+
+UA_StatusCode
+UA_Server_addConditionWithContext_begin(UA_Server *server, const UA_NodeId conditionId,
+                             const UA_NodeId conditionType, const UA_QualifiedName conditionName, 
+                             void *nodeContext, UA_NodeId *outNodeId) {
     if(!outNodeId) {
         UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_USERLAND,
                      "outNodeId cannot be NULL!");
@@ -2575,9 +2589,17 @@ UA_Server_addCondition_begin(UA_Server *server, const UA_NodeId conditionId,
         UA_Server_addNode_begin(server, UA_NODECLASS_OBJECT, conditionId,
                                 UA_NODEID_NULL, UA_NODEID_NULL, conditionName,
                                 conditionType, &oAttr, &UA_TYPES[UA_TYPES_OBJECTATTRIBUTES],
-                                NULL, outNodeId);
+                                nodeContext, outNodeId);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Adding Condition failed", );
     return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_addCondition_begin(UA_Server *server, const UA_NodeId conditionId,
+                             const UA_NodeId conditionType,
+                             const UA_QualifiedName conditionName, UA_NodeId *outConditionId) {
+    return UA_Server_addConditionWithContext_begin(server, conditionId, conditionType,
+                                                   conditionName, NULL, outConditionId);
 }
 
 UA_StatusCode


### PR DESCRIPTION
Adding a custom context to a Condition Object the same way as for regular Objects would be a useful feature since it increases the versatility of Alarms and Conditions. Especially the State Callback functions, Enabled, Acknowledged, Confirmed, Active, will be more usable.

The proposed change would have an impact on the Public API, that's why I left the current function and created a new one around it. The name `UA_Server_createConditionWithContext` might be bulky, but since A&C is still marked as experimental I suggest to put this method in place of the current one. In this way, the additional qualifier would not be necessary and the same design would be used as for the creation of regular Objects.