### PR TITLE
refactor(plugins): remove obsolete "define"s from legacy certificate …

### DIFF
--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -24,11 +24,6 @@
 
 #include "securitypolicy_common.h"
 
-#define REMOTECERTIFICATETRUSTED 1
-#define ISSUERKNOWN              2
-#define DUALPARENT               3
-#define PARENTFOUND              4
-
 /* Configuration parameters */
 
 #define MEMORYCERTSTORE_PARAMETERSSIZE 2


### PR DESCRIPTION
This PR simply removes the legacy "REMOTECERTIFICATETRUSTED", "ISSUERKNOWN", "DUALPARENT" and "PARENTFOUND" DEFINEs from the MbedTLS version of the CertificateGroup plugin.

These have become obsolete with the new certificate verification code.