### PR TITLE
perf(timer): improve batching scalability for large numbers of timers

### DIFF
--- a/arch/common/timer.c
+++ b/arch/common/timer.c
@@ -54,14 +54,12 @@ static UA_DateTime earliest, latest, adjustedNextTime;
 
 static void *
 findTimer2Batch(void *context, UA_TimerEntry *compare) {
-    UA_TimerEntry *te = (UA_TimerEntry*)context;
-
-    /* NextTime deviation within interval? */
-    if(compare->nextTime < earliest || compare->nextTime > latest)
-        return NULL;
+    /* Invariance of ZIP_ITER_KEY  */
+    UA_assert(compare->nextTime >= earliest && compare->nextTime <= latest);
 
     /* One-shot timers have interval == 0.
      * They cannot participate in the modulo-based batching check. */
+    UA_TimerEntry *te = (UA_TimerEntry*)context;
     if(te->interval == 0 || compare->interval == 0)
         return NULL;
 


### PR DESCRIPTION
## Problem

When creating a large number of cyclic timers, the current batching logic scans all existing timers to find a batching candidate.

With many timers, this becomes very expensive and significantly slows down operations such as creating large numbers of monitored items.

## Solution

Replace the global scan with a bounded search in the time-ordered timer tree.

The new implementation keeps the existing batching semantics:
- only batch within the allowed time window
- only batch compatible intervals
- prefer exact interval matches

This improves scalability while preserving timer behavior.

## Result

Creating large numbers of monitored items becomes much faster, while the existing batching behavior is preserved.