### PR TITLE
Fix remote datatype dependency resolution in UA_Client_getRemoteDataTypes

### DIFF
--- a/src/client/ua_client_util.c
+++ b/src/client/ua_client_util.c
@@ -144,8 +144,11 @@ getRemoteDataTypes(UA_Client *client, UA_ReadRequest *req,
         UA_ExtensionObject eo;
         UA_ExtensionObject_setValue(&eo, &descr, &UA_TYPES[UA_TYPES_STRUCTUREDESCRIPTION]);
 
+        UA_DataTypeArray lookupTypes = *dta;
+        lookupTypes.next = client->config.customDataTypes;
+
         res = UA_DataType_fromDescription(&dta->types[dta->typesSize], &eo,
-                                                   client->config.customDataTypes);
+                                          &lookupTypes);
         if(res != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                          "Could not add the DataType %Q (%N) with status code %s",

--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -61,6 +61,12 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
             ${UA_TYPES_TESTS_PLC_SOURCES})
     add_dependencies(check_client_nsMapping open62541-generator-ns-tests-plc)
 
+    ua_add_test(check_client_get_remote_datatypes.c EXTRASOURCES
+            ${UA_NODESET_TESTS_DI_SOURCES}
+            ${UA_TYPES_TESTS_DI_SOURCES})
+    add_dependencies(check_client_get_remote_datatypes open62541-generator-ns-tests-di)
+
+
     # generate AutoID namespace which is using DI (test e.g. for structures with optional fields)
     ua_generate_nodeset_and_datatypes(
             NAME "tests-autoid"

--- a/tests/nodeset-compiler/check_client_get_remote_datatypes.c
+++ b/tests/nodeset-compiler/check_client_get_remote_datatypes.c
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server_config_default.h>
+#include "tests/namespace_tests_di_generated.h"
+
+#include <check.h>
+#include <stdlib.h>
+
+#include "test_helpers.h"
+#include "thread_wrapper.h"
+
+static UA_Server *server;
+static UA_Client *client;
+static UA_Boolean running;
+static THREAD_HANDLE server_thread;
+
+THREAD_CALLBACK(serverloop) {
+    while(running)
+        UA_Server_run_iterate(server, true);
+    return 0;
+}
+
+static void
+setup(void) {
+    running = true;
+    server = UA_Server_newForUnitTest();
+    ck_assert(server != NULL);
+
+    // Add DI datatypes to server
+    const UA_StatusCode resDi = namespace_tests_di_generated(server);
+    ck_assert_uint_eq(resDi, UA_STATUSCODE_GOOD);
+    size_t diIndex = 0;
+    const UA_StatusCode resIdx = UA_Server_getNamespaceByName(server,
+        UA_STRING("http://opcfoundation.org/UA/DI/"), &diIndex);
+    ck_assert_uint_eq(resIdx, UA_STATUSCODE_GOOD);
+    // Verify that n=resIdx;i=15889 (TransferResultDataDataType) exists on server
+    UA_NodeId dataTypeId = UA_NODEID_NUMERIC(diIndex, 15889);
+    const UA_DataType* dt = UA_Server_findDataType(server, &dataTypeId);
+    ck_assert(NULL != dt);
+
+    UA_Server_run_startup(server);
+    THREAD_CREATE(server_thread, serverloop);
+    client = UA_Client_newForUnitTest();
+    ck_assert(NULL != client);
+    const UA_StatusCode resConnect = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(resConnect, UA_STATUSCODE_GOOD);
+}
+
+static void
+teardown(void) {
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+    running = false;
+    THREAD_JOIN(server_thread);
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+}
+
+START_TEST(GetRemoteDatatypes_di) {
+    // Fetch all remote datatypes
+    UA_DataTypeArray* array = NULL;
+    const UA_StatusCode resGet = UA_Client_getRemoteDataTypes(client, 0, NULL, &array);
+    ck_assert_uint_eq(resGet, UA_STATUSCODE_GOOD);
+    ck_assert(NULL != array);
+    ck_assert(NULL != UA_Client_getConfig(client));
+    UA_Client_getConfig(client)->customDataTypes = array;
+
+    UA_UInt16 diIdx = 0;
+    const UA_StatusCode resIdx = UA_Client_getNamespaceIndex(client,
+        UA_STRING("http://opcfoundation.org/UA/DI/"), &diIdx);
+    ck_assert_uint_eq(resIdx, UA_STATUSCODE_GOOD);
+
+    // Client should now have ns=idx,
+    const UA_NodeId dataTypeId = UA_NODEID_NUMERIC(diIdx, 15889);
+    const UA_DataType* dt = UA_Client_findDataType(client, &dataTypeId);
+    ck_assert(NULL != dt);
+}
+END_TEST
+
+static Suite*
+testSuite_GetRemoteDatatypes(void) {
+    Suite *s = suite_create("GetRemoteDatatypes");
+    TCase *tc = tcase_create("Basic");
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, GetRemoteDatatypes_di);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int
+main(void) {
+    Suite *s = testSuite_GetRemoteDatatypes();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
This pull request should fix #7883.

`UA_Client_getRemoteDataTypes()` creates custom datatypes one by one. Before this change,
`UA_DataType_fromDescription()` only looked at `client->config.customDataTypes` when resolving
member type dependencies. As a result, a datatype could fail to load even if its dependency had
already been created earlier in the same import pass.

In the DI reproduction from #7883, `TransferResultDataDataType` depends on
`ParameterResultDataType`. `ParameterResultDataType` was already added to the temporary
`UA_DataTypeArray`, but it was not yet visible during the conversion of
`TransferResultDataDataType`, which resulted in `BadNotFound`.

What changed:
- Make already created datatypes in the current `UA_DataTypeArray` available to
    `UA_DataType_fromDescription()` while the remote datatype import is still in progress.
- Add the reproduction from #7883 as a regression test.

Validation:
- Tested locally on Linux x86_64 with GCC 13.
- `check_client_get_remote_datatypes` passes.
