### PR TITLE
src: pubsub: ua_pubsub_ns0.c: prevent null pointer dereference in removeGroupAction

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -1530,17 +1530,19 @@ removeGroupAction(UA_Server *server,
                   size_t inputSize, const UA_Variant *input,
                   size_t outputSize, UA_Variant *output){
     UA_NodeId nodeToRemove = *((UA_NodeId *)input->data);
-    if(UA_WriterGroup_findWGbyId(server, nodeToRemove)) {
-        UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, nodeToRemove);
+    UA_WriterGroup *wg = UA_WriterGroup_findWGbyId(server, nodeToRemove);
+    if(wg) {
         if(wg->configurationFrozen)
             UA_Server_unfreezeWriterGroupConfiguration(server, nodeToRemove);
         return UA_Server_removeWriterGroup(server, nodeToRemove);
-    } else {
-        UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, nodeToRemove);
-        if(rg->configurationFrozen)
-            UA_Server_unfreezeReaderGroupConfiguration(server, nodeToRemove);
-        return UA_Server_removeReaderGroup(server, nodeToRemove);
     }
+    UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, nodeToRemove);
+    if(!rg)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+
+    if(rg->configurationFrozen)
+        UA_Server_unfreezeReaderGroupConfiguration(server, nodeToRemove);
+    return UA_Server_removeReaderGroup(server, nodeToRemove);
 }
 
 /**********************************************/


### PR DESCRIPTION

The removeGroupAction method did not check if UA_ReaderGroup_findRGbyId returned NULL before dereferencing the pointer to access configurationFrozen. This could lead to a segmentation fault if the provided NodeId does not correspond to any existing ReaderGroup (e.g., invalid input or race condition).

Additionally:
- Optimized WriterGroup path to avoid duplicate lookup
- Added explicit BADNODEIDUNKNOWN return for invalid NodeIds
- Improved code robustness and alignment with open62541 safety practices

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com> 