### PR TITLE
fix(arch): silence remaining unused variable warnings in win32 signal…

### DIFF
--- a/arch/posix/eventloop_posix_interrupt.c
+++ b/arch/posix/eventloop_posix_interrupt.c
@@ -213,6 +213,7 @@ static void
 activateSignal(UA_RegisteredSignal *rs) {
     UA_assert(singletonIM != NULL);
     UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)singletonIM->im.eventSource.eventLoop;
+    (void)el;
     UA_LOCK_ASSERT(&el->elMutex);
 
     /* Register the signal on the OS level */
@@ -237,6 +238,7 @@ static void
 deactivateSignal(UA_RegisteredSignal *rs) {
     UA_assert(singletonIM != NULL);
     UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)singletonIM->im.eventSource.eventLoop;
+    (void)el;
     UA_LOCK_ASSERT(&el->elMutex);
 
     /* Only dectivate if active */


### PR DESCRIPTION
… handling

Follow-up to #7830.

Mark additional variables as intentionally unused to avoid unused-variable warnings with strict compiler flags.