### PR TITLE
plugins: crypto: fix UNCHECKED_FUNC_RES.STAT in ua_securitypolicy_none.c

### DIFF
--- a/plugins/crypto/ua_securitypolicy_none.c
+++ b/plugins/crypto/ua_securitypolicy_none.c
@@ -138,7 +138,11 @@ UA_SecurityPolicy_None(UA_SecurityPolicy *policy, const UA_ByteString localCerti
 #ifdef UA_ENABLE_ENCRYPTION_MBEDTLS
     UA_mbedTLS_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
 #elif defined(UA_ENABLE_ENCRYPTION_OPENSSL) || defined(UA_ENABLE_ENCRYPTION_LIBRESSL)
-    UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
+    UA_StatusCode retval = UA_OpenSSL_LoadLocalCertificate(&localCertificate, &policy->localCertificate);
+    if (retval != UA_STATUSCODE_GOOD) {
+        policy_clear_none(policy); 
+        return retval;
+    }
 #else
     UA_ByteString_copy(&localCertificate, &policy->localCertificate);
 #endif


### PR DESCRIPTION
The function UA_OpenSSL_LoadLocalCertificate returns a UA_StatusCode that was previously ignored in the SecurityPolicy#None implementation. This could lead to undefined behavior if certificate loading failed, while the policy continued initialization as if successful.

Now, the return value is checked. On failure, the partially initialized certificate is cleared via policy_clear_none(), and the error status is propagated upward.

This brings UA_SecurityPolicy_None in line with other security policies (e.g., Basic256, Aes128Sha256) which already perform this check.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>