### PR TITLE
refactor(examples,tools,server,plugins): clang compiler warnings

### DIFF
--- a/arch/posix/eventloop_posix.h
+++ b/arch/posix/eventloop_posix.h
@@ -108,7 +108,7 @@ typedef SSIZE_T ssize_t;
 
 #endif
 
-#define UA_LOG_SOCKET_ERRNO_WRAP(LOG) { \
+#define UA_LOG_SOCKET_ERRNO_WRAP(LOG) do { \
     char *errno_str = NULL; \
     FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, \
     NULL, WSAGetLastError(), \
@@ -116,7 +116,7 @@ typedef SSIZE_T ssize_t;
     (LPSTR)&errno_str, 0, NULL); \
     LOG; \
     LocalFree(errno_str); \
-}
+} while (0)
 #define UA_LOG_SOCKET_ERRNO_GAI_WRAP UA_LOG_SOCKET_ERRNO_WRAP
 
 /* Fix redefinition of SLIST_ENTRY on mingw winnt.h */
@@ -250,9 +250,9 @@ typedef int SOCKET;
 #define UA_clean_errno(STR_FUN) \
     (errno == 0 ? (char*) "None" : (STR_FUN)(errno))
 #define UA_LOG_SOCKET_ERRNO_WRAP(LOG) \
-    { char *errno_str = UA_clean_errno(strerror); LOG; errno = 0; }
+    do { char *errno_str = UA_clean_errno(strerror); LOG; errno = 0; } while (0)
 #define UA_LOG_SOCKET_ERRNO_GAI_WRAP(LOG) \
-    { const char *errno_str = UA_clean_errno(gai_strerror); LOG; errno = 0; }
+    do { const char *errno_str = UA_clean_errno(gai_strerror); LOG; errno = 0; } while (0)
 
 /* epoll_pwait returns bogus data with the tc compiler */
 #if defined(__linux__) && !defined(__TINYC__)

--- a/arch/posix/eventloop_posix_eth.c
+++ b/arch/posix/eventloop_posix_eth.c
@@ -337,7 +337,7 @@ ETH_connectionSocketCallback(UA_ConnectionManager *cm, UA_RegisteredFD *rfd,
     }
 
     /* Use the already allocated receive-buffer */
-    UA_ByteString response = pcm->rxBuffer;;
+    UA_ByteString response = pcm->rxBuffer;
 
     /* Receive */
     UA_RESET_ERRNO;

--- a/arch/zephyr/eventloop_zephyr.h
+++ b/arch/zephyr/eventloop_zephyr.h
@@ -81,17 +81,17 @@ typedef struct zsock_pollfd UA_pollfd;
 
 #define UA_clean_errno(STR_FUN) (errno == 0 ? (char *)"None" : (STR_FUN)(errno))
 #define UA_LOG_SOCKET_ERRNO_WRAP(LOG)                                                    \
-    {                                                                                    \
+    do {                                                                                 \
         char *errno_str = UA_clean_errno(strerror);                                      \
         LOG;                                                                             \
         errno = 0;                                                                       \
-    }
+    } while (0)
 #define UA_LOG_SOCKET_ERRNO_GAI_WRAP(LOG)                                                \
-    {                                                                                    \
+    do {                                                                                 \
         const char *errno_str = UA_clean_errno(gai_strerror);                            \
         LOG;                                                                             \
         errno = 0;                                                                       \
-    }
+    } while (0)
 
 /***********************/
 /* General Definitions */

--- a/examples/client_connect_loop.c
+++ b/examples/client_connect_loop.c
@@ -73,7 +73,7 @@ int main(void) {
         }
         UA_Variant_clear(&value);
         sleep_ms(1000);
-    };
+    }
 
     /* Clean up */
     UA_Variant_clear(&value);

--- a/examples/client_subscription_loop.c
+++ b/examples/client_subscription_loop.c
@@ -166,7 +166,7 @@ main(void) {
         }
 
         UA_Client_run_iterate(client, 1000);
-    };
+    }
 
     /* Clean up */
     UA_Client_delete(client); /* Disconnects the client internally */

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -949,7 +949,7 @@ typedef UA_CallbackValueSource UA_DataSource;
 /* Deprecated API */
 typedef UA_ValueSourceNotifications UA_ValueCallback;
 #define UA_Server_setVariableNode_valueCallback(server, nodeId, callback) \
