### PR TITLE
Fix potential infinite loop in client connect

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1777,14 +1777,14 @@ void
 connectSync(UA_Client *client) {
     UA_LOCK_ASSERT(&client->clientMutex, 1);
 
-    UA_DateTime now = UA_DateTime_nowMonotonic();
-    UA_DateTime maxDate = now + ((UA_DateTime)client->config.timeout * UA_DATETIME_MSEC);
-
     /* Initialize the connection */
     initConnect(client);
     notifyClientState(client);
     if(client->connectStatus != UA_STATUSCODE_GOOD)
         return;
+
+    UA_DateTime now = UA_DateTime_nowMonotonic();
+    UA_DateTime maxDate = now + ((UA_DateTime)client->config.timeout * UA_DATETIME_MSEC);
 
     /* EventLoop is started. Otherwise initConnect would have failed. */
     UA_EventLoop *el = client->config.eventLoop;


### PR DESCRIPTION
Currently in connectSync we first get the current timestamp and calculate the maxDate based on the configured timeout. Then we call the initConnect function. Within this function we start the event loop, if this has not already been done, which in the end leads to a call to the start function of the event loop. This can cause the following problem: 
The start function sets the CLOCK_MONOTONIC_RAW which affects the UA_DateTime_nowMonotonic. As the now and maxDate timestamps are collected beforehand, the timebase is not the same. 

The error occurs for example when using POSIX and trying to connect to an offline server. The maxDate timestamp is due to the wrong timersource and is significantly smaller than the now, which means that the condition if(maxDate < now) will never be true and the process will hang.