### PR TITLE
fix(eventloop) modulo-by-zero in findTimer2Batch (fixes #7859)

### DIFF
--- a/arch/common/timer.c
+++ b/arch/common/timer.c
@@ -60,6 +60,11 @@ findTimer2Batch(void *context, UA_TimerEntry *compare) {
     if(compare->nextTime < earliest || compare->nextTime > latest)
         return NULL;
 
+    /* One-shot timers have interval == 0.
+     * They cannot participate in the modulo-based batching check. */
+    if(te->interval == 0 || compare->interval == 0)
+        return NULL;
+
     /* Check if one interval is a multiple of the other */
     if(te->interval < compare->interval && compare->interval % te->interval != 0)
         return NULL;


### PR DESCRIPTION
One-shot timers in open62541 are created with interval == 0 (e.g. via UA_Server_addTimedCallback with UA_TIMERPOLICY_ONCE).

findTimer2Batch() performs modulo-based checks to determine whether two timer intervals are multiples of each other. When a one-shot timer (interval == 0) is compared against a periodic timer, this can lead to a modulo-by-zero in the following expression:

    te->interval % compare->interval

This patch explicitly excludes timers with interval == 0 from the batching logic before performing modulo operations.

This is consistent with the intended semantics since batching only applies to periodic timers and does not make sense for one-shot timers.

Fixes #7859.

This fix should also be backported to the 1.4 branch in ua_timer.c file.