### PR TITLE
[REVIEW] test: add multicast examples to valgrind build tests

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -179,13 +179,13 @@ jobs:
             cmd_deps: sudo apt-get install -y -qq valgrind openssl mosquitto
             cmd_action: unit_tests_valgrind OPENSSL
 
-          - name: "Valgrind Examples with MbedTLS (gcc)"
+          - name: "Valgrind Examples with MbedTLS and mDNSD (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev mosquitto
-            cmd_action: examples_valgrind MBEDTLS
+            cmd_action: examples_valgrind MBEDTLS MDNSD
 
-          - name: "Valgrind Examples with OpenSSL (gcc)"
-            cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev mosquitto
-            cmd_action: examples_valgrind OPENSSL
+          - name: "Valgrind Examples with OpenSSL and avahi-mdns(gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev mosquitto libavahi-client-dev libavahi-common-dev
+            cmd_action: examples_valgrind OPENSSL AVAHI
 
           - name: "Clang Static Analyzer (clang11)"
             runs_on: "ubuntu-20.04"

--- a/tools/ci/ci.sh
+++ b/tools/ci/ci.sh
@@ -370,6 +370,8 @@ function examples_valgrind {
           -DUA_NAMESPACE_ZERO=FULL \
           -DUA_ENABLE_NODESETLOADER=ON \
           -DUA_ENABLE_PUBSUB_SKS=ON \
+          -DUA_ENABLE_DISCOVERY=ON \
+          -DUA_ENABLE_DISCOVERY_MULTICAST=$2 \
           -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}

--- a/tools/ci/examples_with_valgrind.py
+++ b/tools/ci/examples_with_valgrind.py
@@ -34,6 +34,7 @@ server_needed_examples = {
         "custom_datatype_client":"custom_datatype_server",
         "discovery_client_find_servers":"discovery_server_lds",
         "discovery_server_register":"discovery_server_lds",
+        "discovery_server_multicast":"discovery_server_multicast",
         "pubsub_publish_encrypted":"pubsub_subscribe_encrypted",
         "pubsub_publish_encrypted_sks":"server_pubsub_central_sks server_cert.der server_key.der --enableUnencrypted --enableAnonymous",
         "pubsub_subscribe_encrypted":"pubsub_publish_encrypted",


### PR DESCRIPTION
There are no tests for the multicast examples in CI. This can lead to unintended regressions.
Add both variants of the multicast example to already existent valgrind build tests.