### PR TITLE
WIP Add regression tests for NodeSet datatype loading-order fix (issue 7784)

### DIFF
--- a/tests/nodeset-loader/CMakeLists.txt
+++ b/tests/nodeset-loader/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_compile_definitions(OPEN62541_NODESET_DIR="${UA_NODESET_DIR}/")
+add_compile_definitions(OPEN62541_NODESET_LOADER_TEST_DIR="${CMAKE_CURRENT_SOURCE_DIR}/nodesets/")
 ua_add_test(check_nodeset_loader_di.c)
 ua_add_test(check_nodeset_loader_autoid.c)
+ua_add_test(check_nodeset_loader_issue_7784.c)
 ua_add_test(check_nodeset_loader_plc.c)
 ua_add_test(check_nodeset_loader_input.c)
 

--- a/tests/nodeset-loader/check_nodeset_loader_issue_7784.c
+++ b/tests/nodeset-loader/check_nodeset_loader_issue_7784.c
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/plugin/nodesetloader.h>
+
+#include <check.h>
+#include <stdlib.h>
+
+#include "testing_clock.h"
+#include "test_helpers.h"
+
+UA_Server *server = NULL;
+
+static void
+setup(void) {
+    server = UA_Server_newForUnitTest();
+    ck_assert(server != NULL);
+    UA_Server_run_startup(server);
+}
+
+static void
+teardown(void) {
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+/*
+ * Repro for issue 7784:
+ * TypeA has a member of custom TypeB, but TypeA appears before TypeB in the
+ * nodeset XML.
+ */
+START_TEST(Server_7784_wrong_order_simple) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_LOADER_TEST_DIR "issue_7784_minimal.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+
+    size_t nsIndex = 0;
+    retVal = UA_Server_getNamespaceByName(server,
+        UA_STRING("http://open62541.org/test/issue7784/"), &nsIndex);
+    ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
+
+    /* TypeB: simple struct - must be found (ns=<nsIndex>;i=3002) */
+    UA_NodeId typeBId = UA_NODEID_NUMERIC((UA_UInt16)nsIndex, 3002);
+    const UA_DataType *typeB = UA_Server_findDataType(server, &typeBId);
+    ck_assert_msg(typeB != NULL, "TypeB (ns=X;i=3002) should be found");
+
+    /* TypeA: struct with TypeB member, defined before TypeB in XML (ns=<nsIndex>;i=3001) */
+    UA_NodeId typeAId = UA_NODEID_NUMERIC((UA_UInt16)nsIndex, 3001);
+    const UA_DataType *typeA = UA_Server_findDataType(server, &typeAId);
+    ck_assert_msg(typeA != NULL, "TypeA (ns=X;i=3001) should be found");
+}
+END_TEST
+
+START_TEST(Server_7784_wrong_order_complex) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+
+    retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "AutoID/Opc.Ua.AutoID.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+
+    size_t nsIndex = 0;
+    retVal = UA_Server_getNamespaceByName(server,
+        UA_STRING("http://opcfoundation.org/UA/AutoID/"), &nsIndex);
+    ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
+
+    UA_NodeId dataTypeId = UA_NODEID_NUMERIC(nsIndex, 3020);
+    const UA_DataType *dt1 = UA_Server_findDataType(server, &dataTypeId);
+    ck_assert_msg(dt1 != NULL,
+                  "Expected AutoID datatype ns=X;i=3020 to be present");
+
+    dataTypeId = UA_NODEID_NUMERIC(nsIndex, 3024);
+    const UA_DataType *dt = UA_Server_findDataType(server, &dataTypeId);
+    ck_assert_msg(dt != NULL,
+                  "Expected AutoID datatype ns=X;i=3024 to be present");
+}
+END_TEST
+
+static Suite *
+testSuite_Client(void) {
+    Suite *s = suite_create("Server Nodeset Loader");
+    TCase *tc_server = tcase_create("Issue 7784");
+    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_7784_wrong_order_simple);
+    tcase_add_test(tc_server, Server_7784_wrong_order_complex);
+    suite_add_tcase(s, tc_server);
+    return s;
+}
+
+int
+main(void) {
+    Suite *s = testSuite_Client();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
+++ b/tests/nodeset-loader/check_nodeset_loader_ua_nodeset.c
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  *    Copyright 2026 (c) o6 Automation GmbH (Author: Andreas Ebner)
+ *    Copyright 2026 (c) SICK AG (Author: Joerg Fischer)
  */
 
 /* Test case for all standardized companion nodesets. You can
@@ -10,35 +11,6 @@
  *      - branch: latest
  *      - commit: 54e3513
  * 
- * Currently this test case is missing the following UA-Nodesets:
- *    * NodesetLoader related issues:
- *      - ${OPEN62541_NODESET_DIR}AML/Opc.Ua.AMLLibraries.NodeSet2.xml
- *      - ${OPEN62541_NODESET_DIR}ISA95-JOBCONTROL/opc.ua.isa95-jobcontrol.nodeset2.xml
- *      - ${OPEN62541_NODESET_DIR}TMC/Opc.Ua.TMC.NodeSet2.xml
- *
- *    * Memory leak issues (libXML2 library related):
- *      - ${OPEN62541_NODESET_DIR}CNC/Opc.Ua.CNC.NodeSet.xml
- *      - ${OPEN62541_NODESET_DIR}IJT/Tightening/Opc.Ua.Ijt.Tightening.NodeSet2.xml
- *      - $(OPEN62541_NODESET_DIR)MachineVision/Opc.Ua.MachineVision.NodeSet2.xml
- *      - $(OPEN62541_NODESET_DIR)Mining/General/1.0.0/Opc.Ua.Mining.General.NodeSet2.xml
- *          - Dependent Nodesets:
- *              * $(OPEN62541_NODESET_DIR)Mining/DevelopmentSupport/Dozer/1.0.0/Opc.Ua.Mining.DevelopmentSupport.Dozer.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/DevelopmentSupport/RoofSupportSystem/1.0.0/Opc.Ua.Mining.DevelopmentSupport.RoofSupportSystem.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/Extraction/ShearerLoader/1.0.0/Opc.Ua.Mining.Extraction.ShearerLoader.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/Loading/General/1.0.0/Opc.Ua.Mining.Loading.General.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/Loading/HydraulicExcavator/1.0.0/Opc.Ua.Mining.Loading.HydraulicExcavator.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/MineralProcessing/RockCrusher/1.0.0/Opc.Ua.Mining.MineralProcessing.RockCrusher.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/PELOServices/FaceAlignmentSystem/1.0.0/Opc.Ua.Mining.PELOServices.FaceAlignmentSystem.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/PELOServices/General/1.0.0/Opc.Ua.Mining.PELOServices.General.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/TransportDumping/ArmouredFaceConveyor/1.0.0/Opc.Ua.Mining.TransportDumping.ArmouredFaceConveyor.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/TransportDumping/General/1.0.0/Opc.Ua.Mining.TransportDumping.General.NodeSet2.xml
- *              * $(OPEN62541_NODESET_DIR)Mining/TransportDumping/RearDumpTruck/1.0.0/Opc.Ua.Mining.TransportDumping.RearDumpTruck.NodeSet2.xml
- *      - $(OPEN62541_NODESET_DIR)PADIM/Opc.Ua.IRDI.NodeSet2.xml
- *          - Dependent Nodesets:
- *              * $(OPEN62541_NODESET_DIR)PADIM/Opc.Ua.PADIM.NodeSet2.xml
- *      - $(OPEN62541_NODESET_DIR)POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml
- *      - $(OPEN62541_NODESET_DIR)Pumps/Opc.Ua.Pumps.NodeSet2.xml
- *      - $(OPEN62541_NODESET_DIR)Scales/Opc.Ua.Scales.NodeSet2.xml
  */
 
 #include <open62541/server.h>
@@ -232,12 +204,12 @@ START_TEST(Server_loadMachineToolNodeset) {
 }
 END_TEST
 
-// START_TEST(Server_loadMDISNodeset) {
-//     UA_StatusCode retVal = UA_Server_loadNodeset(server,
-//         OPEN62541_NODESET_DIR "MDIS/Opc.MDIS.NodeSet2.xml", NULL);
-//     ck_assert(UA_StatusCode_isGood(retVal));
-// }
-// END_TEST
+START_TEST(Server_loadMDISNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "MDIS/Opc.MDIS.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
 
 START_TEST(Server_loadMiningDevelopmentSupportGeneralNodeset) {
     UA_StatusCode retVal = UA_Server_loadNodeset(server,
@@ -662,6 +634,190 @@ END_TEST
 START_TEST(Server_loadWoodworkingNodeset) {
     UA_StatusCode retVal = UA_Server_loadNodeset(server,
         OPEN62541_NODESET_DIR "Woodworking/Opc.Ua.Woodworking.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadAMLLibrariesNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "AML/Opc.Ua.AMLLibraries.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadISA95JobControlNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "ISA95-JOBCONTROL/opc.ua.isa95-jobcontrol.nodeset2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadTMCNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "TMC/Opc.Ua.TMC.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadCNCNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "CNC/Opc.Ua.CNC.NodeSet.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadIJTBaseNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "IJT/Base/Opc.Ua.Ijt.Base.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadIJTTighteningNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "IJT/Tightening/Opc.Ua.Ijt.Tightening.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMachineryResultNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Machinery/Result/Opc.Ua.Machinery_Result.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMachineVisionNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "MachineVision/Opc.Ua.MachineVision.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningGeneralNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/General/1.0.0/Opc.Ua.Mining.General.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningDevelopmentSupportDozerNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/DevelopmentSupport/Dozer/1.0.0/Opc.Ua.Mining.DevelopmentSupport.Dozer.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningDevelopmentSupportRoofSupportSystemNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/DevelopmentSupport/RoofSupportSystem/1.0.0/Opc.Ua.Mining.DevelopmentSupport.RoofSupportSystem.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningExtractionShearerLoaderNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/Extraction/ShearerLoader/1.0.0/Opc.Ua.Mining.Extraction.ShearerLoader.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningLoadingGeneralNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/Loading/General/1.0.0/Opc.Ua.Mining.Loading.General.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningLoadingHydraulicExcavatorNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/Loading/HydraulicExcavator/1.0.0/Opc.Ua.Mining.Loading.HydraulicExcavator.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningMineralProcessingRockCrusherNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/MineralProcessing/RockCrusher/1.0.0/Opc.Ua.Mining.MineralProcessing.RockCrusher.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningPELOServicesFaceAlignmentSystemNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/PELOServices/FaceAlignmentSystem/1.0.0/Opc.Ua.Mining.PELOServices.FaceAlignmentSystem.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningPELOServicesGeneralNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/PELOServices/General/1.0.0/Opc.Ua.Mining.PELOServices.General.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningTransportDumpingArmouredFaceConveyorNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/TransportDumping/ArmouredFaceConveyor/1.0.0/Opc.Ua.Mining.TransportDumping.ArmouredFaceConveyor.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningTransportDumpingGeneralNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/TransportDumping/General/1.0.0/Opc.Ua.Mining.TransportDumping.General.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadMiningTransportDumpingRearDumpTruckNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR
+        "Mining/TransportDumping/RearDumpTruck/1.0.0/Opc.Ua.Mining.TransportDumping.RearDumpTruck.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadPADIMNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "PADIM/Opc.Ua.PADIM.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadPOWERLINKNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "POWERLINK/Opc.Ua.POWERLINK.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadPumpsNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Pumps/Opc.Ua.Pumps.NodeSet2.xml", NULL);
+    ck_assert(UA_StatusCode_isGood(retVal));
+}
+END_TEST
+
+START_TEST(Server_loadScalesNodeset) {
+    UA_StatusCode retVal = UA_Server_loadNodeset(server,
+        OPEN62541_NODESET_DIR "Scales/Opc.Ua.Scales.NodeSet2.xml", NULL);
     ck_assert(UA_StatusCode_isGood(retVal));
 }
 END_TEST
@@ -1266,6 +1422,213 @@ static Suite* testSuite_Client(void) {
         tcase_add_test(tc_server, Server_loadDINodeset);
         tcase_add_test(tc_server, Server_loadMachineryNodeset);
         tcase_add_test(tc_server, Server_loadWoodworkingNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load AMLLibraries nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadAMLBaseTypesNodeset);
+        tcase_add_test(tc_server, Server_loadAMLLibrariesNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load ISA95 JobControl nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadISA95JobControlNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load TMC nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPackMLNodeset);
+        tcase_add_test(tc_server, Server_loadTMCNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load CNC nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadCNCNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IJT Tightening nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadAMBNodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMachineryResultNodeset);
+        tcase_add_test(tc_server, Server_loadIJTBaseNodeset);
+        tcase_add_test(tc_server, Server_loadIJTTighteningNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MachineVision nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMachineVisionNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining General nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining DevelopmentSupport Dozer nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningDevelopmentSupportDozerNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining DevelopmentSupport RoofSupportSystem nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningDevelopmentSupportRoofSupportSystemNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining Extraction ShearerLoader nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningExtractionShearerLoaderNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining Loading General nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningLoadingGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining Loading HydraulicExcavator nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningLoadingGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningLoadingHydraulicExcavatorNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining MineralProcessing RockCrusher nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningMineralProcessingRockCrusherNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining PELOServices FaceAlignmentSystem nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningPELOServicesFaceAlignmentSystemNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining PELOServices General nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMiningPELOServicesGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining TransportDumping ArmouredFaceConveyor nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningTransportDumpingArmouredFaceConveyorNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining TransportDumping General nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningTransportDumpingGeneralNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Mining TransportDumping RearDumpTruck nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadMiningGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningTransportDumpingGeneralNodeset);
+        tcase_add_test(tc_server, Server_loadMiningTransportDumpingRearDumpTruckNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load IRDI nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadIrdiNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load PADIM nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIrdiNodeset);
+        tcase_add_test(tc_server, Server_loadPADIMNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load POWERLINK nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadPOWERLINKNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Pumps nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPumpsNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load Scales nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadDINodeset);
+        tcase_add_test(tc_server, Server_loadIANodeset);
+        tcase_add_test(tc_server, Server_loadMachineryNodeset);
+        tcase_add_test(tc_server, Server_loadPackMLNodeset);
+        tcase_add_test(tc_server, Server_loadScalesNodeset);
+        suite_add_tcase(s, tc_server);
+    }
+    {
+        TCase *tc_server = tcase_create("Server load MDIS nodeset");
+        tcase_add_unchecked_fixture(tc_server, setup, teardown);
+        tcase_add_test(tc_server, Server_loadMDISNodeset);
         suite_add_tcase(s, tc_server);
     }
     return s;

--- a/tests/nodeset-loader/nodesets/issue_7784_minimal.xml
+++ b/tests/nodeset-loader/nodesets/issue_7784_minimal.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
+           xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://open62541.org/test/issue7784/</Uri>
+    </NamespaceUris>
+    <Aliases>
+        <Alias Alias="Int32">i=6</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasEncoding">i=38</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+    </Aliases>
+
+    <!-- TypeA depends on TypeB as a member, but is defined first. -->
+    <UADataType NodeId="ns=1;i=3001" BrowseName="1:TypeA">
+        <DisplayName>TypeA</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5001</Reference>
+        </References>
+        <Definition Name="1:TypeA">
+            <Field DataType="ns=1;i=3002" Name="bMember"/>
+        </Definition>
+    </UADataType>
+    <UAObject NodeId="ns=1;i=5001" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=3001</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+
+    <!-- TypeB is a simple struct with one builtin field.
+         It is intentionally placed AFTER TypeA to reproduce the bug. -->
+    <UADataType NodeId="ns=1;i=3002" BrowseName="1:TypeB">
+        <DisplayName>TypeB</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5002</Reference>
+        </References>
+        <Definition Name="1:TypeB">
+            <Field DataType="Int32" Name="value"/>
+        </Definition>
+    </UADataType>
+    <UAObject NodeId="ns=1;i=5002" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasEncoding" IsForward="false">ns=1;i=3002</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+
+</UANodeSet>
+


### PR DESCRIPTION
- There is a NodeSet loading-order issue in the NodeSet Loader dependency that  can result in missing datatypes (see open62541 [issue 7784](https://github.com/open62541/open62541/issues/7784)).
- I submitted a corresponding fix to open62541/open62541-nodeset-loader  ([PR 293](https://github.com/open62541/open62541-nodeset-loader/pull/293)).
- This PR adds integration-level regression coverage so the fix is validated not  only in the dependency itself, but also in open62541 integration scenarios.

What I did:
- Added two test cases: one simple case covering the minimal reproduction pattern  from [issue 7784](https://github.com/open62541/open62541/issues/7784), and one  complex case loading the AutoID Companion Specification.
- Ran tests locally: all passed, except `48 - check_eventloop_eth` and  `103 - check_pubsub_connection_ethernet`, which appear unrelated to the NodeSet Loader changes (env: gcc 13, Linux, x86-64).

Until the NodeSet Loader [PR 293](https://github.com/open62541/open62541-nodeset-loader/pull/293) is merged, I would like to keep this PR in draft state and request review and merge afterward.