### PR TITLE
fix(server): Ensure a non-zero condition enable/disable event Time property

### DIFF
--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -917,9 +917,12 @@ afterWriteCallbackEnabledStateChange(UA_Server *server,
                                  UA_NodeId_clear(&conditionNode););
 
     /* Set disabling/enabling time */
+    UA_DateTime eventTime = data->sourceTimestamp;
+    /* If UA_Server_setConditionVariableFieldProperty() was used, sourceTimestamp is 0 */
+    if (eventTime == 0)
+        eventTime = UA_DateTime_now();
     retval = UA_Server_writeObjectProperty_scalar(server, conditionNode, fieldTimeQN,
-                                                  (const UA_DateTime*)&data->sourceTimestamp,
-                                                  &UA_TYPES[UA_TYPES_DATETIME]);
+                                                  &eventTime, &UA_TYPES[UA_TYPES_DATETIME]);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set enabling/disabling Time failed",
                                  UA_NodeId_clear(&conditionNode);
                                  UA_NodeId_clear(&conditionSource););


### PR DESCRIPTION
The value for Time is taken from the EnabledState/Id property node's sourceTimestamp.
If that node was written using the UA_Server_setConditionVariableFieldProperty() function, the sourceTimestamp is always 0.

Fixes #7541