### PR TITLE
win32: fix unused variable warning in signal handling

### DIFF
--- a/arch/posix/eventloop_posix_interrupt.c
+++ b/arch/posix/eventloop_posix_interrupt.c
@@ -76,6 +76,7 @@ handlePOSIXInterruptEvent(UA_EventSource *es, UA_RegisteredFD *rfd, short event)
 static void
 activateSignal(UA_RegisteredSignal *rs) {
     UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX *)rs->rfd.es->eventLoop;
+    (void)el;
     UA_LOCK_ASSERT(&el->elMutex);
 
     if(rs->active)
@@ -130,6 +131,7 @@ activateSignal(UA_RegisteredSignal *rs) {
 static void
 deactivateSignal(UA_RegisteredSignal *rs) {
     UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX *)rs->rfd.es->eventLoop;
+    (void)el;
     UA_LOCK_ASSERT(&el->elMutex);
 
     /* Only dectivate if active */


### PR DESCRIPTION
When building the amalgamation with UA_ARCHITECTURE=win32, the POSIX signal handling code declares a variable that is not used on Windows builds.

With -Werror enabled this results in a build failure:

    error: unused variable 'el' [-Werror=unused-variable]

Mark the variable as intentionally unused to avoid the warning.