### PR TITLE
build(core): include WinBase.h in ua_util.c

### DIFF
--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -23,6 +23,11 @@
 #include "pcg_basic.h"
 #include "base64.h"
 #include "itoa.h"
+
+#if defined(UA_ARCHITECTURE_WIN32)
+#include <WinBase.h>
+#endif
+
 #include "../../deps/parse_num.h"
 #include "../../deps/libc_time.h"
 


### PR DESCRIPTION
ua_util.c refereces SecureZeroMemory. Compilation fails in some circumstances and [this](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/aa366877(v=vs.85)) resource from microsoft suggests including the windows.h header

Here is a copy of the error I am currently trying to solve 
```
FINE] : [109/112] Building C object CMakeFiles\open62541-plugins.dir\plugins\crypto\openssl\certificategroup.c.obj

[FINE] : D:\a\open62541_dart\open62541_dart\.dart_tool\hooks_runner\shared\open62541\build\download\open62541-1.5.0-rc1\plugins\crypto\openssl\certificategroup.c(971): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
D:\a\open62541_dart\open62541_dart\.dart_tool\hooks_runner\shared\open62541\build\download\open62541-1.5.0-rc1\plugins\crypto\openssl\certificategroup.c(975): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
D:\a\open62541_dart\open62541_dart\.dart_tool\hooks_runner\shared\open62541\build\download\open62541-1.5.0-rc1\plugins\crypto\openssl\certificategroup.c(1137): warning C4267: 'function': conversion from 'size_t' to 'long', possible loss of data

[FINE] : [110/112] Building C object CMakeFiles\open62541-object.dir\src_generated\open62541\namespace0_generated.c.obj

[FINE] : [111/112] Linking C shared library bin\open62541.dll

[FINE] : FAILED: [code=4294967295] bin/open62541.dll bin/open62541.lib 
C:\Windows\SYSTEM32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --msvc-ver=1944 --intdir=CMakeFiles\open62541.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\open62541.rsp  /out:bin\open62541.dll /implib:bin\open62541.lib /pdb:bin\open62541.pdb /dll /version:1.5 /machine:x64 /INCREMENTAL:NO && cd ."
LINK: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\open62541.rsp /out:bin\open62541.dll /implib:bin\open62541.lib /pdb:bin\open62541.pdb /dll /version:1.5 /machine:x64 /INCREMENTAL:NO /MANIFEST:EMBED,ID=2" failed (exit code 1120) with the following output:
   Creating library bin\open62541.lib and object bin\open62541.exp
ua_util.c.obj : error LNK2019: unresolved external symbol SecureZeroMemory referenced in function UA_ByteString_memZer
[FINE] : o
bin\open62541.dll : fatal error LNK1120: 1 unresolved externals
ninja: build stopped: subcommand failed.
```

But it seems this has already caused some other people issues and might solve
#6423 
#7547 ( Already closed, but seems unsolved )