### PR TITLE
[Review] fix(pubsub): adjust UADP over Ethernet connection function

### DIFF
--- a/src/pubsub/ua_pubsub_connection.c
+++ b/src/pubsub/ua_pubsub_connection.c
@@ -713,18 +713,20 @@ UA_PubSubConnection_connectETH(UA_PubSubManager *psm, UA_PubSubConnection *c,
 
     /* Extract hostname and port */
     UA_String address;
-    UA_String vidPCP = UA_STRING_NULL;
-    UA_StatusCode res = UA_parseEndpointUrl(&addressUrl->url, &address, NULL, &vidPCP);
+
+    UA_UInt16 vid = 0;
+    UA_Byte pcp = 0;
+
+    UA_StatusCode res = UA_parseEndpointUrlEthernet(&addressUrl->url, &address, &vid, &pcp);
     if(res != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR_PUBSUB(psm->logging, c, "Could not parse the ETH network URL");
         return res;
     }
 
-    /* Set up the connection parameters.
-     * TDOD: Complete the considered parameters. VID, PCP, etc. */
     UA_Boolean listen = true;
-    UA_KeyValuePair kvp[4];
-    UA_KeyValueMap kvm = {4, kvp};
+    UA_KeyValuePair kvp[7];
+    UA_KeyValueMap kvm = {7, kvp};
+    
     kvp[0].key = UA_QUALIFIEDNAME(0, "address");
     UA_Variant_setScalar(&kvp[0].value, &address, &UA_TYPES[UA_TYPES_STRING]);
     kvp[1].key = UA_QUALIFIEDNAME(0, "listen");
@@ -734,6 +736,15 @@ UA_PubSubConnection_connectETH(UA_PubSubManager *psm, UA_PubSubConnection *c,
                          &UA_TYPES[UA_TYPES_STRING]);
     kvp[3].key = UA_QUALIFIEDNAME(0, "validate");
     UA_Variant_setScalar(&kvp[3].value, &validate, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_UInt16 ether_type = 0xB62C;
+    kvp[4].key = UA_QUALIFIEDNAME(0, "ethertype");
+    UA_Variant_setScalar(&kvp[4].value, &ether_type, &UA_TYPES[UA_TYPES_UINT16]);
+    
+    kvp[5].key = UA_QUALIFIEDNAME(0,"vid");
+    UA_Variant_setScalar(&kvp[5].value, &vid, &UA_TYPES[UA_TYPES_UINT16]);
+
+    kvp[6].key = UA_QUALIFIEDNAME(0,"pcp");
+    UA_Variant_setScalar(&kvp[6].value, &pcp, &UA_TYPES[UA_TYPES_BYTE]);
 
     /* Open recv channels */
     if(validate || (c->recvChannelsSize == 0 && c->readerGroupsSize > 0)) {


### PR DESCRIPTION
Now the vid and pcp are correctly parsed from the endpoint url and will be set in the keyvaluemap for eventloop handling, also this will add the ethertype for uadp over ethernet