### PR TITLE
[Review] fix(plugin): Login callback should be called also with anonymous user

### DIFF
--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -83,6 +83,15 @@ activateSession_default(UA_Server *server, UA_AccessControl *ac,
                     anonymous_policy.length) != 0)) {
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
         }
+
+        /* Call the login callback with anonymous user to handle
+         * the case when user is changed during an active session */
+        if(context->loginCallback) {
+            if(context->loginCallback(NULL, NULL, 0, 0, sessionContext,
+                                      context->loginContext) != UA_STATUSCODE_GOOD) {
+                return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+            }
+        }
     } else if(tokenType == &UA_TYPES[UA_TYPES_USERNAMEIDENTITYTOKEN]) {
         /* Username and password */
         const UA_UserNameIdentityToken *userToken = (UA_UserNameIdentityToken*)


### PR DESCRIPTION
If a user has logged in, and then changes (does not logout) to anonymous user, then no callback is given to handle this case, possibly having invalid user access permissions on application level.