### PR TITLE
fix(tools) Fixes bug created in PR #7321

### DIFF
--- a/tools/nodeset_compiler/datatypes.py
+++ b/tools/nodeset_compiler/datatypes.py
@@ -647,13 +647,15 @@ class LocalizedText(Value):
             tmp = xmlvalue.getElementsByTagName("Locale")
             if len(tmp) > 0 and tmp[0].firstChild != None:
                 self.locale = tmp[0].firstChild.data.strip(' \t\n\r')
-        tmp = xmlvalue.firstChild
-        if tmp and tmp.nodeType == dom.Element.TEXT_NODE:
-            self.text = tmp.data.strip(' \t\n\r')
+
+        tmp = xmlvalue.getElementsByTagName("Text")
+        if len(tmp) > 0 and tmp[0].firstChild != None:
+            self.text = tmp[0].firstChild.data.strip(' \t\n\r')
         else:
-            tmp = xmlvalue.getElementsByTagName("Text")
-            if len(tmp) > 0 and tmp[0].firstChild != None:
-                self.text = tmp[0].firstChild.data.strip(' \t\n\r')
+            tmp = xmlvalue.firstChild
+            if tmp and tmp.nodeType == dom.Element.TEXT_NODE:
+                self.text = tmp.data.strip(' \t\n\r')
+
 
     def __str__(self):
         if self.locale is None and self.text is None:


### PR DESCRIPTION
Pull Request 7321 introduced a bug which caused an error in parsing some LocalizedText elements.
This was caused by whitespace being interpreted as a valid Text node in the LocalizedText element. 

To fix the bug, it will now be checked first if an element with the name Text exists. If it does, then the content of this element will be used as the text for the LocalizedText.
Only if such an element does not exist will the text node be used. 