### PR TITLE
refactor(core): Simplify logic of `UA_StatusCode_isUncertain`

### DIFF
--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -182,7 +182,7 @@ UA_StatusCode_name(UA_StatusCode code);
 UA_EXPORT UA_Boolean
 UA_StatusCode_isBad(UA_StatusCode code);
 
-/* ((code >> 30) == 0x01) && ((code >> 30) < 0x02) */
+/* (code >> 30) == 0x01 */
 UA_EXPORT UA_Boolean
 UA_StatusCode_isUncertain(UA_StatusCode code);
 

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -202,7 +202,7 @@ UA_StatusCode_isBad(UA_StatusCode code) {
 
 UA_Boolean
 UA_StatusCode_isUncertain(UA_StatusCode code) {
-    return (((code >> 30) == 0x01) && ((code >> 30) < 0x02));
+    return ((code >> 30) == 0x01);
 }
 
 UA_Boolean


### PR DESCRIPTION
For every `x`: if `x == 0x01`, then `x < 0x02`.

I checked the related [docs](https://reference.opcfoundation.org/Core/Part4/v104/docs/7.34): the _uncertain_ status is represented by a value `01`, so the original code is just a _confusing typo_.
