### PR TITLE
feat(server): New allowCreateSubscription check for access control plugin

### DIFF
--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -103,6 +103,10 @@ struct UA_AccessControl {
                                   const UA_NodeId *nodeId, void *nodeContext);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
+    /* Allow creating a subscription */
+    UA_Boolean (*allowCreateSubscription)(UA_Server *server, UA_AccessControl *ac,
+                                          const UA_NodeId *sessionId, void *sessionContext);
+
     /* Allow transfer of a subscription to another session. The Server shall
      * validate that the Client of that Session is operating on behalf of the
      * same user */

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -221,6 +221,12 @@ allowBrowseNode_default(UA_Server *server, UA_AccessControl *ac,
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static UA_Boolean
+allowCreateSubscription_default(UA_Server *server, UA_AccessControl *ac,
+                                const UA_NodeId *sessionId, void *sessionContext) {
+    return true;
+}
+
+static UA_Boolean
 allowTransferSubscription_default(UA_Server *server, UA_AccessControl *ac,
                                   const UA_NodeId *oldSessionId, void *oldSessionContext,
                                   const UA_NodeId *newSessionId, void *newSessionContext) {
@@ -315,6 +321,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
     ac->allowBrowseNode = allowBrowseNode_default;
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
+    ac->allowCreateSubscription = allowCreateSubscription_default;
     ac->allowTransferSubscription = allowTransferSubscription_default;
 #endif
 


### PR DESCRIPTION
Subscriptions consume resources on the server. It should be possible to limit this for example to forbid anonymously authenticated sessions to create subscriptions at all.