### PR TITLE
refactor(server): avoid undefined behaviour with memcpy()

### DIFF
--- a/arch/posix/eventloop_posix_eth.c
+++ b/arch/posix/eventloop_posix_eth.c
@@ -678,7 +678,9 @@ ETH_openConnection(UA_ConnectionManager *cm, const UA_KeyValueMap *params,
         return UA_STATUSCODE_BADINTERNALERROR;
     }
     char ifname[128];
-    memcpy(ifname, interface->data, interface->length);
+    if (interface->length) {
+        memcpy(ifname, interface->data, interface->length);
+    }
     ifname[interface->length] = 0;
     int ifindex = (int)if_nametoindex(ifname);
     if(ifindex == 0) {

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -52,8 +52,10 @@ notifySession(UA_Server *server, UA_Session *session,
     UA_Variant_setArray(&payloadData[5].value, session->localeIds,
                         session->localeIdsSize, &UA_TYPES[UA_TYPES_STRING]);
 
-    memcpy(&payloadData[6], session->attributes.map,
-           sizeof(UA_KeyValuePair) * session->attributes.mapSize);
+    if (session->attributes.mapSize) {
+        memcpy(&payloadData[6], session->attributes.map,
+               sizeof(UA_KeyValuePair) * session->attributes.mapSize);
+    }
 
     /* Call the notification callback */
     if(server->config.sessionNotificationCallback)

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -861,7 +861,9 @@ UA_SecureChannel_loadBuffer(UA_SecureChannel *channel, const UA_ByteString buffe
         if(!t)
             return UA_STATUSCODE_BADOUTOFMEMORY;
 
-        memcpy(t + channel->unprocessed.length, buffer.data, buffer.length);
+	if (buffer.length) {
+            memcpy(t + channel->unprocessed.length, buffer.data, buffer.length);
+	}
         channel->unprocessed.data = t;
         channel->unprocessed.length += buffer.length;
         return UA_STATUSCODE_GOOD;

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -188,7 +188,7 @@ static status UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT
 xmlEncodeWriteChars(CtxXml *ctx, const char *c, size_t len) {
     if(ctx->pos + len > ctx->end)
         return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
-    if(!ctx->calcOnly)
+    if(!ctx->calcOnly && len)
         memcpy(ctx->pos, c, len);
     ctx->pos += len;
     return UA_STATUSCODE_GOOD;


### PR DESCRIPTION
Sometimes memcpy() is called with the second parameter set to NULL. This only happens in cases where the length parameter 3 is also set to 0. So add checks for the third parameter before calling memcpy() to avoid undefined behaviour.