### PR TITLE
[Review] fix(deps): fix dependabot github-actions config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
-    directory: ".github"
+    directory: "/"
     target-branch: "master"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
With this dependabot now actually opens PRs like https://github.com/marwinglaser/open62541/pull/6 for outdated actions. Explicitly passing a directory for `github-actions` is [unnecessary](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory) according to the documentation and if specified it likely needs to be the full `.github/workflows`.