### PR TITLE
refactor(plugins): fix unsigned/signed issues in mbedtls plugin

### DIFF
--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -982,7 +982,7 @@ UA_CertificateUtils_checkKeyPair(const UA_ByteString *certificate,
     if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 
-    retval = UA_mbedTLS_LoadPrivateKey(privateKey, &pk, NULL);
+    retval = (UA_mbedTLS_LoadPrivateKey(privateKey, &pk, NULL)? UA_STATUSCODE_BADSECURITYCHECKSFAILED : UA_STATUSCODE_GOOD);
     if(retval != UA_STATUSCODE_GOOD)
         goto cleanup;
 

--- a/plugins/crypto/mbedtls/create_certificate.c
+++ b/plugins/crypto/mbedtls/create_certificate.c
@@ -365,7 +365,7 @@ static int write_private_key(mbedtls_pk_context *key, UA_CertificateFormat keyFo
             return ret;
         }
 
-        len = ret;
+        len = (size_t)ret;
         c = output_buf + sizeof(output_buf) - len;
         break;
     }
@@ -401,7 +401,7 @@ static int write_certificate(mbedtls_x509write_cert *crt, UA_CertificateFormat c
             return ret;
         }
 
-        len = ret;
+        len = (size_t)ret;
         c = output_buf + sizeof(output_buf) - len;
         break;
     }

--- a/plugins/crypto/mbedtls/securitypolicy_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_common.c
@@ -387,9 +387,9 @@ mbedtls_writePrivateKeyDer(mbedtls_pk_context *key, UA_ByteString *outPrivateKey
 
     c = output_buf + sizeof(output_buf) - len;
 
-    if(UA_ByteString_allocBuffer(outPrivateKey, len) != UA_STATUSCODE_GOOD)
+    if(UA_ByteString_allocBuffer(outPrivateKey, (size_t)len) != UA_STATUSCODE_GOOD)
         return UA_STATUSCODE_BADOUTOFMEMORY;
-    outPrivateKey->length = len;
+    outPrivateKey->length = (size_t)len;
     memcpy(outPrivateKey->data, c, outPrivateKey->length);
 
     return UA_STATUSCODE_GOOD;
@@ -411,7 +411,7 @@ mbedtls_createSigningRequest(mbedtls_pk_context *localPrivateKey,
     }
 
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
-    size_t ret = 0;
+    int ret = 0;
     char *subj = NULL;
     const mbedtls_x509_sequence *san_list = NULL;
 
@@ -547,7 +547,7 @@ mbedtls_createSigningRequest(mbedtls_pk_context *localPrivateKey,
     }
 
     /* number of CSR data bytes located at the end of the request buffer */
-    size_t byteCount = ret;
+    size_t byteCount = (size_t)ret;
     size_t offset = sizeof(requestBuf) - byteCount;
 
     /* copy return parameter into a ByteString */

--- a/plugins/crypto/mbedtls/securitypolicy_pubsub_aes128ctr.c
+++ b/plugins/crypto/mbedtls/securitypolicy_pubsub_aes128ctr.c
@@ -35,10 +35,6 @@
 #define UA_AES128CTR_KEYNONCE_LENGTH 4
 #define UA_AES128CTR_MESSAGENONCE_LENGTH 8
 #define UA_AES128CTR_ENCRYPTION_BLOCK_SIZE 16
-#define UA_AES128CTR_PLAIN_TEXT_BLOCK_SIZE 16
-/* counter block=keynonce(4Byte)+Messagenonce(8Byte)+counter(4Byte) see Part14
- * 7.2.2.2.3.2 for details */
-#define UA_AES128CTR_COUNTERBLOCK_SIZE 16
 
 typedef struct {
     mbedtls_ctr_drbg_context drbgContext;

--- a/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
+++ b/plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c
@@ -35,10 +35,6 @@
 #define UA_AES256CTR_KEYNONCE_LENGTH 4
 #define UA_AES256CTR_MESSAGENONCE_LENGTH 8
 #define UA_AES256CTR_ENCRYPTION_BLOCK_SIZE 16
-#define UA_AES256CTR_PLAIN_TEXT_BLOCK_SIZE 16
-// counter block=keynonce(4Byte)+Messagenonce(8Byte)+counter(4Byte) see Part14 7.2.2.2.3.2
-// for details
-#define UA_AES256CTR_COUNTERBLOCK_SIZE 16
 
 typedef struct {
     mbedtls_ctr_drbg_context drbgContext;


### PR DESCRIPTION
Look at some unsigned/signed conversion issues in mbedtls plugin code:
- plugins/crypto/mbedtls/certificategroup.c: UA_mbedTLS_LoadPrivateKey() returns int, add translation into UA_StatusCode
- plugins/crypto/mbedtls/create_certificate.c: plugins/crypto/mbedtls/securitypolicy_common.c: Make explicit  conversion into size_t.
- plugins/crypto/mbedtls/securitypolicy_common.c: Fix "ret" var from size_t to int.
- plugins/crypto/mbedtls/securitypolicy_pubsub_aes128ctr.c: plugins/crypto/mbedtls/securitypolicy_pubsub_aes256ctr.c: Remove unused defines.