### PR TITLE
src: pubsub: ua_pubsub_ns0.c: prevent NULL dereference in onReadLocked for PubSubConnection

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -77,6 +77,8 @@ onReadLocked(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext
     case UA_NS0ID_PUBSUBCONNECTIONTYPE: {
         UA_PubSubConnection *pubSubConnection =
             UA_PubSubConnection_findConnectionbyId(server, *myNodeId);
+        if(!pubSubConnection)
+            return;
         switch(nodeContext->elementClassiefier) {
         case UA_NS0ID_PUBSUBCONNECTIONTYPE_PUBLISHERID:
             switch (pubSubConnection->config.publisherIdType) {


### PR DESCRIPTION


The function UA_PubSubConnection_findConnectionbyId may return NULL if the connection no longer exists. In the onReadLocked callback, the result was dereferenced without a NULL check when reading the PublisherId property, which could lead to a crash.

Added a missing NULL check, consistent with the handling of other PubSub entities (DataSetReader, WriterGroup, etc.) in the same function.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
