### PR TITLE
Fix APPLE || MACH ifdef to only trigger on APPLE && MACH

### DIFF
--- a/arch/posix/clock_posix.c
+++ b/arch/posix/clock_posix.c
@@ -18,7 +18,7 @@
 #include <time.h>
 #include <sys/time.h>
 
-#if defined(__APPLE__) || defined(__MACH__)
+#if defined(__APPLE__) && defined(__MACH__)
 # include <mach/clock.h>
 # include <mach/mach.h>
 #endif
@@ -43,7 +43,7 @@ UA_Int64 UA_DateTime_localTimeUtcOffset(void) {
 }
 
 UA_DateTime UA_DateTime_nowMonotonic(void) {
-#if defined(__APPLE__) || defined(__MACH__)
+#if defined(__APPLE__) && defined(__MACH__)
     /* OS X does not have clock_gettime, use clock_get_time */
     clock_serv_t cclock;
     mach_timespec_t mts;


### PR DESCRIPTION
This is intended to only trigger on OSX, but since Hurd uses Mach as well it overmatches when it should be checking for both `__APPLE__` and `__MACH__`.

https://www.gnu.org/software/hurd/hurd/porting/guidelines.html

```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```