### PR TITLE
src: pubsub: ua_pubsub_networkmessage.c: initialize 'rv' in UA_NetworkMessage_decodePayload to avoid undefined behavior

### DIFF
--- a/src/pubsub/ua_pubsub_networkmessage.c
+++ b/src/pubsub/ua_pubsub_networkmessage.c
@@ -789,7 +789,7 @@ UA_NetworkMessage_decodePayload(const UA_ByteString *src, size_t *offset, UA_Net
     if(dst->networkMessageType != UA_NETWORKMESSAGE_DATASET)
         return UA_STATUSCODE_BADNOTIMPLEMENTED;
 
-    UA_StatusCode rv;
+    UA_StatusCode rv = UA_STATUSCODE_GOOD;
 
     UA_Byte count = 1;
     if(dst->payloadHeaderEnabled) {
@@ -801,6 +801,10 @@ UA_NetworkMessage_decodePayload(const UA_ByteString *src, size_t *offset, UA_Net
                 UA_CHECK_STATUS(rv, return rv);
             }
         }
+    }
+    if(count == 0) {
+        dst->payload.dataSetPayload.dataSetMessages = NULL;
+        return UA_STATUSCODE_GOOD;
     }
 
     dst->payload.dataSetPayload.dataSetMessages = (UA_DataSetMessage*)
@@ -818,6 +822,7 @@ UA_NetworkMessage_decodePayload(const UA_ByteString *src, size_t *offset, UA_Net
                                                 &dst->payload.dataSetPayload.dataSetMessages[i],
                                                 dst->payload.dataSetPayload.sizes[i], customTypes,
                                                 dsm);
+            UA_CHECK_STATUS(rv, return rv);
         }
     }
     UA_CHECK_STATUS(rv, return rv);


### PR DESCRIPTION

The variable 'rv' was declared but not initialized. In the case where dst->payloadHeaderEnabled is true and count == 0, no assignment to 'rv' occurs before UA_CHECK_STATUS(rv, ...), leading to reading uninitialized stack data.

Fixed by initializing 'rv' to UA_STATUSCODE_GOOD and explicitly handling the count == 0 case. Also added error checking inside the multi-message loop.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
