### PR TITLE
fix(server): lock server state while copying out statistics

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1920,7 +1920,7 @@ typedef struct {
    UA_SessionStatistics ss;
 } UA_ServerStatistics;
 
-UA_ServerStatistics UA_EXPORT
+UA_ServerStatistics UA_EXPORT UA_THREADSAFE
 UA_Server_getStatistics(UA_Server *server);
 
 /**

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -632,6 +632,7 @@ verifyServerApplicationURI(const UA_Server *server) {
 UA_ServerStatistics
 UA_Server_getStatistics(UA_Server *server) {
     UA_ServerStatistics stat;
+    lockServer(server);
     stat.scs = server->secureChannelStatistics;
     UA_ServerDiagnosticsSummaryDataType *sds = &server->serverDiagnosticsSummary;
     stat.ss.currentSessionCount = server->activeSessionCount;
@@ -640,6 +641,7 @@ UA_Server_getStatistics(UA_Server *server) {
     stat.ss.rejectedSessionCount = sds->rejectedSessionCount;
     stat.ss.sessionTimeoutCount = sds->sessionTimeoutCount;
     stat.ss.sessionAbortCount = sds->sessionAbortCount;
+    unlockServer(server);
     return stat;
 }
 

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -142,6 +142,8 @@ setBinaryProtocolManagerState(UA_Server *server,
 static void
 deleteServerSecureChannel(UA_BinaryProtocolManager *bpm,
                           UA_SecureChannel *channel) {
+    UA_LOCK_ASSERT(&bpm->server->serviceMutex, 1);
+
     /* Detach the channel from the server list */
     TAILQ_REMOVE(&bpm->channels, (channel_entry*)channel, pointers);
 
