### PR TITLE
plugins: ua_log_syslog.c: remove unreachable code in syslog logger

### DIFF
--- a/plugins/ua_log_syslog.c
+++ b/plugins/ua_log_syslog.c
@@ -51,8 +51,6 @@ UA_Log_Syslog_log(void *context, UA_LogLevel level, UA_LogCategory category,
     }
 
     int logLevelSlot = ((int)level / 100) - 1;
-    if(logLevelSlot < 0 || logLevelSlot > 5)
-        logLevelSlot = 5; /* Set to fatal if the level is outside the range */
 
 #define LOGBUFSIZE 512
     char logbuf[LOGBUFSIZE];


### PR DESCRIPTION
The condition `if(logLevelSlot < 0 || logLevelSlot > 5)` is never true because:
- UA_LOGLEVEL_TRACE (which would yield logLevelSlot = -1) is handled in the switch statement and causes an early return.
- All other valid log levels produce logLevelSlot values in [0, 4].

Thus, the fallback assignment `logLevelSlot = 5` is dead code and can be safely removed without changing runtime behavior.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
