### PR TITLE
fix(core): fix QualifiedName parsing when name contains a semicolon

### DIFF
--- a/src/util/ua_types_lex.c
+++ b/src/util/ua_types_lex.c
@@ -712,10 +712,10 @@ parse_qn(UA_QualifiedName *qn, const u8 *pos, const u8 *end,
     
 {
 	u8 yych;
-	unsigned int yyaccept = 0;
 	yych = YYPEEK();
 	switch (yych) {
-		case 0x00: goto yy41;
+		case 0x00:
+		case ';': goto yy41;
 		case '0':
 		case '1':
 		case '2':
@@ -726,7 +726,6 @@ parse_qn(UA_QualifiedName *qn, const u8 *pos, const u8 *end,
 		case '7':
 		case '8':
 		case '9': goto yy44;
-		case ';': goto yy45;
 		default: goto yy43;
 	}
 yy41:
@@ -734,19 +733,16 @@ yy41:
 yy42:
 	{ pos = begin; goto match_name; }
 yy43:
-	yyaccept = 0;
 	YYSKIP();
 	YYBACKUP();
 	yych = YYPEEK();
 	if (yych <= 0x00) goto yy42;
-	goto yy47;
+	goto yy46;
 yy44:
-	yyaccept = 0;
 	YYSKIP();
 	YYBACKUP();
 	yych = YYPEEK();
 	switch (yych) {
-		case 0x00: goto yy42;
 		case '0':
 		case '1':
 		case '2':
@@ -756,34 +752,30 @@ yy44:
 		case '6':
 		case '7':
 		case '8':
-		case '9': goto yy49;
+		case '9':
 		case ':': goto yy50;
-		default: goto yy47;
+		default: goto yy42;
 	}
 yy45:
 	YYSKIP();
-	{ goto match_uri; }
-yy46:
-	YYSKIP();
 	yych = YYPEEK();
-yy47:
+yy46:
 	switch (yych) {
-		case 0x00: goto yy48;
-		case ';': goto yy45;
-		default: goto yy46;
+		case 0x00: goto yy47;
+		case ';': goto yy48;
+		default: goto yy45;
 	}
-yy48:
+yy47:
 	YYRESTORE();
-	if (yyaccept == 0) {
-		goto yy42;
-	} else {
-		goto yy51;
-	}
+	goto yy42;
+yy48:
+	YYSKIP();
+	{ goto match_uri; }
 yy49:
 	YYSKIP();
 	yych = YYPEEK();
+yy50:
 	switch (yych) {
-		case 0x00: goto yy48;
 		case '0':
 		case '1':
 		case '2':
@@ -794,17 +786,11 @@ yy49:
 		case '7':
 		case '8':
 		case '9': goto yy49;
-		case ':': goto yy50;
-		case ';': goto yy45;
-		default: goto yy46;
+		case ':': goto yy51;
+		default: goto yy47;
 	}
-yy50:
-	yyaccept = 1;
-	YYSKIP();
-	YYBACKUP();
-	yych = YYPEEK();
-	if (yych >= 0x01) goto yy47;
 yy51:
+	YYSKIP();
 	{ goto match_index; }
 }
 

--- a/src/util/ua_types_lex.re
+++ b/src/util/ua_types_lex.re
@@ -319,9 +319,9 @@ parse_qn(UA_QualifiedName *qn, const u8 *pos, const u8 *end,
     qn->namespaceIndex = defaultNamespaceIndex;
 
     /*!re2c // Match the grammar
-    [0-9]+ ":"      { goto match_index; }
-    escaped_uri ";" { goto match_uri; }
-    *               { pos = begin; goto match_name; } */
+    [0-9]+ ":"                  { goto match_index; }
+    [^;\0000-9] [^;\000]* ";"   { goto match_uri; }
+    *                           { pos = begin; goto match_name; } */
 
  match_index:
     len = (size_t)(pos - 1 - begin);

--- a/tests/check_types_parse.c
+++ b/tests/check_types_parse.c
@@ -363,6 +363,49 @@ START_TEST(parseDateTime) {
     ck_assert_int_eq(dt, 133924124240000000);
 } END_TEST
 
+START_TEST(parseQualifiedNameWithSemicolon) {
+    UA_QualifiedName value;
+    UA_QualifiedName_init(&value);
+    value.name = UA_STRING_ALLOC("te;st");
+    value.namespaceIndex = 123;
+
+    UA_ByteString encoded;
+    UA_ByteString_init(&encoded);
+    const UA_StatusCode enc = UA_encodeJson(&value, &UA_TYPES[UA_TYPES_QUALIFIEDNAME], &encoded, NULL);
+    UA_String expected_enc = UA_STRING("\"123:te;st\"");
+    ck_assert(UA_String_equal(&encoded, &expected_enc));
+
+    UA_QualifiedName decoded;
+    UA_QualifiedName_init(&decoded);
+    const UA_StatusCode dec = UA_decodeJson(&encoded, &decoded, &UA_TYPES[UA_TYPES_QUALIFIEDNAME], NULL);
+    UA_String expected_dec = UA_STRING("te;st");
+    ck_assert(UA_String_equal(&decoded.name, &expected_dec));
+    ck_assert_uint_eq(decoded.namespaceIndex, 123);
+
+    UA_ByteString_clear(&encoded);
+    UA_QualifiedName_clear(&value);
+    UA_QualifiedName_clear(&decoded);
+}
+
+START_TEST(parseQualifiedNameWithNamespaceUri) {
+    UA_NamespaceMapping nsMapping;
+    memset(&nsMapping, 0, sizeof(UA_NamespaceMapping));
+    UA_String uris[3];
+    uris[0] = UA_STRING("");
+    uris[1] = UA_STRING("http://opcfoundation.org/UA/");
+    uris[2] = UA_STRING("urn:test");
+    nsMapping.namespaceUris = uris;
+    nsMapping.namespaceUrisSize = 3;
+
+    UA_QualifiedName qn;
+    UA_StatusCode res = UA_QualifiedName_parseEx(&qn, UA_STRING("urn:test;MyName"), &nsMapping);
+    ck_assert_int_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(qn.namespaceIndex, 2);
+    UA_String expected = UA_STRING("MyName");
+    ck_assert(UA_String_equal(&qn.name, &expected));
+    UA_QualifiedName_clear(&qn);
+} END_TEST
+
 int main(void) {
     Suite *s  = suite_create("Test Builtin Type Parsing");
     TCase *tc = tcase_create("test cases");
@@ -384,6 +427,8 @@ int main(void) {
     tcase_add_test(tc, parseSimpleAttributeOperand);
     tcase_add_test(tc, printSimpleAttributeOperand);
     tcase_add_test(tc, parseDateTime);
+    tcase_add_test(tc, parseQualifiedNameWithSemicolon);
+    tcase_add_test(tc, parseQualifiedNameWithNamespaceUri);
     suite_add_tcase(s, tc);
 
     SRunner *sr = srunner_create(s);

--- a/tests/check_types_parse.c
+++ b/tests/check_types_parse.c
@@ -385,7 +385,7 @@ START_TEST(parseQualifiedNameWithSemicolon) {
     UA_ByteString_clear(&encoded);
     UA_QualifiedName_clear(&value);
     UA_QualifiedName_clear(&decoded);
-}
+} END_TEST
 
 START_TEST(parseQualifiedNameWithNamespaceUri) {
     UA_NamespaceMapping nsMapping;


### PR DESCRIPTION
The re2c grammar for parse_qn defined the namespace-URI alternative as [^;\000]*";" which matches any characters up to the first ";". Due to re2c's longest-match rule this pattern would beat the numeric namespace index rule [0-9]+":". For example, "123:te;st" was tokenized as URI="123:te" followed by name="st" instead of nsIndex=123, name="te;st".

Fix by restricting the URI alternative to inputs that start with a non-Digit character. All valid OPC UA namespace URIs (e.g. "http://..." or "urn:...") begin with a letter, so this does not affect legitimate namespace URIs.

Fixes #7801.