### PR TITLE
fix(client): use after free in client asyncServiceCalls

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -515,8 +515,17 @@ UA_Client_AsyncService_cancel(UA_Client *client, AsyncServiceCall *ac,
 }
 
 void UA_Client_AsyncService_removeAll(UA_Client *client, UA_StatusCode statusCode) {
+    /* Make this function reentrant. One of the async callbacks could indirectly
+     * operate on the list. Moving all elements to a local list before iterating
+     * that. */
+    UA_AsyncServiceList asyncServiceCalls = client->asyncServiceCalls;
+    LIST_INIT(&client->asyncServiceCalls);
+    if(asyncServiceCalls.lh_first)
+        asyncServiceCalls.lh_first->pointers.le_prev = &asyncServiceCalls.lh_first;
+
+    /* Cancel and remove the elements from the local list */
     AsyncServiceCall *ac, *ac_tmp;
-    LIST_FOREACH_SAFE(ac, &client->asyncServiceCalls, pointers, ac_tmp) {
+    LIST_FOREACH_SAFE(ac, &asyncServiceCalls, pointers, ac_tmp) {
         LIST_REMOVE(ac, pointers);
         UA_Client_AsyncService_cancel(client, ac, statusCode);
         UA_free(ac);
@@ -627,16 +636,27 @@ UA_Client_removeCallback(UA_Client *client, UA_UInt64 callbackId) {
 
 static void
 asyncServiceTimeoutCheck(UA_Client *client) {
+    /* Make this function reentrant. One of the async callbacks could indirectly
+     * operate on the list. Moving all elements to a local list before iterating
+     * that. */
+    UA_AsyncServiceList asyncServiceCalls;
     AsyncServiceCall *ac, *ac_tmp;
     UA_DateTime now = UA_DateTime_nowMonotonic();
+    LIST_INIT(&asyncServiceCalls);
     LIST_FOREACH_SAFE(ac, &client->asyncServiceCalls, pointers, ac_tmp) {
         if(!ac->timeout)
            continue;
         if(ac->start + (UA_DateTime)(ac->timeout * UA_DATETIME_MSEC) <= now) {
             LIST_REMOVE(ac, pointers);
-            UA_Client_AsyncService_cancel(client, ac, UA_STATUSCODE_BADTIMEOUT);
-            UA_free(ac);
+            LIST_INSERT_HEAD(&asyncServiceCalls, ac, pointers);
         }
+    }
+
+    /* Cancel and remove the elements from the local list */
+    LIST_FOREACH_SAFE(ac, &asyncServiceCalls, pointers, ac_tmp) {
+        LIST_REMOVE(ac, pointers);
+        UA_Client_AsyncService_cancel(client, ac, UA_STATUSCODE_BADTIMEOUT);
+        UA_free(ac);
     }
 }
 

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -95,6 +95,8 @@ void
 UA_Client_AsyncService_cancel(UA_Client *client, AsyncServiceCall *ac,
                               UA_StatusCode statusCode);
 
+typedef LIST_HEAD(UA_AsyncServiceList, AsyncServiceCall) UA_AsyncServiceList;
+
 void
 UA_Client_AsyncService_removeAll(UA_Client *client, UA_StatusCode statusCode);
 
@@ -147,7 +149,7 @@ struct UA_Client {
     UA_Boolean pendingConnectivityCheck;
 
     /* Async Service */
-    LIST_HEAD(, AsyncServiceCall) asyncServiceCalls;
+    UA_AsyncServiceList asyncServiceCalls;
 
     /* Subscriptions */
 #ifdef UA_ENABLE_SUBSCRIPTIONS


### PR DESCRIPTION
Commit de9d691906547c9fc99e0a77198a80fe5bba54b1 fixed a use after free in UA_Client_AsyncService_cancel().  Move all elements to a local list before iterating over the callbacks.  Commit 713cdb419f0f844517afc549c7c1ef48d8498cfb fixed the same bug in in asyncServiceTimeoutCheck().  After timeout, remove the async service calls from the global list and store them in a local one.  Call UA_Client_AsyncService_cancel() and UA_free() while traversing this local list.  Otherwise the callback could free a global list element that asyncServiceTimeoutCheck() is referencing.

Backport these fixes from 1.4 to 1.3.  I have been carrying them in my local patch set for too long.