### PR TITLE
fix(client): Read the Url from the remote endoint

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1713,17 +1713,19 @@ initConnect(UA_Client *client) {
         return;
 
     /* Extract hostname and port from the URL */
+    UA_String currentUrl = (client->endpoint.endpointUrl.length > 0) ?
+                           client->endpoint.endpointUrl :
+                           client->config.endpointUrl;
     UA_String hostname = UA_STRING_NULL;
     UA_String path = UA_STRING_NULL;
     UA_UInt16 port = 4840;
 
     client->connectStatus =
-        UA_parseEndpointUrl(&client->config.endpointUrl, &hostname, &port, &path);
+        UA_parseEndpointUrl(&currentUrl, &hostname, &port, &path);
     if(client->connectStatus != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_NETWORK,
                        "OPC UA URL is invalid: %.*s",
-                       (int)client->config.endpointUrl.length,
-                       client->config.endpointUrl.data);
+                       (int)currentUrl.length, currentUrl.data);
         return;
     }
 
@@ -1766,8 +1768,7 @@ initConnect(UA_Client *client) {
     if(client->connectStatus != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_CLIENT,
                        "Could not open a TCP connection to %.*s",
-                       (int)client->config.endpointUrl.length,
-                       client->config.endpointUrl.data);
+                       (int)currentUrl.length, currentUrl.data);
         client->connectStatus = UA_STATUSCODE_BADCONNECTIONCLOSED;
     }
 }


### PR DESCRIPTION
In case 'reverse connect' is used, read the Url
of the remote endpoint instead of using the
local static configuration.

See https://github.com/open62541/open62541/issues/6871