### PR TITLE
ci(coverity): add local static code analysis

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,6 +1,6 @@
 name: Coverity Scan
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   coverity:
@@ -58,7 +58,28 @@ jobs:
         cd build
         cov-build --dir cov-int make -j$(nproc)
 
+    - name: Coverity Analyze
+      run: |
+        export PATH=$PATH:/tmp/cov-analysis/bin
+        cd build
+        cov-analyze --dir cov-int --strip-path $GITHUB_WORKSPACE \
+          --all --enable-constraint-fpp --enable-fnptr --enable-virtual
+
+    - name: Coverity Format Errors
+      run: |
+        export PATH=$PATH:/tmp/cov-analysis/bin
+        cd build
+        cov-format-errors --dir cov-int --json-output-v7 coverity-errors.json
+        defect_count=$(jq '.issues | length' coverity-errors.json)
+        echo "Found ${defect_count} defect(s)"
+        if [ "${defect_count}" -gt 0 ]; then
+          cov-format-errors --dir cov-int --text-output coverity-errors.txt
+          cat coverity-errors.txt
+          exit 1
+        fi
+
     - name: Submit Build to Coverity Scan
+      if: github.event_name == 'push'
       run: |
         cd build
         tar -czf cov-int.tar.gz cov-int

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,6 +6,7 @@ jobs:
   coverity:
 
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ open62541 is licensed under the Mozilla Public License v2.0 (MPLv2). This allows
 The library is available in standard source and binary form. In addition, the single-file source distribution merges the entire library into a single .c and .h file that can be easily added to existing projects. Example server and client implementations can be found in the [/examples](examples/) directory or further down on this page.
 
 [![Open Hub Project Status](https://www.openhub.net/p/open62541/widgets/project_thin_badge.gif)](https://www.openhub.net/p/open62541/)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/open62541/open62541?branch=master&svg=true)](https://ci.appveyor.com/project/open62541/open62541/branch/master)
 [![Code Scanning](https://github.com/open62541/open62541/actions/workflows/codeql.yml/badge.svg)](https://github.com/open62541/open62541/actions/workflows/codeql.yml)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/open62541.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:open62541)
 [![codecov](https://codecov.io/gh/open62541/open62541/branch/master/graph/badge.svg)](https://codecov.io/gh/open62541/open62541)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The library is available in standard source and binary form. In addition, the si
 [![Code Scanning](https://github.com/open62541/open62541/actions/workflows/codeql.yml/badge.svg)](https://github.com/open62541/open62541/actions/workflows/codeql.yml)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/open62541.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:open62541)
 [![codecov](https://codecov.io/gh/open62541/open62541/branch/master/graph/badge.svg)](https://codecov.io/gh/open62541/open62541)
+[![Coverity Scan](https://scan.coverity.com/projects/12248/badge.svg)](https://scan.coverity.com/projects/open62541-open62541)
 
 ## Documentation and Support
 


### PR DESCRIPTION
To be able to check the results of a Coverity scan directly inside of the CI, the analysis is now done locally and the workflow fails when new defects are found. Uploading to the Coverity servers now only happens on push if the local analysis succeeds.