### PR TITLE
Speed up the CI runtime by executing valgrind tests conditionally

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -179,28 +179,6 @@ jobs:
                 pip3 install --break-system-packages .
               cmd_action: build_tpm_tool   
                  
-          # Valgrind tests for specific Ubuntu versions
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev
-              cmd_action: unit_tests_valgrind MBEDTLS          
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Build & Unit Tests with OpenSSL (gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind openssl
-              cmd_action: unit_tests_valgrind OPENSSL          
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Examples with MbedTLS and mDNSD (gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev python3-netifaces
-              cmd_action: examples_valgrind MBEDTLS MDNSD          
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Examples with OpenSSL and avahi-mdns(gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev python3-netifaces libavahi-client-dev libavahi-common-dev
-              cmd_action: examples_valgrind OPENSSL AVAHI          
-              
           # Clang Static Analyzer Builds
           - os: ubuntu-20.04
             build:
@@ -257,6 +235,64 @@ jobs:
           ETHERNET_INTERFACE: eth0
       - name: Upload coverage to Codecov
         if: matrix.build.os == '' || matrix.build.os == matrix.os
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  valgrind:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/marwinglaser/ci:ubuntu-24.04
+      options: --privileged
+    services:
+      mosquitto:
+        image: eclipse-mosquitto:1.6-openssl
+    env:
+      OPEN62541_TEST_MQTT_BROKER: opc.mqtt://mosquitto:1883
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+        build:
+          - name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev
+            cmd_action: unit_tests_valgrind MBEDTLS
+          - name: "Valgrind Build & Unit Tests with OpenSSL (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind openssl
+            cmd_action: unit_tests_valgrind OPENSSL
+          - name: "Valgrind Examples with MbedTLS and mDNSD (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev python3-netifaces
+            cmd_action: examples_valgrind MBEDTLS MDNSD
+          - name: "Valgrind Examples with OpenSSL and avahi-mdns(gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev python3-netifaces libavahi-client-dev libavahi-common-dev
+            cmd_action: examples_valgrind OPENSSL AVAHI
+    name: ${{ matrix.os }}-${{ matrix.build.name }}
+    steps:
+      - name: Work around disabled ipv6 on actions container networks
+        run: |
+          IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+          echo "Current IPv6 status on eth0: $IPV6"
+          [ "$IPV6" = "1" ] || exit
+
+          echo 0 | sudo tee /proc/sys/net/ipv6/conf/eth0/disable_ipv6 > /dev/null
+          IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+          echo "New IPv6 status on eth0: $IPV6"
+          [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential cmake libcap2-bin pkg-config libssl-dev python3-sphinx graphviz check libxml2-dev libpcap-dev
+          ${{ matrix.build.cmd_deps }}
+      - name: ${{ matrix.build.name }}
+        shell: bash
+        run: source tools/ci/ci.sh && ${{ matrix.build.cmd_action }}
+        env:
+          ETHERNET_INTERFACE: eth0
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -11,46 +11,35 @@ jobs:
         build:
           - name: "Debug Build & Unit Tests (gcc)"
             cmd_action: unit_tests
-
           - name: "Debug Build & Unit Tests (gcc, 32bit)"
             cmd_deps: |
               sudo dpkg --add-architecture i386
               sudo apt-get update
               sudo apt-get install -y -qq gcc-multilib libsubunit-dev:i386 check:i386 libxml2-dev:i386
             cmd_action: unit_tests_32
-
           - name: "Debug Build & Unit Tests without Subscriptions (gcc)"
             cmd_action: unit_tests_nosub
-
           - name: "Debug Build & Unit Tests with Diagnostics (gcc)"
             cmd_action: unit_tests_diag
-
           - name: "Debug Build & Unit Tests with multithreading (gcc)"
             cmd_action: unit_tests_mt
-
           - name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
             cmd_action: unit_tests_alarms
-
           - name: "Debug Build & Unit Tests (tcc)"
             cmd_deps: sudo apt-get install -y -qq tcc
             cmd_action: CC=tcc unit_tests
-
           - name: "Encryption (MbedTLS) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: unit_tests_encryption MBEDTLS
-
           - name: "PubSub Encryption (MbedTLS) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: unit_tests_encryption_mbedtls_pubsub
-
           - name: "PubSub SKS Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev
             cmd_action: unit_tests_pubsub_sks
-
           - name: "Encryption (OpenSSL) Build & Unit Tests (gcc)"
             cmd_deps: sudo apt-get install -y -qq openssl
             cmd_action: unit_tests_encryption OPENSSL
-
           - name: "Encryption (LibreSSL) Build & Unit Tests (gcc)"
             cmd_deps: |
               sudo apt-get install -y -qq curl
@@ -60,17 +49,13 @@ jobs:
               ./configure
               sudo make install
             cmd_action: unit_tests_encryption LIBRESSL
-
           - name: "Release Build"
             cmd_deps: sudo apt-get install -y -qq libmbedtls-dev
             cmd_action: build_release
-
           - name: "Amalgamation Build"
             cmd_action: build_amalgamation
-
           - name: "Amalgamation Build with Multithreading"
             cmd_action: build_amalgamation_mt
-
           - name: "Build All Companion Specifications"
             cmd_action: build_all_companion_specs
 
@@ -218,23 +203,19 @@ jobs:
           echo "New IPv6 status on eth0: $IPV6"
           [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }      
       - uses: actions/checkout@v4
-        if: matrix.build.os == '' || matrix.build.os == matrix.os
         with:
           submodules: true
       - name: Install Dependencies
-        if: matrix.build.os == '' || matrix.build.os == matrix.os
         run: |
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential cmake libcap2-bin pkg-config libssl-dev python3-sphinx graphviz check libxml2-dev libpcap-dev
           ${{ matrix.build.cmd_deps }}      
       - name: ${{ matrix.build.name }}
-        if: matrix.build.os == '' || matrix.build.os == matrix.os
         shell: bash
         run: source tools/ci/ci.sh && ${{ matrix.build.cmd_action }}
         env:
           ETHERNET_INTERFACE: eth0
       - name: Upload coverage to Codecov
-        if: matrix.build.os == '' || matrix.build.os == matrix.os
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -278,7 +259,7 @@ jobs:
           echo 0 | sudo tee /proc/sys/net/ipv6/conf/eth0/disable_ipv6 > /dev/null
           IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
           echo "New IPv6 status on eth0: $IPV6"
-          [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }
+          [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }      
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -286,7 +267,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential cmake libcap2-bin pkg-config libssl-dev python3-sphinx graphviz check libxml2-dev libpcap-dev
-          ${{ matrix.build.cmd_deps }}
+          ${{ matrix.build.cmd_deps }}      
       - name: ${{ matrix.build.name }}
         shell: bash
         run: source tools/ci/ci.sh && ${{ matrix.build.cmd_action }}


### PR DESCRIPTION
This PR speeds up the average CI runtime for pull requests by adding dependent execution of the Valgrind tests. Currently, the Valgrind tests in particular are time-consuming and block the GitHub runners for a long time. This PR ensures that the Valgrind tests are only executed if all other Linux builds are successful. This means that unpolished PRs with general errors do not occupy the limited number of runners for other CI runs.