### PR TITLE
plugins: crypto: openssl: securitypolicy_openssl_common.c: remove unreachable code in UA_Openssl_RSA_Private_Decrypt

### DIFF
--- a/plugins/crypto/openssl/securitypolicy_openssl_common.c
+++ b/plugins/crypto/openssl/securitypolicy_openssl_common.c
@@ -233,10 +233,6 @@ UA_Openssl_RSA_Private_Decrypt (UA_ByteString *      data,
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     }
 
-    if (privateKey == NULL) {
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
-    }
-
     size_t keySize = (size_t) UA_OpenSSL_RSA_Key_Size (privateKey);
     size_t cipherOffset = 0;
     size_t outOffset = 0;


### PR DESCRIPTION

The second NULL check for 'privateKey' is redundant because the first condition already covers it:

    if (data == NULL || privateKey == NULL)
        return ...;

Thus, the subsequent 'if (privateKey == NULL)' block is unreachable.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
