### PR TITLE
Avoid caching open62541_* cmake variables

### DIFF
--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -5,7 +5,10 @@ macro(set_default VAR DEFAULT)
 endmacro()
 
 macro(set_parent VAR)
-    set(${VAR} "${${VAR}}" PARENT_SCOPE)
+    # Only call it when inside a function or a subdirectory (both have a parent)
+    if(DEFINED CMAKE_CURRENT_FUNCTION OR NOT CMAKE_CURRENT_SOURCE_DIR  STREQUAL CMAKE_SOURCE_DIR)
+        set(${VAR} "${${VAR}}" PARENT_SCOPE)
+    endif()
 endmacro()
 
 macro(set_cache VAR)
@@ -14,11 +17,11 @@ endmacro()
 
 # In a local dev environment, manually set the variables from open62541Config.cmake
 set_default(open62541_TOOLS_DIR "${PROJECT_SOURCE_DIR}/tools")
-set_cache(open62541_TOOLS_DIR)
+set_parent(open62541_TOOLS_DIR)
 set_default(open62541_NS0_NODESETS "${UA_NS0_NODESET_FILES}")
-set_cache(open62541_NS0_NODESETS)
+set_parent(open62541_NS0_NODESETS)
 set_default(open62541_SCHEMA_DIR "${UA_SCHEMA_DIR}")
-set_cache(open62541_SCHEMA_DIR)
+set_parent(open62541_SCHEMA_DIR)
 
 # Set global variables to find targets and sources of dependencies
 function(export_target)


### PR DESCRIPTION
The PR fixes the problem described in the issue https://github.com/open62541/open62541/issues/7390 .