### PR TITLE
fix(plugin): double allocation of certificate thumbprint

### DIFF
--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -699,7 +699,7 @@ UA_CertificateVerification_Verify(const UA_CertificateVerification *cv,
        ctx->rejectedListFolder.length > 0) {
             char rejectedFileName[256] = {0};
             UA_ByteString thumbprint;
-            UA_ByteString_allocBuffer(&thumbprint, UA_SHA1_LENGTH);
+            UA_ByteString_init(&thumbprint);
             if(UA_Openssl_X509_GetCertificateThumbprint(certificate, &thumbprint, true) == UA_STATUSCODE_GOOD) {
                 static const char hex2char[] = "0123456789ABCDEF";
                 for(size_t pos = 0, namePos = 0; pos < thumbprint.length; pos++) {


### PR DESCRIPTION
This code was introduced in 805c1ab17a1d4b4ecca2f1c9b11b9185cac2346a. UA_Openssl_X509_GetCertificateThumbprint() will allocate the thumbprint UA_ByteString itself, unlike mbedtls_thumbprint_sha1() (only when the last argument is true). As such, for the OpenSSL plugin, do not allocate the certificate thumbprint ourselves to fix double allocation.

Reported-by: xydan83 <aleksprog@hotmail.com>
Ref #7216