### PR TITLE
[Review] fix(server): permit untrusted certificate in CreateSession

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -468,7 +468,8 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
      * checked for the SecureChannel. But here we use the Session
      * CertificateGroup and we now also have the ApplicationDescription to check
      * the ApplicationUri. */
-    if(request->clientCertificate.length > 0) {
+    if(channel->securityMode != UA_MESSAGESECURITYMODE_NONE &&
+       request->clientCertificate.length > 0) {
         rh->serviceResult =
             validateCertificate(server, &server->config.secureChannelPKI,
                                 channel, NULL, "CreateSession",
@@ -604,7 +605,8 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
     response->authenticationToken = newSession->authenticationToken;
     rh->serviceResult |= UA_ByteString_copy(&newSession->serverNonce,
                                             &response->serverNonce);
-    if(sessionSp)
+    if(sessionSp &&
+       channel->securityMode != UA_MESSAGESECURITYMODE_NONE)
         rh->serviceResult |= UA_ByteString_copy(&sessionSp->localCertificate,
                                                 &response->serverCertificate);
 


### PR DESCRIPTION
If the channel has no security, the server should ignore the certificate in CreateSession.  This means it will skip certificate validation and will also avoid including the certificate in the response.

I assumed `channel->securityMode == UA_MESSAGESECURITYMODE_NONE` follows from the _none_ security policy.  Please tell me whether this assumption is false.

The CTT test `Session Services/Session Base/012.js` now passes.