### PR TITLE
fix typo in transaction state enum

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -189,7 +189,7 @@ UA_GDSTransaction_init(UA_GDSTransaction *transaction, UA_Server *server, const 
 
     memset(transaction, 0, sizeof(UA_GDSTransaction));
 
-    transaction->state = UA_GDSTRANSACIONSTATE_PENDING;
+    transaction->state = UA_GDSTRANSACTIONSTATE_PENDING;
     UA_NodeId_copy(&sessionId, &transaction->sessionId);
     transaction->server = server;
     transaction->localCsrCertificate = csr;
@@ -205,7 +205,7 @@ UA_GDSTransaction_getCertificateGroup(UA_GDSTransaction *transaction,
         return NULL;
 
     /* Check if transaction was initialized */
-    if(transaction->state != UA_GDSTRANSACIONSTATE_PENDING)
+    if(transaction->state != UA_GDSTRANSACTIONSTATE_PENDING)
         return NULL;
 
     for(size_t i = 0; i < transaction->certGroupSize; i++) {
@@ -259,7 +259,7 @@ UA_GDSTransaction_addCertificateInfo(UA_GDSTransaction *transaction,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* Check if transaction was initialized */
-    if(transaction->state != UA_GDSTRANSACIONSTATE_PENDING)
+    if(transaction->state != UA_GDSTRANSACTIONSTATE_PENDING)
         return UA_STATUSCODE_BADINVALIDSTATE;
 
     /* Check if an entry with certificateGroupId and certificateTypeId already exists */
@@ -305,7 +305,7 @@ void UA_GDSTransaction_clear(UA_GDSTransaction *transaction) {
     if(!transaction)
         return;
 
-    transaction->state = UA_GDSTRANSACIONSTATE_FRESH;
+    transaction->state = UA_GDSTRANSACTIONSTATE_FRESH;
     transaction->server = NULL;
     UA_NodeId_clear(&transaction->sessionId);
     UA_ByteString_clear(&transaction->localCsrCertificate);
@@ -930,7 +930,7 @@ UA_Server_updateCertificate(UA_Server *server,
 
     lockServer(server);
 
-    if(server->gdsManager.transaction.state == UA_GDSTRANSACIONSTATE_PENDING) {
+    if(server->gdsManager.transaction.state == UA_GDSTRANSACTIONSTATE_PENDING) {
         unlockServer(server);
         return UA_STATUSCODE_BADTRANSACTIONPENDING;
     }

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -57,8 +57,8 @@ typedef struct {
 /********************/
 
 typedef enum {
-    UA_GDSTRANSACIONSTATE_FRESH,
-    UA_GDSTRANSACIONSTATE_PENDING,
+    UA_GDSTRANSACTIONSTATE_FRESH,
+    UA_GDSTRANSACTIONSTATE_PENDING,
 } UA_GDSTransactionState;
 
 typedef struct {

--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -187,7 +187,7 @@ checkSessionActive(UA_Server *server, void *data) {
     UA_GDSManager *gdsManager = &server->gdsManager;
     UA_GDSTransaction *transaction = &gdsManager->transaction;
     UA_Boolean removingCallback = false;
-    if(transaction->state != UA_GDSTRANSACIONSTATE_FRESH) {
+    if(transaction->state != UA_GDSTRANSACTIONSTATE_FRESH) {
         UA_Boolean foundSession = false;
         session_list_entry *session;
         LIST_FOREACH(session, &server->sessions, pointers) {
@@ -309,7 +309,7 @@ updateCertificate(UA_Server *server,
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     UA_GDSManager *gdsManager = &server->gdsManager;
     UA_GDSTransaction *transaction = &gdsManager->transaction;
-    if(transaction->state == UA_GDSTRANSACIONSTATE_FRESH) {
+    if(transaction->state == UA_GDSTRANSACTIONSTATE_FRESH) {
         retval = UA_GDSTransaction_init(transaction, server, *sessionId);
         if(retval != UA_STATUSCODE_GOOD)
             return retval;
@@ -446,7 +446,7 @@ addCertificate(UA_Server *server,
         return UA_STATUSCODE_BADCERTIFICATEINVALID;
 
     UA_GDSManager *gdsManager = &server->gdsManager;
-    if(gdsManager->transaction.state != UA_GDSTRANSACIONSTATE_FRESH)
+    if(gdsManager->transaction.state != UA_GDSTRANSACTIONSTATE_FRESH)
         return UA_STATUSCODE_BADTRANSACTIONPENDING;
 
     /* CA certificates cannot be added using this method because it does not support adding CRLs */
@@ -506,7 +506,7 @@ removeCertificate(UA_Server *server,
 
     UA_GDSManager *gdsManager = &server->gdsManager;
     UA_GDSTransaction *transaction = &gdsManager->transaction;
-    if(transaction->state != UA_GDSTRANSACIONSTATE_FRESH)
+    if(transaction->state != UA_GDSTRANSACTIONSTATE_FRESH)
         return UA_STATUSCODE_BADTRANSACTIONPENDING;
 
     /* When a certificate is removed, a transaction is created which is then executed directly.
@@ -630,7 +630,7 @@ openTrustList(UA_Server *server,
     UA_GDSManager *gdsManager = &server->gdsManager;
     UA_GDSTransaction *transaction = &gdsManager->transaction;
     /* Cannot be opened when a transaction is running */
-    if(transaction->state == UA_GDSTRANSACIONSTATE_PENDING)
+    if(transaction->state == UA_GDSTRANSACTIONSTATE_PENDING)
         return UA_STATUSCODE_BADTRANSACTIONPENDING;
 
     UA_FileInfo *fileInfo = getFileInfo(gdsManager, certGroup->certificateGroupId);
@@ -720,7 +720,7 @@ openTrustListWithMask(UA_Server *server,
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
     UA_GDSManager *gdsManager = &server->gdsManager;
-    if(gdsManager->transaction.state == UA_GDSTRANSACIONSTATE_PENDING)
+    if(gdsManager->transaction.state == UA_GDSTRANSACTIONSTATE_PENDING)
         return UA_STATUSCODE_BADTRANSACTIONPENDING;
 
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
@@ -1197,7 +1197,7 @@ applyChanges(UA_Server *server,
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_GDSManager *gdsManager = &server->gdsManager;
     UA_GDSTransaction *transaction = &gdsManager->transaction;
-    if(transaction->state == UA_GDSTRANSACIONSTATE_FRESH)
+    if(transaction->state == UA_GDSTRANSACTIONSTATE_FRESH)
         return UA_STATUSCODE_BADNOTHINGTODO;
 
     if(!UA_NodeId_equal(&transaction->sessionId, sessionId))


### PR DESCRIPTION
This PR fixes a typo in the transaction state enum "UA_GDSTransactionState":
UA_GDSTRANSAC*I*ONSTATE -> UA_GDSTRANSAC*TI*ONSTATE
