### PR TITLE
fix(server): Fix comment about timeout interval

### DIFF
--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -176,7 +176,7 @@ UA_AsyncManager_init(UA_AsyncManager *am, UA_Server *server) {
     UA_LOCK_INIT(&am->queueLock);
 
     /* Add a regular callback for cleanup and sending finished responses at a
-     * 100s interval. */
+     * 1s interval. */
     addRepeatedCallback(server, (UA_ServerCallback)checkTimeouts,
                         NULL, 1000.0, &am->checkTimeoutCallbackId);
 }


### PR DESCRIPTION
The interval for checking for timeout of asynchronous operations is 1 second, not 100 seconds.