### PR TITLE
Role-Based Access Control (RBAC): Batch 3 - Role Management and RBAC initialization

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -2486,6 +2486,18 @@ struct UA_ServerConfig {
      * may be garbage-collected when no longer referenced by any node. */
     size_t rolePermissionPresetsSize;
     UA_RolePermissionSet *rolePermissionPresets;
+
+    /* Initial Role Definitions
+     * ~~~~~~~~~~~~~~~~~~~~~~~~
+     * Array of initial role definitions. During server startup, these roles
+     * are copied into the server's internal role registry. Config roles are
+     * treated as **protected**: they cannot be removed at runtime via
+     * UA_Server_removeRole.
+     *
+     * Additional roles can be added at runtime through UA_Server_addRole.
+     * Runtime-added roles can be removed via UA_Server_removeRole. */
+    size_t rolesSize;
+    UA_Role *roles;
 #endif
 };
 
@@ -2640,6 +2652,66 @@ UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_removeNodeRolePermissions(UA_Server *server,
                                     const UA_NodeId nodeId,
                                     UA_Boolean recursive);
+
+/**
+ * Role Management
+ * ~~~~~~~~~~~~~~~
+ * Functions for managing the server's role registry. Roles define which
+ * sessions get which access rights. Config-provided roles are protected
+ * and cannot be removed at runtime. */
+
+/* Add a role to the server's role registry.
+ *
+ * The role's BrowseName (roleName) is the primary unique identifier,
+ * per OPC UA Part 18 Section 4.2. A role with the same roleName must
+ * not already exist.
+ *
+ * @param server The server instance
+ * @param role The role definition to add (deep-copied)
+ * @param outRoleNodeId Output: the NodeId of the new role (caller
+ *        must clear). May be NULL.
+ * @return UA_STATUSCODE_GOOD on success,
+ *         UA_STATUSCODE_BADALREADYEXISTS if a role with the same
+ *         roleName already exists */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_addRole(UA_Server *server, const UA_Role *role,
+                  UA_NodeId *outRoleNodeId);
+
+/* Remove a role from the server's role registry.
+ *
+ * Config-provided (protected) roles cannot be removed.
+ *
+ * @param server The server instance
+ * @param roleName The BrowseName (QualifiedName) of the role to remove
+ * @return UA_STATUSCODE_GOOD on success,
+ *         UA_STATUSCODE_BADUSERACCESSDENIED if the role is protected,
+ *         UA_STATUSCODE_BADNOTFOUND if the role does not exist */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_removeRole(UA_Server *server,
+                     const UA_QualifiedName roleName);
+
+/* Get a copy of a role by its BrowseName.
+ *
+ * @param server The server instance
+ * @param roleName The BrowseName (QualifiedName) of the role
+ * @param outRole Output: deep copy of the role (caller must clear)
+ * @return UA_STATUSCODE_GOOD on success,
+ *         UA_STATUSCODE_BADNOTFOUND if the role does not exist */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_getRole(UA_Server *server,
+                  const UA_QualifiedName roleName,
+                  UA_Role *outRole);
+
+/* Get the BrowseNames of all registered roles.
+ *
+ * @param server The server instance
+ * @param rolesSize Output: number of roles
+ * @param roleNames Output: array of role BrowseNames (caller must
+ *        clear each entry and free the array)
+ * @return UA_STATUSCODE_GOOD on success */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_getRoles(UA_Server *server, size_t *rolesSize,
+                   UA_QualifiedName **roleNames);
 
 #endif /* UA_ENABLE_RBAC */
 

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -117,5 +117,14 @@ UA_ServerConfig_clear(UA_ServerConfig *config) {
         config->rolePermissionPresets = NULL;
         config->rolePermissionPresetsSize = 0;
     }
