### PR TITLE
fix(client): Fixed log message crashing application

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1618,7 +1618,7 @@ verifyClientApplicationURI(const UA_Client *client) {
             UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_CLIENT,
                            "The configured ApplicationURI does not match the URI "
                            "specified in the certificate for the SecurityPolicy %S",
-                           sp->policyUri.length);
+                           sp->policyUri);
         }
     }
 #endif


### PR DESCRIPTION
Wrong data were passed to logger, which resulted in segmentation fault.