### PR TITLE
Run linux CI in an ubuntu container

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -53,7 +53,7 @@ jobs:
                 cd ${HOME}
                 git clone https://github.com/tpm2-software/tpm2-tss.git
                 cd ${HOME}/tpm2-tss
-                git checkout 3.2.3
+                git checkout 2.4.6
                 ./bootstrap && ./configure --with-udevrulesdir=/etc/udev/rules.d --with-udevrulesprefix=70-
                 make -j$(nproc)
                 sudo make install
@@ -63,7 +63,7 @@ jobs:
                 cd ${HOME}
                 git clone https://github.com/tpm2-software/tpm2-pkcs11.git
                 cd ${HOME}/tpm2-pkcs11
-                git checkout 1.7.0
+                git checkout 1.6.0
                 ./bootstrap && ./configure
                 make -j$(nproc)
                 sudo make install

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -24,8 +24,8 @@ jobs:
             cmd_deps: ""
             cmd_action: unit_tests_alarms
           - build_name: "Debug Build & Unit Tests (clang)"
-            cmd_deps: sudo apt-get install -y -qq clang-14 clang-tools-14 mosquitto
-            cmd_action: CC=clang-14 CXX=clang++-14 unit_tests
+            cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 mosquitto
+            cmd_action: CC=clang-11 CXX=clang++-11 unit_tests
           - build_name: "Debug Build & Unit Tests (tcc)"
             cmd_deps: sudo apt-get install -y -qq tcc mosquitto
             cmd_action: CC=tcc unit_tests

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -105,6 +105,16 @@ jobs:
       mosquitto:
         image: eclipse-mosquitto:1.6-openssl
     steps:
+    - name: Work around disabled ipv6 on actions container networks
+      run: |
+        IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+        echo "Current IPv6 status on eth0: $IPV6"
+        [ "$IPV6" = "1" ] || exit
+
+        echo 0 | sudo tee /proc/sys/net/ipv6/conf/eth0/disable_ipv6 > /dev/null
+        IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+        echo "New IPv6 status on eth0: $IPV6"
+        [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }
     - uses: actions/checkout@v4
       with:
         submodules: true

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -104,6 +104,8 @@ jobs:
     services:
       mosquitto:
         image: eclipse-mosquitto:1.6-openssl
