### PR TITLE
fix(plugin): access control default with login callback

### DIFF
--- a/plugins/include/open62541/plugin/accesscontrol_default.h
+++ b/plugins/include/open62541/plugin/accesscontrol_default.h
@@ -42,8 +42,6 @@ UA_EXPORT UA_StatusCode
 UA_AccessControl_defaultWithLoginCallback(UA_ServerConfig *config,
                                           UA_Boolean allowAnonymous,
                                           const UA_String *userTokenPolicyUri,
-                                          size_t usernamePasswordLoginSize,
-                                          const UA_UsernamePasswordLogin *usernamePasswordLogin,
                                           UA_UsernamePasswordLoginCallback loginCallback,
                                           void *loginContext);
 

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -290,14 +290,12 @@ static void clear_default(UA_AccessControl *ac) {
     }
 }
 
-UA_StatusCode
-UA_AccessControl_default(UA_ServerConfig *config,
-                         UA_Boolean allowAnonymous,
-                         const UA_String *userTokenPolicyUri,
-                         size_t usernamePasswordLoginSize,
-                         const UA_UsernamePasswordLogin *usernamePasswordLogin) {
-    UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_SERVER,
-                   "AccessControl: Unconfigured AccessControl. Users have all permissions.");
+static UA_StatusCode
+accessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
+                      const UA_String *userTokenPolicyUri,
+                      size_t usernamePasswordLoginSize,
+                      const UA_UsernamePasswordLogin *usernamePasswordLogin,
+                      UA_UsernamePasswordLoginCallback loginCallback) {
     UA_AccessControl *ac = &config->accessControl;
 
     if(ac->clear)
@@ -370,7 +368,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
     size_t policies = 0;
     if(allowAnonymous)
         policies++;
-    if(usernamePasswordLoginSize > 0)
+    if(usernamePasswordLoginSize > 0 || loginCallback != NULL)
         policies++;
     if(config->sessionPKI.verifyCertificate)
         policies++;
@@ -419,11 +417,11 @@ UA_AccessControl_default(UA_ServerConfig *config,
             policies++;
         }
 
-        if(usernamePasswordLoginSize > 0) {
+        if(usernamePasswordLoginSize > 0 || loginCallback != NULL) {
             ac->userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_USERNAME;
             ac->userTokenPolicies[policies].policyId = UA_STRING_ALLOC(USERNAME_POLICY);
 #if UA_LOGLEVEL <= 400
-            if(UA_String_equal(utpUri, &UA_SECURITY_POLICY_NONE_URI)) {
+            if(!config->securityPolicyNoneDiscoveryOnly && UA_String_equal(utpUri, &UA_SECURITY_POLICY_NONE_URI)) {
                 UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_SERVER,
                                "Username/Password Authentication configured, "
                                "but no encrypting SecurityPolicy. "
@@ -439,17 +437,23 @@ UA_AccessControl_default(UA_ServerConfig *config,
 }
 
 UA_StatusCode
+UA_AccessControl_default(UA_ServerConfig *config, UA_Boolean allowAnonymous,
+                         const UA_String *userTokenPolicyUri,
+                         size_t usernamePasswordLoginSize,
+                         const UA_UsernamePasswordLogin *usernamePasswordLogin) {
+    return accessControl_default(config, allowAnonymous, userTokenPolicyUri,
+                                 usernamePasswordLoginSize, usernamePasswordLogin, NULL);
+}
+
+UA_StatusCode
 UA_AccessControl_defaultWithLoginCallback(UA_ServerConfig *config,
                                           UA_Boolean allowAnonymous,
                                           const UA_String *userTokenPolicyUri,
-                                          size_t usernamePasswordLoginSize,
-                                          const UA_UsernamePasswordLogin *usernamePasswordLogin,
                                           UA_UsernamePasswordLoginCallback loginCallback,
                                           void *loginContext) {
     AccessControlContext *context;
-    UA_StatusCode sc =
-        UA_AccessControl_default(config, allowAnonymous, userTokenPolicyUri,
-                                 usernamePasswordLoginSize, usernamePasswordLogin);
+    UA_StatusCode sc = accessControl_default(config, allowAnonymous, userTokenPolicyUri,
+                                             0, NULL, loginCallback);
     if(sc != UA_STATUSCODE_GOOD)
         return sc;
 
@@ -459,4 +463,3 @@ UA_AccessControl_defaultWithLoginCallback(UA_ServerConfig *config,
 
     return UA_STATUSCODE_GOOD;
 }
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -211,6 +211,7 @@ endif()
 # Test Server
 
 ua_add_test(server/check_accesscontrol.c)
+ua_add_test(server/check_accesscontrol_callback.c)
 ua_add_test(server/check_services_view.c)
 ua_add_test(server/check_services_attributes.c)
 ua_add_test(server/check_services_nodemanagement.c)

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -65,7 +65,7 @@ static void setup(void) {
     server = UA_Server_newForUnitTest();
     ck_assert(server != NULL);
 
-    /* Instatiate a new AccessControl plugin that knows username/pw */
+    /* Instantiate a new AccessControl plugin that knows username/pw */
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_SecurityPolicy *sp = &config->securityPolicies[config->securityPoliciesSize-1];
     UA_AccessControl_default(config, true, &sp->policyUri,


### PR DESCRIPTION
- Access control default with login callback and no hard coded users did not increase policy size correctly and so does not work 
- Removed fixed UA_UsernamePasswordLogin from UA_AccessControl_defaultWithLoginCallback argument
  - If a callback is used, there should be no need to hard code any users
- Disable warning print about leaking credentials in case security policy none is only used for discovery
- Removed unnecessary warning print from default access control