### PR TITLE
WIP - fix(core): separate certificate validation status code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1125,7 +1125,8 @@ endif()
 
 if(UA_ENABLE_ENCRYPTION_MBEDTLS OR UA_ENABLE_AMALGAMATION)
     list(INSERT plugin_sources 0
-         ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/securitypolicy_common.h)
+         ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/securitypolicy_common.h
+         ${PROJECT_SOURCE_DIR}/plugins/crypto/certificategroup_common.h)
     list(APPEND plugin_sources
          ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/securitypolicy_common.c
          ${PROJECT_SOURCE_DIR}/plugins/crypto/mbedtls/securitypolicy_basic128rsa15.c
@@ -1141,7 +1142,8 @@ endif()
 
 if(UA_ENABLE_ENCRYPTION_OPENSSL OR UA_ENABLE_ENCRYPTION_LIBRESSL OR UA_ENABLE_AMALGAMATION)
     list(INSERT plugin_sources 0
-         ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/securitypolicy_common.h)
+         ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/securitypolicy_common.h
+         ${PROJECT_SOURCE_DIR}/plugins/crypto/certificategroup_common.h)
     list(APPEND plugin_sources
          ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/securitypolicy_common.c
          ${PROJECT_SOURCE_DIR}/plugins/crypto/openssl/securitypolicy_basic128rsa15.c

--- a/include/open62541/plugin/certificategroup.h
+++ b/include/open62541/plugin/certificategroup.h
@@ -66,8 +66,9 @@ struct UA_CertificateGroup {
                                         UA_ByteString **crls,
                                         size_t *crlsSize);
 
-    UA_StatusCode (*verifyCertificate)(UA_CertificateGroup *certGroup,
-                                       const UA_ByteString *certificate);
+    UA_SplitStatusCode
+    (*verifyCertificate)(UA_CertificateGroup *certGroup,
+                         const UA_ByteString *certificate);
 
     void (*clear)(UA_CertificateGroup *certGroup);
 };

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -198,6 +198,18 @@ UA_EXPORT UA_Boolean UA_StatusCode_equalTop(UA_StatusCode s1, UA_StatusCode s2);
 #define UA_StatusCode_isEqualTop(s1, s2) UA_StatusCode_equalTop(s1, s2)
 
 /**
+ * Provide a hidden status for client responses.
+ */
+typedef struct {
+    UA_StatusCode status;
+    UA_StatusCode clientResponseStatus;
+} UA_SplitStatusCode;
+
+/* Helper constructors for split status return values */
+#define UA_SPLITSTATUSCODE_BOTH(result) \
+    ((UA_SplitStatusCode){(result), (result)})
+
+/**
  * String
  * ^^^^^^
  * A sequence of Unicode characters. Strings are just an array of UA_Byte. */

--- a/plugins/crypto/certificategroup_common.h
+++ b/plugins/crypto/certificategroup_common.h
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2026 (c) o6 Automation GmbH (Author: Moritz Bruder)
+ */
+
+#ifndef UA_CERTIFICATEGROUP_COMMON_H_
+#define UA_CERTIFICATEGROUP_COMMON_H_
+
+#define UA_SPLITSTATUSCODE_HIDDEN(result) \
+    ((UA_SplitStatusCode){(result), UA_STATUSCODE_BADSECURITYCHECKSFAILED})
+
+#endif /* UA_CERTIFICATEGROUP_COMMON_H_ */

--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -23,6 +23,7 @@
 #endif
 
 #include "securitypolicy_common.h"
+#include "../certificategroup_common.h"
 
 /* Configuration parameters */
 
@@ -472,24 +473,26 @@ mbedtlsCheckSignature(const mbedtls_x509_crt *cert, mbedtls_x509_crt *issuer) {
                                   hash, hash_len, sig->p, sig->len) == 0);
 }
 
-static UA_StatusCode
+static UA_SplitStatusCode
 mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_crt *stack,
                    mbedtls_x509_crt **old_issuers, mbedtls_x509_crt *cert, int depth) {
     /* Maxiumum chain length */
     if(depth == UA_MBEDTLS_MAX_CHAIN_LENGTH)
-        return UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
+    return UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE);
 
     /* Verification Step: Validity Period */
     if(mbedtls_x509_time_is_future(&cert->valid_from) ||
        mbedtls_x509_time_is_past(&cert->valid_to))
