### PR TITLE
fix(server)  #7842 : fix potential dangling pointer in subscription notification data and add test

### DIFF
--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -71,8 +71,10 @@ notifySubscription(UA_Server *server, UA_Subscription *sub,
     };
     UA_KeyValueMap createSubMap = {8, createSubData};
 
-    UA_NodeId sessionId = (sub->session) ? sub->session->sessionId : UA_NODEID_NULL;
-    UA_Boolean enabled = (sub->state = UA_SUBSCRIPTIONSTATE_ENABLED);
+    static UA_THREAD_LOCAL UA_NodeId sessionId;
+    sessionId = (sub->session) ? sub->session->sessionId : UA_NODEID_NULL;
+    static UA_THREAD_LOCAL UA_Boolean enabled;
+    enabled = (sub->state == UA_SUBSCRIPTIONSTATE_ENABLED);
 
     UA_Variant_setScalar(&createSubData[0].value, &sessionId,
                          &UA_TYPES[UA_TYPES_NODEID]);

--- a/tests/server/check_services_subscriptions.c
+++ b/tests/server/check_services_subscriptions.c
@@ -89,6 +89,50 @@ static void teardown(void) {
 
 static UA_UInt32 subscriptionId;
 static UA_UInt32 monitoredItemId;
+static UA_Boolean subscriptionNotificationCalled = false;
+static UA_ApplicationNotificationType subscriptionNotificationType;
+static UA_UInt32 subscriptionNotificationId = 0;
+static UA_Boolean subscriptionNotificationEnabled = false;
+static size_t subscriptionNotificationMapSize = 0;
+
+static const UA_Variant *
+findNotificationValue(const UA_KeyValueMap *map, const char *key) {
+    if(!map || !map->map)
+        return NULL;
+
+    size_t keylen = strlen(key);
+    for(size_t i = 0; i < map->mapSize; i++) {
+        const UA_String *name = &map->map[i].key.name;
+        if(name->length == keylen &&
+           memcmp(name->data, key, keylen) == 0)
+            return &map->map[i].value;
+    }
+
+    return NULL;
+}
+
+static void
+testSubscriptionNotificationCallback(UA_Server *server,
+                                     UA_ApplicationNotificationType type,
+                                     UA_KeyValueMap data) {
+    (void)server;
+
+    subscriptionNotificationCalled = true;
+    subscriptionNotificationType = type;
+    subscriptionNotificationMapSize = data.mapSize;
+
+    const UA_Variant *sid =
+        findNotificationValue(&data, "subscription-id");
+    ck_assert_ptr_ne(sid, NULL);
+    ck_assert_ptr_ne(sid->data, NULL);
+    subscriptionNotificationId = *(const UA_UInt32*)sid->data;
+
+    const UA_Variant *enabled =
+        findNotificationValue(&data, "publishing-enabled");
+    ck_assert_ptr_ne(enabled, NULL);
+    ck_assert_ptr_ne(enabled->data, NULL);
+    subscriptionNotificationEnabled = *(const UA_Boolean*)enabled->data;
+}
 
 static void
 createSubscription(void) {
@@ -1350,6 +1394,39 @@ START_TEST(Server_transferSubscription_sendInitialValues) {
     unlockServer(server);
 } END_TEST
 
+
+START_TEST(Server_createSubscription_notificationCallback) {
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+
+    subscriptionNotificationCalled = false;
+    subscriptionNotificationType = (UA_ApplicationNotificationType)0;
+    subscriptionNotificationId = 0;
+    subscriptionNotificationEnabled = false;
+    subscriptionNotificationMapSize = 0;
+
+    config->subscriptionNotificationCallback = testSubscriptionNotificationCallback;
+
+    UA_CreateSubscriptionRequest request;
+    UA_CreateSubscriptionRequest_init(&request);
+    request.publishingEnabled = true;
+
+    UA_CreateSubscriptionResponse response;
+    UA_CreateSubscriptionResponse_init(&response);
+
+    lockServer(server);
+    Service_CreateSubscription(server, session, &request, &response);
+    unlockServer(server);
+
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert(subscriptionNotificationCalled == true);
+    ck_assert_uint_gt(subscriptionNotificationMapSize, 0);
+    ck_assert_uint_eq(subscriptionNotificationId, response.subscriptionId);
+    ck_assert(subscriptionNotificationEnabled == true);
+
+    config->subscriptionNotificationCallback = NULL;
+    UA_CreateSubscriptionResponse_clear(&response);
+} END_TEST
+
 #endif /* UA_ENABLE_SUBSCRIPTIONS */
 
 static Suite* testSuite_Client(void) {
@@ -1358,6 +1435,7 @@ static Suite* testSuite_Client(void) {
     tcase_add_checked_fixture(tc_server, setup, teardown);
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     tcase_add_test(tc_server, Server_createSubscription);
+    tcase_add_test(tc_server, Server_createSubscription_notificationCallback);
     tcase_add_test(tc_server, Server_modifySubscription);
     tcase_add_test(tc_server, Server_setPublishingMode);
     tcase_add_test(tc_server, Server_negativeSamplingInterval);


### PR DESCRIPTION
## Additionnal question

must be :
    enabled = (sub->state = UA_SUBSCRIPTIONSTATE_ENABLED);
or
    enabled = (sub->state == UA_SUBSCRIPTIONSTATE_ENABLED);

## Description

Fix a build failure with recent GCC versions when compiling with
`-Werror`.

The function `notifySubscription()` stores the address of a stack
variable (`enabled`) in a `UA_Variant` via `UA_Variant_setScalar()`.
Newer GCC versions detect this as a potential dangling pointer
(`-Wdangling-pointer`).

To avoid storing a pointer to a stack variable, the value is now taken
directly from the subscription object instead of using a temporary local
variable.

## Example compiler error

    error: storing the address of local variable 'enabled' in
    'createSubData[7].value.data' [-Werror=dangling-pointer]

## Changes

-   Remove the temporary stack variable `enabled`
-   Use the subscription state directly when populating the `UA_Variant`

### Before

``` c
UA_Boolean enabled = (sub->state = UA_SUBSCRIPTIONSTATE_ENABLED);

UA_Variant_setScalar(&createSubData[7].value, &enabled,
                     &UA_TYPES[UA_TYPES_BOOLEAN]);
```

### After

``` c
sub->enabled = (sub->state == UA_SUBSCRIPTIONSTATE_ENABLED);

UA_Variant_setScalar(&createSubData[7].value, &sub->enabled,
                     &UA_TYPES[UA_TYPES_BOOLEAN]);
```

## Environment

-   OS: Linux
-   Compiler: GCC 13 / GCC 14
-   Build flags: `-Wall -Wextra -Werror`