### PR TITLE
Implement PubSub NS0 states including enable/disable + update in the PubSub file configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -932,6 +932,7 @@ if(UA_ENABLE_PUBSUB)
                             ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_readergroup.c
                             ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_manager.c
                             ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_ns0.c
+                            ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_ns0_sks.c
                             ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_keystorage.c
                             ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_securitygroup.c
                             ${PROJECT_SOURCE_DIR}/src/pubsub/ua_pubsub_config.c)

--- a/src/pubsub/ua_pubsub_config.c
+++ b/src/pubsub/ua_pubsub_config.c
@@ -17,7 +17,7 @@
 static UA_StatusCode
 createPubSubConnection(UA_PubSubManager *psm,
                        const UA_PubSubConnectionDataType *connection,
-                       UA_UInt32 pdsCount, UA_NodeId *pdsIdent);
+                       UA_UInt32 pdsCount, UA_NodeId *pdsIdent, UA_NodeId *connectionIdent);
 
 static UA_StatusCode
 createWriterGroup(UA_PubSubManager *psm,
@@ -100,8 +100,23 @@ updatePubSubConfig(UA_PubSubManager *psm,
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
+    /* Check if the PubSubManager is in an active state and has connections attached. */
+    if(psm->sc.state != UA_LIFECYCLESTATE_STOPPED && psm->connectionsSize > 0) {
+        UA_LOG_WARNING(psm->logging, UA_LOGCATEGORY_PUBSUB,
+                       "[UA_PubSubManager_updatePubSubConfig] PubSub configured and active. "
+                       "Disable the PublishSubscribe state before loading a pubsub configuration");
+        return UA_STATUSCODE_BADINVALIDSTATE;
+    }
+
+    /* Ensure the PubSubManager is stopped before clearing */
+    if(psm->sc.state != UA_LIFECYCLESTATE_STOPPED) {
+        UA_LOG_INFO(psm->logging, UA_LOGCATEGORY_PUBSUB,
+                    "[UA_PubSubManager_updatePubSubConfig] Stopping PubSubManager before loading configuration");
+        UA_PubSubManager_setState(psm, UA_LIFECYCLESTATE_STOPPED);
+    }
+
     /* Clear the PubSubManager to load a new config.
-     * To succeed the PubSubManager needs to be stopped. */
+     * The PubSubManager is now guaranteed to be stopped. */
     UA_StatusCode res = UA_PubSubManager_clear(psm);
     if(res != UA_STATUSCODE_GOOD)
         return res;
@@ -133,21 +148,107 @@ updatePubSubConfig(UA_PubSubManager *psm,
         return UA_STATUSCODE_GOOD;
     }
 
-    for(size_t i = 0; i < configurationParameters->connectionsSize; i++) {
-        res = createPubSubConnection(psm, &configurationParameters->connections[i],
-                                     pdsCount, publishedDataSetIdent);
-        if(res != UA_STATUSCODE_GOOD)
-            break;
+    /* Phase 1: Create all components with enabled = false to avoid premature state changes */
+    UA_LOG_INFO(psm->logging, UA_LOGCATEGORY_PUBSUB,
+                "[UA_PubSubManager_updatePubSubConfig] START CONNECTIONS (Phase 1: Creation)");
+
+    /* Store connection NodeIds for Phase 2 */
+    UA_NodeId *connectionIdents = (UA_NodeId*)UA_calloc(configurationParameters->connectionsSize, sizeof(UA_NodeId));
+    if(!connectionIdents) {
+        UA_free(publishedDataSetIdent);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 
-    UA_free(publishedDataSetIdent);
+    for(size_t i = 0; i < configurationParameters->connectionsSize; i++) {
+        res = createPubSubConnection(psm, &configurationParameters->connections[i],
+                                     pdsCount, publishedDataSetIdent, &connectionIdents[i]);
+        if(res != UA_STATUSCODE_GOOD) {
+            UA_free(connectionIdents);
+            break;
+        }
+    }
+    
+    if(res != UA_STATUSCODE_GOOD) {
+        UA_free(publishedDataSetIdent);
+        return res;
+    }
+    
+    /* Phase 2: Enable components based on original configuration */
+    UA_LOG_INFO(psm->logging, UA_LOGCATEGORY_PUBSUB,
+                "[UA_PubSubManager_updatePubSubConfig] START COMPONENTS (Phase 2: Enabling)");
+    
+    /* Enable connections and their child components */
+    for(size_t i = 0; i < configurationParameters->connectionsSize; i++) {
+        const UA_PubSubConnectionDataType *connParams = &configurationParameters->connections[i];
+        
+        if(connParams->enabled) {
+            UA_PubSubConnection *conn = UA_PubSubConnection_find(psm, connectionIdents[i]);
+            if(conn) {
+                conn->config.enabled = true;
+                UA_PubSubConnection_setPubSubState(psm, conn, UA_PUBSUBSTATE_OPERATIONAL);
+                
+                UA_WriterGroup *wg;
+                size_t wgIndex = 0;
+                LIST_FOREACH(wg, &conn->writerGroups, listEntry) {
+                    if(wgIndex < connParams->writerGroupsSize && connParams->writerGroups[wgIndex].enabled) {
+                        wg->config.enabled = true;
+                        UA_WriterGroup_setPubSubState(psm, wg, UA_PUBSUBSTATE_OPERATIONAL);
+                        
+                        UA_DataSetWriter *dsw;
+                        size_t dswIndex = 0;
+                        LIST_FOREACH(dsw, &wg->writers, listEntry) {
+                            if(dswIndex < connParams->writerGroups[wgIndex].dataSetWritersSize && 
+                               connParams->writerGroups[wgIndex].dataSetWriters[dswIndex].enabled) {
+                                dsw->config.enabled = true;
+                                UA_DataSetWriter_setPubSubState(psm, dsw, UA_PUBSUBSTATE_OPERATIONAL);
+                            }
+                            dswIndex++;
+                        }
+                    }
+                    wgIndex++;
+                }
+                
+                /* Enable reader groups */
+                UA_ReaderGroup *rg;
+                size_t rgIndex = 0;
+                LIST_FOREACH(rg, &conn->readerGroups, listEntry) {
+                    if(rgIndex < connParams->readerGroupsSize && connParams->readerGroups[rgIndex].enabled) {
+                        rg->config.enabled = true;
+                        UA_ReaderGroup_setPubSubState(psm, rg, UA_PUBSUBSTATE_OPERATIONAL);
+                        
+                        /* Enable data set readers */
+                        UA_DataSetReader *dsr;
+                        size_t dsrIndex = 0;
+                        LIST_FOREACH(dsr, &rg->readers, listEntry) {
+                            if(dsrIndex < connParams->readerGroups[rgIndex].dataSetReadersSize && 
+                               connParams->readerGroups[rgIndex].dataSetReaders[dsrIndex].enabled) {
+                                dsr->config.enabled = true;
+                                UA_DataSetReader_setPubSubState(psm, dsr, UA_PUBSUBSTATE_OPERATIONAL, UA_STATUSCODE_GOOD);
+                            }
+                            dsrIndex++;
+                        }
+                    }
+                    rgIndex++;
+                }
+            }
+        }
+    }
 
+    /* Enable PubSubManager if specified */
+    if(configurationParameters->enabled) {
+        UA_LOG_INFO(psm->logging, UA_LOGCATEGORY_PUBSUB,
+                       "[UA_PubSubManager_updatePubSubConfig] PubSubManager is enabled");
+        UA_PubSubManager_setState(psm, UA_LIFECYCLESTATE_STARTED);
+    }
+    
+    UA_free(connectionIdents);
+    UA_free(publishedDataSetIdent);
     return res;
 }
 
 static UA_StatusCode
 createPubSubConnection(UA_PubSubManager *psm, const UA_PubSubConnectionDataType *connParams,
-                       UA_UInt32 pdsCount, UA_NodeId *pdsIdent) {
+                       UA_UInt32 pdsCount, UA_NodeId *pdsIdent, UA_NodeId *connectionIdent) {
     UA_LOCK_ASSERT(&psm->sc.server->serviceMutex);
 
     UA_PubSubConnectionConfig config;
@@ -157,6 +258,7 @@ createPubSubConnection(UA_PubSubManager *psm, const UA_PubSubConnectionDataType 
     config.transportProfileUri =        connParams->transportProfileUri;
     config.connectionProperties.map =   connParams->connectionProperties;
     config.connectionProperties.mapSize = connParams->connectionPropertiesSize;
+    config.enabled = false;  /* Always create disabled, enabling during the last stage of updatePubSubConfig */
 
     UA_StatusCode res = UA_PublisherId_fromVariant(&config.publisherId,
                                                    &connParams->publisherId);
@@ -189,10 +291,7 @@ createPubSubConnection(UA_PubSubManager *psm, const UA_PubSubConnectionDataType 
                        "TransportSettings can not be read");
     }
 
-    /* Load connection config. The enabled flag is false here.
-     * Auto-enable after adding the components. */
-    UA_NodeId connectionIdent;
-    res = UA_PubSubConnection_create(psm, &config, &connectionIdent);
+    res = UA_PubSubConnection_create(psm, &config, connectionIdent);
     if(res != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(psm->logging, UA_LOGCATEGORY_PUBSUB,
                      "[UA_PubSubManager_createPubSubConnection] "
@@ -200,24 +299,13 @@ createPubSubConnection(UA_PubSubManager *psm, const UA_PubSubConnectionDataType 
         return res;
     }
 
-    /* WriterGroups configuration */
     for(size_t i = 0; i < connParams->writerGroupsSize; i++) {
         createWriterGroup(psm, &connParams->writerGroups[i],
-                          connectionIdent, pdsCount, pdsIdent);
+                          *connectionIdent, pdsCount, pdsIdent);
     }
 
-    /* ReaderGroups configuration */
     for(size_t j = 0; j < connParams->readerGroupsSize; j++) {
-        createReaderGroup(psm, &connParams->readerGroups[j], connectionIdent);
-    }
-
-    /* Enable and set the flag */
-    if(connParams->enabled) {
-        UA_PubSubConnection *c = UA_PubSubConnection_find(psm, connectionIdent);
-        if(c) {
-            c->config.enabled = true;
-            UA_PubSubConnection_setPubSubState(psm, c, UA_PUBSUBSTATE_OPERATIONAL);
-        }
+        createReaderGroup(psm, &connParams->readerGroups[j], *connectionIdent);
     }
 
     UA_PublisherId_clear(&config.publisherId);
@@ -280,6 +368,7 @@ createWriterGroup(UA_PubSubManager *psm,
     config.groupProperties.mapSize =   writerGroupParameters->groupPropertiesSize;
     config.groupProperties.map =   writerGroupParameters->groupProperties;
     config.maxEncapsulatedDataSetMessageCount = 255; /* non std parameter */
+    config.enabled = false;  /* Always create disabled, enabling during the last stage of updatePubSubConfig */
 
     UA_StatusCode res = setWriterGroupEncodingType(psm, writerGroupParameters, &config);
     if(res != UA_STATUSCODE_GOOD) {
@@ -300,19 +389,10 @@ createWriterGroup(UA_PubSubManager *psm,
         return res;
     }
 
-    /* Configuration of all DataSetWriters that belong to this WriterGroup */
+    /* Configuration of all DataSetWriters that belong to this WriterGroup - all created disabled */
     for(size_t dsw = 0; dsw < writerGroupParameters->dataSetWritersSize; dsw++) {
         createDataSetWriter(psm, &writerGroupParameters->dataSetWriters[dsw],
                             writerGroupIdent, pdsCount, pdsIdent);
-    }
-
-    /* Enable if the flag is set */
-    if(writerGroupParameters->enabled) {
-        UA_WriterGroup *wg = UA_WriterGroup_find(psm, writerGroupIdent);
-        if(wg) {
-            wg->config.enabled = true;
-            UA_WriterGroup_setPubSubState(psm, wg, UA_PUBSUBSTATE_OPERATIONAL);
-        }
     }
 
     return res;
@@ -358,9 +438,9 @@ createDataSetWriter(UA_PubSubManager *psm,
     config.dataSetName = dataSetWriterParameters->dataSetName;
     config.dataSetWriterProperties.mapSize = dataSetWriterParameters->dataSetWriterPropertiesSize;
     config.dataSetWriterProperties.map = dataSetWriterParameters->dataSetWriterProperties;
-    config.enabled = dataSetWriterParameters->enabled;
+    config.enabled = false;  /* Always create disabled, enabling during the last stage of updatePubSubConfig */
 
-    /* Create the DataSetWriter. It gets enabled internally if the flag is set. */
+    /* Create the DataSetWriter disabled. Enable later in Phase 2. */
     UA_NodeId dataSetWriterIdent;
     UA_StatusCode res =
         UA_DataSetWriter_create(psm, writerGroupIdent, pdsIdent[i],
@@ -385,9 +465,8 @@ createReaderGroup(UA_PubSubManager *psm,
 
     config.name = readerGroupParameters->name;
     config.securityMode = readerGroupParameters->securityMode;
+    config.enabled = false;  /* Always create disabled, enabling during the last stage of updatePubSubConfig */
 
-    /* Create the ReaderGroup. It only gets activated once the DataSetReaders
-     * have been added. */
     UA_NodeId readerGroupIdent;
     UA_StatusCode res = UA_ReaderGroup_create(psm, connectionIdent,
                                               &config, &readerGroupIdent);
@@ -404,15 +483,6 @@ createReaderGroup(UA_PubSubManager *psm,
     for(UA_UInt32 i = 0; i < readerGroupParameters->dataSetReadersSize; i++) {
         createDataSetReader(psm, &readerGroupParameters->dataSetReaders[i],
                             readerGroupIdent);
-    }
-
-    /* Enable the ReaderGroup if the flag is set */
-    if(readerGroupParameters->enabled) {
-        UA_ReaderGroup *rg = UA_ReaderGroup_find(psm, readerGroupIdent);
-        if(rg) {
-            rg->config.enabled = true;
-            UA_ReaderGroup_setPubSubState(psm, rg, UA_PUBSUBSTATE_OPERATIONAL);
-        }
     }
 
     return UA_STATUSCODE_GOOD;
@@ -471,12 +541,12 @@ createDataSetReader(UA_PubSubManager *psm, const UA_DataSetReaderDataType *dsrPa
     config.dataSetFieldContentMask = dsrParams->dataSetFieldContentMask;
     config.messageReceiveTimeout =  dsrParams->messageReceiveTimeout;
     config.messageSettings = dsrParams->messageSettings;
+    config.enabled = false;  /* Always create disabled, enabling during the last stage of updatePubSubConfig */
     UA_StatusCode res = UA_PublisherId_fromVariant(&config.publisherId,
                                                    &dsrParams->publisherId);
     if(res != UA_STATUSCODE_GOOD)
         return res;
 
-    /* Create the Reader. It gets enabled after the SubscribedDataSet has been added.  */
     UA_NodeId dsReaderIdent;
     res = UA_DataSetReader_create(psm, readerGroupIdent, &config, &dsReaderIdent);
     UA_PublisherId_clear(&config.publisherId);
@@ -494,16 +564,6 @@ createDataSetReader(UA_PubSubManager *psm, const UA_DataSetReaderDataType *dsrPa
                      "[UA_PubSubManager_createDataSetReader] "
                      "Create subscribedDataSet failed");
         return res;
-    }
-
-    /* Enable the Reader */
-    if(dsrParams->enabled) {
-        UA_DataSetReader *dsr = UA_DataSetReader_find(psm, dsReaderIdent);
-        if(dsr) {
-            dsr->config.enabled = dsrParams->enabled;
-            UA_DataSetReader_setPubSubState(psm, dsr, UA_PUBSUBSTATE_OPERATIONAL,
-                                            UA_STATUSCODE_GOOD);
-        }
     }
 
     return UA_STATUSCODE_GOOD;
@@ -1105,7 +1165,7 @@ UA_Server_writePubSubConfigurationToByteString(UA_Server *server,
         unlockServer(server);
         return UA_STATUSCODE_BADINTERNALERROR;
     }
-    
+
     UA_PubSubConfigurationDataType config;
     UA_PubSubConfigurationDataType_init(&config);
 

--- a/src/pubsub/ua_pubsub_config.c
+++ b/src/pubsub/ua_pubsub_config.c
@@ -229,6 +229,7 @@ updatePubSubConfig(UA_PubSubManager *psm,
     if(configurationParameters->enabled) {
         UA_LOG_INFO(psm->logging, UA_LOGCATEGORY_PUBSUB,
                        "[UA_PubSubManager_updatePubSubConfig] PubSubManager is enabled");
+        UA_assert(psm->sc.state == UA_LIFECYCLESTATE_STOPPED);
         psm->pubSubInitialSetupMode = true;
         UA_PubSubManager_setState(psm, UA_LIFECYCLESTATE_STARTED);
         psm->pubSubInitialSetupMode = false;

--- a/src/pubsub/ua_pubsub_connection.c
+++ b/src/pubsub/ua_pubsub_connection.c
@@ -939,10 +939,6 @@ UA_Server_updatePubSubConnectionConfig(UA_Server *server,
         goto errout;
     }
 
-    /* Call the state-machine. This can move the connection state from _ERROR to
-     * _DISABLED. */
-    UA_PubSubConnection_setPubSubState(psm, c, UA_PUBSUBSTATE_DISABLED);
-
     UA_PubSubConnectionConfig_clear(&oldConfig);
     unlockServer(server);
     return UA_STATUSCODE_GOOD;

--- a/src/pubsub/ua_pubsub_connection.c
+++ b/src/pubsub/ua_pubsub_connection.c
@@ -388,7 +388,7 @@ UA_PubSubConnection_setPubSubState(UA_PubSubManager *psm, UA_PubSubConnection *c
      * Keep the current child state as the target state for the child. */
     UA_ReaderGroup *rg;
     LIST_FOREACH(rg, &c->readerGroups, listEntry) {
-        if (psm->pubSubInitialSetupMode) {
+        if(psm->pubSubInitialSetupMode && rg->config.enabled) {
             UA_ReaderGroup_setPubSubState(psm, rg, UA_PUBSUBSTATE_OPERATIONAL);
         } else {
             UA_ReaderGroup_setPubSubState(psm, rg, rg->head.state);
@@ -396,7 +396,7 @@ UA_PubSubConnection_setPubSubState(UA_PubSubManager *psm, UA_PubSubConnection *c
     }
     UA_WriterGroup *wg;
     LIST_FOREACH(wg, &c->writerGroups, listEntry) {
-        if (psm->pubSubInitialSetupMode) {
+        if(psm->pubSubInitialSetupMode && wg->config.enabled) {
             UA_WriterGroup_setPubSubState(psm, wg, UA_PUBSUBSTATE_OPERATIONAL);
         } else {
             UA_WriterGroup_setPubSubState(psm, wg, wg->head.state);

--- a/src/pubsub/ua_pubsub_connection.c
+++ b/src/pubsub/ua_pubsub_connection.c
@@ -388,11 +388,19 @@ UA_PubSubConnection_setPubSubState(UA_PubSubManager *psm, UA_PubSubConnection *c
      * Keep the current child state as the target state for the child. */
     UA_ReaderGroup *rg;
     LIST_FOREACH(rg, &c->readerGroups, listEntry) {
-        UA_ReaderGroup_setPubSubState(psm, rg, rg->head.state);
+        if (psm->pubSubInitialSetupMode) {
+            UA_ReaderGroup_setPubSubState(psm, rg, UA_PUBSUBSTATE_OPERATIONAL);
+        } else {
+            UA_ReaderGroup_setPubSubState(psm, rg, rg->head.state);
+        }
     }
     UA_WriterGroup *wg;
     LIST_FOREACH(wg, &c->writerGroups, listEntry) {
-        UA_WriterGroup_setPubSubState(psm, wg, wg->head.state);
+        if (psm->pubSubInitialSetupMode) {
+            UA_WriterGroup_setPubSubState(psm, wg, UA_PUBSUBSTATE_OPERATIONAL);
+        } else {
+            UA_WriterGroup_setPubSubState(psm, wg, wg->head.state);
+        }
     }
 
     /* Update the PubSubManager state. It will go from STOPPING to STOPPED when

--- a/src/pubsub/ua_pubsub_internal.h
+++ b/src/pubsub/ua_pubsub_internal.h
@@ -695,6 +695,11 @@ UA_PubSubConfigurationVersionTimeDifference(UA_DateTime now);
 UA_StatusCode
 initPubSubNS0(UA_Server *server);
 
+#ifdef UA_ENABLE_PUBSUB_SKS
+UA_StatusCode
+initPubSubNS0_SKS(UA_Server *server);
+#endif
+
 UA_StatusCode
 addPubSubConnectionRepresentation(UA_Server *server, UA_PubSubConnection *connection);
 

--- a/src/pubsub/ua_pubsub_internal.h
+++ b/src/pubsub/ua_pubsub_internal.h
@@ -636,6 +636,11 @@ struct UA_PubSubManager {
     size_t reserveIdsSize;
     UA_ReserveIdTree reserveIds;
 
+    /* During the initial activation of the PubSub subsystem (e.g. when loading a configuration file), special behaviour
+     * is required within the PubSub state machine transitions. This global flag can be set to indicate that the
+     * configuration phase is active, and it is evaluated during the state changes of the PubSub components. */
+    UA_Boolean pubSubInitialSetupMode;
+
 #ifdef UA_ENABLE_PUBSUB_SKS
     LIST_HEAD(, UA_PubSubKeyStorage) pubSubKeyList;
 

--- a/src/pubsub/ua_pubsub_internal.h
+++ b/src/pubsub/ua_pubsub_internal.h
@@ -468,7 +468,7 @@ DataSetReader_createTargetVariables(UA_PubSubManager *psm, UA_DataSetReader *dsr
                                     size_t targetsSize, const UA_FieldTargetDataType *targets);
 
 /* Returns an error reason if the target state is `Error` */
-void
+UA_StatusCode
 UA_DataSetReader_setPubSubState(UA_PubSubManager *psm, UA_DataSetReader *dsr,
                                 UA_PubSubState targetState, UA_StatusCode errorReason);
 

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -710,7 +710,11 @@ UA_PubSubManager_setState(UA_PubSubManager *psm, UA_LifecycleState state) {
     if(state == UA_LIFECYCLESTATE_STARTED) {
         UA_PubSubConnection *c;
         TAILQ_FOREACH(c, &psm->connections, listEntry) {
-            UA_PubSubConnection_setPubSubState(psm, c, c->head.state);
+            if (psm->pubSubInitialSetupMode) {
+                UA_PubSubConnection_setPubSubState(psm, c, UA_PUBSUBSTATE_OPERATIONAL);
+            } else {
+                UA_PubSubConnection_setPubSubState(psm, c, c->head.state);
+            }
         }
     }
 }

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -13,7 +13,7 @@
 #include "ua_pubsub_internal.h"
 
 #ifdef UA_ENABLE_PUBSUB_SKS
-#include "ua_pubsub_keystorage.h"
+UA_StatusCode initPubSubNS0_SKS(UA_Server *server);
 #endif
 
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL /* conditional compilation */
@@ -1635,116 +1635,6 @@ addReaderGroupAction(UA_Server *server,
     return retVal;
 }
 
-#ifdef UA_ENABLE_PUBSUB_SKS
-#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
-static UA_Boolean
-isValidParentNode(UA_Server *server, UA_NodeId parentId) {
-    UA_LOCK_ASSERT(&server->serviceMutex);
-    UA_Boolean retval = true;
-    const UA_Node *parentNodeType;
-    const UA_NodeId parentNodeTypeId = UA_NS0ID(SECURITYGROUPFOLDERTYPE);
-    const UA_Node *parentNode = UA_NODESTORE_GET(server, &parentId);
-
-    if(parentNode) {
-        parentNodeType = getNodeType(server, &parentNode->head);
-        if(parentNodeType) {
-            retval = UA_NodeId_equal(&parentNodeType->head.nodeId, &parentNodeTypeId);
-            UA_NODESTORE_RELEASE(server, parentNodeType);
-        }
-        UA_NODESTORE_RELEASE(server, parentNode);
-    }
-    return retval;
-}
-
-static UA_StatusCode
-updateSecurityGroupProperties(UA_Server *server, UA_NodeId *securityGroupNodeId,
-                              UA_SecurityGroupConfig *config) {
-    UA_LOCK_ASSERT(&server->serviceMutex);
-
-    UA_StatusCode retval = UA_STATUSCODE_BAD;
-    UA_Variant value;
-    UA_Variant_init(&value);
-    UA_Variant_setScalar(&value, &config->securityGroupName, &UA_TYPES[UA_TYPES_STRING]);
-    retval = writeObjectProperty(server, *securityGroupNodeId,
-                                 UA_QUALIFIEDNAME(0, "SecurityGroupId"), value);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    /*AddCallbackValueSource*/
-    UA_Variant_setScalar(&value, &config->securityPolicyUri, &UA_TYPES[UA_TYPES_STRING]);
-    retval = writeObjectProperty(server, *securityGroupNodeId,
-                                 UA_QUALIFIEDNAME(0, "SecurityPolicyUri"), value);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    UA_Variant_setScalar(&value, &config->keyLifeTime, &UA_TYPES[UA_TYPES_DURATION]);
-    retval = writeObjectProperty(server, *securityGroupNodeId,
-                                 UA_QUALIFIEDNAME(0, "KeyLifetime"), value);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    UA_Variant_setScalar(&value, &config->maxFutureKeyCount, &UA_TYPES[UA_TYPES_UINT32]);
-    retval = writeObjectProperty(server, *securityGroupNodeId,
-                                 UA_QUALIFIEDNAME(0, "MaxFutureKeyCount"), value);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    UA_Variant_setScalar(&value, &config->maxPastKeyCount, &UA_TYPES[UA_TYPES_UINT32]);
-    retval = writeObjectProperty(server, *securityGroupNodeId,
-                                 UA_QUALIFIEDNAME(0, "MaxPastKeyCount"), value);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    return retval;
-}
-
-UA_StatusCode
-addSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup) {
-    UA_LOCK_ASSERT(&server->serviceMutex);
-    UA_StatusCode retval = UA_STATUSCODE_BAD;
-
-    UA_SecurityGroupConfig *securityGroupConfig = &securityGroup->config;
-    if(!isValidParentNode(server, securityGroup->securityGroupFolderId))
-        return UA_STATUSCODE_BADPARENTNODEIDINVALID;
-
-    if(securityGroupConfig->securityGroupName.length <= 0)
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-
-    UA_QualifiedName browseName;
-    UA_QualifiedName_init(&browseName);
-    browseName.name = securityGroupConfig->securityGroupName;
-
-    UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
-    object_attr.displayName.text = securityGroupConfig->securityGroupName;
-    UA_NodeId refType = UA_NS0ID(HASCOMPONENT);
-    UA_NodeId nodeType = UA_NS0ID(SECURITYGROUPTYPE);
-    retval = addNode(server, UA_NODECLASS_OBJECT, UA_NODEID_NULL,
-                     securityGroup->securityGroupFolderId, refType,
-                     browseName, nodeType, &object_attr,
-                     &UA_TYPES[UA_TYPES_OBJECTATTRIBUTES], NULL,
-                     &securityGroup->securityGroupNodeId);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
-                     "Add SecurityGroup failed with error: %s.",
-                     UA_StatusCode_name(retval));
-        return retval;
-    }
-
-    retval = updateSecurityGroupProperties(server,
-                                           &securityGroup->securityGroupNodeId,
-                                           securityGroupConfig);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
-                     "Add SecurityGroup failed with error: %s.",
-                     UA_StatusCode_name(retval));
-        deleteNode(server, securityGroup->securityGroupNodeId, true);
-    }
-    return retval;
-}
-
-#endif /* UA_ENABLE_PUBSUB_INFORMATIONMODEL*/
-#endif /* UA_ENABLE_PUBSUB_SKS */
-
 /**********************************************/
 /*               DataSetWriter                */
 /**********************************************/
@@ -1882,232 +1772,6 @@ removeDataSetWriterAction(UA_Server *server,
     UA_NodeId nodeToRemove = *((UA_NodeId *) input[0].data);
     return UA_Server_removeDataSetWriter(server, nodeToRemove);
 }
-
-#ifdef UA_ENABLE_PUBSUB_SKS
-
-/**
- * @note The user credentials and permissions are checked in the AccessControl plugin
- * before this callback is executed.
- */
-static UA_StatusCode
-setSecurityKeysAction(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
-                      const UA_NodeId *methodId, void *methodContext,
-                      const UA_NodeId *objectId, void *objectContext, size_t inputSize,
-                      const UA_Variant *input, size_t outputSize, UA_Variant *output) {
-    UA_LOCK_ASSERT(&server->serviceMutex);
-
-    /* Validate the arguments */
-    if(!server || !input)
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    if(inputSize < 7)
-        return UA_STATUSCODE_BADARGUMENTSMISSING;
-    if(inputSize > 7 || outputSize > 0)
-        return UA_STATUSCODE_BADTOOMANYARGUMENTS;
-
-    /* Check whether the channel is encrypted according to specification */
-    UA_Session *session = getSessionById(server, sessionId);
-    if(!session || !session->channel)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    if(session->channel->securityMode != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
-        return UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT;
-
-    /* Check for types */
-    if(!UA_Variant_hasScalarType(&input[0], &UA_TYPES[UA_TYPES_STRING]) || /*SecurityGroupId*/
-        !UA_Variant_hasScalarType(&input[1], &UA_TYPES[UA_TYPES_STRING]) || /*SecurityPolicyUri*/
-        !UA_Variant_hasScalarType(&input[2], &UA_TYPES[UA_TYPES_INTEGERID]) || /*CurrentTokenId*/
-        !UA_Variant_hasScalarType(&input[3], &UA_TYPES[UA_TYPES_BYTESTRING]) || /*CurrentKey*/
-        !UA_Variant_hasArrayType(&input[4], &UA_TYPES[UA_TYPES_BYTESTRING]) || /*FutureKeys*/
-        (!UA_Variant_hasScalarType(&input[5], &UA_TYPES[UA_TYPES_DURATION]) &&
-        !UA_Variant_hasScalarType(&input[5], &UA_TYPES[UA_TYPES_DOUBLE])) || /*TimeToNextKey*/
-        (!UA_Variant_hasScalarType(&input[6], &UA_TYPES[UA_TYPES_DURATION]) &&
-        !UA_Variant_hasScalarType(&input[6], &UA_TYPES[UA_TYPES_DOUBLE]))) /*TimeToNextKey*/
-        return UA_STATUSCODE_BADTYPEMISMATCH;
-
-    UA_Duration callbackTime;
-    UA_String *securityGroupId = (UA_String *)input[0].data;
-    UA_String *securityPolicyUri = (UA_String *)input[1].data;
-    UA_UInt32 currentKeyId = *(UA_UInt32 *)input[2].data;
-    UA_ByteString *currentKey = (UA_ByteString *)input[3].data;
-    UA_ByteString *futureKeys = (UA_ByteString *)input[4].data;
-    size_t futureKeySize = input[4].arrayLength;
-    UA_Duration msTimeToNextKey = *(UA_Duration *)input[5].data;
-    UA_Duration msKeyLifeTime = *(UA_Duration *)input[6].data;
-
-    UA_PubSubManager *psm = getPSM(server);
-    UA_PubSubKeyStorage *ks =
-        UA_PubSubKeyStorage_find(psm, *securityGroupId);
-    if(!ks)
-        return UA_STATUSCODE_BADNOTFOUND;
-
-    if(!UA_String_equal(securityPolicyUri, &ks->policy->policyUri))
-        return UA_STATUSCODE_BADSECURITYPOLICYREJECTED;
-
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    UA_PubSubKeyListItem *current = UA_PubSubKeyStorage_getKeyByKeyId(ks, currentKeyId);
-    if(!current) {
-        UA_PubSubKeyStorage_clearKeyList(ks);
-        retval |= (UA_PubSubKeyStorage_push(ks, currentKey, currentKeyId)) ?
-            UA_STATUSCODE_GOOD : UA_STATUSCODE_BADOUTOFMEMORY;
-    }
-    UA_PubSubKeyStorage_setCurrentKey(ks, currentKeyId);
-    retval |= UA_PubSubKeyStorage_addSecurityKeys(ks, futureKeySize,
-                                                  futureKeys, currentKeyId);
-    ks->keyLifeTime = msKeyLifeTime;
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    retval = UA_PubSubKeyStorage_activateKeyToChannelContext(psm, UA_NODEID_NULL,
-                                                             ks->securityGroupID);
-    if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_INFO(
-            server->config.logging, UA_LOGCATEGORY_SERVER,
-            "Failed to import Symmetric Keys into PubSub Channel Context with %s \n",
-            UA_StatusCode_name(retval));
-        return retval;
-    }
-
-    callbackTime = msKeyLifeTime;
-    if(msTimeToNextKey > 0)
-        callbackTime = msTimeToNextKey;
-
-    /* Move to setSecurityKeysAction */
-    return UA_PubSubKeyStorage_addKeyRolloverCallback(
-        psm, ks, (UA_Callback)UA_PubSubKeyStorage_keyRolloverCallback,
-        callbackTime, &ks->callBackId);
-}
-
-static UA_StatusCode
-getSecurityKeysAction(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
-                      const UA_NodeId *methodId, void *methodContext,
-                      const UA_NodeId *objectId, void *objectContext, size_t inputSize,
-                      const UA_Variant *input, size_t outputSize, UA_Variant *output) {
-    UA_LOCK_ASSERT(&server->serviceMutex);
-
-    /* Validate the arguments */
-    if(!server || !input)
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    if(inputSize < 3 || outputSize < 5)
-        return UA_STATUSCODE_BADARGUMENTSMISSING;
-    if(inputSize > 3 || outputSize > 5)
-        return UA_STATUSCODE_BADTOOMANYARGUMENTS;
-
-    /* Check whether the channel is encrypted according to specification */
-    UA_Session *session = getSessionById(server, sessionId);
-    if(!session || !session->channel)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    if(session->channel->securityMode != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
-        return UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT;
-
-    /* Check for types */
-    if(!UA_Variant_hasScalarType(&input[0],
-                                 &UA_TYPES[UA_TYPES_STRING]) || /*SecurityGroupId*/
-       !UA_Variant_hasScalarType(&input[1],
-                                 &UA_TYPES[UA_TYPES_INTEGERID]) || /*StartingTokenId*/
-       !UA_Variant_hasScalarType(&input[2],
-                                 &UA_TYPES[UA_TYPES_UINT32])) /*RequestedKeyCount*/
-        return UA_STATUSCODE_BADTYPEMISMATCH;
-
-    UA_StatusCode retval = UA_STATUSCODE_BAD;
-    UA_UInt32 currentKeyCount = 1;
-
-    /* Input */
-    UA_String *securityGroupId = (UA_String *)input[0].data;
-    UA_UInt32 startingTokenId = *(UA_UInt32 *)input[1].data;
-    UA_UInt32 requestedKeyCount = *(UA_UInt32 *)input[2].data;
-
-    UA_PubSubManager *psm = getPSM(server);
-    UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_find(psm, *securityGroupId);
-    if(!ks)
-        return UA_STATUSCODE_BADNOTFOUND;
-
-    UA_Boolean executable = false;
-    UA_SecurityGroup *sg = UA_SecurityGroup_findByName(psm, *securityGroupId);
-    void *sgNodeCtx;
-    getNodeContext(server, sg->securityGroupNodeId, (void **)&sgNodeCtx);
-    executable = server->config.accessControl.getUserExecutableOnObject(
-        server, &server->config.accessControl, sessionId, sessionContext, methodId,
-        methodContext, &sg->securityGroupNodeId, sgNodeCtx);
-
-    if(!executable)
-        return UA_STATUSCODE_BADUSERACCESSDENIED;
-
-    /* If the caller requests a number larger than the Security Key Service
-     * permits, then the SKS shall return the maximum it allows.*/
-    if(requestedKeyCount > sg->config.maxFutureKeyCount)
-        requestedKeyCount =(UA_UInt32) sg->keyStorage->keyListSize;
-    else
-        requestedKeyCount = requestedKeyCount + currentKeyCount; /* Add Current keyCount */
-
-    /* The current token is requested by passing 0. */
-    UA_PubSubKeyListItem *startingItem = NULL;
-    if(startingTokenId == 0) {
-        /* currentItem is always set by the server when a security group is added */
-        UA_assert(sg->keyStorage->currentItem != NULL);
-        startingItem = sg->keyStorage->currentItem;
-    } else {
-        startingItem = UA_PubSubKeyStorage_getKeyByKeyId(sg->keyStorage, startingTokenId);
-        /* If the StartingTokenId is unknown, the oldest (firstItem) available
-         * tokens are returned. */
-        if(!startingItem)
-            startingItem = TAILQ_FIRST(&sg->keyStorage->keyList);
-    }
-
-    /* SecurityPolicyUri */
-    retval = UA_Variant_setScalarCopy(&output[0], &(sg->keyStorage->policy->policyUri),
-                         &UA_TYPES[UA_TYPES_STRING]);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    /* FirstTokenId */
-    retval = UA_Variant_setScalarCopy(&output[1], &startingItem->keyID,
-                                      &UA_TYPES[UA_TYPES_INTEGERID]);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    /* TimeToNextKey */
-    UA_EventLoop *el = server->config.eventLoop;
-    UA_DateTime baseTime = sg->baseTime;
-    UA_DateTime currentTime = el->dateTime_nowMonotonic(el);
-    UA_Duration interval = sg->config.keyLifeTime;
-    UA_Duration timeToNextKey =
-        (UA_Duration)((currentTime - baseTime) / UA_DATETIME_MSEC);
-    timeToNextKey = interval - timeToNextKey;
-    retval = UA_Variant_setScalarCopy(&output[3], &timeToNextKey,
-                                      &UA_TYPES[UA_TYPES_DURATION]);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    /* KeyLifeTime */
-    retval = UA_Variant_setScalarCopy(&output[4], &sg->config.keyLifeTime,
-                         &UA_TYPES[UA_TYPES_DURATION]);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
-    /* Keys */
-    UA_PubSubKeyListItem *iterator = startingItem;
-    output[2].data = (UA_ByteString *)
-        UA_calloc(requestedKeyCount, startingItem->key.length);
-    if(!output[2].data)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-
-    UA_ByteString *requestedKeys = (UA_ByteString *)output[2].data;
-    UA_UInt32 retkeyCount = 0;
-    for(size_t i = 0; i < requestedKeyCount; i++) {
-        UA_ByteString_copy(&iterator->key, &requestedKeys[i]);
-        ++retkeyCount;
-        iterator = TAILQ_NEXT(iterator, keyListEntry);
-        if(!iterator) {
-            requestedKeyCount = retkeyCount;
-            break;
-        }
-    }
-
-    UA_Variant_setArray(&output[2], requestedKeys, requestedKeyCount,
-                        &UA_TYPES[UA_TYPES_BYTESTRING]);
-    return retval;
-}
-
-#endif
 
 /**********************************************/
 /*                Destructors                 */
@@ -2395,10 +2059,6 @@ initPubSubNS0(UA_Server *server) {
         retVal |= setMethodNode_callback(server, UA_NS0ID(READERGROUPTYPE_ADDDATASETREADER), addDataSetReaderAction);
         retVal |= setMethodNode_callback(server, UA_NS0ID(READERGROUPTYPE_REMOVEDATASETREADER), removeDataSetReaderAction);
         retVal |= setMethodNode_callback(server, UA_NS0ID(PUBLISHSUBSCRIBE_PUBSUBCONFIGURATION_RESERVEIDS), addReserveIdsAction);
-#ifdef UA_ENABLE_PUBSUB_SKS
-        retVal |= setMethodNode_callback(server, UA_NS0ID(PUBLISHSUBSCRIBE_SETSECURITYKEYS), setSecurityKeysAction);
-        retVal |= setMethodNode_callback(server, UA_NS0ID(PUBLISHSUBSCRIBE_GETSECURITYKEYS), getSecurityKeysAction);
-#endif
 
 #ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
         /* Adds method node to server. This method is used to load binary files for
@@ -2471,6 +2131,11 @@ initPubSubNS0(UA_Server *server) {
 
     lifeCycle.destructor = subscribedDataSetTypeDestructor;
     retVal |= setNodeTypeLifecycle(server, UA_NS0ID(STANDALONESUBSCRIBEDDATASETTYPE), lifeCycle);
+
+#ifdef UA_ENABLE_PUBSUB_SKS
+    /* Initialize SKS-specific functionality */
+    retVal |= initPubSubNS0_SKS(server);
+#endif
 
     return retVal;
 }

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -12,10 +12,6 @@
 
 #include "ua_pubsub_internal.h"
 
-#ifdef UA_ENABLE_PUBSUB_SKS
-UA_StatusCode initPubSubNS0_SKS(UA_Server *server);
-#endif
-
 #ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL /* conditional compilation */
 
 typedef struct {

--- a/src/pubsub/ua_pubsub_ns0_sks.c
+++ b/src/pubsub/ua_pubsub_ns0_sks.c
@@ -1,0 +1,359 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2022 Linutronix GmbH (Author: Muddasir Shakil)
+ * Copyright (c) 2025 Fraunhofer IOSB (Author: Julius Pfrommer)
+ */
+
+#include "ua_pubsub_internal.h"
+
+#ifdef UA_ENABLE_PUBSUB_SKS
+#include "ua_pubsub_keystorage.h"
+
+#ifdef UA_ENABLE_PUBSUB_INFORMATIONMODEL
+
+static UA_Boolean
+isValidParentNode(UA_Server *server, UA_NodeId parentId) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+    UA_Boolean retval = true;
+    const UA_Node *parentNodeType;
+    const UA_NodeId parentNodeTypeId = UA_NS0ID(SECURITYGROUPFOLDERTYPE);
+    const UA_Node *parentNode = UA_NODESTORE_GET(server, &parentId);
+
+    if(parentNode) {
+        parentNodeType = getNodeType(server, &parentNode->head);
+        if(parentNodeType) {
+            retval = UA_NodeId_equal(&parentNodeType->head.nodeId, &parentNodeTypeId);
+            UA_NODESTORE_RELEASE(server, parentNodeType);
+        }
+        UA_NODESTORE_RELEASE(server, parentNode);
+    }
+    return retval;
+}
+
+static UA_StatusCode
+updateSecurityGroupProperties(UA_Server *server, UA_NodeId *securityGroupNodeId,
+                              UA_SecurityGroupConfig *config) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_Variant value;
+    UA_Variant_init(&value);
+    UA_Variant_setScalar(&value, &config->securityGroupName, &UA_TYPES[UA_TYPES_STRING]);
+    retval = writeObjectProperty(server, *securityGroupNodeId,
+                                 UA_QUALIFIEDNAME(0, "SecurityGroupId"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /*AddCallbackValueSource*/
+    UA_Variant_setScalar(&value, &config->securityPolicyUri, &UA_TYPES[UA_TYPES_STRING]);
+    retval = writeObjectProperty(server, *securityGroupNodeId,
+                                 UA_QUALIFIEDNAME(0, "SecurityPolicyUri"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    UA_Variant_setScalar(&value, &config->keyLifeTime, &UA_TYPES[UA_TYPES_DURATION]);
+    retval = writeObjectProperty(server, *securityGroupNodeId,
+                                 UA_QUALIFIEDNAME(0, "KeyLifetime"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    UA_Variant_setScalar(&value, &config->maxFutureKeyCount, &UA_TYPES[UA_TYPES_UINT32]);
+    retval = writeObjectProperty(server, *securityGroupNodeId,
+                                 UA_QUALIFIEDNAME(0, "MaxFutureKeyCount"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    UA_Variant_setScalar(&value, &config->maxPastKeyCount, &UA_TYPES[UA_TYPES_UINT32]);
+    retval = writeObjectProperty(server, *securityGroupNodeId,
+                                 UA_QUALIFIEDNAME(0, "MaxPastKeyCount"), value);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    return retval;
+}
+
+UA_StatusCode
+addSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGroup) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+
+    UA_SecurityGroupConfig *securityGroupConfig = &securityGroup->config;
+    if(!isValidParentNode(server, securityGroup->securityGroupFolderId))
+        return UA_STATUSCODE_BADPARENTNODEIDINVALID;
+
+    if(securityGroupConfig->securityGroupName.length <= 0)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    UA_QualifiedName browseName;
+    UA_QualifiedName_init(&browseName);
+    browseName.name = securityGroupConfig->securityGroupName;
+
+    UA_ObjectAttributes object_attr = UA_ObjectAttributes_default;
+    object_attr.displayName.text = securityGroupConfig->securityGroupName;
+    UA_NodeId refType = UA_NS0ID(HASCOMPONENT);
+    UA_NodeId nodeType = UA_NS0ID(SECURITYGROUPTYPE);
+    retval = addNode(server, UA_NODECLASS_OBJECT, UA_NODEID_NULL,
+                     securityGroup->securityGroupFolderId, refType,
+                     browseName, nodeType, &object_attr,
+                     &UA_TYPES[UA_TYPES_OBJECTATTRIBUTES], NULL,
+                     &securityGroup->securityGroupNodeId);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
+                     "Add SecurityGroup failed with error: %s.",
+                     UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    retval = updateSecurityGroupProperties(server,
+                                           &securityGroup->securityGroupNodeId,
+                                           securityGroupConfig);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
+                     "Add SecurityGroup failed with error: %s.",
+                     UA_StatusCode_name(retval));
+        deleteNode(server, securityGroup->securityGroupNodeId, true);
+    }
+    return retval;
+}
+
+/**
+ * @note The user credentials and permissions are checked in the AccessControl plugin
+ * before this callback is executed.
+ */
+static UA_StatusCode
+setSecurityKeysAction(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                      const UA_NodeId *methodId, void *methodContext,
+                      const UA_NodeId *objectId, void *objectContext, size_t inputSize,
+                      const UA_Variant *input, size_t outputSize, UA_Variant *output) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+    /* Validate the arguments */
+    if(!server || !input)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    if(inputSize < 7)
+        return UA_STATUSCODE_BADARGUMENTSMISSING;
+    if(inputSize > 7 || outputSize > 0)
+        return UA_STATUSCODE_BADTOOMANYARGUMENTS;
+
+    /* Check whether the channel is encrypted according to specification */
+    UA_Session *session = getSessionById(server, sessionId);
+    if(!session || !session->channel)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    if(session->channel->securityMode != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
+        return UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT;
+
+    /* Check for types */
+    if(!UA_Variant_hasScalarType(&input[0], &UA_TYPES[UA_TYPES_STRING]) || /*SecurityGroupId*/
+        !UA_Variant_hasScalarType(&input[1], &UA_TYPES[UA_TYPES_STRING]) || /*SecurityPolicyUri*/
+        !UA_Variant_hasScalarType(&input[2], &UA_TYPES[UA_TYPES_INTEGERID]) || /*CurrentTokenId*/
+        !UA_Variant_hasScalarType(&input[3], &UA_TYPES[UA_TYPES_BYTESTRING]) || /*CurrentKey*/
+        !UA_Variant_hasArrayType(&input[4], &UA_TYPES[UA_TYPES_BYTESTRING]) || /*FutureKeys*/
+        (!UA_Variant_hasScalarType(&input[5], &UA_TYPES[UA_TYPES_DURATION]) &&
+        !UA_Variant_hasScalarType(&input[5], &UA_TYPES[UA_TYPES_DOUBLE])) || /*TimeToNextKey*/
+        (!UA_Variant_hasScalarType(&input[6], &UA_TYPES[UA_TYPES_DURATION]) &&
+        !UA_Variant_hasScalarType(&input[6], &UA_TYPES[UA_TYPES_DOUBLE]))) /*TimeToNextKey*/
+        return UA_STATUSCODE_BADTYPEMISMATCH;
+
+    UA_Duration callbackTime;
+    UA_String *securityGroupId = (UA_String *)input[0].data;
+    UA_String *securityPolicyUri = (UA_String *)input[1].data;
+    UA_UInt32 currentKeyId = *(UA_UInt32 *)input[2].data;
+    UA_ByteString *currentKey = (UA_ByteString *)input[3].data;
+    UA_ByteString *futureKeys = (UA_ByteString *)input[4].data;
+    size_t futureKeySize = input[4].arrayLength;
+    UA_Duration msTimeToNextKey = *(UA_Duration *)input[5].data;
+    UA_Duration msKeyLifeTime = *(UA_Duration *)input[6].data;
+
+    UA_PubSubManager *psm = getPSM(server);
+    UA_PubSubKeyStorage *ks =
+        UA_PubSubKeyStorage_find(psm, *securityGroupId);
+    if(!ks)
+        return UA_STATUSCODE_BADNOTFOUND;
+
+    if(!UA_String_equal(securityPolicyUri, &ks->policy->policyUri))
+        return UA_STATUSCODE_BADSECURITYPOLICYREJECTED;
+
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    UA_PubSubKeyListItem *current = UA_PubSubKeyStorage_getKeyByKeyId(ks, currentKeyId);
+    if(!current) {
+        UA_PubSubKeyStorage_clearKeyList(ks);
+        retval |= (UA_PubSubKeyStorage_push(ks, currentKey, currentKeyId)) ?
+            UA_STATUSCODE_GOOD : UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    UA_PubSubKeyStorage_setCurrentKey(ks, currentKeyId);
+    retval |= UA_PubSubKeyStorage_addSecurityKeys(ks, futureKeySize,
+                                                  futureKeys, currentKeyId);
+    ks->keyLifeTime = msKeyLifeTime;
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    retval = UA_PubSubKeyStorage_activateKeyToChannelContext(psm, UA_NODEID_NULL,
+                                                             ks->securityGroupID);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_INFO(
+            server->config.logging, UA_LOGCATEGORY_SERVER,
+            "Failed to import Symmetric Keys into PubSub Channel Context with %s \n",
+            UA_StatusCode_name(retval));
+        return retval;
+    }
+
+    callbackTime = msKeyLifeTime;
+    if(msTimeToNextKey > 0)
+        callbackTime = msTimeToNextKey;
+
+    /* Move to setSecurityKeysAction */
+    return UA_PubSubKeyStorage_addKeyRolloverCallback(
+        psm, ks, (UA_Callback)UA_PubSubKeyStorage_keyRolloverCallback,
+        callbackTime, &ks->callBackId);
+}
+
+static UA_StatusCode
+getSecurityKeysAction(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext,
+                      const UA_NodeId *methodId, void *methodContext,
+                      const UA_NodeId *objectId, void *objectContext, size_t inputSize,
+                      const UA_Variant *input, size_t outputSize, UA_Variant *output) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+    /* Validate the arguments */
+    if(!server || !input)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    if(inputSize < 3 || outputSize < 5)
+        return UA_STATUSCODE_BADARGUMENTSMISSING;
+    if(inputSize > 3 || outputSize > 5)
+        return UA_STATUSCODE_BADTOOMANYARGUMENTS;
+
+    /* Check whether the channel is encrypted according to specification */
+    UA_Session *session = getSessionById(server, sessionId);
+    if(!session || !session->channel)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    if(session->channel->securityMode != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT)
+        return UA_STATUSCODE_BADSECURITYMODEINSUFFICIENT;
+
+    /* Check for types */
+    if(!UA_Variant_hasScalarType(&input[0],
+                                 &UA_TYPES[UA_TYPES_STRING]) || /*SecurityGroupId*/
+       !UA_Variant_hasScalarType(&input[1],
+                                 &UA_TYPES[UA_TYPES_INTEGERID]) || /*StartingTokenId*/
+       !UA_Variant_hasScalarType(&input[2],
+                                 &UA_TYPES[UA_TYPES_UINT32])) /*RequestedKeyCount*/
+        return UA_STATUSCODE_BADTYPEMISMATCH;
+
+    UA_StatusCode retval = UA_STATUSCODE_BAD;
+    UA_UInt32 currentKeyCount = 1;
+
+    /* Input */
+    UA_String *securityGroupId = (UA_String *)input[0].data;
+    UA_UInt32 startingTokenId = *(UA_UInt32 *)input[1].data;
+    UA_UInt32 requestedKeyCount = *(UA_UInt32 *)input[2].data;
+
+    UA_PubSubManager *psm = getPSM(server);
+    UA_PubSubKeyStorage *ks = UA_PubSubKeyStorage_find(psm, *securityGroupId);
+    if(!ks)
+        return UA_STATUSCODE_BADNOTFOUND;
+
+    UA_Boolean executable = false;
+    UA_SecurityGroup *sg = UA_SecurityGroup_findByName(psm, *securityGroupId);
+    void *sgNodeCtx;
+    getNodeContext(server, sg->securityGroupNodeId, (void **)&sgNodeCtx);
+    executable = server->config.accessControl.getUserExecutableOnObject(
+        server, &server->config.accessControl, sessionId, sessionContext, methodId,
+        methodContext, &sg->securityGroupNodeId, sgNodeCtx);
+
+    if(!executable)
+        return UA_STATUSCODE_BADUSERACCESSDENIED;
+
+    /* If the caller requests a number larger than the Security Key Service
+     * permits, then the SKS shall return the maximum it allows.*/
+    if(requestedKeyCount > sg->config.maxFutureKeyCount)
+        requestedKeyCount =(UA_UInt32) sg->keyStorage->keyListSize;
+    else
+        requestedKeyCount = requestedKeyCount + currentKeyCount; /* Add Current keyCount */
+
+    /* The current token is requested by passing 0. */
+    UA_PubSubKeyListItem *startingItem = NULL;
+    if(startingTokenId == 0) {
+        /* currentItem is always set by the server when a security group is added */
+        UA_assert(sg->keyStorage->currentItem != NULL);
+        startingItem = sg->keyStorage->currentItem;
+    } else {
+        startingItem = UA_PubSubKeyStorage_getKeyByKeyId(sg->keyStorage, startingTokenId);
+        /* If the StartingTokenId is unknown, the oldest (firstItem) available
+         * tokens are returned. */
+        if(!startingItem)
+            startingItem = TAILQ_FIRST(&sg->keyStorage->keyList);
+    }
+
+    /* SecurityPolicyUri */
+    retval = UA_Variant_setScalarCopy(&output[0], &(sg->keyStorage->policy->policyUri),
+                         &UA_TYPES[UA_TYPES_STRING]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* FirstTokenId */
+    retval = UA_Variant_setScalarCopy(&output[1], &startingItem->keyID,
+                                      &UA_TYPES[UA_TYPES_INTEGERID]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* TimeToNextKey */
+    UA_EventLoop *el = server->config.eventLoop;
+    UA_DateTime baseTime = sg->baseTime;
+    UA_DateTime currentTime = el->dateTime_nowMonotonic(el);
+    UA_Duration interval = sg->config.keyLifeTime;
+    UA_Duration timeToNextKey =
+        (UA_Duration)((currentTime - baseTime) / UA_DATETIME_MSEC);
+    timeToNextKey = interval - timeToNextKey;
+    retval = UA_Variant_setScalarCopy(&output[3], &timeToNextKey,
+                                      &UA_TYPES[UA_TYPES_DURATION]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* KeyLifeTime */
+    retval = UA_Variant_setScalarCopy(&output[4], &sg->config.keyLifeTime,
+                         &UA_TYPES[UA_TYPES_DURATION]);
+    if(retval != UA_STATUSCODE_GOOD)
+        return retval;
+
+    /* Keys */
+    UA_PubSubKeyListItem *iterator = startingItem;
+    output[2].data = (UA_ByteString *)
+        UA_calloc(requestedKeyCount, startingItem->key.length);
+    if(!output[2].data)
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+
+    UA_ByteString *requestedKeys = (UA_ByteString *)output[2].data;
+    UA_UInt32 retkeyCount = 0;
+    for(size_t i = 0; i < requestedKeyCount; i++) {
+        UA_ByteString_copy(&iterator->key, &requestedKeys[i]);
+        ++retkeyCount;
+        iterator = TAILQ_NEXT(iterator, keyListEntry);
+        if(!iterator) {
+            requestedKeyCount = retkeyCount;
+            break;
+        }
+    }
+
+    UA_Variant_setArray(&output[2], requestedKeys, requestedKeyCount,
+                        &UA_TYPES[UA_TYPES_BYTESTRING]);
+    return retval;
+}
+
+UA_StatusCode
+initPubSubNS0_SKS(UA_Server *server) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+    UA_StatusCode retVal = UA_STATUSCODE_GOOD;
+    
+    if(server->config.pubSubConfig.enableInformationModelMethods) {
+        /* Set SKS method callbacks */
+        retVal |= setMethodNode_callback(server, UA_NS0ID(PUBLISHSUBSCRIBE_SETSECURITYKEYS), setSecurityKeysAction);
+        retVal |= setMethodNode_callback(server, UA_NS0ID(PUBLISHSUBSCRIBE_GETSECURITYKEYS), getSecurityKeysAction);
+    }
+
+    return retVal;
+}
+
+#endif /* UA_ENABLE_PUBSUB_INFORMATIONMODEL*/
+#endif /* UA_ENABLE_PUBSUB_SKS */

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -801,11 +801,6 @@ UA_Server_updateDataSetReaderConfig(UA_Server *server, const UA_NodeId dsrId,
     if(retVal != UA_STATUSCODE_GOOD)
         goto errout;
 
-    /* Call the state-machine. This can move the connection state from _ERROR to
-     * _DISABLED. */
-    UA_DataSetReader_setPubSubState(psm, dsr, UA_PUBSUBSTATE_DISABLED,
-                                    UA_STATUSCODE_GOOD);
-
     /* Clean up and return */
     UA_DataSetReaderConfig_clear(&oldConfig);
     unlockServer(server);

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -187,7 +187,8 @@ UA_ReaderGroup_create(UA_PubSubManager *psm, UA_NodeId connectionId,
 
     /* Trigger the connection state machine. It might open a socket only when
      * the first ReaderGroup is attached. */
-    UA_PubSubConnection_setPubSubState(psm, c, c->head.state);
+    if(rgc->enabled)
+        UA_PubSubConnection_setPubSubState(psm, c, c->head.state);
 
     /* Copying a numeric NodeId always succeeds */
     if(readerGroupId)
@@ -1177,10 +1178,6 @@ UA_Server_updateReaderGroupConfig(UA_Server *server, const UA_NodeId rgId,
         }
     }
 #endif
-
-    /* Call the state-machine. This can move the rg state from _ERROR to
-     * _DISABLED. */
-    UA_ReaderGroup_setPubSubState(psm, rg, UA_PUBSUBSTATE_DISABLED);
 
     /* Clean up and return */
     UA_ReaderGroupConfig_clear(&oldConfig);

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -379,7 +379,7 @@ UA_ReaderGroup_setPubSubState(UA_PubSubManager *psm, UA_ReaderGroup *rg,
      * Keep the current child state as the target state for the child. */
     UA_DataSetReader *dsr;
     LIST_FOREACH(dsr, &rg->readers, listEntry) {
-        if (psm->pubSubInitialSetupMode) {
+        if(psm->pubSubInitialSetupMode && dsr->config.enabled) {
             UA_DataSetReader_setPubSubState(psm, dsr, UA_PUBSUBSTATE_OPERATIONAL, UA_STATUSCODE_GOOD);
         } else {
             UA_DataSetReader_setPubSubState(psm, dsr, dsr->head.state, UA_STATUSCODE_GOOD);

--- a/src/pubsub/ua_pubsub_readergroup.c
+++ b/src/pubsub/ua_pubsub_readergroup.c
@@ -380,7 +380,7 @@ UA_ReaderGroup_setPubSubState(UA_PubSubManager *psm, UA_ReaderGroup *rg,
     UA_DataSetReader *dsr;
     LIST_FOREACH(dsr, &rg->readers, listEntry) {
         if(psm->pubSubInitialSetupMode && dsr->config.enabled) {
-            UA_DataSetReader_setPubSubState(psm, dsr, UA_PUBSUBSTATE_OPERATIONAL, UA_STATUSCODE_GOOD);
+            UA_DataSetReader_setPubSubState(psm, dsr, UA_PUBSUBSTATE_PREOPERATIONAL, UA_STATUSCODE_GOOD);
         } else {
             UA_DataSetReader_setPubSubState(psm, dsr, dsr->head.state, UA_STATUSCODE_GOOD);
         }

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -831,10 +831,6 @@ UA_Server_updateDataSetWriterConfig(UA_Server *server, const UA_NodeId dswId,
         dsw->config = newConfig;
     }
 
-    /* Call the state-machine. This can move the connection state from _ERROR to
-     * _DISABLED. */
-    UA_DataSetWriter_setPubSubState(psm, dsw, UA_PUBSUBSTATE_DISABLED);
-
     unlockServer(server);
     return res;
 }

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -531,7 +531,7 @@ UA_WriterGroup_setPubSubState(UA_PubSubManager *psm, UA_WriterGroup *wg,
      * Keep the current child state as the target state for the child. */
     UA_DataSetWriter *writer;
     LIST_FOREACH(writer, &wg->writers, listEntry) {
-        if (psm->pubSubInitialSetupMode) {
+        if(psm->pubSubInitialSetupMode && writer->config.enabled) {
             UA_DataSetWriter_setPubSubState(psm, writer, UA_PUBSUBSTATE_OPERATIONAL);
         } else {
             UA_DataSetWriter_setPubSubState(psm, writer, writer->head.state);

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -245,7 +245,8 @@ UA_WriterGroup_create(UA_PubSubManager *psm, const UA_NodeId connection,
 
     /* Trigger the connection state machine. It might open a socket only when
      * the first WriterGroup is attached. */
-    UA_PubSubConnection_setPubSubState(psm, c, c->head.state);
+    if(config->enabled)
+        UA_PubSubConnection_setPubSubState(psm, c, c->head.state);
 
     /* Copying a numeric NodeId always succeeds */
     if(writerGroupIdentifier)
@@ -1530,10 +1531,6 @@ UA_Server_updateWriterGroupConfig(UA_Server *server, const UA_NodeId wgId,
         }
     }
 #endif
-
-    /* Call the state-machine. This can move the wg state from _ERROR to
-     * _DISABLED. */
-    UA_WriterGroup_setPubSubState(psm, wg, UA_PUBSUBSTATE_DISABLED);
 
     /* Clean up and return */
     UA_WriterGroupConfig_clear(&oldConfig);

--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -531,7 +531,11 @@ UA_WriterGroup_setPubSubState(UA_PubSubManager *psm, UA_WriterGroup *wg,
      * Keep the current child state as the target state for the child. */
     UA_DataSetWriter *writer;
     LIST_FOREACH(writer, &wg->writers, listEntry) {
-        UA_DataSetWriter_setPubSubState(psm, writer, writer->head.state);
+        if (psm->pubSubInitialSetupMode) {
+            UA_DataSetWriter_setPubSubState(psm, writer, UA_PUBSUBSTATE_OPERATIONAL);
+        } else {
+            UA_DataSetWriter_setPubSubState(psm, writer, writer->head.state);
+        }
     }
 
     /* Update the PubSubManager state. It will go from STOPPING to STOPPED when


### PR DESCRIPTION
This PR introduces the following changes:

- Representation of the State Object for all PubSub entities in the NS0.
- Implementation of the enable/disable functions in NS0.
- Mapping the internal PubSubManager state to the state of the PublishSubscribe object.
- Overhauling file-based PubSub loading with respect to state machine interaction. Ensuring the entire configuration is loaded until the state machines of the components are triggered.
- Add a state flag to the PubSubManager to indicate a 'configuration phase', influencing state changes to enable all components when a complete configuration is applied.