### PR TITLE
fix(deps): Remove maybe-uninitialized warning from ziptree

### DIFF
--- a/deps/ziptree.c
+++ b/deps/ziptree.c
@@ -127,7 +127,7 @@ __ZIP_INSERT(void *h, zip_cmp_cb cmp, unsigned short fieldoffset,
      * than "x" */
     zip_elem *prev = NULL;
     zip_elem *cur = head->root;
-    enum ZIP_CMP cur_order, prev_order;
+    enum ZIP_CMP cur_order, prev_order = ZIP_CMP_EQ;
     do {
         cur_order = __ZIP_UNIQUE_CMP(cmp, x_key, ZIP_KEY_PTR(cur));
         if(cur_order == ZIP_CMP_EQ)


### PR DESCRIPTION
Warning appears (at least) with GCC 11.5.0 and 14.2.1 when using -O2, so reproduce for example with both -O2 and -Werror=maybe-uninitialized and get:
```
‘prev_order’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
```
Could fix also #6738