### PR TITLE
fix checking result value in Operation_SetMonitoringMode

### DIFF
--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -298,7 +298,7 @@ checkAdjustMonitoredItemParams(UA_Server *server, UA_Session *session,
             UA_NODESTORE_RELEASE(server, node);
         }
     }
-        
+
 
     /* A negative number indicates that the sampling interval is the publishing
      * interval of the Subscription. Note that the sampling interval selected
@@ -913,7 +913,7 @@ Operation_SetMonitoringMode(UA_Server *server, UA_Session *session,
     }
     *result = UA_MonitoredItem_setMonitoringMode(server, mon, smc->monitoringMode);
 
-    if(result == UA_STATUSCODE_GOOD)
+    if(*result == UA_STATUSCODE_GOOD)
         notifyMonitoredItem(server, mon, UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_MONITORINGMODE);
 }
 


### PR DESCRIPTION
In Operation_SetMonitoringMode, the "result" _pointer_ is compared against UA_STATUSCODE_GOOD instead of its value.