### PR TITLE
fix(tests): Remove Null pointer dereference in `client.c`

### DIFF
--- a/tests/nodeset-loader/client.c
+++ b/tests/nodeset-loader/client.c
@@ -48,7 +48,6 @@ int main(int argc, char *argv[]) {
         nodeids = fopen(argv[i], "r");
         if(nodeids == NULL) {
             printf("Failed to open file: %s.\n", argv[i]);
-            fclose(nodeids);
             goto failure;
         }
 


### PR DESCRIPTION
There is no need to run `fclose` at this point.

Minimal example: https://godbolt.org/z/zbs4jE63o