### PR TITLE
refactor(client,server,tools): fix warnings from "gcc -Wshadow"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,7 @@ if((CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang") AND
     check_add_cc_flag("-Wall")      # Warnings
     check_add_cc_flag("-Wextra")    # More warnings
     check_add_cc_flag("-Wpedantic") # Standard compliance
+    #check_add_cc_flag("-Wshadow")  # still disabled per default
     if(UA_FORCE_WERROR)
         check_add_cc_flag("-Werror") # All warnings are errors
         check_add_cc_flag("-Wunused-command-line-argument") # Warning for command line args instead of error

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1963,7 +1963,6 @@ __Client_networkCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
                 client->channel.unprocessedDelayed.callback = delayedNetworkCallback;
                 client->channel.unprocessedDelayed.application = client;
                 client->channel.unprocessedDelayed.context = &client->channel;
-                UA_EventLoop *el = client->config.eventLoop;
                 el->addDelayedCallback(el, &client->channel.unprocessedDelayed);
             }
             res = UA_STATUSCODE_GOOD;

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -1132,14 +1132,14 @@ UA_Client_MonitoredItem_getContext(UA_Client *client, UA_UInt32 subscriptionId,
 		return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
 	}
 
-	UA_StatusCode status = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
+	UA_StatusCode itemstatus = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
 	UA_Client_MonitoredItem *monItem = findMonitoredItemById(sub, monitoredItemId);
 	if(monItem) {
 		*monContext = monItem->context;
-		status = UA_STATUSCODE_GOOD;
+		itemstatus = UA_STATUSCODE_GOOD;
 	}
 	unlockClient(client);
-	return status;
+	return itemstatus;
 }
 
 UA_StatusCode
@@ -1155,14 +1155,14 @@ UA_Client_MonitoredItem_setContext(UA_Client *client, UA_UInt32 subscriptionId,
 		return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
 	}
 
-	UA_StatusCode status = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
+	UA_StatusCode itemstatus = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
 	UA_Client_MonitoredItem *monItem = findMonitoredItemById(sub, monitoredItemId);
 	if(monItem) {
 		monItem->context = monContext;
-		status = UA_STATUSCODE_GOOD;
+		itemstatus = UA_STATUSCODE_GOOD;
 	}
 	unlockClient(client);
