### PR TITLE
src: pubsub: ua_pubsub_ns0.c: prevent null pointer dereference in addDataSetReaderLocked

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -950,6 +950,12 @@ addDataSetReaderLocked(UA_Server *server,
     UA_LOCK_ASSERT(&server->serviceMutex, 1);
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     UA_ReaderGroup *rg = UA_ReaderGroup_findRGbyId(server, *objectId);
+    if(!rg) {
+        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
+                     "ReaderGroup not found for NodeId %S",
+                     UA_NODEID_PRINT(*objectId));
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+    }
     if(rg->configurationFrozen) {
         UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
                      "AddDataSetReader cannot be done because ReaderGroup config frozen");


### PR DESCRIPTION

The function UA_ReaderGroup_findRGbyId may return NULL if the ReaderGroup does not exist. Previously, the returned pointer was dereferenced without a NULL check when accessing rg->configurationFrozen, which could cause a segmentation fault on invalid or malicious method calls.

Added an explicit NULL check and return UA_STATUSCODE_BADNODEIDUNKNOWN with proper logging using UA_NODEID_PRINT for safety and diagnostics.

This aligns with error handling patterns used elsewhere in the PubSub information model (e.g., addDataSetWriterLocked).

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
