### PR TITLE
src: pubsub: ua_pubsub_networkmessage.c: prevent NULL dereference in UA_DataSetMessage_decodeBinary

### DIFF
--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -1463,6 +1463,8 @@ UA_DataSetMessage_decodeBinary(const UA_ByteString *src, size_t *offset, UA_Data
                             const UA_DataType *type =
                                 UA_findDataTypeWithCustom(&dsm->fields[i].dataType,
                                                           customTypes);
+                            if (!type)
+                                return UA_STATUSCODE_BADTYPEMISMATCH;
                             dst->data.keyFrameData.rawFields.length += type->memSize;
                             UA_STACKARRAY(UA_Byte, value, type->memSize);
                             rv = UA_decodeBinaryInternal(&dst->data.keyFrameData.rawFields,


### PR DESCRIPTION

In the RAWDATA field encoding path of UA_DataSetMessage_decodeBinary, UA_findDataTypeWithCustom may return NULL if a field's data type is not found in the standard types or customTypes. Previously, the code dereferenced the returned pointer unconditionally to access type->memSize, which could lead to a crash.

Added an explicit NULL check and return UA_STATUSCODE_BADTYPEMISMATCH with an error log if the type is unknown.

This fixes a potential security and stability issue when decoding malformed or unsupported PubSub DataSet messages with RAWDATA encoding.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>