### PR TITLE
fix(arch): compile error related to zsock_fd_set

### DIFF
--- a/arch/zephyr/eventloop_zephyr.h
+++ b/arch/zephyr/eventloop_zephyr.h
@@ -75,7 +75,7 @@
 #define UA_gethostname zsock_gethostname
 
 typedef int UA_socket_fd;
-typedef struct zsock_fd_set UA_fd_set;
+typedef  zsock_fd_set UA_fd_set;
 typedef struct zsock_addrinfo UA_addrinfo;
 typedef struct zsock_pollfd UA_pollfd;
 


### PR DESCRIPTION
when compiling with West version: v1.5.0, zephyr v4.3.0, and gcc (GCC) 15.2.0 ther is an error related to wrong type for UA_fd_set. seems like the type is wrapped twice in a struct.