### PR TITLE
Consistency in the use of the Windows architecture flag

### DIFF
--- a/arch/eventloop_posix.c
+++ b/arch/eventloop_posix.c
@@ -415,7 +415,7 @@ UA_EventLoopPOSIX_free(UA_EventLoopPOSIX *el) {
     /* Process remaining delayed callbacks */
     processDelayed(el);
 
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
     /* Stop the Windows networking subsystem */
     WSACleanup();
 #endif
@@ -437,7 +437,7 @@ UA_EventLoop_new_POSIX(const UA_Logger *logger) {
     UA_LOCK_INIT(&el->elMutex);
     UA_Timer_init(&el->timer);
 
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
     /* Start the WSA networking subsystem on Windows */
     WSADATA wsaData;
     WSAStartup(MAKEWORD(2, 2), &wsaData);
@@ -519,7 +519,7 @@ cmpFD(const UA_FD *a, const UA_FD *b) {
 
 UA_StatusCode
 UA_EventLoopPOSIX_setNonBlocking(UA_FD sockfd) {
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
     int opts = fcntl(sockfd, F_GETFL);
     if(opts < 0 || fcntl(sockfd, F_SETFL, opts | O_NONBLOCK) < 0)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -545,7 +545,7 @@ UA_EventLoopPOSIX_setNoSigPipe(UA_FD sockfd) {
 UA_StatusCode
 UA_EventLoopPOSIX_setReusable(UA_FD sockfd) {
     int enableReuseVal = 1;
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
     int res = UA_setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR,
                             (const char*)&enableReuseVal, sizeof(enableReuseVal));
     res |= UA_setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT,

--- a/arch/eventloop_posix_eth.c
+++ b/arch/eventloop_posix_eth.c
@@ -328,7 +328,7 @@ ETH_connectionSocketCallback(UA_ConnectionManager *cm, UA_RegisteredFD *rfd,
         return;
 
     /* Receive */
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
     ssize_t ret = UA_recv(rfd->fd, (char*)response.data,
                           response.length, MSG_DONTWAIT);
 #else

--- a/arch/eventloop_posix_select.c
+++ b/arch/eventloop_posix_select.c
@@ -114,7 +114,7 @@ UA_EventLoopPOSIX_pollFDs(UA_EventLoopPOSIX *el, UA_DateTime listenTimeout) {
     }
 
     struct timeval tmptv = {
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
         (time_t)(listenTimeout / UA_DATETIME_SEC),
         (suseconds_t)((listenTimeout % UA_DATETIME_SEC) / UA_DATETIME_USEC)
 #else

--- a/arch/eventloop_posix_tcp.c
+++ b/arch/eventloop_posix_tcp.c
@@ -119,7 +119,7 @@ TCP_delayedClose(void *application, void *context) {
 static int
 getSockError(TCP_FD *conn) {
     int error = 0;
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
     socklen_t errlen = sizeof(int);
     int err = getsockopt(conn->rfd.fd, SOL_SOCKET, SO_ERROR, &error, &errlen);
 #else
@@ -191,7 +191,7 @@ TCP_connectionSocketCallback(UA_ConnectionManager *cm, TCP_FD *conn,
     UA_ByteString response = pcm->rxBuffer;
 
     /* Receive */
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
     ssize_t ret = UA_recv(conn->rfd.fd, (char*)response.data,
                           response.length, MSG_DONTWAIT);
 #else
@@ -558,7 +558,7 @@ TCP_registerListenSockets(UA_POSIXConnectionManager *pcm, const char *hostname,
 
     int retcode = getaddrinfo(hostname, portstr, &hints, &res);
     if(retcode != 0) {
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
         UA_LOG_SOCKET_ERRNO_WRAP(
         UA_LOG_WARNING(pcm->cm.eventSource.eventLoop->logger, UA_LOGCATEGORY_NETWORK,
                        "TCP\t| Lookup for \"%s\" on port %u failed (%s)",
@@ -808,7 +808,7 @@ TCP_openActiveConnection(UA_POSIXConnectionManager *pcm, const UA_KeyValueMap *p
     hints.ai_socktype = SOCK_STREAM;
     int error = getaddrinfo(hostname, portStr, &hints, &info);
     if(error != 0) {
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
         UA_LOG_SOCKET_ERRNO_WRAP(
         UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
                        "TCP\t| Lookup of %s failed (%s)",

--- a/examples/common.h
+++ b/examples/common.h
@@ -7,7 +7,7 @@
 #include <errno.h>
 
 /* sleep_ms */
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
 # include <synchapi.h>
 # define sleep_ms(ms) Sleep(ms)
 #else

--- a/examples/tutorial_server_method_async.c
+++ b/examples/tutorial_server_method_async.c
@@ -38,7 +38,7 @@
 #include <stdlib.h>
 #include "common.h"
 
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
 #include <pthread.h>
 #define THREAD_HANDLE pthread_t
 #define THREAD_CREATE(handle, callback) do {            \

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -25,7 +25,7 @@
 #include "../deps/mp_printf.h"
 
 #include <stdio.h>
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
 # include <winsock2.h>
 #else
 # include <unistd.h>

--- a/src/server/ua_discovery_mdns.c
+++ b/src/server/ua_discovery_mdns.c
@@ -19,7 +19,7 @@
 
 #include "../deps/mp_printf.h"
 
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
 /* inet_ntoa is deprecated on MSVC but used for compatibility */
 # define _WINSOCK_DEPRECATED_NO_WARNINGS
 # include <winsock2.h>
@@ -132,7 +132,7 @@ UA_DiscoveryManager_addEntryToServersOnNetwork(UA_DiscoveryManager *dm,
     return UA_STATUSCODE_GOOD;
 }
 
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
 
 /* see http://stackoverflow.com/a/10838854/869402 */
 static IP_ADAPTER_ADDRESSES *
@@ -178,7 +178,7 @@ getInterfaces(UA_DiscoveryManager *dm) {
     return adapter_addresses;
 }
 
-#endif /* _WIN32 */
+#endif /* UA_ARCHITECTURE_WIN32 */
 
 UA_StatusCode
 UA_DiscoveryManager_removeEntryFromServersOnNetwork(UA_DiscoveryManager *dm,
@@ -523,7 +523,7 @@ mdns_set_address_record_if(UA_DiscoveryManager *dm, const char *fullServiceDomai
 }
 
 /* Loop over network interfaces and run set_address_record on each */
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
 
 void mdns_set_address_record(UA_DiscoveryManager *dm, const char *fullServiceDomain,
                              const char *localDomain) {
@@ -617,7 +617,7 @@ mdns_set_address_record(UA_DiscoveryManager *dm, const char *fullServiceDomain,
     /* Clean up */
     freeifaddrs(ifaddr);
 }
-#else /* _WIN32 */
+#else /* UA_ARCHITECTURE_WIN32 */
 
 void
 mdns_set_address_record(UA_DiscoveryManager *dm, const char *fullServiceDomain,
@@ -634,7 +634,7 @@ mdns_set_address_record(UA_DiscoveryManager *dm, const char *fullServiceDomain,
     }
 }
 
-#endif /* _WIN32 */
+#endif /* UA_ARCHITECTURE_WIN32 */
 
 typedef enum {
     UA_DISCOVERY_TCP,    /* OPC UA TCP mapping */

--- a/src/ua_util.c
+++ b/src/ua_util.c
@@ -579,7 +579,7 @@ void
 UA_ByteString_memZero(UA_ByteString *bs) {
 #if defined(__STDC_LIB_EXT1__)
    memset_s(bs->data, bs->length, 0, bs->length);
-#elif defined(_WIN32)
+#elif defined(UA_ARCHITECTURE_WIN32)
    SecureZeroMemory(bs->data, bs->length);
 #else
    volatile unsigned char *volatile ptr =

--- a/src/ua_util_internal.h
+++ b/src/ua_util_internal.h
@@ -182,7 +182,7 @@ isTrue(uint8_t expr) {
  * ----------------- */
 
 #ifdef UA_ENABLE_DISCOVERY_SEMAPHORE
-# ifdef _WIN32
+# ifdef UA_ARCHITECTURE_WIN32
 #  include <io.h>
 #  define UA_fileExists(X) ( _access(X, 0) == 0)
 # else

--- a/tests/check_eventloop_interrupt.c
+++ b/tests/check_eventloop_interrupt.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <check.h>
 
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
 #define TESTSIG SIGUSR1
 #else
 #define TESTSIG SIGINT

--- a/tests/check_types_memory.c
+++ b/tests/check_types_memory.c
@@ -143,14 +143,14 @@ START_TEST(decodeScalarBasicTypeFromRandomBufferShallSucceed) {
     UA_UInt32 buflen = 256;
     UA_StatusCode retval = UA_ByteString_allocBuffer(&msg1, buflen); // fixed size
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
     srand(42);
 #else
     srandom(42);
 #endif
     for(int n = 0;n < RANDOM_TESTS;n++) {
         for(UA_UInt32 i = 0;i < buflen;i++) {
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
             UA_UInt32 rnd;
             rnd = rand();
             msg1.data[i] = rnd;
@@ -179,7 +179,7 @@ START_TEST(decodeComplexTypeFromRandomBufferShallSurvive) {
     UA_UInt32 buflen = 256;
     UA_StatusCode retval = UA_ByteString_allocBuffer(&msg1, buflen); // fixed size
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
     srand(42);
 #else
     srandom(42);
@@ -187,7 +187,7 @@ START_TEST(decodeComplexTypeFromRandomBufferShallSurvive) {
     // when
     for(int n = 0; n < RANDOM_TESTS; n++) {
         for(UA_UInt32 i = 0; i < buflen; i++) {
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
             UA_UInt32 rnd;
             rnd = rand();
             msg1.data[i] = rnd;

--- a/tests/server/check_discovery.c
+++ b/tests/server/check_discovery.c
@@ -15,14 +15,14 @@
 
 #include "testing_clock.h"
 #include "thread_wrapper.h"
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
 #include <sys/stat.h>
 #endif
 
 #include <check.h>
 #include <stdlib.h>
 
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
 #include <sys/stat.h>
 #endif
 
@@ -32,7 +32,7 @@
 #define checkWait registerTimeout + 11
 
 #ifdef UA_ENABLE_DISCOVERY_SEMAPHORE
-# ifndef _WIN32
+# ifndef UA_ARCHITECTURE_WIN32
 #  define SEMAPHORE_PATH "/tmp/open62541-unit-test-semaphore"
 # else
 #  define SEMAPHORE_PATH ".\\open62541-unit-test-semaphore"
@@ -246,7 +246,7 @@ unregisterServer(void) {
 static void
 Server_register_semaphore(void) {
     // create the semaphore
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
     int fd = open(SEMAPHORE_PATH, O_RDWR|O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
     ck_assert_int_ne(fd, -1);
     close(fd);

--- a/tests/testing-plugins/testing_clock.c
+++ b/tests/testing-plugins/testing_clock.c
@@ -31,7 +31,7 @@ UA_fakeSleep(UA_UInt32 duration) {
 
 void
 UA_realSleep(UA_UInt32 duration) {
-#ifdef _WIN32
+#ifdef UA_ARCHITECTURE_WIN32
     Sleep(duration);
 #else
     UA_UInt32 sec = duration / 1000;

--- a/tests/testing-plugins/thread_wrapper.h
+++ b/tests/testing-plugins/thread_wrapper.h
@@ -6,7 +6,7 @@
 
 /* Threads */
 
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
 #include <pthread.h>
 #define THREAD_HANDLE pthread_t
 #define THREAD_CREATE(handle, callback) pthread_create(&handle, NULL, callback, NULL)
@@ -31,7 +31,7 @@
 /* Windows returns non-zero on success and pthread returns zero,
  * so compare to zero to achieve consistent return values */
 
-#ifndef _WIN32
+#ifndef UA_ARCHITECTURE_WIN32
 #define MUTEX_HANDLE pthread_mutex_t
 
 /* Will return UA_TRUE when zero */


### PR DESCRIPTION
The stack uses UA_ARCHITECTURE_WIN32 and _WIN32 to check for the Windows platform.
Standardize this by consolidating the usage and removing _WIN32.