### PR TITLE
style(core): Add missing standard headers

### DIFF
--- a/include/open62541/common.h
+++ b/include/open62541/common.h
@@ -15,6 +15,8 @@
 #include <open62541/config.h>
 #include <open62541/nodeids.h>
 
+#include <stddef.h>
+
 _UA_BEGIN_DECLS
 
 /**

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -22,6 +22,9 @@
 #include <open62541/common.h>
 #include <open62541/statuscodes.h>
 
+#include <stdbool.h>
+#include <stdint.h>
+
 struct UA_NamespaceMapping;
 typedef struct UA_NamespaceMapping UA_NamespaceMapping;
 

--- a/tests/server/historical_read_test_data.h
+++ b/tests/server/historical_read_test_data.h
@@ -14,6 +14,7 @@
 #include <open62541/types.h>
 
 #include <limits.h>
+#include <stdbool.h>
 
 typedef struct {
     UA_DateTime start;


### PR DESCRIPTION
One should not rely on transitive includes.
