### PR TITLE
fix(ci): remove python-six dependency from doc_upload workflow

### DIFF
--- a/.github/workflows/doc_upload.yml
+++ b/.github/workflows/doc_upload.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y -qq python3-sphinx graphviz python-six texlive-fonts-recommended texlive-latex-extra texlive-plain-generic texlive-latex-recommended latexmk texlive-fonts-extra
+          sudo apt-get install -y -qq python3-sphinx graphviz texlive-fonts-recommended texlive-latex-extra texlive-plain-generic texlive-latex-recommended latexmk texlive-fonts-extra
           pip install sphinx-rtd-theme
       - name: Build Documentation
         run: source tools/ci.sh && build_docs_pdf


### PR DESCRIPTION
Backport https://github.com/open62541/open62541/pull/6978 to 1.4 to fix doc upload worflow.