### PR TITLE
win32: fix case-sensitive includes for mingw cross-compilation

### DIFF
--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -25,8 +25,8 @@
 #include "itoa.h"
 
 #if defined(UA_ARCHITECTURE_WIN32)
-#include <WTypes.h>
-#include <WinBase.h>
+#include <wtypes.h>
+#include <winbase.h>
 #endif
 
 #include "../../deps/parse_num.h"


### PR DESCRIPTION
When cross-compiling on Linux with mingw-w64, the Windows headers are installed with lowercase filenames (e.g. wtypes.h, winbase.h).

The current includes use mixed case (WTypes.h, WinBase.h) which works on Windows but fails on case-sensitive filesystems during mingw cross-compilation.

This patch changes the includes to lowercase to match the actual header names and ensure successful cross-compilation.