### PR TITLE
Support defining UA_LOGLEVEL in an external CMakefile

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -39,7 +39,9 @@
  * ---------------
  * Changing the feature options has no effect on a pre-compiled library. */
 
+#ifndef UA_LOGLEVEL /* allows overriding UA_LOGLEVEL from an external Makefile */
 #define UA_LOGLEVEL ${UA_LOGLEVEL}
+#endif
 #cmakedefine UA_ENABLE_AMALGAMATION
 #cmakedefine UA_ENABLE_METHODCALLS
 #cmakedefine UA_ENABLE_NODEMANAGEMENT


### PR DESCRIPTION
Allows to compile the library as a amalgamated open62541 .c/.h pair, and then change the UA_LOGLEVEL in the CMakefile of the project that's using the amalgamated files.

This was already pulled with https://github.com/open62541/open62541/pull/6068, but then was reverted by https://github.com/open62541/open62541/commit/e907a0ed91427e449ed711bada7a5db3947cd644 .
I just tried creating the amalgamated files from the official 1.3.13 release, and this little edit is still needed before the open62541 .h/.c files can be compiled without errors.
This would, allow to use untouched files from the official open62541 repository.