### PR TITLE
feat(server): add allowCreateSubscription callback to access control plugin

### DIFF
--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -114,6 +114,10 @@ struct UA_AccessControl {
                                   const UA_NodeId *nodeId, void *nodeContext);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
+    /* Allow creating a subscription */
+    UA_Boolean (*allowCreateSubscription)(UA_Server *server, UA_AccessControl *ac,
+                                          const UA_NodeId *sessionId, void *sessionContext);
+
     /* Allow transfer of a subscription to another session. The Server shall
      * validate that the Client of that Session is operating on behalf of the
      * same user */

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -184,6 +184,12 @@ allowBrowseNode_default(UA_Server *server, UA_AccessControl *ac,
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static UA_Boolean
+allowCreateSubscription_default(UA_Server *server, UA_AccessControl *ac,
+                                const UA_NodeId *sessionId, void *sessionContext) {
+    return true;
+}
+
+static UA_Boolean
 allowTransferSubscription_default(UA_Server *server, UA_AccessControl *ac,
                                   const UA_NodeId *oldSessionId, void *oldSessionContext,
                                   const UA_NodeId *newSessionId, void *newSessionContext) {
@@ -299,6 +305,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
     ac->allowBrowseNode = allowBrowseNode_default;
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
+    ac->allowCreateSubscription = allowCreateSubscription_default;
     ac->allowTransferSubscription = allowTransferSubscription_default;
 #endif
 

--- a/src/server/ua_services_subscription.c
+++ b/src/server/ua_services_subscription.c
@@ -103,6 +103,15 @@ Service_CreateSubscription(UA_Server *server, UA_Session *session,
                            UA_CreateSubscriptionResponse *response) {
     UA_LOCK_ASSERT(&server->serviceMutex);
 
+    /* Check with AccessControl if the creation is allowed */
+    if(server->config.accessControl.allowCreateSubscription &&
+       !server->config.accessControl.
+           allowCreateSubscription(server, &server->config.accessControl,
+                                   &session->sessionId, session->context)) {
+        response->responseHeader.serviceResult = UA_STATUSCODE_BADUSERACCESSDENIED;
+        return true;
+    }
+
     /* Check limits for the number of subscriptions */
     if(((server->config.maxSubscriptions != 0) &&
         (server->subscriptionsSize >= server->config.maxSubscriptions)) ||

--- a/tests/server/check_accesscontrol.c
+++ b/tests/server/check_accesscontrol.c
@@ -10,6 +10,11 @@
 #include <open62541/plugin/accesscontrol_default.h>
 #include <open62541/types.h>
 
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+#include "server/ua_server_internal.h"
+#include "server/ua_services.h"
+#endif
+
 #include <stdlib.h>
 #include <check.h>
 
@@ -195,6 +200,107 @@ START_TEST(Server_setSessionParameter) {
     UA_Server_delete(server);
 } END_TEST
 
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+/* Always denies subscription creation */
+static UA_Boolean
+denyCreateSubscription(UA_Server *s, UA_AccessControl *ac,
+                       const UA_NodeId *sessionId, void *sessionContext) {
+    return false;
+}
+
+/* Regression test for feat/accesscontrol-allow-create-subscription:
+ * When allowCreateSubscription denies the request, CreateSubscription
+ * must return BadUserAccessDenied instead of succeeding.
+ * Uses a direct service call (no network round-trip) to avoid
+ * timing-related flakiness. */
+START_TEST(Server_denyCreateSubscription) {
+    server = UA_Server_newForUnitTest();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_AccessControl_default(config, true, NULL, 0, NULL);
+    config->accessControl.allowCreateSubscription = denyCreateSubscription;
+    UA_Server_run_startup(server);
+
+    UA_CreateSubscriptionRequest request;
+    UA_CreateSubscriptionRequest_init(&request);
+    UA_CreateSubscriptionResponse response;
+    UA_CreateSubscriptionResponse_init(&response);
+
+    UA_LOCK(&server->serviceMutex);
+    Service_CreateSubscription(server, &server->adminSession,
+                               &request, &response);
+    UA_UNLOCK(&server->serviceMutex);
+
+    ck_assert_uint_eq(response.responseHeader.serviceResult,
+                      UA_STATUSCODE_BADUSERACCESSDENIED);
+
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+} END_TEST
+
+/* When allowCreateSubscription is NULL (not configured), subscription
+ * creation is allowed for backward compatibility — matching the pattern
+ * of allowAddNode, allowDeleteNode, etc. */
+START_TEST(Server_nullCreateSubscriptionCallback) {
+    server = UA_Server_newForUnitTest();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_AccessControl_default(config, true, NULL, 0, NULL);
+    config->accessControl.allowCreateSubscription = NULL;
+    UA_Server_run_startup(server);
+
+    UA_CreateSubscriptionRequest request;
+    UA_CreateSubscriptionRequest_init(&request);
+    request.requestedPublishingInterval = 500.0;
+    request.requestedLifetimeCount = 10000;
+    request.requestedMaxKeepAliveCount = 10;
+    request.maxNotificationsPerPublish = 0;
+    request.publishingEnabled = true;
+    UA_CreateSubscriptionResponse response;
+    UA_CreateSubscriptionResponse_init(&response);
+
+    UA_LOCK(&server->serviceMutex);
+    Service_CreateSubscription(server, &server->adminSession,
+                               &request, &response);
+    UA_UNLOCK(&server->serviceMutex);
+
+    ck_assert_uint_eq(response.responseHeader.serviceResult,
+                      UA_STATUSCODE_GOOD);
+    ck_assert_uint_ne(response.subscriptionId, 0);
+
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+} END_TEST
+/* When the default allowCreateSubscription callback is used (returns true),
+ * CreateSubscription must succeed. */
+START_TEST(Server_allowCreateSubscription) {
+    server = UA_Server_newForUnitTest();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_AccessControl_default(config, true, NULL, 0, NULL);
+    UA_Server_run_startup(server);
+
+    UA_CreateSubscriptionRequest request;
+    UA_CreateSubscriptionRequest_init(&request);
+    request.requestedPublishingInterval = 500.0;
+    request.requestedLifetimeCount = 10000;
+    request.requestedMaxKeepAliveCount = 10;
+    request.maxNotificationsPerPublish = 0;
+    request.publishingEnabled = true;
+    UA_CreateSubscriptionResponse response;
+    UA_CreateSubscriptionResponse_init(&response);
+
+    UA_LOCK(&server->serviceMutex);
+    Service_CreateSubscription(server, &server->adminSession,
+                               &request, &response);
+    UA_UNLOCK(&server->serviceMutex);
+
+    ck_assert_uint_eq(response.responseHeader.serviceResult,
+                      UA_STATUSCODE_GOOD);
+    ck_assert_uint_ne(response.subscriptionId, 0);
+
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+} END_TEST
+#endif /* UA_ENABLE_SUBSCRIPTIONS */
+
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Client");
     TCase *tc_client_user = tcase_create("Client User/Password");
@@ -208,6 +314,11 @@ static Suite* testSuite_Client(void) {
     TCase *tc_server = tcase_create("Server-Side Access Control");
     tcase_add_test(tc_server, Server_sessionParameter);
     tcase_add_test(tc_server, Server_setSessionParameter);
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    tcase_add_test(tc_server, Server_allowCreateSubscription);
+    tcase_add_test(tc_server, Server_denyCreateSubscription);
+    tcase_add_test(tc_server, Server_nullCreateSubscriptionCallback);
+#endif
     suite_add_tcase(s,tc_server);
     return s;
 }


### PR DESCRIPTION
Adds an optional allowCreateSubscription callback to UA_AccessControl, allowing server integrators to control whether a session is permitted to create subscriptions.

This PR extends and replaces #7467 