### PR TITLE
dllexport default to inlinable cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,7 +459,10 @@ endif()
 ##########################
 
 # Building shared libs (dll, so). This option is written into ua_config.h.
-set(UA_DYNAMIC_LINKING OFF)
+# Default is to use inlinable export, so if you choose to export inlinable methods,
+# it will dllexport them. This means that if you build a static lib you will be able to
+# link and include all symbols, like using /WHOLEARCHIVE.
+set(UA_DYNAMIC_LINKING ${UA_ENABLE_INLINABLE_EXPORT})
 if(BUILD_SHARED_LIBS)
   set(UA_DYNAMIC_LINKING ON)
   if(UA_ENABLE_DISCOVERY_MULTICAST)


### PR DESCRIPTION
I presume when a user of this library chooses to export inlinable methods he would like to get those exports even though he is not building shared library.

At least this is beneficial for me when I static link open62541 to the executable than I can dynamically load the executable and use the library.