### PR TITLE
fix(plugin): handle return values of fseek and ftell while parsing a certificate file

### DIFF
--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -1074,11 +1074,28 @@ loadCertificateFile(const char *const path) {
     }
 
     /* Get the file length, allocate the data and read */
-    fseek(fp, 0, SEEK_END);
-    fileContents.length = (size_t)ftell(fp);
+    if(fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        errno = 0;
+        return fileContents;
+    }
+
+    long length = ftell(fp);
+    if(length < 0) {
+        fclose(fp);
+        errno = 0;
+        return fileContents;
+    }
+
+    fileContents.length = (size_t)length;
     fileContents.data = (UA_Byte *)UA_malloc(fileContents.length * sizeof(UA_Byte));
     if(fileContents.data) {
-        fseek(fp, 0, SEEK_SET);
+        if(fseek(fp, 0, SEEK_SET) != 0) {
+            fclose(fp);
+            UA_ByteString_clear(&fileContents);
+            errno = 0;
+            return fileContents;
+        }
         size_t read = fread(fileContents.data, sizeof(UA_Byte), fileContents.length, fp);
         if(read != fileContents.length)
             UA_ByteString_clear(&fileContents);


### PR DESCRIPTION
This is a follow up of #7889 where this was fixed for examples/common.h. The same issue is fixed by this PR for plugins/ua_config_json.c.

Currently, the return value of fseek is completely ignored, even on failure. The same case holds for ftell, where a negative return value due to some failure is just written to the length of `fileContents`. By introducing checks on the respective return values, those cases can be handled properly.