### PR TITLE
fix(pubsub): prevent potential double-free in NS0 type destructors

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -2266,22 +2266,25 @@ publishedDataItemsTypeDestructor(UA_Server *server,
     void *childContext;
     UA_NodeId node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "PublishedData"),
                                          UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY), *nodeId);
-    getNodeContext(server, node, (void**)&childContext);
-    if(!UA_NodeId_isNull(&node))
+    if(!UA_NodeId_isNull(&node)) {
+        getNodeContext(server, node, (void**)&childContext);
         UA_free(childContext);
+    }
 
     node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "ConfigurationVersion"),
                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY),
                                *nodeId);
-    getNodeContext(server, node, (void**)&childContext);
-    if(!UA_NodeId_isNull(&node))
+    if(!UA_NodeId_isNull(&node)) {
+        getNodeContext(server, node, (void**)&childContext);
         UA_free(childContext);
+    }
 
     node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "DataSetMetaData"),
                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY), *nodeId);
-    getNodeContext(server, node, (void**)&childContext);
-    if(!UA_NodeId_isNull(&node))
+    if(!UA_NodeId_isNull(&node)) {
+        getNodeContext(server, node, (void**)&childContext);
         UA_free(childContext);
+    }
 }
 
 static void
@@ -2296,15 +2299,17 @@ standaloneSubscribedDataSetTypeDestructor(UA_Server *server,
     UA_NodeId node =
         findSingleChildNode(server, UA_QUALIFIEDNAME(0, "DataSetMetaData"),
                             UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY), *nodeId);
-    getNodeContext(server, node, (void**)&childContext);
-    if(!UA_NodeId_equal(&UA_NODEID_NULL , &node))
+    if(!UA_NodeId_isNull(&node)) {
+        getNodeContext(server, node, (void**)&childContext);
         UA_free(childContext);
+    }
     node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "IsConnected"),
                                UA_NODEID_NUMERIC(0, UA_NS0ID_HASPROPERTY),
                                *nodeId);
-    getNodeContext(server, node, (void**)&childContext);
-    if(!UA_NodeId_equal(&UA_NODEID_NULL , &node))
+    if(!UA_NodeId_isNull(&node)) {
+        getNodeContext(server, node, (void**)&childContext);
         UA_free(childContext);
+    }
 }
 
 /*************************************/


### PR DESCRIPTION
In `publishedDataItemsTypeDestructor` and `standaloneSubscribedDataSetTypeDestructor`, `getNodeContext` was called unconditionally before checking whether `findSingleChildNode` returned a valid non-null NodeId. When `findSingleChildNode` fails and returns a null NodeId, `getNodeContext` also fails and leaves the childContext pointer unchanged, retaining the value written by the previous `getNodeContext` call in the same function. If a subsequent null-check guard were to pass spuriously, that same pointer could be freed a second time. Fix by moving `getNodeContext` inside the `UA_NodeId_isNull` guard so it is only called when a valid child node was actually found.