### PR TITLE
refactor(server): use MDNSD_free() instead of UA_free() for "packet"

### DIFF
--- a/src/server/ua_discovery_mdns.c
+++ b/src/server/ua_discovery_mdns.c
@@ -523,7 +523,7 @@ mdns_create_txt(UA_DiscoveryManager *dm, const char *fullServiceDomain, const ch
     xht_free(h);
     mdnsd_set_raw(mdnsPrivateData.mdnsDaemon, r, (char *) packet,
                   (unsigned short) txtRecordLength);
-    UA_free(packet);
+    MDNSD_free(packet);
 }
 
 static mdns_record_t *


### PR DESCRIPTION
"packet" is allocated within sd2txt() and with MDNSD_malloc(), so use MDNSD_free() instead of UA_free().