### PR TITLE
refactor build_linux workflow

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -69,40 +69,40 @@ jobs:
 
           - name: "Encryption (LibreSSL) Build & Unit Tests (gcc)"
             cmd_deps: |
-                sudo apt-get install -y -qq curl
-                curl https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.9.1.tar.gz --output libressl.tar.gz
-                tar -xvz -f libressl.tar.gz
-                cd libressl-3.9.1
-                ./configure
-                sudo make install
+              sudo apt-get install -y -qq curl
+              curl https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.9.1.tar.gz --output libressl.tar.gz
+              tar -xvz -f libressl.tar.gz
+              cd libressl-3.9.1
+              ./configure
+              sudo make install
             cmd_action: unit_tests_encryption LIBRESSL
 
           - name: "TPM Tool Build ubuntu-20.04"
             runs_on: "ubuntu-20.04"
             cmd_deps: |
-                sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev
-                cd ${HOME}
-                git clone https://github.com/tpm2-software/tpm2-tss.git
-                cd ${HOME}/tpm2-tss
-                git checkout 3.2.3
-                ./bootstrap && ./configure --with-udevrulesdir=/etc/udev/rules.d --with-udevrulesprefix=70-
-                make -j$(nproc)
-                sudo make install
-                sudo ldconfig
-                sudo udevadm control --reload-rules && sudo udevadm trigger
-                sudo apt-get install -y -qq tpm2-tools opensc
-                cd ${HOME}
-                git clone https://github.com/tpm2-software/tpm2-pkcs11.git
-                cd ${HOME}/tpm2-pkcs11
-                git checkout 1.7.0
-                ./bootstrap && ./configure
-                make -j$(nproc)
-                sudo make install
-                sudo ldconfig
-                sudo cp ${HOME}/tpm2-pkcs11/src/pkcs11.h /usr/include
-                cd ${HOME}/tpm2-pkcs11/tools/
-                sudo pip3 install pyasn1_modules
-                pip3 install .
+              sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev
+              cd ${HOME}
+              git clone https://github.com/tpm2-software/tpm2-tss.git
+              cd ${HOME}/tpm2-tss
+              git checkout 3.2.3
+              ./bootstrap && ./configure --with-udevrulesdir=/etc/udev/rules.d --with-udevrulesprefix=70-
+              make -j$(nproc)
+              sudo make install
+              sudo ldconfig
+              sudo udevadm control --reload-rules && sudo udevadm trigger
+              sudo apt-get install -y -qq tpm2-tools opensc
+              cd ${HOME}
+              git clone https://github.com/tpm2-software/tpm2-pkcs11.git
+              cd ${HOME}/tpm2-pkcs11
+              git checkout 1.7.0
+              ./bootstrap && ./configure
+              make -j$(nproc)
+              sudo make install
+              sudo ldconfig
+              sudo cp ${HOME}/tpm2-pkcs11/src/pkcs11.h /usr/include
+              cd ${HOME}/tpm2-pkcs11/tools/
+              sudo pip3 install pyasn1_modules
+              pip3 install .
             cmd_action: build_tpm_tool
 
           - name: "TPM Tool Build ubuntu-22.04"

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -12,51 +12,65 @@ jobs:
           - name: "Debug Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq mosquitto
             cmd_action: unit_tests
+
           - name: "Debug Build & Unit Tests (gcc, 32bit)"
             cmd_deps: |
               sudo dpkg --add-architecture i386
               sudo apt-get update
               sudo apt-get install -y -qq gcc-multilib libsubunit-dev:i386 check:i386 libxml2-dev:i386
             cmd_action: unit_tests_32
+
           - name: "Debug Build & Unit Tests without Subscriptions (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_nosub
+
           - name: "Debug Build & Unit Tests with Diagnostics (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_diag
+
           - name: "Debug Build & Unit Tests with multithreading (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_mt
+
           - name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_alarms
+
           - name: "Debug Build & Unit Tests (clang-11)"
             runs_on: "ubuntu-20.04"
             cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 mosquitto
             cmd_action: CC=clang-11 CXX=clang++-11 unit_tests
+
           - name: "Debug Build & Unit Tests (clang-15)"
             runs_on: "ubuntu-22.04"
             cmd_deps: sudo apt-get install -y -qq clang-15 clang-tools-15 mosquitto && sudo sysctl -w vm.mmap_rnd_bits=28
             cmd_action: CC=clang-15 CXX=clang++-15 unit_tests
