### PR TITLE
refactor: convert issue template to new format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,7 @@
+---
+name: Bug Report
+about: 'Report a bug'
+---
 <!--
 !ATTENTION!
 Please read the following page carefully and provide us with all the


### PR DESCRIPTION
GitHub broke the old ISSUE_TEMPLATE.md format in the top-level directory with the "New Issue Experience" feature preview, so it's probably time to update to the new format.

This is the bare minimum to make the issue template show up again. In the future, this should probably be cleaned up a bit and updated to adopt new features GitHub provides (e.g., having multiple templates for different types of issues).

You can compare the UI by trying to open an issue in [this repository](https://github.com/open62541/open62541/issues) vs. [my fork](https://github.com/marwinglaser/open62541/issues), which has this commit applied on the HEAD branch.