### PR TITLE
doc(ex): indicate that native_sim may be wrong for some systems

### DIFF
--- a/examples/zephyr/server/README.md
+++ b/examples/zephyr/server/README.md
@@ -6,6 +6,8 @@ cd examples/zephyr
 west init -l server
 west update
 # Build the native sim executable
+# "native_sim" may need to be changed based on your system.
+# (see https://docs.zephyrproject.org/latest/boards/native/native_sim/doc/index.html#and-64bit-versions )
 cd server
 west build -p -b native_sim
 # Setup host side ethernet interface (see


### PR DESCRIPTION
native_sim builds for 32bit systems. for 64bit systems there are some requirements regarding multilib or a 32bit superspace (documented by zephyr)