### PR TITLE
fix(plugin): fix namelist allocated from scandir not freed

### DIFF
--- a/plugins/crypto/openssl/ua_pki_openssl.c
+++ b/plugins/crypto/openssl/ua_pki_openssl.c
@@ -312,6 +312,10 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
             }
             UA_ByteString_clear (&strCert);
         }
+        for (i = 0; i < numCertificates; i++) {
+            free(dirlist[i]);
+        }
+        free(dirlist);
     }
 
     if (ctx->issuerListFolder.length > 0) {
@@ -347,6 +351,10 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
             }
             UA_ByteString_clear (&strCert);
         }
+        for (i = 0; i < numCertificates; i++) {
+            free(dirlist[i]);
+        }
+        free(dirlist);
     }
 
     if (ctx->revocationListFolder.length > 0) {
@@ -382,6 +390,10 @@ UA_ReloadCertFromFolder (CertContext * ctx) {
             }
             UA_ByteString_clear (&strCert);
         }
+        for (i = 0; i < numCertificates; i++) {
+            free(dirlist[i]);
+        }
+        free(dirlist);
     }
 
     ret = UA_STATUSCODE_GOOD;


### PR DESCRIPTION
(cherry picked from commit bcb02196fbed8ba2fd77eb0d119372b6f74c9760)

This fixes #7265 for the 1.3 branch.