-        return (depth == 0) ? UA_STATUSCODE_BADCERTIFICATETIMEINVALID :
-            UA_STATUSCODE_BADCERTIFICATEISSUERTIMEINVALID;
+        return (depth == 0) ?
+            UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATETIMEINVALID) :
+            UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATEISSUERTIMEINVALID);
 
     /* Return the most specific error code. BADCERTIFICATECHAININCOMPLETE is
      * returned only if all possible chains are incomplete. */
     mbedtls_x509_crt *issuer = NULL;
-    UA_StatusCode ret = UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
-    while(ret != UA_STATUSCODE_GOOD) {
+    UA_SplitStatusCode ret =
+        UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE);
+    while(ret.status != UA_STATUSCODE_GOOD) {
         /* Find the issuer. This can return the same certificate if it is
          * self-signed (subject == issuer). We come back here to try a different
          * "path" if a subsequent verification fails. */
@@ -500,13 +503,13 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
         /* Verification Step: Certificate Usage
          * Can the issuer act as CA? Omit for self-signed leaf certificates. */
         if((depth > 0 || issuer != cert) && !mbedtlsCheckCA(issuer)) {
-            ret = UA_STATUSCODE_BADCERTIFICATEISSUERUSENOTALLOWED;
+            ret = UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATEISSUERUSENOTALLOWED);
             continue;
         }
 
         /* Verification Step: Signature */
         if(!mbedtlsCheckSignature(cert, issuer)) {
-            ret = UA_STATUSCODE_BADCERTIFICATEINVALID;  /* Wrong issuer, try again */
+            ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEINVALID); /* Wrong issuer, try again */
             continue;
         }
 
@@ -519,25 +522,29 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
          * Break here as we have reached the end of the chain. Omit the
          * Revocation Check for self-signed certificates. */
         if(issuer == cert || mbedtlsSameBuf(&cert->tbs, &issuer->tbs)) {
-            ret = UA_STATUSCODE_BADCERTIFICATEUNTRUSTED;
+            ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEUNTRUSTED);
             break;
         }
 
         /* Verification Step: Revocation Check */
-        ret = mbedtlsCheckRevoked(cg, ctx, cert);
+        UA_StatusCode revokeCheckStatus = mbedtlsCheckRevoked(cg, ctx, cert);
+        ret = UA_SPLITSTATUSCODE_BOTH(revokeCheckStatus);
         if(depth > 0) {
-            if(ret == UA_STATUSCODE_BADCERTIFICATEREVOKED)
-                ret = UA_STATUSCODE_BADCERTIFICATEISSUERREVOKED;
-            if(ret == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN)
-                ret = UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN;
+            if(revokeCheckStatus == UA_STATUSCODE_BADCERTIFICATEREVOKED)
+                ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEISSUERREVOKED);
+            else if(revokeCheckStatus == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN)
+                ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN);
+        } else if(ret.status == UA_STATUSCODE_BADCERTIFICATEREVOKED ||
+                  ret.status == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN) {
+            ret = UA_SPLITSTATUSCODE_HIDDEN(revokeCheckStatus);
         }
-        if(ret != UA_STATUSCODE_GOOD)
+        if(ret.status != UA_STATUSCODE_GOOD)
             continue;
 
         /* Detect (endless) loops of issuers */
         for(int i = 0; i < depth; i++) {
             if(old_issuers[i] == issuer)
-                return UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
+                return UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE);
         }
         old_issuers[depth] = issuer;
 
@@ -548,10 +555,10 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 
     /* The chain is complete, but we haven't yet identified a trusted
      * certificate "on the way down". Can we trust this certificate? */
-    if(ret == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED) {
+    if(ret.status == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED) {
         for(mbedtls_x509_crt *t = &ctx->trustedCertificates; t; t = t->next) {
             if(mbedtlsSameBuf(&cert->tbs, &t->tbs))
-                return UA_STATUSCODE_GOOD;
+                return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_GOOD);
         }
     }
 
@@ -560,18 +567,18 @@ mbedtlsVerifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, mbedtls_x509_c
 
 /* This follows Part 6, 6.1.3 Determining if a Certificate is trusted.
  * It defines a sequence of steps for certificate verification. */