@@ -670,6 +672,8 @@ sendResponse(UA_Server *server, UA_Session *session, UA_SecureChannel *channel,
 UA_StatusCode
 getBoundSession(UA_Server *server, const UA_SecureChannel *channel,
                 const UA_NodeId *token, UA_Session **session) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+
     UA_DateTime now = UA_DateTime_nowMonotonic();
     UA_SessionHeader *sh;
     SLIST_FOREACH(sh, &channel->sessions, next) {
@@ -1072,6 +1076,8 @@ configServerSecureChannel(void *application, UA_SecureChannel *channel,
 static UA_StatusCode
 createServerSecureChannel(UA_BinaryProtocolManager *bpm, UA_ConnectionManager *cm,
                           uintptr_t connectionId, UA_SecureChannel **outChannel) {
+    UA_LOCK_ASSERT(&bpm->server->serviceMutex, 1);
+
     UA_Server *server = bpm->server;
     UA_ServerConfig *config = &server->config;
 

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -469,6 +469,8 @@ getServicePointers(UA_UInt32 requestTypeId, const UA_DataType **requestType,
 /* HEL -> Open up the connection */
 static UA_StatusCode
 processHEL(UA_Server *server, UA_SecureChannel *channel, const UA_ByteString *msg) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+
     UA_ConnectionManager *cm = channel->connectionManager;
     if(!cm || (channel->state != UA_SECURECHANNELSTATE_CONNECTED &&
                channel->state != UA_SECURECHANNELSTATE_RHE_SENT))
@@ -541,6 +543,8 @@ processHEL(UA_Server *server, UA_SecureChannel *channel, const UA_ByteString *ms
 static UA_StatusCode
 processOPN(UA_Server *server, UA_SecureChannel *channel,
            const UA_UInt32 requestId, const UA_ByteString *msg) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+
     if(channel->state != UA_SECURECHANNELSTATE_ACK_SENT &&
        channel->state != UA_SECURECHANNELSTATE_OPEN)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -714,12 +718,12 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
                   const UA_DataType *requestType, UA_Response *response,
                   const UA_DataType *responseType, UA_Boolean sessionRequired,
                   size_t counterOffset) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+
     UA_Session anonymousSession;
     UA_Session *session = NULL;
     UA_StatusCode channelRes = UA_STATUSCODE_GOOD;
     UA_ResponseHeader *rh = &response->responseHeader;
-
-    lockServer(server);
 
     /* If it is an unencrypted (#None) channel, only allow the discovery services */
     if(server->config.securityPolicyNoneDiscoveryOnly &&
@@ -753,7 +757,8 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
     /* Get the Session bound to the SecureChannel (not necessarily activated) */
     if(!UA_NodeId_isNull(&request->requestHeader.authenticationToken)) {
         rh->serviceResult = getBoundSession(server, channel,
-                      &request->requestHeader.authenticationToken, &session);
+                                            &request->requestHeader.authenticationToken,
+                                            &session);
         if(rh->serviceResult != UA_STATUSCODE_GOOD)
             goto send_response;
     }
@@ -811,7 +816,6 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
             Service_Publish(server, session, &request->publishRequest, requestId);
 
         /* Don't send a response */
-        unlockServer(server);
         goto update_statistics;
     }
 #endif
@@ -828,7 +832,6 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
          * statistic. */
         if(UA_LIKELY(finished))
             goto send_response;
-        unlockServer(server);
         goto update_statistics;
     }
 #endif
@@ -838,7 +841,6 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
 
     /* Upon success, send the response. Otherwise a ServiceFault. */
  send_response:
-    unlockServer(server);
     channelRes = sendResponse(server, session, channel,
                               requestId, response, responseType);
 
@@ -865,6 +867,8 @@ processMSGDecoded(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 reques
 static UA_StatusCode
 processMSG(UA_Server *server, UA_SecureChannel *channel,
            UA_UInt32 requestId, const UA_ByteString *msg) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+
     if(channel->state != UA_SECURECHANNELSTATE_OPEN)
         return UA_STATUSCODE_BADINTERNALERROR;
     /* Decode the nodeid */
@@ -959,6 +963,8 @@ static UA_StatusCode
 processSecureChannelMessage(UA_Server *server, UA_SecureChannel *channel,
                             UA_MessageType messagetype, UA_UInt32 requestId,
                             UA_ByteString *message) {
+    UA_LOCK_ASSERT(&server->serviceMutex, 1);
+
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     switch(messagetype) {
     case UA_MESSAGETYPE_HEL:
@@ -1173,13 +1179,14 @@ addDiscoveryUrl(UA_Server *server, const UA_String hostname, UA_UInt16 port) {
 }
 
 /* Callback of a TCP socket (server socket or an active connection) */
-void
-serverNetworkCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
-                      void *application, void **connectionContext,
-                      UA_ConnectionState state,
-                      const UA_KeyValueMap *params,
-                      UA_ByteString msg) {
+static void
+serverNetworkCallbackLocked(UA_ConnectionManager *cm, uintptr_t connectionId,
+                            void *application, void **connectionContext,
+                            UA_ConnectionState state,
+                            const UA_KeyValueMap *params,
+                            UA_ByteString msg) {
     UA_BinaryProtocolManager *bpm = (UA_BinaryProtocolManager*)application;
+    UA_LOCK_ASSERT(&bpm->server->serviceMutex, 1);
 
     /* A server socket that is not yet registered in the server. Register it and
      * set the connection context to the pointer in the
@@ -1313,6 +1320,19 @@ serverNetworkCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
         UA_SecureChannel_sendError(channel, &error);
         UA_SecureChannel_shutdown(channel, UA_SHUTDOWNREASON_ABORT);
     }
+}
+
+void
+serverNetworkCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
+                      void *application, void **connectionContext,
+                      UA_ConnectionState state,
+                      const UA_KeyValueMap *params,
+                      UA_ByteString msg) {
+    UA_BinaryProtocolManager *bpm = (UA_BinaryProtocolManager*)application;
+    lockServer(bpm->server);
+    serverNetworkCallbackLocked(cm, connectionId, application, connectionContext,
+                                state, params, msg);
+    unlockServer(bpm->server);
 }
 
 static UA_StatusCode
@@ -1675,13 +1695,15 @@ UA_Server_removeReverseConnect(UA_Server *server, UA_UInt64 handle) {
     return result;
 }
 
-void
-serverReverseConnectCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
-                             void *application, void **connectionContext,
-                             UA_ConnectionState state, const UA_KeyValueMap *params,
-                             UA_ByteString msg) {
+static void
+serverReverseConnectCallbackLocked(UA_ConnectionManager *cm, uintptr_t connectionId,
+                                   void *application, void **connectionContext,
+                                   UA_ConnectionState state, const UA_KeyValueMap *params,
+                                   UA_ByteString msg) {
     (void)params;
     UA_BinaryProtocolManager *bpm = (UA_BinaryProtocolManager*)application;
+    UA_LOCK_ASSERT(&bpm->server->serviceMutex, 1);
+
     UA_LOG_DEBUG(bpm->logging, UA_LOGCATEGORY_SERVER,
                  "Activity for reverse connect %lu with state %d",
                  (long unsigned)connectionId, state);
@@ -1800,6 +1822,18 @@ serverReverseConnectCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
 
     /* Update the state with the current SecureChannel state */
     setReverseConnectState(bpm->server, context, context->channel->state);
+}
+
+void
+serverReverseConnectCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
+                             void *application, void **connectionContext,
+                             UA_ConnectionState state, const UA_KeyValueMap *params,
+                             UA_ByteString msg) {
+    UA_BinaryProtocolManager *bpm = (UA_BinaryProtocolManager*)application;
+    lockServer(bpm->server);
+    serverReverseConnectCallbackLocked(cm, connectionId, application, connectionContext,
+                                       state, params, msg);
+    unlockServer(bpm->server);
 }
 
 /***************************/


### PR DESCRIPTION
This is necessary to prevent concurrent processes updating the data while we copy it out into `UA_ServerStatistics`.

Fixes #7189