### PR TITLE
refactor(arch): change functions related to time for zephyr

### DIFF
--- a/arch/zephyr/clock_zephyr.c
+++ b/arch/zephyr/clock_zephyr.c
@@ -19,22 +19,20 @@
 
 UA_DateTime
 UA_DateTime_now(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (tv.tv_sec * UA_DATETIME_SEC) + (tv.tv_usec * UA_DATETIME_USEC) +
+    struct timespec ts;
+    sys_clock_gettime(CLOCK_REALTIME,&ts);
+    UA_DateTime time= (ts.tv_sec * UA_DATETIME_SEC) + (ts.tv_nsec*UA_DATETIME_NSEC) +
            UA_DATETIME_UNIX_EPOCH;
+    return time;
 }
 
 /* Credit to
  * https://stackoverflow.com/questions/13804095/get-the-time-zone-gmt-offset-in-c */
 UA_Int64
 UA_DateTime_localTimeUtcOffset(void) {
-    time_t rawtime = time(NULL);
-    struct tm *ptm = gmtime(&rawtime);
-    /* Request mktime() to look up dst in timezone database */
-    ptm->tm_isdst = -1;
-    time_t gmt = mktime(ptm);
-    return (UA_Int64)(difftime(rawtime, gmt) * UA_DATETIME_SEC);
+    /*Zephyr does not provide any mechanism to 
+    calculate local time(may change for zephyr 4.4 or newer).*/
+    return 0;
 }
 
 UA_DateTime

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -279,6 +279,7 @@ UA_String_vformat(UA_String *str, const char *format, va_list args);
 typedef int64_t UA_DateTime;
 
 /* Multiples to convert durations to DateTime */
+#define UA_DATETIME_NSEC (1LL / 1000LL)
 #define UA_DATETIME_USEC 10LL
 #define UA_DATETIME_MSEC (UA_DATETIME_USEC * 1000LL)
 #define UA_DATETIME_SEC (UA_DATETIME_MSEC * 1000LL)


### PR DESCRIPTION
…fset

- changing UA_DateTime_now to use clock_gettime instead of gettimeofday.
- make UA_DateTime_localTimeUtcOffset return 0 since zephyr, as of now, doesn't support local and UTC time.
  - this is mostly to reduce code size since mktime() adds allot of  code without providing any functionality.