### PR TITLE
refactor(examples): Deregistration timing, config cleanup, and invalid mDNS IP in server_multicast.c

### DIFF
--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -2,6 +2,7 @@
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
  *
  * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
+ * Copyright 2025 (c) Construction Future Lab gGmbH (Author: Jianbin Liu)
  */
 
 /*
@@ -241,8 +242,11 @@ int main(int argc, char **argv) {
     config->mdnsConfig.mdnsServerName = UA_String_fromChars("Sample-Multicast-Server");
 
 #ifdef UA_ENABLE_DISCOVERY_MULTICAST_MDNSD
-    //setting custom outbound interface for libmdnsd
-    config->mdnsInterfaceIP = UA_String_fromChars("0.0.0.0");
+    // Use loopback interface for mDNS announcements by default.
+    // This only works when the LDS and this server run on the same device.
+    // For deployment in LAN or across multiple devices, replace "127.0.0.1" with the IP of your network interface,
+    // such as "192.168.1.100" or the IP of wlan0/eth0.
+    config->mdnsInterfaceIP = UA_String_fromChars("127.0.0.1");
 #endif
 
     // See http://www.opcfoundation.org/UA/schemas/1.03/ServerCapabilities.csv
@@ -325,8 +329,6 @@ int main(int argc, char **argv) {
     while(running)
         UA_Server_run_iterate(server, true);
 
-    UA_Server_run_shutdown(server);
-
     /* Deregister the server from the discovery server */
     memset(&cc, 0, sizeof(UA_ClientConfig));
     retval = getRegisterClient(&cc, endpointRegister, argc, argv);
@@ -335,7 +337,9 @@ int main(int argc, char **argv) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
                      "Could not unregister server from discovery server. "
                      "StatusCode %s", UA_StatusCode_name(retval));
+    UA_ClientConfig_clear(&cc);
 
+    UA_Server_run_shutdown(server);
     UA_Server_delete(server);
     UA_EndpointDescription_delete(endpointRegister);
     return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/examples/discovery/server_multicast.c
+++ b/examples/discovery/server_multicast.c
@@ -2,7 +2,7 @@
  * See http://creativecommons.org/publicdomain/zero/1.0/ for more information.
  *
  * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
- * Copyright 2025 (c) Construction Future Lab gGmbH (Author: Jianbin Liu)
+ * Copyright (c) 2025 Construction Future Lab gGmbH (Author: Jianbin Liu)
  */
 
 /*


### PR DESCRIPTION
Hi @jpfr,

This patch resolves three critical issues in `examples/discovery/server_multicast.c`:

1. **Incorrect shutdown order**
   `UA_Server_deregisterDiscovery()` was called *after* `UA_Server_run_shutdown()`, which may lead to undefined behavior, as the server instance is already partially torn down.
2. **Missing cleanup on failure**
   If `getRegisterClient()` fails, `UA_ClientConfig_clear()` was not invoked, causing potential memory leaks.
3. **Invalid mDNS interface IP**
   The example used `0.0.0.0` as the outbound interface IP for libmdnsd, which is not valid for multicast.
   This has been replaced with `127.0.0.1` by default, along with a comment on when to use a proper interface IP for deployment.

All changes are confined to the example and have been verified on both loopback and local interfaces.
Please let me know if anything needs further clarification.

Best regards,
Jianbin