-	return status;
+	return itemstatus;
 }
 
 /*************************************/

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -486,10 +486,10 @@ UA_Server_delete(UA_Server *server) {
     /* Clean up the custom datatypes */
     if(server->customTypes_internal != NULL) {
         for(size_t i = 0; i < server->customTypes_internalSize; i++) {
-            UA_DataTypeArray *current = &server->customTypes_internal[i];
-            for(size_t j = 0; j < current->typesSize; j++)
-                UA_DataType_clear(&current->types[j]);
-            UA_free(current->types);
+            UA_DataTypeArray *curr = &server->customTypes_internal[i];
+            for(size_t j = 0; j < curr->typesSize; j++)
+                UA_DataType_clear(&curr->types[j]);
+            UA_free(curr->types);
         }
         UA_free(server->customTypes_internal);
     }

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -11,7 +11,7 @@
 /* Cancel the operation, but don't _clear it here */
 static void
 UA_AsyncOperation_cancel(UA_Server *server, UA_AsyncOperation *op,
-                         UA_StatusCode status) {
+                         UA_StatusCode opstatus) {
     UA_ServerConfig *sc = &server->config;
     void *cancelPtr = NULL;
 
@@ -20,30 +20,30 @@ UA_AsyncOperation_cancel(UA_Server *server, UA_AsyncOperation *op,
     case UA_ASYNCOPERATIONTYPE_READ_REQUEST:
         cancelPtr = op->output.read;
         op->output.read->hasStatus = true;
-        op->output.read->status = status;
+        op->output.read->status = opstatus;
         break;
     case UA_ASYNCOPERATIONTYPE_READ_DIRECT:
         cancelPtr = &op->output.directRead;
         op->output.directRead.hasStatus = true;
-        op->output.directRead.status = status;
+        op->output.directRead.status = opstatus;
         break;
     case UA_ASYNCOPERATIONTYPE_WRITE_REQUEST:
         cancelPtr = &op->context.writeValue.value;
-        *op->output.write = status;
+        *op->output.write = opstatus;
         break;
     case UA_ASYNCOPERATIONTYPE_WRITE_DIRECT:
         cancelPtr = &op->context.writeValue.value;
-        op->output.directWrite = status;
+        op->output.directWrite = opstatus;
         break;
     case UA_ASYNCOPERATIONTYPE_CALL_REQUEST:
         /* outputArguments is always an allocated pointer, also if the length is zero */
         cancelPtr = op->output.call->outputArguments;
-        op->output.call->statusCode = status;
+        op->output.call->statusCode = opstatus;
         break;
     case UA_ASYNCOPERATIONTYPE_CALL_DIRECT:
         /* outputArguments is always an allocated pointer, also if the length is zero */
         cancelPtr = op->output.directCall.outputArguments;
-        op->output.directCall.statusCode = status;
+        op->output.directCall.statusCode = opstatus;
         break;
     default: UA_assert(false); return;
     }
@@ -469,7 +469,7 @@ persistAsyncDirectOperation(UA_Server *server, UA_AsyncOperation *op,
 }
 
 void
-async_cancel(UA_Server *server, void *context, UA_StatusCode status,
+async_cancel(UA_Server *server, void *context, UA_StatusCode opstatus,
              UA_Boolean cancelSynchronous) {
     UA_AsyncManager *am = &server->asyncManager;
     UA_AsyncOperation *op = NULL, *op_tmp = NULL;
@@ -481,7 +481,7 @@ async_cancel(UA_Server *server, void *context, UA_StatusCode status,
 
         /* Cancel the operation. This sets the StatusCode and calls the
          * asyncOperationCancelCallback. */
-        UA_AsyncOperation_cancel(server, op, status);
+        UA_AsyncOperation_cancel(server, op, opstatus);
 
         /* Call the result-callback of the local async operation.
          * Right away or in the next EventLoop iteration. */
@@ -511,10 +511,10 @@ async_cancel(UA_Server *server, void *context, UA_StatusCode status,
 }
 
 void
-UA_Server_cancelAsync(UA_Server *server, void *context, UA_StatusCode status,
+UA_Server_cancelAsync(UA_Server *server, void *context, UA_StatusCode opstatus,
                       UA_Boolean synchronousResultCallback) {
     lockServer(server);
-    async_cancel(server, context, status, synchronousResultCallback);
+    async_cancel(server, context, opstatus, synchronousResultCallback);
     unlockServer(server);
 }
 

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -1374,8 +1374,8 @@ evaluateSelectClause(UA_FilterEvalContext *ctx, UA_EventFieldList *efl) {
         /* Ensure a deep copy */
         if(field->storageType == UA_VARIANT_DATA_NODELETE) {
             UA_Variant tmp_val;
-            UA_StatusCode res = UA_Variant_copy(field, &tmp_val);
-            (void)res; /* Ignore the result - returns an empty variant if copying fails */
+            UA_StatusCode res_ign = UA_Variant_copy(field, &tmp_val);
+            (void)res_ign; /* Ignore the result - returns an empty variant if copying fails */
             *field = tmp_val;
         }
     }

--- a/src/ua_types_definition.c
+++ b/src/ua_types_definition.c
@@ -213,9 +213,9 @@ UA_DataType_fromStructureDescription(UA_DataType *type,
 #endif
 
         /* Memory size and padding for the scalar case */
-        UA_Byte alignment = type_alignment(dtm->memberType);
+        UA_Byte talignment = type_alignment(dtm->memberType);
         size_t memSize = dtm->memberType->memSize;
-        dtm->padding = PADDING(type->memSize, alignment);
+        dtm->padding = PADDING(type->memSize, talignment);
 
         /* Handle valuerank and array dimensions */
         if(sf->valueRank == 1) {

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -65,8 +65,8 @@ xml_tokenize(const char *xml, unsigned int len,
 #ifdef __clang_analyzer__
         UA_assert(stack[top] != NULL);
 #endif
-        yxml_ret_t status = yxml_parse(&ctx, xml[pos]);
-        switch(status) {
+        yxml_ret_t xml_status = yxml_parse(&ctx, xml[pos]);
+        switch(xml_status) {
         case YXML_EEOF:
         case YXML_EREF:
         case YXML_ECLOSE:
@@ -78,7 +78,7 @@ xml_tokenize(const char *xml, unsigned int len,
             continue;
         case YXML_ELEMSTART:
         case YXML_ATTRSTART:
-            if(status == YXML_ELEMSTART) {
+            if(xml_status == YXML_ELEMSTART) {
                 stack[top]->children++;
                 stack[top]->content = UA_STRING_NULL; /* Only the leaf elements have content */
             } else {
@@ -89,10 +89,10 @@ xml_tokenize(const char *xml, unsigned int len,
                 goto errout; /* nesting too deep */
             stack[top] = (tokenPos < max_tokens) ? &tokens[tokenPos] : &backup_tokens[top];
             memset(stack[top], 0, sizeof(xml_token));
-            stack[top]->type = (status == YXML_ELEMSTART) ? XML_TOKEN_ELEMENT : XML_TOKEN_ATTRIBUTE;
+            stack[top]->type = (xml_status == YXML_ELEMSTART) ? XML_TOKEN_ELEMENT : XML_TOKEN_ATTRIBUTE;
             stack[top]->name = backtrackName(xml, pos);
             const char *start = xml + pos;
-            if(status == YXML_ELEMSTART) {
+            if(xml_status == YXML_ELEMSTART) {
                 while(*start != '<')
                     start--;
             }
@@ -113,7 +113,7 @@ xml_tokenize(const char *xml, unsigned int len,
                 stack[top]->content.length = stack[top]->end + 1 - val_begin;
             }
             stack[top]->end = pos;
-            if(status == YXML_ELEMEND) {
+            if(xml_status == YXML_ELEMEND) {
                 /* Saw "</", looking for the closing ">" */
                 while(stack[top]->end < len && xml[stack[top]->end] != '>')
                     stack[top]->end++;
@@ -462,15 +462,15 @@ ENCODE_XML(ExtensionObject) {
         ret |= writeXmlElemNameEnd(ctx, UA_XML_EXTENSIONOBJECT_BODY);
     } else {
         /* Write the decoded value */
-        const UA_DataType *type = src->content.decoded.type;
+        const UA_DataType *decoded_type = src->content.decoded.type;
 
         /* Write the type NodeId */
         ret = writeXmlElement(ctx, UA_XML_EXTENSIONOBJECT_TYPEID,
-                              &type->typeId, &UA_TYPES[UA_TYPES_NODEID]);
+                              &decoded_type->typeId, &UA_TYPES[UA_TYPES_NODEID]);
 
         /* Write the body */
         ret |= writeXmlElemNameBegin(ctx, UA_XML_EXTENSIONOBJECT_BODY);
-        ret |= writeXmlElement(ctx, type->typeName, src->content.decoded.data, type);
+        ret |= writeXmlElement(ctx, decoded_type->typeName, src->content.decoded.data, decoded_type);
         ret |= writeXmlElemNameEnd(ctx, UA_XML_EXTENSIONOBJECT_BODY);
     }
 
@@ -524,16 +524,16 @@ ENCODE_XML(Variant) {
     UA_StatusCode ret = UA_STATUSCODE_GOOD;
     ret |= writeXmlElemNameBegin(ctx, UA_XML_VARIANT_VALUE);
     if(!isArray) {
-        const UA_DataType *type = src->type;
+        const UA_DataType *srctype = src->type;
         void *ptr = src->data;
         UA_ExtensionObject eo;
-        if(type->typeKind > UA_DATATYPEKIND_DIAGNOSTICINFO) {
+        if(srctype->typeKind > UA_DATATYPEKIND_DIAGNOSTICINFO) {
             /* Wrap value in an ExtensionObject */
-            UA_ExtensionObject_setValue(&eo, (void*)(uintptr_t)ptr, type);
+            UA_ExtensionObject_setValue(&eo, (void*)(uintptr_t)ptr, srctype);
             ptr = &eo;
-            type = &UA_TYPES[UA_TYPES_EXTENSIONOBJECT];
+            srctype = &UA_TYPES[UA_TYPES_EXTENSIONOBJECT];
         }
-        ret |= writeXmlElement(ctx, type->typeName, ptr, type);
+        ret |= writeXmlElement(ctx, srctype->typeName, ptr, srctype);
     } else {
         ret |= Array_encodeXml(ctx, src->data, src->arrayLength, src->type);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ if(MSVC)
         $<$<CONFIG:Release>:/MD>
     )
 else()
-    add_compile_options(-Wno-unused-variable -Wno-unused-function)
+    add_compile_options(-Wno-unused-variable -Wno-unused-function -Wno-shadow)
     add_compile_options(-Wno-gnu-zero-variadic-macro-arguments) # silence warning for the check library
 endif()
 

--- a/tools/ua-cli/ua.c
+++ b/tools/ua-cli/ua.c
@@ -265,15 +265,15 @@ parseVariant(UA_Variant *v, UA_String valstr) {
     UA_String s = UA_STRING_NULL;
     UA_StatusCode res = UA_STATUSCODE_GOOD;
     if(valstr.data[0] == '\"' || valstr.data[0] == '\'') {
-        UA_StatusCode res = UA_decodeJson(&valstr, &s, &UA_TYPES[UA_TYPES_STRING], NULL);
+        res = UA_decodeJson(&valstr, &s, &UA_TYPES[UA_TYPES_STRING], NULL);
         res |= UA_Variant_setScalarCopy(v, &s, &UA_TYPES[UA_TYPES_STRING]);
         return res;
     }
 
     /* Detect integer and float */
-    UA_Int32 i;
-    UA_Float ff;
     if(valstr.data[0] == '.' || isdigit(valstr.data[0])) {
+        UA_Int32 i;
+        UA_Float ff;
         res = UA_decodeJson(&valstr, &i, &UA_TYPES[UA_TYPES_INT32], NULL);
         if(res == UA_STATUSCODE_GOOD)
             return UA_Variant_setScalarCopy(v, &i, &UA_TYPES[UA_TYPES_INT32]);


### PR DESCRIPTION
A start to fix compiler warnings from "gcc -Wshadow". This compiler warning stays disabled by default and it is actively disabled for test source code.
Fix source code to remove shadow variables.