### PR TITLE
refactor(ci): exclude tests and examples from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,8 +4,8 @@ coverage:
 
 # Ignore examples, tests and generated files
 ignore:
-  - "**/tests/**"
-  - "**/examples/**"
+  - "tests/"
+  - "examples/"
   - "**/ua_eventfilter_grammar.c"
   - "**/ua_eventfilter_lex.c"
   - "**/ua_types_lex.c"


### PR DESCRIPTION
coverage tree on master: https://app.codecov.io/github/open62541/open62541/commit/7c500a124244911d1f06695d59ac6d96965a564f/tree
coverage tree with this patch: https://app.codecov.io/github/open62541/open62541/pull/7055/tree