### PR TITLE
fix(arch) : Timer batching performance improvement for large numbers …

### DIFF
--- a/arch/common/timer.c
+++ b/arch/common/timer.c
@@ -49,49 +49,37 @@ UA_Timer_init(UA_Timer *t) {
     UA_LOCK_INIT(&t->timerMutex);
 }
 
-/* Global variables, only used behind the mutex */
-static UA_DateTime earliest, latest, adjustedNextTime;
-
-static void *
-findTimer2Batch(void *context, UA_TimerEntry *compare) {
-    UA_TimerEntry *te = (UA_TimerEntry*)context;
-
-    /* NextTime deviation within interval? */
-    if(compare->nextTime < earliest || compare->nextTime > latest)
-        return NULL;
-
-    /* One-shot timers have interval == 0.
-     * They cannot participate in the modulo-based batching check. */
-    if(te->interval == 0 || compare->interval == 0)
-        return NULL;
-
-    /* Check if one interval is a multiple of the other */
-    if(te->interval < compare->interval && compare->interval % te->interval != 0)
-        return NULL;
-    if(te->interval > compare->interval && te->interval % compare->interval != 0)
-        return NULL;
-
-    adjustedNextTime = compare->nextTime; /* Candidate found */
-
-    /* Abort when a perfect match is found */
-    return (te->interval == compare->interval) ? te : NULL;
-}
-
 /* Adjust the nextTime to batch cyclic callbacks. Look in an interval around the
  * original nextTime. Deviate from the original nextTime by at most 1/4 of the
  * interval and at most by 1s. */
 static void
 batchTimerEntry(UA_Timer *t, UA_TimerEntry *te) {
+    (void)t;
+    
     if(te->timerPolicy != UA_TIMERPOLICY_CURRENTTIME)
         return;
     UA_DateTime deviate = te->interval / 4;
+
+    if(deviate <= 0)
+        return;
     if(deviate > UA_DATETIME_SEC)
         deviate = UA_DATETIME_SEC;
-    earliest = te->nextTime - deviate;
-    latest = te->nextTime + deviate;
-    adjustedNextTime = te->nextTime;
-    ZIP_ITER(UA_TimerIdTree, &t->idTree, findTimer2Batch, te);
-    te->nextTime = adjustedNextTime;
+    /* Deterministic O(1) batching:
+     * round nextTime to the nearest bucket boundary, with a maximum
+     * adjustment of +/- deviate. This preserves the idea of batching
+     * nearby timers without scanning all existing timers. */
+    UA_DateTime quantum = deviate * 2;
+    if(quantum <= 0)
+        return;
+
+    UA_DateTime remainder = te->nextTime % quantum;
+    if(remainder < 0)
+        remainder += quantum;
+
+    if(remainder <= deviate)
+        te->nextTime -= remainder;
+    else
+        te->nextTime += (quantum - remainder);
 }
 
 /* Adding repeated callbacks: Add an entry with the "nextTime" timestamp in the


### PR DESCRIPTION
…of monitored items

# Timer batching performance improvement for large numbers of monitored items

## Context

While testing open62541 with a large number of monitored items, we observed significant delays when creating subscriptions containing many monitored items.

Test setup:

Server: - open62541 v1.5 - \~50,000 variables

Client: - UaExpert

Scenario: - The client creates a subscription - The client creates \~50,000 monitored items - Sampling interval: 250 ms

With the current implementation, the `CreateMonitoredItems` call took **more than 20 seconds** to complete.

This delay happens entirely on the server side during timer registration.

------------------------------------------------------------------------

# Root cause

The issue originates in `UA_Timer_add()` during the batching logic:

    batchTimerEntry()

The current implementation attempts to batch timers by searching for an existing timer with a similar `nextTime`.

To do this it iterates over the entire timer id tree:

    ZIP_ITER(UA_TimerIdTree, &t->idTree, findTimer2Batch, te);

This means that **every time a timer is added**, the server scans all previously registered timers.

When many timers are added during a large `CreateMonitoredItems` operation, the complexity becomes approximately:

    O(n²)

because: - N timers are added - each insertion scans up to N existing timers.

This explains the large delays observed when creating tens of thousands of monitored items.

------------------------------------------------------------------------

# Proposed solution

Instead of scanning all existing timers, this patch replaces the batching logic with a **constant-time quantization approach**.

The idea is:

1.  Compute the allowed batching deviation from the sampling interval
2.  Round `nextTime` to the nearest bucket boundary within that deviation window

This preserves the intent of batching timers that fire close together while avoiding any global search through existing timers.

The algorithm therefore becomes **constant time per timer insertion**.

------------------------------------------------------------------------

# Results

Using the same test scenario:

Server: - open62541 v1.5 - \~50,000 variables

Client: - UaExpert

Operation: - Create \~50,000 monitored items

Observed results:

  Version                  CreateMonitoredItems time
  ------------------------ ---------------------------
  Current implementation   \> 20 seconds
  With this patch          \~0.1 seconds

The monitored item creation time becomes essentially linear and the timer registration overhead becomes negligible.

------------------------------------------------------------------------

# Behavioural impact

This change:

-   removes a quadratic performance bottleneck
-   keeps timer batching behaviour
-   significantly improves scalability when large numbers of monitored items are created

The batching strategy is slightly different, but still guarantees that timers with similar execution times will be grouped within the allowed deviation window.

------------------------------------------------------------------------

# Conclusion

The previous implementation scales poorly for large monitored item counts due to a global timer scan.

Replacing the scan with deterministic time quantization removes the bottleneck while preserving batching behaviour and restoring predictable performance for large subscriptions.