### PR TITLE
refactor(ci): use open62541 CI images and remove redundant deps

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -92,14 +92,14 @@ jobs:
             build:
               name: "Debug Build & Unit Tests (clang-18)"
               cmd_deps: sudo apt-get install -y -qq clang-18 clang-tools-18 && sudo sysctl -w vm.mmap_rnd_bits=28
-              cmd_action: CC=clang-18 CXX=clang++-18 unit_tests          
+              cmd_action: CC=clang-18 CXX=clang++-18 unit_tests
           
           # TPM Tool Builds for specific Ubuntu versions
           - os: ubuntu-20.04
             build:
               name: "TPM Tool Build ubuntu-20.04"
               cmd_deps: |
-                sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev
+                sudo apt-get install -y -qq acl autoconf autoconf-archive automake doxygen iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libsqlite3-dev libtool libyaml-dev procps python3-pip sqlite3 udev uthash-dev
                 cd ${HOME}
                 git clone https://github.com/tpm2-software/tpm2-tss.git
                 cd ${HOME}/tpm2-tss
@@ -127,7 +127,7 @@ jobs:
             build:
               name: "TPM Tool Build ubuntu-22.04"
               cmd_deps: |
-                sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev
+                sudo apt-get install -y -qq acl autoconf autoconf-archive automake doxygen iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libsqlite3-dev libtool libyaml-dev procps python3-pip sqlite3 udev uthash-dev
                 cd ${HOME}
                 git clone https://github.com/tpm2-software/tpm2-tss.git
                 cd ${HOME}/tpm2-tss
@@ -155,7 +155,7 @@ jobs:
             build:
               name: "TPM Tool Build ubuntu-24.04"
               cmd_deps: |
-                sudo apt-get install -y -qq acl autoconf autoconf-archive automake build-essential cmake doxygen gcc git iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libssl-dev libsqlite3-dev libtool libyaml-dev pkg-config procps python3-pip sqlite3 udev uthash-dev libltdl-dev python3-pyasn1-modules
+                sudo apt-get install -y -qq acl autoconf autoconf-archive automake doxygen iproute2 libcurl4-openssl-dev libjson-c-dev libcmocka0 libcmocka-dev libgcrypt20-dev libglib2.0-dev libini-config-dev libmbedtls-dev libsqlite3-dev libtool libyaml-dev procps python3-pip sqlite3 udev uthash-dev libltdl-dev python3-pyasn1-modules
                 cd ${HOME}
                 git clone https://github.com/tpm2-software/tpm2-tss.git
                 cd ${HOME}/tpm2-tss
@@ -221,7 +221,7 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.build.name }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/marwinglaser/ci:${{ matrix.os }}
+      image: ghcr.io/open62541/open62541-ci:${{ matrix.os }}
       options: --privileged
     services:
       mosquitto:
@@ -247,8 +247,7 @@ jobs:
         if: matrix.build.os == '' || matrix.build.os == matrix.os
         run: |
           sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential cmake libcap2-bin pkg-config libssl-dev python3-sphinx graphviz check libxml2-dev libpcap-dev
-          ${{ matrix.build.cmd_deps }}      
+          ${{ matrix.build.cmd_deps }}
       - name: ${{ matrix.build.name }}
         if: matrix.build.os == '' || matrix.build.os == matrix.os
         shell: bash


### PR DESCRIPTION
CI image creation has been moved to [open62541-ci](https://github.com/open62541/open62541-ci). Those now also include the installation of common build packages needed such that they do not need to be installed seperately on every run.