-    UA_Server_setVariableNode_internalValueSource(server, nodeId, NULL, &callback);
+    UA_Server_setVariableNode_internalValueSource(server, nodeId, NULL, &callback)
 
 /**
  * .. _local-monitoreditems:
@@ -1796,7 +1796,7 @@ void UA_EXPORT UA_THREADSAFE
 UA_Server_removeCallback(UA_Server *server, UA_UInt64 callbackId);
 
 #define UA_Server_removeRepeatedCallback(server, callbackId) \
-    UA_Server_removeCallback(server, callbackId);
+    UA_Server_removeCallback(server, callbackId)
 
 /**
  * Update the Server Certificate at Runtime

--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -366,7 +366,7 @@ PARSE_JSON(StringArrayField) {
     UA_String *stringArray = (UA_String*)UA_malloc(sizeof(UA_String) * tok.size);
     size_t stringArraySize = 0;
     for(size_t j = tok.size; j > 0; j--) {
-        UA_String out = {.length = 0, .data = NULL};;
+        UA_String out = {.length = 0, .data = NULL};
         parseJsonJumpTable[UA_SERVERCONFIGFIELD_STRING](ctx, &out, NULL);
         UA_String_copy(&out, &stringArray[stringArraySize++]);
         UA_String_clear(&out);
@@ -394,7 +394,7 @@ PARSE_JSON(UInt32ArrayField) {
         return UA_STATUSCODE_BADARGUMENTSMISSING;
     }
     cj5_token tok = ctx->tokens[++ctx->index];
-    UA_UInt32 *numberArray = (UA_UInt32*)UA_malloc(sizeof(UA_UInt32) * tok.size);;
+    UA_UInt32 *numberArray = (UA_UInt32*)UA_malloc(sizeof(UA_UInt32) * tok.size);
     size_t numberArraySize = 0;
     for(size_t j = tok.size; j > 0; j--) {
         UA_UInt32 value;

--- a/plugins/ua_log_stdout.c
+++ b/plugins/ua_log_stdout.c
@@ -19,17 +19,17 @@
 # define ANSI_COLOR_RED     "\x1b[31m"
 # define ANSI_COLOR_GREEN   "\x1b[32m"
 # define ANSI_COLOR_YELLOW  "\x1b[33m"
-# define ANSI_COLOR_BLUE    "\x1b[34m"
+/* # define ANSI_COLOR_BLUE    "\x1b[34m" */
 # define ANSI_COLOR_MAGENTA "\x1b[35m"
-# define ANSI_COLOR_CYAN    "\x1b[36m"
+/* # define ANSI_COLOR_CYAN    "\x1b[36m" */
 # define ANSI_COLOR_RESET   "\x1b[0m"
 #else
 # define ANSI_COLOR_RED     ""
 # define ANSI_COLOR_GREEN   ""
 # define ANSI_COLOR_YELLOW  ""
-# define ANSI_COLOR_BLUE    ""
+/* # define ANSI_COLOR_BLUE    "" */
 # define ANSI_COLOR_MAGENTA ""
-# define ANSI_COLOR_CYAN    ""
+/* # define ANSI_COLOR_CYAN    "" */
 # define ANSI_COLOR_RESET   ""
 #endif
 

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -142,6 +142,7 @@ UA_Session_dequeuePublishReq(UA_Session *session);
  * string of length zero). */
 
 #define UA_LOG_SESSION_INTERNAL(LOGGER, LEVEL, SESSION, MSG, ...)       \
+    do {                                                                \
     if(UA_LOGLEVEL <= UA_LOGLEVEL_##LEVEL) {                            \
         UA_String sessionName = (SESSION) ? (SESSION)->sessionName: UA_STRING_NULL; \
         unsigned long sockId = ((SESSION) && (SESSION)->channel) ?      \
@@ -150,8 +151,9 @@ UA_Session_dequeuePublishReq(UA_Session *session);
             (SESSION)->channel->securityToken.channelId : 0;            \
         UA_LOG_##LEVEL(LOGGER, UA_LOGCATEGORY_SESSION,                  \
                        "TCP %lu\t| SC %" PRIu32 "\t| Session \"%S\"\t| " MSG "%.0s", \
-                       sockId, chanId, sessionName, __VA_ARGS__);   \
-    }
+                       sockId, chanId, sessionName, __VA_ARGS__);       \
+    }                                                                   \
+    } while (0)
 
 #define UA_LOG_TRACE_SESSION(LOGGER, SESSION, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_SESSION_INTERNAL(LOGGER, TRACE, SESSION, __VA_ARGS__, ""))

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -378,11 +378,12 @@ evaluateWhereClause(UA_Server *server, UA_Session *session, const UA_NodeId *eve
 /***********/
 
 /* Setting an integer value within bounds */
-#define UA_BOUNDEDVALUE_SETWBOUNDS(BOUNDS, SRC, DST) { \
+#define UA_BOUNDEDVALUE_SETWBOUNDS(BOUNDS, SRC, DST)   \
+    do { \
         if(SRC > BOUNDS.max) DST = BOUNDS.max;         \
         else if(SRC < BOUNDS.min) DST = BOUNDS.min;    \
         else DST = SRC;                                \
-    }
+    } while (0)
 
 /* Logging
  * See a description of the tricks used in ua_session.h */

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -366,12 +366,14 @@ UA_Boolean isEccPolicy(const UA_SecurityPolicy* const p);
  * string of length zero). */
 
 #define UA_LOG_CHANNEL_INTERNAL(LOGGER, LEVEL, CHANNEL, MSG, ...)       \
