### PR TITLE
src: pubsub: ua_pubsub_writergroup.c: prevent null pointer dereference in UA_WriterGroup_publishCallback

### DIFF
--- a/src/pubsub/ua_pubsub_writergroup.c
+++ b/src/pubsub/ua_pubsub_writergroup.c
@@ -1368,8 +1368,7 @@ UA_WriterGroup_publishCallback(UA_Server *server, UA_WriterGroup *writerGroup) {
     if(!connection) {
         UA_LOG_ERROR_WRITERGROUP(server->config.logging, writerGroup,
                                  "Publish failed. PubSubConnection invalid");
-        UA_WriterGroup_setPubSubState(server, writerGroup, UA_PUBSUBSTATE_ERROR,
-                                      UA_STATUSCODE_BADNOTCONNECTED);
+        writerGroup->state = UA_PUBSUBSTATE_ERROR;
         unlockServer(server);
         return;
     }


### PR DESCRIPTION

When writerGroup->linkedConnection is NULL, the publish callback previously called UA_WriterGroup_setPubSubState, which internally dereferences writerGroup->linkedConnection (e.g., in UA_PubSubConnection_setPubSubState). This leads to a segmentation fault if the connection has been removed or was never set.

Fixed by directly setting writerGroup->state = UA_PUBSUBSTATE_ERROR instead of invoking UA_WriterGroup_setPubSubState when the connection is missing. This avoids unsafe pointer dereference while preserving correct error state and logging.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
