### PR TITLE
[Review] fix(core): use of null pointer in certificate verification

### DIFF
--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -610,7 +610,7 @@ unpackPayloadOPN(UA_SecureChannel *channel, UA_Chunk *chunk) {
     UA_CHECK_STATUS(res, return res);
 
     if(asymHeader.senderCertificate.length > 0) {
-        if(channel->certificateVerification)
+        if(channel->certificateVerification && channel->certificateVerification->verifyCertificate)
             res = channel->certificateVerification->
                 verifyCertificate(channel->certificateVerification,
                                   &asymHeader.senderCertificate);


### PR DESCRIPTION
In case UA_ENABLE_ENCRYPTION is not set and a client tries to connect with a certificate, channel->certificateVerification is set, but certificateVerification->verityCertificate callback is (most likely) not set, causing null pointer dereference.