### PR TITLE
[Review] Re-use functions from "ua_server.c" in GDS code for adding and removing single certificates

### DIFF
--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -468,16 +468,17 @@ addCertificate(UA_Server *server,
     if(fileInfo->openCount > 0)
         return UA_STATUSCODE_BADINVALIDSTATE;
 
-    UA_TrustListDataType trustList;
-    memset(&trustList, 0, sizeof(UA_TrustListDataType));
-    UA_ByteString certificates[1];
-    certificates[0] = certificate;
+    /* use UA_Server_addCertificates() function to do the actual work */
+    UA_ByteString certsToAdd[1];
+    certsToAdd[0] = certificate;
+    UA_Boolean appendToTrustList = true;
 
-    trustList.specifiedLists = UA_TRUSTLISTMASKS_TRUSTEDCERTIFICATES;
-    trustList.trustedCertificates = certificates;
-    trustList.trustedCertificatesSize = 1;
-
-    UA_StatusCode retval = certGroup->addToTrustList(certGroup, &trustList);
+    UA_StatusCode retval = UA_Server_addCertificates(server,
+                                                     certGroup->certificateGroupId,
+                                                     certsToAdd, 1,
+                                                     NULL, 0,
+                                                     isTrustedCertificate,
+                                                     appendToTrustList);
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
@@ -509,30 +510,24 @@ removeCertificate(UA_Server *server,
     if(transaction->state != UA_GDSTRANSACIONSTATE_FRESH)
         return UA_STATUSCODE_BADTRANSACTIONPENDING;
 
-    /* When a certificate is removed, a transaction is created which is then executed directly.
-     * No apply cahnges is required */
-    UA_StatusCode retval = UA_GDSTransaction_init(transaction, server, *sessionId);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
-
+    /* use UA_Server_removeCertificates() function to do the actual work */
     UA_CertificateGroup *certGroup = getCertGroup(server, objectId);
     if(!certGroup)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
 
-    /* This Method cannot be called if the containing TrustList Object is open */
-    UA_FileInfo *fileInfo = getFileInfo(gdsManager, certGroup->certificateGroupId);
-    if(!fileInfo)
-        return UA_STATUSCODE_BADINTERNALERROR;
-    if(fileInfo->openCount > 0)
-        return UA_STATUSCODE_BADINVALIDSTATE;
-
     UA_TrustListDataType trustList;
-    memset(&trustList, 0, sizeof(UA_TrustListDataType));
+    UA_TrustListDataType_init(&trustList);
     trustList.specifiedLists = UA_TRUSTLISTMASKS_ALL;
 
     UA_ByteString *certificates;
     size_t certificatesSize = 0;
-    certGroup->getTrustList(certGroup, &trustList);
+
+    /* check return value and abort on error */
+    UA_StatusCode retval = certGroup->getTrustList(certGroup, &trustList);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_TrustListDataType_clear(&trustList);
+        return retval;
+    }
 
     if(isTrustedCertificate) {
         certificates = trustList.trustedCertificates;
@@ -542,69 +537,43 @@ removeCertificate(UA_Server *server,
         certificatesSize = trustList.issuerCertificatesSize;
     }
 
-    UA_TrustListDataType list;
-    memset(&list, 0, sizeof(UA_TrustListDataType));
-
-    UA_ByteString *crls = NULL;
-    size_t crlsSize = 0;
-
     UA_String thumbpr = UA_STRING_NULL;
     thumbpr.length = (UA_SHA1_LENGTH * 2);
     thumbpr.data = (UA_Byte*)UA_malloc(sizeof(UA_Byte)*thumbpr.length);
+    if (NULL == thumbpr.data) {
+        retval = UA_STATUSCODE_BADOUTOFMEMORY;
+        goto cleanup;
+    }
 
+    UA_ByteString certificate;
+    UA_ByteString_init(&certificate);
     for(size_t i = 0; i < certificatesSize; i++) {
         UA_CertificateUtils_getThumbprint( &certificates[i], &thumbpr);
         /* Compare thumbprint */
         if(!UA_String_equal_ignorecase(&thumbprint, &thumbpr))
             continue;
 
-        UA_ByteString certificate = certificates[i];
-        retval = certGroup->getCertificateCrls(certGroup, &certificate, isTrustedCertificate,
-                                               &crls, &crlsSize);
-        if(retval != UA_STATUSCODE_GOOD) {
-            goto cleanup;
-        }
-
-        if(isTrustedCertificate) {
-            list.specifiedLists = UA_TRUSTLISTMASKS_TRUSTEDCERTIFICATES | UA_TRUSTLISTMASKS_TRUSTEDCRLS;
-            list.trustedCertificates = &certificate;
-            list.trustedCertificatesSize = 1;
-            list.trustedCrls = crls;
-            list.trustedCrlsSize = crlsSize;
-        } else {
-            list.specifiedLists = UA_TRUSTLISTMASKS_ISSUERCERTIFICATES | UA_TRUSTLISTMASKS_ISSUERCRLS;
-            list.issuerCertificates = &certificate;
-            list.issuerCertificatesSize = 1;
-            list.issuerCrls = crls;
-            list.issuerCrlsSize = crlsSize;
-        }
+        certificate = certificates[i];
         break;
     }
 
-    UA_CertificateGroup *transactionCertGroup =
-        UA_GDSTransaction_getCertificateGroup(transaction, certGroup);
-    if(!transactionCertGroup) {
-        retval = UA_STATUSCODE_BADINTERNALERROR;
-        goto cleanup;
-    }
-
-    if(list.specifiedLists != UA_TRUSTLISTMASKS_NONE) {
-        retval = transactionCertGroup->removeFromTrustList(transactionCertGroup, &list);
-        if(retval != UA_STATUSCODE_GOOD) {
-            goto cleanup;
-        }
-    } else {
-        UA_LOG_INFO(server->config.logging, UA_LOGCATEGORY_SERVER, "The certificate to remove was not found");
+    /* no certificate matching the given fingerprint found */
+    if(certificate.data == NULL) {
         retval = UA_STATUSCODE_BADINVALIDARGUMENT;
         goto cleanup;
     }
 
-    retval = applyChangesToServer(server);
+    UA_ByteString certsToRemove[1];
+    certsToRemove[0] = certificate;
+
+    retval = UA_Server_removeCertificates(server,
+                                          certGroup->certificateGroupId,
+                                          certsToRemove, 1,
+                                          isTrustedCertificate);
 
 cleanup:
     UA_String_clear(&thumbpr);
     UA_TrustListDataType_clear(&trustList);
-    UA_Array_delete(crls, crlsSize, &UA_TYPES[UA_TYPES_BYTESTRING]);
 
     return retval;
 }


### PR DESCRIPTION
Before version 1.5, the GDS code in "ua_server_ns0_gds.c" used the functions "UA_Server_addCertificates" and "UA_Server_removeCertificates" defined in "ua_server.c" for implementing the "AddCertificate" and "RemoveCertificate" Methods.

In newer versions, the functionality is duplicated between "ua_server.c" (the "UA_Server_addCertificates" and "UA_Server_removeCertificates" functions still exist there) and "ua_server_ns0_gds.c", which provides independent implementations "addCertificate" and "removeCertificate".

This removes the code duplication for adding and removing single certificates between "ua_server.c" and "ua_server_ns0_gds.c". In my opinion, having only a single implementation for a certain task simplifies maintaining the code, and in this special case, it also does away with the creation and immediate execution of a transaction (which is unnecessary in my opinion, as it does not have any advantages over removing the certificate right away). It further allows calling RemoveCertificate while the TrustList is currently open for "Read", something which the OPC specification (if I interpret it correctly) does not explicitly forbid (cf. https://reference.opcfoundation.org/GDS/v105/docs/7.8.2.7 - they only state that "This Method returns Bad_NotWritable if the TrustList Object is read only.", which I think applies to the case when the TrustList is open for "Write").