### PR TITLE
feat(server): Add infrastructure for DeleteEventDetails handling

### DIFF
--- a/include/open62541/plugin/historydatabase.h
+++ b/include/open62541/plugin/historydatabase.h
@@ -178,6 +178,17 @@ struct UA_HistoryDatabase {
                          const UA_DeleteRawModifiedDetails *details,
                          UA_HistoryUpdateResult *result);
 
+    /* No default implementation is provided by UA_HistoryDatabase_default
+     * for the following function */
+    void
+    (*deleteEvent)(UA_Server *server,
+                   void *hdbContext,
+                   const UA_NodeId *sessionId,
+                   void *sessionContext,
+                   const UA_RequestHeader *requestHeader,
+                   const UA_DeleteEventDetails *details,
+                   UA_HistoryUpdateResult *result);
+
     /* Add more function pointer here.
      * For example for read_event, read_annotation, update_details */
 };

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -2271,6 +2271,20 @@ Service_HistoryUpdate(UA_Server *server, UA_Session *session,
             continue;
         }
 
+        if(updateDetailsType == &UA_TYPES[UA_TYPES_DELETEEVENTDETAILS]) {
+            if(!server->config.historyDatabase.deleteEvent) {
+                response->results[i].statusCode = UA_STATUSCODE_BADNOTSUPPORTED;
+                continue;
+            }
+            server->config.historyDatabase.
+                deleteEvent(server, server->config.historyDatabase.context,
+                            &session->sessionId, session->context,
+                            &request->requestHeader,
+                            (UA_DeleteEventDetails*)updateDetailsData,
+                            &response->results[i]);
+            continue;
+        }
+
         response->results[i].statusCode = UA_STATUSCODE_BADNOTSUPPORTED;
     }
 


### PR DESCRIPTION
This commit extends UA_HistoryDatabase with a deleteEvent() function pointer and ties it into Service_HistoryUpdate().