### PR TITLE
feat(ci): run valgrind checks on ubuntu-24.04 (current latest) only

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -172,18 +172,22 @@ jobs:
             cmd_action: build_amalgamation_mt
 
           - name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
+            runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev mosquitto
             cmd_action: unit_tests_valgrind MBEDTLS
 
           - name: "Valgrind Build & Unit Tests with OpenSSL (gcc)"
+            runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq valgrind openssl mosquitto
             cmd_action: unit_tests_valgrind OPENSSL
 
           - name: "Valgrind Examples with MbedTLS and mDNSD (gcc)"
+            runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev mosquitto
             cmd_action: examples_valgrind MBEDTLS MDNSD
 
           - name: "Valgrind Examples with OpenSSL and avahi-mdns(gcc)"
+            runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev mosquitto libavahi-client-dev libavahi-common-dev
             cmd_action: examples_valgrind OPENSSL AVAHI
 


### PR DESCRIPTION
Targeting master as that's where all the resources are used. This should likely be backported to 1.4 as well, but that needs to be done manually, as there are a bunch of conflicts because https://github.com/open62541/open62541/pull/7033 happened on master only (my bad). Maybe I should backport that as well?