+
           - name: "Debug Build & Unit Tests (clang-18)"
             runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq clang-18 clang-tools-18 mosquitto && sudo sysctl -w vm.mmap_rnd_bits=28
             cmd_action: CC=clang-18 CXX=clang++-18 unit_tests
+
           - name: "Debug Build & Unit Tests (tcc)"
             cmd_deps: sudo apt-get install -y -qq tcc mosquitto
             cmd_action: CC=tcc unit_tests
+
           - name: "Encryption (MbedTLS) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: unit_tests_encryption MBEDTLS
+
           - name: "PubSub Encryption (MbedTLS) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: unit_tests_encryption_mbedtls_pubsub
+
           - name: "PubSub SKS Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev
             cmd_action: unit_tests_pubsub_sks
+
           - name: "Encryption (OpenSSL) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq openssl
             cmd_action: unit_tests_encryption OPENSSL
+
           - name: "Encryption (LibreSSL) Build & Unit Tests (gcc)"
             cmd_deps: |
                 sudo apt-get install -y -qq curl
@@ -66,6 +80,7 @@ jobs:
                 ./configure
                 sudo make install
             cmd_action: unit_tests_encryption LIBRESSL
+
           - name: "TPM Tool Build ubuntu-20.04"
             runs_on: "ubuntu-20.04"
             cmd_deps: |
@@ -93,6 +108,7 @@ jobs:
                 sudo pip3 install pyasn1_modules
                 pip3 install .
             cmd_action: build_tpm_tool
+
           - name: "TPM Tool Build ubuntu-22.04"
             runs_on: "ubuntu-22.04"
             cmd_deps: |
@@ -120,6 +136,7 @@ jobs:
               sudo pip3 install pyasn1_modules
               pip3 install .
             cmd_action: build_tpm_tool
+
           - name: "TPM Tool Build ubuntu-24.04"
             runs_on: "ubuntu-24.04"
             cmd_deps: |
@@ -147,39 +164,50 @@ jobs:
               sudo pip3 install pyasn1_modules
               pip3 install .
             cmd_action: build_tpm_tool
+
           - name: "Release Build"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: build_release
+
           - name: "Amalgamation Build"
             cmd_deps: ""
             cmd_action: build_amalgamation
+
           - name: "Amalgamation Build with Multithreading"
             cmd_deps: ""
             cmd_action: build_amalgamation_mt
+
           - name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev mosquitto
             cmd_action: unit_tests_valgrind MBEDTLS
+
           - name: "Valgrind Build & Unit Tests with OpenSSL (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind openssl mosquitto
             cmd_action: unit_tests_valgrind OPENSSL
+
           - name: "Valgrind Examples with MbedTLS (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev mosquitto
             cmd_action: examples_valgrind MBEDTLS
+
           - name: "Valgrind Examples with OpenSSL (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev mosquitto
             cmd_action: examples_valgrind OPENSSL
+
           - name: "Clang Static Analyzer (clang11)"
             runs_on: "ubuntu-20.04"
             cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 libmbedtls-dev mosquitto
             cmd_action: CC=clang-11 CXX=clang++-11 build_clang_analyzer 11
+
           - name: "Clang Static Analyzer (clang15)"
             runs_on: "ubuntu-22.04"
             cmd_deps: sudo apt-get install -y -qq clang-15 clang-tools-15 libmbedtls-dev mosquitto
             cmd_action: CC=clang-15 CXX=clang++-15 build_clang_analyzer 15
+
           - name: "Clang Static Analyzer (clang18)"
             runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq clang-18 clang-tools-18 libmbedtls-dev mosquitto
             cmd_action: CC=clang-18 CXX=clang++-18 build_clang_analyzer 18
