### PR TITLE
[Review] fix(build): adds C++ support for C11 atomics

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -234,7 +234,13 @@
 #  endif
 # elif defined(__has_include) && __has_include(<stdatomic.h>)
 #  define UA_HAVE_C11_ATOMICS
-#  include <stdatomic.h>
+#  ifdef __cplusplus
+#    include <atomic>
+#    define _Atomic(T) std::atomic<T>
+#    define atomic_uintptr_t std::atomic_uintptr_t
+#  else
+#    include <stdatomic.h>
+#  endif
 # elif !defined(HAVE_GCC_SYNC_BUILTINS)
 #  error Atomic operations not implemented
 # endif


### PR DESCRIPTION
Adds support for C++ compilation when using C11 atomics. It achieves this by including the `atomic` header in C++ and defining aliases for the C-style atomic types and functions to their C++ counterparts.

Closes #7076.