### PR TITLE
refactor(ci): make Coverity scan non-blocking and add scan badge to README

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,6 +6,7 @@ jobs:
   coverity:
 
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ open62541 is licensed under the Mozilla Public License v2.0 (MPLv2). This allows
 The library is available in standard source and binary form. In addition, the single-file source distribution merges the entire library into a single .c and .h file that can be easily added to existing projects. Example server and client implementations can be found in the [/examples](examples/) directory or further down on this page.
 
 [![Open Hub Project Status](https://www.openhub.net/p/open62541/widgets/project_thin_badge.gif)](https://www.openhub.net/p/open62541/)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/open62541/open62541?branch=master&svg=true)](https://ci.appveyor.com/project/open62541/open62541/branch/master)
 [![Code Scanning](https://github.com/open62541/open62541/actions/workflows/codeql.yml/badge.svg)](https://github.com/open62541/open62541/actions/workflows/codeql.yml)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/open62541.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:open62541)
 [![codecov](https://codecov.io/gh/open62541/open62541/branch/master/graph/badge.svg)](https://codecov.io/gh/open62541/open62541)
+[![Coverity Scan](https://scan.coverity.com/projects/12248/badge.svg)](https://scan.coverity.com/projects/open62541-open62541)
 
 ## Documentation and Support
 


### PR DESCRIPTION
The Coverity scan is now a non-blocking workflow. A badge showing the number of newly found defects is added to the README while the badge for the build status on AppVeyor was removed since it's not used anymore.