### PR TITLE
refactor(tools): fix possible NULL-pointer dereference in ua-cli

### DIFF
--- a/tools/ua-cli/ua.c
+++ b/tools/ua-cli/ua.c
@@ -616,8 +616,11 @@ explore(int argc, char **argv, int argpos) {
         abortWithStatus(res);
 
     char relativepath[512];
-    size_t pos = strlen(pathArg);
-    memcpy(relativepath, pathArg, pos);
+    size_t pos = 0;
+    if (pathArg) {
+        pos = strlen(pathArg);
+        memcpy(relativepath, pathArg, pos);
+    }
 
     exploreRecursive(relativepath, pos, ao.nodeId, nc, depth);
 


### PR DESCRIPTION
Fix possible NULL-pointer dereference in ua-cli as reported by clang scan-build.