### PR TITLE
Use a standard header for system limits to improve portability

### DIFF
--- a/arch/posix/eventloop_posix.h
+++ b/arch/posix/eventloop_posix.h
@@ -260,14 +260,11 @@ typedef int SOCKET;
 /*---------------------------*/
 
 #include <dirent.h>
-#include <errno.h>
-#include <fcntl.h>
 #include <libgen.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <sys/inotify.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #ifndef __ANDROID__
 #include <bits/stdio_lim.h>


### PR DESCRIPTION
Use <limits.h> and <sys/params.h> instead of <linux/limits.h> as this is not available on all Linux distributions.
Also remove redundant headers.