+    do {                                                                \
     if(UA_LOGLEVEL <= UA_LOGLEVEL_##LEVEL) {                            \
         UA_LOG_##LEVEL(LOGGER, UA_LOGCATEGORY_SECURECHANNEL,            \
                        "TCP %lu\t| SC %" PRIu32 "\t| " MSG "%.0s", \
                        (long unsigned)(CHANNEL)->connectionId,          \
                        (CHANNEL)->securityToken.channelId, __VA_ARGS__); \
-    }
+    } \
+    } while (0)
 
 #define UA_LOG_TRACE_CHANNEL(LOGGER, CHANNEL, ...)                      \
     UA_MACRO_EXPAND(UA_LOG_CHANNEL_INTERNAL(LOGGER, TRACE, CHANNEL, __VA_ARGS__, ""))

--- a/src/util/ua_eventfilter_grammar.c
+++ b/src/util/ua_eventfilter_grammar.c
@@ -1052,7 +1052,7 @@ static YYACTIONTYPE yy_reduce(
       /* (24) namedOperandAssignmentList ::= namedOperandAssignment (OPTIMIZED OUT) */ assert(yyruleno!=24);
         break;
 /********** End reduce actions ************************************************/
-  };
+  }
   assert( yyruleno<sizeof(yyRuleInfoLhs)/sizeof(yyRuleInfoLhs[0]) );
   yygoto = yyRuleInfoLhs[yyruleno];
   yysize = yyRuleInfoNRhs[yyruleno];

--- a/tests/check_types_builtin_xml.c
+++ b/tests/check_types_builtin_xml.c
@@ -1406,7 +1406,7 @@ START_TEST(UA_LocalizedText_xml_encode) {
     UA_LocalizedText src;
     UA_LocalizedText_init(&src);
     src.locale = UA_STRING_ALLOC("en");
-    src.text = UA_STRING_ALLOC("enabled");;
+    src.text = UA_STRING_ALLOC("enabled");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_LOCALIZEDTEXT];
     size_t size = UA_calcSizeXml((void*)&src, type, NULL);
 

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -1267,7 +1267,7 @@ createSubscriptionCallback2(UA_Client *client, void *userdata, UA_UInt32 request
     /* Add a MonitoredItem */
     UA_NodeId currentTime =
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME);
-    UA_CreateMonitoredItemsRequest req;;
+    UA_CreateMonitoredItemsRequest req;
     UA_CreateMonitoredItemsRequest_init(&req);
     UA_MonitoredItemCreateRequest monRequest =
         UA_MonitoredItemCreateRequest_default(currentTime);

--- a/tests/server/check_session.c
+++ b/tests/server/check_session.c
@@ -133,7 +133,7 @@ START_TEST(Session_setSessionAttribute_ShallWork) {
     UA_NodeId_copy(&createRes.authenticationToken, &client->authenticationToken);
 
     /* Set an attribute for the session. */
-    UA_QualifiedName key = UA_QUALIFIEDNAME(1, "myAttribute");;
+    UA_QualifiedName key = UA_QUALIFIEDNAME(1, "myAttribute");
     UA_Variant *variant = UA_Variant_new();
     UA_Variant_init(variant);
     status s = UA_Server_setSessionAttribute(server, &createRes.sessionId, key, variant);

--- a/tools/ua-cli/ua.c
+++ b/tools/ua-cli/ua.c
@@ -47,9 +47,9 @@ static UA_LogLevel logLevel = UA_LOGLEVEL_ERROR;
 #define ANSI_COLOR_RED     "\x1b[31m"
 #define ANSI_COLOR_GREEN   "\x1b[32m"
 #define ANSI_COLOR_YELLOW  "\x1b[33m"
-#define ANSI_COLOR_BLUE    "\x1b[34m"
+/* #define ANSI_COLOR_BLUE    "\x1b[34m" */
 #define ANSI_COLOR_MAGENTA "\x1b[35m"
-#define ANSI_COLOR_CYAN    "\x1b[36m"
+/* #define ANSI_COLOR_CYAN    "\x1b[36m" */
 #define ANSI_COLOR_RESET   "\x1b[0m"
 
 static const char *
@@ -101,7 +101,7 @@ abortWithStatus(UA_StatusCode res) {
         UA_Client_disconnect(client);
         UA_Client_delete(client);
     }
-    exit(res);
+    exit((int)res);
 }
 
 static void


### PR DESCRIPTION
Fix some clang compiler warnings about:
- not-needed semicolons
- unused macros
- sign conversion in ua-cli