### PR TITLE
src: server: ua_server.c: prevent null pointer dereference in UA_Server_run_startup

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -786,6 +786,15 @@ UA_Server_run_startup(UA_Server *server) {
     /* Check that the binary protocol support component have been started */
     UA_ServerComponent *binaryProtocolManager =
         getServerComponentByName(server, UA_STRING("binary"));
+    if(!binaryProtocolManager) {
+        UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
+                     "Binary protocol support component not found.");
+        /* Stop all server components that have already been started */
+        ZIP_ITER(UA_ServerComponentTree, &server->serverComponents,
+                 stopServerComponent, server);
+        unlockServer(server);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
     if(binaryProtocolManager->state != UA_LIFECYCLESTATE_STARTED) {
         UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
                        "The binary protocol support component could not been started.");


### PR DESCRIPTION

The function getServerComponentByName may return NULL if the "binary" component was not successfully created (e.g., due to memory allocation failure). Previously, the returned pointer was dereferenced without a NULL check, leading to a potential segmentation fault during server startup.

Added explicit NULL check and proper error handling with logging and cleanup.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
