### PR TITLE
fix(server) Resolve issues detected during coverage improvements

### DIFF
--- a/deps/base64.c
+++ b/deps/base64.c
@@ -17,7 +17,7 @@ unsigned char *
 UA_base64(const unsigned char *src, size_t len, size_t *out_len) {
     if(len == 0) {
         *out_len = 0;
-        return (unsigned char*)UA_EMPTY_ARRAY_SENTINEL;
+        return NULL;
     }
 
     size_t olen = 4*((len + 2) / 3); /* 3-byte blocks to 4-byte */

--- a/deps/parse_num.c
+++ b/deps/parse_num.c
@@ -104,8 +104,8 @@ size_t parseDouble(const char *str, size_t size, double *result) {
     buf[size] = 0;
     errno = 0;
     char *endptr;
-    *result = strtod(str, &endptr);
+    *result = strtod(buf, &endptr);
     if(errno != 0 && errno != ERANGE)
         return 0;
-    return (uintptr_t)endptr - (uintptr_t)str;
+    return (uintptr_t)endptr - (uintptr_t)buf;
 }

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -327,16 +327,9 @@ addEphemeralKeyAdditionalHeader(UA_Server *server, UA_Session *session,
     if(res != UA_STATUSCODE_GOOD)
         return res;
 
-    /* Allocate the EphemeralKey structure */
-    UA_EphemeralKeyType *ephKey = UA_EphemeralKeyType_new();
-    if(!ephKey)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-
-    /* Add the EphemeralKeyto the map */
-    res = UA_KeyValueMap_setScalarShallow(map, UA_QUALIFIEDNAME(0, "ECDHKey"),
-                                          ephKey, &UA_TYPES[UA_TYPES_EPHEMERALKEYTYPE]);
-    if(res != UA_STATUSCODE_GOOD)
-        return res;
+    /* Initialize the EphemeralKey on the stack */
+    UA_EphemeralKeyType ephKey;
+    UA_EphemeralKeyType_init(&ephKey);
 
     /* Allocate the ephemeral key buffer to the exact size of the ephemeral key
      * for the used ECC policy so that the nonce generation function knows that
@@ -345,24 +338,32 @@ addEphemeralKeyAdditionalHeader(UA_Server *server, UA_Session *session,
      *
      * TODO: There should be a more stable way to signal the generation of an
      * ephemeral key */
-    res = UA_ByteString_allocBuffer(&ephKey->publicKey, sp->nonceLength);
+    res = UA_ByteString_allocBuffer(&ephKey.publicKey, sp->nonceLength);
     if(res != UA_STATUSCODE_GOOD)
         return res;
 
     /* Allocate the signature buffer */
     size_t signatureSize =
         sp->asymSignatureAlgorithm.getLocalSignatureSize(sp, spContext);
-    res = UA_ByteString_allocBuffer(&ephKey->signature, signatureSize);
-    if(res != UA_STATUSCODE_GOOD)
+    res = UA_ByteString_allocBuffer(&ephKey.signature, signatureSize);
+    if(res != UA_STATUSCODE_GOOD) {
+        UA_EphemeralKeyType_clear(&ephKey);
         return res;
+    }
 
     /* Generate the ephemeral key and signature */
-    ephKey->publicKey.data[0] = 'e';
-    ephKey->publicKey.data[1] = 'p';
-    ephKey->publicKey.data[2] = 'h';
-    res |= sp->generateNonce(sp, spContext, &ephKey->publicKey);
-    res |= sp->asymSignatureAlgorithm.sign(sp, spContext, &ephKey->publicKey,
-                                           &ephKey->signature);
+    ephKey.publicKey.data[0] = 'e';
+    ephKey.publicKey.data[1] = 'p';
+    ephKey.publicKey.data[2] = 'h';
+    res |= sp->generateNonce(sp, spContext, &ephKey.publicKey);
+    res |= sp->asymSignatureAlgorithm.sign(sp, spContext, &ephKey.publicKey,
+                                           &ephKey.signature);
+
+    /* Add the EphemeralKey to the map (deep copy) */
+    if(res == UA_STATUSCODE_GOOD)
+        res = UA_KeyValueMap_setScalar(map, UA_QUALIFIEDNAME(0, "ECDHKey"),
+                                       &ephKey, &UA_TYPES[UA_TYPES_EPHEMERALKEYTYPE]);
+    UA_EphemeralKeyType_clear(&ephKey);
     return res;
 }
 

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -105,8 +105,6 @@ UA_FilterEvalContext_init(UA_FilterEvalContext *ctx) {
 
 void
 UA_FilterEvalContext_reset(UA_FilterEvalContext *ctx) {
-    if(ctx->eventId.data && ctx->eventId.data != ctx->eventIdBuf)
-        UA_ByteString_clear(&ctx->eventId);
     UA_KeyValueMap_clear(&ctx->fieldCache);
 
     /* The data of the EventId is either in the eventIdBuf or in the fieldCache
@@ -151,13 +149,15 @@ cacheEventId(UA_FilterEvalContext *ctx) {
         UA_Boolean isIdString = UA_Variant_hasScalarType(&val, &UA_TYPES[UA_TYPES_BYTESTRING]);
         UA_assert(!isIdString || val.data != NULL); /* pacify a clang-analyzer warning */
         if(isIdString && ((UA_ByteString*)val.data)->length > 0) {
-            res = UA_KeyValueMap_setShallow(&ctx->fieldCache,
-                                            UA_QUALIFIEDNAME(0, "/EventId"), &val);
-            if(res != UA_STATUSCODE_GOOD) {
-                UA_Variant_clear(&val);
+            res = UA_KeyValueMap_set(&ctx->fieldCache,
+                                     UA_QUALIFIEDNAME(0, "/EventId"), &val);
+            UA_Variant_clear(&val);
+            if(res != UA_STATUSCODE_GOOD)
                 return res;
-            }
-            ctx->eventId = *(UA_ByteString*)val.data; /* shallow copy */
+            const UA_Variant *cached =
+                UA_KeyValueMap_get(&ctx->fieldCache,
+                                   UA_QUALIFIEDNAME(0, "/EventId"));
+            ctx->eventId = *(UA_ByteString*)cached->data; /* shallow copy */
             return UA_STATUSCODE_GOOD;
         }
 

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -359,6 +359,9 @@ ENCODE_XML(ByteString) {
     if(!src->data)
         return xmlEncodeWriteChars(ctx, "null", 4);
 
+    if(src->length == 0)
+        return UA_STATUSCODE_GOOD;
+
     size_t flen = 0;
     unsigned char *ba64 = UA_base64(src->data, src->length, &flen);
 

--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -315,7 +315,7 @@ UA_StatusCode
 UA_ByteString_toBase64(const UA_ByteString *byteString,
                        UA_String *str) {
     UA_String_init(str);
-    if(!byteString || !byteString->data)
+    if(!byteString || !byteString->data || byteString->length == 0)
         return UA_STATUSCODE_GOOD;
 
     str->data = (UA_Byte*)
@@ -479,6 +479,7 @@ UA_KeyValueMap_setShallow(UA_KeyValueMap *map,
     }
 
     *target = *value;
+    target->storageType = UA_VARIANT_DATA_NODELETE;
     return UA_STATUSCODE_GOOD;
 }
 

--- a/tests/check_base64.c
+++ b/tests/check_base64.c
@@ -14,7 +14,7 @@ START_TEST(encodeEmpty) {
     size_t out_len = 42;
     unsigned char *out = UA_base64((const unsigned char *)"", 0, &out_len);
     ck_assert_uint_eq(out_len, 0);
-    ck_assert_ptr_eq(out, UA_EMPTY_ARRAY_SENTINEL);
+    ck_assert_ptr_eq(out, NULL);
 } END_TEST
 
 START_TEST(encodeF) {

--- a/tests/check_parse_num.c
+++ b/tests/check_parse_num.c
@@ -217,6 +217,16 @@ START_TEST(parseDoubleInteger) {
     ck_assert((result) == (42.0));
 } END_TEST
 
+START_TEST(parseDoubleSubstring) {
+    /* Parse "3.14" from a buffer that is NOT null-terminated at position 4.
+     * Before the fix, strtod was called on the original (non-terminated)
+     * pointer instead of the null-terminated local copy. */
+    char buf[8] = {'3', '.', '1', '4', 'X', 'Y', 'Z', '!'};
+    double result = 0.0;
+    size_t len = parseDouble(buf, 4, &result);
+    ck_assert_uint_eq(len, 4);
+    ck_assert(fabs(result - 3.14) <= 1e-9);
+} END_TEST
 
 static Suite *testSuite_parse_num(void) {
     TCase *tc_uint = tcase_create("parseUInt64");
@@ -251,6 +261,7 @@ static Suite *testSuite_parse_num(void) {
     tcase_add_test(tc_double, parseDoubleScientific);
     tcase_add_test(tc_double, parseDoubleTooLong);
     tcase_add_test(tc_double, parseDoubleInteger);
+    tcase_add_test(tc_double, parseDoubleSubstring);
 
     Suite *s = suite_create("Test number parsing functions");
     suite_add_tcase(s, tc_uint);

--- a/tests/check_util_functions.c
+++ b/tests/check_util_functions.c
@@ -76,7 +76,7 @@ START_TEST(kvm_setShallow) {
     UA_UInt32 val = 77;
     UA_Variant v;
     UA_Variant_setScalar(&v, &val, &UA_TYPES[UA_TYPES_UINT32]);
-    v.storageType = UA_VARIANT_DATA_NODELETE;
+    /* storageType is now enforced to NODELETE inside setShallow itself */
 
     UA_StatusCode res = UA_KeyValueMap_setShallow(map, key, &v);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
@@ -89,7 +89,6 @@ START_TEST(kvm_setShallow) {
     UA_UInt32 val2 = 99;
     UA_Variant v2;
     UA_Variant_setScalar(&v2, &val2, &UA_TYPES[UA_TYPES_UINT32]);
-    v2.storageType = UA_VARIANT_DATA_NODELETE;
     res = UA_KeyValueMap_setShallow(map, key, &v2);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
 
@@ -117,12 +116,8 @@ START_TEST(kvm_setScalarShallow) {
     ck_assert_ptr_ne(scalar, NULL);
     ck_assert_uint_eq(*(const UA_UInt32 *)scalar, 55);
 
-    /* Remove entry before deleting map to avoid freeing stack pointer.
-     * Note: UA_KeyValueMap_setScalarShallow does not set
-     * storageType = UA_VARIANT_DATA_NODELETE, so UA_KeyValueMap_delete
-     * would try to free the stack pointer - this is a library bug. */
-    res = UA_KeyValueMap_remove(map, key);
-    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    /* UA_KeyValueMap_setShallow always sets storageType = UA_VARIANT_DATA_NODELETE,
+     * so UA_KeyValueMap_delete will not try to free the caller-owned stack pointer. */
     UA_KeyValueMap_delete(map);
 } END_TEST
 
@@ -539,11 +534,9 @@ static Suite *testSuite_util(void) {
     tcase_add_test(tc_kvm, kvm_new_delete);
     tcase_add_test(tc_kvm, kvm_set_get_remove);
     tcase_add_test(tc_kvm, kvm_setShallow);
-    /* kvm_setScalarShallow skipped: UA_KeyValueMap_setScalarShallow
-     * does not set storageType=NODELETE, causing crash on cleanup
-     * (library bug). setShallow is tested above with explicit NODELETE. */
-    //tcase_add_test(tc_kvm, kvm_copy);
-    //tcase_add_test(tc_kvm, kvm_merge);
+    tcase_add_test(tc_kvm, kvm_setScalarShallow);
+    tcase_add_test(tc_kvm, kvm_copy);
+    tcase_add_test(tc_kvm, kvm_merge);
 
     TCase *tc_url = tcase_create("EndpointURL");
     tcase_add_test(tc_url, parseEndpointUrl_opc_tcp);

--- a/tests/check_utils_url_kvm.c
+++ b/tests/check_utils_url_kvm.c
@@ -281,12 +281,13 @@ START_TEST(kvm_set_shallow) {
 
     UA_QualifiedName key = UA_QUALIFIEDNAME(0, "shallowKey");
 
-    /* Use heap-allocated data so cleanup is safe */
-    UA_Int32 *val = UA_Int32_new();
-    *val = 77;
+    /* setShallow semantics: the caller owns the data; the map stores a
+     * non-owning reference and will never call UA_free on it. Use
+     * stack-allocated data to make that contract explicit. */
+    UA_Int32 val = 77;
     UA_Variant v;
     UA_Variant_init(&v);
-    UA_Variant_setScalar(&v, val, &UA_TYPES[UA_TYPES_INT32]);
+    UA_Variant_setScalar(&v, &val, &UA_TYPES[UA_TYPES_INT32]);
 
     UA_StatusCode res = UA_KeyValueMap_setShallow(map, key, &v);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
@@ -294,17 +295,20 @@ START_TEST(kvm_set_shallow) {
     /* Read back */
     const UA_Variant *got = UA_KeyValueMap_get(map, key);
     ck_assert_ptr_ne(got, NULL);
+    ck_assert_int_eq(*(UA_Int32 *)got->data, 77);
 
-    /* Overwrite with new heap value - old one will be freed via clear */
-    UA_Int32 *val2 = UA_Int32_new();
-    *val2 = 88;
+    /* Overwrite with another stack value */
+    UA_Int32 val2 = 88;
     UA_Variant v2;
     UA_Variant_init(&v2);
-    UA_Variant_setScalar(&v2, val2, &UA_TYPES[UA_TYPES_INT32]);
+    UA_Variant_setScalar(&v2, &val2, &UA_TYPES[UA_TYPES_INT32]);
     res = UA_KeyValueMap_setShallow(map, key, &v2);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
 
-    /* Delete map (will clear the remaining entry) */
+    got = UA_KeyValueMap_get(map, key);
+    ck_assert_int_eq(*(UA_Int32 *)got->data, 88);
+
+    /* Delete map - data lives on the stack, nothing to free */
     UA_KeyValueMap_delete(map);
 } END_TEST
 

--- a/tests/check_xml_encoding_roundtrip.c
+++ b/tests/check_xml_encoding_roundtrip.c
@@ -234,10 +234,10 @@ START_TEST(xml_bytestring) {
 } END_TEST
 
 START_TEST(xml_bytestring_empty) {
-    /* Uses BYTESTRING_NULL here. A non-NULL data pointer with length=0
-     * triggers BUG: UA_base64() returns UA_EMPTY_ARRAY_SENTINEL (0x1)
-     * which crashes on UA_free(). See COVERAGE_BUGS.md #8. */
-    UA_ByteString src = UA_BYTESTRING_NULL;
+    /* Test that encoding a non-null ByteString with length=0 succeeds.
+     * (encodeXml returns early before calling UA_base64 for empty input) */
+    UA_Byte dummy = 0;
+    UA_ByteString src = {0, &dummy};
     UA_ByteString buf;
     UA_ByteString_init(&buf);
     UA_StatusCode res = UA_encodeXml(&src, &UA_TYPES[UA_TYPES_BYTESTRING], &buf, NULL);


### PR DESCRIPTION
During the latest push of large unit test sets, a few minor issues surfaced. This PR resolves those issues and adds additional tests to prevent future regressions.

1. parseDouble read-beyond-bounds: parseDouble() copied input to a null-terminated local buffer but passed the original (potentially unterminated) pointer to strtod(), causing an out-of-bounds read when the input was not null-terminated.
2. UA_KeyValueMap_setScalarShallow crash on free: The variant stored a pointer to caller-owned data without setting storageType = UA_VARIANT_DATA_NODELETE, so UA_Variant_clear() would later call free() on a stack variable.
3. UA_base64 invalid pointer on empty input: UA_base64() returned UA_EMPTY_ARRAY_SENTINEL (0x1) for zero-length input; callers that passed the result to UA_free() would crash because 0x1 is not a valid heap pointer.