### PR TITLE
Add socket limit configuration flag

### DIFF
--- a/arch/posix/eventloop_posix.h
+++ b/arch/posix/eventloop_posix.h
@@ -353,6 +353,11 @@ struct UA_RegisteredFD {
     UA_FD fd;
     short listenEvents; /* UA_FDEVENT_IN | UA_FDEVENT_OUT*/
 
+    /* Information to reopen listen socket */
+    UA_String hostname;
+    UA_UInt16 port;
+    UA_Boolean reuseaddr;
+
     UA_EventSource *es; /* Backpointer to the EventSource */
     UA_FDCallback eventSourceCB;
 };
@@ -360,6 +365,13 @@ struct UA_RegisteredFD {
 enum ZIP_CMP cmpFD(const UA_FD *a, const UA_FD *b);
 typedef ZIP_HEAD(UA_FDTree, UA_RegisteredFD) UA_FDTree;
 ZIP_FUNCTIONS(UA_FDTree, UA_RegisteredFD, zipPointers, UA_FD, fd, cmpFD)
+
+typedef struct UA_DeregisteredListenFD {
+    LIST_ENTRY(UA_DeregisteredListenFD) pointers;
+    UA_RegisteredFD *listenFd;
+} UA_DeregisteredListenFD;
+
+typedef LIST_HEAD(UA_DeregisteredListenFDList, UA_DeregisteredListenFD) UA_DeregisteredListenFDList;
 
 /* All ConnectionManager in the POSIX EventLoop can be cast to
  * UA_ConnectionManagerPOSIX. They carry a sorted tree of their open
@@ -374,6 +386,9 @@ typedef struct {
     /* Sorted tree of the FDs */
     size_t fdsSize;
     UA_FDTree fds;
+
+    /* Closed listening sockets queued for later reopening */
+    UA_DeregisteredListenFDList listenFDs;
 } UA_POSIXConnectionManager;
 
 typedef struct {
@@ -399,6 +414,10 @@ typedef struct {
     /* Flag determining whether the eventloop is currently within the
      * "run" method */
     volatile UA_Boolean executing;
+
+    /* Indicates that the maximum number of sockets has been reached.
+     * All listening sockets will be closed. */
+    UA_Boolean maxSocketsLimitReached;
 
 #if defined(UA_ARCHITECTURE_POSIX) && !defined(__APPLE__) && !defined(__MACH__)
     /* Clocks for the eventloop's time domain */

--- a/arch/posix/eventloop_posix_tcp.c
+++ b/arch/posix/eventloop_posix_tcp.c
@@ -45,6 +45,12 @@ typedef struct {
 static void
 TCP_shutdown(UA_ConnectionManager *cm, TCP_FD *conn);
 
+static UA_StatusCode
+TCP_registerListenSockets(UA_POSIXConnectionManager *pcm, const char *hostname,
+                          UA_UInt16 port, void *application, void *context,
+                          UA_ConnectionManager_connectionCallback connectionCallback,
+                          UA_Boolean validate, UA_Boolean reuseaddr);
+
 /* Do not merge packets on the socket (disable Nagle's algorithm) */
 static UA_StatusCode
 TCP_setNoNagle(UA_FD sockfd) {
@@ -68,19 +74,70 @@ TCP_checkStopped(UA_POSIXConnectionManager *pcm) {
     }
 }
 
-static UA_Boolean maxSocketsLimitReached = false;
+static void
+TCP_delayedReopen(void *application, void *context) {
+    UA_POSIXConnectionManager *pcm = (UA_POSIXConnectionManager*)application;
+    UA_ConnectionManager *cm = &pcm->cm;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)cm->eventSource.eventLoop;
+    UA_DeregisteredListenFD *listenRfd = (UA_DeregisteredListenFD*)context;
+    UA_RegisteredFD *rfd = listenRfd->listenFd;
+    TCP_FD *conn = (TCP_FD*)rfd;
 
-static void *
-addListenSockets(void *application, UA_RegisteredFD *rfd) {
-    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)application;
-    int optval;
-    socklen_t optlen = sizeof(optval);
+    UA_LOCK(&el->elMutex);
 
-    if(UA_getsockopt(rfd->fd, SOL_SOCKET, SO_ACCEPTCONN, &optval, &optlen) == 0 && optval) {
-        UA_EventLoopPOSIX_registerFD(el, rfd);
+    UA_LOG_DEBUG(el->eventLoop.logger, UA_LOGCATEGORY_EVENTLOOP,
+                 "TCP %u\t| Delayed reopen of the listen socket",
+                 (unsigned)conn->rfd.fd);
+
+    char hostname[UA_MAXHOSTNAME_LENGTH] = {0};
+    mp_snprintf(hostname, UA_MAXHOSTNAME_LENGTH, "%.*s",
+                (int)rfd->hostname.length, (char*)rfd->hostname.data);
+
+    TCP_registerListenSockets(pcm, hostname, rfd->port, conn->application,
+                              conn->context, conn->applicationCB, false, rfd->reuseaddr);
+
+    LIST_REMOVE(listenRfd, pointers);
+    UA_String_clear(&listenRfd->listenFd->hostname);
+    UA_free(listenRfd->listenFd);
+    UA_free(listenRfd);
+
+    if(!pcm->listenFDs.lh_first) {
+        el->maxSocketsLimitReached = false;
     }
 
-    return NULL;
+    UA_UNLOCK(&el->elMutex);
+}
+
+static UA_StatusCode
+addListenSockets(void *application) {
+    UA_POSIXConnectionManager *pcm = (UA_POSIXConnectionManager*)application;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)pcm->cm.eventSource.eventLoop;
+    UA_LOCK_ASSERT(&el->elMutex);
+
+    UA_DeregisteredListenFD *listenFd;
+    LIST_FOREACH(listenFd, &pcm->listenFDs, pointers) {
+        if(listenFd->listenFd->dc.callback) {
+            UA_LOG_DEBUG(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                         "TCP %u\t| Cannot close - already closing",
+                         (unsigned)listenFd->listenFd->fd);
+            return UA_STATUSCODE_BADINTERNALERROR;
+        }
+
+        UA_LOG_DEBUG(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+             "TCP %u\t| Reopen listen socket triggered",
+             (unsigned)listenFd->listenFd->fd);
+
+        /* Add to the delayed callback list. Will be cleaned up in the next
+         * iteration. */
+        UA_DelayedCallback *dc = &listenFd->listenFd->dc;
+        dc->callback = TCP_delayedReopen;
+        dc->application = application;
+        dc->context = listenFd;
+
+        /* Adding a delayed callback does not take a lock */
+        UA_EventLoopPOSIX_addDelayedCallback(pcm->cm.eventSource.eventLoop, dc);
+    }
+    return UA_STATUSCODE_GOOD;
 }
 
 static void
@@ -128,13 +185,13 @@ TCP_delayedClose(void *application, void *context) {
                           (unsigned)conn->rfd.fd, errno_str));
     }
 
