### PR TITLE
[WIP] feat(ci): remove ubuntu-20.04 ci

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         build:
           - name: "Debug Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq mosquitto
@@ -31,11 +31,6 @@ jobs:
 
           - name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
             cmd_action: unit_tests_alarms
-
-          - name: "Debug Build & Unit Tests (clang-11)"
-            runs_on: "ubuntu-20.04"
-            cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 mosquitto
-            cmd_action: CC=clang-11 CXX=clang++-11 unit_tests
 
           - name: "Debug Build & Unit Tests (clang-15)"
             runs_on: "ubuntu-22.04"
@@ -76,34 +71,6 @@ jobs:
               ./configure
               sudo make install
             cmd_action: unit_tests_encryption LIBRESSL
-
-          - name: "TPM Tool Build ubuntu-20.04"
-            runs_on: "ubuntu-20.04"
-            cmd_deps: |
-              sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev
-              cd ${HOME}
-              git clone https://github.com/tpm2-software/tpm2-tss.git
-              cd ${HOME}/tpm2-tss
-              git checkout 3.2.3
-              ./bootstrap && ./configure --with-udevrulesdir=/etc/udev/rules.d --with-udevrulesprefix=70-
-              make -j$(nproc)
-              sudo make install
-              sudo ldconfig
-              sudo udevadm control --reload-rules && sudo udevadm trigger
-              sudo apt-get install -y -qq tpm2-tools opensc
-              cd ${HOME}
-              git clone https://github.com/tpm2-software/tpm2-pkcs11.git
-              cd ${HOME}/tpm2-pkcs11
-              git checkout 1.7.0
-              ./bootstrap && ./configure
-              make -j$(nproc)
-              sudo make install
-              sudo ldconfig
-              sudo cp ${HOME}/tpm2-pkcs11/src/pkcs11.h /usr/include
-              cd ${HOME}/tpm2-pkcs11/tools/
-              sudo pip3 install pyasn1_modules
-              pip3 install .
-            cmd_action: build_tpm_tool
 
           - name: "TPM Tool Build ubuntu-22.04"
             runs_on: "ubuntu-22.04"
@@ -190,11 +157,6 @@ jobs:
             runs_on: "ubuntu-24.04"
             cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev mosquitto libavahi-client-dev libavahi-common-dev
             cmd_action: examples_valgrind OPENSSL AVAHI
-
-          - name: "Clang Static Analyzer (clang11)"
-            runs_on: "ubuntu-20.04"
-            cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 libmbedtls-dev mosquitto
-            cmd_action: CC=clang-11 CXX=clang++-11 build_clang_analyzer 11
 
           - name: "Clang Static Analyzer (clang15)"
             runs_on: "ubuntu-22.04"


### PR DESCRIPTION
GitHub is deprecating ubuntu-20.04 runners. See https://github.com/actions/runner-images/issues/11101.

1.4: https://github.com/open62541/open62541/pull/7134
1.3: https://github.com/open62541/open62541/pull/7133