### PR TITLE
BUG: Asynchronus Object's Methods Call Locks the Async and Main Threads Execution

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1217,6 +1217,9 @@ UA_Server_getMethodNodeCallback(UA_Server *server,
 
 UA_CallMethodResult UA_EXPORT UA_THREADSAFE
 UA_Server_call(UA_Server *server, const UA_CallMethodRequest *request);
+
+UA_CallMethodResult UA_EXPORT UA_THREADSAFE
+UA_Server_callEx(UA_Server *server, const UA_CallMethodRequest *request, void* context);
 #endif
 
 /**

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -112,6 +112,7 @@ getServerComponentByName(UA_Server *server, UA_String name);
 /********************/
 
 typedef struct session_list_entry {
+    unsigned int nReferences;
     UA_DelayedCallback cleanupCallback;
     LIST_ENTRY(session_list_entry) pointers;
     UA_Session session;
@@ -264,6 +265,9 @@ getSessionByToken(UA_Server *server, const UA_NodeId *token);
 
 UA_Session *
 getSessionById(UA_Server *server, const UA_NodeId *sessionId);
+
+session_list_entry *acquireSessionEntryById(UA_Server *server, const UA_NodeId *sessionId, UA_Session **pSession);
+void releaseSessionEntry(UA_Server *server, session_list_entry *sentry);
 
 /*****************/
 /* Node Handling */

--- a/src/server/ua_services_method.c
+++ b/src/server/ua_services_method.c
@@ -265,12 +265,15 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
 
     /* Verify access rights */
     UA_Boolean executable = method->executable;
-    if(session != &server->adminSession) {
+    if (executable && session != &server->adminSession) {
+        UA_LOCK_ASSERT(&server->serviceMutex, 1);
+        UA_UNLOCK(&server->serviceMutex);
         executable = executable && server->config.accessControl.
             getUserExecutableOnObject(server, &server->config.accessControl,
                                       &session->sessionId, session->sessionHandle,
                                       &request->methodId, method->head.context,
                                       &request->objectId, object->head.context);
+        UA_LOCK(&server->serviceMutex);
     }
 
     if(!executable) {
@@ -347,11 +350,14 @@ callWithMethodAndObject(UA_Server *server, UA_Session *session,
     UA_NODESTORE_RELEASE(server, (const UA_Node*)outputArguments);
 
     /* Call the method */
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+    UA_UNLOCK(&server->serviceMutex); // It may be ASYNC (in other thread)
     result->statusCode = method->method(server, &session->sessionId, session->sessionHandle,
                                         &method->head.nodeId, method->head.context,
                                         &object->head.nodeId, object->head.context,
                                         request->inputArgumentsSize, mutableInputArgs,
                                         result->outputArgumentsSize, result->outputArguments);
+    UA_LOCK(&server->serviceMutex);
     /* TODO: Verify Output matches the argument definition */
 }
 

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -37,6 +37,13 @@ void UA_Session_clear(UA_Session *session, UA_Server* server) {
     }
 #endif
 
+    /* Callback into userland access control */
+    if(server->config.accessControl.closeSession) {
+        server->config.accessControl.
+            closeSession(server, &server->config.accessControl,
+                         &session->sessionId, session->sessionHandle);
+    }
+
 #ifdef UA_ENABLE_DIAGNOSTICS
     deleteNode(server, session->sessionId, true);
 #endif

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -38,7 +38,7 @@ void UA_Session_clear(UA_Session *session, UA_Server* server) {
 #endif
 
     /* Callback into userland access control */
-    if(server->config.accessControl.closeSession) {
+    if(server->config.accessControl.closeSession && &server->adminSession != session) {
         server->config.accessControl.
             closeSession(server, &server->config.accessControl,
                          &session->sessionId, session->sessionHandle);


### PR DESCRIPTION
The "Recurrent Lock" optimization leads that the serviceMutex is locked (owned) during a method callback execution.
It isn't a issue for one-thread execution, but completely eliminates the ability to execute methods in additional worker threads - so long asynchronus method callback execution (in UA_Server_call) blocks other worker threads (UA_Server_call) and main loop (for example UA_Server_read) too.

So I offer to restore serviceMutex unlock during callbacks that could be async executed (in other thread). 