-static UA_StatusCode
+static UA_SplitStatusCode
 verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
     /* Check parameter */
     if (certGroup == NULL || certGroup->context == NULL) {
-        return UA_STATUSCODE_BADINTERNALERROR;
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADINTERNALERROR);
     }
 
     MemoryCertStore *context = (MemoryCertStore *)certGroup->context;
     if(context->reloadRequired) {
         UA_StatusCode retval = reloadCertificates(certGroup);
         if(retval != UA_STATUSCODE_GOOD) {
-            return retval;
+            return UA_SPLITSTATUSCODE_BOTH(retval);
         }
         context->reloadRequired = false;
     }
@@ -583,7 +590,7 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
     int mbedErr = mbedtls_x509_crt_parse(&cert, certificate->data,
                                          certificate->length);
     if(mbedErr)
-        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+        return UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEINVALID);
 
     /* Verification Step: Certificate Usage
      * Check whether the certificate is a User certificate or a CA certificate.
@@ -591,7 +598,7 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
      * for more details. */
     if(mbedtlsCheckCA(&cert)) {
         mbedtls_x509_crt_free(&cert);
-        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED);
     }
 
     /* These steps are performed outside of this method.
@@ -603,21 +610,22 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
     /* Verification Step: Build Certificate Chain
      * We perform the checks for each certificate inside. */
     mbedtls_x509_crt *old_issuers[UA_MBEDTLS_MAX_CHAIN_LENGTH];
-    UA_StatusCode ret = mbedtlsVerifyChain(certGroup, context, &cert, old_issuers, &cert, 0);
+    UA_SplitStatusCode ret =
+        mbedtlsVerifyChain(certGroup, context, &cert, old_issuers, &cert, 0);
     mbedtls_x509_crt_free(&cert);
     return ret;
 }
 
-static UA_StatusCode
+static UA_SplitStatusCode
 MemoryCertStore_verifyCertificate(UA_CertificateGroup *certGroup,
                                   const UA_ByteString *certificate) {
     /* Check parameter */
     if(certGroup == NULL || certificate == NULL) {
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADINVALIDARGUMENT);
     }
 
-    UA_StatusCode retval = verifyCertificate(certGroup, certificate);
-    if(retval != UA_STATUSCODE_GOOD) {
+    UA_SplitStatusCode retval = verifyCertificate(certGroup, certificate);
+    if(retval.status != UA_STATUSCODE_GOOD) {
         if(MemoryCertStore_addToRejectedList(certGroup, certificate) != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,
                            "Could not append certificate to rejected list");

--- a/plugins/crypto/openssl/certificategroup.c
+++ b/plugins/crypto/openssl/certificategroup.c
@@ -18,6 +18,7 @@
 
 #include "libc_time.h"
 #include "securitypolicy_common.h"
+#include "../certificategroup_common.h"
 
 #define SHA1_DIGEST_LENGTH 20
 
@@ -531,25 +532,27 @@ openSSLCheckRevoked(UA_CertificateGroup *cg, MemoryCertStore *ctx, X509 *cert) {
 
 #define UA_OPENSSL_MAX_CHAIN_LENGTH 10
 
-static UA_StatusCode
+static UA_SplitStatusCode
 openSSL_verifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, STACK_OF(X509) *stack,
                     X509 **old_issuers, X509 *cert, int depth) {
     /* Maxiumum chain length */
     if(depth == UA_OPENSSL_MAX_CHAIN_LENGTH)
-        return UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
+        return UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE);
 
     /* Verification Step: Validity Period */
     ASN1_TIME *notBefore = X509_get_notBefore(cert);
     ASN1_TIME *notAfter = X509_get_notAfter(cert);
     if(X509_cmp_current_time(notBefore) != -1 || X509_cmp_current_time(notAfter) != 1)
-        return (depth == 0) ? UA_STATUSCODE_BADCERTIFICATETIMEINVALID :
-            UA_STATUSCODE_BADCERTIFICATEISSUERTIMEINVALID;
+        return (depth == 0) ?
+            UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATETIMEINVALID) :
+            UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATEISSUERTIMEINVALID);
 
     /* Return the most specific error code. BADCERTIFICATECHAININCOMPLETE is
      * returned only if all possible chains are incomplete. */
     X509 *issuer = NULL;
