### PR TITLE
fix(utils): Set defaults first when parsing an empty AttributeOperand…

### DIFF
--- a/src/util/ua_types_lex.c
+++ b/src/util/ua_types_lex.c
@@ -1010,12 +1010,14 @@ UA_RelativePath_parseWithServer(UA_Server *server, UA_RelativePath *rp,
 /* Always uses the percent-escaping */
 static UA_StatusCode
 parseAttributeOperand(UA_AttributeOperand *ao, const UA_String str, UA_NodeId defaultId) {
+    /* Initialize and set the default values */
     UA_AttributeOperand_init(ao);
+    ao->nodeId = defaultId;
+    ao->attributeId = UA_ATTRIBUTEID_VALUE;
+
+    /* Nothing to parse */
     if(str.length == 0)
         return UA_STATUSCODE_GOOD;
-
-    /* Set the default NodeId */
-    ao->nodeId = defaultId;
 
     const u8 *pos = str.data;
     const u8 *end = pos + str.length;
@@ -1162,7 +1164,6 @@ yy65:
         goto cleanup;
 
     /* Parse the AttributeId */
-    ao->attributeId = UA_ATTRIBUTEID_VALUE;
     if(pos < end && *pos == '#') {
         const u8 *attr_pos = ++pos;
         while(pos < end && ((*pos >= 'a' && *pos <= 'z') ||

--- a/src/util/ua_types_lex.re
+++ b/src/util/ua_types_lex.re
@@ -527,12 +527,14 @@ UA_RelativePath_parseWithServer(UA_Server *server, UA_RelativePath *rp,
 /* Always uses the percent-escaping */
 static UA_StatusCode
 parseAttributeOperand(UA_AttributeOperand *ao, const UA_String str, UA_NodeId defaultId) {
+    /* Initialize and set the default values */
     UA_AttributeOperand_init(ao);
+    ao->nodeId = defaultId;
+    ao->attributeId = UA_ATTRIBUTEID_VALUE;
+
+    /* Nothing to parse */
     if(str.length == 0)
         return UA_STATUSCODE_GOOD;
-
-    /* Set the default NodeId */
-    ao->nodeId = defaultId;
 
     const u8 *pos = str.data;
     const u8 *end = pos + str.length;
@@ -570,7 +572,6 @@ parseAttributeOperand(UA_AttributeOperand *ao, const UA_String str, UA_NodeId de
         goto cleanup;
 
     /* Parse the AttributeId */
-    ao->attributeId = UA_ATTRIBUTEID_VALUE;
     if(pos < end && *pos == '#') {
         const u8 *attr_pos = ++pos;
         while(pos < end && ((*pos >= 'a' && *pos <= 'z') ||

--- a/tests/client/check_client_securechannel.c
+++ b/tests/client/check_client_securechannel.c
@@ -224,7 +224,7 @@ END_TEST
  * #None SecureChannels. To be compatible with them, only check if the
  * certificate matches IF it gets sent in th asymHeader of the OPN message. */
 START_TEST(SecureChannel_serverCert) {
-    UA_Client *client = UA_Client_new();
+    UA_Client *client = UA_Client_newForUnitTest();
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));
 
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
@@ -263,7 +263,7 @@ dateTime_nowMonotonicWithOffset(UA_EventLoop *el) {
 
 /* Simulate a deviation between the "wallclock" and the monotonic clock */
 START_TEST(SecureChannel_differentMonotonicClock) {
-    UA_Client *client = UA_Client_new();
+    UA_Client *client = UA_Client_newForUnitTest();
     UA_ClientConfig_setDefault(UA_Client_getConfig(client));
 
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");

--- a/tests/encryption/check_crl_validation.c
+++ b/tests/encryption/check_crl_validation.c
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 
+#include "test_helpers.h"
 #include "certificates.h"
 #include "check.h"
 #include "thread_wrapper.h"
@@ -74,7 +75,7 @@ static void setup1(void) {
     revocationList[0] = rootCaCrl;
     revocationList[1] = intermediateCaCrl;
 
-    server = UA_Server_new();
+    server = UA_Server_newForUnitTest();
     ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
@@ -136,7 +137,7 @@ static void setup2(void) {
     revocationList[0] = rootCaCrl;
     revocationList[1] = intermediateCaCrl;
 
-    server = UA_Server_new();
+    server = UA_Server_newForUnitTest();
     ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
@@ -198,7 +199,7 @@ static void setup3(void) {
     revocationList[0] = rootCaCrl;
     revocationList[1] = intermediateCaCrl;
 
-    server = UA_Server_new();
+    server = UA_Server_newForUnitTest();
     ck_assert(server != NULL);
     UA_ServerConfig *config = UA_Server_getConfig(server);
     UA_ServerConfig_setDefaultWithSecurityPolicies(config, 4840, &certificate, &privateKey,
@@ -241,7 +242,7 @@ START_TEST(encryption_connect_valid) {
     size_t revocationListSize = 0;
 
     /* Secure client initialization */
-    UA_Client *client = UA_Client_new();
+    UA_Client *client = UA_Client_newForUnitTest();
     UA_ClientConfig *cc = UA_Client_getConfig(client);
     UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
                                          trustList, trustListSize,
@@ -285,7 +286,7 @@ START_TEST(encryption_connect_revoked) {
     size_t revocationListSize = 0;
 
     /* Secure client initialization */
-    UA_Client *client = UA_Client_new();
+    UA_Client *client = UA_Client_newForUnitTest();
     UA_ClientConfig *cc = UA_Client_getConfig(client);
     UA_ClientConfig_setDefaultEncryption(cc, certificate, privateKey,
                                          trustList, trustListSize,

--- a/tests/server/check_server_userspace.c
+++ b/tests/server/check_server_userspace.c
@@ -16,7 +16,7 @@
 #endif
 
 START_TEST(Server_Namespace1_check) {
-    UA_Server *server = UA_Server_new();
+    UA_Server *server = UA_Server_newForUnitTest();
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
     const char *namespace1 = "http://namespace1";

--- a/tools/ua-cli/ua.c
+++ b/tools/ua-cli/ua.c
@@ -11,6 +11,7 @@
 #include <open62541/client_config_default.h>
 #include <open62541/plugin/certificategroup_default.h>
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
… encoding

This issue was reported by the UC Berkeley CyberGym Team after an assert triggered in the fuzzing harness.  No security vulnerabilities immediately apparent.