### PR TITLE
Fix json encoding problem when compiling as Release

### DIFF
--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -170,7 +170,7 @@ writeJsonArrElm(CtxJson *ctx, const void *value,
 status
 writeJsonObjElm(CtxJson *ctx, const char *key,
                 const void *value, const UA_DataType *type) {
-    ret = writeJsonKey(ctx, key);
+    status ret = writeJsonKey(ctx, key);
     return ret | encodeJsonJumpTable[type->typeKind](ctx, value, type);
 }
 

--- a/src/ua_types_encoding_json_105.c
+++ b/src/ua_types_encoding_json_105.c
@@ -166,7 +166,8 @@ writeJsonArrElm(CtxJson *ctx, const void *value,
 status
 writeJsonObjElm(CtxJson *ctx, const char *key,
                 const void *value, const UA_DataType *type) {
-    return writeJsonKey(ctx, key) | encodeJsonJumpTable[type->typeKind](ctx, value, type);
+    status ret = writeJsonKey(ctx, key);
+    return ret | encodeJsonJumpTable[type->typeKind](ctx, value, type);
 }
 
 /* Keys for JSON */


### PR DESCRIPTION
Following up the issue #6237 , I applied a fix on both src/ua_types_encoding_json.c and src/ua_types_encoding_json_105.c. Tested it with mqtt pub sub and json encoding, as Debug and as Release.