### PR TITLE
fix use-after-free bug in UA_Server_updateCertificate/secureChannel_delayedClose

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -901,7 +901,7 @@ UA_Server_removeCertificates(UA_Server *server,
 
 typedef struct UpdateCertInfo {
     UA_Server *server;
-    const UA_NodeId *certificateTypeId;
+    UA_NodeId certificateTypeId;
 } UpdateCertInfo;
 
 static void
@@ -912,9 +912,10 @@ secureChannel_delayedClose(void *application, void *context) {
     UA_SecureChannel *channel;
     TAILQ_FOREACH(channel, &info->server->channels, serverEntry) {
         const UA_SecurityPolicy *policy = channel->securityPolicy;
-        if(UA_NodeId_equal(&policy->certificateTypeId, info->certificateTypeId))
+        if(UA_NodeId_equal(&policy->certificateTypeId, &(info->certificateTypeId)))
             UA_SecureChannel_shutdown(channel, UA_SHUTDOWNREASON_CLOSE);
     }
+    UA_NodeId_clear(&(info->certificateTypeId));
     UA_free(info);
     UA_free(dc);
 }
@@ -992,7 +993,7 @@ UA_Server_updateCertificate(UA_Server *server,
 
     UpdateCertInfo *certInfo = (UpdateCertInfo*)UA_calloc(1, sizeof(UpdateCertInfo));
     certInfo->server = server;
-    certInfo->certificateTypeId = &certificateTypeId;
+    UA_NodeId_copy(&certificateTypeId, &(certInfo->certificateTypeId));
 
     dc->callback = secureChannel_delayedClose;
     dc->application = certInfo;


### PR DESCRIPTION
This PR fixes a use-after-free bug that occurs between "UA_Server_updateCertificate" and "secureChannel_delayedClose":

In the current code, a pointer to the function parameter "certificateTypeId" of the function "UA_Server_updateCertificate" is written into the "certificateTypeId" field of the struct "UpdateCertInfo". Since the parameter has a scope like a local variable, it gets freed as soon as the "UA_Server_updateCertificate" function returns.
Later, in the callback "secureChannel_delayedClose" (i.e. the function that closes the SecureChannel(s) whose Application Instance Certificate changed), this pointer is used for comparing the certificateTypeId stored in a SecurityPolicy struct against it, but since the memory has been freed, this pointer now points to un-allocated memory.

Storing a copy of the NodeId fixes this problem.