### PR TITLE
fix(server): Fixed issue building with UA_ENABLE_SUBSCRIPTIONS_EVENTS=OFF (#7326)

### DIFF
--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -39,7 +39,9 @@ typedef struct {
     void *context;
     union {
         UA_Server_DataChangeNotificationCallback dataChangeCallback;
+#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
         UA_Server_EventNotificationCallback eventCallback;
+#endif
     } callback;
 
     /* For Event-MonitoredItems only. The value fields are overwritten before

--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -596,6 +596,7 @@ UA_Server_createDataChangeMonitoredItem(UA_Server *server,
     return result;
 }
 
+#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
 UA_MonitoredItemCreateResult
 UA_Server_createEventMonitoredItemEx(UA_Server *server,
                                      const UA_MonitoredItemCreateRequest item,
@@ -695,6 +696,7 @@ UA_Server_createEventMonitoredItem(UA_Server *server, const UA_NodeId nodeId,
                                 &UA_TYPES[UA_TYPES_EVENTFILTER]);
     return UA_Server_createEventMonitoredItemEx(server, item, monitoredItemContext, callback);
 }
+#endif
 
 static void
 Operation_ModifyMonitoredItem(UA_Server *server, UA_Session *session, UA_Subscription *sub,


### PR DESCRIPTION
Fixed (#7326). Issue seemed to be that struct callback would attempt to include UA_Server_EventNotificationCallback in a union when it was not defined. Additionally, headers for both UA_Server_createEventMonitoredItem and UA_Server_createEventMonitoredItemEx had correct preprocessor dirrectives, buyt function implementation did not, causing another compilation error.