### PR TITLE
refactor(examples,tests): avoid spaces for mDNS records

### DIFF
--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
     // Enable the mDNS announce and response functionality
     config->mdnsEnabled = true;
 
-    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample Multicast Server");
+    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample-Multicast-Server");
 
     //setting custom outbound interface
     config->mdnsInterfaceIP = UA_String_fromChars("0.0.0.0");

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
     UA_String_clear(&config->applicationDescription.applicationUri);
     config->applicationDescription.applicationUri =
         UA_String_fromChars("urn:open62541.example.server_register");
-    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample Server");
+    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample-Server");
     // See http://www.opcfoundation.org/UA/schemas/1.04/ServerCapabilities.csv
     //config.serverCapabilitiesSize = 1;
     //UA_String caps = UA_String_fromChars("LDS");

--- a/tests/fuzz/corpus_generator.c
+++ b/tests/fuzz/corpus_generator.c
@@ -55,7 +55,7 @@ static void start_server(void) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
     config->applicationDescription.applicationType = UA_APPLICATIONTYPE_SERVER;
     config->mdnsEnabled = true;
-    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample Multicast Server");
+    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample-Multicast-Server");
 
     UA_Server_run_startup(server);
     pthread_create(&server_thread, NULL, serverloop, NULL);

--- a/tests/fuzz/fuzz_tcp_message.cc
+++ b/tests/fuzz/fuzz_tcp_message.cc
@@ -70,7 +70,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     // Enable the mDNS announce and response functionality
     config->mdnsEnabled = true;
-    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample Multicast Server");
+    config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample-Multicast-Server");
 
     retval = UA_Server_run_startup(server);
     if(retval != UA_STATUSCODE_GOOD) {


### PR DESCRIPTION
Avoid spaces in mdnsServerName as this is used for mDNS records.

This is a backport of 711b0323845245a0f65d5b67f5f5ea40065462e1 into the 1.4 branch.