### PR TITLE
fix(ci): pass CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,3 +28,5 @@ jobs:
           tree .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I *think* this works and the docs/examples indicate it should, but I don't know how to properly test it.
Also, this requires a GitHub actions secret called `CODECOV_TOKEN` that contains the repository upload token found [here](https://app.codecov.io/gh/open62541/open62541/config/general) (requires authentication). I don't have the permission to modify GitHub secrets, so someone else will have to create that.

The same is the case for the 1.4 release branch. What is the policy for changes that should go into multiple branches? I see there is a [PR to merge 1.4 back into master](https://github.com/open62541/open62541/pull/6946), but that is relatively old and Codecov is broken on both now. 

Context: https://github.com/open62541/open62541/pull/7033#issuecomment-2604607901