### PR TITLE
[WIP] customisable certificate verification

### DIFF
--- a/drivers/gds_receiver/gds_receiver.c
+++ b/drivers/gds_receiver/gds_receiver.c
@@ -658,15 +658,6 @@ UA_GDSReceiver_addCertificate(UA_GDSReceiverContext *ctx,
     UA_Server *server = ctx->drv.server;
     UA_ServerConfig *sc = UA_Server_getConfig(server);
 
-    /* CA certificates cannot be added using this method because it does not
-     * support adding CRLs */
-    if(UA_CertificateUtils_checkCA(certificate) == UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(sc->logging, UA_LOGCATEGORY_SERVER,
-                     "The certificate could not be added because it is a CA certificate. "
-                     "CA certificates must be added using the FileType methods.");
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    }
-
     /* This method cannot be called if the containing TrustList Object is open */
     UA_FileInfo *fileInfo =
         UA_GDSReceiver_getFileInfo(ctx, certGroup->certificateGroupId);
@@ -675,13 +666,24 @@ UA_GDSReceiver_addCertificate(UA_GDSReceiverContext *ctx,
     if(fileInfo->openCount > 0)
         return UA_STATUSCODE_BADINVALIDSTATE;
 
+    /* Ensure certificate validity before adding it */
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageInstanceCert = (certGroup == &(server->config.secureChannelPKI));
+    verSettings.allowUsageUserCert = (certGroup == &(server->config.sessionPKI));
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_VALIDITY;
+    UA_StatusCode res = certGroup->verifyCertificate(certGroup, certificate, verSettings);
+    if(retval != UA_STATUSCODE_GOOD) {
+        // mask error with UA_STATUSCODE_BADCERTIFICATEINVALID
+        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+    }
+
     UA_TrustListDataType trustList;
     UA_TrustListDataType_init(&trustList);
     trustList.specifiedLists = UA_TRUSTLISTMASKS_TRUSTEDCERTIFICATES;
     trustList.trustedCertificates = certificate;
     trustList.trustedCertificatesSize = 1;
 
-    UA_StatusCode res = certGroup->addToTrustList(certGroup, &trustList);
+    res = certGroup->addToTrustList(certGroup, &trustList);
     if(res != UA_STATUSCODE_GOOD)
         return res;
 
@@ -724,6 +726,18 @@ UA_GDSReceiver_stageCertificateUpdate(UA_GDSReceiverContext *ctx,
         retval = UA_CertificateUtils_checkKeyPair(certificate, privateKey);
         if(retval != UA_STATUSCODE_GOOD)
             return UA_STATUSCODE_BADNOTSUPPORTED;
+    }
+
+    /* Ensure certificate integrity before accepting it */
+    UA_ServerConfig *sc = UA_Server_getConfig(ctx->drv.server);
+    UA_CertficateGroup *certGroup = &(sc->secureChannelPKI);
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageInstanceCert= true;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY;
+    retval = certGroup->verifyCertificate(certGroup, certificate, verSettings);
+    if(retval != UA_STATUSCODE_GOOD) {
+        // mask error with UA_STATUSCODE_BADCERTIFICATEINVALID
+        return UA_STATUSCODE_BADCERTIFICATEINVALID;
     }
 
     UA_GDSTransaction *transaction = &ctx->transaction;

--- a/include/open62541/plugin/certificategroup.h
+++ b/include/open62541/plugin/certificategroup.h
@@ -4,6 +4,7 @@
  *
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2024 (c) Fraunhofer IOSB (Author: Noel Graf)
+ *    Copyright (c) 2025 Pilz GmbH & Co. KG, Author: Marcel Patzlaff
  */
 
 #ifndef UA_PLUGIN_CERTIFICATEGROUP_H
@@ -13,6 +14,41 @@
 #include <open62541/plugin/log.h>
 
 _UA_BEGIN_DECLS
+
+typedef enum
+{
+    /* Apply integrity checks to ensure the integrity of the certificate and its chain:
+     * * Certificate Structure (1)
+     * * Certificate Usage (9)
+     * * Build Certificate Chain (2)
+     * * Signature (3)
+     * * Security Policy Check (4)*/
+    UA_CERTIFICATEVERIFICATION_INTEGRITY = 0,
+
+    /* Additionally apply checks to ensure the validity of the certificate:
+     * * Validity Period (6)
+     * * Find Revocation List (10)
+     * * Revocation Check (11)*/
+    UA_CERTIFICATEVERIFICATION_VALIDITY,
+
+    /* Additionally apply checks to ensure that the certificate can be trusted:
+     * * Host Name (7)
+     * * URI (Application or Product URI check) (8)
+     * * Trust List Check (5)*/
+    UA_CERTIFICATEVERIFICATION_TRUST,
+} UA_CertificateVerification;
+
+typedef struct
+{
+    UA_Boolean allowUsageInstanceCert: 1;
+    UA_Boolean allowUsageIssuerCert: 1;
+    UA_Boolean allowUsageUserCert: 1;
+    UA_Boolean skipTrustListChecks: 1;
+    UA_CertificateVerification verificationLevel: 2;
+} UA_CertificateVerificationSettings;
+
+#define UA_CERTIFICATEVERIFICATIONSETTINGS_NONE() \
+    {false, false, false, false, UA_CERTIFICATEVERIFICATION_INTEGRITY}
 
 struct UA_CertificateGroup;
 typedef struct UA_CertificateGroup UA_CertificateGroup;
@@ -67,7 +103,8 @@ struct UA_CertificateGroup {
                                         size_t *crlsSize);
 
     UA_StatusCode (*verifyCertificate)(UA_CertificateGroup *certGroup,
-                                       const UA_ByteString *certificate);
+                                       const UA_ByteString *certificate,
+                                       UA_CertificateVerificationSettings settings);
 
     void (*clear)(UA_CertificateGroup *certGroup);
 };

--- a/include/open62541/plugin/certificategroup.h
+++ b/include/open62541/plugin/certificategroup.h
@@ -15,40 +15,72 @@
 
 _UA_BEGIN_DECLS
 
