### PR TITLE
feat(server): Extended the access control plugin with check for receiving events

### DIFF
--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -113,6 +113,17 @@ struct UA_AccessControl {
                                   const UA_NodeId *sessionId, void *sessionContext,
                                   const UA_NodeId *nodeId, void *nodeContext);
 
+#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
+    /* Allow reception of events
+     * The nodes to be checked are the source node (event origin) and the
+     * event type node.*/
+    UA_Boolean (*allowReceiveEvents)(UA_Server *server, UA_AccessControl *ac,
+                                     const UA_NodeId *sessionId, void *sessionContext,
+                                     const UA_NodeId *sourceNodeId, void *sourceNodeContext,
+                                     const UA_NodeId *typeNodeId, void *typeNodeContext);
+
+#endif
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /* Allow creating a subscription */
     UA_Boolean (*allowCreateSubscription)(UA_Server *server, UA_AccessControl *ac,

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -352,6 +352,17 @@ allowBrowseNode_default(UA_Server *server, UA_AccessControl *ac,
 #endif
 }
 
+#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
+static UA_Boolean
+allowReceiveEvents_default(UA_Server *server, UA_AccessControl *ac,
+                           const UA_NodeId *sessionId, void *sessionContext,
+                           const UA_NodeId *sourceNodeId, void *sourceNodeContext,
+                           const UA_NodeId *typeNodeId, void *typeNodeContext) {
+    return true;
+}
+
+#endif
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static UA_Boolean
 allowCreateSubscription_default(UA_Server *server, UA_AccessControl *ac,
@@ -568,6 +579,10 @@ UA_AccessControl_default(UA_ServerConfig *config,
     ac->allowAddNode = allowAddNode_default;
     ac->allowAddReference = allowAddReference_default;
     ac->allowBrowseNode = allowBrowseNode_default;
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
+    ac->allowReceiveEvents = allowReceiveEvents_default;
+#endif
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     ac->allowCreateSubscription = allowCreateSubscription_default;

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -6,6 +6,7 @@
  *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart (for VDW and umati)
  *    Copyright 2021 (c) Fraunhofer IOSB (Author: Andreas Ebner)
  *    Copyright 2022, 2025 (c) Fraunhofer IOSB (Author: Julius Pfrommer)
+ *    Copyright (c) 2026 Pilz GmbH & Co. KG, Author: Marcel Patzlaff
  */
 
 #include <open62541/types.h>
@@ -1528,6 +1529,26 @@ setHistoricalEvent(UA_Server *server, const UA_NodeId *emitNode,
 }
 #endif
 
+/* Utility function to fetch the event type node from the various possible locations.*/
+static const UA_Node*
+getEventTypeNode(UA_FilterEvalContext *ctx) {
+    /* Read the /EventType event field */
+    static UA_QualifiedName eventTypeName = {0, UA_STRING_STATIC("EventType")};
+    UA_SimpleAttributeOperand sao;
+    UA_SimpleAttributeOperand_init(&sao);
+    sao.attributeId = UA_ATTRIBUTEID_VALUE;
+    sao.browsePath = &eventTypeName;
+    sao.browsePathSize = 1;
+    UA_Variant eventType;
+    UA_Variant_init(&eventType);
+    if(UA_STATUSCODE_GOOD != resolveSAO(ctx, &sao, &eventType))
+        return NULL;
+
+    const UA_Node *typeNode = UA_NODESTORE_GET(ctx->server, (UA_NodeId*) eventType.data);
+    UA_Variant_clear(&eventType);
+    return typeNode;
+}
+
 #define EMIT_REFS_ROOT_COUNT 4
 static const UA_NodeId emitReferencesRoots[EMIT_REFS_ROOT_COUNT] =
     {{0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_ORGANIZES}},
@@ -1651,6 +1672,13 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
             return res;
     }
 
+    const UA_Node *evTypeNode = getEventTypeNode(&ctx);
+    if(!evTypeNode) {
+        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
+                     "Events: Could not fetch event type node");
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
     /* Loop over all nodes that emit this event instance */
     for(size_t i = 0; i < emitNodesSize; i++) {
         /* We can only emit on local nodes */
@@ -1688,6 +1716,23 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
             /* Filter on the MonitoredItemId */
             if(ed->monitoredItemId && *ed->monitoredItemId != mon->monitoredItemId)
                 continue;
+
+            /* Check ReceiveEvents permission */
+            if(sub->session && server->config.accessControl.allowReceiveEvents) {
+                if(!server->config.accessControl.
+                    allowReceiveEvents(server, &server->config.accessControl,
+                                       &sub->session->sessionId, sub->session->context,
+                                       &node->head.nodeId, node->head.context,
+                                       &evTypeNode->head.nodeId, evTypeNode->head.context)
+                ) {
+                    UA_LOG_INFO_SUBSCRIPTION(server->config.logging, mon->subscription,
+                                             "Session %N is not allowed to receive "
+                                             "event of type %N from source %N",
+                                             sub->session->sessionId, evTypeNode->head.nodeId,
+                                             node->head.nodeId);
+                    continue;
+                }
+            }
 
             /* Get the EventFilter from the MonitoredItem */
             if(!UA_ExtensionObject_hasDecodedType(&mon->parameters.filter,
@@ -1749,6 +1794,8 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
             setHistoricalEvent(server, &emitNodes[i].nodeId, ed);
 #endif
     }
+
+    UA_NODESTORE_RELEASE(server, evTypeNode);
 
     /* Clean up and return */
     if(outEventId && res != UA_STATUSCODE_GOOD)


### PR DESCRIPTION
The ReceiveEvents permission from the OPC UA specification was missing in the AccessControl plugin. This change adds it now.