-    UA_free(conn);
-
     /* Resuming listen sockets in the socket list when socket space becomes available */
     if(el->maxSocketsLimitReached) {
-        ZIP_ITER(UA_FDTree, &pcm->fds, addListenSockets, application);
-        el->maxSocketsLimitReached = false;
+        addListenSockets(application);
     }
+
+    UA_String_clear(&conn->rfd.hostname);
+    UA_free(conn);
 
     /* Check if this was the last connection for a closing ConnectionManager */
     TCP_checkStopped(pcm);
@@ -254,12 +311,63 @@ TCP_connectionSocketCallback(UA_ConnectionManager *cm, TCP_FD *conn,
 
 static void *
 removeListenSockets(void *application, UA_RegisteredFD *rfd) {
-    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)application;
+    UA_POSIXConnectionManager *pcm = (UA_POSIXConnectionManager*)application;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)pcm->cm.eventSource.eventLoop;
     int optval;
     socklen_t optlen = sizeof(optval);
 
     if(UA_getsockopt(rfd->fd, SOL_SOCKET, SO_ACCEPTCONN, &optval, &optlen) == 0 && optval) {
+        TCP_FD *fd = (TCP_FD*)rfd;
+        /* Check if it's already listed for reopening */
+        UA_Boolean alreadyAdded = UA_FALSE;
+        UA_DeregisteredListenFD *listenFd;
+        LIST_FOREACH(listenFd, &pcm->listenFDs, pointers) {
+            if(UA_String_equal(&listenFd->listenFd->hostname, &rfd->hostname)){
+                alreadyAdded = UA_TRUE;
+                break;
+            }
+        }
+
+        if(!alreadyAdded) {
+            listenFd = (UA_DeregisteredListenFD*)UA_calloc(1, sizeof(UA_DeregisteredListenFD));
+            listenFd->listenFd = rfd;
+            LIST_INSERT_HEAD(&pcm->listenFDs, listenFd, pointers);
+        }
+
+        /* Ensure reuse is possible right away. Port-stealing is no longer an issue
+         * as the socket gets closed anyway. And we do not want to wait for the
+         * timeout to open a new socket for the same address and port. */
+        UA_EventLoopPOSIX_setReusable(rfd->fd);
         UA_EventLoopPOSIX_deregisterFD(el, rfd);
+
+        /* Deregister internally */
+        ZIP_REMOVE(UA_FDTree, &pcm->fds, rfd);
+        UA_assert(pcm->fdsSize > 0);
+        pcm->fdsSize--;
+
+        /* Signal closing to the application */
+        fd->applicationCB(&pcm->cm, (uintptr_t)rfd->fd,
+                          fd->application, &fd->context,
+                          UA_CONNECTIONSTATE_BLOCKING,
+                          &UA_KEYVALUEMAP_NULL, UA_BYTESTRING_NULL);
+
+        /* Close the socket */
+        UA_RESET_ERRNO;
+        int ret = UA_close(rfd->fd);
+        if(ret == 0) {
+            UA_LOG_INFO(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                        "TCP %u\t| Socket closed", (unsigned)rfd->fd);
+        } else {
+            UA_LOG_SOCKET_ERRNO_WRAP(
+               UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                              "TCP %u\t| Could not close the socket (%s)",
+                              (unsigned)rfd->fd, errno_str));
+        }
+
+        if(alreadyAdded) {
+            UA_String_clear(&rfd->hostname);
+            UA_free(rfd);
+        }
     }
 
     return NULL;