-    UA_StatusCode ret = UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
-    while(ret != UA_STATUSCODE_GOOD) {
+    UA_SplitStatusCode ret =
+        UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE);
+    while(ret.status != UA_STATUSCODE_GOOD) {
         /* Find the issuer. We jump back here to find a different path if a
          * subsequent check fails. */
         issuer = openSSLFindNextIssuer(ctx, stack, cert, issuer);
@@ -559,16 +562,16 @@ openSSL_verifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, STACK_OF(X509
         /* Verification Step: Certificate Usage
          * Can the issuer act as CA? Omit for self-signed leaf certificates. */
         if((depth > 0 || issuer != cert) && !openSSLCheckCA(issuer)) {
-            ret = UA_STATUSCODE_BADCERTIFICATEISSUERUSENOTALLOWED;
+            ret = UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATEISSUERUSENOTALLOWED);
             continue;
         }
 
         /* Verification Step: Signature */
         int opensslRet = X509_verify(cert, X509_get0_pubkey(issuer));
         if(opensslRet == -1) {
-            return UA_STATUSCODE_BADCERTIFICATEINVALID; /* Ill-formed signature */
+            return UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEINVALID); /* Ill-formed signature */
         } else if(opensslRet == 0) {
-            ret = UA_STATUSCODE_BADCERTIFICATEINVALID;  /* Wrong issuer, try again */
+            ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEINVALID); /* Wrong issuer, try again */
             continue;
         }
 
@@ -581,26 +584,30 @@ openSSL_verifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, STACK_OF(X509
          * Break here as we have reached the end of the chain. Omit the
          * Revocation Check for self-signed certificates. */
         if(cert == issuer || X509_cmp(cert, issuer) == 0) {
-            ret = UA_STATUSCODE_BADCERTIFICATEUNTRUSTED;
+            ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEUNTRUSTED);
             break;
         }
 
         /* Verification Step: Revocation Check */
-        ret = openSSLCheckRevoked(cg, ctx, cert);
+        UA_StatusCode revokeCheckStatus = openSSLCheckRevoked(cg, ctx, cert);
+        ret = UA_SPLITSTATUSCODE_BOTH(revokeCheckStatus);
         if(depth > 0) {
-            if(ret == UA_STATUSCODE_BADCERTIFICATEREVOKED)
-                ret = UA_STATUSCODE_BADCERTIFICATEISSUERREVOKED;
-            if(ret == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN)
-                ret = UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN;
+            if(revokeCheckStatus == UA_STATUSCODE_BADCERTIFICATEREVOKED)
+                ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEISSUERREVOKED);
+            else if(revokeCheckStatus == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN)
+                ret = UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN);
+        } else if(revokeCheckStatus == UA_STATUSCODE_BADCERTIFICATEREVOKED ||
+                  revokeCheckStatus == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN) {
+            ret = UA_SPLITSTATUSCODE_HIDDEN(revokeCheckStatus);
         }
-        if(ret != UA_STATUSCODE_GOOD)
+        if(ret.status != UA_STATUSCODE_GOOD)
             continue;
 
         /* Detect (endless) loops of issuers. The last one can be skipped by the
          * check for self-signed just before. */
         for(int i = 0; i < depth; i++) {
             if(old_issuers[i] == issuer)
-                return UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE;
+                return UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATECHAININCOMPLETE);
         }
         old_issuers[depth] = issuer;
 
@@ -610,10 +617,10 @@ openSSL_verifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, STACK_OF(X509
     }
 
     /* Is the certificate in the trust list? If yes, then we are done. */
-    if(ret == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED) {
+    if(ret.status == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED) {
         for(int i = 0; i < sk_X509_num(ctx->trustedCertificates); i++) {
             if(X509_cmp(cert, sk_X509_value(ctx->trustedCertificates, i)) == 0)
-                return UA_STATUSCODE_GOOD;
+                return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_GOOD);
         }
     }
 
