### PR TITLE
allow removal of CA certificates without valid CRL with UA_Server_removeCertificates

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -877,7 +877,9 @@ UA_Server_removeCertificates(UA_Server *server,
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     for(size_t i = 0; i < certificatesSize; i++) {
         retval = certGroup->getCertificateCrls(certGroup, &certificates[i], isTrusted, &crls, &crlsSize);
-        if(retval != UA_STATUSCODE_GOOD) {
+        /* Tolerate "Bad_NoMatch" to support removing CA certificates that do
+         * not have an associated CRL. */
+        if((retval != UA_STATUSCODE_GOOD) && (retval != UA_STATUSCODE_BADNOMATCH)) {
             UA_Array_delete(crls, crlsSize, &UA_TYPES[UA_TYPES_BYTESTRING]);
             return retval;
         }


### PR DESCRIPTION
The "UA_Server_removeCertificates" function in "ua_server.c" (which is currently unused, I know 😄 ) calls "getCertificateCrls" when removing a CA certificate to obtain a list of the associated CRLs. However, this function may return "Bad_NoMatch" when either no or no valid CRL exists (e.g. the CRL has expired). In that case, trying to remove a CA certificate via "UA_Server_removeCertificates" will fail.

My assumption however is that _removing_ a certificate should always be possible, even if it is a CA certificate that currently has no valid associated CRL stored in the TrustList. Hence I propose to make "UA_Server_removeCertificates" accept "Bad_NoMatch" from "getCertificateCrls", so CA certificates that do not have an associated valid CRL can still be removed.