### PR TITLE
refactor(examples,server): clang compiler warnings

### DIFF
--- a/deps/cj5.c
+++ b/deps/cj5.c
@@ -165,10 +165,10 @@ cj5__parse_primitive(cj5__parser* parser) {
     // Make the comparison case-insensitive.
     uint32_t fourcc = 0;
     if(start + 3 < len) {
-        fourcc += json5[start] | 32;
-        fourcc += (json5[start+1] | 32) << 8;
-        fourcc += (json5[start+2] | 32) << 16;
-        fourcc += (json5[start+3] | 32) << 24;
+        fourcc += (unsigned char)json5[start] | 32U;
+        fourcc += ((unsigned char)json5[start+1] | 32U) << 8;
+        fourcc += ((unsigned char)json5[start+2] | 32U) << 16;
+        fourcc += ((unsigned char)json5[start+3] | 32U) << 24;
     }
     
     cj5_token_type type;
@@ -658,7 +658,7 @@ cj5_get_str(const cj5_result *r, unsigned int tok_index,
         case 'r': buf[outpos++] = '\r'; break;
         case 'n': buf[outpos++] = '\n'; break;
         case 't': buf[outpos++] = '\t'; break;
-        default:  buf[outpos++] = c;    break;
+        default:  buf[outpos++] = (char)c; break;
         case 'u': {
             // Parse a unicode code point
             if(pos + 4 >= end)

--- a/examples/nodeset/server_nodeset_plcopen.c
+++ b/examples/nodeset/server_nodeset_plcopen.c
@@ -12,7 +12,7 @@
 #include <limits.h>
 #include <stdlib.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");

--- a/examples/nodeset/server_nodeset_powerlink.c
+++ b/examples/nodeset/server_nodeset_powerlink.c
@@ -12,7 +12,7 @@
 #include <limits.h>
 #include <stdlib.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");

--- a/examples/nodeset/server_testnodeset.c
+++ b/examples/nodeset/server_testnodeset.c
@@ -14,9 +14,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 
-UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTNODESET_COUNT, UA_TYPES_TESTNODESET, UA_FALSE};
+static UA_DataTypeArray customTypesArray = { NULL, UA_TYPES_TESTNODESET_COUNT, UA_TYPES_TESTNODESET, UA_FALSE};
 
 static void stopHandler(int sign) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "received ctrl-c");

--- a/src/server/ua_subscription_datachange.c
+++ b/src/server/ua_subscription_datachange.c
@@ -21,7 +21,7 @@
     TYPE v2 = *(const TYPE*)data2;                              \
     TYPE diff = (v1 > v2) ? (TYPE)(v1 - v2) : (TYPE)(v2 - v1);  \
     return ((UA_Double)diff > deadband);                        \
-} while(false);
+} while(false)
 
 static UA_Boolean
 detectScalarDeadBand(const void *data1, const void *data2,

--- a/src/ua_types_encoding_json_105.c
+++ b/src/ua_types_encoding_json_105.c
@@ -430,7 +430,7 @@ encodeJsonArray(CtxJson *ctx, const void *ptr, size_t length,
     return ret | writeJsonArrEnd(ctx, type);
 }
 
-static const u8 hexmap[16] =
+static const char hexmap[16] =
     {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
 ENCODE_JSON(String) {
@@ -477,7 +477,7 @@ ENCODE_JSON(String) {
             if(*pos >= ' ' && *pos != 127) {
                 /* Escape \ or " */
                 escape_buf[0] = '\\';
-                escape_buf[1] = *pos;
+                escape_buf[1] = (char)*pos;
             } else {
                 /* Unprintable characters need to be escaped */
                 escape_buf[0] = '\\';


### PR DESCRIPTION
Fix some clang compiler warnings about:
- sign conversions
- not-needed semicolons
- adding "static" to file-local vars