### PR TITLE
fix(ci): fix release workflow after bad merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           submodules: true
       - run: sudo apt-get install -y -qq libmbedtls-dev
-      - run: source tools/ci.sh && build_release_amalgamation
+      - run: source tools/ci/ci.sh && build_release_amalgamation
       - run: gh release upload ${{ github.ref_name }} build/open62541.{c,h}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tools/ci/ci.sh
+++ b/tools/ci/ci.sh
@@ -98,8 +98,8 @@ function build_release_amalgamation {
           -DUA_ENABLE_PUBSUB_ENCRYPTION=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           ..
-
-    make ${MAKEOPTS}
+    make open62541-amalgamation ${MAKEOPTS}
+    gcc -Wall -Werror -c open62541.c
 }
 
 ######################


### PR DESCRIPTION
These are the small required changes mentioned in https://github.com/open62541/open62541/pull/6956, which [broke the release workflow on master](https://github.com/open62541/open62541/actions/workflows/release.yml?query=branch%3Amaster) after https://github.com/open62541/open62541/pull/6946