### PR TITLE
src: pubsub: ua_pubsub_dataset.c: prevent NULL dereference in generateFieldMetaData

### DIFF
--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -252,18 +252,25 @@ generateFieldMetaData(UA_Server *server, UA_PublishedDataSet *pds,
             UA_findDataTypeWithCustom(&fieldMetaData->dataType,
                                       server->config.customDataTypes);
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-        UA_LOG_DEBUG_DATASET(server->config.logging, pds,
-                             "MetaData creation: Found DataType %s",
-                             currentDataType->typeName);
+        if(currentDataType) {
+            UA_LOG_DEBUG_DATASET(server->config.logging, pds,
+                                "MetaData creation: Found DataType %s",
+                                currentDataType->typeName);
+        } else {
+            UA_LOG_DEBUG_DATASET(server->config.logging, pds,
+                                "MetaData creation: DataType not found for NodeId %d",
+                                fieldMetaData->dataType.identifier.numeric);
+        }
 #endif
         /* Check if the datatype is a builtInType, if yes set the builtinType. */
-        if(currentDataType->typeKind <= UA_DATATYPEKIND_ENUM)
+        if(currentDataType && currentDataType->typeKind <= UA_DATATYPEKIND_ENUM)
             fieldMetaData->builtInType = (UA_Byte)currentDataType->typeId.identifier.numeric;
         /* set the maxStringLength attribute */
         if(field->config.field.variable.maxStringLength != 0){
-            if(currentDataType->typeKind == UA_DATATYPEKIND_BYTESTRING ||
+            if(currentDataType &&
+            (currentDataType->typeKind == UA_DATATYPEKIND_BYTESTRING ||
             currentDataType->typeKind == UA_DATATYPEKIND_STRING ||
-            currentDataType->typeKind == UA_DATATYPEKIND_LOCALIZEDTEXT) {
+            currentDataType->typeKind == UA_DATATYPEKIND_LOCALIZEDTEXT)) {
                 fieldMetaData->maxStringLength = field->config.field.variable.maxStringLength;
             } else {
                 UA_LOG_WARNING_DATASET(server->config.logging, pds,


### PR DESCRIPTION

The function UA_findDataTypeWithCustom may return NULL if the DataType referenced in a PublishedDataSet field is not found in the standard or custom type dictionaries. Previously, the code unconditionally accessed currentDataType->typeName (in debug log) and currentDataType->typeKind, which could lead to a crash when using unknown or unregistered data types.

Added explicit NULL checks before all accesses to currentDataType. In debug builds, a helpful message is logged when the type is not found.

This improves robustness against misconfigured or malicious PubSub configurations and aligns with defensive coding practices.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>