### PR TITLE
fix(core): allow recursive locking with musl libc

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -401,7 +401,11 @@ typedef struct {
     int mutexCounter;
 } UA_Lock;
 
+#if defined(__GLIBC__)
 #define UA_LOCK_STATIC_INIT {PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP, 0}
+#else
+#define UA_LOCK_STATIC_INIT {PTHREAD_MUTEX_INITIALIZER, 0}
+#endif
 
 static UA_INLINE void
 UA_LOCK_INIT(UA_Lock *lock) {


### PR DESCRIPTION
* refactor(core): Use recursive locks [93838cd37c166464b324d648ea52d916429c478d] introduced recursive locking.

* PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP is not defined in musl libc
* use PTHREAD_MUTEX_INITIALIZER on musl libc systems

Fixes #7039 