@@ -622,18 +629,18 @@ openSSL_verifyChain(UA_CertificateGroup *cg, MemoryCertStore *ctx, STACK_OF(X509
 
 /* This follows Part 6, 6.1.3 Determining if a Certificate is trusted.
  * It defines a sequence of steps for certificate verification. */
-static UA_StatusCode
+static UA_SplitStatusCode
 verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
     /* Check parameter */
     if(certGroup == NULL || certGroup->context == NULL)
-        return UA_STATUSCODE_BADINTERNALERROR;
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADINTERNALERROR);
 
     UA_StatusCode ret = UA_STATUSCODE_GOOD;
     MemoryCertStore *context = (MemoryCertStore *)certGroup->context;
     if(context->reloadRequired) {
         ret = reloadCertificates(certGroup);
         if(ret != UA_STATUSCODE_GOOD)
-            return ret;
+            return UA_SPLITSTATUSCODE_BOTH(ret);
         context->reloadRequired = false;
     }
 
@@ -641,7 +648,7 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
     STACK_OF(X509) *stack = openSSLLoadCertificateStack(*certificate);
     if(!stack || sk_X509_num(stack) < 1) {
         sk_X509_pop_free(stack, X509_free);
-        return UA_STATUSCODE_BADCERTIFICATEINVALID;
+        return UA_SPLITSTATUSCODE_HIDDEN(UA_STATUSCODE_BADCERTIFICATEINVALID);
     }
 
     /* Verification Step: Certificate Usage
@@ -651,7 +658,7 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
     X509 *leaf = sk_X509_value(stack, 0);
     if(openSSLCheckCA(leaf)) {
         sk_X509_pop_free(stack, X509_free);
-        return UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED;
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED);
     }
 
     /* These steps are performed outside of this method.
@@ -663,21 +670,22 @@ verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certifica
     /* Verification Step: Build Certificate Chain
      * We perform the checks for each certificate inside. */
     X509 *old_issuers[UA_OPENSSL_MAX_CHAIN_LENGTH];
-    ret = openSSL_verifyChain(certGroup, context, stack, old_issuers, leaf, 0);
+    UA_SplitStatusCode result =
+        openSSL_verifyChain(certGroup, context, stack, old_issuers, leaf, 0);
     sk_X509_pop_free(stack, X509_free);
-    return ret;
+    return result;
 }
 
-static UA_StatusCode
+static UA_SplitStatusCode
 MemoryCertStore_verifyCertificate(UA_CertificateGroup *certGroup,
                                   const UA_ByteString *certificate) {
     /* Check parameter */
     if(certGroup == NULL || certificate == NULL) {
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADINVALIDARGUMENT);
     }
 
