### PR TITLE
[Review] Fix UA_FILE_NS0_PRIVATE variable unset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,7 +1086,7 @@ endif()
 set(UA_FILE_NODESETS) # List of nodeset-xml files to be considered in the generated information model
 set(UA_NODESET_DIR ${PROJECT_SOURCE_DIR}/deps/ua-nodeset CACHE STRING "The path to the node-set directory (e.g. from https://github.com/OPCFoundation/UA-Nodeset)")
 
-unset(UA_FILE_NS0_PRIVATE)
+set(UA_FILE_NS0_PRIVATE "")
 if(UA_FILE_NS0)
     set(UA_FILE_NS0_PRIVATE "${UA_FILE_NS0}")
 endif()


### PR DESCRIPTION
According to the CMake [documentation](https://cmake.org/cmake/help/latest/command/unset.html): "unsetting a normal variable can expose a cache variable that was previously hidden".
This can lead to wrong build results if UA_NAMESPACE_ZERO is changed to FULL after configuring the project with default REDUCED value. This happens e.g. if ccmake is used like shown in the documentation.

Set UA_FILE_NS0_PRIVATE to "" like proposed in the CMake documentation to prevent this behavior.

This fixes https://github.com/open62541/open62541/issues/6937