### PR TITLE
fix(ci): make codecov run for release branches

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,13 +1,11 @@
 name: "Coverage Test"
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, 1.* ]
     tags:
       - v1.*
   pull_request:
-    branches: [ main, master ]
-    tags:
-      - v1.*
+    branches: [ main, master, 1.* ]
 
 jobs:
   run:


### PR DESCRIPTION
Targeting this to 1.4 makes it conflict with some changes from #6979 (my bad for targeting that against master). Maybe that one should be backported first?