-    UA_StatusCode retval = verifyCertificate(certGroup, certificate);
-    if(retval != UA_STATUSCODE_GOOD) {
+    UA_SplitStatusCode retval = verifyCertificate(certGroup, certificate);
+    if(retval.status != UA_STATUSCODE_GOOD) {
         if(MemoryCertStore_addToRejectedList(certGroup, certificate) != UA_STATUSCODE_GOOD) {
             UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_SECURITYPOLICY,
                            "Could not append certificate to rejected list");

--- a/plugins/crypto/ua_certificategroup_filestore.c
+++ b/plugins/crypto/ua_certificategroup_filestore.c
@@ -595,24 +595,25 @@ FileCertStore_getCertificateCrls(UA_CertificateGroup *certGroup, const UA_ByteSt
     return context->store->getCertificateCrls(context->store, certificate, isTrusted, crls, crlsSize);
 }
 
-static UA_StatusCode
+static UA_SplitStatusCode
 FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteString *certificate) {
     /* Check parameter */
-    if(certGroup == NULL || certificate == NULL)
-        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    if(certGroup == NULL || certificate == NULL) {
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADINVALIDARGUMENT);
+    }
 
     FileCertStore *context = (FileCertStore *)certGroup->context;
     /* It will only re-read the Cert store on the file system if there have been changes to files. */
     UA_StatusCode retval = reloadTrustStore(certGroup);
     if(retval != UA_STATUSCODE_GOOD) {
-        return retval;
+        return UA_SPLITSTATUSCODE_BOTH(retval);
     }
 
-    retval = context->store->verifyCertificate(context->store, certificate);
-    if(retval == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED ||
-       retval == UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED ||
-       retval == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN ||
-       retval == UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN) {
+    UA_SplitStatusCode result = context->store->verifyCertificate(context->store, certificate);
+    if(result.status == UA_STATUSCODE_BADCERTIFICATEUNTRUSTED ||
+       result.status == UA_STATUSCODE_BADCERTIFICATEUSENOTALLOWED ||
+       result.status == UA_STATUSCODE_BADCERTIFICATEREVOCATIONUNKNOWN ||
+       result.status == UA_STATUSCODE_BADCERTIFICATEISSUERREVOCATIONUNKNOWN) {
         /* write rejectedList to filestore */
         UA_ByteString *rejectedList = NULL;
         size_t rejectedListSize = 0;
@@ -621,7 +622,7 @@ FileCertStore_verifyCertificate(UA_CertificateGroup *certGroup, const UA_ByteStr
         UA_Array_delete(rejectedList, rejectedListSize, &UA_TYPES[UA_TYPES_BYTESTRING]);
     }
 
-    return retval;
+    return result;
 }
 
 static void

--- a/plugins/crypto/ua_certificategroup_none.c
+++ b/plugins/crypto/ua_certificategroup_none.c
@@ -7,12 +7,12 @@
 
 #include <open62541/plugin/certificategroup_default.h>
 
-static UA_StatusCode
+static UA_SplitStatusCode
 verifyCertificateAllowAll(UA_CertificateGroup *certGroup,
                           const UA_ByteString *certificate) {
     UA_LOG_WARNING(certGroup->logging, UA_LOGCATEGORY_APPLICATION,
                    "No certificate store configured. Accepting the certificate.");
-    return UA_STATUSCODE_GOOD;
+    return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_GOOD);
 }
 
 static void

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1739,7 +1739,7 @@ initSecurityPolicy(UA_Client *client) {
     if(client->endpoint.serverCertificate.length > 0) {
         res = client->config.certificateVerification.
             verifyCertificate(&client->config.certificateVerification,
-                              &client->endpoint.serverCertificate);
+                              &client->endpoint.serverCertificate).status;
         if(res != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                          "Cannot validate the server certificate "

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -785,10 +785,10 @@ secureChannel_delayedCloseTrustList(void *application, void *context) {
             continue;
         if(channel->remoteCertificate.length == 0)
             continue; /* SecureChannels w/o security */
-        UA_StatusCode res =
+        UA_SplitStatusCode res =
             validateCertificate(server, certGroup, channel, channel->sessions,
                                 "RenewTrustList", NULL, channel->remoteCertificate);
-        if(res != UA_STATUSCODE_GOOD)
+        if(res.status != UA_STATUSCODE_GOOD)
             UA_SecureChannel_shutdown(channel, UA_SHUTDOWNREASON_CLOSE);
     }
     UA_free(dc);

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -296,7 +296,7 @@ ZIP_FUNCTIONS(UA_ReferenceNameTree, UA_ReferenceTargetTreeElem, nameTreeEntry,
 
 /* Session and channel can be NULL, only used for logging.
  * Ad can be NULL, then the ApplicationUri is not checked. */
-UA_StatusCode
+UA_SplitStatusCode
 validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                     UA_SecureChannel *channel, UA_Session *session,
                     const char *logPrefix,

--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -1085,7 +1085,7 @@ secureChannel_delayedClose(void *application, void *context) {
     TAILQ_FOREACH(channel, &server->channels, serverEntry) {
         if(channel->state == UA_SECURECHANNELSTATE_CLOSED || channel->state == UA_SECURECHANNELSTATE_CLOSING)
             continue;
-        if(certGroup.verifyCertificate(&certGroup, &channel->remoteCertificate) != UA_STATUSCODE_GOOD)
+        if(certGroup.verifyCertificate(&certGroup, &channel->remoteCertificate).status != UA_STATUSCODE_GOOD)
             UA_SecureChannel_shutdown(channel, UA_SHUTDOWNREASON_CLOSE);
     }
 

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -348,7 +348,7 @@ editNode(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId,
 /* Certificate Validation */
 /**************************/
 
-UA_StatusCode
+UA_SplitStatusCode
 validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                     UA_SecureChannel *channel, UA_Session *session,
                     const char *logPrefix,
@@ -384,8 +384,9 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                                  ad->applicationUri);
                 }
             }
-            if(server->config.allowAllCertificateUris <= UA_RULEHANDLING_ABORT)
-                return UA_STATUSCODE_BADCERTIFICATEINVALID;
+            if(server->config.allowAllCertificateUris <= UA_RULEHANDLING_ABORT) {
+                return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADCERTIFICATEINVALID);
+            }
         }
     }
 
@@ -393,13 +394,13 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
         UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
                      "%s: Could not validate the certificate "
                      "as the CertificateGroup is not configured", logPrefix);
