### PR TITLE
feat(pubsub) warn when structure fields with nested strings use RawData encoding

### DIFF
--- a/src/pubsub/ua_pubsub_internal.h
+++ b/src/pubsub/ua_pubsub_internal.h
@@ -734,6 +734,29 @@ addSecurityGroupRepresentation(UA_Server *server, UA_SecurityGroup *securityGrou
 
 #endif /* UA_ENABLE_PUBSUB_INFORMATIONMODEL */
 
+/* Recursively check whether a data type contains String or ByteString
+ * members. Used to warn about RawData encoding where maxStringLength
+ * padding is not applied for strings inside structures. */
+static UA_INLINE UA_Boolean
+typeContainsString(const UA_DataType *type, size_t depth) {
+    if(!type || depth > 10)
+        return false;
+    if(type->typeKind == UA_DATATYPEKIND_STRING ||
+       type->typeKind == UA_DATATYPEKIND_BYTESTRING)
+        return true;
+    if(type->typeKind != UA_DATATYPEKIND_STRUCTURE &&
+       type->typeKind != UA_DATATYPEKIND_OPTSTRUCT &&
+       type->typeKind != UA_DATATYPEKIND_UNION)
+        return false;
+    if(type->pointerFree)
+        return false;
+    for(size_t i = 0; i < type->membersSize; i++) {
+        if(typeContainsString(type->members[i].memberType, depth + 1))
+            return true;
+    }
+    return false;
+}
+
 #endif /* UA_ENABLE_PUBSUB */
 
 _UA_END_DECLS

--- a/src/pubsub/ua_pubsub_reader.c
+++ b/src/pubsub/ua_pubsub_reader.c
@@ -132,6 +132,25 @@ validateDSRConfig(UA_PubSubManager *psm, UA_DataSetReader *dsr) {
                                     "set in MetaData when using RawData field encoding.");
                 return UA_STATUSCODE_BADCONFIGURATIONERROR;
             }
+
+            /* Warn if the field is a structure type that contains
+             * String/ByteString members. MaxStringLength padding is not
+             * yet applied for strings nested inside structures. */
+            const UA_DataType *type =
+                UA_findDataTypeWithCustom(&field->dataType,
+                                          psm->sc.server->config.customDataTypes);
+            if(type &&
+               (type->typeKind == UA_DATATYPEKIND_STRUCTURE ||
+                type->typeKind == UA_DATATYPEKIND_UNION ||
+                type->typeKind == UA_DATATYPEKIND_OPTSTRUCT) &&
+               typeContainsString(type, 0)) {
+                UA_LOG_WARNING_PUBSUB(psm->logging, dsr,
+                                      "Field %.*s uses a structure type that "
+                                      "contains String/ByteString members. "
+                                      "MaxStringLength padding is not applied for "
+                                      "strings inside structures with RawData encoding.",
+                                      (int)field->name.length, field->name.data);
+            }
         }
     }
     return UA_STATUSCODE_GOOD;

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -211,6 +211,32 @@ UA_DataSetWriter_create(UA_PubSubManager *psm,
         /* Save the current version of the connected PublishedDataSet */
         dsw->connectedDataSetVersion = pds->dataSetMetaData.configurationVersion;
 
+        /* Warn about structures containing strings with RawData encoding.
+         * MaxStringLength padding is only applied for top-level
+         * String/ByteString fields, not for strings nested inside
+         * structures. */
+        if(dswConfig->dataSetFieldContentMask &
+           (u64)UA_DATASETFIELDCONTENTMASK_RAWDATA) {
+            for(size_t i = 0; i < pds->dataSetMetaData.fieldsSize; i++) {
+                const UA_FieldMetaData *fmd = &pds->dataSetMetaData.fields[i];
+                const UA_DataType *type =
+                    UA_findDataTypeWithCustom(&fmd->dataType,
+                                              psm->sc.server->config.customDataTypes);
+                if(type &&
+                   (type->typeKind == UA_DATATYPEKIND_STRUCTURE ||
+                    type->typeKind == UA_DATATYPEKIND_UNION ||
+                    type->typeKind == UA_DATATYPEKIND_OPTSTRUCT) &&
+                   typeContainsString(type, 0)) {
+                    UA_LOG_WARNING_PUBSUB(psm->logging, wg,
+                                          "DataSetWriter field %.*s uses a structure "
+                                          "type that contains String/ByteString members. "
+                                          "MaxStringLength padding is not applied for "
+                                          "strings inside structures with RawData encoding.",
+                                          (int)fmd->name.length, fmd->name.data);
+                }
+            }
+        }
+
         if(psm->sc.server->config.pubSubConfig.enableDeltaFrames) {
             /* Initialize the queue for the last values */
             if(pds->fieldSize > 0) {


### PR DESCRIPTION
This PR introduces a warning when byte strings or regular strings are used inside nested structures with PubSub. Our current implementation only supports the maxStringLength attribute for direct fields of a DatasetMessage. Using string fields deeper in the hierarchy has long been unsupported, and this change finally adds a clear warning to help developers catch these cases early.