### PR TITLE
[Discussion] feat(core): add name for struct UA_NodeId for C++ forward declare

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -377,7 +377,7 @@ enum UA_NodeIdType {
     UA_NODEIDTYPE_BYTESTRING = 5
 };
 
-typedef struct {
+typedef struct UA_NodeId {
     UA_UInt16 namespaceIndex;
     enum UA_NodeIdType identifierType;
     union {


### PR DESCRIPTION
anonymous structs cannot be forward declared in c++
Question: should all structs have a name for c++ compatibility? There is some inconsistency, e.g. in types.h:

```
typedef struct UA_DateTimeStruct {
    UA_UInt16 nanoSec;
    UA_UInt16 microSec;
    UA_UInt16 milliSec;
    UA_UInt16 sec;
    UA_UInt16 min;
    UA_UInt16 hour;
    UA_UInt16 day;   /* From 1 to 31 */
    UA_UInt16 month; /* From 1 to 12 */
    UA_Int16 year;   /* Can be negative (BC) */
} UA_DateTimeStruct;
```

```
typedef struct {
    UA_UInt32 data1;
    UA_UInt16 data2;
    UA_UInt16 data3;
    UA_Byte   data4[8];
} UA_Guid;
```