### PR TITLE
Change VLAN tag format according to the IEEE 802.1Q standard

### DIFF
--- a/arch/posix/eventloop_posix_eth.c
+++ b/arch/posix/eventloop_posix_eth.c
@@ -191,7 +191,7 @@ setETHHeader(unsigned char *buf,
     if(vid > 0 && vid != ETH_P_ALL) {
         *(UA_UInt16*)&buf[pos] = htons(0x8100);
         pos += 2;
-        UA_UInt16 vlan = (UA_UInt16)((UA_UInt16)pcp + (((UA_UInt16)dei) << 3) + (vid << 4));
+        UA_UInt16 vlan = (UA_UInt16)(((UA_UInt16)pcp << 13) | (dei << 12) | vid);
         *(UA_UInt16*)&buf[pos] = htons(vlan);
         pos += 2;
     }


### PR DESCRIPTION
This pull request addresses [issue #7336](https://github.com/open62541/open62541/issues/7336) by correcting the bit order of the PCP, DEI, and VID fields in the VLAN tag to match the IEEE 802.1Q standard.