### PR TITLE
Fix amalgamation build without selected architecture

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -70,6 +70,9 @@ jobs:
           - name: "Amalgamation Build with Multithreading"
             cmd_action: build_amalgamation_mt
 
+          - name: "Amalgamation Build with none Architecture"
+            cmd_action: build_amalgamation_none_arch
+
           - name: "Build All Companion Specifications"
             cmd_action: build_all_companion_specs
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1015,7 +1015,7 @@ set(plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_log_stdout.c
                    ${PROJECT_SOURCE_DIR}/plugins/crypto/ua_securitypolicy_none.c)
 
 # Add clock implementation based on the base architecture
-if(UA_ARCHITECTURE_POSIX OR UA_ARCHITECTURE_WIN32)
+if(UA_ARCHITECTURE_POSIX OR UA_ARCHITECTURE_WIN32 OR UA_ARCHITECTURE_LWIP OR UA_ENABLE_AMALGAMATION)
     list(APPEND plugin_sources ${PROJECT_SOURCE_DIR}/arch/posix/clock_posix.c)
 endif()
 

--- a/tools/ci/linux/ci.sh
+++ b/tools/ci/linux/ci.sh
@@ -111,6 +111,24 @@ function build_amalgamation_mt {
     gcc -Wall -Werror -c open62541.c
 }
 
+function build_amalgamation_none_arch {
+    mkdir -p build; cd build; rm -rf *
+    cmake -DCMAKE_BUILD_TYPE=Debug \
+          -DUA_ENABLE_AMALGAMATION=ON \
+          -DUA_ARCHITECTURE=none \
+          -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+          -DUA_ENABLE_JSON_ENCODING=ON \
+          -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_PUBSUB=ON \
+          -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=ON \
+          ..
+    make open62541-amalgamation ${MAKEOPTS}
+
+    # Check if the expected code is included into the amalgamation
+    # and if the ifdef based architecture autodetection works
+    gcc -Wall -Werror -c open62541.c
+}
+
 ############################
 # Build and Run Unit Tests #
 ############################


### PR DESCRIPTION
Currently, the clock functions for posix and win32 are only included into the amalgamation if one of the two architectures is selected.

This extends bc6e26b 

The last time I did a similar modification, it broke amalgamation for one of the more exotic architectures (see #7691). I think this won't happen this time because the concerned file has an architecture based ifdef, but I don't have a way to test this.