+
           - name: "Build All Companion Specifications"
             cmd_deps: ""
             cmd_action: build_all_companion_specs

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -8,87 +8,56 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        build_name: [
-          "Debug Build & Unit Tests (gcc)",
-          "Debug Build & Unit Tests (gcc, 32bit)",
-          "Debug Build & Unit Tests without Subscriptions (gcc)",
-          "Debug Build & Unit Tests with Diagnostics (gcc)",
-          "Debug Build & Unit Tests with multithreading (gcc)",
-          "Debug Build & Unit Tests with Alarms&Conditions (gcc)",
-          "Debug Build & Unit Tests (clang-11)",
-          "Debug Build & Unit Tests (clang-15)",
-          "Debug Build & Unit Tests (clang-18)",
-          "Debug Build & Unit Tests (tcc)",
-          "Encryption (MbedTLS) Build & Unit Tests (gcc)",
-          "PubSub Encryption (MbedTLS) Build & Unit Tests (gcc)",
-          "PubSub SKS Build & Unit Tests (gcc)",
-          "Encryption (OpenSSL) Build & Unit Tests (gcc)",
-          "Encryption (LibreSSL) Build & Unit Tests (gcc)",
-          "TPM Tool Build ubuntu-20.04",
-          "TPM Tool Build ubuntu-22.04",
-          "TPM Tool Build ubuntu-24.04",
-          "Release Build",
-          "Amalgamation Build",
-          "Amalgamation Build with Multithreading",
-          "Valgrind Build & Unit Tests with MbedTLS (gcc)",
-          "Valgrind Build & Unit Tests with OpenSSL (gcc)",
-          "Valgrind Examples with MbedTLS (gcc)",
-          "Valgrind Examples with OpenSSL (gcc)",
-          "Clang Static Analyzer (clang11)",
-          "Clang Static Analyzer (clang15)",
-          "Clang Static Analyzer (clang18)",
-          "Build All Companion Specifications"
-        ]
-        include:
-          - build_name: "Debug Build & Unit Tests (gcc)"
+        build:
+          - name: "Debug Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq mosquitto
             cmd_action: unit_tests
-          - build_name: "Debug Build & Unit Tests (gcc, 32bit)"
+          - name: "Debug Build & Unit Tests (gcc, 32bit)"
             cmd_deps: |
               sudo dpkg --add-architecture i386
               sudo apt-get update
               sudo apt-get install -y -qq gcc-multilib libsubunit-dev:i386 check:i386 libxml2-dev:i386
             cmd_action: unit_tests_32
-          - build_name: "Debug Build & Unit Tests without Subscriptions (gcc)"
+          - name: "Debug Build & Unit Tests without Subscriptions (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_nosub
-          - build_name: "Debug Build & Unit Tests with Diagnostics (gcc)"
+          - name: "Debug Build & Unit Tests with Diagnostics (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_diag
-          - build_name: "Debug Build & Unit Tests with multithreading (gcc)"
+          - name: "Debug Build & Unit Tests with multithreading (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_mt
-          - build_name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
+          - name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
             cmd_deps: ""
             cmd_action: unit_tests_alarms
-          - build_name: "Debug Build & Unit Tests (clang-11)"
+          - name: "Debug Build & Unit Tests (clang-11)"
             runs_on: "ubuntu-20.04"
             cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 mosquitto
             cmd_action: CC=clang-11 CXX=clang++-11 unit_tests
-          - build_name: "Debug Build & Unit Tests (clang-15)"
+          - name: "Debug Build & Unit Tests (clang-15)"
             runs_on: "ubuntu-22.04"
             cmd_deps: sudo apt-get install -y -qq clang-15 clang-tools-15 mosquitto && sudo sysctl -w vm.mmap_rnd_bits=28
             cmd_action: CC=clang-15 CXX=clang++-15 unit_tests
-          - build_name: "Debug Build & Unit Tests (clang-18)"
+          - name: "Debug Build & Unit Tests (clang-18)"
             runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq clang-18 clang-tools-18 mosquitto && sudo sysctl -w vm.mmap_rnd_bits=28
             cmd_action: CC=clang-18 CXX=clang++-18 unit_tests
-          - build_name: "Debug Build & Unit Tests (tcc)"
+          - name: "Debug Build & Unit Tests (tcc)"
             cmd_deps: sudo apt-get install -y -qq tcc mosquitto
             cmd_action: CC=tcc unit_tests
-          - build_name: "Encryption (MbedTLS) Build & Unit Tests (gcc)"
+          - name: "Encryption (MbedTLS) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: unit_tests_encryption MBEDTLS
-          - build_name: "PubSub Encryption (MbedTLS) Build & Unit Tests (gcc)"
+          - name: "PubSub Encryption (MbedTLS) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: unit_tests_encryption_mbedtls_pubsub
-          - build_name: "PubSub SKS Build & Unit Tests (gcc)"
+          - name: "PubSub SKS Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev
             cmd_action: unit_tests_pubsub_sks
