### PR TITLE
fix(util): Add : to the extended-percent-encoding to ensure Qualified…

### DIFF
--- a/include/open62541/util.h
+++ b/include/open62541/util.h
@@ -336,12 +336,12 @@ UA_readNumberWithBase(const UA_Byte *buf, size_t buflen,
  * the following (in addition to whitespaces and unprintable ASCII control
  * codes).::
  *
- *    ' ' - %20     '(' - %28     '>' - %3E
- *    '"' - %22     ')' - %29     '[' - %5B
- *    '#' - %23     ',' - %2C     '\' - %5C
- *    '%' - %25     '/' - %2F     ']' - %5D
- *    '&' - %26     ';' - %3B     '`' - %60
- *    ''' - %27     '<' - %3C
+ *    ' ' - %20     '(' - %28     '<' - %3C
+ *    '"' - %22     ')' - %29     '>' - %3E
+ *    '#' - %23     ',' - %2C     '[' - %5B
+ *    '%' - %25     '/' - %2F     '\' - %5C
+ *    '&' - %26     ':' - %3A     ']' - %5D
+ *    ''' - %27     ';' - %3B     '`' - %60
  *
  * .. _relativepath:
  *

--- a/src/util/ua_util_internal.h
+++ b/src/util/ua_util_internal.h
@@ -90,10 +90,9 @@ isReservedPercent(u8 c) {
 
 static UA_INLINE UA_Boolean
 isReservedPercentExtended(u8 c) {
-    return (isReservedPercent(c) || c == '#' || c == '[' ||
-            c == ']' || c == '&' || c == '(' || c == ')' ||
-            c == ',' || c == '<' || c == '>' || c == '`' ||
-            c == '/' || c == '\\' || c == '"' || c == '\'' );
+    return (isReservedPercent(c) || c == ':' || c == '#' || c == '[' || c == ']' ||
+            c == '&' || c == '(' || c == ')' || c == ',' || c == '<' || c == '>' ||
+            c == '`' || c == '/' || c == '\\' || c == '"' || c == '\'' );
 }
 
 /* Unescape string. The copyEscape boolean indicates whether a copy of the


### PR DESCRIPTION
…Names don't mix up the NamespaceIndex