### PR TITLE
src: client: ua_client_discovery.c: fix avoid double lock in UA_Client_findServersOnNetwork

### DIFF
--- a/src/client/ua_client_discovery.c
+++ b/src/client/ua_client_discovery.c
@@ -178,7 +178,7 @@ UA_Client_findServersOnNetwork(UA_Client *client, const char *serverUrl,
     if(!connected) {
         retval = connectSecureChannel(client, serverUrl);
         if(retval != UA_STATUSCODE_GOOD) {
-            lockClient(client);
+            unlockClient(client);
             return retval;
         }
     }


### PR DESCRIPTION

In UA_Client_findServersOnNetwork, a second call to lockClient() was erroneously made on the error path after connectSecureChannel() failed. Since the client mutex is already locked at the beginning of the function, this leads to a double-lock attempt on a non-recursive mutex, causing undefined behavior (typically a deadlock).

The erroneous lockClient() call is replaced with unlockClient() to properly release the mutex before returning, consistent with the error handling in UA_Client_getEndpoints and UA_Client_findServers.

Fixes a potential deadlock in multithreaded client usage.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