+#define UA_CERTIFICATEVERIFICATION_STEP(name, number) UA_CERTIFICATEVERIFICATION_STEP_ ## name = (1u << (number))
+
 typedef enum
 {
+    UA_CERTIFICATEVERIFICATION_STEP(CERTIFICATE_STRUCTURE,    1),
+    UA_CERTIFICATEVERIFICATION_STEP(BUILD_CERTIFICATE_CHAIN,  2),
+    UA_CERTIFICATEVERIFICATION_STEP(SIGNATURE,                3),
+    UA_CERTIFICATEVERIFICATION_STEP(SECURITY_POLICY_CHECK,    4),
+    UA_CERTIFICATEVERIFICATION_STEP(TRUST_LIST_CHECK,         5),
+    UA_CERTIFICATEVERIFICATION_STEP(VALIDITY_PERIOD,          6),
+    UA_CERTIFICATEVERIFICATION_STEP(HOST_NAME,                7),
+    UA_CERTIFICATEVERIFICATION_STEP(URI,                      8),
+    UA_CERTIFICATEVERIFICATION_STEP(CERTIFICATE_USAGE,        9),
+    UA_CERTIFICATEVERIFICATION_STEP(FIND_REVOCATION_LIST,    10),
+    UA_CERTIFICATEVERIFICATION_STEP(REVOCATION_CHECK,        11),
+
     /* Apply integrity checks to ensure the integrity of the certificate and its chain:
      * * Certificate Structure (1)
      * * Certificate Usage (9)
      * * Build Certificate Chain (2)
      * * Signature (3)
      * * Security Policy Check (4)*/
-    UA_CERTIFICATEVERIFICATION_INTEGRITY = 0,
+    UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY = (
+          UA_CERTIFICATEVERIFICATION_STEP_CERTIFICATE_STRUCTURE
+        | UA_CERTIFICATEVERIFICATION_STEP_CERTIFICATE_USAGE
+        | UA_CERTIFICATEVERIFICATION_STEP_BUILD_CERTIFICATE_CHAIN
+        | UA_CERTIFICATEVERIFICATION_STEP_SIGNATURE
+        | UA_CERTIFICATEVERIFICATION_STEP_SECURITY_POLICY_CHECK
+    ),
 
     /* Additionally apply checks to ensure the validity of the certificate:
      * * Validity Period (6)
      * * Find Revocation List (10)
      * * Revocation Check (11)*/
-    UA_CERTIFICATEVERIFICATION_VALIDITY,
+    UA_CERTIFICATEVERIFICATION_FOR_VALIDITY = (
+          UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY
+        | UA_CERTIFICATEVERIFICATION_STEP_VALIDITY_PERIOD
+        | UA_CERTIFICATEVERIFICATION_STEP_FIND_REVOCATION_LIST
+        | UA_CERTIFICATEVERIFICATION_STEP_REVOCATION_CHECK
+    ),
 
     /* Additionally apply checks to ensure that the certificate can be trusted:
      * * Host Name (7)
      * * URI (Application or Product URI check) (8)
      * * Trust List Check (5)*/
-    UA_CERTIFICATEVERIFICATION_TRUST,
+    UA_CERTIFICATEVERIFICATION_FOR_TRUST = (
+        UA_CERTIFICATEVERIFICATION_FOR_VALIDITY
+      | UA_CERTIFICATEVERIFICATION_STEP_HOST_NAME
+      | UA_CERTIFICATEVERIFICATION_STEP_URI
+      | UA_CERTIFICATEVERIFICATION_STEP_TRUST_LIST_CHECK
+    )
 } UA_CertificateVerification;
+
+#define UA_CERTIFICATEVERIFICATION_SELECTED(steps, name) (((steps) & UA_CERTIFICATEVERIFICATION_STEP_ ## name) != 0u)
 
 typedef struct
 {
     UA_Boolean allowUsageInstanceCert: 1;
     UA_Boolean allowUsageIssuerCert: 1;
     UA_Boolean allowUsageUserCert: 1;
-    UA_Boolean skipTrustListChecks: 1;
-    UA_CertificateVerification verificationLevel: 2;
+
+    UA_UInt32 verificationSteps;
 } UA_CertificateVerificationSettings;
 
 #define UA_CERTIFICATEVERIFICATIONSETTINGS_NONE() \
-    {false, false, false, false, UA_CERTIFICATEVERIFICATION_INTEGRITY}
+    {false, false, false, UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY}
 
 struct UA_CertificateGroup;
 typedef struct UA_CertificateGroup UA_CertificateGroup;

--- a/include/open62541/plugin/certificategroup.h
+++ b/include/open62541/plugin/certificategroup.h
@@ -4,6 +4,7 @@
  *
  *    Copyright 2018 (c) Mark Giraud, Fraunhofer IOSB
  *    Copyright 2024 (c) Fraunhofer IOSB (Author: Noel Graf)
+ *    Copyright (c) 2026 Pilz GmbH & Co. KG, Author: Marcel Patzlaff
  */
 
 #ifndef UA_PLUGIN_CERTIFICATEGROUP_H
@@ -13,6 +14,73 @@
 #include <open62541/plugin/log.h>
 
 _UA_BEGIN_DECLS
+
+#define UA_CERTIFICATEVERIFICATION_STEP(name, number) UA_CERTIFICATEVERIFICATION_STEP_ ## name = (1u << (number))
+
+typedef enum
+{
+    UA_CERTIFICATEVERIFICATION_STEP(CERTIFICATE_STRUCTURE,    1),
+    UA_CERTIFICATEVERIFICATION_STEP(BUILD_CERTIFICATE_CHAIN,  2),
+    UA_CERTIFICATEVERIFICATION_STEP(SIGNATURE,                3),
+    UA_CERTIFICATEVERIFICATION_STEP(SECURITY_POLICY_CHECK,    4),
+    UA_CERTIFICATEVERIFICATION_STEP(TRUST_LIST_CHECK,         5),
+    UA_CERTIFICATEVERIFICATION_STEP(VALIDITY_PERIOD,          6),
+    UA_CERTIFICATEVERIFICATION_STEP(HOST_NAME,                7),
+    UA_CERTIFICATEVERIFICATION_STEP(URI,                      8),
+    UA_CERTIFICATEVERIFICATION_STEP(CERTIFICATE_USAGE,        9),
+    UA_CERTIFICATEVERIFICATION_STEP(FIND_REVOCATION_LIST,    10),
+    UA_CERTIFICATEVERIFICATION_STEP(REVOCATION_CHECK,        11),
+
+    /* Apply integrity checks to ensure the integrity of the certificate and its chain:
+     * * Certificate Structure (1)
+     * * Certificate Usage (9)
+     * * Build Certificate Chain (2)
+     * * Signature (3)
+     * * Security Policy Check (4)*/
+    UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY = (
+          UA_CERTIFICATEVERIFICATION_STEP_CERTIFICATE_STRUCTURE
+        | UA_CERTIFICATEVERIFICATION_STEP_CERTIFICATE_USAGE
+        | UA_CERTIFICATEVERIFICATION_STEP_BUILD_CERTIFICATE_CHAIN
+        | UA_CERTIFICATEVERIFICATION_STEP_SIGNATURE
+        | UA_CERTIFICATEVERIFICATION_STEP_SECURITY_POLICY_CHECK
+    ),
+
+    /* Additionally apply checks to ensure the validity of the certificate:
+     * * Validity Period (6)
+     * * Find Revocation List (10)
+     * * Revocation Check (11)*/
+    UA_CERTIFICATEVERIFICATION_FOR_VALIDITY = (
+          UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY
+        | UA_CERTIFICATEVERIFICATION_STEP_VALIDITY_PERIOD
+        | UA_CERTIFICATEVERIFICATION_STEP_FIND_REVOCATION_LIST
+        | UA_CERTIFICATEVERIFICATION_STEP_REVOCATION_CHECK
+    ),
+
+    /* Additionally apply checks to ensure that the certificate can be trusted:
+     * * Host Name (7)
+     * * URI (Application or Product URI check) (8)
+     * * Trust List Check (5)*/
+    UA_CERTIFICATEVERIFICATION_FOR_TRUST = (
+        UA_CERTIFICATEVERIFICATION_FOR_VALIDITY
+      | UA_CERTIFICATEVERIFICATION_STEP_HOST_NAME
+      | UA_CERTIFICATEVERIFICATION_STEP_URI
+      | UA_CERTIFICATEVERIFICATION_STEP_TRUST_LIST_CHECK
+    )
+} UA_CertificateVerification;
+
+#define UA_CERTIFICATEVERIFICATION_SELECTED(steps, name) (((steps) & UA_CERTIFICATEVERIFICATION_STEP_ ## name) != 0u)
+
+typedef struct
+{
+    UA_Boolean allowUsageInstanceCert: 1;
+    UA_Boolean allowUsageIssuerCert: 1;
+    UA_Boolean allowUsageUserCert: 1;
+
+    UA_UInt32 verificationSteps;
+} UA_CertificateVerificationSettings;
+
+#define UA_CERTIFICATEVERIFICATIONSETTINGS_NONE() \
+    {false, false, false, UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY}
 
 struct UA_CertificateGroup;
 typedef struct UA_CertificateGroup UA_CertificateGroup;
