### PR TITLE
refactor(server): eliminate intentional integer underflow in UA_Node_deleteReferencesSubset

### DIFF
--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -1091,11 +1091,14 @@ UA_Node_deleteReference(UA_Node *node, UA_Byte refTypeIndex, UA_Boolean isForwar
 void
 UA_Node_deleteReferencesSubset(UA_Node *node, const UA_ReferenceTypeSet *keepSet) {
     UA_NodeHead *head = &node->head;
-    for(size_t i = 0; i < head->referencesSize; i++) {
+    size_t i = 0;
+    while (i < head->referencesSize) {
         /* Keep the references of this type? */
         UA_NodeReferenceKind *refs = &head->references[i];
-        if(UA_ReferenceTypeSet_contains(keepSet, refs->referenceTypeIndex))
+        if(UA_ReferenceTypeSet_contains(keepSet, refs->referenceTypeIndex)){
+            i++;
             continue;
+        }
 
         /* Remove all target entries. Don't remove entries from browseName tree.
          * The entire ReferenceKind will be removed anyway. */
@@ -1110,12 +1113,11 @@ UA_Node_deleteReferencesSubset(UA_Node *node, const UA_ReferenceTypeSet *keepSet
         }
 
         /* Move last references-kind entry to this position. Don't memcpy over
-         * the same position. Decrease i to repeat at this location. */
+         * the same position. Don't increment i: the swapped-in element must be
+         * checked on the next iteration. */
         head->referencesSize--;
-        if(i != head->referencesSize) {
+        if(i != head->referencesSize)
             head->references[i] = head->references[head->referencesSize];
-            i--;
-        }
     }
 
     if(head->referencesSize > 0) {


### PR DESCRIPTION
By replacing the for with a while loop with explicit incrementation of the counter only on advance, an intentional underflow of the counter is eliminated. This did not produce any bug, but the intent wasn't self-evident.