### PR TITLE
posix: avoid double fclose in writeByteStringToFile

### DIFF
--- a/plugins/crypto/ua_filestore_common.c
+++ b/plugins/crypto/ua_filestore_common.c
@@ -60,10 +60,8 @@ writeByteStringToFile(const char *const path, const UA_ByteString *data) {
 
     /* Write byte string to file */
     size_t len = UA_fwrite(data->data, sizeof(UA_Byte), data->length * sizeof(UA_Byte), fp);
-    if(len != data->length) {
-        UA_fclose(fp);
+    if(len != data->length)
         retval = UA_STATUSCODE_BADINTERNALERROR;
-    }
 
     UA_fclose(fp);
     return retval;


### PR DESCRIPTION
writeByteStringToFile closed the file twice when UA_fwrite returned a short write:

- once inside the error path
- once again before returning

This can trigger a use-after-free warning with GCC when building with -Werror. Only close the file once before returning.