### PR TITLE
feat: Add pause to historical data gathering

### DIFF
--- a/plugins/historydata/ua_history_data_gathering_default.c
+++ b/plugins/historydata/ua_history_data_gathering_default.c
@@ -16,6 +16,7 @@ typedef struct {
     UA_NodeId nodeId;
     UA_HistorizingNodeIdSettings setting;
     UA_MonitoredItemCreateResult monitoredResult;
+    UA_Boolean paused;
 } UA_NodeIdStoreContextItem_gathering_default;
 
 typedef struct {
@@ -199,6 +200,8 @@ setValue_gathering_default(UA_Server *server,
     if (!item) {
         return;
     }
+    if(item->paused)
+        return;
     if (item->setting.historizingUpdateStrategy == UA_HISTORIZINGUPDATESTRATEGY_VALUESET) {
         item->setting.historizingBackend.serverSetHistoryData(server,
                                                               item->setting.historizingBackend.context,
@@ -256,3 +259,11 @@ UA_HistoryDataGathering_Circular(size_t initialNodeIdStoreSize) {
     gathering.registerNodeId = &registerNodeId_gathering_circular;
     return gathering;
 }
+
+void gathering_default_pauseRecording(UA_HistoryDataGathering *gathering, const UA_NodeId *nodeId, UA_Boolean pause) {
+    UA_NodeIdStoreContext *ctx = (UA_NodeIdStoreContext*)gathering->context;
+    UA_NodeIdStoreContextItem_gathering_default *item = getNodeIdStoreContextItem_gathering_default(ctx, nodeId);
+    if(item)
+        item->paused = pause;
+}
+

--- a/plugins/include/open62541/plugin/historydata/history_data_gathering_default.h
+++ b/plugins/include/open62541/plugin/historydata/history_data_gathering_default.h
@@ -23,6 +23,17 @@ UA_HistoryDataGathering_Default(size_t initialNodeIdStoreSize);
 UA_HistoryDataGathering UA_EXPORT
 UA_HistoryDataGathering_Circular(size_t initialNodeIdStoreSize);
 
+/**
+ * Pauses historical data recording for a specific NodeId.
+ *
+ * @param gathering The history data gathering context.
+ * @param nodeId The NodeId for which recording should be paused or resumed.
+ * @param pause If true, pauses recording; if false, resumes recording.
+ *
+ * When paused, new values for the specified NodeId will not be stored in the historical database,
+ * but existing historical data will remain unaffected.
+ */
+void gathering_default_pauseRecording(UA_HistoryDataGathering *gathering, const UA_NodeId *nodeId, UA_Boolean pause);
 _UA_END_DECLS
 
 #endif /* UA_HISTORYDATAGATHERING_DEFAULT_H_ */


### PR DESCRIPTION
Stopping a node from in memory historizing removes both recording and the ability to read historical data. There is no way to stop recording new values while keeping the existing historical data available for clients.

I propose adding a paused flag to the backend's context. When paused is true, new values are not recorded, but historical reads still work. This is implemented by checking the flag in setValue_gathering_default and providing a function to set the flag.