### PR TITLE
refactor(build): Remove -ftls-model=initial-exec compiler option - th…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,7 +677,6 @@ if((CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang") AND
     # Threading support
     if(UA_MULTITHREADING GREATER_EQUAL 100 AND NOT WIN32)
         check_add_cc_flag("-pthread")
-        check_add_cc_flag("-ftls-model=initial-exec") # Enable thread-local variables in the .so shared object
     endif()
 
     # Force 32bit build


### PR DESCRIPTION
…e compiler defaults are more robust