+
+    /* RBAC Roles */
+    if(config->roles) {
+        for(size_t i = 0; i < config->rolesSize; i++)
+            UA_Role_clear(&config->roles[i]);
+        UA_free(config->roles);
+        config->roles = NULL;
+        config->rolesSize = 0;
+    }
 #endif
 }

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -289,6 +289,12 @@ struct UA_Server {
      * UA_ROLEPERMISSIONS_REFCOUNT_PROTECTED and are never deleted. */
     size_t rolePermissionsSize;
     UA_RolePermissionEntry *rolePermissions;
+
+    /* Internal role registry. Roles from the config are marked as
+     * protected and cannot be removed at runtime. */
+    size_t rolesSize;
+    UA_Role *roles;
+    UA_Boolean *rolesProtected; /* Parallel array: true for config roles */
 #endif
 };
 

--- a/src/server/ua_server_rbac.c
+++ b/src/server/ua_server_rbac.c
@@ -364,6 +364,38 @@ incrementRefCount(UA_Server *server, UA_PermissionIndex index) {
 /* RBAC Init/Cleanup  */
 /**********************/
 
+/* Apply config roles into server's internal role registry via UA_Server_addRole.
+ * Config roles are marked as protected (cannot be removed at runtime).
+ * Duplicate names or NodeIds are skipped with a warning. */
+static UA_StatusCode
+initializeRolesFromConfig(UA_Server *server) {
+    UA_ServerConfig *config = &server->config;
+    if(config->rolesSize == 0 || !config->roles)
+        return UA_STATUSCODE_GOOD;
+
+    for(size_t i = 0; i < config->rolesSize; i++) {
+        UA_NodeId outId;
+        UA_StatusCode res = UA_Server_addRole(server, &config->roles[i], &outId);
+        if(res == UA_STATUSCODE_BADALREADYEXISTS) {
+            UA_LOG_WARNING(server->config.logging, UA_LOGCATEGORY_SERVER,
+                           "RBAC: Config role '%.*s' (ns=%u) skipped - "
+                           "a role with the same name or NodeId already exists",
+                           (int)config->roles[i].roleName.name.length,
+                           config->roles[i].roleName.name.data,
+                           config->roles[i].roleName.namespaceIndex);
+            continue;
+        }
+        if(res != UA_STATUSCODE_GOOD)
+            return res;
+
+        /* Mark as protected (cannot be removed at runtime) */
+        if(server->rolesSize > 0)
+            server->rolesProtected[server->rolesSize - 1] = true;
+        UA_NodeId_clear(&outId);
+    }
+    return UA_STATUSCODE_GOOD;
+}
+
 UA_StatusCode
 UA_Server_initRBAC(UA_Server *server) {
     if(!server)
@@ -410,6 +442,16 @@ UA_Server_initRBAC(UA_Server *server) {
                 "%zu preset(s) loaded.",
                 server->rolePermissionsSize);
 
+    /* Copy config roles into the internal role registry */
+    UA_StatusCode initRes = initializeRolesFromConfig(server);
+    if(initRes != UA_STATUSCODE_GOOD)
+        return initRes;
+
+    if(server->rolesSize > 0)
+        UA_LOG_INFO(server->config.logging, UA_LOGCATEGORY_SERVER,
+                    "RBAC: %zu role(s) loaded from config (protected).",
+                    server->rolesSize);
+
     return UA_STATUSCODE_GOOD;
 }
 
@@ -417,11 +459,235 @@ void
 UA_Server_cleanupRBAC(UA_Server *server) {
     if(!server)
         return;
+
+    /* Clean up role-permission entries */
     for(size_t i = 0; i < server->rolePermissionsSize; i++)
         rolePermissionEntry_clear(&server->rolePermissions[i]);
     UA_free(server->rolePermissions);
     server->rolePermissions = NULL;
     server->rolePermissionsSize = 0;
+
+    /* Clean up role registry */
+    for(size_t i = 0; i < server->rolesSize; i++)
+        UA_Role_clear(&server->roles[i]);
+    UA_free(server->roles);
+    server->roles = NULL;
+    UA_free(server->rolesProtected);
+    server->rolesProtected = NULL;
+    server->rolesSize = 0;
+}
+
+/************************************/
+/* Internal Helpers: Role Registry  */
+/************************************/
+
+static UA_Role *
+findRoleByName(UA_Server *server, const UA_QualifiedName *roleName) {
+    for(size_t i = 0; i < server->rolesSize; i++) {
+        if(UA_QualifiedName_equal(&server->roles[i].roleName, roleName))
+            return &server->roles[i];
+    }
+    return NULL;
+}
+
+static UA_Role*
+findRoleById(UA_Server *server, const UA_NodeId *roleId) {
+    for(size_t i = 0; i < server->rolesSize; i++) {
+        if(UA_NodeId_equal(&server->roles[i].roleId, roleId))
+            return &server->roles[i];
+    }
+    return NULL;
+}
+
+/************************************/
+/* Public API: Role Management      */
+/************************************/
+
+UA_StatusCode
+UA_Server_addRole(UA_Server *server, const UA_Role *role,
+                  UA_NodeId *outRoleNodeId) {
+    if(!server || !role)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    lockServer(server);
+
+    /* Check for duplicate roleName (BrowseName uniqueness per Part 18) */
+    if(findRoleByName(server, &role->roleName)) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADALREADYEXISTS;
+    }
+
+    /* Check for duplicate roleId (if the caller provided one) */
+    if(!UA_NodeId_isNull(&role->roleId) &&
+       findRoleById(server, &role->roleId)) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADALREADYEXISTS;
+    }
+
+    /* Grow the arrays */
+    UA_Role *newRoles = (UA_Role*)
+        UA_realloc(server->roles,
+                   (server->rolesSize + 1) * sizeof(UA_Role));
+    if(!newRoles) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    server->roles = newRoles;
+
+    UA_Boolean *newProtected = (UA_Boolean*)
+        UA_realloc(server->rolesProtected,
+                   (server->rolesSize + 1) * sizeof(UA_Boolean));
+    if(!newProtected) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    server->rolesProtected = newProtected;
+
+    /* Deep-copy the role */
+    UA_Role *newRole = &server->roles[server->rolesSize];
+    UA_StatusCode res = UA_Role_copy(role, newRole);
+    if(res != UA_STATUSCODE_GOOD) {
+        unlockServer(server);
+        return res;
+    }
+
+    server->rolesProtected[server->rolesSize] = false;
+    server->rolesSize++;
+
+    /* Return the assigned roleId */
+    if(outRoleNodeId) {
+        res = UA_NodeId_copy(&newRole->roleId, outRoleNodeId);
+        if(res != UA_STATUSCODE_GOOD) {
+            /* Rollback */
+            server->rolesSize--;
+            UA_Role_clear(newRole);
+            unlockServer(server);
+            return res;
+        }
+    }
+
+    unlockServer(server);
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_removeRole(UA_Server *server,
+                     const UA_QualifiedName roleName) {
+    if(!server)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    lockServer(server);
+
+    UA_Role *role = findRoleByName(server, &roleName);
+    if(!role) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+
+    size_t roleIndex = (size_t)(role - server->roles);
+
+    /* Protected roles (from config) cannot be removed */
+    if(server->rolesProtected[roleIndex]) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADUSERACCESSDENIED;
+    }
+
+    UA_Role_clear(&server->roles[roleIndex]);
+
+    /* Shift remaining entries */
+    if(roleIndex < server->rolesSize - 1) {
+        memmove(&server->roles[roleIndex],
+                &server->roles[roleIndex + 1],
+                (server->rolesSize - roleIndex - 1) * sizeof(UA_Role));
+        memmove(&server->rolesProtected[roleIndex],
+                &server->rolesProtected[roleIndex + 1],
+                (server->rolesSize - roleIndex - 1) * sizeof(UA_Boolean));
+    }
+
+    server->rolesSize--;
+
+    if(server->rolesSize > 0) {
+        UA_Role *r = (UA_Role*)
+            UA_realloc(server->roles,
+                       server->rolesSize * sizeof(UA_Role));
+        if(r)
+            server->roles = r;
+        UA_Boolean *p = (UA_Boolean*)
+            UA_realloc(server->rolesProtected,
+                       server->rolesSize * sizeof(UA_Boolean));
+        if(p)
+            server->rolesProtected = p;
+    } else {
+        UA_free(server->roles);
+        server->roles = NULL;
+        UA_free(server->rolesProtected);
+        server->rolesProtected = NULL;
+    }
+
+    unlockServer(server);
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_getRole(UA_Server *server,
+                  const UA_QualifiedName roleName,
+                  UA_Role *outRole) {
+    if(!server || !outRole)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    lockServer(server);
+
+    UA_Role *role = findRoleByName(server, &roleName);
+    if(!role) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+
+    UA_StatusCode res = UA_Role_copy(role, outRole);
+
+    unlockServer(server);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_getRoles(UA_Server *server, size_t *rolesSize,
+                   UA_QualifiedName **roleNames) {
+    if(!server || !rolesSize || !roleNames)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    lockServer(server);
+
+    *rolesSize = 0;
+    *roleNames = NULL;
+
+    if(server->rolesSize == 0) {
+        unlockServer(server);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    *roleNames = (UA_QualifiedName*)
+        UA_malloc(server->rolesSize * sizeof(UA_QualifiedName));
+    if(!*roleNames) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    for(size_t i = 0; i < server->rolesSize; i++) {
+        UA_StatusCode res = UA_QualifiedName_copy(&server->roles[i].roleName,
+                                                   &(*roleNames)[i]);
+        if(res != UA_STATUSCODE_GOOD) {
+            for(size_t j = 0; j < i; j++)
+                UA_QualifiedName_clear(&(*roleNames)[j]);
+            UA_free(*roleNames);
+            *roleNames = NULL;
+            unlockServer(server);
+            return res;
+        }
+    }
+    *rolesSize = server->rolesSize;
+
+    unlockServer(server);
+    return UA_STATUSCODE_GOOD;
 }
 
 /*****************************************/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -319,6 +319,10 @@ ua_add_test(server/check_server_node_services.c)
 ua_add_test(server/check_server_client_readwrite.c)
 ua_add_test(server/check_services_attributes_all.c)
 
+if(UA_ENABLE_RBAC)
+    ua_add_test(server/check_server_rbac.c)
+endif()
+
 if(UA_ENABLE_SUBSCRIPTIONS)
     ua_add_test(server/check_services_subscriptions_modify.c)
     ua_add_test(server/check_local_monitored_item.c)

--- a/tests/server/check_server_rbac.c
+++ b/tests/server/check_server_rbac.c
@@ -1,0 +1,369 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2025-2026 (c) o6 Automation GmbH (Author: Andreas Ebner)
+ */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/log_stdout.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <check.h>
+
+#include "test_helpers.h"
+#include "testing_clock.h"
+
+#ifdef UA_ENABLE_RBAC
+
+static UA_Server *server;
+
+static void setup(void) {
+    server = UA_Server_newForUnitTest();
+    ck_assert(server != NULL);
+    UA_Server_run_startup(server);
+}
+
+static void teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+/* ---- Role Type API tests ---- */
+
+START_TEST(Role_initClearCopy) {
+    UA_Role r;
+    UA_Role_init(&r);
+    ck_assert(UA_NodeId_isNull(&r.roleId));
+    ck_assert_uint_eq(r.identityMappingRulesSize, 0);
+    ck_assert_ptr_null(r.identityMappingRules);
+
+    /* Set up a role with data */
+    r.roleId = UA_NODEID_NUMERIC(0, 42);
+    r.roleName = UA_QUALIFIEDNAME_ALLOC(0, "TestRole");
+
+    UA_Role copy;
+    UA_StatusCode res = UA_Role_copy(&r, &copy);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert(UA_NodeId_equal(&r.roleId, &copy.roleId));
+    ck_assert(UA_QualifiedName_equal(&r.roleName, &copy.roleName));
+
+    ck_assert(UA_Role_equal(&r, &copy));
+
+    UA_Role_clear(&r);
+    UA_Role_clear(&copy);
+}
+END_TEST
+
+/* ---- addRole / getRoles / getRole ---- */
+
+START_TEST(addRole_basic) {
+    UA_Role role;
+    UA_Role_init(&role);
+    role.roleId = UA_NODEID_NUMERIC(1, 50000);
+    role.roleName = UA_QUALIFIEDNAME(1, "MyCustomRole");
+
+    UA_NodeId outId = UA_NODEID_NULL;
+    UA_StatusCode res = UA_Server_addRole(server, &role, &outId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert(UA_NodeId_equal(&outId, &role.roleId));
+
+    /* Verify via getRole (by roleName) */
+    UA_Role fetched;
+    res = UA_Server_getRole(server, role.roleName, &fetched);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert(UA_NodeId_equal(&fetched.roleId, &role.roleId));
+    ck_assert(UA_QualifiedName_equal(&fetched.roleName, &role.roleName));
+    UA_Role_clear(&fetched);
+
+    UA_NodeId_clear(&outId);
+}
+END_TEST
+
+START_TEST(addRole_duplicateNameFails) {
+    UA_Role role;
+    UA_Role_init(&role);
+    role.roleId = UA_NODEID_NUMERIC(1, 60000);
+    role.roleName = UA_QUALIFIEDNAME(1, "DuplicateTest");
+
+    UA_NodeId outId = UA_NODEID_NULL;
+    UA_StatusCode res = UA_Server_addRole(server, &role, &outId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&outId);
+
+    /* Adding with same roleName should fail */
+    role.roleId = UA_NODEID_NUMERIC(1, 60001); /* different nodeId */
+    res = UA_Server_addRole(server, &role, &outId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADALREADYEXISTS);
+}
+END_TEST
+
+START_TEST(addRole_nullRoleIdAllowed) {
+    UA_Role role;
+    UA_Role_init(&role);
+    /* roleId is null => server accepts it as-is */
+    role.roleName = UA_QUALIFIEDNAME(1, "NullIdRole");
+
+    UA_NodeId outId = UA_NODEID_NULL;
+    UA_StatusCode res = UA_Server_addRole(server, &role, &outId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    /* The roleId in the registry is null (no auto-generation in this batch) */
+    UA_NodeId_clear(&outId);
+}
+END_TEST
+
+/* ---- getRoles ---- */
+
+START_TEST(getRoles_empty) {
+    size_t rolesSize = 99;
+    UA_QualifiedName *roleNames = NULL;
+    UA_StatusCode res = UA_Server_getRoles(server, &rolesSize, &roleNames);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(rolesSize, 0);
+    ck_assert_ptr_null(roleNames);
+}
+END_TEST
+
+START_TEST(getRoles_afterAdd) {
+    UA_Role r1, r2;
+    UA_Role_init(&r1);
+    r1.roleId = UA_NODEID_NUMERIC(0, 70001);
+    r1.roleName = UA_QUALIFIEDNAME(0, "RoleA");
+
+    UA_Role_init(&r2);
+    r2.roleId = UA_NODEID_NUMERIC(0, 70002);
+    r2.roleName = UA_QUALIFIEDNAME(0, "RoleB");
+
+    UA_StatusCode res = UA_Server_addRole(server, &r1, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    res = UA_Server_addRole(server, &r2, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    size_t rolesSize = 0;
+    UA_QualifiedName *roleNames = NULL;
+    res = UA_Server_getRoles(server, &rolesSize, &roleNames);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(rolesSize, 2);
+    ck_assert_ptr_nonnull(roleNames);
+
+    /* Check that both names are present */
+    UA_Boolean found1 = false, found2 = false;
+    for(size_t i = 0; i < rolesSize; i++) {
+        if(UA_QualifiedName_equal(&roleNames[i], &r1.roleName))
+            found1 = true;
+        if(UA_QualifiedName_equal(&roleNames[i], &r2.roleName))
+            found2 = true;
+        UA_QualifiedName_clear(&roleNames[i]);
+    }
+    UA_free(roleNames);
+    ck_assert(found1);
+    ck_assert(found2);
+}
+END_TEST
+
+/* ---- getRole ---- */
+
+START_TEST(getRole_notFound) {
+    UA_QualifiedName badName = UA_QUALIFIEDNAME(0, "NonExistentRole");
+    UA_Role out;
+    UA_StatusCode res = UA_Server_getRole(server, badName, &out);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADNOTFOUND);
+}
+END_TEST
+
+/* ---- removeRole ---- */
+
+START_TEST(removeRole_basic) {
+    UA_Role role;
+    UA_Role_init(&role);
+    role.roleId = UA_NODEID_NUMERIC(1, 80001);
+    role.roleName = UA_QUALIFIEDNAME(1, "RemovableRole");
+
+    UA_StatusCode res = UA_Server_addRole(server, &role, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    /* Remove by roleName */
+    res = UA_Server_removeRole(server, role.roleName);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    /* Should no longer be found */
+    UA_Role fetched;
+    res = UA_Server_getRole(server, role.roleName, &fetched);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADNOTFOUND);
+}
+END_TEST
+
+START_TEST(removeRole_notFound) {
+    UA_QualifiedName badName = UA_QUALIFIEDNAME(0, "NoSuchRole");
+    UA_StatusCode res = UA_Server_removeRole(server, badName);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADNOTFOUND);
+}
+END_TEST
+
+/* ---- Config roles (protected) ---- */
+
+static UA_Server *serverWithConfigRoles;
+
+static void setupWithConfigRoles(void) {
+    /* Build a config with roles set BEFORE server creation,
+     * since initRBAC runs during UA_Server_newWithConfig. */
+    UA_ServerConfig sc;
+    memset(&sc, 0, sizeof(UA_ServerConfig));
+    sc.logging = UA_Log_Stdout_new(UA_LOGLEVEL_INFO);
+    UA_ServerConfig_setMinimal(&sc, 4840, NULL);
+
+    /* Add two config roles */
+    sc.rolesSize = 2;
+    sc.roles = (UA_Role*)UA_calloc(2, sizeof(UA_Role));
+    ck_assert_ptr_nonnull(sc.roles);
+
+    UA_Role_init(&sc.roles[0]);
+    sc.roles[0].roleId = UA_NODEID_NUMERIC(0, 15001);
+    sc.roles[0].roleName = UA_QUALIFIEDNAME_ALLOC(0, "ConfigOperator");
+
+    UA_Role_init(&sc.roles[1]);
+    sc.roles[1].roleId = UA_NODEID_NUMERIC(0, 15002);
+    sc.roles[1].roleName = UA_QUALIFIEDNAME_ALLOC(0, "ConfigEngineer");
+
+    serverWithConfigRoles = UA_Server_newWithConfig(&sc);
+    ck_assert_ptr_nonnull(serverWithConfigRoles);
+
+    UA_ServerConfig *config = UA_Server_getConfig(serverWithConfigRoles);
+    config->eventLoop->dateTime_now = UA_DateTime_now_fake;
+    config->eventLoop->dateTime_nowMonotonic = UA_DateTime_now_fake;
+    config->tcpReuseAddr = true;
+
+    UA_Server_run_startup(serverWithConfigRoles);
+}
+
+static void teardownWithConfigRoles(void) {
+    UA_Server_run_shutdown(serverWithConfigRoles);
+    UA_Server_delete(serverWithConfigRoles);
+}
+
+START_TEST(configRoles_areLoaded) {
+    size_t rolesSize = 0;
+    UA_QualifiedName *roleNames = NULL;
+    UA_StatusCode res = UA_Server_getRoles(serverWithConfigRoles,
+                                           &rolesSize, &roleNames);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(rolesSize, 2);
+
+    for(size_t i = 0; i < rolesSize; i++)
+        UA_QualifiedName_clear(&roleNames[i]);
+    UA_free(roleNames);
+}
+END_TEST
+
+START_TEST(configRoles_cannotBeRemoved) {
+    UA_QualifiedName configRoleName = UA_QUALIFIEDNAME(0, "ConfigOperator");
+    UA_StatusCode res = UA_Server_removeRole(serverWithConfigRoles,
+                                             configRoleName);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADUSERACCESSDENIED);
+
+    /* Still accessible */
+    UA_Role out;
+    res = UA_Server_getRole(serverWithConfigRoles, configRoleName, &out);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_Role_clear(&out);
+}
+END_TEST
+
+START_TEST(configRoles_runtimeRolesCanBeRemoved) {
+    /* Add a runtime role */
+    UA_Role role;
+    UA_Role_init(&role);
+    role.roleId = UA_NODEID_NUMERIC(1, 90001);
+    role.roleName = UA_QUALIFIEDNAME(1, "RuntimeRole");
+
+    UA_StatusCode res = UA_Server_addRole(serverWithConfigRoles, &role, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    /* Can remove runtime role by name */
+    res = UA_Server_removeRole(serverWithConfigRoles, role.roleName);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    /* Config roles still intact */
+    size_t rolesSize = 0;
+    UA_QualifiedName *roleNames = NULL;
+    res = UA_Server_getRoles(serverWithConfigRoles, &rolesSize, &roleNames);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(rolesSize, 2);
+
+    for(size_t i = 0; i < rolesSize; i++)
+        UA_QualifiedName_clear(&roleNames[i]);
+    UA_free(roleNames);
+}
+END_TEST
+
+/* ---- Test suite assembly ---- */
+
+static Suite *testSuite_RolTypeAPI(void) {
+    Suite *s = suite_create("RBAC Role Type API");
+    TCase *tc = tcase_create("RoleType");
+    tcase_add_test(tc, Role_initClearCopy);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+static Suite *testSuite_RoleManagement(void) {
+    Suite *s = suite_create("RBAC Role Management");
+
+    TCase *tc_add = tcase_create("AddRole");
+    tcase_add_checked_fixture(tc_add, setup, teardown);
+    tcase_add_test(tc_add, addRole_basic);
+    tcase_add_test(tc_add, addRole_duplicateNameFails);
+    tcase_add_test(tc_add, addRole_nullRoleIdAllowed);
+    suite_add_tcase(s, tc_add);
+
+    TCase *tc_get = tcase_create("GetRoles");
+    tcase_add_checked_fixture(tc_get, setup, teardown);
+    tcase_add_test(tc_get, getRoles_empty);
+    tcase_add_test(tc_get, getRoles_afterAdd);
+    tcase_add_test(tc_get, getRole_notFound);
+    suite_add_tcase(s, tc_get);
+
+    TCase *tc_rm = tcase_create("RemoveRole");
+    tcase_add_checked_fixture(tc_rm, setup, teardown);
+    tcase_add_test(tc_rm, removeRole_basic);
+    tcase_add_test(tc_rm, removeRole_notFound);
+    suite_add_tcase(s, tc_rm);
+
+    return s;
+}
+
+static Suite *testSuite_ConfigRoles(void) {
+    Suite *s = suite_create("RBAC Config Roles");
+    TCase *tc = tcase_create("ConfigRoles");
+    tcase_add_checked_fixture(tc, setupWithConfigRoles, teardownWithConfigRoles);
+    tcase_add_test(tc, configRoles_areLoaded);
+    tcase_add_test(tc, configRoles_cannotBeRemoved);
+    tcase_add_test(tc, configRoles_runtimeRolesCanBeRemoved);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void) {
+    int number_failed = 0;
+    SRunner *sr;
+
+    sr = srunner_create(testSuite_RolTypeAPI());
+    srunner_add_suite(sr, testSuite_RoleManagement());
+    srunner_add_suite(sr, testSuite_ConfigRoles());
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed += srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+#else /* UA_ENABLE_RBAC not defined */
+
+int main(void) {
+    return EXIT_SUCCESS;
+}
+
+#endif /* UA_ENABLE_RBAC */


### PR DESCRIPTION
Work on implementing Role-Based Access Control according to Part 18 of the OPC UA specification began in PR https://github.com/open62541/open62541/pull/7458. As this is a substantial subsystem, the mechanism will be merged into the main branch over a series of ~7 PRs.

Batch 1: Configuration option, core RBAC types and initialisation. (merged)
Batch 2: Add Roles and Permissions confugration structures and handling API.
Batch 3: Role Management and RBAC initialization