### PR TITLE
historydatabase: hide UA_HistoryDatabase when UA_ENABLE_HISTORIZING i…

### DIFF
--- a/include/open62541/plugin/historydatabase.h
+++ b/include/open62541/plugin/historydatabase.h
@@ -12,6 +12,8 @@
 
 _UA_BEGIN_DECLS
 
+#ifdef UA_ENABLE_HISTORIZING
+
 typedef struct UA_HistoryDatabase UA_HistoryDatabase;
 
 struct UA_HistoryDatabase {
@@ -192,6 +194,8 @@ struct UA_HistoryDatabase {
     /* Add more function pointer here.
      * For example for read_event, read_annotation, update_details */
 };
+
+#endif /* UA_ENABLE_HISTORIZING */
 
 _UA_END_DECLS
 


### PR DESCRIPTION
### Problem

`UA_HistoryDatabase` is declared unconditionally in
`include/open62541/plugin/historydatabase.h`, even when
`UA_ENABLE_HISTORIZING=OFF`.

The structure references several HistoryRead/HistoryUpdate types
(e.g. `UA_ReadRawModifiedDetails`, `UA_DeleteEventDetails`, etc.)
which are not available when Historizing is disabled, especially
when `UA_NAMESPACE_ZERO=REDUCED`.

This causes compilation errors in the generated amalgamation header
(`open62541.h`).

### Fix

Guard the `UA_HistoryDatabase` declaration with
`#ifdef UA_ENABLE_HISTORIZING`.

This ensures the history database plugin API is only visible when
Historizing support is enabled.