### PR TITLE
Fix inverted condition in UA_Client_getNamespaceUri

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -1219,7 +1219,7 @@ UA_Client_getNamespaceUri(UA_Client *client, UA_UInt16 index,
                           UA_String *nsUri) {
     lockClient(client);
     UA_StatusCode res = UA_STATUSCODE_GOOD;
-    if(index > client->namespacesSize)
+    if(index < client->namespacesSize)
         res = UA_String_copy(&client->namespaces[index], nsUri);
     else
         res = UA_STATUSCODE_BADNOTFOUND;


### PR DESCRIPTION
## Summary

- The condition in `UA_Client_getNamespaceUri` is inverted (`>` instead of `<`), causing `UA_STATUSCODE_BADNOTFOUND` for valid indices and out-of-bounds memory access for invalid ones
- Same fix as #7850, retargeted to `1.5` per maintainer request

Supersedes #7850

## Test plan

- Valid namespace index (e.g. 0) should return the namespace URI
- Invalid namespace index (e.g. 9999) should return `UA_STATUSCODE_BADNOTFOUND` without memory corruption