### PR TITLE
fix(test): client async connect is not instant

### DIFF
--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -180,7 +180,7 @@ START_TEST(Client_renewSecureChannel) {
     UA_fakeSleep((UA_UInt32)((UA_Double)cc->secureChannelLifeTime * 0.8));
 
     /* Make the client renew the channel */
-    retval = UA_Client_run_iterate(client, 0);
+    retval = UA_Client_run_iterate(client, 1);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     /* Now read */
@@ -224,7 +224,7 @@ START_TEST(Client_renewSecureChannelWithActiveSubscription) {
     for(int i = 0; i < 15; ++i) {
         UA_fakeSleep(1000);
         UA_Server_run_iterate(server, true);
-        retval = UA_Client_run_iterate(client, 0);
+        retval = UA_Client_run_iterate(client, 1);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     }
 

--- a/tests/client/check_client_async_connect.c
+++ b/tests/client/check_client_async_connect.c
@@ -90,8 +90,8 @@ START_TEST(Client_connect_async) {
     UA_BrowseRequest_clear(&bReq);
     ck_assert_uint_eq(connected, true);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    /* With default setting the client uses 7 iterations to connect */
-    ck_assert_uint_eq(asyncCounter, 10-7);
+    /* With default setting the client uses 7 or 8 iterations to connect */
+    ck_assert(asyncCounter == 10-7 || asyncCounter == 10-8);
     UA_Client_disconnectAsync(client);
     while(connected) {
         UA_Server_run_iterate(server, false);
@@ -149,7 +149,7 @@ START_TEST(Client_no_connection) {
     //simulating unconnected server
     UA_Client_recvTesting_result = UA_STATUSCODE_BADCONNECTIONCLOSED;
     UA_Server_run_iterate(server, false);
-    retval = UA_Client_run_iterate(client, 0);  /* Open connection */
+    retval = UA_Client_run_iterate(client, 1);  /* Open connection */
     UA_Server_run_iterate(server, false);
     retval |= UA_Client_run_iterate(client, 0); /* Send HEL */
     UA_Server_run_iterate(server, false);

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -209,7 +209,7 @@ START_TEST(Client_subscription_async) {
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_Server_run_iterate(server, true);
-    UA_Client_run_iterate(client, 0);
+    UA_Client_run_iterate(client, 1);
 
     ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
     UA_UInt32 subId = response.subscriptionId;


### PR DESCRIPTION
Some tests assume that async TCP connect(2) system call succeeds immediately when run over loopback device.  This behavior depends on the implementation of the kernel, in OpenBSD this is often not the case.
Allow the test client to iterate until the connection is established. Adapt the assertion how many iterations are needed.

Some of these fixes are already in 1.4, but I missed the 1.3 branch.