-          - build_name: "Encryption (OpenSSL) Build & Unit Tests (gcc)"
+          - name: "Encryption (OpenSSL) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq openssl
             cmd_action: unit_tests_encryption OPENSSL
-          - build_name: "Encryption (LibreSSL) Build & Unit Tests (gcc)"
+          - name: "Encryption (LibreSSL) Build & Unit Tests (gcc)"
             cmd_deps: |
                 sudo apt-get install -y -qq curl
                 curl https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.9.1.tar.gz --output libressl.tar.gz
@@ -97,7 +66,7 @@ jobs:
                 ./configure
                 sudo make install
             cmd_action: unit_tests_encryption LIBRESSL
-          - build_name: "TPM Tool Build ubuntu-20.04"
+          - name: "TPM Tool Build ubuntu-20.04"
             runs_on: "ubuntu-20.04"
             cmd_deps: |
                 sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev
@@ -124,7 +93,7 @@ jobs:
                 sudo pip3 install pyasn1_modules
                 pip3 install .
             cmd_action: build_tpm_tool
-          - build_name: "TPM Tool Build ubuntu-22.04"
+          - name: "TPM Tool Build ubuntu-22.04"
             runs_on: "ubuntu-22.04"
             cmd_deps: |
               sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev
@@ -151,7 +120,7 @@ jobs:
               sudo pip3 install pyasn1_modules
               pip3 install .
             cmd_action: build_tpm_tool
-          - build_name: "TPM Tool Build ubuntu-24.04"
+          - name: "TPM Tool Build ubuntu-24.04"
             runs_on: "ubuntu-24.04"
             cmd_deps: |
               sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev libltdl-dev
@@ -178,57 +147,57 @@ jobs:
               sudo pip3 install pyasn1_modules
               pip3 install .
             cmd_action: build_tpm_tool
-          - build_name: "Release Build"
+          - name: "Release Build"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: build_release
-          - build_name: "Amalgamation Build"
+          - name: "Amalgamation Build"
             cmd_deps: ""
             cmd_action: build_amalgamation
-          - build_name: "Amalgamation Build with Multithreading"
+          - name: "Amalgamation Build with Multithreading"
             cmd_deps: ""
             cmd_action: build_amalgamation_mt
-          - build_name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
+          - name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev mosquitto
             cmd_action: unit_tests_valgrind MBEDTLS
-          - build_name: "Valgrind Build & Unit Tests with OpenSSL (gcc)"
+          - name: "Valgrind Build & Unit Tests with OpenSSL (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind openssl mosquitto
             cmd_action: unit_tests_valgrind OPENSSL
-          - build_name: "Valgrind Examples with MbedTLS (gcc)"
+          - name: "Valgrind Examples with MbedTLS (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev mosquitto
             cmd_action: examples_valgrind MBEDTLS
-          - build_name: "Valgrind Examples with OpenSSL (gcc)"
+          - name: "Valgrind Examples with OpenSSL (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev mosquitto
             cmd_action: examples_valgrind OPENSSL
-          - build_name: "Clang Static Analyzer (clang11)"
+          - name: "Clang Static Analyzer (clang11)"
             runs_on: "ubuntu-20.04"
             cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 libmbedtls-dev mosquitto
             cmd_action: CC=clang-11 CXX=clang++-11 build_clang_analyzer 11
-          - build_name: "Clang Static Analyzer (clang15)"
+          - name: "Clang Static Analyzer (clang15)"
             runs_on: "ubuntu-22.04"
             cmd_deps: sudo apt-get install -y -qq clang-15 clang-tools-15 libmbedtls-dev mosquitto
             cmd_action: CC=clang-15 CXX=clang++-15 build_clang_analyzer 15
-          - build_name: "Clang Static Analyzer (clang18)"
+          - name: "Clang Static Analyzer (clang18)"
             runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq clang-18 clang-tools-18 libmbedtls-dev mosquitto
             cmd_action: CC=clang-18 CXX=clang++-18 build_clang_analyzer 18
-          - build_name: "Build All Companion Specifications"
+          - name: "Build All Companion Specifications"
             cmd_deps: ""
             cmd_action: build_all_companion_specs
 
