### PR TITLE
All architecture-specific files isolated in single folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ MESSAGE(STATUS "open62541 Version: ${OPEN62541_VERSION}")
 set(UA_ARCHITECTURES "none" "posix" "win32" "zephyr" "freertos-lwip" "posix-lwip")
 set(UA_ARCHITECTURE "" CACHE STRING "Architecture to build open62541 for")
 SET_PROPERTY(CACHE UA_ARCHITECTURE PROPERTY STRINGS "" ${UA_ARCHITECTURES})
+set(UA_ARCH_FOLDER "" CACHE PATH
+    "Folder with the architecture-specific sources (defaults to arch/posix)")
 
 if("${UA_ARCHITECTURE}" STREQUAL "")
     if(WIN32)
@@ -1097,16 +1099,16 @@ set(plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_log_stdout.c
                    ${PROJECT_SOURCE_DIR}/plugins/crypto/ua_securitypolicy_none.c)
 
 # Add clock implementation based on the base architecture
-if(UA_ARCHITECTURE_POSIX OR UA_ARCHITECTURE_WIN32 OR UA_ENABLE_AMALGAMATION)
-    list(APPEND plugin_sources ${PROJECT_SOURCE_DIR}/arch/posix/clock_posix.c)
-endif()
-
 if(UA_ARCHITECTURE_ZEPHYR)
     list(APPEND plugin_sources ${PROJECT_SOURCE_DIR}/arch/zephyr/clock_zephyr.c)
 endif()
 
 if(UA_ARCHITECTURE_FREERTOS)
     list(APPEND plugin_sources ${PROJECT_SOURCE_DIR}/arch/freertos/clock_freertos.c)
+endif()
+
+if(UA_ARCHITECTURE_POSIX AND UA_ARCHITECTURE_LWIP)
+    list(APPEND plugin_sources ${PROJECT_SOURCE_DIR}/arch/posix/clock_posix.c)
 endif()
 
 # Add eventloop and common files (mutually exclusive based on eventloop type)
@@ -1132,18 +1134,20 @@ elseif(UA_ARCHITECTURE_ZEPHYR)
          ${PROJECT_SOURCE_DIR}/arch/zephyr/eventloop_zephyr.c
          ${PROJECT_SOURCE_DIR}/arch/zephyr/eventloop_zephyr_tcp.c)
 elseif(UA_ARCHITECTURE_POSIX OR UA_ARCHITECTURE_WIN32 OR UA_ENABLE_AMALGAMATION)
-    # POSIX eventloop (default for amalgamation)
+    # Common eventloop files shared across all POSIX/Win32 builds
     list(APPEND plugin_sources
          ${PROJECT_SOURCE_DIR}/arch/common/timer.h
          ${PROJECT_SOURCE_DIR}/arch/common/timer.c
          ${PROJECT_SOURCE_DIR}/arch/common/eventloop_common.h
-         ${PROJECT_SOURCE_DIR}/arch/common/eventloop_common.c
-         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix.h
-         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix.c
-         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix_tcp.c
-         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix_udp.c
-         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix_eth.c
-         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix_interrupt.c)
+         ${PROJECT_SOURCE_DIR}/arch/common/eventloop_common.c)
+    # Architecture-specific files (clock, TCP, UDP, eth, interrupt)
+    if(NOT UA_ARCH_FOLDER)
+        set(UA_ARCH_FOLDER "${PROJECT_SOURCE_DIR}/arch/posix")
+    endif()
+    if(NOT EXISTS "${UA_ARCH_FOLDER}/CMakeLists.txt")
+        message(FATAL_ERROR "UA_ARCH_FOLDER (${UA_ARCH_FOLDER}) contains no CMakeLists.txt")
+    endif()
+    include("${UA_ARCH_FOLDER}/CMakeLists.txt")
 endif()
 
 if(UA_ARCHITECTURE_FREERTOS)

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -1,0 +1,15 @@
+# This file is included from the top-level CMakeLists.txt. A custom
+# architecture folder (UA_ARCH_FOLDER) provides its own copy of it. The
+# in-tree folder remains on the include path so that the relative includes
+# (../common, ../../deps) also resolve for folders outside the source tree.
+# The paths are quoted as UA_ARCH_FOLDER may contain spaces.
+include_directories("${CMAKE_CURRENT_LIST_DIR}" "${PROJECT_SOURCE_DIR}/arch/posix")
+
+list(APPEND plugin_sources
+     "${CMAKE_CURRENT_LIST_DIR}/eventloop_posix.h"
+     "${CMAKE_CURRENT_LIST_DIR}/clock_posix.c"
+     "${CMAKE_CURRENT_LIST_DIR}/eventloop_posix.c"
+     "${CMAKE_CURRENT_LIST_DIR}/eventloop_posix_tcp.c"
+     "${CMAKE_CURRENT_LIST_DIR}/eventloop_posix_udp.c"
+     "${CMAKE_CURRENT_LIST_DIR}/eventloop_posix_eth.c"
+     "${CMAKE_CURRENT_LIST_DIR}/eventloop_posix_interrupt.c")

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -250,6 +250,15 @@ Main Build Options
     Multiple threads are allowed to call these functions of the SDK at the same time without causing race conditions.
     Furthermore, this level support the handling of asynchronous method calls from external worker threads.
 
