### PR TITLE
Fix segfault triggered by createEvent() debug output

### DIFF
--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -1509,7 +1509,7 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
     }
 
     UA_LOG_DEBUG(server->config.logging, UA_LOGCATEGORY_SERVER,
-                 "Events: An event of severity %su is emitted by node %N",
+                 "Events: An event of severity %u is emitted by node %N",
                  ed->severity, ed->sourceNode);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS


### PR DESCRIPTION
The %su placeholder treats the severity as a string which leads to a segfault if the event's severity is not 0.