### PR TITLE
[Review] fix(server): fix duplicate entries in discoveryUrls list

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -449,9 +449,18 @@ setCurrentEndPointsArray(UA_Server *server, const UA_String endpointUrl,
                 /* Mirror back the requested EndpointUrl and also add it to the
                  * array of discovery urls */
                 retval |= UA_String_copy(&endpointUrl, &ed->endpointUrl);
-                retval |= UA_Array_appendCopy((void**)&ed->server.discoveryUrls,
-                                              &ed->server.discoveryUrlsSize,
-                                              &endpointUrl, &UA_TYPES[UA_TYPES_STRING]);
+
+                /* Check if the ServerUrl is already present in the DiscoveryUrl array */
+                size_t k = 0;
+                for(; k < ed->server.discoveryUrlsSize; k++) {
+                    if(UA_String_equal(&ed->endpointUrl, &ed->server.discoveryUrls[k]))
+                        break;
+                }
+                if(k == ed->server.discoveryUrlsSize) {
+                    retval |= UA_Array_appendCopy(
+                        (void **)&ed->server.discoveryUrls, &ed->server.discoveryUrlsSize,
+                        &endpointUrl, &UA_TYPES[UA_TYPES_STRING]);
+                }
             }
             if(retval != UA_STATUSCODE_GOOD)
                 goto error;


### PR DESCRIPTION
Fix issue where the same URL is in the discovery URLs list multiple times:
![image](https://github.com/user-attachments/assets/8d31b19c-8ccf-4514-920e-f8c1592ed9de)