### PR TITLE
fix(client): Fix authSecurityPolicies usage for username identity token

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -1779,6 +1779,23 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
         config->securityPoliciesSize = 1;
     }
 
+    /* TODO: This is only necessary if we don't have special cases for authentication tokens
+     * with the None policy in ua_client_connect.c and don't require a valid sp pointer. */
+
+    if(config->authSecurityPoliciesSize == 0) {
+        config->authSecurityPolicies = (UA_SecurityPolicy*)UA_malloc(sizeof(UA_SecurityPolicy));
+        if(!config->authSecurityPolicies)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        UA_StatusCode retval = UA_SecurityPolicy_None(config->authSecurityPolicies,
+                                                      UA_BYTESTRING_NULL, config->logging);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_free(config->authSecurityPolicies);
+            config->authSecurityPolicies = NULL;
+            return retval;
+        }
+        config->authSecurityPoliciesSize = 1;
+    }
+
     if(config->requestedSessionTimeout == 0)
         config->requestedSessionTimeout = 1200000;
 

--- a/tests/client/check_client_authentication.c
+++ b/tests/client/check_client_authentication.c
@@ -201,13 +201,13 @@ START_TEST(client_connect_none_username_basic256Sha256) {
         cc->clientDescription.applicationUri = UA_STRING_ALLOC("urn:open62541.server.application");
 
         /* Only use the relevant security policy in authSecurityPolicies */
-        for(size_t i = 0; i < cc->securityPoliciesSize; ++i)
-            cc->securityPolicies[i].clear(&cc->securityPolicies[i]);
-        UA_free(cc->securityPolicies);
-        cc->securityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
-        cc->securityPoliciesSize = 2;
-        UA_SecurityPolicy_None(&cc->securityPolicies[0], certificate, cc->logging);
-        UA_SecurityPolicy_Basic256Sha256(&cc->securityPolicies[1], certificate, privateKey, cc->logging);
+        for(size_t i = 0; i < cc->authSecurityPoliciesSize; ++i)
+            cc->authSecurityPolicies[i].clear(&cc->authSecurityPolicies[i]);
+        UA_free(cc->authSecurityPolicies);
+        cc->authSecurityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
+        cc->authSecurityPoliciesSize = 2;
+        UA_SecurityPolicy_None(&cc->authSecurityPolicies[0], certificate, cc->logging);
+        UA_SecurityPolicy_Basic256Sha256(&cc->authSecurityPolicies[1], certificate, privateKey, cc->logging);
 
         UA_StatusCode retval = UA_Client_connectUsername(client, "opc.tcp://localhost:4840", "admin", "admin");
 
@@ -272,12 +272,12 @@ START_TEST(client_connect_none_username_eccpnist256) {
 
     /* Only use the relevant security policy in authSecurityPolicies */
     for(size_t i = 0; i < cc->authSecurityPoliciesSize; ++i)
-        cc->securityPolicies[i].clear(&cc->securityPolicies[i]);
-    UA_free(cc->securityPolicies);
-    cc->securityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
-    cc->securityPoliciesSize = 2;
-    UA_SecurityPolicy_None(&cc->securityPolicies[0], certificate, cc->logging);
-    UA_SecurityPolicy_EccNistP256(&cc->securityPolicies[1],
+        cc->authSecurityPolicies[i].clear(&cc->authSecurityPolicies[i]);
+    UA_free(cc->authSecurityPolicies);
+    cc->authSecurityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
+    cc->authSecurityPoliciesSize = 2;
+    UA_SecurityPolicy_None(&cc->authSecurityPolicies[0], certificate, cc->logging);
+    UA_SecurityPolicy_EccNistP256(&cc->authSecurityPolicies[1],
                                   UA_APPLICATIONTYPE_CLIENT,
                                   certificate, privateKey, cc->logging);
 
@@ -410,12 +410,15 @@ START_TEST(client_connect_basic256Sha256_anonymous) {
     UA_String_clear(&cc->clientDescription.applicationUri);
     cc->clientDescription.applicationUri = UA_STRING_ALLOC("urn:open62541.server.application");
 
-    /* Use empty security policies array */
+    /* Only use the relevant security policy in authSecurityPolicies */
     for(size_t i = 0; i < cc->authSecurityPoliciesSize; ++i)
         cc->authSecurityPolicies[i].clear(&cc->authSecurityPolicies[i]);
     UA_free(cc->authSecurityPolicies);
-    cc->authSecurityPolicies = NULL;
-    cc->authSecurityPoliciesSize = 0;
+    cc->authSecurityPolicies = (UA_SecurityPolicy *)
+        UA_calloc(1, sizeof(UA_SecurityPolicy));
+    cc->authSecurityPoliciesSize = 1;
+    UA_SecurityPolicy_Basic256Sha256(&cc->authSecurityPolicies[0],
+                                     certificate, privateKey, cc->logging);
 
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
 

--- a/tests/network_replay/check_network_replay.c
+++ b/tests/network_replay/check_network_replay.c
@@ -125,6 +125,11 @@ START_TEST(unified_cpp_basic256sha256) {
         sp->generateNonce = reproducibleNonce;
     }
 
+    for(size_t i = 0; i < cc->authSecurityPoliciesSize; i++) {
+        UA_SecurityPolicy *sp = &cc->authSecurityPolicies[i];
+        sp->generateNonce = reproducibleNonce;
+    }
+
     /* Reset the rng */
     UA_random_seed_deterministic(0);
 
@@ -175,6 +180,11 @@ START_TEST(prosys_basic256sha256) {
     /* Replace the nonce-generating function in the SecurityPolicies */
     for(size_t i = 0; i < cc->securityPoliciesSize; i++) {
         UA_SecurityPolicy *sp = &cc->securityPolicies[i];
+        sp->generateNonce = reproducibleNonce;
+    }
+
+    for(size_t i = 0; i < cc->authSecurityPoliciesSize; i++) {
+        UA_SecurityPolicy *sp = &cc->authSecurityPolicies[i];
         sp->generateNonce = reproducibleNonce;
     }
 


### PR DESCRIPTION
If the token is not an X.509 identity token, the securityPolicies array in the client config was searched instead of authSecurityPolicies.