### PR TITLE
fix(server): Missing session attribute init and KVM removal

### DIFF
--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -309,8 +309,10 @@ UA_Server_deleteSessionAttribute(UA_Server *server, const UA_NodeId *sessionId,
         UA_UNLOCK(&server->serviceMutex);
         return UA_STATUSCODE_BADSESSIONIDINVALID;
     }
-    UA_StatusCode res =
-        UA_KeyValueMap_remove(session->attributes, key);
+    UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
+    if (session->attributes) {
+        res = UA_KeyValueMap_remove(session->attributes, key);
+    }
     UA_UNLOCK(&server->serviceMutex);
     return res;
 }

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -287,10 +287,13 @@ UA_Server_setSessionAttribute(UA_Server *server, const UA_NodeId *sessionId,
         return UA_STATUSCODE_BADNOTWRITABLE;
     UA_LOCK(&server->serviceMutex);
     UA_Session *session = getSessionById(server, sessionId);
-    UA_StatusCode res = UA_STATUSCODE_BADSESSIONIDINVALID;
-    if(session)
-        res = UA_KeyValueMap_set(session->attributes,
-                                 key, value);
+    if(!session) {
+        UA_UNLOCK(&server->serviceMutex);
+        return UA_STATUSCODE_BADSESSIONIDINVALID;
+    }
+    if(!session->attributes)
+        session->attributes = UA_KeyValueMap_new();
+    UA_StatusCode res = UA_KeyValueMap_set(session->attributes, key, value);
     UA_UNLOCK(&server->serviceMutex);
     return res;
 }

--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -464,7 +464,6 @@ UA_KeyValueMap_remove(UA_KeyValueMap *map,
         UA_Array_resize((void**)&map->map, &map->mapSize, map->mapSize - 1,
                           &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
     (void)res;
-    map->mapSize--;
     return UA_STATUSCODE_GOOD;
 }
 

--- a/tests/check_kvm_utils.c
+++ b/tests/check_kvm_utils.c
@@ -69,7 +69,6 @@ START_TEST(CheckKVMContains) {
 END_TEST
 
 START_TEST(CheckKVMCopy) {
-
         UA_KeyValueMap *kvm = keyValueMap_setup(10, 0, 0);
         UA_KeyValueMap kvmCopy;
         UA_KeyValueMap_copy(kvm, &kvmCopy);
@@ -79,6 +78,20 @@ START_TEST(CheckKVMCopy) {
         }
         UA_KeyValueMap_delete(kvm);
         UA_KeyValueMap_clear(&kvmCopy);
+}
+END_TEST
+
+START_TEST(CheckKVMRemove) {
+        UA_KeyValueMap *kvm = keyValueMap_setup(10, 0, 0);
+        
+        for(size_t i = 0; i < 10; i++) {
+            char key[10];
+            snprintf(key, 10, "key%02d", (UA_UInt16) i);
+            UA_StatusCode retval = UA_KeyValueMap_remove(kvm, UA_QUALIFIEDNAME(0, key));
+            ck_assert_uint_eq(retval,UA_STATUSCODE_GOOD);
+            ck_assert_uint_eq(kvm->mapSize, 9-i);
+        }
+        UA_KeyValueMap_delete(kvm);
 }
 END_TEST
 
@@ -167,6 +180,7 @@ int main(void) {
     tcase_add_test(tc, CheckNullArgs);
     tcase_add_test(tc, CheckKVMContains);
     tcase_add_test(tc, CheckKVMCopy);
+    tcase_add_test(tc, CheckKVMRemove);
     tcase_add_test(tc, CheckKVMCountMergedIntersecting);
     tcase_add_test(tc, CheckKVMCountMergedComplementary);
     tcase_add_test(tc, CheckKVMCountMergedCommon);


### PR DESCRIPTION
Fixed issues related to:

- Initializing a session's attribute key value map
- Removing values from a key value map (mapSize was reduced twice)

Also added test cases that check against the fixed issues.

Related to:

- https://github.com/open62541/open62541/issues/6724
- https://github.com/open62541pp/open62541pp/issues/362