### PR TITLE
Fix ASAN crash in removeFieldFromEncoding by validating memory bounds

### DIFF
--- a/src/ua_types_encoding_json_105.c
+++ b/src/ua_types_encoding_json_105.c
@@ -2003,7 +2003,9 @@ removeFieldFromEncoding(ParseCtx *ctx, UA_ByteString *encoding, size_t tokenInde
     /* Subtract the offset between ctx->json5 end encoding */
     start -= objStart;
     end -= objStart;
-
+    /* Fix: Bounds and sanity check */
+    if(end < start || end > encoding->length || start > encoding->length)
+        return;
     /* Cut out the field we want to remove */
     size_t remaining = encoding->length - end;
     memmove(encoding->data + start, encoding->data + end, remaining);


### PR DESCRIPTION
issue link: https://issues.oss-fuzz.com/issues/387317444
In this PR a high-severity vulnerability in `removeFieldFromEncoding `where an invalid memory range (negative size) could be passed to `memmove`(), triggering an ASAN crash (Negative-size-param). The fix adds bounds checks to ensure that start and end are within the valid range of the UA_ByteString and that end >= start. This prevents undefined behavior when removing fields during JSON decoding in ExtensionObjects.