### PR TITLE
Fix for build error when `UA_DEBUG_DUMP_PKGS` is defined

### DIFF
--- a/plugins/ua_debug_dump_pkgs.c
+++ b/plugins/ua_debug_dump_pkgs.c
@@ -5,7 +5,7 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  */
 
-#include "ua_util_internal.h"
+#include "../src/util/ua_util_internal.h"
 
 #include <ctype.h>
 #include <stdio.h>

--- a/plugins/ua_debug_dump_pkgs.c
+++ b/plugins/ua_debug_dump_pkgs.c
@@ -5,8 +5,6 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  */
 
-#include "../src/util/ua_util_internal.h"
-
 #include <ctype.h>
 #include <stdio.h>
 

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -810,10 +810,10 @@ serverNetworkCallbackLocked(UA_ConnectionManager *cm, uintptr_t connectionId,
 
     /* Received a message on a normal connection */
 #ifdef UA_DEBUG_DUMP_PKGS
-    UA_dump_hex_pkg(message->data, message->length);
+    UA_dump_hex_pkg(msg.data, msg.length);
 #endif
 #ifdef UA_DEBUG_DUMP_PKGS_FILE
-    UA_debug_dumpCompleteChunk(server, channel->connection, message);
+    UA_debug_dumpCompleteChunk(server, channel->connection, msg);
 #endif
 
     UA_EventLoop *el = bpm->sc.server->config.eventLoop;

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -813,7 +813,7 @@ serverNetworkCallbackLocked(UA_ConnectionManager *cm, uintptr_t connectionId,
     UA_dump_hex_pkg(msg.data, msg.length);
 #endif
 #ifdef UA_DEBUG_DUMP_PKGS_FILE
-    UA_debug_dumpCompleteChunk(server, channel->connection, msg);
+    UA_debug_dumpCompleteChunk(server, channel->connection, &msg);
 #endif
 
     UA_EventLoop *el = bpm->sc.server->config.eventLoop;


### PR DESCRIPTION
A build error occurs when `` is defined.

Steps to reproduce:
```shell
> mkdir build && cd build
> cmake -DCMAKE_BUILD_TYPE=Debug -DUA_LOGLEVEL=100 -DUA_DEBUG=ON -DUA_DEBUG_DUMP_PKGS=ON ..
> make
```
This will result in the following compilation error:
```shell
../src/open62541/src/server/ua_server_binary.c: In function ‘serverNetworkCallbackLocked’:
../src/open62541/src/server/ua_server_binary.c:826:21: error: ‘message’ undeclared (first use in this function)
  826 |     UA_dump_hex_pkg(message->data, message->length);
      |                     ^~~~~~~
../src/open62541/src/server/ua_server_binary.c:826:21: note: each undeclared identifier is reported only once for each function it appears in
At top level:
cc1: note: unrecognized command-line option ‘-Wno-static-in-inline’ may have been intended to silence earlier diagnostics
make[2]: *** [CMakeFiles/open62541-object.dir/build.make:337: CMakeFiles/open62541-object.dir/src/server/ua_server_binary.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:271: CMakeFiles/open62541-object.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```
This was performed on an Ubuntu 24 LTS install on x64 (though it should repro on any system that includes this file and option).

It appears that `message` was redefined a while ago but the codeo to dump packages was not updated. 