### PR TITLE
fix(server): correct range check in UA_CAST_SIGNED macro

### DIFF
--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -487,7 +487,7 @@ implicitCastTargetType(const UA_DataType *t1, const UA_DataType *t2) {
  *   conversion error. */
 
 #define UA_CAST_SIGNED(t, T)                                         \
-    if(i < T##_MIN || (i > 0 && (t)i > T##_MAX))                     \
+    if(i < (UA_Int64)T##_MIN || i > (UA_Int64)T##_MAX)               \
         return;                                                      \
     *(t*)data = (t)i;                                                \
     do { } while(0)


### PR DESCRIPTION
The bounds check `(t)i > T##_MAX` cast the source value to the narrower target type before comparing, making the expression always false (e.g. `(UA_Byte)i > 255`). Out-of-range values therefore passed the check silently and were stored with truncation. Now, we compare the original UA_Int64 value against the bounds directly.