### PR TITLE
refactor(core): Remove UA_LOCK_STATIC_INIT and its only user

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -401,12 +401,6 @@ typedef struct {
     int mutexCounter;
 } UA_Lock;
 
-#if defined(__GLIBC__)
-#define UA_LOCK_STATIC_INIT {PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP, 0}
-#else
-#define UA_LOCK_STATIC_INIT {PTHREAD_RECURSIVE_MUTEX_INITIALIZER, 0}
-#endif
-
 static UA_INLINE void
 UA_LOCK_INIT(UA_Lock *lock) {
     pthread_mutexattr_t mattr;

--- a/plugins/ua_log_stdout.c
+++ b/plugins/ua_log_stdout.c
@@ -42,12 +42,9 @@ logCategoryNames[UA_LOGCATEGORIES] =
     {"network", "channel", "session", "server", "client",
      "userland", "securitypolicy", "eventloop", "pubsub", "discovery"};
 
-/* Protect crosstalk during logging via global lock.
- * Use a spinlock on non-POSIX as we cannot statically initialize a global lock. */
+/* Protect crosstalk during logging via global lock. Use a spinlock as we cannot
+ * statically initialize a global lock across all platforms. */
 #if UA_MULTITHREADING >= 100
-# ifdef UA_ARCHITECTURE_POSIX
-UA_Lock logLock = UA_LOCK_STATIC_INIT;
-# else
 void * volatile logSpinLock = NULL;
 static UA_INLINE void spinLock(void) {
     while(UA_atomic_cmpxchg(&logSpinLock, NULL, (void*)0x1) != NULL) {}
@@ -55,7 +52,6 @@ static UA_INLINE void spinLock(void) {
 static UA_INLINE void spinUnLock(void) {
     UA_atomic_xchg(&logSpinLock, NULL);
 }
-# endif
 #endif
 
 #ifdef __clang__
@@ -78,11 +74,7 @@ UA_Log_Stdout_log(void *context, UA_LogLevel level, UA_LogCategory category,
 
     /* Lock */
 #if UA_MULTITHREADING >= 100
-# ifdef UA_ARCHITECTURE_POSIX
-    UA_LOCK(&logLock);
-# else
     spinLock();
-# endif
 #endif
 
     /* Log */
@@ -96,11 +88,7 @@ UA_Log_Stdout_log(void *context, UA_LogLevel level, UA_LogCategory category,
 
     /* Unlock */
 #if UA_MULTITHREADING >= 100
-# ifdef UA_ARCHITECTURE_POSIX
-    UA_UNLOCK(&logLock);
-# else
     spinUnLock();
-# endif
 #endif
 }
 


### PR DESCRIPTION
There is no cross-plattform way to statically initialize a recursive lock.