### PR TITLE
[Review] fix(build): only try to read open62541 version number from git when it is the main CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,11 @@ set(OPEN62541_VER_PATCH 8)
 set(OPEN62541_VER_LABEL "-undefined") # like "-rc1" or "-g4538abcd" or "-g4538abcd-dirty"
 set(OPEN62541_VER_COMMIT "unknown-commit")
 
-# Overwrite the version information based on git if available
-include(SetGitBasedVersion)
-set_open62541_version()
+# Overwrite the version information based on git if available and we are the main cmake project.
+if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    include(SetGitBasedVersion)
+    set_open62541_version()
+endif()
 
 # Examples for the version string are:
 # v1.2


### PR DESCRIPTION
When open62541 gets included into another CMake project using CPM, it still tries to read the version info from a git tag. This leads to wrong version numbers within the config.h header. This PR fix fixes the problem and only changes the version number from git when open62541 is the main CMake project.