### PR TITLE
[Review] fix(eventloop): Fix deadlock with event loop mutex

### DIFF
--- a/examples/pubsub_realtime/server_pubsub_publisher_rt_level.c
+++ b/examples/pubsub_realtime/server_pubsub_publisher_rt_level.c
@@ -176,9 +176,10 @@ int main(void) {
     pubSubEL->stop(pubSubEL);
     while(pubSubEL->state != UA_EVENTLOOPSTATE_STOPPED)
         pubSubEL->run(pubSubEL, 0);
-    pubSubEL->free(pubSubEL);
 
     UA_Server_delete(server);
+
+    pubSubEL->free(pubSubEL);
 
     return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/pubsub/ua_pubsub.h
+++ b/src/pubsub/ua_pubsub.h
@@ -184,7 +184,7 @@ UA_PubSubConnection_create(UA_Server *server,
 void
 UA_PubSubConnectionConfig_clear(UA_PubSubConnectionConfig *connectionConfig);
 
-void
+UA_StatusCode
 UA_PubSubConnection_delete(UA_Server *server, UA_PubSubConnection *c);
 
 UA_StatusCode
@@ -851,6 +851,16 @@ UA_StatusCode
 UA_PubSubManager_setDefaultMonitoringCallbacks(UA_PubSubMonitoringInterface *monitoringInterface);
 
 #endif /* UA_ENABLE_PUBSUB_MONITORING */
+
+/*********************/
+/* Locking/Unlocking */
+/*********************/
+
+/* In order to prevent deadlocks between the EventLoop mutex and the
+ * server-mutex, we always take the EventLoop mutex first. */
+
+void lockPubSubServer(UA_Server *server);
+void unlockPubSubServer(UA_Server *server);
 
 #endif /* UA_ENABLE_PUBSUB */
 

--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -81,9 +81,9 @@ getPublishedDataSetConfig(UA_Server *server, const UA_NodeId pds,
 UA_StatusCode
 UA_Server_getPublishedDataSetConfig(UA_Server *server, const UA_NodeId pds,
                                     UA_PublishedDataSetConfig *config) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = getPublishedDataSetConfig(server, pds, config);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -92,12 +92,12 @@ UA_Server_getPublishedDataSetMetaData(UA_Server *server, const UA_NodeId pds,
                                       UA_DataSetMetaDataType *metaData) {
     if(!metaData)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PublishedDataSet *currentPDS = UA_PublishedDataSet_findPDSbyId(server, pds);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     if(currentPDS)
         res = UA_DataSetMetaDataType_copy(&currentPDS->dataSetMetaData, metaData);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -414,10 +414,10 @@ UA_DataSetFieldResult
 UA_Server_addDataSetField(UA_Server *server, const UA_NodeId publishedDataSet,
                           const UA_DataSetFieldConfig *fieldConfig,
                           UA_NodeId *fieldIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetFieldResult res =
         UA_DataSetField_create(server, publishedDataSet, fieldConfig, fieldIdentifier);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -510,17 +510,17 @@ UA_DataSetField_remove(UA_Server *server, UA_DataSetField *currentField) {
 
 UA_DataSetFieldResult
 UA_Server_removeDataSetField(UA_Server *server, const UA_NodeId dsf) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetFieldResult res;
     memset(&res, 0, sizeof(UA_DataSetFieldResult));
     UA_DataSetField *field = UA_DataSetField_findDSFbyId(server, dsf);
     if(!field) {
         res.result = UA_STATUSCODE_BADNOTFOUND;
-        unlockServer(server);
+        unlockPubSubServer(server);
         return res;
     }
     res = UA_DataSetField_remove(server, field);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -545,12 +545,12 @@ UA_Server_getDataSetFieldConfig(UA_Server *server, const UA_NodeId dsf,
                                 UA_DataSetFieldConfig *config) {
     if(!config)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetField *currentDataSetField = UA_DataSetField_findDSFbyId(server, dsf);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     if(currentDataSetField)
         res = UA_DataSetFieldConfig_copy(&currentDataSetField->config, config);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -733,10 +733,10 @@ UA_AddPublishedDataSetResult
 UA_Server_addPublishedDataSet(UA_Server *server,
                               const UA_PublishedDataSetConfig *publishedDataSetConfig,
                               UA_NodeId *pdsIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_AddPublishedDataSetResult res =
         UA_PublishedDataSet_create(server, publishedDataSetConfig, pdsIdentifier);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -777,14 +777,14 @@ UA_PublishedDataSet_remove(UA_Server *server, UA_PublishedDataSet *publishedData
 
 UA_StatusCode
 UA_Server_removePublishedDataSet(UA_Server *server, const UA_NodeId pds) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PublishedDataSet *currentPDS = UA_PublishedDataSet_findPDSbyId(server, pds);
     if(!currentPDS) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_PublishedDataSet_remove(server, currentPDS);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 

--- a/src/pubsub/ua_pubsub_eventloop.c
+++ b/src/pubsub/ua_pubsub_eventloop.c
@@ -151,7 +151,7 @@ PubSubChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     UA_Server *server = (UA_Server*)application;
     UA_PubSubConnection *psc = (UA_PubSubConnection*)*connectionContext;
 
-    lockServer(server);
+    lockPubSubServer(server);
 
     /* The connection is closing in the EventLoop. This is the last callback
      * from that connection. Clean up the SecureChannel in the client. */
@@ -161,8 +161,12 @@ PubSubChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
 
         /* PSC marked for deletion and the last EventLoop connection has closed */
         if(psc->deleteFlag && psc->recvChannelsSize == 0 && psc->sendChannel == 0) {
-            UA_PubSubConnection_delete(server, psc);
-            unlockServer(server);
+            /* Get locked event loop mutex */
+            UA_EventLoop *el = UA_PubSubConnection_getEL(server, psc);
+            UA_StatusCode ret = UA_PubSubConnection_delete(server, psc);
+            if((ret == UA_STATUSCODE_GOOD) && el && el->unlock)
+                el->unlock(el);  /* Unlock event loop mutex */
+            unlockPubSubServer(server);
             return;
         }
 
@@ -173,7 +177,7 @@ PubSubChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
         if(psc->state == UA_PUBSUBSTATE_OPERATIONAL)
             UA_PubSubConnection_connect(server, psc, false);
 
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
@@ -186,13 +190,13 @@ PubSubChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
                                   "No more space for an additional EventLoop connection");
         if(psc->cm)
             psc->cm->closeConnection(psc->cm, connectionId);
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
     /* No message received */
     if(!recv || msg.length == 0) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
@@ -263,7 +267,7 @@ PubSubChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
         }
     }
 
-    unlockServer(server);
+    unlockPubSubServer(server);
 }
 
 static void
@@ -526,7 +530,7 @@ WriterGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     UA_Server *server = (UA_Server*)application;
     UA_WriterGroup *wg = (UA_WriterGroup*)*connectionContext;
 
-    lockServer(server);
+    lockPubSubServer(server);
 
     /* The connection is closing in the EventLoop. This is the last callback
      * from that connection. Clean up the SecureChannel in the client. */
@@ -538,7 +542,7 @@ WriterGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
             /* PSC marked for deletion and the last EventLoop connection has closed */
             if(wg->deleteFlag) {
                 UA_WriterGroup_remove(server, wg);
-                unlockServer(server);
+                unlockPubSubServer(server);
                 return;
             }
         }
@@ -550,7 +554,7 @@ WriterGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
         if(wg->state == UA_PUBSUBSTATE_OPERATIONAL)
             UA_WriterGroup_connect(server, wg, false);
 
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
@@ -558,7 +562,7 @@ WriterGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     if(wg->sendChannel && wg->sendChannel != connectionId) {
         UA_LOG_WARNING_WRITERGROUP(server->config.logging, wg,
                                   "WriterGroup is already bound to a different channel");
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
     wg->sendChannel = connectionId;
@@ -569,7 +573,7 @@ WriterGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
                                       UA_STATUSCODE_GOOD);
     
     /* Send-channels don't receive messages */
-    unlockServer(server);
+    unlockPubSubServer(server);
 }
 
 static UA_StatusCode
@@ -826,7 +830,7 @@ ReaderGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     UA_Server *server = (UA_Server*)application;
     UA_ReaderGroup *rg = (UA_ReaderGroup*)*connectionContext;
 
-    lockServer(server);
+    lockPubSubServer(server);
 
     /* The connection is closing in the EventLoop. This is the last callback
      * from that connection. Clean up the SecureChannel in the client. */
@@ -837,13 +841,13 @@ ReaderGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
         /* PSC marked for deletion and the last EventLoop connection has closed */
         if(rg->deleteFlag && rg->recvChannelsSize == 0) {
             UA_ReaderGroup_remove(server, rg);
-            unlockServer(server);
+            unlockPubSubServer(server);
             return;
         }
 
         /* Reconnect if still operational */
         UA_ReaderGroup_setPubSubState(server, rg, rg->state, UA_STATUSCODE_GOOD);
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
@@ -855,13 +859,13 @@ ReaderGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
         UA_PubSubConnection *c = rg->linkedConnection;
         if(c && c->cm)
             c->cm->closeConnection(c->cm, connectionId);
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
     /* No message received */
     if(msg.length == 0) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
@@ -878,14 +882,14 @@ ReaderGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     if(rg->state != UA_PUBSUBSTATE_OPERATIONAL) {
         UA_LOG_WARNING_READERGROUP(server->config.logging, rg,
                                    "Received a messaage for a non-operational ReaderGroup");
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
     /* ReaderGroup with realtime processing */
     if(rg->config.rtLevel & UA_PUBSUB_RT_FIXED_SIZE) {
         UA_ReaderGroup_decodeAndProcessRT(server, rg, &msg);
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
@@ -906,14 +910,14 @@ ReaderGroupChannelCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     if(res != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING_READERGROUP(server->config.logging, rg,
                                   "Verify, decrypt and decode network message failed");
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
     /* Process the decoded message */
     UA_ReaderGroup_process(server, rg, &nm);
     UA_NetworkMessage_clear(&nm);
-    unlockServer(server);
+    unlockPubSubServer(server);
 }
 
 static UA_StatusCode

--- a/src/pubsub/ua_pubsub_keystorage.c
+++ b/src/pubsub/ua_pubsub_keystorage.c
@@ -374,7 +374,7 @@ nextGetSecuritykeysCallback(UA_Server *server, UA_PubSubKeyStorage *keyStorage) 
 void
 UA_PubSubKeyStorage_keyRolloverCallback(UA_Server *server, UA_PubSubKeyStorage *keyStorage) {
     /* Callbacks from the EventLoop are initially unlocked */
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode retval =
         UA_PubSubKeyStorage_addKeyRolloverCallback(server, keyStorage,
                                      (UA_ServerCallback)UA_PubSubKeyStorage_keyRolloverCallback,
@@ -407,7 +407,7 @@ UA_PubSubKeyStorage_keyRolloverCallback(UA_Server *server, UA_PubSubKeyStorage *
             server->config.eventLoop, (UA_Callback)nextGetSecuritykeysCallback, server,
             keyStorage, dateTimeToNextGetSecurityKeys, NULL);
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
 }
 
 UA_StatusCode
@@ -528,7 +528,7 @@ storeFetchedKeys(UA_Client *client, void *userdata, UA_UInt32 requestId,
     UA_Server *server = ctx->server;
     UA_StatusCode retval = response->responseHeader.serviceResult;
 
-    lockServer(server);
+    lockPubSubServer(server);
     /* check if the call to getSecurityKeys was a success */
     if(response->resultsSize != 0)
         retval = response->results->statusCode;
@@ -599,7 +599,7 @@ cleanup:
     UA_Client_disconnectAsync(client);
     addDelayedSksClientCleanupCb(client, ctx);
 
-    unlockServer(server);
+    unlockPubSubServer(server);
 }
 
 static UA_StatusCode
@@ -728,10 +728,10 @@ UA_Server_setSksClient(UA_Server *server, UA_String securityGroupId,
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
     UA_StatusCode retval = UA_STATUSCODE_BADNOTFOUND;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, securityGroupId);
     if(!ks) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return retval;
     }
 
@@ -751,7 +751,7 @@ UA_Server_setSksClient(UA_Server *server, UA_String securityGroupId,
     if(ks->keyListSize == 0) {
         retval = getSecurityKeysAndStoreFetchedKeys(server, ks);
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return retval;
 }
 

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -303,9 +303,9 @@ UA_StatusCode
 UA_Server_addStandaloneSubscribedDataSet(UA_Server *server,
                                          const UA_StandaloneSubscribedDataSetConfig *sdsConfig,
                                          UA_NodeId *sdsIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = addStandaloneSubscribedDataSet(server, sdsConfig, sdsIdentifier);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -350,9 +350,9 @@ removeStandaloneSubscribedDataSet(UA_Server *server, const UA_NodeId sds) {
 
 UA_StatusCode
 UA_Server_removeStandaloneSubscribedDataSet(UA_Server *server, const UA_NodeId sds) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = removeStandaloneSubscribedDataSet(server, sds);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -406,11 +406,18 @@ UA_PubSubManager_init(UA_Server *server, UA_PubSubManager *pubSubManager) {
 
 void
 UA_PubSubManager_shutdown(UA_Server *server, UA_PubSubManager *pubSubManager) {
+
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+    // assure locking order event loop -> server
+    unlockServer(server);
+    lockPubSubServer(server);
     UA_PubSubConnection *tmpConnection;
     TAILQ_FOREACH(tmpConnection, &server->pubSubManager.connections, listEntry) {
         UA_PubSubConnection_setPubSubState(server, tmpConnection,
                                            UA_PUBSUBSTATE_DISABLED, UA_STATUSCODE_GOOD);
     }
+    unlockPubSubServer(server);
+    lockServer(server);
 }
 
 /* Delete the current PubSub configuration including all nested members. This
@@ -420,12 +427,22 @@ UA_PubSubManager_delete(UA_Server *server, UA_PubSubManager *pubSubManager) {
     UA_LOG_INFO(server->config.logging, UA_LOGCATEGORY_SERVER,
                 "PubSub cleanup was called.");
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
+    // assure locking order event loop -> server
+    unlockServer(server);
+    lockPubSubServer(server);
 
     /* Remove Connections - this also remove WriterGroups and ReaderGroups */
     UA_PubSubConnection *tmpConnection1, *tmpConnection2;
+    UA_EventLoop *el;
+    UA_StatusCode ret;
     TAILQ_FOREACH_SAFE(tmpConnection1, &server->pubSubManager.connections,
                        listEntry, tmpConnection2) {
-        UA_PubSubConnection_delete(server, tmpConnection1);
+        /* Get locked event loop mutex */
+        el = UA_PubSubConnection_getEL(server, tmpConnection1);
+
+        ret = UA_PubSubConnection_delete(server, tmpConnection1);
+        if((ret == UA_STATUSCODE_GOOD) && el && el->unlock)
+            el->unlock(el);  /* Unlock event loop mutex */
     }
 
     /* Remove the DataSets */
@@ -467,6 +484,9 @@ UA_PubSubManager_delete(UA_Server *server, UA_PubSubManager *pubSubManager) {
         UA_PubSubKeyStorage_delete(server, ks);
     }
 #endif
+
+    unlockPubSubServer(server);
+    lockServer(server);
 }
 
 #ifdef UA_ENABLE_PUBSUB_MONITORING

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -266,10 +266,10 @@ UA_StatusCode
 UA_Server_addDataSetReader(UA_Server *server, UA_NodeId readerGroupIdentifier,
                            const UA_DataSetReaderConfig *dataSetReaderConfig,
                            UA_NodeId *readerIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = UA_DataSetReader_create(server, readerGroupIdentifier,
                                                 dataSetReaderConfig, readerIdentifier);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -347,14 +347,14 @@ UA_DataSetReader_remove(UA_Server *server, UA_DataSetReader *dsr) {
 
 UA_StatusCode
 UA_Server_removeDataSetReader(UA_Server *server, UA_NodeId readerIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetReader *dsr = UA_ReaderGroup_findDSRbyId(server, readerIdentifier);
     if(!dsr) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_DataSetReader_remove(server, dsr);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -433,15 +433,15 @@ UA_Server_DataSetReader_updateConfig(UA_Server *server, UA_NodeId dataSetReaderI
     if(config == NULL)
        return UA_STATUSCODE_BADINVALIDARGUMENT;
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetReader *dsr = UA_ReaderGroup_findDSRbyId(server, dataSetReaderIdentifier);
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, readerGroupIdentifier);
     if(!dsr || !rg) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = DataSetReader_updateConfig(server, rg, dsr, config);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -450,12 +450,12 @@ UA_Server_DataSetReader_getConfig(UA_Server *server, UA_NodeId dataSetReaderIden
                                  UA_DataSetReaderConfig *config) {
     if(!config)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     UA_DataSetReader *dsr = UA_ReaderGroup_findDSRbyId(server, dataSetReaderIdentifier);
     if(dsr)
         res = UA_DataSetReaderConfig_copy(&dsr->config, config);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -521,14 +521,14 @@ UA_Server_DataSetReader_getState(UA_Server *server, UA_NodeId dataSetReaderIdent
     if(!server || !state)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     UA_DataSetReader *dsr = UA_ReaderGroup_findDSRbyId(server, dataSetReaderIdentifier);
     if(dsr) {
         res = UA_STATUSCODE_GOOD;
         *state = dsr->state;
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -672,15 +672,15 @@ UA_Server_DataSetReader_createTargetVariables(UA_Server *server,
                                               UA_NodeId dataSetReaderIdentifier,
                                               size_t targetVariablesSize,
                                               const UA_FieldTargetVariable *targetVariables) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetReader *dataSetReader = UA_ReaderGroup_findDSRbyId(server, dataSetReaderIdentifier);
     if(!dataSetReader) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
     UA_StatusCode res = DataSetReader_createTargetVariables(server, dataSetReader,
                                                             targetVariablesSize, targetVariables);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -180,11 +180,11 @@ UA_StatusCode
 UA_Server_addReaderGroup(UA_Server *server, UA_NodeId connectionIdentifier,
                          const UA_ReaderGroupConfig *readerGroupConfig,
                          UA_NodeId *readerGroupIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res =
         UA_ReaderGroup_create(server, connectionIdentifier,
                               readerGroupConfig, readerGroupIdentifier);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -257,15 +257,15 @@ UA_ReaderGroup_remove(UA_Server *server, UA_ReaderGroup *rg) {
 
 UA_StatusCode
 UA_Server_removeReaderGroup(UA_Server *server, UA_NodeId groupIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_ReaderGroup* readerGroup =
         UA_ReaderGroup_findRGbyId(server, groupIdentifier);
     if(!readerGroup) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_ReaderGroup_remove(server, readerGroup);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -275,20 +275,20 @@ UA_Server_ReaderGroup_getConfig(UA_Server *server, UA_NodeId readerGroupIdentifi
     if(!config)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
-    lockServer(server);
+    lockPubSubServer(server);
 
     /* Identify the readergroup through the readerGroupIdentifier */
     UA_ReaderGroup *currentReaderGroup =
         UA_ReaderGroup_findRGbyId(server, readerGroupIdentifier);
     if(!currentReaderGroup) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
 
     UA_StatusCode ret =
         UA_ReaderGroupConfig_copy(&currentReaderGroup->config, config);
 
-    unlockServer(server);
+    unlockPubSubServer(server);
     return ret;
 }
 
@@ -297,7 +297,7 @@ UA_Server_ReaderGroup_getState(UA_Server *server, UA_NodeId readerGroupIdentifie
                                UA_PubSubState *state) {
     if((server == NULL) || (state == NULL))
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode ret = UA_STATUSCODE_BADNOTFOUND;
     UA_ReaderGroup *rg =
         UA_ReaderGroup_findRGbyId(server, readerGroupIdentifier);
@@ -305,7 +305,7 @@ UA_Server_ReaderGroup_getState(UA_Server *server, UA_NodeId readerGroupIdentifie
         *state = rg->state;
         ret = UA_STATUSCODE_GOOD;
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return ret;
 }
 
@@ -482,7 +482,7 @@ UA_ReaderGroup_setPubSubState(UA_Server *server,
 UA_StatusCode
 UA_Server_setReaderGroupOperational(UA_Server *server,
                                     const UA_NodeId readerGroupId) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode ret = UA_STATUSCODE_BADNOTFOUND;
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, readerGroupId);
     if(rg) {
@@ -491,7 +491,7 @@ UA_Server_setReaderGroupOperational(UA_Server *server,
             UA_StatusCode retval = UA_PubSubKeyStorage_activateKeyToChannelContext(
                 server, rg->identifier, rg->config.securityGroupId);
             if(retval != UA_STATUSCODE_GOOD) {
-                unlockServer(server);
+                unlockPubSubServer(server);
                 return retval;
             }
         }
@@ -499,20 +499,20 @@ UA_Server_setReaderGroupOperational(UA_Server *server,
         ret = UA_ReaderGroup_setPubSubState(server, rg, UA_PUBSUBSTATE_OPERATIONAL,
                                             UA_STATUSCODE_GOOD);
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return ret;
 }
 
 UA_StatusCode
 UA_Server_setReaderGroupDisabled(UA_Server *server,
                                  const UA_NodeId readerGroupId) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode ret = UA_STATUSCODE_BADNOTFOUND;
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, readerGroupId);
     if(rg)
         ret = UA_ReaderGroup_setPubSubState(server, rg, UA_PUBSUBSTATE_DISABLED,
                                             UA_STATUSCODE_BADRESOURCEUNAVAILABLE);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return ret;
 }
 
@@ -563,11 +563,11 @@ UA_Server_setReaderGroupEncryptionKeys(UA_Server *server,
                                        const UA_ByteString signingKey,
                                        const UA_ByteString encryptingKey,
                                        const UA_ByteString keyNonce) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = setReaderGroupEncryptionKeys(server, readerGroup,
                                                      securityTokenId, signingKey,
                                                      encryptingKey, keyNonce);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 #endif
@@ -680,14 +680,14 @@ UA_ReaderGroup_freezeConfiguration(UA_Server *server, UA_ReaderGroup *rg) {
 UA_StatusCode
 UA_Server_freezeReaderGroupConfiguration(UA_Server *server,
                                          const UA_NodeId readerGroupId) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, readerGroupId);
     if(!rg) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_ReaderGroup_freezeConfiguration(server, rg);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -719,14 +719,14 @@ UA_ReaderGroup_unfreezeConfiguration(UA_Server *server, UA_ReaderGroup *rg) {
 UA_StatusCode
 UA_Server_unfreezeReaderGroupConfiguration(UA_Server *server,
                                            const UA_NodeId readerGroupId) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, readerGroupId);
     if(!rg) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_ReaderGroup_unfreezeConfiguration(server, rg);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 

--- a/src/pubsub/ua_pubsub_securitygroup.c
+++ b/src/pubsub/ua_pubsub_securitygroup.c
@@ -277,10 +277,10 @@ UA_StatusCode
 UA_Server_addSecurityGroup(UA_Server *server, UA_NodeId securityGroupFolderNodeId,
                            const UA_SecurityGroupConfig *securityGroupConfig,
                            UA_NodeId *securityGroupNodeId) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode retval = addSecurityGroup(server, securityGroupFolderNodeId,
                                             securityGroupConfig, securityGroupNodeId);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return retval;
 }
 
@@ -340,7 +340,7 @@ removeSecurityGroup(UA_Server *server, UA_SecurityGroup *securityGroup) {
 
 UA_StatusCode
 UA_Server_removeSecurityGroup(UA_Server *server, const UA_NodeId securityGroup) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroup);
     UA_StatusCode res = UA_STATUSCODE_GOOD;
     if(sg) {
@@ -348,7 +348,7 @@ UA_Server_removeSecurityGroup(UA_Server *server, const UA_NodeId securityGroup) 
     } else {
         res = UA_STATUSCODE_BADBOUNDNOTFOUND;
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -42,12 +42,12 @@ UA_Server_getDataSetWriterConfig(UA_Server *server, const UA_NodeId dsw,
                                  UA_DataSetWriterConfig *config) {
     if(!config)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetWriter *currentDataSetWriter = UA_DataSetWriter_findDSWbyId(server, dsw);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     if(currentDataSetWriter)
         res = UA_DataSetWriterConfig_copy(&currentDataSetWriter->config, config);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -56,7 +56,7 @@ UA_Server_DataSetWriter_getState(UA_Server *server, UA_NodeId dataSetWriterIdent
                                UA_PubSubState *state) {
     if((server == NULL) || (state == NULL))
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetWriter *currentDataSetWriter =
         UA_DataSetWriter_findDSWbyId(server, dataSetWriterIdentifier);
     UA_StatusCode res = UA_STATUSCODE_GOOD;
@@ -65,7 +65,7 @@ UA_Server_DataSetWriter_getState(UA_Server *server, UA_NodeId dataSetWriterIdent
     } else {
         res = UA_STATUSCODE_BADNOTFOUND;
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -322,12 +322,12 @@ UA_Server_addDataSetWriter(UA_Server *server,
                            const UA_NodeId writerGroup, const UA_NodeId dataSet,
                            const UA_DataSetWriterConfig *dataSetWriterConfig,
                            UA_NodeId *writerIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     /* Delete the reserved IDs if the related session no longer exists. */
     UA_PubSubManager_freeIds(server);
     UA_StatusCode res = UA_DataSetWriter_create(server, writerGroup, dataSet,
                                                 dataSetWriterConfig, writerIdentifier);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -508,14 +508,14 @@ UA_DataSetWriter_remove(UA_Server *server, UA_DataSetWriter *dataSetWriter) {
 
 UA_StatusCode
 UA_Server_removeDataSetWriter(UA_Server *server, const UA_NodeId dsw) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_DataSetWriter *dataSetWriter = UA_DataSetWriter_findDSWbyId(server, dsw);
     if(!dataSetWriter) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_DataSetWriter_remove(server, dataSetWriter);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -211,10 +211,10 @@ UA_StatusCode
 UA_Server_addWriterGroup(UA_Server *server, const UA_NodeId connection,
                          const UA_WriterGroupConfig *writerGroupConfig,
                          UA_NodeId *writerGroupIdentifier) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = UA_WriterGroup_create(server, connection, writerGroupConfig,
                                               writerGroupIdentifier);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -288,14 +288,14 @@ UA_WriterGroup_remove(UA_Server *server, UA_WriterGroup *wg) {
 
 UA_StatusCode
 UA_Server_removeWriterGroup(UA_Server *server, const UA_NodeId writerGroup) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     if(!wg) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_WriterGroup_remove(server, wg);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -450,14 +450,14 @@ UA_WriterGroup_freezeConfiguration(UA_Server *server, UA_WriterGroup *wg) {
 UA_StatusCode
 UA_Server_freezeWriterGroupConfiguration(UA_Server *server,
                                          const UA_NodeId writerGroup) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     if(!wg) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_WriterGroup_freezeConfiguration(server, wg);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -487,21 +487,21 @@ UA_WriterGroup_unfreezeConfiguration(UA_Server *server, UA_WriterGroup *wg) {
 UA_StatusCode
 UA_Server_unfreezeWriterGroupConfiguration(UA_Server *server,
                                            const UA_NodeId writerGroup) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     if(!wg) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     UA_StatusCode res = UA_WriterGroup_unfreezeConfiguration(server, wg);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
 UA_StatusCode
 UA_Server_setWriterGroupOperational(UA_Server *server,
                                     const UA_NodeId writerGroup) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     if(wg) {
@@ -510,7 +510,7 @@ UA_Server_setWriterGroupOperational(UA_Server *server,
             res = UA_PubSubKeyStorage_activateKeyToChannelContext(
                 server, wg->identifier, wg->config.securityGroupId);
             if(res != UA_STATUSCODE_GOOD) {
-                unlockServer(server);
+                unlockPubSubServer(server);
                 return res;
             }
         }
@@ -519,20 +519,20 @@ UA_Server_setWriterGroupOperational(UA_Server *server,
         res = UA_WriterGroup_setPubSubState(server, wg, UA_PUBSUBSTATE_OPERATIONAL,
                                             UA_STATUSCODE_GOOD);
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
 UA_StatusCode
 UA_Server_setWriterGroupDisabled(UA_Server *server,
                                  const UA_NodeId writerGroup) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     if(wg)
         res = UA_WriterGroup_setPubSubState(server, wg, UA_PUBSUBSTATE_DISABLED,
                                             UA_STATUSCODE_BADRESOURCEUNAVAILABLE);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -558,12 +558,12 @@ UA_Server_getWriterGroupConfig(UA_Server *server, const UA_NodeId writerGroup,
                                UA_WriterGroupConfig *config) {
     if(!config)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_WriterGroup *currentWG = UA_WriterGroup_findWGbyId(server, writerGroup);
     UA_StatusCode res = UA_STATUSCODE_BADNOTFOUND;
     if(currentWG)
         res = UA_WriterGroupConfig_copy(&currentWG->config, config);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -618,15 +618,15 @@ UA_WriterGroup_updateConfig(UA_Server *server, UA_WriterGroup *wg,
 UA_StatusCode
 UA_Server_updateWriterGroupConfig(UA_Server *server, UA_NodeId writerGroupIdentifier,
                                   const UA_WriterGroupConfig *config) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroupIdentifier);
     if(!wg) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
 
     UA_StatusCode res = UA_WriterGroup_updateConfig(server, wg, config);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
@@ -635,7 +635,7 @@ UA_Server_WriterGroup_getState(UA_Server *server, UA_NodeId writerGroupIdentifie
                                UA_PubSubState *state) {
     if((server == NULL) || (state == NULL))
         return UA_STATUSCODE_BADINVALIDARGUMENT;
-    lockServer(server);
+    lockPubSubServer(server);
     UA_WriterGroup *currentWriterGroup =
         UA_WriterGroup_findWGbyId(server, writerGroupIdentifier);
     UA_StatusCode res = UA_STATUSCODE_GOOD;
@@ -644,22 +644,22 @@ UA_Server_WriterGroup_getState(UA_Server *server, UA_NodeId writerGroupIdentifie
     } else {
         res = UA_STATUSCODE_BADNOTFOUND;
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 
 UA_StatusCode
 UA_Server_WriterGroup_publish(UA_Server *server, const UA_NodeId writerGroupIdentifier){
-    lockServer(server);
+    lockPubSubServer(server);
 
     //search WriterGroup ToDo create lookup table for more efficiency
     UA_WriterGroup *writerGroup;
     writerGroup = UA_WriterGroup_findWGbyId(server, writerGroupIdentifier);
     if(writerGroup == NULL){
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
     UA_WriterGroup_publishCallback(server, writerGroup);
     return UA_STATUSCODE_GOOD;
 }
@@ -667,16 +667,16 @@ UA_Server_WriterGroup_publish(UA_Server *server, const UA_NodeId writerGroupIden
 UA_StatusCode
 UA_WriterGroup_lastPublishTimestamp(UA_Server *server, const UA_NodeId writerGroupId,
                                     UA_DateTime *timestamp){
-    lockServer(server);
+    lockPubSubServer(server);
     //search WriterGroup ToDo create lookup table for more efficiency
     UA_WriterGroup *writerGroup;
     writerGroup = UA_WriterGroup_findWGbyId(server, writerGroupId);
     if(writerGroup == NULL){
-        unlockServer(server);
+        unlockPubSubServer(server);
         return UA_STATUSCODE_BADNOTFOUND;
     }
     *timestamp = writerGroup->lastPublishTimeStamp;
-    unlockServer(server);
+    unlockPubSubServer(server);
     return UA_STATUSCODE_BADNOTFOUND;
 }
 
@@ -738,10 +738,10 @@ UA_Server_setWriterGroupEncryptionKeys(UA_Server *server, const UA_NodeId writer
                                        const UA_ByteString signingKey,
                                        const UA_ByteString encryptingKey,
                                        const UA_ByteString keyNonce) {
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode res = setWriterGroupEncryptionKeys(server, writerGroup, securityTokenId,
                                                      signingKey, encryptingKey, keyNonce);
-    unlockServer(server);
+    unlockPubSubServer(server);
     return res;
 }
 #endif
@@ -1208,7 +1208,7 @@ sendNetworkMessageBinary(UA_Server *server, UA_PubSubConnection *connection, UA_
 
 static void
 sampleOffsetPublishingValues(UA_Server *server, UA_WriterGroup *wg) {
-    lockServer(server);
+    lockPubSubServer(server);
 
     size_t fieldPos = 0;
     UA_DataSetWriter *dsw;
@@ -1247,7 +1247,7 @@ sampleOffsetPublishingValues(UA_Server *server, UA_WriterGroup *wg) {
         }
     }
 
-    unlockServer(server);
+    unlockPubSubServer(server);
 }
 
 static void
@@ -1359,7 +1359,7 @@ UA_WriterGroup_publishCallback(UA_Server *server, UA_WriterGroup *writerGroup) {
     UA_assert(writerGroup != NULL);
     UA_assert(server != NULL);
 
-    lockServer(server);
+    lockPubSubServer(server);
 
     UA_LOG_DEBUG_WRITERGROUP(server->config.logging, writerGroup, "Publish Callback");
 
@@ -1370,20 +1370,20 @@ UA_WriterGroup_publishCallback(UA_Server *server, UA_WriterGroup *writerGroup) {
                                  "Publish failed. PubSubConnection invalid");
         UA_WriterGroup_setPubSubState(server, writerGroup, UA_PUBSUBSTATE_ERROR,
                                       UA_STATUSCODE_BADNOTCONNECTED);
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
     /* Realtime path - update the buffer message and send directly */
     if(writerGroup->config.rtLevel & UA_PUBSUB_RT_FIXED_SIZE) {
         publishWithOffsets(server, writerGroup, connection);
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
     /* Nothing to do? */
     if(writerGroup->writersCount == 0) {
-        unlockServer(server);
+        unlockPubSubServer(server);
         return;
     }
 
@@ -1474,7 +1474,7 @@ UA_WriterGroup_publishCallback(UA_Server *server, UA_WriterGroup *writerGroup) {
         UA_DataSetMessage_clear(&dsmStore[i]);
     }
 
-    unlockServer(server);
+    unlockPubSubServer(server);
 }
 
 #endif /* UA_ENABLE_PUBSUB */

--- a/tests/pubsub/check_pubsub_configuration.c
+++ b/tests/pubsub/check_pubsub_configuration.c
@@ -34,9 +34,9 @@ static void teardown(void) {
 START_TEST(AddPublisherUsingBinaryFile) {
     UA_ByteString publisherConfiguration = loadFile("../../tests/pubsub/check_publisher_configuration.bin");
     ck_assert(publisherConfiguration.length > 0);
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode retVal = UA_PubSubManager_loadPubSubConfigFromByteString(server, publisherConfiguration);
-    unlockServer(server);
+    unlockPubSubServer(server);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_PubSubConnection *connection;
     UA_WriterGroup *writerGroup;
@@ -69,9 +69,9 @@ START_TEST(AddPublisherUsingBinaryFile) {
 START_TEST(AddSubscriberUsingBinaryFile) {
     UA_ByteString subscriberConfiguration = loadFile("../../tests/pubsub/check_subscriber_configuration.bin");
     ck_assert(subscriberConfiguration.length > 0);
-    lockServer(server);
+    lockPubSubServer(server);
     UA_StatusCode retVal = UA_PubSubManager_loadPubSubConfigFromByteString(server, subscriberConfiguration);
-    unlockServer(server);
+    unlockPubSubServer(server);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_PubSubConnection *connection;
     UA_ReaderGroup *readerGroup;

--- a/tests/pubsub/check_pubsub_publisherid.c
+++ b/tests/pubsub/check_pubsub_publisherid.c
@@ -1566,9 +1566,9 @@ START_TEST(Test_string_publisherId_file_config) {
     UA_PubSubConfigurationDataType_clear(&config);
 }
     /* load and apply config from ByteString buffer */
-    lockServer(server);
+    lockPubSubServer(server);
     ck_assert_int_eq(UA_STATUSCODE_GOOD, UA_PubSubManager_loadPubSubConfigFromByteString(server, encodedConfigDataBuffer));
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     /* groups are already operational */
     /* check that publish/subscribe works -> set some test values */

--- a/tests/pubsub/check_pubsub_sks_client.c
+++ b/tests/pubsub/check_pubsub_sks_client.c
@@ -534,11 +534,11 @@ START_TEST(AddValidSksClientwithWriterGroup) {
                   "Expected Statuscode to be Good, but failed with: %s ",
                   UA_StatusCode_name(retval));
     ck_assert(wg->keyStorage->keyListSize > 0);
-    lockServer(sksServer);
+    lockPubSubServer(sksServer);
     UA_PubSubKeyListItem *sksKsItr =
         UA_PubSubKeyStorage_findKeyStorage(sksServer, securityGroupId)
             ->currentItem;
-    unlockServer(sksServer);
+    unlockPubSubServer(sksServer);
     UA_PubSubKeyListItem *wgKsItr = TAILQ_FIRST(&wg->keyStorage->keyList);
     for(size_t i = 0; i < wg->keyStorage->keyListSize; i++) {
         ck_assert_msg(UA_ByteString_equal(&sksKsItr->key, &wgKsItr->key) == UA_TRUE,
@@ -580,11 +580,11 @@ START_TEST(AddValidSksClientwithReaderGroup) {
                   "Expected Statuscode to be Good, but failed with: %s ",
                   UA_StatusCode_name(retval));
     ck_assert(rg->keyStorage->keyListSize > 0);
-    lockServer(sksServer);
+    lockPubSubServer(sksServer);
     UA_PubSubKeyListItem *sksKsItr =
         UA_PubSubKeyStorage_findKeyStorage(sksServer, securityGroupId)
             ->currentItem;
-    unlockServer(sksServer);
+    unlockPubSubServer(sksServer);
     UA_PubSubKeyListItem *rgKsItr = TAILQ_FIRST(&rg->keyStorage->keyList);
     for(size_t i = 0; i < rg->keyStorage->keyListSize; i++) {
         ck_assert_msg(UA_ByteString_equal(&sksKsItr->key, &rgKsItr->key) == UA_TRUE,
@@ -860,14 +860,14 @@ START_TEST(FetchNextbatchOfKeys) {
     }
     ck_assert(retryCnt < MAX_RETRIES);
 
-    lockServer(publisherApp);
+    lockPubSubServer(publisherApp);
     UA_PubSubKeyStorage *pubKs = UA_PubSubKeyStorage_findKeyStorage(
         publisherApp, securityGroupId);
-    unlockServer(publisherApp);
-    lockServer(subscriberApp);
+    unlockPubSubServer(publisherApp);
+    lockPubSubServer(subscriberApp);
     UA_PubSubKeyStorage *subKs = UA_PubSubKeyStorage_findKeyStorage(
         subscriberApp, securityGroupId);
-    unlockServer(subscriberApp);
+    unlockPubSubServer(subscriberApp);
     retval = UA_Server_setWriterGroupOperational(publisherApp, writerGroupId);
     ck_assert(retval == UA_STATUSCODE_GOOD);
 

--- a/tests/pubsub/check_pubsub_sks_keystorage.c
+++ b/tests/pubsub/check_pubsub_sks_keystorage.c
@@ -123,7 +123,7 @@ createKeyStoragewithkeys(UA_UInt32 currentTokenId, UA_UInt32 keysize,
     addTestWriterGroup(SecurityGroupId);
     addTestReaderGroup(SecurityGroupId);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *tKeyStorage =
         UA_PubSubKeyStorage_findKeyStorage(server, SecurityGroupId);
 
@@ -160,7 +160,7 @@ createKeyStoragewithkeys(UA_UInt32 currentTokenId, UA_UInt32 keysize,
     retval = UA_PubSubKeyStorage_addKeyRolloverCallback(
         server, tKeyStorage, (UA_ServerCallback)UA_PubSubKeyStorage_keyRolloverCallback, callbackTime,
         &tKeyStorage->callBackId);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     return tKeyStorage;
 }
@@ -225,7 +225,7 @@ START_TEST(TestPubSubKeyStorage_initialize) {
         UA_calloc(1, sizeof(UA_PubSubKeyStorage));
     ck_assert_ptr_ne(tKeyStorage, NULL);
 
-    lockServer(server);
+    lockPubSubServer(server);
 
     retval =
         UA_PubSubKeyStorage_init(server, tKeyStorage,
@@ -244,7 +244,7 @@ START_TEST(TestPubSubKeyStorage_initialize) {
     /*check if the keystorage is in the Server Keystorage list*/
     ck_assert_ptr_eq(server->pubSubManager.pubSubKeyList.lh_first, tKeyStorage);
 
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(TestPubSubKeyStorageSetKeys){
@@ -253,7 +253,7 @@ START_TEST(TestPubSubKeyStorageSetKeys){
     UA_Duration msTimeToNextKey = 2000;
     UA_String testSecurityGroupId = UA_STRING("TestSecurityGroup");
     UA_PubSubKeyStorage *tKeyStorage = createKeyStoragewithkeys(currentTokenId, futureKeySize, msTimeToNextKey, 0, testSecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyListItem *keyListIterator;
     ck_assert_ptr_ne(tKeyStorage, NULL);
     ck_assert_msg(UA_ByteString_equal(&currentKey, &tKeyStorage->keyList.tqh_first->key), "Expected CurrentKey to be equal to the first key in the KeyList");
@@ -267,7 +267,7 @@ START_TEST(TestPubSubKeyStorageSetKeys){
     ck_assert_msg(UA_ByteString_equal(&futureKey[futureKeySize - 1], &keyListIterator->key), "Expected lastItem to be equal to the last FutureKey");
     ck_assert_msg(futureKeySize + 1 == tKeyStorage->keyListSize,"Expected KeyListSize to be equal to FutureKeySize + 1");
     ck_assert_msg(tKeyStorage->keyLifeTime == msTimeToNextKey, "Expected keyLifetime to be equal to the Keystorage->keyLifeTime");
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(TestPubSubKeyStorage_MovetoNextKeyCallback){
@@ -277,11 +277,11 @@ START_TEST(TestPubSubKeyStorage_MovetoNextKeyCallback){
     UA_String testSecurityGroupId = UA_STRING("TestSecurityGroup");
 
     UA_PubSubKeyStorage *tKeyStorage = createKeyStoragewithkeys(currentTokenId, futureKeySize, msTimeToNextKey, 0, testSecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
     ck_assert_ptr_ne(tKeyStorage, NULL);
     UA_PubSubKeyListItem *nextCurrentKey = TAILQ_NEXT(tKeyStorage->currentItem, keyListEntry);
     UA_fakeSleep(2000);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     UA_Server_run_iterate(server,false);
     ck_assert_ptr_eq(nextCurrentKey, tKeyStorage->currentItem);
@@ -313,7 +313,7 @@ START_TEST(TestPubSubKeystorage_ImportedKey){
     UA_ByteString_copy(&buffer, &expect_buf);
 
     createKeyStoragewithkeys(currentTokenId, futureKeySize, msTimeToNextKey,0, testSecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
 
     /*encrypt and sign with Writer channelContext*/
 
@@ -338,62 +338,62 @@ START_TEST(TestPubSubKeystorage_ImportedKey){
     UA_ByteString_clear(&signature);
     UA_ByteString_clear(&buffer);
 
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(TestPubSubKeyStorage_InitWithWriterGroup){
     addTestWriterGroup(SecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, SecurityGroupId);
     ck_assert_ptr_ne(wg->keyStorage, NULL);
     ck_assert_ptr_eq(ks, wg->keyStorage);
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(TestPubSubKeyStorage_InitWithReaderGroup){
     addTestReaderGroup(SecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, readerGroup);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, SecurityGroupId);
     ck_assert_ptr_ne(rg->keyStorage, NULL);
     ck_assert_ptr_eq(ks, rg->keyStorage);
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(TestAddingNewGroupToExistingKeyStorage){
     addTestWriterGroup(SecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, SecurityGroupId);
     ck_assert_msg(ks->referenceCount == 1, "Expected the reference Count to be exactly 1 after adding one Group");
-    unlockServer(server);
+    unlockPubSubServer(server);
     addTestReaderGroup(SecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
     ck_assert_msg(ks->referenceCount == 2, "Expected the reference Count to be exactly 2 after adding second Group same SecurityGroupId");
     UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, writerGroup);
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, readerGroup);
     ck_assert_ptr_eq(ks, rg->keyStorage);
     ck_assert_ptr_eq(ks, wg->keyStorage);
     ck_assert_ptr_eq(rg->keyStorage, wg->keyStorage);
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(TestRemoveAPubSubGroupWithKeyStorage){
     addTestWriterGroup(SecurityGroupId);
     addTestReaderGroup(SecurityGroupId);
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, SecurityGroupId);
     UA_UInt32 refCountBefore = ks->referenceCount;
-    unlockServer(server);
+    unlockPubSubServer(server);
     UA_Server_removeWriterGroup(server, writerGroup);
     --refCountBefore;
     ck_assert_msg(ks->referenceCount == refCountBefore, "Expected keyStroage referenceCount to be One less then before after removing a Group");
     UA_Server_removeReaderGroup(server, readerGroup);
-    lockServer(server);
+    lockPubSubServer(server);
     ks = NULL;
     ks = UA_PubSubKeyStorage_findKeyStorage(server, SecurityGroupId);
     ck_assert_ptr_eq(ks, NULL);
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 int

--- a/tests/pubsub/check_pubsub_sks_push.c
+++ b/tests/pubsub/check_pubsub_sks_push.c
@@ -296,9 +296,9 @@ START_TEST(TestSetSecurityKeys_GOOD) {
 
     UA_StatusCode retval = encyrptedclientconnect(client);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, securityGroupId);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     retval = callSetSecurityKey(client, securityGroupId, currentTokenId, futureKeySize);
     ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected StatusCode Good but erorr code : %s \n",
@@ -324,9 +324,9 @@ START_TEST(TestSetSecurityKeys_UpdateCurrentKeyFromExistingList){
 
     UA_StatusCode retval = encyrptedclientconnect(client);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, securityGroupId);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     retval = callSetSecurityKey(client, securityGroupId, currentTokenId, futureKeySize);
     ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected StatusCode Good but erorr code : %s \n", UA_StatusCode_name(retval));
@@ -347,9 +347,9 @@ START_TEST(TestSetSecurityKeys_UpdateCurrentKeyFromExistingListAndAddNewFutureKe
     size_t keyListSize;
     UA_StatusCode retval = encyrptedclientconnect(client);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, securityGroupId);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     retval = callSetSecurityKey(client, securityGroupId, currentTokenId, futureKeySize);
     ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected StatusCode Good but erorr code : %s \n", UA_StatusCode_name(retval));
@@ -380,9 +380,9 @@ START_TEST(TestSetSecurityKeys_ReplaceExistingKeyListWithFetchedKeyList){
 
     UA_StatusCode retval = encyrptedclientconnect(client);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, securityGroupId);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     retval = callSetSecurityKey(client, securityGroupId, currentTokenId, futureKeySize);
     ck_assert_msg(retval == UA_STATUSCODE_GOOD, "Expected StatusCode Good but erorr code : %s \n", UA_StatusCode_name(retval));

--- a/tests/pubsub/check_pubsub_sks_securitygroups.c
+++ b/tests/pubsub/check_pubsub_sks_securitygroups.c
@@ -154,7 +154,7 @@ START_TEST(AddSecurityGroupWithvalidConfig) {
                                         &securityGroupNodeId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
     ck_assert_ptr_ne(sg, NULL);
     ck_assert(UA_NodeId_equal(&sg->securityGroupNodeId, &securityGroupNodeId) == UA_TRUE);
@@ -164,7 +164,7 @@ START_TEST(AddSecurityGroupWithvalidConfig) {
 #endif
     ck_assert(UA_String_equal(&sg->securityGroupId, &config.securityGroupName) ==
               UA_TRUE);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
     /*check properties*/
@@ -246,17 +246,17 @@ START_TEST(RemoveSecurityGroup) {
                                         &securityGroupNodeId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
     ck_assert_ptr_ne(sg, NULL);
-    unlockServer(server);
+    unlockPubSubServer(server);
 
     UA_Server_removeSecurityGroup(server, securityGroupNodeId);
 
-    lockServer(server);
+    lockPubSubServer(server);
     sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
     ck_assert_ptr_eq(sg, NULL);
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(AddSecurityGroupWithKeyManagement){
@@ -277,7 +277,7 @@ START_TEST(AddSecurityGroupWithKeyManagement){
                                         &securityGroupNodeId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
     ck_assert_ptr_ne(sg, NULL);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, sg->securityGroupId);
@@ -292,7 +292,7 @@ START_TEST(AddSecurityGroupWithKeyManagement){
         iterator = TAILQ_NEXT(iterator, keyListEntry);
         expectKeyId++;
     }
-    unlockServer(server);
+    unlockPubSubServer(server);
 } END_TEST
 
 START_TEST(SecurityGroupPeriodicInsertNewKeys){
@@ -313,7 +313,7 @@ START_TEST(SecurityGroupPeriodicInsertNewKeys){
                                         &securityGroupNodeId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
-    lockServer(server);
+    lockPubSubServer(server);
     UA_SecurityGroup *sg = UA_SecurityGroup_findSGbyId(server, securityGroupNodeId);
     ck_assert_ptr_ne(sg, NULL);
     UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_findKeyStorage(server, sg->securityGroupId);
@@ -321,7 +321,7 @@ START_TEST(SecurityGroupPeriodicInsertNewKeys){
 
     UA_UInt32 expectKeyId = 1;
     UA_PubSubKeyListItem *preLastItem = TAILQ_LAST(&ks->keyList, keyListItems);
-    unlockServer(server);
+    unlockPubSubServer(server);
     for (size_t i = 0; i < ks->keyListSize; i++) {
         UA_fakeSleep(500);
         UA_Server_run_iterate(server, false);


### PR DESCRIPTION
As specific connection is not known yet, lock event loop mutexes of
all connections.
When adding and removing a connection from the server list, lock/unlock
the mutex to match the locking counter.

Resolves https://github.com/open62541/open62541/issues/7074