+**UA_ARCH_FOLDER**
+   Folder with the architecture-specific sources (clock and eventloop
+   implementations) for POSIX/Win32 builds. Defaults to :file:`arch/posix` in
+   the source tree. A custom architecture port provides its own folder --
+   under :file:`arch` or outside of the source tree -- with an adapted copy of
+   :file:`arch/posix/CMakeLists.txt` that lists the contained sources. That
+   way the top-level :file:`CMakeLists.txt` does not have to be modified for
+   a custom architecture build.
+
 Select build artefacts
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/server/check_discovery_mdnsd.c
+++ b/tests/server/check_discovery_mdnsd.c
@@ -231,6 +231,25 @@ static TestUdpIntercept *testUdpInterceptLds;
 static TestUdpIntercept *testUdpInterceptRegister;
 static size_t globalInterceptedMdnsMessages;
 
+/* Callbacks that run on the server threads must not ck_assert: with CK_NOFORK
+ * a failing assert there writes to libcheck's messaging file after it was
+ * closed. They record failures here instead; a checked fixture asserts the
+ * counter on the main thread after every test. */
+static size_t threadCallbackFailures;
+
+static void
+recordThreadCallbackFailure(const char *msg) {
+    fprintf(stderr, "%s\n", msg);
+    threadCallbackFailures++;
+}
+
+static void
+checkThreadCallbackFailures(void) {
+    size_t failures = threadCallbackFailures;
+    threadCallbackFailures = 0;
+    ck_assert_uint_eq(failures, 0);
+}
+
 static void
 serverDiscoveryNotificationCallback(UA_Server *server,
                                     UA_ApplicationNotificationType type,
@@ -398,6 +417,8 @@ serverOnNetworkHasTxtData(const UA_ServerOnNetwork *serverOnNetwork) {
     return false;
 }
 
+/* Runs on the server threads -- record failures instead of ck_assert
+ * (see threadCallbackFailures) */
 static UA_StatusCode
 interceptingSend(UA_ConnectionManager *cm, uintptr_t connectionId,
                  const UA_KeyValueMap *params, UA_ByteString *buf) {
@@ -405,7 +426,12 @@ interceptingSend(UA_ConnectionManager *cm, uintptr_t connectionId,
     (void)params;
     TestUdpIntercept *intercept =
         (TestUdpIntercept*)TestConnectionManager_getContext(cm);
-    ck_assert_ptr_ne(intercept, NULL);
+    if(!intercept) {
+        recordThreadCallbackFailure("interceptingSend: "
+                                    "intercept context missing");
+        UA_ByteString_clear(buf);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
 
     intercept->sentMessages++;
     if(buf->length > 0) {
@@ -414,10 +440,14 @@ interceptingSend(UA_ConnectionManager *cm, uintptr_t connectionId,
         globalInterceptedMdnsMessages++;
         UA_ByteString_clear(&intercept->lastMessage);
         UA_ByteString_clear(&intercept->recentMessages[slot]);
-        ck_assert_uint_eq(UA_ByteString_copy(buf, &intercept->lastMessage),
-                          UA_STATUSCODE_GOOD);
-        ck_assert_uint_eq(UA_ByteString_copy(buf, &intercept->recentMessages[slot]),
-                          UA_STATUSCODE_GOOD);
+        UA_StatusCode res = UA_ByteString_copy(buf, &intercept->lastMessage);
+        res |= UA_ByteString_copy(buf, &intercept->recentMessages[slot]);
+        if(res != UA_STATUSCODE_GOOD) {
+            recordThreadCallbackFailure("interceptingSend: "
+                                        "copying the message failed");
+            UA_ByteString_clear(buf);
+            return res;
+        }
         intercept->recentMessageSequence[slot] = globalInterceptedMdnsMessages;
         intercept->recentMessageCursor++;
     }
@@ -1256,10 +1286,13 @@ serverDiscoveryNotificationCallback(UA_Server *server,
         UA_KeyValueMap_getScalar(&payload, UA_QUALIFIEDNAME(0, "server-updated"),
                                  &UA_TYPES[UA_TYPES_BOOLEAN]);
 
-    ck_assert_ptr_ne(serverOnNetwork, NULL);
-    ck_assert_ptr_ne(serverAdded, NULL);
-    ck_assert_ptr_ne(serverRemoved, NULL);
-    ck_assert_ptr_ne(serverUpdated, NULL);
+    /* Server-thread code path -- record failures instead of ck_assert
+     * (see threadCallbackFailures) */
+    if(!serverOnNetwork || !serverAdded || !serverRemoved || !serverUpdated) {
+        recordThreadCallbackFailure("serverDiscoveryNotificationCallback: "
+                                    "incomplete notification payload");
+        return;
+    }
 
     DiscoveryIntegrationCounters *counters = &discoveryCounters;
     UA_Boolean isServerAnnounce = (*serverAdded || *serverUpdated);
@@ -2332,6 +2365,7 @@ testSuite_DiscoveryMdnsd(void) {
 #if defined(UA_ENABLE_DISCOVERY_MULTICAST_MDNSD)
     TCase *tc = tcase_create("Send path scaffolding");
     tcase_add_unchecked_fixture(tc, setup_server, teardown_server);
+    tcase_add_checked_fixture(tc, NULL, checkThreadCallbackFailures);
     tcase_add_test(tc, MdnsStartupTriggersSendPath);
     tcase_add_test(tc, MdnsShutdownSendsSelfGoodbyeAndDrainsQueue);
     tcase_add_test(tc, MdnsUpdateOnlineOfflineTriggersSendPath);
@@ -2340,6 +2374,7 @@ testSuite_DiscoveryMdnsd(void) {
     suite_add_tcase(s, tc);
 
     TCase *tc_query = tcase_create("Query behavior");
+    tcase_add_checked_fixture(tc_query, NULL, checkThreadCallbackFailures);
     tcase_add_test(tc_query, MdnsQueryPresenceSendsStartupPtrQuery);
     tcase_add_test(tc_query, MdnsQueryDetailsSendsSrvTxtQueriesForPtr);
     tcase_add_test(tc_query, MdnsQueryDetailsSendsTxtQueryForSrvOnly);
@@ -2357,6 +2392,8 @@ testSuite_DiscoveryMdnsd(void) {
     tcase_add_unchecked_fixture(tc_integration,
                                 setup_public_api_servers,
                                 teardown_public_api_servers);
+    tcase_add_checked_fixture(tc_integration, NULL,
+                              checkThreadCallbackFailures);
     tcase_add_test(tc_integration, PublicApiRegisterDeregisterCallback);
     tcase_add_test(tc_integration, PublicApiDeregisterDiscoveryKeepsLocalMdnsRecord);
     tcase_add_test(tc_integration, PublicApiFindServersOnNetworkListsRegisteredServers);


### PR DESCRIPTION
This PR replaces, rebases and extends #6370.

Now custom architecture-specific source files can be located in one isolated folder. For default architectures (win32 and posix), it is the folder arch/eventloop_posix. For custom architectures, this folder could be under the arch folder for public code, or outside of the open62541 source code tree for private code. The location of the folder with architecture-specific files can be set using the new build option UA_ARCH_FOLDER. Default architecture-specific files under the folder arch/eventloop_posix are renamed, they start with "eventloop_arch_ ". This way no need to modify the list of files in the file CMakeLists.txt for custom architecture build.