### PR TITLE
[REVIEW] fix(pubsub): Implicit declaration of pthread_create

### DIFF
--- a/examples/pubsub_realtime/server_pubsub_publisher_rt_level.c
+++ b/examples/pubsub_realtime/server_pubsub_publisher_rt_level.c
@@ -7,6 +7,7 @@
 #include <open62541/server_pubsub.h>
 #include <open62541/types.h>
 
+#include <pthread.h>
 #include <signal.h>
 
 #define PUBSUB_CONFIG_PUBLISH_CYCLE_MS 100


### PR DESCRIPTION
## Description
Hi everyone! 

When building Master Yocto for a Aarch32 device, I am running into a Implicit declaration error. 

## Background Information / Reproduction Steps
Yocto setup info: 
- Overall setup: https://git.ti.com/cgit/arago-project/oe-layersetup/tree/ using the arago-master-config.txt config file. 
- MACHINE: am57xx-evm

Cross Compiler: 
- arm-oe-linux-gnueabi-gcc (GCC) 15.2.0

## Error Log 

```bash
examples/pubsub_realtime/server_pubsub_publisher_rt_level.c:78:5: error: implicit declaration of function 'pthread_create' [-Wimplicit-function-declaration]
   78 |     pthread_create(&pubSubELThread, NULL, runPubSubEL, NULL);
      |     ^~~~~~~~~~~~~~
```

## Used CMake options:

Using the default ones setup by the upstream recipe found within meta-openembedded layer. 

## Fix 

Include the right header file. 
