### PR TITLE
fix(plugin): Enable parsing Alternative Subject Names for mbedtls.

### DIFF
--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -694,7 +694,7 @@ cleanup:
     return retval;
 }
 
-#if !defined(mbedtls_x509_subject_alternative_name)
+#if MBEDTLS_VERSION_NUMBER < 0x03040000
 
 static const unsigned char *
 UA_Bstrstr(const unsigned char *s1, size_t l1, const unsigned char *s2, size_t l2) {
@@ -725,8 +725,8 @@ UA_CertificateUtils_verifyApplicationUri(const UA_ByteString *certificate,
     if(retval != UA_STATUSCODE_GOOD)
         return retval;
 
-#if defined(mbedtls_x509_subject_alternative_name)
-    /* Get the Subject Alternative Name and compate */
+#if MBEDTLS_VERSION_NUMBER >= 0x03040000
+    /* Get the Subject Alternative Name and compare */
     mbedtls_x509_subject_alternative_name san;
     mbedtls_x509_sequence *cur = &remoteCertificate.subject_alt_names;
     retval = UA_STATUSCODE_BADCERTIFICATEURIINVALID;


### PR DESCRIPTION
mbedtls_x509_subject_alternative_name is no define, so use MBEDTLS_X509_CRT_PARSE_C and MBEDTLS_X509_CSR_PARSE_C to enable this.