@@ -67,7 +135,8 @@ struct UA_CertificateGroup {
                                         size_t *crlsSize);
 
     UA_StatusCode (*verifyCertificate)(UA_CertificateGroup *certGroup,
-                                       const UA_ByteString *certificate);
+                                       const UA_ByteString *certificate,
+                                       UA_CertificateVerificationSettings settings);
 
     void (*clear)(UA_CertificateGroup *certGroup);
 };

--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -661,7 +661,7 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
      * - Host Name
      * - URI */
     UA_StatusCode ret = UA_STATUSCODE_GOOD;
-    if(settings.verificationLevel >= UA_CERTIFICATEVERIFICATION_INTEGRITY) {
+    if(UA_CERTIFICATEVERIFICATION_SELECTED(settings.verificationSteps, BUILD_CERTIFICATE_CHAIN)) {
         /* Verification Step: Build Certificate Chain
          * We perform the checks for each certificate inside. */
         mbedtls_x509_crt *old_issuers[UA_MBEDTLS_MAX_CHAIN_LENGTH];

--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -5,6 +5,7 @@
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
  *    Copyright 2019 (c) Julius Pfrommer, Fraunhofer IOSB
  *    Copyright 2024 (c) Fraunhofer IOSB (Author: Noel Graf)
+ *    Copyright (c) 2025 Pilz GmbH & Co. KG, Author: Marcel Patzlaff
  */
 
 #include <open62541/util.h>
@@ -15,6 +16,7 @@
 #include <mbedtls/x509.h>
 #include <mbedtls/oid.h>
 #include <mbedtls/x509_crt.h>
+#include <mbedtls/pk.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/version.h>
 #include <mbedtls/sha256.h>
@@ -55,7 +57,15 @@ typedef struct {
     mbedtls_x509_crl issuerCrls;
 } MemoryCertStore;
 
-static UA_Boolean mbedtlsCheckCA(mbedtls_x509_crt *cert);
+typedef enum
+{
+    CERTTYPE_INVALID = 0,
+    CERTTYPE_ISSUER,
+    CERTTYPE_INSTANCE,
+    CERTTYPE_USER
+} CertType;
+
+static CertType mbedtlsGetUsage(mbedtls_x509_crt *cert);
 
 static UA_StatusCode
 MemoryCertStore_removeFromTrustList(UA_CertificateGroup *certGroup, const UA_TrustListDataType *trustList) {
@@ -157,7 +167,7 @@ mbedtlsFindCrls(UA_CertificateGroup *certGroup, const UA_ByteString *certificate
 
     /* Check if the certificate is a CA certificate.
      * Only a CA certificate can have a CRL. */
-    if(!mbedtlsCheckCA(&cert)) {
+    if(CERTTYPE_ISSUER != mbedtlsGetUsage(&cert)) {
         UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,
                "The certificate is not a CA certificate and therefore does not have a CRL.");
         mbedtls_x509_crt_free(&cert);
@@ -339,21 +349,66 @@ reloadCertificates(UA_CertificateGroup *certGroup) {
 #define MBEDTLS_PRIVATE(x) x
 #endif
 
-/* Is the certificate a CA? */
-static UA_Boolean
-mbedtlsCheckCA(mbedtls_x509_crt *cert) {
-    /* The Basic Constraints extension must be set and the cert acts as CA */
-    if(!(cert->MBEDTLS_PRIVATE(ext_types) & MBEDTLS_X509_EXT_BASIC_CONSTRAINTS) ||
-       !cert->MBEDTLS_PRIVATE(ca_istrue))
-        return false;
+/* What type of certificate do we have here? */
+static CertType
+mbedtlsGetUsage(mbedtls_x509_crt *cert) {
+    CertType defUsage = CERTTYPE_USER;
 
-    /* The Key Usage extension must be set to cert signing and CRL issuing */
-    if(!(cert->MBEDTLS_PRIVATE(ext_types) & MBEDTLS_X509_EXT_KEY_USAGE) ||
-       mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_KEY_CERT_SIGN) != 0 ||
-       mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_CRL_SIGN) != 0)
-        return false;
+    // basicConstraints must always be present
+    if(!(cert->MBEDTLS_PRIVATE(ext_types) & MBEDTLS_X509_EXT_BASIC_CONSTRAINTS))
+        return CERTTYPE_INVALID;
 
-    return true;
+    const UA_Boolean hasKeyUsage = (cert->MBEDTLS_PRIVATE(ext_types) & MBEDTLS_X509_EXT_KEY_USAGE);
+
+    if(cert->MBEDTLS_PRIVATE(ca_istrue)) {
+        // can be issuer or self-signed instance cert
+
+        // ensure that the key usage extension is available in the certificate
+        if (!hasKeyUsage)
+            return CERTTYPE_INVALID;
+
+        // check if the Key Usage extension is set to cert signing and CRL signing
+        if(mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_KEY_CERT_SIGN) == 0 &&
+           mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_CRL_SIGN) == 0) {
+            return CERTTYPE_ISSUER;
+        }
+
+        // user certificates must set CA:FALSE
+        defUsage = CERTTYPE_INVALID;
+    }
+
+    // can be user or instance cert or just invalid
+    if(!hasKeyUsage)
+        return defUsage;
+
+    const mbedtls_pk_type_t pk_alg = mbedtls_pk_get_type(&(cert->pk));
+    if((MBEDTLS_PK_RSA == pk_alg) || (MBEDTLS_PK_RSASSA_PSS == pk_alg)) {
+        // RSA profiles require digitalSignature, nonRepudiation, keyEncipherment and dataEncipherment in keyUsage
+        // and at least clientAuth in extendedKeyUsage
+        const UA_Boolean hasExtKeyUsage = (cert->MBEDTLS_PRIVATE(ext_types) & MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE);
+        if(!hasExtKeyUsage)
+            return defUsage;
+
+        if((mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_DIGITAL_SIGNATURE) != 0) ||
+           (mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_NON_REPUDIATION) != 0) ||
+           (mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_KEY_ENCIPHERMENT) != 0) ||
+           (mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_DATA_ENCIPHERMENT) != 0)) {
+            return defUsage;
+        }
+
+        if((mbedtls_x509_crt_check_extended_key_usage(
+            cert, MBEDTLS_OID_CLIENT_AUTH, sizeof(MBEDTLS_OID_CLIENT_AUTH) - 1)) != 0) {
+            return defUsage;
+        }
+    } else if((MBEDTLS_PK_ECDSA == pk_alg) || (MBEDTLS_PK_ECKEY == pk_alg) || (MBEDTLS_PK_ECKEY_DH == pk_alg)) {
+        // ECC profiles only require digitalSignature in keyUsage
+        if((mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_DIGITAL_SIGNATURE) != 0))
+            return defUsage;
+    } else
+        return CERTTYPE_INVALID;
+
+    // it is with high-propability an Application Instance Certificate
+    return CERTTYPE_INSTANCE;
 }
 
 static UA_Boolean
