### PR TITLE
wipe private key before free in UA_Server_createSigningRequest

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -1070,7 +1070,7 @@ cleanup:
     if(newPrivateKey)
     {
         /* wipe private key before freeing its memory */
-        memset(newPrivateKey->data, 0, newPrivateKey->length);
+        UA_ByteString_memZero(newPrivateKey);
         UA_ByteString_delete(newPrivateKey);
     }
 


### PR DESCRIPTION
This PR zeroes the memory where a created private key was stored during UA_Server_createSigningRequest before freeing the memory. As far as I know, this is best practice with security-sensitive information.