### PR TITLE
src: client: ua_client_connect.c: fix prevent potential use of close depollfd in synchronous disconnect

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -2483,7 +2483,13 @@ disconnectSecureChannel(UA_Client *client, UA_Boolean sync) {
        el->state != UA_EVENTLOOPSTATE_FRESH &&
        el->state != UA_EVENTLOOPSTATE_STOPPED) {
         while(client->channel.state != UA_SECURECHANNELSTATE_CLOSED) {
-            el->run(el, 100);
+            UA_StatusCode runStatus = el->run(el, 100);
+            if(runStatus != UA_STATUSCODE_GOOD) {
+                UA_LOG_DEBUG(client->config.logging, UA_LOGCATEGORY_CLIENT,
+                             "EventLoop run returned %s during synchronous disconnect, "
+                             "stopping wait loop", UA_StatusCode_name(runStatus));
+                break;
+            }
         }
     }
 


### PR DESCRIPTION

In UA_Client_disconnectSecureChannel, the synchronous wait loop calls el->run() repeatedly until the secure channel is closed. However, the EventLoop may be stopped (and its epollfd closed) inside one of these run() calls — e.g., due to connection shutdown callbacks. A subsequent el->run() invocation would then operate on a closed file descriptor, triggering warnings from static analyzers and risking undefined behavior in edge cases.

Fix by checking the return status of el->run(). If it returns an error (e.g., BADINTERNALERROR when epollfd < 0), break out of the loop instead of continuing to call run().

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
