### PR TITLE
docs(ex): specify codeblock as sh

### DIFF
--- a/examples/zephyr/server/README.md
+++ b/examples/zephyr/server/README.md
@@ -1,6 +1,6 @@
 # Zephyr server example
 ## HOWTO
-```
+```sh
 # Initialize the west workspace
 cd examples/zephyr
 west init -l server


### PR DESCRIPTION
specify that the code block is of type .sh. this is to have color formatting.