### PR TITLE
Fix EndpointDescription consistent certificate conversion for openssl

### DIFF
--- a/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
+++ b/plugins/crypto/openssl/ua_openssl_aes128sha256rsaoaep.c
@@ -589,9 +589,9 @@ UA_SecurityPolicy_Aes128Sha256RsaOaep(UA_SecurityPolicy *policy,
     channelModule->compareCertificate =
         UA_ChannelM_Aes128Sha256RsaOaep_compareCertificate;
 
-    /* Copy the certificate and add a NULL to the end */
-
-    retval = UA_copyCertificate(&policy->localCertificate, &localCertificate);
+    /* Load and convert to DER if necessary */
+    retval =
+        UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 

--- a/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
+++ b/plugins/crypto/openssl/ua_openssl_aes256sha256rsapss.c
@@ -641,9 +641,9 @@ UA_SecurityPolicy_Aes256Sha256RsaPss(UA_SecurityPolicy *policy,
     channelModule->compareCertificate =
         UA_ChannelM_Aes256Sha256RsaPss_compareCertificate;
 
-    /* Copy the certificate and add a NULL to the end */
-
-    retval = UA_copyCertificate(&policy->localCertificate, &localCertificate);
+    /* Load and convert to DER if necessary */
+    retval =
+        UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 


### PR DESCRIPTION
At the moment, the PEM to DER conversion in openssl is only done for
http://opcfoundation.org/UA/SecurityPolicy#None
http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256

This fix will also automatically convert PEM certificates to DER for:
http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss
http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep

Reported here:
https://github.com/umati/Sample-Server/issues/1348

Code taken from Basic256Sha256:
https://github.com/open62541/open62541/blob/42b58674bcf6afc3a3465e81bf95523379c45ade/plugins/crypto/openssl/ua_openssl_basic256sha256.c#L558-L561