### PR TITLE
src: pubsub: ua_pubsub_ns0.c: add null check after UA_Array_new in addDataSetReaderConfig

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -865,6 +865,12 @@ addDataSetReaderConfig(UA_Server *server, UA_NodeId readerGroupId,
     pMetaData->fieldsSize = dataSetReader->dataSetMetaData.fieldsSize;
     pMetaData->fields = (UA_FieldMetaData*)UA_Array_new (pMetaData->fieldsSize,
                         &UA_TYPES[UA_TYPES_FIELDMETADATA]);
+    if(pMetaData->fieldsSize > 0 && !pMetaData->fields) {
+        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_PUBSUB,
+                     "Failed to allocate memory for DataSetReader MetaData fields");
+        UA_PublisherId_clear(&readerConfig.publisherId);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
     for(size_t i = 0; i < pMetaData->fieldsSize; i++){
         UA_FieldMetaData_init (&pMetaData->fields[i]);
         UA_NodeId_copy(&dataSetReader->dataSetMetaData.fields[i].dataType,


### PR DESCRIPTION

In addDataSetReaderConfig, the result of UA_Array_new was used without checking for NULL when copying DataSetMetaData fields. If memory allocation failed (e.g., due to OOM), the subsequent loop would dereference a null pointer, causing a crash.

Added a check for allocation failure when fieldsSize > 0, consistent with other parts of the codebase that handle UA_Array_new. Returns UA_STATUSCODE_BADOUTOFMEMORY and cleans up partially initialized config.

This improves robustness under low-memory conditions in PubSub subscriber setup.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
