### PR TITLE
[Review] fix(plugins): return BadSecurityChecksFailed on untrusted cert or unknown issuer

### DIFF
--- a/plugins/crypto/mbedtls/ua_pki_mbedtls.c
+++ b/plugins/crypto/mbedtls/ua_pki_mbedtls.c
@@ -388,8 +388,10 @@ mbedtlsVerifyChain(CertInfo *ci, mbedtls_x509_crt *stack, mbedtls_x509_crt **old
          * self-signed (subject == issuer). We come back here to try a different
          * "path" if a subsequent verification fails. */
         issuer = mbedtlsFindNextIssuer(ci, stack, cert, issuer);
-        if(!issuer)
+        if(!issuer) {
+            ret = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
             break;
+        }
 
         /* Verification Step: Certificate Usage
          * Can the issuer act as CA? Omit for self-signed leaf certificates. */

--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -566,8 +566,10 @@ openSSL_verifyChain(CertContext *ctx, STACK_OF(X509) *stack, X509 **old_issuers,
         /* Find the issuer. We jump back here to find a different path if a
          * subsequent check fails. */
         issuer = openSSLFindNextIssuer(ctx, stack, cert, issuer);
-        if(!issuer)
+        if(!issuer) {
+            ret = UA_STATUSCODE_BADSECURITYCHECKSFAILED;
             break;
+        }
 
         /* Verification Step: Certificate Usage
          * Can the issuer act as CA? Omit for self-signed leaf certificates. */


### PR DESCRIPTION
In OPC UA CTT "Security ->Security Certificate Validation -> cases 005 and 009" expects BadSecurityChecksFailed when certificate is untrusted or issuer is unknown.