@@ -474,7 +529,8 @@ mbedtlsCheckSignature(const mbedtls_x509_crt *cert, mbedtls_x509_crt *issuer) {
 
 static UA_StatusCode
 mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_crt *stack,
-                   mbedtls_x509_crt **old_issuers, mbedtls_x509_crt *cert, int depth) {
+                   mbedtls_x509_crt **old_issuers, mbedtls_x509_crt *cert, int depth,
+                   UA_CertificateVerificationSettings settings) {
     /* Maxiumum chain length */
     if(depth == UA_MBEDTLS_MAX_CHAIN_LENGTH)
         return UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
@@ -499,7 +555,7 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 
         /* Verification Step: Certificate Usage
          * Can the issuer act as CA? Omit for self-signed leaf certificates. */
-        if((depth > 0 || issuer != cert) && !mbedtlsCheckCA(issuer)) {
+        if((depth > 0 || issuer != cert) && (CERTTYPE_ISSUER != mbedtlsGetUsage(issuer))) {
             ret = UA_STATUSCODE_BADCERTIFICATEISSUERUSENOTALLOWED;
             continue;
         }
@@ -543,7 +599,7 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 
         /* We have found the issuer certificate used for the signature. Recurse
          * to the next certificate in the chain (verify the current issuer). */
-        ret = mbedtlsVerifyChain(cg, ctx, stack, old_issuers, issuer, depth + 1);
+        ret = mbedtlsVerifyChain(cg, ctx, stack, old_issuers, issuer, depth + 1, settings);
     }
 
     /* The chain is complete, but we haven't yet identified a trusted
@@ -561,7 +617,8 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 /* This follows Part 6, 6.1.3 Determining if a Certificate is trusted.
  * It defines a sequence of steps for certificate verification. */
 static UA_StatusCode
-verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
+verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate,
+                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if (certGroup == NULL || certGroup->context == NULL) {
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -589,7 +646,11 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
      * Check whether the certificate is a User certificate or a CA certificate.
      * Refer the test case CTT/Security/Security Certificate Validation/029.js
      * for more details. */
-    if(mbedtlsCheckCA(&cert)) {
+    CertType certType = mbedtlsGetUsage(&cert);
+    if((CERTTYPE_INVALID == certType) ||
+       ((CERTTYPE_INSTANCE == certType) && !settings.allowUsageInstanceCert) ||
+       ((CERTTYPE_ISSUER == certType) && !settings.allowUsageIssuerCert) ||
+       ((CERTTYPE_USER == certType) && !settings.allowUsageUserCert)) {
         mbedtls_x509_crt_free(&cert);
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
     }
@@ -599,24 +660,28 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
      * - Security Policy
      * - Host Name
      * - URI */
+    UA_StatusCode ret = UA_STATUSCODE_GOOD;
+    if(settings.verificationLevel >= UA_CERTIFICATEVERIFICATION_INTEGRITY) {
+        /* Verification Step: Build Certificate Chain
+         * We perform the checks for each certificate inside. */
+        mbedtls_x509_crt *old_issuers[UA_MBEDTLS_MAX_CHAIN_LENGTH];
+        ret = mbedtlsVerifyChain(certGroup, context, &cert, old_issuers, &cert, 0, settings);
+    }
 
-    /* Verification Step: Build Certificate Chain
-     * We perform the checks for each certificate inside. */
-    mbedtls_x509_crt *old_issuers[UA_MBEDTLS_MAX_CHAIN_LENGTH];
-    UA_StatusCode ret = mbedtlsVerifyChain(certGroup, context, &cert, old_issuers, &cert, 0);
     mbedtls_x509_crt_free(&cert);
     return ret;
 }
 
 static UA_StatusCode
 MemoryCertStore_verifyCertificate(UA_CertificateGroup *certGroup,
-                                  const UA_ByteString *certificate) {
+                                  const UA_ByteString *certificate,
+                                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(certGroup == NULL || certificate == NULL) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    UA_StatusCode retval = verifyCertificate(certGroup, certificate);
+    UA_StatusCode retval = verifyCertificate(certGroup, certificate, settings);
     if(retval != UA_STATUSCODE_GOOD) {
         if(MemoryCertStore_addToRejectedList(certGroup, certificate) != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,
@@ -1019,7 +1084,7 @@ UA_CertificateUtils_checkCA(const UA_ByteString *certificate) {
     if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    retval = mbedtlsCheckCA(&cert) ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOMATCH;
+    retval = (CERTTYPE_ISSUER == mbedtlsGetUsage(&cert)) ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOMATCH;
 
 cleanup:
     mbedtls_x509_crt_free(&cert);

--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -5,6 +5,7 @@
  *    Copyright 2019 (c) Kalycito Infotech Private Limited
  *    Copyright 2019 (c) Julius Pfrommer, Fraunhofer IOSB
  *    Copyright 2024 (c) Fraunhofer IOSB (Author: Noel Graf)
+ *    Copyright (c) 2026 Pilz GmbH & Co. KG, Author: Marcel Patzlaff
  */
 
 #include <open62541/util.h>
@@ -50,7 +51,15 @@ typedef struct {
     mbedtls_x509_crl issuerCrls;
 } MemoryCertStore;
 
-static UA_Boolean mbedtlsCheckCA(mbedtls_x509_crt *cert);
+typedef enum
+{
+    CERTTYPE_INVALID = 0,
+    CERTTYPE_ISSUER,
+    CERTTYPE_INSTANCE,
+    CERTTYPE_USER
+} CertType;
+
+static CertType mbedtlsGetUsage(mbedtls_x509_crt *cert);
 
 static UA_Boolean
 certificateGroupValidByteString(const UA_ByteString *value) {
@@ -156,7 +165,7 @@ mbedtlsFindCrls(UA_CertificateGroup *certGroup, const UA_ByteString *certificate
 
     /* Check if the certificate is a CA certificate.
      * Only a CA certificate can have a CRL. */
-    if(!mbedtlsCheckCA(&cert)) {
+    if(CERTTYPE_ISSUER != mbedtlsGetUsage(&cert)) {
         UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,
                "The certificate is not a CA certificate and therefore does not have a CRL.");
         mbedtls_x509_crt_free(&cert);
@@ -417,21 +426,66 @@ cleanupCandidate:
 #define UA_MBEDTLS_MAX_CHAIN_LENGTH 10
 #define UA_MBEDTLS_MAX_DN_LENGTH 256
 
-/* Is the certificate a CA? */
-static UA_Boolean
-mbedtlsCheckCA(mbedtls_x509_crt *cert) {
-    /* The Basic Constraints extension must be set and the cert acts as CA */
-    if(!mbedtls_x509_crt_has_ext_type(cert, MBEDTLS_X509_EXT_BASIC_CONSTRAINTS) ||
-       !mbedtls_x509_crt_get_ca_istrue(cert))
-        return false;
+/* What type of certificate do we have here? */
+static CertType
+mbedtlsGetUsage(mbedtls_x509_crt *cert) {
+    CertType defUsage = CERTTYPE_USER;
 
-    /* The Key Usage extension must be set to cert signing and CRL issuing */
-    if(!mbedtls_x509_crt_has_ext_type(cert, MBEDTLS_X509_EXT_KEY_USAGE) ||
-       mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_KEY_CERT_SIGN) != 0 ||
-       mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_CRL_SIGN) != 0)
-        return false;
+    // The Basic Constraints extension must always be set
+    if(!mbedtls_x509_crt_has_ext_type(cert, MBEDTLS_X509_EXT_BASIC_CONSTRAINTS))
+        return CERTTYPE_INVALID;
 
-    return true;
+    const UA_Boolean hasKeyUsage = mbedtls_x509_crt_has_ext_type(cert, MBEDTLS_X509_EXT_KEY_USAGE);
+
+    if(mbedtls_x509_crt_get_ca_istrue(cert)) {
+        // can be issuer or self-signed instance cert
+
+        // ensure that the key usage extension is available in the certificate
+        if (!hasKeyUsage)
+            return CERTTYPE_INVALID;
+
+        // check if the Key Usage extension is set to cert signing and CRL signing
+        if(mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_KEY_CERT_SIGN) == 0 &&
+           mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_CRL_SIGN) == 0) {
+            return CERTTYPE_ISSUER;
+        }
+
+        // user certificates must set CA:FALSE
+        defUsage = CERTTYPE_INVALID;
+    }
+
+    // can be user or instance cert or just invalid
+    if(!hasKeyUsage)
+        return defUsage;
+
+    const mbedtls_pk_type_t pk_alg = mbedtls_pk_get_type(&(cert->pk));
+    if((MBEDTLS_PK_RSA == pk_alg) || (MBEDTLS_PK_RSASSA_PSS == pk_alg)) {
+        // RSA profiles require digitalSignature, nonRepudiation, keyEncipherment and dataEncipherment in keyUsage
+        // and at least clientAuth in extendedKeyUsage
+        const UA_Boolean hasExtKeyUsage = mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE);
+        if(!hasExtKeyUsage)
+            return defUsage;
+
+        if((mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_DIGITAL_SIGNATURE) != 0) ||
+           (mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_NON_REPUDIATION) != 0) ||
+           (mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_KEY_ENCIPHERMENT) != 0) ||
+           (mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_DATA_ENCIPHERMENT) != 0)) {
+            return defUsage;
+        }
+
+        if((mbedtls_x509_crt_check_extended_key_usage(
+            cert, MBEDTLS_OID_CLIENT_AUTH, sizeof(MBEDTLS_OID_CLIENT_AUTH) - 1)) != 0) {
+            return defUsage;
+        }
+    } else if((MBEDTLS_PK_ECDSA == pk_alg) || (MBEDTLS_PK_ECKEY == pk_alg) || (MBEDTLS_PK_ECKEY_DH == pk_alg)) {
+        // ECC profiles only require digitalSignature in keyUsage
+        if((mbedtls_x509_crt_check_key_usage(cert, MBEDTLS_X509_KU_DIGITAL_SIGNATURE) != 0))
+            return defUsage;
+    } else
+        return CERTTYPE_INVALID;
+
+    // it is with high-propability an Application Instance Certificate
+    return CERTTYPE_INSTANCE;
 }
 
 static UA_Boolean
@@ -529,7 +583,8 @@ mbedtlsCheckRevoked(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_
 /* Verify that the public key of the issuer was used to sign the certificate */
 static UA_StatusCode
 mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_crt *stack,
-                   mbedtls_x509_crt **old_issuers, mbedtls_x509_crt *cert, int depth) {
+                   mbedtls_x509_crt **old_issuers, mbedtls_x509_crt *cert, int depth,
+                   UA_CertificateVerificationSettings settings) {
     /* Maxiumum chain length */
     if(depth == UA_MBEDTLS_MAX_CHAIN_LENGTH)
         return UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
@@ -549,7 +604,7 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 
         /* Verification Step: Certificate Usage
          * Can the issuer act as CA? Omit for self-signed leaf certificates. */
-        if((depth > 0 || issuer != cert) && !mbedtlsCheckCA(issuer)) {
+        if((depth > 0 || issuer != cert) && (CERTTYPE_ISSUER != mbedtlsGetUsage(issuer))) {
             ret = UA_STATUSCODE_BADCERTIFICATEISSUERUSENOTALLOWED;
             continue;
         }
@@ -593,7 +648,7 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 
         /* We have found the issuer certificate used for the signature. Recurse
          * to the next certificate in the chain (verify the current issuer). */
-        ret = mbedtlsVerifyChain(cg, ctx, stack, old_issuers, issuer, depth + 1);
+        ret = mbedtlsVerifyChain(cg, ctx, stack, old_issuers, issuer, depth + 1, settings);
     }
 
     /* The chain is complete, but we haven't yet identified a trusted
@@ -621,7 +676,8 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 /* This follows Part 6, 6.1.3 Determining if a Certificate is trusted.
  * It defines a sequence of steps for certificate verification. */
 static UA_StatusCode
-verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
+verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate,
+                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(!certGroup || !certGroup->context || !certificate ||
        (certificate->length > 0 && !certificate->data))
@@ -644,7 +700,11 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
      * Check whether the certificate is a User certificate or a CA certificate.
      * Refer the test case CTT/Security/Security Certificate Validation/029.js
      * for more details. */
-    if(mbedtlsCheckCA(&cert)) {
+    CertType certType = mbedtlsGetUsage(&cert);
+    if((CERTTYPE_INVALID == certType) ||
+       ((CERTTYPE_INSTANCE == certType) && !settings.allowUsageInstanceCert) ||
+       ((CERTTYPE_ISSUER == certType) && !settings.allowUsageIssuerCert) ||
+       ((CERTTYPE_USER == certType) && !settings.allowUsageUserCert)) {
         mbedtls_x509_crt_free(&cert);
         return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
     }
@@ -654,24 +714,28 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
      * - Security Policy
      * - Host Name
      * - URI */
+    UA_StatusCode ret = UA_STATUSCODE_GOOD;
+    if(UA_CERTIFICATEVERIFICATION_SELECTED(settings.verificationSteps, BUILD_CERTIFICATE_CHAIN)) {
+        /* Verification Step: Build Certificate Chain
+         * We perform the checks for each certificate inside. */
+        mbedtls_x509_crt *old_issuers[UA_MBEDTLS_MAX_CHAIN_LENGTH];
+        ret = mbedtlsVerifyChain(certGroup, context, &cert, old_issuers, &cert, 0, settings);
+    }
 
-    /* Verification Step: Build Certificate Chain
-     * We perform the checks for each certificate inside. */
-    mbedtls_x509_crt *old_issuers[UA_MBEDTLS_MAX_CHAIN_LENGTH];
-    UA_StatusCode ret = mbedtlsVerifyChain(certGroup, context, &cert, old_issuers, &cert, 0);
     mbedtls_x509_crt_free(&cert);
     return ret;
 }
 
 static UA_StatusCode
 MemoryCertStore_verifyCertificate(UA_CertificateGroup *certGroup,
-                                  const UA_ByteString *certificate) {
+                                  const UA_ByteString *certificate,
+                                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(!certGroup || !certGroup->context || !certificate) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    UA_StatusCode retval = verifyCertificate(certGroup, certificate);
+    UA_StatusCode retval = verifyCertificate(certGroup, certificate, settings);
     if(retval != UA_STATUSCODE_GOOD) {
         if(MemoryCertStore_addToRejectedList(certGroup, certificate) != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,
@@ -1168,7 +1232,7 @@ UA_CertificateUtils_checkCA(const UA_ByteString *certificate) {
     if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    retval = mbedtlsCheckCA(&cert) ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOMATCH;
+    retval = (CERTTYPE_ISSUER == mbedtlsGetUsage(&cert)) ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADNOMATCH;
 
 cleanup:
     mbedtls_x509_crt_free(&cert);

--- a/plugins/crypto/openssl/certificategroup.c
+++ b/plugins/crypto/openssl/certificategroup.c
@@ -623,7 +623,8 @@ openSSL_verifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, STACK_OF(X509
 /* This follows Part 6, 6.1.3 Determining if a Certificate is trusted.
  * It defines a sequence of steps for certificate verification. */
 static UA_StatusCode
-verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
+verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate,
+                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(certGroup == NULL || certGroup->context == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -670,13 +671,14 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
 
 static UA_StatusCode
 MemoryCertStore_verifyCertificate(UA_CertificateGroup *certGroup,
-                                  const UA_ByteString *certificate) {
+                                  const UA_ByteString *certificate,
+                                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(certGroup == NULL || certificate == NULL) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    UA_StatusCode retval = verifyCertificate(certGroup, certificate);
+    UA_StatusCode retval = verifyCertificate(certGroup, certificate, settings);
     if(retval != UA_STATUSCODE_GOOD) {
         if(MemoryCertStore_addToRejectedList(certGroup, certificate) != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,

--- a/plugins/crypto/openssl/certificategroup.c
+++ b/plugins/crypto/openssl/certificategroup.c
@@ -627,7 +627,8 @@ openSSL_verifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, STACK_OF(X509
 /* This follows Part 6, 6.1.3 Determining if a Certificate is trusted.
  * It defines a sequence of steps for certificate verification. */
 static UA_StatusCode
-verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
+verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate,
+                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(certGroup == NULL || certGroup->context == NULL)
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -674,13 +675,14 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
 
 static UA_StatusCode
 MemoryCertStore_verifyCertificate(UA_CertificateGroup *certGroup,
-                                  const UA_ByteString *certificate) {
+                                  const UA_ByteString *certificate,
+                                  UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(certGroup == NULL || certificate == NULL) {
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    UA_StatusCode retval = verifyCertificate(certGroup, certificate);
+    UA_StatusCode retval = verifyCertificate(certGroup, certificate, settings);
     if(retval != UA_STATUSCODE_GOOD) {
         if(MemoryCertStore_addToRejectedList(certGroup, certificate) != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,

--- a/plugins/crypto/ua_certificategroup_filestore.c
+++ b/plugins/crypto/ua_certificategroup_filestore.c
@@ -586,7 +586,8 @@ FileCertStore_getCertificateCrls(UA_CertificateGroup *certGroup, const UA_ByteSt
 }
 
 static UA_StatusCode
-FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
+FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate,
+                                UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(certGroup == NULL || certificate == NULL)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -598,7 +599,7 @@ FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteStr
         return retval;
     }
 
-    retval = context->store->verifyCertificate(context->store, certificate);
+    retval = context->store->verifyCertificate(context->store, certificate, settings);
     if(retval == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED ||
        retval == UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED ||
        retval == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN ||

--- a/plugins/crypto/ua_certificategroup_filestore.c
+++ b/plugins/crypto/ua_certificategroup_filestore.c
@@ -640,7 +640,8 @@ FileCertStore_getCertificateCrls(UA_CertificateGroup *certGroup, const UA_ByteSt
 }
 
 static UA_StatusCode
-FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
+FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate,
+                                UA_CertificateVerificationSettings settings) {
     /* Check parameter */
     if(certGroup == NULL || certificate == NULL)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -652,7 +653,7 @@ FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteStr
         return retval;
     }
 
-    retval = context->store->verifyCertificate(context->store, certificate);
+    retval = context->store->verifyCertificate(context->store, certificate, settings);
     if(retval == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED ||
        retval == UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED ||
        retval == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN ||

--- a/plugins/crypto/ua_certificategroup_none.c
+++ b/plugins/crypto/ua_certificategroup_none.c
@@ -9,7 +9,8 @@
 
 static UA_StatusCode
 verifyCertificateAllowAll(UA_CertificateGroup *certGroup,
-                          const UA_ByteString *certificate) {
+                          const UA_ByteString *certificate,
+                          UA_CertificateVerificationSettings settings) {
     UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_APPLICATION,
                    "No certificate store configured. Accepting the certificate.");
     return UA_STATUSCODE_GOOD;

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1737,9 +1737,12 @@ initSecurityPolicy(UA_Client *client) {
     /* Verify the remote server certificate */
     UA_StatusCode res;
     if(client->endpoint.serverCertificate.length > 0) {
+        UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+        verSettings.allowUsageInstanceCert = true;
+        verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
         res = client->config.certificateVerification.
             verifyCertificate(&client->config.certificateVerification,
-                              &client->endpoint.serverCertificate);
+                              &client->endpoint.serverCertificate, verSettings);
         if(res != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                          "Cannot validate the server certificate "

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1739,7 +1739,7 @@ initSecurityPolicy(UA_Client *client) {
     if(client->endpoint.serverCertificate.length > 0) {
         UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
         verSettings.allowUsageInstanceCert = true;
-        verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
+        verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
         res = client->config.certificateVerification.
             verifyCertificate(&client->config.certificateVerification,
                               &client->endpoint.serverCertificate, verSettings);

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -2013,9 +2013,12 @@ initSecurityPolicy(UA_Client *client, const UA_ClientTransport *transport) {
     /* Verify the remote server certificate */
     UA_StatusCode res;
     if(client->endpoint.serverCertificate.length > 0) {
+        UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+        verSettings.allowUsageInstanceCert = true;
+        verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
         res = client->config.certificateVerification.
             verifyCertificate(&client->config.certificateVerification,
-                              &client->endpoint.serverCertificate);
+                              &client->endpoint.serverCertificate, verSettings);
         if(res != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                          "Cannot validate the server certificate "

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -793,6 +793,9 @@ secureChannel_delayedCloseTrustList(void *application, void *context) {
 
     UA_CertificateGroup *certGroup = &server->config.secureChannelPKI;
     UA_SecureChannel *channel;
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageInstanceCert = true;
+    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
     TAILQ_FOREACH(channel, &server->channels, serverEntry) {
         if(channel->state != UA_SECURECHANNELSTATE_CLOSED &&
            channel->state != UA_SECURECHANNELSTATE_CLOSING)
@@ -801,7 +804,7 @@ secureChannel_delayedCloseTrustList(void *application, void *context) {
             continue; /* SecureChannels w/o security */
         UA_StatusCode res =
             validateCertificate(server, certGroup, channel, channel->sessions,
-                                "RenewTrustList", NULL, channel->remoteCertificate);
+                                "RenewTrustList", NULL, channel->remoteCertificate, verSettings);
         if(res != UA_STATUSCODE_GOOD)
             UA_SecureChannel_shutdown(channel, UA_SHUTDOWNREASON_CLOSE);
     }

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -795,7 +795,7 @@ secureChannel_delayedCloseTrustList(void *application, void *context) {
     UA_SecureChannel *channel;
     UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
     verSettings.allowUsageInstanceCert = true;
-    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
     TAILQ_FOREACH(channel, &server->channels, serverEntry) {
         if(channel->state != UA_SECURECHANNELSTATE_CLOSED &&
            channel->state != UA_SECURECHANNELSTATE_CLOSING)

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -707,6 +707,9 @@ secureChannel_delayedCloseTrustList(void *application, void *context) {
 
     lockServer(server);
     UA_CertificateGroup *certGroup = &server->config.secureChannelPKI;
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageInstanceCert = true;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
     UA_SecureChannel *channel, *next;
     TAILQ_FOREACH_SAFE(channel, &server->channels, serverEntry, next) {
         if(channel->state != UA_SECURECHANNELSTATE_OPEN ||
@@ -715,7 +718,7 @@ secureChannel_delayedCloseTrustList(void *application, void *context) {
         UA_StatusCode res =
             validateCertificate(server, certGroup, channel->securityPolicy,
                                 channel, channel->sessions,
-                                "RenewTrustList", NULL, channel->remoteCertificate);
+                                "RenewTrustList", NULL, channel->remoteCertificate, verSettings);
         if(res != UA_STATUSCODE_GOOD)
             shutdownSecureChannel(server, channel, UA_SHUTDOWNREASON_CLOSE);
     }

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -338,7 +338,8 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                     UA_SecureChannel *channel, UA_Session *session,
                     const char *logPrefix,
                     const UA_ApplicationDescription *ad,
-                    const UA_ByteString certificate);
+                    const UA_ByteString certificate,
+                    UA_CertificateVerificationSettings settings);
 
 void
 serverNetworkCallback(UA_ConnectionManager *cm, uintptr_t connectionId,

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -308,7 +308,8 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                     UA_SecureChannel *channel, UA_Session *session,
                     const char *logPrefix,
                     const UA_ApplicationDescription *ad,
-                    const UA_ByteString certificate);
+                    const UA_ByteString certificate,
+                    UA_CertificateVerificationSettings settings);
 
 void
 serverNetworkCallback(UA_ConnectionManager *cm, uintptr_t connectionId,

--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -309,13 +309,11 @@ updateCertificate(UA_Server *server,
     /* Ensure certificate integrity before accepting it */
     UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
     verSettings.allowUsageInstanceCert= true;
-    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_INTEGRITY;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_INTEGRITY;
     UA_StatusCode retval = validateCertificate(server, &server->config.secureChannelPKI,
                                                NULL, NULL, "UpdateCertificate", // TODO: session pointer from somewhere?
                                                NULL, *certificate, verSettings);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
-            "Certificate verification failed with %s", UA_StatusCode_name(retval));
         // mask error with UA_STATUSCODE_BADCERTIFICATEINVALID
         return UA_STATUSCODE_BADCERTIFICATEINVALID;
     }
@@ -478,13 +476,11 @@ addCertificate(UA_Server *server,
     UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
     verSettings.allowUsageInstanceCert = (certGroup == &(server->config.secureChannelPKI));
     verSettings.allowUsageUserCert = (certGroup == &(server->config.sessionPKI));
-    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_VALIDITY;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_VALIDITY;
     UA_StatusCode retval = validateCertificate(server, certGroup,
                                                NULL, NULL, "AddCertificate", // TODO: session pointer from somewhere?
                                                NULL, certificate, verSettings);
     if(retval != UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
-            "Certificate verification failed with %s", UA_StatusCode_name(retval));
         // mask error with UA_STATUSCODE_BADCERTIFICATEINVALID
         return UA_STATUSCODE_BADCERTIFICATEINVALID;
     }
@@ -1105,7 +1101,7 @@ secureChannel_delayedClose(void *application, void *context) {
     UA_SecureChannel *channel;
     UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
     verSettings.allowUsageInstanceCert = true;
-    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
     TAILQ_FOREACH(channel, &server->channels, serverEntry) {
         if(channel->state == UA_SECURECHANNELSTATE_CLOSED || channel->state == UA_SECURECHANNELSTATE_CLOSING)
             continue;

--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -306,7 +306,21 @@ updateCertificate(UA_Server *server,
             return UA_STATUSCODE_BADNOTSUPPORTED;
     }
 
-    UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    /* Ensure certificate integrity before accepting it */
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageInstanceCert= true;
+    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_INTEGRITY;
+    UA_StatusCode retval = validateCertificate(server, &server->config.secureChannelPKI,
+                                               NULL, NULL, "UpdateCertificate", // TODO: session pointer from somewhere?
+                                               NULL, *certificate, verSettings);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
+            "Certificate verification failed with %s", UA_StatusCode_name(retval));
+        // mask error with UA_STATUSCODE_BADCERTIFICATEINVALID
+        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+    }
+
+    retval = UA_STATUSCODE_GOOD;
     UA_GDSManager *gdsManager = &server->gdsManager;
     UA_GDSTransaction *transaction = &gdsManager->transaction;
     if(transaction->state == UA_GDSTRANSACTIONSTATE_FRESH) {
@@ -449,14 +463,6 @@ addCertificate(UA_Server *server,
     if(gdsManager->transaction.state != UA_GDSTRANSACTIONSTATE_FRESH)
         return UA_STATUSCODE_BADTRANSACTIONPENDING;
 
-    /* CA certificates cannot be added using this method because it does not support adding CRLs */
-    if(UA_CertificateUtils_checkCA(&certificate) == UA_STATUSCODE_GOOD) {
-        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
-            "The certificate could not be added because it is a CA certificate. "
-            "CA certificates must be added using the FileType methods.");
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    }
-
     UA_CertificateGroup *certGroup = getCertGroup(server, objectId);
     if(!certGroup)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
@@ -468,6 +474,21 @@ addCertificate(UA_Server *server,
     if(fileInfo->openCount > 0)
         return UA_STATUSCODE_BADINVALIDSTATE;
 
+    /* Ensure certificate validity before adding it */
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageInstanceCert = (certGroup == &(server->config.secureChannelPKI));
+    verSettings.allowUsageUserCert = (certGroup == &(server->config.sessionPKI));
+    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_VALIDITY;
+    UA_StatusCode retval = validateCertificate(server, certGroup,
+                                               NULL, NULL, "AddCertificate", // TODO: session pointer from somewhere?
+                                               NULL, certificate, verSettings);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
+            "Certificate verification failed with %s", UA_StatusCode_name(retval));
+        // mask error with UA_STATUSCODE_BADCERTIFICATEINVALID
+        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+    }
+
     UA_TrustListDataType trustList;
     memset(&trustList, 0, sizeof(UA_TrustListDataType));
     UA_ByteString certificates[1];
@@ -477,7 +498,7 @@ addCertificate(UA_Server *server,
     trustList.trustedCertificates = certificates;
     trustList.trustedCertificatesSize = 1;
 
-    UA_StatusCode retval = certGroup->addToTrustList(certGroup, &trustList);
+    retval = certGroup->addToTrustList(certGroup, &trustList);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
@@ -1082,10 +1103,13 @@ secureChannel_delayedClose(void *application, void *context) {
 
     UA_CertificateGroup certGroup = server->config.secureChannelPKI;
     UA_SecureChannel *channel;
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageInstanceCert = true;
+    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
     TAILQ_FOREACH(channel, &server->channels, serverEntry) {
         if(channel->state == UA_SECURECHANNELSTATE_CLOSED || channel->state == UA_SECURECHANNELSTATE_CLOSING)
             continue;
-        if(certGroup.verifyCertificate(&certGroup, &channel->remoteCertificate) != UA_STATUSCODE_GOOD)
+        if(certGroup.verifyCertificate(&certGroup, &channel->remoteCertificate, verSettings) != UA_STATUSCODE_GOOD)
             UA_SecureChannel_shutdown(channel, UA_SHUTDOWNREASON_CLOSE);
     }
 

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -357,7 +357,7 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                     UA_CertificateVerificationSettings settings) {
     /* Verify the ApplicationUri */
     UA_StatusCode res = UA_STATUSCODE_GOOD;
-    if(ad && (settings.verificationLevel == UA_CERTIFICATEVERIFICATION_TRUST)) {
+    if(ad && UA_CERTIFICATEVERIFICATION_SELECTED(settings.verificationSteps, URI)) {
         res = UA_CertificateUtils_verifyApplicationUri(&certificate, &ad->applicationUri);
         if(res != UA_STATUSCODE_GOOD) {
             if(server->config.allowAllCertificateUris <= UA_RULEHANDLING_WARN) {

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -353,10 +353,11 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                     UA_SecureChannel *channel, UA_Session *session,
                     const char *logPrefix,
                     const UA_ApplicationDescription *ad,
-                    const UA_ByteString certificate) {
+                    const UA_ByteString certificate,
+                    UA_CertificateVerificationSettings settings) {
     /* Verify the ApplicationUri */
     UA_StatusCode res = UA_STATUSCODE_GOOD;
-    if(ad) {
+    if(ad && (settings.verificationLevel == UA_CERTIFICATEVERIFICATION_TRUST)) {
         res = UA_CertificateUtils_verifyApplicationUri(&certificate, &ad->applicationUri);
         if(res != UA_STATUSCODE_GOOD) {
             if(server->config.allowAllCertificateUris <= UA_RULEHANDLING_WARN) {
@@ -407,7 +408,7 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
     }
 
     /* Validate in the CertificateGroup */
-    res = cg->verifyCertificate(cg, &certificate);
+    res = cg->verifyCertificate(cg, &certificate, settings);
     if(res != UA_STATUSCODE_GOOD) {
         const char *descr = UA_StatusCode_name(res);
         if(session) {

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -667,10 +667,11 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                     UA_SecureChannel *channel, UA_Session *session,
                     const char *logPrefix,
                     const UA_ApplicationDescription *ad,
-                    const UA_ByteString certificate) {
+                    const UA_ByteString certificate,
+                    UA_CertificateVerificationSettings settings) {
     /* Verify the ApplicationUri */
     UA_StatusCode res = UA_STATUSCODE_GOOD;
-    if(ad) {
+    if(ad && UA_CERTIFICATEVERIFICATION_SELECTED(settings.verificationSteps, URI)) {
         res = UA_CertificateUtils_verifyApplicationUri(&certificate, &ad->applicationUri);
         if(res != UA_STATUSCODE_GOOD) {
             if(server->config.allowAllCertificateUris <= UA_RULEHANDLING_WARN) {
@@ -744,7 +745,7 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
     }
 
     /* Validate in the CertificateGroup */
-    res = cg->verifyCertificate(cg, &certificate);
+    res = cg->verifyCertificate(cg, &certificate, settings);
     if(res != UA_STATUSCODE_GOOD) {
         const char *descr = UA_StatusCode_name(res);
         if(session) {

--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -60,7 +60,7 @@ processOPN_AsymHeader(void *application, UA_SecureChannel *channel,
     if(asymHeader->senderCertificate.length > 0) {
         UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
         verSettings.allowUsageInstanceCert = true;
-        verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
+        verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
         UA_StatusCode res =
             validateCertificate(server, &sc->secureChannelPKI, channel, NULL,
                                 "OpenSecureChannel", NULL, asymHeader->senderCertificate, verSettings);

--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -58,9 +58,12 @@ processOPN_AsymHeader(void *application, UA_SecureChannel *channel,
      * Here we don't have the ApplicationDescription.
      * This check follows in the CreateSession service. */
     if(asymHeader->senderCertificate.length > 0) {
+        UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+        verSettings.allowUsageInstanceCert = true;
+        verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
         UA_StatusCode res =
             validateCertificate(server, &sc->secureChannelPKI, channel, NULL,
-                                "OpenSecureChannel", NULL, asymHeader->senderCertificate);
+                                "OpenSecureChannel", NULL, asymHeader->senderCertificate, verSettings);
         UA_CHECK_STATUS(res, return res);
     }
 

--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -58,10 +58,13 @@ processOPN_AsymHeader(void *application, UA_SecureChannel *channel,
      * Here we don't have the ApplicationDescription.
      * This check follows in the CreateSession service. */
     if(asymHeader->senderCertificate.length > 0) {
+        UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+        verSettings.allowUsageInstanceCert = true;
+        verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
         UA_StatusCode res =
             validateCertificate(server, &sc->secureChannelPKI, securityPolicy,
                                 channel, NULL,
-                                "OpenSecureChannel", NULL, asymHeader->senderCertificate);
+                                "OpenSecureChannel", NULL, asymHeader->senderCertificate, verSettings);
         UA_CHECK_STATUS(res, return res);
     }
 

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -486,11 +486,15 @@ Service_CreateSession_inner(UA_Server *server, UA_SecureChannel *channel,
                                    "on SecurityPolicy None (Part 4, 5.6.2.2)");
         }
     } else if(request->clientCertificate.length > 0) {
+        UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+        verSettings.allowUsageInstanceCert = true;
+        verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_INTEGRITY;
         rh->serviceResult =
             validateCertificate(server, &server->config.secureChannelPKI,
                                 channel, NULL, "CreateSession",
                                 &request->clientDescription,
-                                request->clientCertificate);
+                                request->clientCertificate,
+                                verSettings);
         if(rh->serviceResult != UA_STATUSCODE_GOOD) {
             server->serverDiagnosticsSummary.securityRejectedSessionCount++;
             server->serverDiagnosticsSummary.rejectedSessionCount++;
@@ -884,9 +888,12 @@ checkActivateSessionX509(UA_Server *server, UA_Session *session,
     }
 
     /* Validate the certificate against the SessionPKI */
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageUserCert = true;
+    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
     res = validateCertificate(server, &server->config.sessionPKI,
                               session->channel, session, "ActivateSession",
-                              NULL, token->certificateData);
+                              NULL, token->certificateData, verSettings);
 
  out:
     /* Delete the temporary channel context */

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -488,7 +488,7 @@ Service_CreateSession_inner(UA_Server *server, UA_SecureChannel *channel,
     } else if(request->clientCertificate.length > 0) {
         UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
         verSettings.allowUsageInstanceCert = true;
-        verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_INTEGRITY;
+        verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
         rh->serviceResult =
             validateCertificate(server, &server->config.secureChannelPKI,
                                 channel, NULL, "CreateSession",
@@ -890,7 +890,7 @@ checkActivateSessionX509(UA_Server *server, UA_Session *session,
     /* Validate the certificate against the SessionPKI */
     UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
     verSettings.allowUsageUserCert = true;
-    verSettings.verificationLevel = UA_CERTIFICATEVERIFICATION_TRUST;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
     res = validateCertificate(server, &server->config.sessionPKI,
                               session->channel, session, "ActivateSession",
                               NULL, token->certificateData, verSettings);

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -545,12 +545,16 @@ Service_CreateSession_inner(UA_Server *server, UA_SecureChannel *channel,
                                    "on SecurityPolicy None (Part 4, 5.6.2.2)");
         }
     } else if(request->clientCertificate.length > 0) {
+        UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+        verSettings.allowUsageInstanceCert = true;
+        verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
         rh->serviceResult =
             validateCertificate(server, &server->config.secureChannelPKI,
                                 channel->securityPolicy,
                                 channel, NULL, "CreateSession",
                                 &request->clientDescription,
-                                request->clientCertificate);
+                                request->clientCertificate,
+                                verSettings);
         if(rh->serviceResult != UA_STATUSCODE_GOOD) {
             server->serverDiagnosticsSummary.securityRejectedSessionCount++;
             server->serverDiagnosticsSummary.rejectedSessionCount++;
@@ -1002,9 +1006,12 @@ checkActivateSessionX509(UA_Server *server, UA_SecureChannel *channel, UA_Sessio
     }
 
     /* Validate the certificate against the SessionPKI */
+    UA_CertificateVerificationSettings verSettings = UA_CERTIFICATEVERIFICATIONSETTINGS_NONE();
+    verSettings.allowUsageUserCert = true;
+    verSettings.verificationSteps = UA_CERTIFICATEVERIFICATION_FOR_TRUST;
     res = validateCertificate(server, &server->config.sessionPKI, tokenSp,
                               session->channel, session, "ActivateSession",
-                              NULL, token->certificateData);
+                              NULL, token->certificateData, verSettings);
     res = hideX509IdentityTokenValidationStatus(res);
 
  out:


### PR DESCRIPTION
This PR introduces an API change to allow the configuration of the certificate validation.
It can be configured which level of validation is requested as well as what types of certificates (Instance Certificate, User Certificate or Issuer Certificate) are allowed.

Further this PR will add the missing certificate and trust list checks for the GDS push management.