-        return UA_STATUSCODE_BADINTERNALERROR;
+        return UA_SPLITSTATUSCODE_BOTH(UA_STATUSCODE_BADINTERNALERROR);
     }
 
     /* Validate in the CertificateGroup */
-    res = cg->verifyCertificate(cg, &certificate);
-    if(res != UA_STATUSCODE_GOOD) {
-        const char *descr = UA_StatusCode_name(res);
+    UA_SplitStatusCode result = cg->verifyCertificate(cg, &certificate);
+    if(result.status != UA_STATUSCODE_GOOD) {
+        const char *descr = UA_StatusCode_name(result.status);
         if(session) {
             UA_LOG_ERROR_SESSION(server->config.logging, session,
                                  "%s: The client certificate failed the verification "
@@ -417,7 +418,7 @@ validateCertificate(UA_Server *server, UA_CertificateGroup *cg,
                          logPrefix, descr);
         }
     }
-    return res;
+    return result;
 }
 
 /*********************************/

--- a/src/server/ua_services_securechannel.c
+++ b/src/server/ua_services_securechannel.c
@@ -62,7 +62,7 @@ processOPN_AsymHeader(void *application, UA_SecureChannel *channel,
     if(asymHeader->senderCertificate.length > 0) {
         UA_StatusCode res =
             validateCertificate(server, &sc->secureChannelPKI, channel, NULL,
-                                "OpenSecureChannel", NULL, asymHeader->senderCertificate);
+                                "OpenSecureChannel", NULL, asymHeader->senderCertificate).status;
         UA_CHECK_STATUS(res, return res);
     }
 

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -479,11 +479,12 @@ Service_CreateSession(UA_Server *server, UA_SecureChannel *channel,
                                    "on SecurityPolicy None (Part 4, 5.6.2.2)");
         }
     } else if(request->clientCertificate.length > 0) {
-        rh->serviceResult =
+        UA_SplitStatusCode validateRes =
             validateCertificate(server, &server->config.secureChannelPKI,
                                 channel, NULL, "CreateSession",
                                 &request->clientDescription,
                                 request->clientCertificate);
+        rh->serviceResult = validateRes.clientResponseStatus;
         if(rh->serviceResult != UA_STATUSCODE_GOOD) {
             server->serverDiagnosticsSummary.securityRejectedSessionCount++;
             server->serverDiagnosticsSummary.rejectedSessionCount++;
@@ -874,10 +875,11 @@ checkActivateSessionX509(UA_Server *server, UA_SecureChannel *channel, UA_Sessio
     }
 
     /* Validate the certificate against the SessionPKI */
-    res = validateCertificate(server, &server->config.sessionPKI,
-                              session->channel, session, "ActivateSession",
-                              NULL, token->certificateData);
-
+    UA_SplitStatusCode validateRes =
+        validateCertificate(server, &server->config.sessionPKI,
+                            session->channel, session, "ActivateSession",
+                            NULL, token->certificateData);
+    res = validateRes.clientResponseStatus;
  out:
     /* Delete the temporary channel context */
     tokenSp->deleteChannelContext(tokenSp, tempChannelContext);


### PR DESCRIPTION
Add a separate UA_StatusCode for certificate validation client responses.  In the validation algorithm, hide the client response for the steps and return codes mentioned in the specification.

# Advantages
* It enables a more verbatim implementation of the specification.  In the [specification](https://reference.opcfoundation.org/Core/Part4/v105/docs/6.1.3) table 100 lists all of the steps and the corresponding return values including the result for the client.  This should be very maintainable if the specification changes.  (I also updated the code with AI, which I checked line by line, using a link to the specification.)
* Code using the verification result can pick the status code it wants.
* The code trades a few conditional jumps, if the status code is replaced conditionally instead, against a few additional bytes in stack frames, from the return value.

# Disadvantages
* In 1.5, the ABI is broken, since one part of the CertificateGroup plugin API is exposed, and we also need to expose the type itself. _I could base this on master instead._
* Some minor duplication for different crypto backends.

# Future Work
* The resulting `UA_SplitStatusCode` might need to be pushed down further to reach all potential responses, where necessary.

# Testing Done
I ran a full CTT run with the standard server profile and all of the failures related to return values, except for those related to `Bad_CertificateTimeInvalid`, went away.