### PR TITLE
refactor(examples): fix clang compiler warnings

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -135,8 +135,6 @@ if(UA_ENABLE_ENCRYPTION OR
     add_example(server_encryption encryption/server_encryption.c)
     add_example(server_encryption_filestore encryption/server_encryption_filestore.c)
     add_example(client_encryption encryption/client_encryption.c)
-    target_include_directories(server_encryption PRIVATE "${PROJECT_SOURCE_DIR}/examples")
-    target_include_directories(client_encryption PRIVATE "${PROJECT_SOURCE_DIR}/examples")
     if(UA_ENABLE_TPM2_KEYSTORE)
         add_example(server_encryption_tpm_keystore encryption/server_encryption_tpm_keystore.c)
         add_example(client_encryption_tpm_keystore encryption/client_encryption_tpm_keystore.c)

--- a/examples/encryption/server_encryption.c
+++ b/examples/encryption/server_encryption.c
@@ -19,7 +19,7 @@
 
 #include "common.h"
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void stopHandler(int sig) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_APPLICATION, "received ctrl-c");
     running = false;

--- a/examples/encryption/server_encryption_filestore.c
+++ b/examples/encryption/server_encryption_filestore.c
@@ -14,7 +14,7 @@
 
 #include "common.h"
 
-UA_Boolean running = true;
+static UA_Boolean running = true;
 static void stopHandler(int sig) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_APPLICATION, "received ctrl-c");
     running = false;
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
         /* If no path is specified, the current working directory is used */
         char storePathDir[4096];
         if(!getcwd(storePathDir, sizeof(storePathDir)))
-            return UA_STATUSCODE_BADINTERNALERROR;
+            return EXIT_FAILURE;
         storePath = UA_STRING(storePathDir);
     }
 

--- a/examples/pubsub/pubsub_publish_encrypted.c
+++ b/examples/pubsub/pubsub_publish_encrypted.c
@@ -13,11 +13,11 @@
 #define UA_AES128CTR_KEY_LENGTH 16
 #define UA_AES128CTR_KEYNONCE_LENGTH 4
 
-UA_Byte signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = {0};
-UA_Byte encryptingKey[UA_AES128CTR_KEY_LENGTH] = {0};
-UA_Byte keyNonce[UA_AES128CTR_KEYNONCE_LENGTH] = {0};
+static UA_Byte signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = {0};
+static UA_Byte encryptingKey[UA_AES128CTR_KEY_LENGTH] = {0};
+static UA_Byte keyNonce[UA_AES128CTR_KEYNONCE_LENGTH] = {0};
 
-UA_NodeId connectionIdent, publishedDataSetIdent, writerGroupIdent;
+static UA_NodeId connectionIdent, publishedDataSetIdent, writerGroupIdent;
 
 static void
 addPubSubConnection(UA_Server *server, UA_String *transportProfile,

--- a/examples/pubsub/pubsub_subscribe_encrypted.c
+++ b/examples/pubsub/pubsub_subscribe_encrypted.c
@@ -19,15 +19,15 @@
 #define UA_AES128CTR_KEY_LENGTH 16
 #define UA_AES128CTR_KEYNONCE_LENGTH 4
 
-UA_Byte signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = {0};
-UA_Byte encryptingKey[UA_AES128CTR_KEY_LENGTH] = {0};
-UA_Byte keyNonce[UA_AES128CTR_KEYNONCE_LENGTH] = {0};
+static UA_Byte signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = {0};
+static UA_Byte encryptingKey[UA_AES128CTR_KEY_LENGTH] = {0};
+static UA_Byte keyNonce[UA_AES128CTR_KEYNONCE_LENGTH] = {0};
 
-UA_NodeId connectionIdentifier;
-UA_NodeId readerGroupIdentifier;
-UA_NodeId readerIdentifier;
+static UA_NodeId connectionIdentifier;
+static UA_NodeId readerGroupIdentifier;
+static UA_NodeId readerIdentifier;
 
-UA_DataSetReaderConfig readerConfig;
+static UA_DataSetReaderConfig readerConfig;
 
 static void fillTestDataSetMetaData(UA_DataSetMetaDataType *pMetaData);
 


### PR DESCRIPTION
Fix a few clang compiler warnings:
- Non-existant include dirs used in examples/CMakeLists.txt
- examples/encryption/server_encryption_filestore.c: Fix main() return code.
- Add static modifier to some variables.