### PR TITLE
fix(test): remove stray assert

### DIFF
--- a/tests/encryption/check_encryption_basic128rsa15.c
+++ b/tests/encryption/check_encryption_basic128rsa15.c
@@ -216,7 +216,6 @@ START_TEST(encryption_connect) {
 
     /* Secure client connect */
     retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
-    assert(retval == UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
     UA_Variant val;


### PR DESCRIPTION
The naked assert is a remnant of manual testing and should not have been committed to ba5ee03403f3a02d32f3371eca46d1489303c9c8.

Closes #7700

See also https://github.com/open62541/open62541/issues/7700#issuecomment-3881018248
Kind ping to @jpfr