### PR TITLE
 fix(server): allow removal of CA certificates without valid CRL

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -877,7 +877,9 @@ UA_Server_removeCertificates(UA_Server *server,
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     for(size_t i = 0; i < certificatesSize; i++) {
         retval = certGroup->getCertificateCrls(certGroup, &certificates[i], isTrusted, &crls, &crlsSize);
-        if(retval != UA_STATUSCODE_GOOD) {
+        /* Tolerate "Bad_NoMatch" to support removing CA certificates that do
+         * not have an associated CRL. */
+        if((retval != UA_STATUSCODE_GOOD) && (retval != UA_STATUSCODE_BADNOMATCH)) {
             UA_Array_delete(crls, crlsSize, &UA_TYPES[UA_TYPES_BYTESTRING]);
             return retval;
         }

--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -561,7 +561,9 @@ removeCertificate(UA_Server *server,
         UA_ByteString certificate = certificates[i];
         retval = certGroup->getCertificateCrls(certGroup, &certificate, isTrustedCertificate,
                                                &crls, &crlsSize);
-        if(retval != UA_STATUSCODE_GOOD) {
+        /* Tolerate "Bad_NoMatch" to support removing CA certificates that do
+         * not have an associated CRL. */
+        if((retval != UA_STATUSCODE_GOOD) && (retval != UA_STATUSCODE_BADNOMATCH)) {
             goto cleanup;
         }
 

--- a/tests/encryption/check_update_trustlist.c
+++ b/tests/encryption/check_update_trustlist.c
@@ -277,6 +277,42 @@ START_TEST(remove_certificate_issuerlist) {
 }
 END_TEST
 
+/* Regression test for fix/ca-removal-without-crl:
+ * Removing a CA certificate that has no associated CRL must succeed.
+ * Without the fix, getCertificateCrls returns Bad_NoMatch and the
+ * remove call fails with that status code. */
+START_TEST(remove_ca_certificate_without_crl) {
+    UA_NodeId defaultApplicationGroup =
+        UA_NS0ID(SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTAPPLICATIONGROUP);
+
+    /* Add a CA certificate with no CRL */
+    UA_ByteString caCert;
+    caCert.length = ROOT_CERT_DER_LENGTH;
+    caCert.data = ROOT_CERT_DER_DATA;
+
+    UA_StatusCode retval =
+        UA_Server_addCertificates(server, defaultApplicationGroup,
+                                  &caCert, 1, NULL, 0, true, true);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    /* Remove it — must succeed even though there is no CRL */
+    retval = UA_Server_removeCertificates(server, defaultApplicationGroup,
+                                          &caCert, 1, true);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    /* Verify the trust list is back to its initial state */
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_TrustListDataType trustList;
+    UA_TrustListDataType_init(&trustList);
+    trustList.specifiedLists = UA_TRUSTLISTMASKS_ALL;
+    retval = config->secureChannelPKI.getTrustList(&config->secureChannelPKI, &trustList);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(trustList.trustedCertificatesSize, initialTrustSize);
+    ck_assert_uint_eq(trustList.trustedCrlsSize, 0);
+    UA_TrustListDataType_clear(&trustList);
+}
+END_TEST
+
 START_TEST(add_application_certificate_trustlist) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
@@ -316,6 +352,7 @@ static Suite* testSuite_create_certificate(void) {
     tcase_add_test(tc_cert, add_ca_certificate_issuerlist);
     tcase_add_test(tc_cert, remove_certificate_trustlist);
     tcase_add_test(tc_cert, remove_certificate_issuerlist);
+    tcase_add_test(tc_cert, remove_ca_certificate_without_crl);
     tcase_add_test(tc_cert, add_application_certificate_trustlist);
 #endif /* UA_ENABLE_ENCRYPTION */
     suite_add_tcase(s,tc_cert);
@@ -328,6 +365,7 @@ static Suite* testSuite_create_certificate(void) {
     tcase_add_test(tc_cert_filestore, add_ca_certificate_issuerlist);
     tcase_add_test(tc_cert_filestore, remove_certificate_trustlist);
     tcase_add_test(tc_cert_filestore, remove_certificate_issuerlist);
+    tcase_add_test(tc_cert_filestore, remove_ca_certificate_without_crl);
     tcase_add_test(tc_cert_filestore, add_application_certificate_trustlist);
 #endif /* UA_ENABLE_ENCRYPTION */
     suite_add_tcase(s,tc_cert_filestore);


### PR DESCRIPTION
When removing a CA certificate from the trust store, getCertificateCrls may return BadNoMatch if no CRL is associated with that certificate. Previously, this was treated as a hard failure, preventing the certificate from being removed.

This PR extends and replaces #7662 