### PR TITLE
src: server: ua_server_async.c: check return value of addRepeatedCallback in UA_AsyncManager_init

### DIFF
--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -177,8 +177,15 @@ UA_AsyncManager_init(UA_AsyncManager *am, UA_Server *server) {
 
     /* Add a regular callback for cleanup and sending finished responses at a
      * 1s interval. */
-    addRepeatedCallback(server, (UA_ServerCallback)checkTimeouts,
-                        NULL, 1000.0, &am->checkTimeoutCallbackId);
+    UA_StatusCode res = addRepeatedCallback(server, (UA_ServerCallback)checkTimeouts,
+                    NULL, 1000.0, &am->checkTimeoutCallbackId);
+    if(res != UA_STATUSCODE_GOOD) {
+        UA_LOG_WARNING(server->config.logging, UA_LOGCATEGORY_SERVER,
+                    "Failed to register async timeout callback. "
+                    "Async operations will not be cleaned up on timeout. StatusCode: %s",
+                    UA_StatusCode_name(res));
+        am->checkTimeoutCallbackId = 0;
+    }
 }
 
 void


### PR DESCRIPTION
The function addRepeatedCallback may fail (e.g. due to out-of-memory) and return a non-good StatusCode. Previously, the return value was ignored in UA_AsyncManager_init, which could lead to the timeout cleanup callback (checkTimeouts) never being registered.

As a result:
- Async operations would not be cleaned up on timeout,
- Stale operations could accumulate in queues,
- Memory leaks and performance degradation could occur silently.

Now the return status is checked. On failure, a warning is logged and checkTimeoutCallbackId is set to zero to ensure safe cleanup.

This improves robustness and observability of the async method infrastructure

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
