### PR TITLE
feat(ci): run release workflow for pull_requests as well

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Build Release Artifacts
 
 on:
   push:
+  pull_request:
   release:
     types: [published]
 


### PR DESCRIPTION
The "Build Release Artifacts" workflow is broken on master since https://github.com/open62541/open62541/pull/7154. I haven't spent any time trying to fix it due to time constraints, but this change should make it obvious when PRs would break release builds in the future.