### PR TITLE
fix(tests): add missing include for mDNS/mbedtls combination

### DIFF
--- a/tests/server/check_discovery.c
+++ b/tests/server/check_discovery.c
@@ -8,6 +8,7 @@
 #include <open62541/plugin/certificategroup_default.h>
 
 #include "server/ua_server_internal.h"
+#include "client/ua_client_internal.h"
 #include "../encryption/certificates.h"
 
 #include <fcntl.h>


### PR DESCRIPTION
If mDNS is enabled and also mbedTLS, then check_discovery.c is calling __UA_Client_Service(), so we need to include "client/ua_client_internal.h" to compile correctly.