### PR TITLE
[Review] fix(server): avoid GCC -Warray-bounds in cmpRefTargetName

### DIFF
--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -272,11 +272,11 @@ cmpRefTargetId(const void *a, const void *b) {
 
 enum ZIP_CMP
 cmpRefTargetName(const void *a, const void *b) {
-    const UA_ReferenceTargetTreeElem *aa = (const UA_ReferenceTargetTreeElem*)a;
-    const UA_ReferenceTargetTreeElem *bb = (const UA_ReferenceTargetTreeElem*)b;
-    if(aa->target.targetNameHash == bb->target.targetNameHash)
+    const UA_ReferenceTarget *aa = (const UA_ReferenceTarget*)a;
+    const UA_ReferenceTarget *bb = (const UA_ReferenceTarget*)b;
+    if(aa->targetNameHash == bb->targetNameHash)
         return ZIP_CMP_EQ;
-    return (aa->target.targetNameHash < bb->target.targetNameHash) ?
+    return (aa->targetNameHash < bb->targetNameHash) ?
         ZIP_CMP_LESS : ZIP_CMP_MORE;
 }
 


### PR DESCRIPTION
fix(server): compare reference-name tree keys as UA_ReferenceTarget

cmpRefTargetName cast its arguments to UA_ReferenceTargetTreeElem, while walkBrowsePathElement passes a temporary UA_ReferenceTarget key to ZIP_ITER_KEY for UA_ReferenceNameTree.

Recent GCC versions diagnose this as -Warray-bounds because the temporary lookup key is smaller than UA_ReferenceTargetTreeElem.

```
In function 'cmpRefTargetName',
    inlined from '__ZIP_ITER_KEY' at ../../src/libs/open62541_win32.c:72375:23,
    inlined from 'UA_ReferenceNameTree_ZIP_ITER_KEY' at ../../src/libs/open62541_win32.c:4094:1,
    inlined from 'walkBrowsePathElement.constprop.isra' at ../../src/libs/open62541_win32.c:51854:21:
../../src/libs/open62541.c:34347:18: error: array subscript 'UA_ReferenceTargetTreeElem[0]' is partly outside array bounds of 'UA_ReferenceTarget[1]' [-Werror=array-bounds=]
34347 |     if(aa->target.targetNameHash == bb->target.targetNameHash)
      |        ~~~~~~~~~~^~~~~~~~~~~~~~~
```

Compare UA_ReferenceTarget keys directly instead.