### PR TITLE
openssl: fix unused return value from BIO_reset with -Werror

### DIFF
--- a/plugins/crypto/openssl/securitypolicy_common.c
+++ b/plugins/crypto/openssl/securitypolicy_common.c
@@ -1253,7 +1253,7 @@ UA_OpenSSL_LoadPrivateKey(const UA_ByteString *privateKey) {
 
     if(result == NULL) {
         /* Try to read PEM encoded private key */
-        BIO_reset(bio);
+        (void)BIO_reset(bio);
         result = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
     }
     BIO_free(bio);


### PR DESCRIPTION
Follow-up to #7831

When building open62541 with -Werror, OpenSSL's BIO_reset macro produces a warning because the return value is not used:

value computed is not used [-Wunused-value]

Cast the call to (void) to mark the return value as intentionally unused and avoid the warning.