### PR TITLE
[Review] fix(server): do not pick SecurityPolicy from policyId

### DIFF
--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -718,8 +718,8 @@ selectTokenPolicy(UA_Server *server, UA_SecureChannel *channel,
         if(!UA_String_equal(&policyPrefix, &pol->policyId))
             continue;
 
-        /* Get the SecurityPolicy for the endpoint from the postfix */
-        UA_String utPolPostfix = securityPolicyUriPostfix(token->policyId);
+        /* Get the SecurityPolicy */
+        UA_String utPolPostfix = securityPolicyUriPostfix(pol->securityPolicyUri);
         UA_SecurityPolicy *candidateSp =
             getSecurityPolicyByPostfix(server, utPolPostfix);
         if(!candidateSp) {


### PR DESCRIPTION
The function selectTokenPolicy failed picking the correct UserTokenPolicy because the SecurityPolicy was wrongly extracted from UserIdentityToken::policyId.  The code checks before that the policyId of the token matches that of the policy.

I stumbled upon this when I was trying to create a proper configuration for the client JSON configuration parser and could not get the policy to work, even though everything was correct.  I debugged it and found that the code that tries to derive the policy there from a URL but is doing it on something that is not a URL, so it never returned a valid policy, leading to authentication failure always.

In fact, I don't understand the block above including the comment.  I checked `setCurrentEndPointsArray` but I cannot find what is mentioned in the comment (there is nothing appended to the policyId anywhere).  I also checked the specification and found nothing about the policyId ever being prepended or appended with the security mode.


Maybe it would make sense to replace the whole block above:
```
        /* In setCurrentEndPointsArray we prepend the PolicyId with the
         * SecurityMode of the endpoint and the postfix of the
         * SecurityPolicyUri to make it unique. Check the PolicyId. */
        if(pol->policyId.length > token->policyId.length)
            continue;
        UA_String policyPrefix = token->policyId;
        policyPrefix.length = pol->policyId.length;
        if(!UA_String_equal(&policyPrefix, &pol->policyId))
            continue;
```
with just:
```
    if (!UA_String_equal(&pol->policyId, &token->policyId))
        continue;
```