### PR TITLE
arch: eventloop_posix_udp.c: check return value of getsockname in UDP_registerListenSocket

### DIFF
--- a/arch/eventloop_posix_udp.c
+++ b/arch/eventloop_posix_udp.c
@@ -808,7 +808,14 @@ UDP_registerListenSocket(UA_POSIXConnectionManager *pcm, UA_UInt16 port,
         struct sockaddr_in sin;
         memset(&sin, 0, sizeof(sin));
         socklen_t len = sizeof(sin);
-        getsockname(listenSocket, (struct sockaddr *)&sin, &len);
+        if(getsockname(listenSocket, (struct sockaddr *)&sin, &len) != 0) {
+            UA_LOG_SOCKET_ERRNO_WRAP(
+                UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                            "UDP %u\t| getsockname failed (%s)",
+                            (unsigned)listenSocket, errno_str));
+            UA_close(listenSocket);
+            return UA_STATUSCODE_BADCONNECTIONREJECTED;
+        }
         port = ntohs(sin.sin_port);
     }
 


### PR DESCRIPTION

The return value of getsockname() was not checked when retrieving the dynamically assigned port after binding a UDP socket. If getsockname() fails (e.g., due to EBADF or memory issues), the port variable would be set from uninitialized memory, leading to undefined behavior.

Added proper error checking and logging using UA_LOG_SOCKET_ERRNO_WRAP. Also improved robustness by using sockaddr_storage to support both IPv4 and IPv6 address families.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