+    env:
+      OPEN62541_TEST_MQTT_BROKER: opc.mqtt://mosquitto:1883
     steps:
     - name: Work around disabled ipv6 on actions container networks
       run: |

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -98,7 +98,7 @@ jobs:
             cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 libmbedtls-dev
             cmd_action: build_clang_analyzer
     name: ${{matrix.build_name}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         include: 
           - build_name: "Debug Build & Unit Tests (gcc)"
-            cmd_deps: sudo apt-get install -y -qq mosquitto
             cmd_action: unit_tests
           - build_name: "Debug Build & Unit Tests without Subscriptions (gcc)"
             cmd_deps: ""
@@ -24,10 +23,10 @@ jobs:
             cmd_deps: ""
             cmd_action: unit_tests_alarms
           - build_name: "Debug Build & Unit Tests (clang)"
-            cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 mosquitto
+            cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11
             cmd_action: CC=clang-11 CXX=clang++-11 unit_tests
           - build_name: "Debug Build & Unit Tests (tcc)"
-            cmd_deps: sudo apt-get install -y -qq tcc mosquitto
+            cmd_deps: sudo apt-get install -y -qq tcc
             cmd_action: CC=tcc unit_tests
           - build_name: "Encryption (MbedTLS) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
@@ -98,17 +97,24 @@ jobs:
             cmd_deps: sudo apt-get install -y -qq clang-11 clang-tools-11 libmbedtls-dev
             cmd_action: build_clang_analyzer
     name: ${{matrix.build_name}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/marwinglaser/ci:ubuntu-20.04
+      options: --privileged
+    services:
+      mosquitto:
+        image: eclipse-mosquitto:1.6-openssl
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y -qq python3-sphinx graphviz check
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq cmake libcap2-bin pkg-config libssl-dev python3-sphinx graphviz check
         ${{ matrix.cmd_deps }}
     - name: ${{matrix.build_name}}
+      shell: bash
       run: source tools/ci.sh && ${{matrix.cmd_action}}
       env:
         ETHERNET_INTERFACE: eth0

--- a/.github/workflows/build_ubuntu2204.yml
+++ b/.github/workflows/build_ubuntu2204.yml
@@ -1,0 +1,29 @@
+name: Linux Build & Test with OpenSSL3.0
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include: 
+          - build_name: "Encryption (OpenSSL3.0) Build & Unit Tests (gcc)"
+            cmd_deps: sudo apt-get install -y -qq openssl
+            cmd_action: unit_tests_encryption OPENSSL
+    name: ${{matrix.build_name}}
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y -qq python3-sphinx graphviz check
+        ${{ matrix.cmd_deps }}
+    - name: ${{matrix.build_name}}
+      run: source tools/ci.sh && ${{matrix.cmd_action}}
+      env:
+        ETHERNET_INTERFACE: eth0
+

--- a/.github/workflows/build_ubuntu2204.yml
+++ b/.github/workflows/build_ubuntu2204.yml
@@ -17,6 +17,16 @@ jobs:
       image: ghcr.io/marwinglaser/ci:ubuntu-22.04
       options: --privileged
     steps:
+    - name: Work around disabled ipv6 on actions container networks
+      run: |
+        IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+        echo "Current IPv6 status on eth0: $IPV6"
+        [ "$IPV6" = "1" ] || exit
+
+        echo 0 | sudo tee /proc/sys/net/ipv6/conf/eth0/disable_ipv6 > /dev/null
+        IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+        echo "New IPv6 status on eth0: $IPV6"
+        [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }
     - uses: actions/checkout@v4
       with:
         submodules: true

--- a/.github/workflows/build_ubuntu2204.yml
+++ b/.github/workflows/build_ubuntu2204.yml
@@ -12,17 +12,21 @@ jobs:
             cmd_deps: sudo apt-get install -y -qq openssl
             cmd_action: unit_tests_encryption OPENSSL
     name: ${{matrix.build_name}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/marwinglaser/ci:ubuntu-22.04
+      options: --privileged
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y -qq python3-sphinx graphviz check
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq cmake pkg-config libssl-dev python3-sphinx graphviz check
         ${{ matrix.cmd_deps }}
     - name: ${{matrix.build_name}}
+      shell: bash
       run: source tools/ci.sh && ${{matrix.cmd_action}}
       env:
         ETHERNET_INTERFACE: eth0

--- a/tests/pubsub/check_pubsub_connection_mqtt.c
+++ b/tests/pubsub/check_pubsub_connection_mqtt.c
@@ -17,7 +17,7 @@
 #include <check.h>
 
 //#define TEST_MQTT_SERVER "opc.mqtt://test.mosquitto.org:1883"
-#define TEST_MQTT_SERVER "opc.mqtt://localhost:1883"
+#define TEST_MQTT_SERVER "opc.mqtt://mosquitto:1883"
 
 UA_Server *server = NULL;
 UA_ServerConfig *config = NULL;
@@ -86,7 +86,7 @@ START_TEST(AddConnectionWithInvalidAddress){
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("MQTT Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl =
-        {UA_STRING_NULL, UA_STRING("opc.mqtt://127.0..1:1883/")};
+        {UA_STRING_NULL, UA_STRING(TEST_MQTT_SERVER "/")};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =

--- a/tests/pubsub/check_pubsub_connection_mqtt.c
+++ b/tests/pubsub/check_pubsub_connection_mqtt.c
@@ -15,12 +15,16 @@
 #include "ua_server_internal.h"
 
 #include <check.h>
-
-//#define TEST_MQTT_SERVER "opc.mqtt://test.mosquitto.org:1883"
-#define TEST_MQTT_SERVER "opc.mqtt://mosquitto:1883"
+#include <stdlib.h>
 
 UA_Server *server = NULL;
 UA_ServerConfig *config = NULL;
+
+static char* get_mqtt_broker_address(void) {
+    char* broker = getenv("OPEN62541_TEST_MQTT_BROKER");
+    if (!broker) broker = "opc.mqtt://localhost:1883";
+    return broker;
+}
 
 static void setup(void) {
     server = UA_Server_new();
@@ -39,7 +43,7 @@ START_TEST(AddConnectionsWithMinimalValidConfiguration){
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("Mqtt Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl =
-        {UA_STRING_NULL, UA_STRING(TEST_MQTT_SERVER)};
+        {UA_STRING_NULL, UA_STRING(get_mqtt_broker_address())};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
@@ -60,7 +64,7 @@ START_TEST(AddRemoveAddConnectionWithMinimalValidConfiguration){
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("Mqtt Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl =
-        {UA_STRING_NULL, UA_STRING(TEST_MQTT_SERVER)};
+        {UA_STRING_NULL, UA_STRING(get_mqtt_broker_address())};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
@@ -86,7 +90,7 @@ START_TEST(AddConnectionWithInvalidAddress){
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("MQTT Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl =
-        {UA_STRING_NULL, UA_STRING(TEST_MQTT_SERVER "/")};
+        {UA_STRING_NULL, UA_STRING(get_mqtt_broker_address())};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
@@ -104,7 +108,7 @@ START_TEST(AddConnectionWithUnknownTransportURL){
     memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
     connectionConfig.name = UA_STRING("MQTT Connection");
     UA_NetworkAddressUrlDataType networkAddressUrl =
-        {UA_STRING_NULL, UA_STRING(TEST_MQTT_SERVER)};
+        {UA_STRING_NULL, UA_STRING(get_mqtt_broker_address())};
     UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
                          &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     connectionConfig.transportProfileUri =
@@ -124,7 +128,7 @@ START_TEST(AddConnectionWithNullConfig){
 
 START_TEST(AddSingleConnectionWithMaximalConfiguration){
     UA_NetworkAddressUrlDataType networkAddressUrlData =
-        {UA_STRING("127.0.0.1"), UA_STRING(TEST_MQTT_SERVER)};
+        {UA_STRING("127.0.0.1"), UA_STRING(get_mqtt_broker_address())};
     UA_Variant address;
     UA_Variant_setScalar(&address, &networkAddressUrlData, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     UA_KeyValuePair connectionOptions[3];
@@ -156,7 +160,7 @@ START_TEST(AddSingleConnectionWithMaximalConfiguration){
 
 START_TEST(GetMaximalConnectionConfigurationAndCompareValues){
     UA_NetworkAddressUrlDataType networkAddressUrlData =
-        {UA_STRING("127.0.0.1"), UA_STRING(TEST_MQTT_SERVER)};
+        {UA_STRING("127.0.0.1"), UA_STRING(get_mqtt_broker_address())};
     UA_Variant address;
     UA_Variant_setScalar(&address, &networkAddressUrlData, &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
     UA_KeyValuePair connectionOptions[3];

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -130,12 +130,6 @@ function set_capabilities {
 } 
 
 function unit_tests {
-    if [ "${CC:-x}" = "tcc" ]; then
-        PUBSUB_ETHERNET=OFF
-    else
-        PUBSUB_ETHERNET=ON
-    fi
-
     mkdir -p build; cd build; rm -rf *
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DUA_BUILD_EXAMPLES=ON \
@@ -146,7 +140,7 @@ function unit_tests {
           -DUA_ENABLE_HISTORIZING=ON \
           -DUA_ENABLE_JSON_ENCODING=ON \
           -DUA_ENABLE_PUBSUB=ON \
-          -DUA_ENABLE_PUBSUB_ETH_UADP=${PUBSUB_ETHERNET} \
+          -DUA_ENABLE_PUBSUB_ETH_UADP=ON \
           -DUA_ENABLE_PUBSUB_DELTAFRAMES=ON \
           -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
           -DUA_ENABLE_PUBSUB_MONITORING=ON \

--- a/tools/valgrind_check_error.py
+++ b/tools/valgrind_check_error.py
@@ -60,7 +60,7 @@ log_content = replace_re.sub('', log_content)
 
 # Try to parse the output. Look for the following line:
 # ==17054== FILE DESCRIPTORS: 5 open at exit.
-descriptors_re = re.compile(r".*==(\d+)==\s+FILE DESCRIPTORS: (\d+) open(\s\(\d std\))? at exit\..*")
+descriptors_re = re.compile(r".*==(\d+)==\s+FILE DESCRIPTORS: (\d+) open at exit\..*")
 m = descriptors_re.match(log_content)
 
 if not m:

--- a/tools/valgrind_suppressions.supp
+++ b/tools/valgrind_suppressions.supp
@@ -10,24 +10,6 @@
 }
 
 
-{
-   <ubuntu2204_pthread_create>
-   Memcheck:Leak
-   match-leak-kinds: possible
-   fun:calloc
-   fun:calloc
-   fun:allocate_dtv
-   fun:_dl_allocate_tls
-   fun:allocate_stack
-   fun:pthread_create@@GLIBC_2.34
-   ...
-   fun:setup*
-   fun:srunner_run_setup
-   ...
-   fun:srunner_run_tagged
-   fun:main
-}
-
 
 # Custom suppressions added by @Pro
 


### PR DESCRIPTION
This reverts the changes from #7133 and instead uses an ubuntu 20.04 container. This allows us to keep using this older Ubuntu version as long as we need to. A similar PR for the rewritten CI on the master branch that works with the version matrix is also in the works, where it can also be expanded to build on even older ubuntu versions or even different distributions.

This depends on a minimally modified custom docker image, which is currently built in a new repository (https://github.com/marwinglaser/images) and stored in GitHub's container registry. Before this PR is merged these images should be migrated to the open62541 organization. Interestingly enough we already have a similar repository that currently seems unused (https://github.com/open62541/open62541-ci), which would be a nice location.