### PR TITLE
feat(server): make updating private keys with GDS Push optional

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -193,6 +193,12 @@ struct UA_ServerConfig {
      * Make sure you really need this before enabling plain text passwords. */
     UA_Boolean allowNonePolicyPassword;
 
+    /* Allow clients to update the Private Key of the server.
+     * Updating of private keys should only be allowed for servers that do not have
+     * access to the entropy necessary for creating private keys.
+     */
+    UA_Boolean allowPrivateKeyUpdate;
+
     /* Different sets of certificates are trusted for SecureChannel / Session */
     UA_CertificateGroup secureChannelPKI;
     UA_CertificateGroup sessionPKI;


### PR DESCRIPTION
- Servers should allow transfer of private keys only if the server does not have access to the entropy necessary for creating private keys

OPC 10000-12:

> The SupportedPrivateKeyFormats specifies the PrivateKey formats supported by the Server. Possible values include “PEM” (see RFC 5958) or “PFX”. The array is empty if the Server does not allow external Clients to update the PrivateKey.

- Fix max trust list size to use the configured maximum size