### PR TITLE
Set the parent scope for some open62541 variables

### DIFF
--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -10,8 +10,11 @@ endmacro()
 
 # In a local dev environment, manually set the variables from open62541Config.cmake
 set_default(open62541_TOOLS_DIR "${PROJECT_SOURCE_DIR}/tools")
+set_parent(open62541_TOOLS_DIR)
 set_default(open62541_NS0_NODESETS ${UA_NS0_NODESET_FILES})
+set_parent(open62541_NS0_NODESETS)
 set_default(open62541_SCHEMA_DIR ${UA_SCHEMA_DIR})
+set_parent(open62541_SCHEMA_DIR)
 
 # Set global variables to find targets and sources of dependencies
 function(export_target)


### PR DESCRIPTION
When the stack is added to a CMake project as a dependency using add_subdirectory, some CMake variables are not properly propagated. This PR updates the relevant variables to be set in the parent scope, ensuring they are accessible from the main project's CMake configuration.