### PR TITLE
feat(ci): build and upload amalgamation sources for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Build Release Artifacts
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: sudo apt-get install -y -qq libmbedtls-dev
+      - run: source tools/ci.sh && build_release_amalgamation
+      - run: gh release upload ${{ github.ref_name }} build/open62541.{c,h}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build Release Artifacts
 
 on:
+  push:
   release:
     types: [published]
 
@@ -16,3 +17,4 @@ jobs:
       - run: gh release upload ${{ github.ref_name }} build/open62541.{c,h}
         env:
           GH_TOKEN: ${{ github.token }}
+        if: github.event_name == 'release'

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -85,6 +85,21 @@ function build_release {
     make ${MAKEOPTS}
 }
 
+function build_release_amalgamation {
+    mkdir -p build; cd build; rm -rf *
+    cmake -DCMAKE_BUILD_TYPE=None \
+          -DUA_ENABLE_AMALGAMATION=ON \
+          -DUA_NAMESPACE_ZERO=FULL \
+          -DUA_ENABLE_DATATYPES_ALL=ON \
+          -DUA_ENABLE_ENCRYPTION=MBEDTLS \
+          -DUA_ENABLE_PUBSUB=ON \
+          -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
+          ..
+
+    make ${MAKEOPTS}
+}
+
 ######################
 # Build Amalgamation #
 ######################


### PR DESCRIPTION
Add a workflow that automatically builds and uploads an amalgamation build based on the debian (salsa) configuration for every release.
To ensure we catch failures before the actual release, this workflow builds on every push, but only tries to upload when it was triggered by a release being published.

Here are example runs for [push events](https://github.com/marwinglaser/open62541/actions/runs/12259608912/job/34202174116) and [release events](https://github.com/marwinglaser/open62541/actions/runs/12259890365/job/34203154860), as well as the corresponding [release](https://github.com/marwinglaser/open62541/releases/tag/v1.4.8-test) with the attached files.

(This needs some small changes when merging back into master to adapt to e907a0ed91427e449ed711bada7a5db3947cd644 and 12bd03568b4b0c8e16b8a6fefd18d03fbbb2e759)