### PR TITLE
fix(types): make UA_String_append an exported function, 

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -200,7 +200,7 @@ UA_String_fromChars(const char *src) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
 UA_Boolean UA_EXPORT
 UA_String_isEmpty(const UA_String *s);
 
-UA_StatusCode
+UA_StatusCode UA_EXPORT
 UA_String_append(UA_String *s, const UA_String s2);
 
 UA_EXPORT extern const UA_String UA_STRING_NULL;


### PR DESCRIPTION
so that ua-cli can use it when open62541 is compiled as shared library