### PR TITLE
refactor(examples): do not set an invalid IP in server_multicast.c

### DIFF
--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
     config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample Multicast Server");
 
     //setting custom outbound interface
-    config->mdnsInterfaceIP = UA_String_fromChars("42.42.42.42"); //this line will produce an error and set the interface to 0.0.0.0
+    config->mdnsInterfaceIP = UA_String_fromChars("0.0.0.0");
 
     // See http://www.opcfoundation.org/UA/schemas/1.03/ServerCapabilities.csv
     // For a LDS server, you should only indicate the LDS capability.


### PR DESCRIPTION
Currently an IP 42.42.42.42 is set and the comment suggests that the network stack resets this to 0.0.0.0 in server_multicast.c. Just set 0.0.0.0 directly.

This is a backport of 253fc8abd5855851acc0f0d7fa62c98d2487f4f2 to the 1.3 branch.