### PR TITLE
[Review] fix(ci): remove python-six dependency from doc_upload workflow

### DIFF
--- a/.github/workflows/doc_upload.yml
+++ b/.github/workflows/doc_upload.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y -qq python3-sphinx graphviz python-six texlive-fonts-recommended texlive-latex-extra texlive-plain-generic texlive-latex-recommended latexmk texlive-fonts-extra
+          sudo apt-get install -y -qq python3-sphinx graphviz texlive-fonts-recommended texlive-latex-extra texlive-plain-generic texlive-latex-recommended latexmk texlive-fonts-extra
           pip install sphinx-rtd-theme
       - name: Build Documentation
         run: source tools/ci/ci.sh && build_docs_pdf


### PR DESCRIPTION
GitHub is rolling out the [update of ubuntu-latest runners to ubuntu 24.04](https://github.com/actions/runner-images/issues/10636). This version of ubuntu has removed the un-versioned package `python-six`, only providing `python3-six`, which has made the doc_upload [workflow](https://github.com/open62541/open62541/actions/runs/12297577071/job/34319033378) [fail](https://github.com/open62541/open62541/actions/runs/12297600427/job/34319108388).
(Note that the `python-six` package in ubuntu 22.04 only contains the python2 interface while this workflow uses python3)

This PR fixes the workflow by removing the package completely as it appears to be unused and it seems to work.