### PR TITLE
fix(server): Rename UA_ServerConfig_clean to UA_ServerConfig_clear

### DIFF
--- a/examples/pubsub/sks/server_pubsub_central_sks.c
+++ b/examples/pubsub/sks/server_pubsub_central_sks.c
@@ -515,7 +515,7 @@ cleanup:
     if(server)
         UA_Server_delete(server);
     else
-        UA_ServerConfig_clean(&config);
+        UA_ServerConfig_clear(&config);
 
     UA_ByteString_clear(&certificate);
 #if defined(UA_ENABLE_ENCRYPTION)

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -395,7 +395,12 @@ struct UA_ServerConfig {
 };
 
 void UA_EXPORT
-UA_ServerConfig_clean(UA_ServerConfig *config);
+UA_ServerConfig_clear(UA_ServerConfig *config);
+
+UA_DEPRECATED static UA_INLINE void
+UA_ServerConfig_clean(UA_ServerConfig *config) {
+    UA_ServerConfig_clear(config);
+}
 
 /**
  * .. _server-lifecycle:

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -651,7 +651,7 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
 
     UA_StatusCode retval = setDefaultConfig(config, portNumber);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
@@ -661,14 +661,14 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     /* Allocate the SecurityPolicies */
     retval = UA_ServerConfig_addSecurityPolicyNone(config, certificate);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
     /* Initialize the Access Control plugin */
     retval = UA_AccessControl_default(config, true, NULL, 0, NULL);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
@@ -676,7 +676,7 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
     retval = UA_ServerConfig_addEndpoint(config, UA_SECURITY_POLICY_NONE_URI,
                                          UA_MESSAGESECURITYMODE_NONE);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(config);
+        UA_ServerConfig_clear(config);
         return retval;
     }
 
@@ -988,7 +988,7 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
                                                size_t revocationListSize) {
     UA_StatusCode retval = setDefaultConfig(conf, portNumber);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
@@ -1014,13 +1014,13 @@ UA_ServerConfig_setDefaultWithSecurityPolicies(UA_ServerConfig *conf,
         retval = UA_AccessControl_default(conf, true, NULL, 0, NULL);
     }
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
     retval = UA_ServerConfig_addAllEndpoints(conf);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
@@ -1040,7 +1040,7 @@ UA_ServerConfig_setDefaultWithSecureSecurityPolicies(UA_ServerConfig *conf,
                                                size_t revocationListSize) {
     UA_StatusCode retval = setDefaultConfig(conf, portNumber);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
@@ -1064,13 +1064,13 @@ UA_ServerConfig_setDefaultWithSecureSecurityPolicies(UA_ServerConfig *conf,
         retval = UA_AccessControl_default(conf, false, NULL, 0, NULL);
     }
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
 
     retval = UA_ServerConfig_addAllSecureEndpoints(conf);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_ServerConfig_clean(conf);
+        UA_ServerConfig_clear(conf);
         return retval;
     }
     conf->securityPolicyNoneDiscoveryOnly = true;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -300,7 +300,7 @@ UA_Server_delete(UA_Server *server) {
     unlockServer(server); /* The timer has its own mutex */
 
     /* Clean up the config */
-    UA_ServerConfig_clean(&server->config);
+    UA_ServerConfig_clear(&server->config);
 
 #if UA_MULTITHREADING >= 100
     UA_LOCK_DESTROY(&server->serviceMutex);
@@ -424,7 +424,7 @@ UA_Server_newWithConfig(UA_ServerConfig *config) {
                  config->logging, UA_LOGCATEGORY_SERVER, "No EventLoop configured");
 
     UA_Server *server = (UA_Server *)UA_calloc(1, sizeof(UA_Server));
-    UA_CHECK_MEM(server, UA_ServerConfig_clean(config); return NULL);
+    UA_CHECK_MEM(server, UA_ServerConfig_clear(config); return NULL);
 
     server->config = *config;
 

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -11,7 +11,7 @@
 #include "ua_server_internal.h"
 
 void
-UA_ServerConfig_clean(UA_ServerConfig *config) {
+UA_ServerConfig_clear(UA_ServerConfig *config) {
     if(!config)
         return;
 


### PR DESCRIPTION
 to match other functions that clear an object structure. This has been already applied to master but should be also backported to the 1.4 branch.