### PR TITLE
[Review] Fix null pointer dereference in ua_services_discovery.c

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -266,6 +266,8 @@ Service_FindServersOnNetwork(UA_Server *server, UA_Session *session,
             continue;
         filtered[filteredCount++] = current;
         current = UA_DiscoveryManager_getNextServerOnNetworkRecord(dm, current);
+        if(!current)
+            break;
     }
 
     if(filteredCount == 0)


### PR DESCRIPTION
UA_DiscoveryManager_getNextServerOnNetworkRecord returns NULL if there is no entry.
Add a break to the entry loop to avoid dereferencing a NULL pointer.