### PR TITLE
Removing architecture dependency from the filestore backend plugin

### DIFF
--- a/plugins/crypto/ua_certificategroup_filestore.c
+++ b/plugins/crypto/ua_certificategroup_filestore.c
@@ -8,8 +8,6 @@
  */
 
 #include <open62541/util.h>
-#include "../../arch/posix/eventloop_posix.h"
-#include "ua_filestore_common.h"
 #include <open62541/plugin/certificategroup_default.h>
 
 #include "ua_filestore_common.h"

--- a/plugins/crypto/ua_filestore_common.c
+++ b/plugins/crypto/ua_filestore_common.c
@@ -5,12 +5,11 @@
  *    Copyright 2024 (c) Fraunhofer IOSB (Author: Noel Graf)
  */
 
-#include "../../arch/posix/eventloop_posix.h"
 #include "ua_filestore_common.h"
 
 #ifdef UA_ENABLE_ENCRYPTION
 
-#if defined(__linux__) || defined(UA_ARCHITECTURE_WIN32) || defined(__APPLE__)
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32) || defined(__APPLE__)
 
 #ifdef UA_ARCHITECTURE_WIN32
 /* TODO: Replace with a proper dirname implementation. This is a just minimal
@@ -70,6 +69,6 @@ writeByteStringToFile(const char *const path, const UA_ByteString *data) {
     return retval;
 }
 
-#endif /* defined(__linux__) || defined(UA_ARCHITECTURE_WIN32) */
+#endif /* defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32) || defined(__APPLE__) */
 
 #endif /* UA_ENABLE_ENCRYPTION */

--- a/plugins/crypto/ua_filestore_common.h
+++ b/plugins/crypto/ua_filestore_common.h
@@ -12,7 +12,7 @@
 
 #ifdef UA_ENABLE_ENCRYPTION
 
-#if defined(__linux__) || defined(UA_ARCHITECTURE_WIN32) || defined(__APPLE__)
+#if defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32) || defined(__APPLE__)
 
 #include "../../arch/posix/eventloop_posix.h"
 
@@ -24,7 +24,7 @@ UA_StatusCode
 writeByteStringToFile(const char *const path,
                       const UA_ByteString *data);
 
-#endif /* __linux__ || UA_ARCHITECTURE_WIN32 */
+#endif /* defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32) || defined(__APPLE__) */
 
 #endif /* UA_ENABLE_ENCRYPTION */
 


### PR DESCRIPTION
Removed inclusion of unguarded architecture-specific headers from the filestore backend plugin