### PR TITLE
fix(pubsub): Timeout when disabling all PubSub components

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -210,7 +210,14 @@ typedef enum  {
 UA_EXPORT UA_StatusCode
 UA_Server_enableAllPubSubComponents(UA_Server *server);
 
-/* Disable all PubSubComponents (same order as for _enableAll) */
+/* Disable all PubSubComponents.
+ * They are triggered in the following order:
+ * DataSetReader, ReaderGroups, DataSetWriter, WriterGroups, PubSubConnections.
+ *
+ * A timeout might occur if the writers are disabled before the readers
+ * in case of a loopback configuration on the same server.
+ * So disable the reader side before the writer side.
+ */
 UA_EXPORT void
 UA_Server_disableAllPubSubComponents(UA_Server *server);
 

--- a/src/pubsub/ua_pubsub_manager.c
+++ b/src/pubsub/ua_pubsub_manager.c
@@ -389,15 +389,6 @@ static void
 disableAllPubSubComponents(UA_PubSubManager *psm) {
     UA_PubSubConnection *c;
     TAILQ_FOREACH(c, &psm->connections, listEntry) {
-        UA_WriterGroup *wg;
-        LIST_FOREACH(wg, &c->writerGroups, listEntry) {
-            UA_DataSetWriter *dsw;
-            LIST_FOREACH(dsw, &wg->writers, listEntry) {
-                UA_DataSetWriter_setPubSubState(psm, dsw, UA_PUBSUBSTATE_DISABLED);
-            }
-            UA_WriterGroup_setPubSubState(psm, wg, UA_PUBSUBSTATE_DISABLED);
-        }
-
         UA_ReaderGroup *rg;
         LIST_FOREACH(rg, &c->readerGroups, listEntry) {
             UA_DataSetReader *dsr;
@@ -406,6 +397,15 @@ disableAllPubSubComponents(UA_PubSubManager *psm) {
                                                 UA_STATUSCODE_BADSHUTDOWN);
             }
             UA_ReaderGroup_setPubSubState(psm, rg, UA_PUBSUBSTATE_DISABLED);
+        }
+
+        UA_WriterGroup *wg;
+        LIST_FOREACH(wg, &c->writerGroups, listEntry) {
+            UA_DataSetWriter *dsw;
+            LIST_FOREACH(dsw, &wg->writers, listEntry) {
+                UA_DataSetWriter_setPubSubState(psm, dsw, UA_PUBSUBSTATE_DISABLED);
+            }
+            UA_WriterGroup_setPubSubState(psm, wg, UA_PUBSUBSTATE_DISABLED);
         }
 
         UA_PubSubConnection_setPubSubState(psm, c, UA_PUBSUBSTATE_DISABLED);


### PR DESCRIPTION
When calling UA_Server_disableAllPubSubComponents, a timeout might occur if the writers are disabled before the readers in case of a loopback configuration on the same server. So disable the reader side before the writer side.