-    name: ${{matrix.os}}-${{matrix.build_name}}
+    name: ${{matrix.os}}-${{matrix.build.name}}
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies
-        if: ${{ matrix.runs_on == '' || matrix.runs_on == matrix.os }}
+        if: ${{ matrix.build.runs_on == '' || matrix.build.runs_on == matrix.os }}
         run: |
           sudo apt-get update
           sudo apt-get install -y -qq python3-sphinx graphviz check
-          ${{ matrix.cmd_deps }}
-      - name: ${{matrix.build_name}}
-        if: ${{ matrix.runs_on == '' || matrix.runs_on == matrix.os }}
-        run: source tools/ci/ci.sh && ${{matrix.cmd_action}}
+          ${{ matrix.build.cmd_deps }}
+      - name: ${{matrix.build.name}}
+        if: ${{ matrix.build.runs_on == '' || matrix.build.runs_on == matrix.os }}
+        run: source tools/ci/ci.sh && ${{matrix.build.cmd_action}}
         env:
           ETHERNET_INTERFACE: eth0

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -205,8 +205,8 @@ jobs:
           - name: "Build All Companion Specifications"
             cmd_action: build_all_companion_specs
 
-    name: ${{matrix.os}}-${{matrix.build.name}}
-    runs-on: ${{matrix.os}}
+    name: ${{ matrix.os }}-${{ matrix.build.name }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -217,8 +217,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y -qq python3-sphinx graphviz check
           ${{ matrix.build.cmd_deps }}
-      - name: ${{matrix.build.name}}
+      - name: ${{ matrix.build.name }}
         if: ${{ matrix.build.runs_on == '' || matrix.build.runs_on == matrix.os }}
-        run: source tools/ci/ci.sh && ${{matrix.build.cmd_action}}
+        run: source tools/ci/ci.sh && ${{ matrix.build.cmd_action }}
         env:
           ETHERNET_INTERFACE: eth0

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -21,19 +21,15 @@ jobs:
             cmd_action: unit_tests_32
 
           - name: "Debug Build & Unit Tests without Subscriptions (gcc)"
-            cmd_deps: ""
             cmd_action: unit_tests_nosub
 
           - name: "Debug Build & Unit Tests with Diagnostics (gcc)"
-            cmd_deps: ""
             cmd_action: unit_tests_diag
 
           - name: "Debug Build & Unit Tests with multithreading (gcc)"
-            cmd_deps: ""
             cmd_action: unit_tests_mt
 
           - name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
-            cmd_deps: ""
             cmd_action: unit_tests_alarms
 
           - name: "Debug Build & Unit Tests (clang-11)"
@@ -170,11 +166,9 @@ jobs:
             cmd_action: build_release
 
           - name: "Amalgamation Build"
-            cmd_deps: ""
             cmd_action: build_amalgamation
 
           - name: "Amalgamation Build with Multithreading"
-            cmd_deps: ""
             cmd_action: build_amalgamation_mt
 
           - name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
@@ -209,7 +203,6 @@ jobs:
             cmd_action: CC=clang-18 CXX=clang++-18 build_clang_analyzer 18
 
           - name: "Build All Companion Specifications"
-            cmd_deps: ""
             cmd_action: build_all_companion_specs
 
     name: ${{matrix.os}}-${{matrix.build.name}}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -209,6 +209,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ matrix.build.runs_on == '' || matrix.build.runs_on == matrix.os }}
         with:
           submodules: true
       - name: Install Dependencies


### PR DESCRIPTION
GitHub Actions [support objects as matrix values](https://github.com/github/docs/issues/26469#issuecomment-1760332235) (see below), so lets use this instead of `include:` to simplify the build_linux matrix. The remaining commits are some minor cleanup in the same file.

Note that the linter in the GitHub web editor complains about this, but in this case [it appears like the linter is wrong](https://github.com/github/docs/issues/26469#issuecomment-1892388775)

---

From https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-a-multi-dimension-matrix:

> A variable configuration in a matrix can be an array of objects.
>
> ```yaml
> matrix:
>   os:
>     - ubuntu-latest
>     - macos-latest
>   node:
>     - version: 14
>     - version: 20
>       env: NODE_OPTIONS=--openssl-legacy-provider
> ```