### PR TITLE
feat(client): Add readDatatypeDefinitionAttribute convenience function.

### DIFF
--- a/include/open62541/client_highlevel.h
+++ b/include/open62541/client_highlevel.h
@@ -138,6 +138,10 @@ UA_Client_readUserExecutableAttribute(UA_Client *client,
                                       const UA_NodeId nodeId,
                                       UA_Boolean *out);
 
+UA_EXPORT UA_THREADSAFE UA_StatusCode
+UA_Client_readDatatypeDefinitionAttribute(UA_Client* client, const UA_NodeId nodeId,
+                                          UA_StructureDefinition *out);
+
 /**
  * Historical Access
  * ~~~~~~~~~~~~~~~~~

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -1013,6 +1013,13 @@ UA_Client_readUserExecutableAttribute(UA_Client *client, const UA_NodeId nodeId,
                                   out, &UA_TYPES[UA_TYPES_BOOLEAN]);
 }
 
+UA_StatusCode
+UA_Client_readDatatypeDefinitionAttribute(UA_Client* client, const UA_NodeId nodeId,
+                                          UA_StructureDefinition *out) {
+    return __Client_readAttribute(client, &nodeId, UA_ATTRIBUTEID_DATATYPEDEFINITION,
+                                  out, &UA_TYPES[UA_TYPES_STRUCTUREDEFINITION]);
+}
+
 static UA_StatusCode
 processReadArrayDimensionsResult(UA_ReadResponse *response,
                                  UA_UInt32 **outArrayDimensions,


### PR DESCRIPTION
I don’t know the reason why the convenience functions stop at attribute ID 22 and whether this one should be added. This PR adds another one that we need for a use case.