### PR TITLE
refactor(examples,tools,server,plugins,pubsub): clang compiler warnings

### DIFF
--- a/deps/dtoa.c
+++ b/deps/dtoa.c
@@ -35,7 +35,7 @@
 #define fracmask  0x000FFFFFFFFFFFFFU
 #define expmask   0x7FF0000000000000U
 #define hiddenbit 0x0010000000000000U
-#define signmask  0x8000000000000000U
+//#define signmask  0x8000000000000000U
 #define expbias   (1023 + 52)
 
 #define absv(n) ((n) < 0 ? -(n) : (n))

--- a/deps/libc_time.c
+++ b/deps/libc_time.c
@@ -134,8 +134,8 @@ musl_year_to_secs(const long long year, int *is_leap) {
             *is_leap = 0;
             leaps = 0;
         } else {
-            leaps = rem / 4U;
-            rem %= 4U;
+            leaps = rem / 4;
+            rem %= 4;
             *is_leap = !rem;
         }
     }

--- a/deps/mp_printf.h
+++ b/deps/mp_printf.h
@@ -60,7 +60,7 @@ extern "C" {
  * characters. Alternatively, it can be NULL, in which case nothing will be
  * printed, and only the number of characters which _could_ have been printed is
  * tallied and returned.
- * @param n The maximum number of characters to write to the array, including a
+ * @param count The maximum number of characters to write to the array, including a
  * terminating null character
  * @param format A string specifying the format of the output, with %-marked
  * specifiers of how to interpret additional arguments.
@@ -72,8 +72,8 @@ extern "C" {
  * than @p n, the null-terminated string has been fully and successfully
  * printed.
  */
-int  mp_snprintf(char* s, size_t count, const char* format, ...);
 int mp_vsnprintf(char* s, size_t count, const char* format, va_list arg);
+int  mp_snprintf(char* s, size_t count, const char* format, ...);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/examples/ci_server.c
+++ b/examples/ci_server.c
@@ -19,8 +19,6 @@
 * The server certificate and private key are loaded from the command line arguments.
 */
 
-#define MIN_ARGS 4
-
 static UA_UsernamePasswordLogin logins[3] = {
     {UA_STRING_STATIC("peter"), UA_STRING_STATIC("peter123")},
     {UA_STRING_STATIC("paula"), UA_STRING_STATIC("paula123")},

--- a/examples/client_connect_loop.c
+++ b/examples/client_connect_loop.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include "common.h"
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_CLIENT, "Received Ctrl-C");

--- a/examples/client_method_async.c
+++ b/examples/client_method_async.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <signal.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void InitCallMulti(UA_Client* client);
 
 #ifdef UA_ENABLE_METHODCALLS

--- a/examples/client_subscription_loop.c
+++ b/examples/client_subscription_loop.c
@@ -19,7 +19,7 @@
 #include <signal.h>
 #include <stdlib.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "Received Ctrl-C");

--- a/examples/custom_datatype/client_types_custom.c
+++ b/examples/custom_datatype/client_types_custom.c
@@ -92,7 +92,7 @@ int main(void) {
         char message[STRING_BUFFER_SIZE];
         memcpy(message, u->fields.optionB.data, u->fields.optionB.length);
         message[u->fields.optionB.length] = '\0';
-        printf("Union member selection: %i , member content: %s \n", u->switchField, message);
+        printf("Union member selection: %u , member content: %s \n", u->switchField, message);
     }
 
     /* Clean up */

--- a/examples/custom_datatype/server_types_custom.c
+++ b/examples/custom_datatype/server_types_custom.c
@@ -10,14 +10,14 @@
 
 #include "custom_datatype.h"
 
-UA_Boolean running = true;
-const UA_NodeId pointVariableTypeId = {
+static UA_Boolean running = true;
+static const UA_NodeId pointVariableTypeId = {
     1, UA_NODEIDTYPE_NUMERIC, {4243}};
-const UA_NodeId measurementVariableTypeId = {
+static const UA_NodeId measurementVariableTypeId = {
     1, UA_NODEIDTYPE_NUMERIC, {4444}};
-const UA_NodeId optstructVariableTypeId = {
+static const UA_NodeId optstructVariableTypeId = {
     1, UA_NODEIDTYPE_NUMERIC, {4645}};
-const UA_NodeId unionVariableTypeId = {
+static const UA_NodeId unionVariableTypeId = {
     1, UA_NODEIDTYPE_NUMERIC, {4846}};
 
 static void stopHandler(int sig) {

--- a/examples/discovery/server_lds.c
+++ b/examples/discovery/server_lds.c
@@ -12,7 +12,7 @@
 #include <signal.h>
 #include <stdlib.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void stopHandler(int sig) {
     running = false;
 }

--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -22,17 +22,17 @@
 #include <stdio.h>
 #include <errno.h>
 
-const UA_ByteString UA_SECURITY_POLICY_BASIC128_URI =
+static const UA_ByteString UA_SECURITY_POLICY_BASIC128_URI =
     {56, (UA_Byte *)"http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15"};
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
     running = false;
 }
 
-char *discovery_url = NULL;
+static char *discovery_url = NULL;
 
 static void
 serverOnNetworkCallback(const UA_ServerOnNetwork *serverOnNetwork, UA_Boolean isServerAnnounce,

--- a/examples/discovery/server_register.c
+++ b/examples/discovery/server_register.c
@@ -19,7 +19,7 @@
 
 #define DISCOVERY_SERVER_ENDPOINT "opc.tcp://localhost:4840"
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");

--- a/examples/events/client_eventfilter.c
+++ b/examples/events/client_eventfilter.c
@@ -21,8 +21,6 @@
 #include <signal.h>
 #include <stdio.h>
 
-#define USE_FILTER_OR_TYPEOF
-
 static UA_Boolean running = true;
 #define SELECT_CLAUSE_FIELD_COUNT 3
 

--- a/examples/events/server_random_events.c
+++ b/examples/events/server_random_events.c
@@ -159,7 +159,7 @@ addGenerateSampleEventsMethodCallback(UA_Server *server,
                              const UA_NodeId *objectId, void *objectContext,
                              size_t inputSize, const UA_Variant *input,
                              size_t outputSize, UA_Variant *output) {
-    UA_StatusCode retval;
+    UA_StatusCode retval = UA_STATUSCODE_BADINTERNALERROR;
     UA_NodeId* eventNodeId;
     eventNodeId = (UA_NodeId*)
         UA_Array_new(SAMPLE_EVENT_TYPES_COUNT, &UA_TYPES[UA_TYPES_NODEID]);

--- a/examples/nodeset/server_nodeset.c
+++ b/examples/nodeset/server_nodeset.c
@@ -13,7 +13,7 @@
 #include <signal.h>
 #include <stdlib.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");

--- a/examples/pubsub/pubsub_subscribe_standalone_dataset.c
+++ b/examples/pubsub/pubsub_subscribe_standalone_dataset.c
@@ -9,10 +9,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-UA_NodeId connectionIdentifier;
-UA_NodeId readerGroupIdentifier;
-UA_NodeId readerIdentifier;
-UA_DataSetReaderConfig readerConfig;
+static UA_NodeId connectionIdentifier;
+static UA_NodeId readerGroupIdentifier;
+static UA_NodeId readerIdentifier;
+static UA_DataSetReaderConfig readerConfig;
 
 static void
 addTargetVariable(UA_Server *server) {

--- a/examples/pubsub/server_pubsub_publisher_iop.c
+++ b/examples/pubsub/server_pubsub_publisher_iop.c
@@ -55,7 +55,7 @@ static UA_NodeId ds2DateTimeId;
 static UA_NodeId ds2UInt32ArrId;
 static UA_UInt32 ds2UInt32ArrValue[10] = { 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 };
 
-UA_NodeId connectionIdent;
+static UA_NodeId connectionIdent;
 
 void
 timerCallback(UA_Server *server, void *data);

--- a/examples/pubsub/server_pubsub_publisher_on_demand.c
+++ b/examples/pubsub/server_pubsub_publisher_on_demand.c
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-UA_NodeId connectionIdent, publishedDataSetIdent, writerGroupIdent;
+static UA_NodeId connectionIdent, publishedDataSetIdent, writerGroupIdent;
 
 static void
 addPubSubConnection(UA_Server *server, UA_String *transportProfile,

--- a/examples/pubsub/server_pubsub_subscribe_custom_monitoring.c
+++ b/examples/pubsub/server_pubsub_subscribe_custom_monitoring.c
@@ -13,10 +13,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-UA_NodeId connectionIdentifier;
-UA_NodeId readerGroupIdentifier;
-UA_NodeId readerIdentifier;
-UA_DataSetReaderConfig readerConfig;
+static UA_NodeId connectionIdentifier;
+static UA_NodeId readerGroupIdentifier;
+static UA_NodeId readerIdentifier;
+static UA_DataSetReaderConfig readerConfig;
 
 static void
 addPubSubConnection(UA_Server *server, UA_String *transportProfile,

--- a/examples/pubsub/tutorial_pubsub_publish.c
+++ b/examples/pubsub/tutorial_pubsub_publish.c
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-UA_NodeId connectionIdent, publishedDataSetIdent, writerGroupIdent,
+static UA_NodeId connectionIdent, publishedDataSetIdent, writerGroupIdent,
     dataSetWriterIdent;
 
 static void

--- a/examples/pubsub/tutorial_pubsub_subscribe.c
+++ b/examples/pubsub/tutorial_pubsub_subscribe.c
@@ -22,11 +22,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-UA_NodeId connectionIdentifier;
-UA_NodeId readerGroupIdentifier;
-UA_NodeId readerIdentifier;
+static UA_NodeId connectionIdentifier;
+static UA_NodeId readerGroupIdentifier;
+static UA_NodeId readerIdentifier;
 
-UA_DataSetReaderConfig readerConfig;
+static UA_DataSetReaderConfig readerConfig;
 
 static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData);
 

--- a/examples/pubsub_realtime/server_pubsub_publish_rt_offsets.c
+++ b/examples/pubsub_realtime/server_pubsub_publish_rt_offsets.c
@@ -13,9 +13,9 @@ static UA_NodeId publishedDataSetIdent, dataSetFieldIdent, writerGroupIdent, con
 
 /* Values in static locations. We cycle the dvPointers double-pointer to the
  * next with atomic operations. */
-UA_UInt32 valueStore[PUBSUB_CONFIG_FIELD_COUNT];
-UA_DataValue dvStore[PUBSUB_CONFIG_FIELD_COUNT];
-UA_NodeId publishVariables[PUBSUB_CONFIG_FIELD_COUNT];
+static UA_UInt32 valueStore[PUBSUB_CONFIG_FIELD_COUNT];
+static UA_DataValue dvStore[PUBSUB_CONFIG_FIELD_COUNT];
+static UA_NodeId publishVariables[PUBSUB_CONFIG_FIELD_COUNT];
 
 static UA_StatusCode
 readCallback(UA_Server *server, const UA_NodeId *sessionId,

--- a/examples/pubsub_realtime/server_pubsub_publish_rt_state_machine.c
+++ b/examples/pubsub_realtime/server_pubsub_publish_rt_state_machine.c
@@ -37,9 +37,9 @@ static UA_NodeId publishedDataSetIdent, dataSetFieldIdent, writerGroupIdent, con
 
 /* Values in static locations. We cycle the dvPointers double-pointer to the
  * next with atomic operations. */
-UA_UInt32 valueStore[PUBSUB_CONFIG_FIELD_COUNT];
-UA_DataValue dvStore[PUBSUB_CONFIG_FIELD_COUNT];
-UA_NodeId publishVariables[PUBSUB_CONFIG_FIELD_COUNT];
+static UA_UInt32 valueStore[PUBSUB_CONFIG_FIELD_COUNT];
+static UA_DataValue dvStore[PUBSUB_CONFIG_FIELD_COUNT];
+static UA_NodeId publishVariables[PUBSUB_CONFIG_FIELD_COUNT];
 
 static UA_StatusCode
 readCallback(UA_Server *server, const UA_NodeId *sessionId,

--- a/examples/pubsub_realtime/server_pubsub_subscribe_rt_offsets.c
+++ b/examples/pubsub_realtime/server_pubsub_subscribe_rt_offsets.c
@@ -27,9 +27,9 @@ static UA_String transportProfile =
  * the buffered NetworkMessage will only be updated.
  */
 
-UA_Server *server;
-UA_DataSetReaderConfig readerConfig;
-UA_NodeId connectionIdentifier, readerGroupIdentifier, readerIdentifier;
+static UA_Server *server;
+static UA_DataSetReaderConfig readerConfig;
+static UA_NodeId connectionIdentifier, readerGroupIdentifier, readerIdentifier;
 
 /* Add new connection to the server */
 static void

--- a/examples/pubsub_realtime/server_pubsub_subscribe_rt_state_machine.c
+++ b/examples/pubsub_realtime/server_pubsub_subscribe_rt_state_machine.c
@@ -40,15 +40,15 @@ static UA_String transportProfile =
  * the buffered NetworkMessage will only be updated.
  */
 
-UA_NodeId connectionIdentifier;
-UA_NodeId readerGroupIdentifier;
-UA_NodeId readerIdentifier;
+static UA_NodeId connectionIdentifier;
+static UA_NodeId readerGroupIdentifier;
+static UA_NodeId readerIdentifier;
 
-UA_Server *server;
-pthread_t listenThread;
-int listenSocket;
+static UA_Server *server;
+static pthread_t listenThread;
+static int listenSocket;
 
-UA_DataSetReaderConfig readerConfig;
+static UA_DataSetReaderConfig readerConfig;
 
 static void *
 listenUDP(void *_) {

--- a/examples/server_instantiation.c
+++ b/examples/server_instantiation.c
@@ -8,7 +8,7 @@
 #include <signal.h>
 #include <stdlib.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void stopHandler(int sig) {
     running = false;
 }

--- a/examples/server_loglevel.c
+++ b/examples/server_loglevel.c
@@ -12,7 +12,7 @@
 #include <getopt.h>
 #endif
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void stopHandler(int sig) {
     running = false;
 }

--- a/examples/server_mainloop.c
+++ b/examples/server_mainloop.c
@@ -8,7 +8,7 @@
 
 #include <signal.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
     running = false;

--- a/examples/server_repeated_job.c
+++ b/examples/server_repeated_job.c
@@ -13,7 +13,7 @@ testCallback(UA_Server *server, void *data) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND, "testcallback");
 }
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");
     running = false;

--- a/examples/tutorial_client_events.c
+++ b/examples/tutorial_client_events.c
@@ -64,7 +64,7 @@ handler_events(UA_Client *client, UA_UInt32 subId, void *subContext,
     }
 }
 
-const size_t nSelectClauses = 2;
+static const size_t nSelectClauses = 2;
 
 static UA_SimpleAttributeOperand *
 setupSelectClauses(void) {

--- a/examples/tutorial_server_object.c
+++ b/examples/tutorial_server_object.c
@@ -159,7 +159,7 @@ manuallyDefinePump(UA_Server *server) {
  * to an object that representes the `mandatory` modelling rule. */
 
 /* predefined identifier for later use */
-UA_NodeId pumpTypeId = {1, UA_NODEIDTYPE_NUMERIC, {1001}};
+static UA_NodeId pumpTypeId = {1, UA_NODEIDTYPE_NUMERIC, {1001}};
 
 static void
 defineObjectTypes(UA_Server *server) {

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -29,9 +29,9 @@ typedef struct {
 #define ANONYMOUS_POLICY "open62541-anonymous-policy"
 #define CERTIFICATE_POLICY "open62541-certificate-policy"
 #define USERNAME_POLICY "open62541-username-policy"
-const UA_String anonymous_policy = UA_STRING_STATIC(ANONYMOUS_POLICY);
-const UA_String certificate_policy = UA_STRING_STATIC(CERTIFICATE_POLICY);
-const UA_String username_policy = UA_STRING_STATIC(USERNAME_POLICY);
+static const UA_String anonymous_policy = UA_STRING_STATIC(ANONYMOUS_POLICY);
+static const UA_String certificate_policy = UA_STRING_STATIC(CERTIFICATE_POLICY);
+static const UA_String username_policy = UA_STRING_STATIC(USERNAME_POLICY);
 
 /************************/
 /* Access Control Logic */

--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -156,8 +156,8 @@ PARSE_JSON(LocalizedTextField) {
      */
     cj5_token tok = ctx->tokens[++ctx->index];
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    UA_String locale;
-    UA_String text;
+    UA_String locale = {.length = 0, .data = NULL};
+    UA_String text = {.length = 0, .data = NULL};
     for(size_t j = tok.size/2; j > 0; j--) {
         tok = ctx->tokens[++ctx->index];
         switch (tok.type) {

--- a/plugins/ua_log_stdout.c
+++ b/plugins/ua_log_stdout.c
@@ -47,7 +47,7 @@ logCategoryNames[UA_LOGCATEGORIES] =
 /* Protect crosstalk during logging via global lock. Use a spinlock as we cannot
  * statically initialize a global lock across all platforms. */
 #if UA_MULTITHREADING >= 100
-void *logSpinLock = NULL;
+static void *logSpinLock = NULL;
 static UA_INLINE void spinLock(void) {
     while(UA_atomic_cmpxchg(&logSpinLock, NULL, (void*)0x1) != NULL) {}
 }

--- a/plugins/ua_log_syslog.c
+++ b/plugins/ua_log_syslog.c
@@ -13,9 +13,9 @@
 #include <stdio.h>
 #include "mp_printf.h"
 
-const char *syslogLevelNames[6] = {"trace", "debug", "info",
+static const char *syslogLevelNames[6] = {"trace", "debug", "info",
                                    "warn", "error", "fatal"};
-const char *syslogCategoryNames[UA_LOGCATEGORIES] =
+static const char *syslogCategoryNames[UA_LOGCATEGORIES] =
     {"network", "channel", "session", "server", "client",
      "userland", "security", "eventloop", "pubsub", "discovery"};
 

--- a/src/pubsub/ua_pubsub_networkmessage_binary.c
+++ b/src/pubsub/ua_pubsub_networkmessage_binary.c
@@ -1360,7 +1360,7 @@ UA_DataSetMessage_keyFrame_encodeBinary(PubSubEncodeCtx *ctx,
         return UA_STATUSCODE_GOOD;
 
     /* Part 14: The FieldCount shall be omitted if RawData field encoding is set */
-    UA_StatusCode rv;
+    UA_StatusCode rv = UA_STATUSCODE_BADINTERNALERROR;
     if(src->header.fieldEncoding != UA_FIELDENCODING_RAWDATA) {
         rv = _ENCODE_BINARY(&src->fieldCount, UINT16);
         UA_CHECK_STATUS(rv, return rv);

--- a/src/pubsub/ua_pubsub_networkmessage_json.c
+++ b/src/pubsub/ua_pubsub_networkmessage_json.c
@@ -12,20 +12,19 @@
 #include "../ua_types_encoding_json.h"
 
 /* Json keys for dsm */
-const char * UA_DECODEKEY_MESSAGES = "Messages";
-const char * UA_DECODEKEY_MESSAGETYPE = "MessageType";
-const char * UA_DECODEKEY_MESSAGEID = "MessageId";
-const char * UA_DECODEKEY_PUBLISHERID = "PublisherId";
-const char * UA_DECODEKEY_DATASETCLASSID = "DataSetClassId";
+static const char * UA_DECODEKEY_MESSAGES = "Messages";
+static const char * UA_DECODEKEY_MESSAGETYPE = "MessageType";
+static const char * UA_DECODEKEY_MESSAGEID = "MessageId";
+static const char * UA_DECODEKEY_PUBLISHERID = "PublisherId";
+static const char * UA_DECODEKEY_DATASETCLASSID = "DataSetClassId";
 
 /* Json keys for dsm */
-const char * UA_DECODEKEY_DATASETWRITERID = "DataSetWriterId";
-const char * UA_DECODEKEY_SEQUENCENUMBER = "SequenceNumber";
-const char * UA_DECODEKEY_METADATAVERSION = "MetaDataVersion";
-const char * UA_DECODEKEY_TIMESTAMP = "Timestamp";
-const char * UA_DECODEKEY_DSM_STATUS = "Status";
-const char * UA_DECODEKEY_PAYLOAD = "Payload";
-const char * UA_DECODEKEY_DS_TYPE = "Type";
+static const char * UA_DECODEKEY_DATASETWRITERID = "DataSetWriterId";
+static const char * UA_DECODEKEY_SEQUENCENUMBER = "SequenceNumber";
+static const char * UA_DECODEKEY_METADATAVERSION = "MetaDataVersion";
+static const char * UA_DECODEKEY_TIMESTAMP = "Timestamp";
+static const char * UA_DECODEKEY_DSM_STATUS = "Status";
+static const char * UA_DECODEKEY_PAYLOAD = "Payload";
 
 /* -- json encoding/decoding -- */
 static UA_StatusCode writeJsonKey_UA_String(CtxJson *ctx, const UA_String *in) {

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -21,8 +21,6 @@
 #include "ua_pubsub_keystorage.h"
 #endif
 
-#define UA_MAX_STACKBUF 128 /* Max size of network messages on the stack */
-
 static UA_StatusCode
 encryptAndSign(UA_WriterGroup *wg, const UA_NetworkMessage *nm,
                UA_Byte *signStart, UA_Byte *encryptStart,

--- a/src/server/ua_discovery_mdns.c
+++ b/src/server/ua_discovery_mdns.c
@@ -968,10 +968,6 @@ addMdnsRecordForNetworkLayer(UA_DiscoveryManager *dm, const UA_String serverName
     return UA_STATUSCODE_GOOD;
 }
 
-#ifndef IN_ZERONET
-#define IN_ZERONET(addr) ((addr & IN_CLASSA_NET) == 0)
-#endif
-
 /* Create multicast 224.0.0.251:5353 socket */
 static void
 discovery_createMulticastSocket(UA_DiscoveryManager *dm) {

--- a/src/server/ua_discovery_mdns_avahi.c
+++ b/src/server/ua_discovery_mdns_avahi.c
@@ -414,10 +414,6 @@ addMdnsRecordForNetworkLayer(UA_DiscoveryManager *dm, const UA_String serverName
     return UA_STATUSCODE_GOOD;
 }
 
-#ifndef IN_ZERONET
-#define IN_ZERONET(addr) ((addr & IN_CLASSA_NET) == 0)
-#endif
-
 /* Callback when the client state changes */
 static
 void client_callback(AvahiClient *c, AvahiClientState state, void *userdata) {

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -279,10 +279,6 @@ UA_Server_editNode(UA_Server *server, UA_Session *session, const UA_NodeId *node
     return retval;
 }
 
-/* A few global NodeId definitions */
-const UA_NodeId subtypeId = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASSUBTYPE}};
-const UA_NodeId hierarchicalReferences = {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HIERARCHICALREFERENCES}};
-
 /*********************************/
 /* Default attribute definitions */
 /*********************************/

--- a/src/server/ua_services.c
+++ b/src/server/ua_services.c
@@ -39,7 +39,7 @@ UA_NodeId unsafe_fuzz_authenticationToken = {0, UA_NODEIDTYPE_NUMERIC, {0}};
 # define UA_SERVICECOUNTER_OFFSET(X, requiresSession) requiresSession
 #endif
 
-UA_ServiceDescription serviceDescriptions[] = {
+static UA_ServiceDescription serviceDescriptions[] = {
     {UA_NS0ID_GETENDPOINTSREQUEST_ENCODING_DEFAULTBINARY,
      UA_SERVICECOUNTER_OFFSET_NONE(false), (UA_Service)Service_GetEndpoints,
      &UA_TYPES[UA_TYPES_GETENDPOINTSREQUEST], &UA_TYPES[UA_TYPES_GETENDPOINTSRESPONSE]},

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1091,10 +1091,10 @@ compatibleValueArrayDimensions(const UA_Variant *value, size_t targetArrayDimens
                                      valueArrayDimensionsSize, valueArrayDimensions);
 }
 
-const char *reason_EmptyType = "Empty value only allowed for BaseDataType";
-const char *reason_ValueDataType = "DataType of the value is incompatible";
-const char *reason_ValueArrayDimensions = "ArrayDimensions of the value are incompatible";
-const char *reason_ValueValueRank = "ValueRank of the value is incompatible";
+static const char *reason_EmptyType = "Empty value only allowed for BaseDataType";
+static const char *reason_ValueDataType = "DataType of the value is incompatible";
+static const char *reason_ValueArrayDimensions = "ArrayDimensions of the value are incompatible";
+static const char *reason_ValueValueRank = "ValueRank of the value is incompatible";
 
 UA_Boolean
 compatibleValue(UA_Server *server, UA_Session *session, const UA_NodeId *targetDataTypeId,

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -311,7 +311,7 @@ getDefaultEncryptedSecurityPolicy(UA_Server *server) {
     return NULL; /* No encrypted policy found */
 }
 
-const char *securityModeStrs[4] = {"-invalid", "-none", "-sign", "-sign+encrypt"};
+static const char *securityModeStrs[4] = {"-invalid", "-none", "-sign", "-sign+encrypt"};
 
 UA_String
 securityPolicyUriPostfix(const UA_String uri) {

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -92,7 +92,7 @@ checkSetIsDynamicVariable(UA_Server *server, UA_Session *session,
 
 #define UA_PARENT_REFERENCES_COUNT 2
 
-const UA_NodeId parentReferences[UA_PARENT_REFERENCES_COUNT] = {
+static const UA_NodeId parentReferences[UA_PARENT_REFERENCES_COUNT] = {
     {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASSUBTYPE}},
     {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASCOMPONENT}}
 };

--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -26,7 +26,7 @@
 #include "../../deps/parse_num.h"
 #include "../../deps/libc_time.h"
 
-const char * attributeIdNames[28] = {
+static const char * attributeIdNames[28] = {
     "Invalid", "NodeId", "NodeClass", "BrowseName", "DisplayName", "Description",
     "WriteMask", "UserWriteMask", "IsAbstract", "Symmetric", "InverseName",
     "ContainsNoLoops", "EventNotifier", "Value", "DataType", "ValueRank",

--- a/tests/check_chunking.c
+++ b/tests/check_chunking.c
@@ -10,10 +10,10 @@
 #include <stdlib.h>
 #include <check.h>
 
-UA_ByteString *buffers;
-size_t bufIndex;
-size_t counter;
-size_t dataCount;
+static UA_ByteString *buffers;
+static size_t bufIndex;
+static size_t counter;
+static size_t dataCount;
 
 static UA_StatusCode
 sendChunkMockUp(void *_, UA_Byte **bufPos, const UA_Byte **bufEnd) {

--- a/tests/check_eventloop.c
+++ b/tests/check_eventloop.c
@@ -12,8 +12,8 @@
 
 #define N_EVENTS 10000
 
-UA_EventLoop *el;
-size_t count = 0;
+static UA_EventLoop *el;
+static size_t count = 0;
 
 static void
 timerCallback(void *application, void *data) {

--- a/tests/check_eventloop_interrupt.c
+++ b/tests/check_eventloop_interrupt.c
@@ -19,7 +19,7 @@
 #define TESTSIG SIGINT
 #endif
 
-unsigned counter = 0;
+static unsigned counter = 0;
 
 static void
 interruptCallback(UA_InterruptManager *im,

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -28,11 +28,11 @@
 #define DEFAULT_ASYM_REMOTE_PLAINTEXT_BLOCKSIZE 256
 #define DEFAULT_ASYM_REMOTE_BLOCKSIZE 256
 
-UA_SecureChannel testChannel;
-UA_ByteString dummyCertificate =
+static UA_SecureChannel testChannel;
+static UA_ByteString dummyCertificate =
     UA_BYTESTRING_STATIC("DUMMY CERTIFICATE DUMMY CERTIFICATE DUMMY CERTIFICATE");
-UA_SecurityPolicy dummyPolicy;
-UA_ByteString sentData;
+static UA_SecurityPolicy dummyPolicy;
+static UA_ByteString sentData;
 
 static funcs_called fCalled;
 static key_sizes keySizes;
@@ -236,7 +236,7 @@ START_TEST(SecureChannel_sendAsymmetricOPNMessage_sentDataIsValid) {
     UA_SequenceHeader sequenceHeader;
     retval = UA_decodeBinaryInternal(&sentData, &offset, &sequenceHeader, &UA_TRANSPORT[UA_TRANSPORT_SEQUENCEHEADER], NULL);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_msg(sequenceHeader.requestId == requestId, "Expected requestId to be %i but was %i",
+    ck_assert_msg(sequenceHeader.requestId == requestId, "Expected requestId to be %u but was %u",
                   requestId,
                   sequenceHeader.requestId);
 
@@ -311,7 +311,7 @@ START_TEST(Securechannel_sendAsymmetricOPNMessage_extraPaddingPresentWhenKeyLarg
     UA_SequenceHeader sequenceHeader;
     retval = UA_decodeBinaryInternal(&sentData, &offset, &sequenceHeader, &UA_TRANSPORT[UA_TRANSPORT_SEQUENCEHEADER], NULL);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    ck_assert_msg(sequenceHeader.requestId == requestId, "Expected requestId to be %i but was %i",
+    ck_assert_msg(sequenceHeader.requestId == requestId, "Expected requestId to be %u but was %u",
                   requestId, sequenceHeader.requestId);
 
     UA_NodeId requestTypeId;

--- a/tests/check_timer.c
+++ b/tests/check_timer.c
@@ -11,7 +11,7 @@
 
 #define N_EVENTS 10000
 
-size_t count = 0;
+static size_t count = 0;
 
 static void
 timerCallback(void *application, void *data) {

--- a/tests/check_types_custom.c
+++ b/tests/check_types_custom.c
@@ -78,7 +78,7 @@ static const UA_DataType PointType = {
     members
 };
 
-const UA_DataTypeArray customDataTypes = {NULL, 1, &PointType, UA_FALSE};
+static const UA_DataTypeArray customDataTypes = {NULL, 1, &PointType, UA_FALSE};
 
 typedef struct {
     UA_Int16 a;
@@ -138,7 +138,7 @@ static const UA_DataType OptType = {
         Opt_members
 };
 
-const UA_DataTypeArray customDataTypesOptStruct = {&customDataTypes, 2, &OptType, UA_FALSE};
+static const UA_DataTypeArray customDataTypesOptStruct = {&customDataTypes, 2, &OptType, UA_FALSE};
 
 typedef struct {
     UA_String description;
@@ -197,7 +197,7 @@ static const UA_DataType ArrayOptType = {
     ArrayOptStruct_members
 };
 
-const UA_DataTypeArray customDataTypesOptArrayStruct = {&customDataTypesOptStruct, 3, &ArrayOptType, UA_FALSE};
+static const UA_DataTypeArray customDataTypesOptArrayStruct = {&customDataTypesOptStruct, 3, &ArrayOptType, UA_FALSE};
 
 typedef enum {UA_UNISWITCH_NONE = 0, UA_UNISWITCH_OPTIONA = 1, UA_UNISWITCH_OPTIONB = 2} UA_UniSwitch;
 
@@ -239,7 +239,7 @@ static const UA_DataType UniType = {
         Uni_members
 };
 
-const UA_DataTypeArray customDataTypesUnion = {&customDataTypesOptArrayStruct, 2, &UniType, UA_FALSE};
+static const UA_DataTypeArray customDataTypesUnion = {&customDataTypesOptArrayStruct, 2, &UniType, UA_FALSE};
 
 typedef enum {
     UA_SELFCONTAININGUNIONSWITCH_NONE = 0,
@@ -291,7 +291,7 @@ const UA_DataType selfContainingUnionType = {
     SelfContainingUnion_members  /* .members */
 };
 
-const UA_DataTypeArray customDataTypesSelfContainingUnion = {NULL, 1, &selfContainingUnionType, UA_FALSE};
+static const UA_DataTypeArray customDataTypesSelfContainingUnion = {NULL, 1, &selfContainingUnionType, UA_FALSE};
 
 START_TEST(parseCustomScalar) {
     Point p;

--- a/tests/check_types_memory.c
+++ b/tests/check_types_memory.c
@@ -72,7 +72,7 @@ START_TEST(encodeShallYieldDecode) {
     void *obj2 = UA_new(&UA_TYPES[_i]);
     size_t offset = 0;
     retval = UA_decodeBinaryInternal(&msg1, &offset, obj2, &UA_TYPES[_i], NULL);
-    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "could not decode idx=%d,nodeid=%i",
+    ck_assert_msg(retval == UA_STATUSCODE_GOOD, "could not decode idx=%d,nodeid=%u",
                   _i, UA_TYPES[_i].typeId.identifier.numeric);
     ck_assert(!memcmp(obj1, obj2, UA_TYPES[_i].memSize)); // bit identical decoding
     retval = UA_ByteString_allocBuffer(&msg2, 65000);
@@ -86,7 +86,7 @@ START_TEST(encodeShallYieldDecode) {
     msg1.length = offset;
     msg2.length = offset;
     ck_assert_msg(UA_ByteString_equal(&msg1, &msg2) == true,
-                  "messages differ idx=%d,nodeid=%i", _i,
+                  "messages differ idx=%d,nodeid=%u", _i,
                   UA_TYPES[_i].typeId.identifier.numeric);
     ck_assert(UA_order(obj1, obj2, &UA_TYPES[_i]) == UA_ORDER_EQ);
 
@@ -163,7 +163,7 @@ START_TEST(decodeScalarBasicTypeFromRandomBufferShallSucceed) {
         (void)retval;
         //then
         ck_assert_msg(retval == UA_STATUSCODE_GOOD,
-                      "Decoding %d from random buffer",
+                      "Decoding %u from random buffer",
                       UA_TYPES[_i].typeId.identifier.numeric);
         // finally
         UA_delete(obj1, &UA_TYPES[_i]);

--- a/tests/pubsub/check_pubsub_publish_json.c
+++ b/tests/pubsub/check_pubsub_publish_json.c
@@ -15,8 +15,8 @@
 #include <check.h>
 #include <stdlib.h>
 
-UA_Server *server = NULL;
-UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
+static UA_Server *server = NULL;
+static UA_NodeId connection1, writerGroup1, publishedDataSet1, dataSetWriter1;
 
 static void setup(void) {
     server = UA_Server_newForUnitTest();

--- a/tests/server/check_accesscontrol.c
+++ b/tests/server/check_accesscontrol.c
@@ -15,9 +15,9 @@
 #include "test_helpers.h"
 #include "thread_wrapper.h"
 
-UA_Server *server;
-UA_Boolean running;
-THREAD_HANDLE server_thread;
+static UA_Server *server;
+static UA_Boolean running;
+static THREAD_HANDLE server_thread;
 
 static const size_t usernamePasswordsSize = 2;
 static UA_UsernamePasswordLogin usernamePasswords[2] = {

--- a/tests/server/check_services_view.c
+++ b/tests/server/check_services_view.c
@@ -16,9 +16,9 @@
 #include "test_helpers.h"
 #include "thread_wrapper.h"
 
-UA_Server *server_translate_browse;
-UA_Boolean *running_translate_browse;
-THREAD_HANDLE server_thread_translate_browse;
+static UA_Server *server_translate_browse;
+static UA_Boolean *running_translate_browse;
+static THREAD_HANDLE server_thread_translate_browse;
 
 THREAD_CALLBACK(serverloop_register) {
     while (*running_translate_browse)

--- a/tests/server/check_subscription_event_filter.c
+++ b/tests/server/check_subscription_event_filter.c
@@ -651,7 +651,7 @@ START_TEST(ofTypeOperatorValidation_failure) {
     UA_Variant literalContent;
     UA_NodeId *nodeId = UA_NodeId_new();
     UA_NodeId_init(nodeId);
-    *nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+    *nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE);
     UA_Variant_setScalar(&literalContent, nodeId, &UA_TYPES[UA_TYPES_NODEID]);
     setupLiteralOperand(&filter.whereClause.elements[0], 1, &literalContent);
 

--- a/tools/ua-cli/ua.c
+++ b/tools/ua-cli/ua.c
@@ -24,10 +24,10 @@ static char *password = NULL;
 static UA_ByteString certificate;
 static UA_ByteString privateKey;
 static UA_ByteString securityPolicyUri;
-int return_value = 0;
+static int return_value = 0;
 
 /* Custom logger that prints to stderr. So the "good output" can be easily separated. */
-UA_LogLevel logLevel = UA_LOGLEVEL_ERROR;
+static UA_LogLevel logLevel = UA_LOGLEVEL_ERROR;
 
 /* ANSI escape sequences for color output taken from here:
  * https://stackoverflow.com/questions/3219393/stdlib-and-colored-output-in-c*/
@@ -72,7 +72,7 @@ cliLog(void *context, UA_LogLevel level, UA_LogCategory category,
     fflush(stderr);
 }
 
-UA_Logger stderrLog = {cliLog, NULL, NULL};
+static UA_Logger stderrLog = {cliLog, NULL, NULL};
 
 static void
 usage(void) {
@@ -521,7 +521,7 @@ exploreRecursive(char *pathString, size_t pos, const UA_NodeId current,
         if(!UA_ExpandedNodeId_isLocal(&rd->nodeId))
             continue;
         char browseName[80];
-        int len = snprintf(browseName, 80, "%d:%.*s",
+        int len = snprintf(browseName, 80, "%u:%.*s",
                            (unsigned)rd->browseName.namespaceIndex,
                            (int)rd->browseName.name.length,
                            (char*)rd->browseName.name.data);
@@ -530,7 +530,7 @@ exploreRecursive(char *pathString, size_t pos, const UA_NodeId current,
         if(len > 80)
             len = 80;
         memcpy(pathString + pos, "/", 1);
-        memcpy(pathString + pos + 1, browseName, len);
+        memcpy(pathString + pos + 1, browseName, (size_t)len);
         exploreRecursive(pathString, pos + 1 + (size_t)len, rd->nodeId.nodeId, rd->nodeClass, depth-1);
     }
 


### PR DESCRIPTION
Fix some clang compiler warnings about:
- unused macros
- sign conversions
- adding "static" modifier
- printf formatting