### PR TITLE
fix(plugin): prevent unterminated filestore paths

### DIFF
--- a/plugins/crypto/ua_certificategroup_filestore.c
+++ b/plugins/crypto/ua_certificategroup_filestore.c
@@ -386,7 +386,8 @@ FileCertStore_setupStorePath(char *directory, char *rootDirectory,
     char path[UA_PATH_MAX] = {0};
     size_t pathSize = 0;
 
-    strncpy(path, rootDirectory, UA_PATH_MAX);
+    strncpy(path, rootDirectory, UA_PATH_MAX - 1);
+    path[UA_PATH_MAX - 1] = '\0';
     pathSize = strnlen(path, UA_PATH_MAX);
 
     strncpy(&path[pathSize], directory, UA_PATH_MAX - pathSize);


### PR DESCRIPTION
This is a result of a static code analysis done using Coverity Scan.