### PR TITLE
Resolve missing parent scope warning in CMake with amalgamation enabled

### DIFF
--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -8,13 +8,17 @@ macro(set_parent VAR)
     set(${VAR} "${${VAR}}" PARENT_SCOPE)
 endmacro()
 
+macro(set_cache VAR)
+    set(${VAR} "${${VAR}}" CACHE INTERNAL "")
+endmacro()
+
 # In a local dev environment, manually set the variables from open62541Config.cmake
 set_default(open62541_TOOLS_DIR "${PROJECT_SOURCE_DIR}/tools")
-set_parent(open62541_TOOLS_DIR)
+set_cache(open62541_TOOLS_DIR)
 set_default(open62541_NS0_NODESETS ${UA_NS0_NODESET_FILES})
-set_parent(open62541_NS0_NODESETS)
+set_cache(open62541_NS0_NODESETS)
 set_default(open62541_SCHEMA_DIR ${UA_SCHEMA_DIR})
-set_parent(open62541_SCHEMA_DIR)
+set_cache(open62541_SCHEMA_DIR)
 
 # Set global variables to find targets and sources of dependencies
 function(export_target)


### PR DESCRIPTION
This resolves the CMake warnings that occur when amalgamation is enabled. In this configuration, there is no parent scope available, which leads to warnings during the configuration process.

To address this issue, the variables are not set for the parent scope. Instead, they are defined as internal cache variables. This prevents warnings and ensures that the variables remain available in CMake projects that include the stack via add_subdirectory.