### PR TITLE
[REVIEW] test(server): add a test for json server configurations

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,9 @@ if(UA_ENABLE_JSON_ENCODING)
     ua_add_test(check_cj5.c)
     ua_add_test(check_types_builtin_json.c)
 
+    configure_file(${CMAKE_SOURCE_DIR}/tests/server/server_json_config.json5 ${CMAKE_BINARY_DIR}/tests/server_json_config.json5 COPYONLY)
+    ua_add_test(server/check_json_config.c)
+
     if(UA_ENABLE_PUBSUB)
         ua_add_test(pubsub/check_pubsub_encoding_json.c)
         ua_add_test(pubsub/check_pubsub_publish_json.c)

--- a/tests/server/check_json_config.c
+++ b/tests/server/check_json_config.c
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server_config_file_based.h>
+
+#include "../common.h"
+
+#include <check.h>
+
+#if defined(_MSC_VER)
+# pragma warning(disable: 4146)
+#endif
+
+static char const * const file_name = "server_json_config.json5";
+
+START_TEST(UA_new_server_from_json) {
+
+    UA_ByteString json_config = loadFile(file_name);
+
+    /* test setup failure */
+    ck_assert(!UA_ByteString_equal(&json_config, &UA_BYTESTRING_NULL));
+
+    UA_Server *server = UA_Server_newFromFile(json_config);
+
+    ck_assert_ptr_ne(server, NULL);
+    UA_ByteString_clear(&json_config);
+    UA_Server_delete(server);
+}
+END_TEST
+
+static Suite *testSuite_server_from_json(void) {
+    Suite *s = suite_create("Load server from json config");
+    TCase *tc_new = tcase_create("new");
+    tcase_add_test(tc_new, UA_new_server_from_json);
+    suite_add_tcase(s, tc_new);
+    return s;
+}
+
+int main(void) {
+    int      number_failed = 0;
+    Suite   *s;
+    SRunner *sr;
+    s  = testSuite_server_from_json();
+    sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed += srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/server/server_json_config.json5
+++ b/tests/server/server_json_config.json5
@@ -1,0 +1,201 @@
+// JSON 5 server configuration
+{
+  // Server Description
+  buildInfo: {
+    productUri: "build.product.test.org",
+    manufacturerName: "Manufacture GmbH",
+    productName: "Product Name",
+    softwareVersion: "0.1.0",
+    buildNumber: "0.9.4",
+    buildDate: "2022-11-02T15:31:03Z",
+  },
+  // The applicationType is not just descriptive, it changes the actual functionality of the server.
+  // It just sets the value in the information model (https://reference.opcfoundation.org/Core/Part4/v104/docs/7.1).
+  applicationDescription: {
+    applicationUri: "urn:open62541.server.application",
+    productUri: "urn:product.test.org",
+    applicationName: {
+      locale: "en-EN",
+      text: "Test Application"
+    },
+    // Server = 0, Client = 1, Client&Server = 2, Discovery_Server = 3
+    applicationType: 0,
+    gatewayServerUri: "GATEWAY",
+    discoveryProfileUri: "DISC",
+    discoveryUrls: [
+      "opc.tcp://10.0.20.240:2017",
+      "opc.tcp://10.0.20.240:2018",
+      "opc.tcp://10.0.20.241:2020"
+    ],
+  },
+  // Value is in milliseconds.
+  shutdownDelay: 5000.00,
+
+  // Verify that the server sends a timestamp in the request header.
+  //    DEFAULT = 0
+  //    ABORT = 1  /* Abort the operation and return an error code */
+  //    WARN = 2   /* Print a message in the logs and continue */
+  //    ACCEPT = 3 /* Continue and disregard the broken rule */
+  verifyRequestTimestamp: 0,
+  // Variables (that don't have a DataType of BaseDataType) must not have an empty variant value.
+  // The default behaviour is to auto-create a matching zeroed-out value for empty VariableNodes when they are added.
+  //    DEFAULT = 0
+  //    ABORT = 1  /* Abort the operation and return an error code */
+  //    WARN = 2   /* Print a message in the logs and continue */
+  //    ACCEPT = 3 /* Continue and disregard the broken rule */
+  allowEmptyVariables: 0,
+
+  // Networking
+  // Set up the local ServerUrls. They are used during startup to initialize the server sockets.
+  serverUrls: [
+    "opc.tcp://localhost:4840",
+  ],
+  tcpEnabled: true,
+  tcp: {
+    tcpBufSize: 64000,
+    tcpMaxMsgSize: 0,
+    tcpMaxChunks: 0,
+  },
+
+  // Limits for SecureChannels
+  maxSecureChannels: 10,
+  maxSecurityTokenLifetime: 300000,
+
+  // Limits for Sessions
+  maxSessions: 50,
+  maxSessionTimeout: 3600000,
+
+  // Operation limits
+  maxNodesPerRead: 10000,
+  maxNodesPerWrite: 10000,
+  maxNodesPerMethodCall: 10000,
+  maxNodesPerBrowse: 10000,
+  maxNodesPerRegisterNodes: 10000,
+  maxNodesPerTranslateBrowsePathsToNodeIds: 10000,
+  maxNodesPerNodeManagement: 10000,
+  maxMonitoredItemsPerCall: 10000,
+
+  // Limits for Requests
+  maxReferencesPerNode: 0,
+
+  // Limits for Async Operations
+  asyncOperationTimeout: 120000,
+  maxAsyncOperationQueueSize: 1000000,
+
+  // Discovery Multicast
+  mdnsEnabled: false,
+  mdns: {
+    mdnsServerName: "mdnsServerName",
+    // See https://reference.opcfoundation.org/GDS/v105/docs/D
+    serverCapabilities: [
+      // "NA" should be first and only server capability:
+      //"NA"
+      "LDS",
+      "GDS"
+    ],
+    mdnsInterfaceIP: "127.0.0.1",
+    mdnsIpAddressList: [
+      1,
+      2,
+      3
+    ]
+  },
+
+  subscriptionsEnabled: true,
+  subscriptions: {
+    // Limits for Subscriptions
+    maxSubscriptions: 100,
+    maxSubscriptionsPerSession: 50,
+    publishingIntervalLimits: {
+      min: 100.0,
+      max: 3600000.0,
+    },
+    lifeTimeCountLimits: {
+      min: 3,
+      max: 15000
+    },
+    keepAliveCountLimits: {
+      min: 1,
+      max: 100
+    },
+    maxNotificationsPerPublish: 1000,
+    enableRetransmissionQueue: true,
+    maxRetransmissionQueueSize: 0,
+    maxEventsPerNode: 0,
+
+    // Limits for MonitoredItems
+    maxMonitoredItems: 0,
+    maxMonitoredItemsPerSubscription: 0,
+    samplingIntervalLimits: {
+      min: 50.0,
+      max: 86400000.0
+    },
+    queueSizeLimits: {
+      min: 1,
+      max: 100
+    },
+
+    // Limits for PublishRequests
+    maxPublishReqPerSession: 5
+  },
+
+  // PubSub Configuration
+  pubsubEnabled: true,
+  pubsub: {
+    enableDeltaFrames: true,
+    enableInformationModelMethods: true
+  },
+
+  // Limits for Historizing
+  historizingEnabled: true,
+  historizing: {
+    accessHistoryDataCapability: false,
+    maxReturnDataValues: 0,
+    accessHistoryEventsCapability: false,
+    maxReturnEventValues: 0,
+    insertDataCapability: false,
+    insertEventCapability: false,
+    insertAnnotationsCapability: false,
+    replaceDataCapability: false,
+    replaceEventCapability: false,
+    updateDataCapability: false,
+    updateEventCapability: false,
+    deleteRawCapability: false,
+    deleteEventCapability: false,
+    deleteAtTimeDataCapability: false,
+  },
+
+  // Reverse Connect
+  reverseReconnectInterval: 20000,
+
+  // Security Settings
+//  securityPolicies: [
+//    {
+//      policy: "http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15",
+//      certificate: "/path/to/certificate",
+//      privateKey: "/path/to/privateKey"
+//    },
+//    {
+//      policy: "http://opcfoundation.org/UA/SecurityPolicy#Basic256",
+//      certificate: "/path/to/certificate",
+//      privateKey: "/path/to/privateKey"
+//    },
+//    {
+//      policy: "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
+//      certificate: "/path/to/certificate",
+//      privateKey: "/path/to/privateKey"
+//    },
+//    {
+//      policy: "http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep",
+//      certificate: "/path/to/certificate",
+//      privateKey: "/path/to/privateKey"
+//    },
+//    {
+//      policy: "http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss"",
+//      certificate: "/path/to/certificate",
+//      privateKey: "/path/to/privateKey"
+//    }
+//  ],
+
+//  pkiFolder: "/store",
+}


### PR DESCRIPTION
Add a new test that checks whether parsing a server configuration from a json file succeeds.  Also add a test resource that is copied to the test directory.