### PR TITLE
fix(client): Read the Url from the remote endoint

### DIFF
--- a/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
+++ b/plugins/crypto/mbedtls/ua_mbedtls_create_certificate.c
@@ -374,23 +374,23 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
     unsigned char *c = output_buf;
     size_t len = 0;
 
-    memset(output_buf, 0, 16000);
+    memset(output_buf, 0, sizeof(output_buf));
     switch(keyFormat) {
     case UA_CERTIFICATEFORMAT_DER: {
-        if((ret = mbedtls_pk_write_key_pem(key, output_buf, 16000)) != 0) {
-            return ret;
-        }
-
-        len = strlen((char *) output_buf);
-        break;
-    }
-    case UA_CERTIFICATEFORMAT_PEM: {
-        if((ret = mbedtls_pk_write_key_der(key, output_buf, 16000)) < 0) {
+        if((ret = mbedtls_pk_write_key_der(key, output_buf, sizeof(output_buf))) < 0) {
             return ret;
         }
 
         len = ret;
         c = output_buf + sizeof(output_buf) - len;
+        break;
+    }
+    case UA_CERTIFICATEFORMAT_PEM: {
+        if((ret = mbedtls_pk_write_key_pem(key, output_buf, sizeof(output_buf))) != 0) {
+            return ret;
+        }
+
+        len = strlen((char *)output_buf);
         break;
     }
     }
@@ -410,19 +410,19 @@ static int write_certificate(mbedtls_x509write_cert *crt, UA_CertificateFormat c
     unsigned char *c = output_buf;
     size_t len = 0;
 
-    memset(output_buf, 0, 4096);
+    memset(output_buf, 0, sizeof(output_buf));
     switch(certFormat) {
     case UA_CERTIFICATEFORMAT_DER: {
-        if((ret = mbedtls_x509write_crt_der(crt, output_buf, 4096, f_rng, p_rng)) < 0) {
+        if((ret = mbedtls_x509write_crt_der(crt, output_buf, sizeof(output_buf), f_rng, p_rng)) < 0) {
             return ret;
         }
 
         len = ret;
-        c = output_buf + 4096 - len;
+        c = output_buf + sizeof(output_buf) - len;
         break;
     }
     case UA_CERTIFICATEFORMAT_PEM: {
-        if((ret = mbedtls_x509write_crt_pem(crt, output_buf, 4096, f_rng, p_rng)) < 0) {
+        if((ret = mbedtls_x509write_crt_pem(crt, output_buf, sizeof(output_buf), f_rng, p_rng)) < 0) {
             return ret;
         }
 

--- a/plugins/server_config.json5
+++ b/plugins/server_config.json5
@@ -187,6 +187,11 @@
 //      policy: "http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep",
 //      certificate: "/path/to/certificate",
 //      privateKey: "/path/to/privateKey"
+//    },
+//    {
+//      policy: "http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss"",
+//      certificate: "/path/to/certificate",
+//      privateKey: "/path/to/privateKey"
 //    }
 //  ],
 

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -301,7 +301,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
     UA_AccessControl *ac = &config->accessControl;
 
     if(ac->clear)
-        clear_default(ac);
+        ac->clear(ac);
 
     ac->clear = clear_default;
     ac->activateSession = activateSession_default;

--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -647,6 +647,7 @@ PARSE_JSON(SecurityPolciesField) {
     UA_String basic256uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
     UA_String basic256Sha256uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256");
     UA_String aes128sha256rsaoaepuri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep");
+    UA_String aes256sha256rsapssuri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss");
 
     cj5_token tok = ctx->tokens[++ctx->index];
     for(size_t j = tok.size; j > 0; j--) {
@@ -740,6 +741,13 @@ PARSE_JSON(SecurityPolciesField) {
             if(retval != UA_STATUSCODE_GOOD) {
                 UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_USERLAND,
                                "Could not add SecurityPolicy#Aes128Sha256RsaOaep with error code %s",
+                               UA_StatusCode_name(retval));
+            }
+        } else if(UA_String_equal(&policy, &aes256sha256rsapssuri)) {
+             retval = UA_ServerConfig_addSecurityPolicyAes256Sha256RsaPss(config, &certificate, &privateKey);
+             if(retval != UA_STATUSCODE_GOOD) {
+                 UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_USERLAND,
+                                "Could not add SecurityPolicy#Aes256Sha256RsaPss with error code %s",
                                UA_StatusCode_name(retval));
             }
         } else {

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1713,17 +1713,19 @@ initConnect(UA_Client *client) {
         return;
 
     /* Extract hostname and port from the URL */
+    UA_String currentUrl = (client->endpoint.endpointUrl.length > 0) ?
+                           client->endpoint.endpointUrl :
+                           client->config.endpointUrl;
     UA_String hostname = UA_STRING_NULL;
     UA_String path = UA_STRING_NULL;
     UA_UInt16 port = 4840;
 
     client->connectStatus =
-        UA_parseEndpointUrl(&client->config.endpointUrl, &hostname, &port, &path);
+        UA_parseEndpointUrl(&currentUrl, &hostname, &port, &path);
     if(client->connectStatus != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_NETWORK,
                        "OPC UA URL is invalid: %.*s",
-                       (int)client->config.endpointUrl.length,
-                       client->config.endpointUrl.data);
+                       (int)currentUrl.length, currentUrl.data);
         return;
     }
 
@@ -1766,8 +1768,7 @@ initConnect(UA_Client *client) {
     if(client->connectStatus != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_CLIENT,
                        "Could not open a TCP connection to %.*s",
-                       (int)client->config.endpointUrl.length,
-                       client->config.endpointUrl.data);
+                       (int)currentUrl.length, currentUrl.data);
         client->connectStatus = UA_STATUSCODE_BADCONNECTIONCLOSED;
     }
 }

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -41,13 +41,11 @@ findUserTokenPolicy(UA_Client *client, UA_EndpointDescription *endpoint);
  * We fall back if connecting to an EndpointUrl fails. */
 static UA_String
 getEndpointUrl(UA_Client *client) {
-    if(client->endpoint.endpointUrl.length > 0) {
+    if(client->endpoint.endpointUrl.length > 0)
         return client->endpoint.endpointUrl;
-    } else if(client->discoveryUrl.length > 0) {
+    if(client->discoveryUrl.length > 0)
         return client->discoveryUrl;
-    } else {
-        return client->config.endpointUrl;
-    }
+    return client->config.endpointUrl;
 }
 
 /* If an EndpointUrl doesn't work (TCP connection fails), fall back to the

--- a/src/pubsub/ua_pubsub_keystorage.c
+++ b/src/pubsub/ua_pubsub_keystorage.c
@@ -68,7 +68,7 @@ UA_PubSubKeyStorage_delete(UA_Server *server, UA_PubSubKeyStorage *keyStorage) {
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
 
     /* Remove callback */
-    if(!keyStorage->callBackId) {
+    if(!keyStorage->callBackId != 0) {
         removeCallback(server, keyStorage->callBackId);
         keyStorage->callBackId = 0;
     }

--- a/src/pubsub/ua_pubsub_keystorage.c
+++ b/src/pubsub/ua_pubsub_keystorage.c
@@ -208,7 +208,12 @@ UA_PubSubKeyStorage_addKeyRolloverCallback(UA_Server *server,
     if(!server || !keyStorage || !callback || timeToNextMs <= 0)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
-    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+    // Check if the callback already exist
+    if(*callbackID != 0) {
+        return UA_STATUSCODE_GOOD;
+    }
+    
+    UA_LOCK_ASSERT(&psm->sc.server->serviceMutex);
 
     UA_DateTime dateTimeToNextKey = UA_DateTime_nowMonotonic() +
         (UA_DateTime)(UA_DATETIME_MSEC * timeToNextMs);

--- a/src/ua_util.c
+++ b/src/ua_util.c
@@ -420,15 +420,16 @@ UA_KeyValueMap_remove(UA_KeyValueMap *map,
         m[i] = m[s-1];
         UA_KeyValuePair_init(&m[s-1]);
     }
-    
+
     /* Ignore the result. In case resize fails, keep the longer original array
-     * around. Resize never fails when reducing the size to zero. Reduce the
-     * size integer in any case. */
+     * around. Resize never fails when reducing the size to zero. */
     UA_StatusCode res =
         UA_Array_resize((void**)&map->map, &map->mapSize, map->mapSize - 1,
                           &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-    (void)res;
-    map->mapSize--;
+    /* Adjust map->mapSize only when UA_Array_resize() failed. On success, the
+     * value has already been decremented by UA_Array_resize(). */
+    if(res != UA_STATUSCODE_GOOD)
+        map->mapSize--;
     return UA_STATUSCODE_GOOD;
 }
 

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -567,6 +567,22 @@ START_TEST(idOrderString) {
     ck_assert(UA_NodeId_order(&id_str_d, &id_str_c) == UA_ORDER_MORE);
 } END_TEST
 
+START_TEST(kvmRemove) {
+    UA_KeyValueMap *kvm = UA_KeyValueMap_new();
+
+    UA_UInt16 value_1 = 1;
+    UA_KeyValueMap_setScalar(kvm, UA_QUALIFIEDNAME(0, "value-1"), (void *)&value_1,
+                             &UA_TYPES[UA_TYPES_UINT16]);
+    UA_UInt16 value_2 = 2;
+    UA_KeyValueMap_setScalar(kvm, UA_QUALIFIEDNAME(0, "value-2"), (void *)&value_2,
+                             &UA_TYPES[UA_TYPES_UINT16]);
+
+    UA_KeyValueMap_remove(kvm, UA_QUALIFIEDNAME(0, "value-1"));
+    ck_assert(UA_KeyValueMap_contains(kvm, UA_QUALIFIEDNAME(0, "value-2")));
+
+    UA_KeyValueMap_delete(kvm);
+} END_TEST
+
 static Suite* testSuite_Utils(void) {
     Suite *s = suite_create("Utils");
     TCase *tc_endpointUrl_split = tcase_create("EndpointUrl_split");
@@ -597,6 +613,10 @@ static Suite* testSuite_Utils(void) {
     tcase_add_test(tc1, idOrderGuid);
     tcase_add_test(tc1, idOrderString);
     suite_add_tcase(s, tc2);
+
+    TCase *tc3 = tcase_create("test keyvaluemap");
+    tcase_add_test(tc3, kvmRemove);
+    suite_add_tcase(s, tc3);
 
     return s;
 }

--- a/tests/client/check_client_securechannel.c
+++ b/tests/client/check_client_securechannel.c
@@ -220,6 +220,41 @@ START_TEST(SecureChannel_cableunplugged) {
 }
 END_TEST
 
+/* Some servers have a certificate in their endpoint which they do not use for
+ * #None SecureChannels. To be compatible with them, only check if the
+ * certificate matches IF it gets sent in th asymHeader of the OPN message. */
+START_TEST(SecureChannel_serverCert) {
+    UA_Client *client = UA_Client_new();
+    UA_ClientConfig_setDefault(UA_Client_getConfig(client));
+
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    /* Copy the endpont and disconnect */
+    UA_EndpointDescription endpoint;
+    UA_EndpointDescription_copy(&client->endpoint, &endpoint);
+    UA_Client_disconnect(client);
+
+    /* Add a fake certificate information to the endpoint - which is not getting
+     * used during the connect with #None. */
+    endpoint.serverCertificate = UA_STRING_ALLOC("random 123");
+    client->config.endpoint = endpoint;
+
+    /* Reconnect */
+    retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Variant val;
+    UA_Variant_init(&val);
+    UA_NodeId nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
+    retval = UA_Client_readValueAttribute(client, nodeId, &val);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Variant_clear(&val);
+    UA_Client_delete(client);
+}
+END_TEST
+
 int main(void) {
     TCase *tc_sc = tcase_create("Client SecureChannel");
     tcase_add_checked_fixture(tc_sc, setup, teardown);
@@ -229,6 +264,7 @@ int main(void) {
     tcase_add_test(tc_sc, SecureChannel_networkfail);
     tcase_add_test(tc_sc, SecureChannel_reconnect);
     tcase_add_test(tc_sc, SecureChannel_cableunplugged);
+    tcase_add_test(tc_sc, SecureChannel_serverCert);
 
     Suite *s = suite_create("Client");
     suite_add_tcase(s, tc_sc);


### PR DESCRIPTION
In case 'reverse connect' is used, read the Url
of the remote endpoint instead of using the
local static configuration.

See https://github.com/open62541/open62541/issues/6871