### PR TITLE
fix(ex): fix key copy and memory leaks in pubsub TPM keystore publisher

### DIFF
--- a/examples/pubsub/pubsub_publish_encrypted_tpm_keystore.c
+++ b/examples/pubsub/pubsub_publish_encrypted_tpm_keystore.c
@@ -533,16 +533,36 @@ int main(int argc, char **argv) {
     rv = decrypt(slotId, userpin, keyLabel, &encrypt_in_data, &encrypt_out_data);
     if (rv != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SECURITYPOLICY, "Decrypt failed for encryption key");
+        if (sign_out_data) {
+            if (sign_out_data->data)
+                UA_free(sign_out_data->data);
+            UA_free(sign_out_data);
+        }
+        if (encrypt_out_data) {
+            if (encrypt_out_data->data)
+                UA_free(encrypt_out_data->data);
+            UA_free(encrypt_out_data);
+        }
         return EXIT_FAILURE;
     }
     rv = decrypt(slotId, userpin, keyLabel, &sign_in_data, &sign_out_data);
     if (rv != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SECURITYPOLICY, "Decrypt failed for signing key");
+        if (sign_out_data) {
+            if (sign_out_data->data)
+                UA_free(sign_out_data->data);
+            UA_free(sign_out_data);
+        }
+        if (encrypt_out_data) {
+            if (encrypt_out_data->data)
+                UA_free(encrypt_out_data->data);
+            UA_free(encrypt_out_data);
+        }
         return EXIT_FAILURE;
     }
 
-    signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = *(UA_Byte*)sign_out_data->data;
-    encryptingKey[UA_AES128CTR_KEY_LENGTH] = *(UA_Byte*)encrypt_out_data->data;
+    memcpy(signingKey, sign_out_data->data, UA_AES128CTR_SIGNING_KEY_LENGTH);
+    memcpy(encryptingKey, encrypt_out_data->data, UA_AES128CTR_KEY_LENGTH);
 
     UA_ByteString_clear(&encrypt_in_data);
     UA_ByteString_clear(&sign_in_data);


### PR DESCRIPTION
Replace out-of-bounds single-byte key assignments with memcpy for the signing and encrypting keys. Also free allocated output buffers on the early-return error paths to avoid memory leaks.
Fixes #7809.