### PR TITLE
[Review] Add size check of uploaded TrustList to "writeTrustList"

### DIFF
--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -858,6 +858,14 @@ writeTrustList(UA_Server *server,
     if(fileContext->openFileMode != (UA_OPENFILEMODE_WRITE | UA_OPENFILEMODE_ERASEEXISTING))
         return UA_STATUSCODE_BADINVALIDSTATE;
 
+    /* abort when TrustList size would exceed the maximum allowed value */
+    if (((fileContext->dataToWrite.length + data.length) * sizeof(UA_Byte)) > server->config.maxTrustListSize)
+    {
+        UA_LOG_WARNING(server->config.logging, UA_LOGCATEGORY_SERVER,
+            "Write on trust list exceeds limit");
+        return UA_STATUSCODE_BADREQUESTTOOLARGE;
+    }
+
     UA_ByteString dataToWrite = UA_BYTESTRING_NULL;
     UA_StatusCode retval = UA_ByteString_allocBuffer(&dataToWrite, fileContext->dataToWrite.length + data.length);
     if(retval != UA_STATUSCODE_GOOD)


### PR DESCRIPTION
The OPC specification states that writing a TrustList that exceeds the maximum configured size should fail with "Bad_RequestTooLarge" (see https://reference.opcfoundation.org/GDS/v105/docs/7.8.2.5 ).

This PR adds a corresponding check at the "Write" stage when updating a TrustList. I am not completely sure if this is the best place to put the check, seeing that the spec only mentions the size check in "CloseAndUpdate"; however, we have all necessary information at hand already during "Write" and I personally see no advantage in postponing this check to the "CloseAndUpdate" stage.