### PR TITLE
[Review] fix memory leak in UA_Server_delete when cleaning up "fileInfoContext"s

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -337,24 +337,6 @@ void UA_GDSTransaction_delete(UA_GDSTransaction *transaction) {
     UA_free(transaction);
 }
 
-/********************/
-/*   GDS Manager    */
-/********************/
-
-void
-UA_GDSManager_clear(UA_GDSManager *gdsManager) {
-    if(!gdsManager)
-        return;
-    gdsManager->checkSessionCallbackId = 0;
-    UA_GDSTransaction_clear(&gdsManager->transaction);
-    void *fileInfoContext = gdsManager->fileInfoContext;
-    while(fileInfoContext) {
-        void *next = *((void **)fileInfoContext);
-        UA_free(fileInfoContext);
-        fileInfoContext = next;
-    }
-}
-
 /*********************/
 /* Server Components */
 /*********************/
@@ -481,7 +463,9 @@ UA_Server_delete(UA_Server *server) {
     UA_LOCK_DESTROY(&server->serviceMutex);
 #endif
 
+#ifdef UA_ENABLE_GDS_PUSHMANAGEMENT
     UA_GDSManager_clear(&server->gdsManager);
+#endif
 
     /* Delete the server itself and return */
     UA_free(server);


### PR DESCRIPTION
When calling "UA_Server_delete" while a TrustList is open, the "UA_GDSManager_clear" function loops over all "fileInfoContext" structs and frees their memory. However, the "fileContext" structs stored inside "fileInfoContext" were not freed currently.

As the "fileInfoContext" struct is defined in "ua_server_ns0_gds.c", I had to move the code freeing the internal "fileContext" from "ua_server.c" to "ua_server_ns0_gds.c". Another option would have been to make "fileInfoContext" struct accessible from "ua_server.c", but I think moving the clean-up code is clearer; also, it matches the pattern of "init_*" and "clear_*" functions.