@@ -367,11 +475,11 @@ TCP_listenSocketCallback(UA_ConnectionManager *cm, TCP_FD *conn, short event) {
      * If true, remove listen sockets from the socket list to stop
      * accepting additional connection requests */
     const UA_UInt32 *maxSockets = (const UA_UInt32 *)UA_KeyValueMap_getScalar(
-        &cm->eventSource.params, UA_QUALIFIEDNAME(0, "max-sockets"),
+        &cm->eventSource.params, UA_QUALIFIEDNAME(0, "max-connections"),
         &UA_TYPES[UA_TYPES_UINT32]);
     if(maxSockets && *maxSockets != 0 && pcm->fdsSize >= (size_t)*maxSockets) {
-        ZIP_ITER(UA_FDTree, &pcm->fds, removeListenSockets, el);
-        maxSocketsLimitReached = true;
+        ZIP_ITER(UA_FDTree, &pcm->fds, removeListenSockets, cm);
+        el->maxSocketsLimitReached = true;
     }
 
     /* Forward the remote hostname to the application */
@@ -402,9 +510,9 @@ TCP_registerListenSocket(UA_POSIXConnectionManager *pcm, struct addrinfo *ai,
 
     /* Check that the maximum number of sockets has not been exceeded */
     const UA_UInt32 *maxSockets = (const UA_UInt32 *)UA_KeyValueMap_getScalar(
-        &pcm->cm.eventSource.params, UA_QUALIFIEDNAME(0, "max-sockets"),
+        &pcm->cm.eventSource.params, UA_QUALIFIEDNAME(0, "max-connections"),
         &UA_TYPES[UA_TYPES_UINT32]);
-    if(maxSockets && *maxSockets != 0 && pcm->fdsSize >= (size_t)*maxSockets) {
+    if(el->maxSocketsLimitReached || (maxSockets && *maxSockets != 0 && pcm->fdsSize >= (size_t)*maxSockets)) {
         UA_LOG_ERROR(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
                      "TCP\t| Unable to establish connection: no available sockets");
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -559,6 +667,11 @@ TCP_registerListenSocket(UA_POSIXConnectionManager *pcm, struct addrinfo *ai,
     newConn->application = application;
     newConn->context = context;
 
+    /* Information to reopen listen socket */
+    newConn->rfd.hostname = UA_String_fromChars(hostname);
+    newConn->rfd.port = port;
+    newConn->rfd.reuseaddr = reuseaddr;
+
     /* Register in the EventLoop */
     UA_StatusCode res = UA_EventLoopPOSIX_registerFD(el, &newConn->rfd);
     if(res != UA_STATUSCODE_GOOD) {
@@ -583,6 +696,15 @@ TCP_registerListenSocket(UA_POSIXConnectionManager *pcm, struct addrinfo *ai,
     params[1].key = UA_QUALIFIEDNAME(0, "listen-port");
     UA_Variant_setScalar(&params[1].value, &port, &UA_TYPES[UA_TYPES_UINT16]);
     UA_KeyValueMap paramMap = {2, params};
+
+    if(el->maxSocketsLimitReached) {
+        /* Announce the reopening of the listen-socket in the application */
+        connectionCallback(&pcm->cm, (uintptr_t)listenSocket,
+                           application, &newConn->context,
+                           UA_CONNECTIONSTATE_REOPENING,
+                           &paramMap, UA_BYTESTRING_NULL);
+        return UA_STATUSCODE_GOOD;
+    }
 
     /* Announce the listen-socket in the application */
     connectionCallback(&pcm->cm, (uintptr_t)listenSocket,
@@ -826,9 +948,9 @@ TCP_openActiveConnection(UA_POSIXConnectionManager *pcm, const UA_KeyValueMap *p
 
     /* Check that the maximum number of sockets has not been exceeded */
     const UA_UInt32 *maxSockets = (const UA_UInt32 *)UA_KeyValueMap_getScalar(
-        &pcm->cm.eventSource.params, UA_QUALIFIEDNAME(0, "max-sockets"),
+        &pcm->cm.eventSource.params, UA_QUALIFIEDNAME(0, "max-connections"),
         &UA_TYPES[UA_TYPES_UINT32]);
-    if(maxSockets && *maxSockets != 0 && pcm->fdsSize >= (size_t)*maxSockets) {
+    if(el->maxSocketsLimitReached || (maxSockets && *maxSockets != 0 && pcm->fdsSize >= (size_t)*maxSockets)) {
         UA_LOG_ERROR(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
                      "TCP\t| Unable to establish connection: no available sockets");
         return UA_STATUSCODE_BADINTERNALERROR;

--- a/include/open62541/common.h
+++ b/include/open62541/common.h
@@ -207,7 +207,9 @@ typedef enum {
                                       fully established */
     UA_CONNECTIONSTATE_ESTABLISHED,/* The socket is open and the connection
                                     * configured */
-    UA_CONNECTIONSTATE_CLOSING     /* The socket is closing down */
+    UA_CONNECTIONSTATE_CLOSING,    /* The socket is closing down */
+    UA_CONNECTIONSTATE_BLOCKING,   /* Listening disabled (e.g. max connections reached) */
+    UA_CONNECTIONSTATE_REOPENING   /* Listening resumed after being blocked */
 } UA_ConnectionState;
 
 

--- a/include/open62541/plugin/eventloop.h
+++ b/include/open62541/plugin/eventloop.h
@@ -456,7 +456,7 @@ struct UA_InterruptManager {
 #if (defined(UA_ARCHITECTURE_POSIX) && !defined(UA_ARCHITECTURE_LWIP)) || defined(UA_ARCHITECTURE_WIN32)
 
 /**
- * POSIX EventLop Implementation
+ * POSIX EventLoop Implementation
  * -----------------------------
  * The POSIX compatibility of Win32 is 'close enough'. So a joint implementation
  * is provided. The configuration paramaters must be set before starting the
@@ -495,6 +495,9 @@ UA_EventLoop_new_POSIX(const UA_Logger *logger);
  * the first callback are different between server and client connections.
  *
  * **Configuration parameters for the ConnectionManager (set before start)**
+ *
+ * 0:max-sockets [uint32]
+ *    max sockets (default: 0 -> unbounded).
  *
  * 0:recv-bufsize [uint32]
  *    Size of the buffer that is statically allocated for receiving messages

--- a/include/open62541/plugin/eventloop.h
+++ b/include/open62541/plugin/eventloop.h
@@ -496,8 +496,9 @@ UA_EventLoop_new_POSIX(const UA_Logger *logger);
  *
  * **Configuration parameters for the ConnectionManager (set before start)**
  *
- * 0:max-sockets [uint32]
- *    max sockets (default: 0 -> unbounded).
+ * 0:max-connections [uint32]
+ *    max connections (default: 0 -> unbounded).
+ *    The server sockets get deactivated if the limit is reached.
  *
  * 0:recv-bufsize [uint32]
  *    Size of the buffer that is statically allocated for receiving messages

--- a/tests/check_eventloop_tcp.c
+++ b/tests/check_eventloop_tcp.c
@@ -27,6 +27,10 @@ static void setupEL(void) {
 #elif defined(UA_ARCHITECTURE_POSIX) || defined(UA_ARCHITECTURE_WIN32)
     el = UA_EventLoop_new_POSIX(UA_Log_Stdout);
     cm = UA_ConnectionManager_new_POSIX_TCP(UA_STRING("tcpCM"));
+    /* Set up the TCP EventLoop parameters */
+    UA_UInt32 maxSockets = 2; /* Max number of server sockets (default: 0 -> unbounded) */
+    UA_KeyValueMap_setScalar(&cm->eventSource.params, UA_QUALIFIEDNAME(0, "max-sockets"),
+                             (void *)&maxSockets, &UA_TYPES[UA_TYPES_UINT32]);
     el->registerEventSource(el, &cm->eventSource);
 #else
 #error Add other EventLoop implementations here
@@ -86,9 +90,18 @@ START_TEST(listenTCP) {
 
     ck_assert_uint_eq(connCount, 0);
 
-    cm->openConnection(cm, &paramsMap, NULL, NULL, connectionCallback);
+    UA_StatusCode retval = cm->openConnection(cm, &paramsMap, NULL, NULL, connectionCallback);
 
+    ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert(connCount > 0);
+
+#if !defined(UA_ARCHITECTURE_LWIP)
+    port = 4841;
+    /* This should fail because the maximum number of sockets has been reached */
+    retval = cm->openConnection(cm, &paramsMap, NULL, NULL, connectionCallback);
+
+    ck_assert_int_ne(retval, UA_STATUSCODE_GOOD);
+#endif
 
     for(size_t i = 0; i < 10; i++) {
         UA_DateTime next = el->run(el, 1);
@@ -137,6 +150,13 @@ START_TEST(connectTCP) {
 
     size_t listenSockets = connCount;
 
+#if !defined(UA_ARCHITECTURE_LWIP)
+    /* Set up the TCP EventLoop parameters */
+    UA_UInt32 maxSockets = listenSockets + 1; /* Max number of server sockets (default: 0 -> unbounded) */
+    UA_KeyValueMap_setScalar(&cm->eventSource.params, UA_QUALIFIEDNAME(0, "max-sockets"),
+                             (void *)&maxSockets, &UA_TYPES[UA_TYPES_UINT32]);
+#endif
+
     /* Open a client connection */
     clientId = 0;
     listen = false;
@@ -165,6 +185,17 @@ START_TEST(connectTCP) {
         UA_fakeSleep((UA_UInt32)((next - UA_DateTime_now()) / UA_DATETIME_MSEC));
     }
     ck_assert(received);
+
+#if !defined(UA_ARCHITECTURE_LWIP)
+    /* Open a second client connection.
+     * This should fail because the maximum number of sockets has been reached */
+    retval = cm->openConnection(cm, &paramsMap, NULL, (void*)0x01, connectionCallback);
+    ck_assert_uint_ne(retval, UA_STATUSCODE_GOOD);
+    for(size_t i = 0; i < 2; i++) {
+        UA_DateTime next = el->run(el, 1);
+        UA_fakeSleep((UA_UInt32)((next - UA_DateTime_now()) / UA_DATETIME_MSEC));
+    }
+#endif
 
     /* Close the connection */
     retval = cm->closeConnection(cm, clientId);


### PR DESCRIPTION
Currently, there is no way to limit the number of open sockets. This PR introduces a new server configuration flag that limits the maximum number of open sockets.

Once a connection has been accepted, the server verifies whether the maximum limit has been reached. If so, the listening sockets are deregistered from the socket list.