### PR TITLE
fix(server): interpret a null or empty UserIdentityToken as anonymous

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -469,6 +469,7 @@ selectEndpointAndTokenPolicy(UA_Server *server, UA_SecureChannel *channel,
                pol->tokenType == UA_USERTOKENTYPE_ANONYMOUS) {
                 *ed = desc;
                 *utp = pol;
+                *tokenSp = channel->securityPolicy;
                 return;
             }
 


### PR DESCRIPTION
OPC UA Part 4 is required that a NULL or empty UserIdentityToken shall be treated as Anonymous. In selectEndpointAndTokenPolicy(), when a NULL token (ENCODED_NOBODY) matched an anonymous UserTokenPolicy we return Bad_IdentityTokenInvalid.

This is fixed in 1.5. and master but can not be directly backported. In addition this PR also add's a test-case to ensure regression.