### PR TITLE
fix(client): use authSecurityPolicies for non-X509 token authentication

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -2153,6 +2153,27 @@ UA_ClientConfig_setDefault(UA_ClientConfig *config) {
         config->securityPoliciesSize = 1;
     }
 
+    /* Initialize authSecurityPolicies with the None policy as a fallback.
+     * This is needed so that non-X509 token types (e.g. username/password,
+     * anonymous) can look up a matching SecurityPolicy for authentication.
+     * When UA_ClientConfig_setAuthenticationCert is called later, this gets
+     * replaced with the full set of authentication SecurityPolicies. */
+    if(config->authSecurityPoliciesSize == 0) {
+        config->authSecurityPolicies =
+            (UA_SecurityPolicy*)UA_malloc(sizeof(UA_SecurityPolicy));
+        if(!config->authSecurityPolicies)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        UA_StatusCode retval =
+            UA_SecurityPolicy_None(config->authSecurityPolicies,
+                                   UA_BYTESTRING_NULL, config->logging);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_free(config->authSecurityPolicies);
+            config->authSecurityPolicies = NULL;
+            return retval;
+        }
+        config->authSecurityPoliciesSize = 1;
+    }
+
     if(config->requestedSessionTimeout == 0)
         config->requestedSessionTimeout = 1200000;
 

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -98,15 +98,16 @@ getSecurityPolicy(UA_Client *client, UA_String policyUri) {
 }
 
 /* Match PolicyUri and certificate. The returned SecurityPolicy instance carries
- * the private key to sign with the given ceertificate. */
+ * the private key to sign with the given certificate. When the certificate is
+ * NULL, only the PolicyUri is matched (used for non-X509 token types). */
 static UA_SecurityPolicy *
 getAuthSecurityPolicy(UA_Client *client, const UA_String policyUri,
-                      const UA_ByteString certificate) {
+                      const UA_ByteString *certificate) {
     for(size_t i = 0; i < client->config.authSecurityPoliciesSize; i++) {
         UA_SecurityPolicy *sp = &client->config.authSecurityPolicies[i];
         if(!UA_String_equal(&policyUri, &sp->policyUri))
             continue;
-        if(!UA_ByteString_equal(&certificate, &sp->localCertificate))
+        if(certificate && !UA_ByteString_equal(certificate, &sp->localCertificate))
             continue;
         return sp;
     }
@@ -168,19 +169,22 @@ initUserTokenPolicy(UA_Client *client, const UA_UserTokenPolicy **outUtp,
     UA_String tokenSecurityPolicyUri = (utp->securityPolicyUri.length > 0) ?
         utp->securityPolicyUri : client->endpoint.securityPolicyUri;
 
-    /* Get the SecurityPolicy for authentication */
+    /* Get the SecurityPolicy for authentication.
+     * For X509 tokens, match both PolicyUri and certificate.
+     * For other token types (username/anonymous), match only PolicyUri
+     * in the authSecurityPolicies. */
     UA_SecurityPolicy *utsp;
     if(utp->tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
         UA_X509IdentityToken *token = (UA_X509IdentityToken*)
             client->config.userIdentityToken.content.decoded.data;
         utsp = getAuthSecurityPolicy(client, tokenSecurityPolicyUri,
-                                     token->certificateData);
+                                     &token->certificateData);
     } else {
-        utsp = getSecurityPolicy(client, tokenSecurityPolicyUri);
+        utsp = getAuthSecurityPolicy(client, tokenSecurityPolicyUri, NULL);
     }
     if(!utsp) {
         UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
-                     "%s: SecurityPoliocy %S not available for the "
+                     "%s: SecurityPolicy %S not available for the "
                      "UserTokenPolicy", logPrefix, tokenSecurityPolicyUri);
         return UA_STATUSCODE_BADSECURITYPOLICYREJECTED;
     }
@@ -190,7 +194,7 @@ initUserTokenPolicy(UA_Client *client, const UA_UserTokenPolicy **outUtp,
         if(!UA_String_equal(&client->utpSp->policyUri,
                             &tokenSecurityPolicyUri)) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
-                         "%s: SecurityPoliocy %S cannot be instantiated. "
+                         "%s: SecurityPolicy %S cannot be instantiated. "
                          "A different SecurityPolicy %s is in place already",
                          logPrefix, tokenSecurityPolicyUri,
                          client->utpSp->policyUri);
@@ -1253,15 +1257,18 @@ matchUserTokenPolicy(UA_Client *client, UA_EndpointDescription *endpoint,
     if(utp->tokenType == UA_USERTOKENTYPE_ANONYMOUS)
         return true;
 
-    /* Get the SecurityPolicy */
+    /* Get the SecurityPolicy for authentication.
+     * For X509 tokens, match both PolicyUri and certificate.
+     * For other token types (username/anonymous), match only PolicyUri
+     * in the authSecurityPolicies. */
     UA_SecurityPolicy *utsp;
     if(utp->tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
         UA_X509IdentityToken *token = (UA_X509IdentityToken*)
             client->config.userIdentityToken.content.decoded.data;
         utsp = getAuthSecurityPolicy(client, tokenPolicyUri,
-                                     token->certificateData);
+                                     &token->certificateData);
     } else {
-        utsp = getSecurityPolicy(client, tokenPolicyUri);
+        utsp = getAuthSecurityPolicy(client, tokenPolicyUri, NULL);
     }
     if(!utsp) {
         if(logPrefix) {

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -195,7 +195,7 @@ initUserTokenPolicy(UA_Client *client, const UA_UserTokenPolicy **outUtp,
                             &tokenSecurityPolicyUri)) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                          "%s: SecurityPolicy %S cannot be instantiated. "
-                         "A different SecurityPolicy %s is in place already",
+                         "A different SecurityPolicy %S is in place already",
                          logPrefix, tokenSecurityPolicyUri,
                          client->utpSp->policyUri);
             return UA_STATUSCODE_BADSECURITYPOLICYREJECTED;

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -169,10 +169,10 @@ initUserTokenPolicy(UA_Client *client, const UA_UserTokenPolicy **outUtp,
     UA_String tokenSecurityPolicyUri = (utp->securityPolicyUri.length > 0) ?
         utp->securityPolicyUri : client->endpoint.securityPolicyUri;
 
-    /* Get the SecurityPolicy for authentication.
-     * For X509 tokens, match both PolicyUri and certificate.
-     * For other token types (username/anonymous), match only PolicyUri
-     * in the authSecurityPolicies. */
+    /* Get the SecurityPolicy for the UserIdentityToken. X509 tokens sign with
+     * a private key, so they must use an authSecurityPolicy (matched by
+     * PolicyUri and certificate). Other tokens only encrypt with the server
+     * certificate, so fall back to the SecureChannel securityPolicies. */
     UA_SecurityPolicy *utsp;
     if(utp->tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
         UA_X509IdentityToken *token = (UA_X509IdentityToken*)
@@ -181,6 +181,8 @@ initUserTokenPolicy(UA_Client *client, const UA_UserTokenPolicy **outUtp,
                                      &token->certificateData);
     } else {
         utsp = getAuthSecurityPolicy(client, tokenSecurityPolicyUri, NULL);
+        if(!utsp)
+            utsp = getSecurityPolicy(client, tokenSecurityPolicyUri);
     }
     if(!utsp) {
         UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
@@ -1257,10 +1259,9 @@ matchUserTokenPolicy(UA_Client *client, UA_EndpointDescription *endpoint,
     if(utp->tokenType == UA_USERTOKENTYPE_ANONYMOUS)
         return true;
 
-    /* Get the SecurityPolicy for authentication.
-     * For X509 tokens, match both PolicyUri and certificate.
-     * For other token types (username/anonymous), match only PolicyUri
-     * in the authSecurityPolicies. */
+    /* Get the SecurityPolicy for the UserIdentityToken (see
+     * initUserTokenPolicy for the authSecurityPolicies/securityPolicies
+     * lookup rationale). */
     UA_SecurityPolicy *utsp;
     if(utp->tokenType == UA_USERTOKENTYPE_CERTIFICATE) {
         UA_X509IdentityToken *token = (UA_X509IdentityToken*)
@@ -1269,6 +1270,8 @@ matchUserTokenPolicy(UA_Client *client, UA_EndpointDescription *endpoint,
                                      &token->certificateData);
     } else {
         utsp = getAuthSecurityPolicy(client, tokenPolicyUri, NULL);
+        if(!utsp)
+            utsp = getSecurityPolicy(client, tokenPolicyUri);
     }
     if(!utsp) {
         if(logPrefix) {

--- a/tests/client/check_client_authentication.c
+++ b/tests/client/check_client_authentication.c
@@ -200,7 +200,13 @@ START_TEST(client_connect_none_username_basic256Sha256) {
         UA_String_clear(&cc->clientDescription.applicationUri);
         cc->clientDescription.applicationUri = UA_STRING_ALLOC("urn:open62541.server.application");
 
-        /* Only use the relevant security policy in authSecurityPolicies */
+        /* Rebind the SecureChannel None policy with the client certificate */
+        for(size_t i = 0; i < cc->securityPoliciesSize; ++i) {
+            cc->securityPolicies[i].clear(&cc->securityPolicies[i]);
+            UA_SecurityPolicy_None(&cc->securityPolicies[i], certificate, cc->logging);
+        }
+
+        /* Use the relevant security policies in authSecurityPolicies */
         for(size_t i = 0; i < cc->authSecurityPoliciesSize; ++i)
             cc->authSecurityPolicies[i].clear(&cc->authSecurityPolicies[i]);
         UA_free(cc->authSecurityPolicies);

--- a/tests/client/check_client_authentication.c
+++ b/tests/client/check_client_authentication.c
@@ -201,13 +201,13 @@ START_TEST(client_connect_none_username_basic256Sha256) {
         cc->clientDescription.applicationUri = UA_STRING_ALLOC("urn:open62541.server.application");
 
         /* Only use the relevant security policy in authSecurityPolicies */
-        for(size_t i = 0; i < cc->securityPoliciesSize; ++i)
-            cc->securityPolicies[i].clear(&cc->securityPolicies[i]);
-        UA_free(cc->securityPolicies);
-        cc->securityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
-        cc->securityPoliciesSize = 2;
-        UA_SecurityPolicy_None(&cc->securityPolicies[0], certificate, cc->logging);
-        UA_SecurityPolicy_Basic256Sha256(&cc->securityPolicies[1], certificate, privateKey, cc->logging);
+        for(size_t i = 0; i < cc->authSecurityPoliciesSize; ++i)
+            cc->authSecurityPolicies[i].clear(&cc->authSecurityPolicies[i]);
+        UA_free(cc->authSecurityPolicies);
+        cc->authSecurityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
+        cc->authSecurityPoliciesSize = 2;
+        UA_SecurityPolicy_None(&cc->authSecurityPolicies[0], certificate, cc->logging);
+        UA_SecurityPolicy_Basic256Sha256(&cc->authSecurityPolicies[1], certificate, privateKey, cc->logging);
 
         UA_StatusCode retval = UA_Client_connectUsername(client, "opc.tcp://localhost:4840", "admin", "admin");
 
@@ -272,14 +272,23 @@ START_TEST(client_connect_none_username_eccpnist256) {
 
     /* Only use the relevant security policy in authSecurityPolicies */
     for(size_t i = 0; i < cc->authSecurityPoliciesSize; ++i)
-        cc->securityPolicies[i].clear(&cc->securityPolicies[i]);
-    UA_free(cc->securityPolicies);
-    cc->securityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
-    cc->securityPoliciesSize = 2;
-    UA_SecurityPolicy_None(&cc->securityPolicies[0], certificate, cc->logging);
-    UA_SecurityPolicy_EccNistP256(&cc->securityPolicies[1],
+        cc->authSecurityPolicies[i].clear(&cc->authSecurityPolicies[i]);
+    UA_free(cc->authSecurityPolicies);
+    cc->authSecurityPolicies = (UA_SecurityPolicy*)UA_calloc(2, sizeof(UA_SecurityPolicy));
+    cc->authSecurityPoliciesSize = 2;
+    UA_SecurityPolicy_None(&cc->authSecurityPolicies[0], certificate, cc->logging);
+    UA_SecurityPolicy_EccNistP256(&cc->authSecurityPolicies[1],
                                   UA_APPLICATIONTYPE_CLIENT,
                                   certificate, privateKey, cc->logging);
+
+    /* Rebind the SecureChannel None policy with the client certificate so the
+     * server can determine the session-level SecurityPolicy for ECC */
+    for(size_t i = 0; i < cc->securityPoliciesSize; ++i)
+        cc->securityPolicies[i].clear(&cc->securityPolicies[i]);
+    UA_free(cc->securityPolicies);
+    cc->securityPolicies = (UA_SecurityPolicy*)UA_calloc(1, sizeof(UA_SecurityPolicy));
+    cc->securityPoliciesSize = 1;
+    UA_SecurityPolicy_None(&cc->securityPolicies[0], certificate, cc->logging);
 
     UA_StatusCode retval = UA_Client_connectUsername(client, "opc.tcp://localhost:4840", "admin", "admin");
 
@@ -415,12 +424,14 @@ START_TEST(client_connect_basic256Sha256_anonymous) {
     UA_String_clear(&cc->clientDescription.applicationUri);
     cc->clientDescription.applicationUri = UA_STRING_ALLOC("urn:open62541.server.application");
 
-    /* Use empty security policies array */
+    /* Override authSecurityPolicies with Basic256Sha256 so that an
+     * anonymous token can be matched against it */
     for(size_t i = 0; i < cc->authSecurityPoliciesSize; ++i)
         cc->authSecurityPolicies[i].clear(&cc->authSecurityPolicies[i]);
     UA_free(cc->authSecurityPolicies);
-    cc->authSecurityPolicies = NULL;
-    cc->authSecurityPoliciesSize = 0;
+    cc->authSecurityPolicies = (UA_SecurityPolicy*)UA_calloc(1, sizeof(UA_SecurityPolicy));
+    cc->authSecurityPoliciesSize = 1;
+    UA_SecurityPolicy_Basic256Sha256(&cc->authSecurityPolicies[0], certificate, privateKey, cc->logging);
 
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
 

--- a/tests/network_replay/check_network_replay.c
+++ b/tests/network_replay/check_network_replay.c
@@ -125,6 +125,12 @@ START_TEST(unified_cpp_basic256sha256) {
         sp->generateNonce = reproducibleNonce;
     }
 
+    /* Also replace the nonce-generating function in authSecurityPolicies */
+    for(size_t i = 0; i < cc->authSecurityPoliciesSize; i++) {
+        UA_SecurityPolicy *sp = &cc->authSecurityPolicies[i];
+        sp->generateNonce = reproducibleNonce;
+    }
+
     /* Reset the rng */
     UA_random_seed_deterministic(0);
 
@@ -175,6 +181,12 @@ START_TEST(prosys_basic256sha256) {
     /* Replace the nonce-generating function in the SecurityPolicies */
     for(size_t i = 0; i < cc->securityPoliciesSize; i++) {
         UA_SecurityPolicy *sp = &cc->securityPolicies[i];
+        sp->generateNonce = reproducibleNonce;
+    }
+
+    /* Also replace the nonce-generating function in authSecurityPolicies */
+    for(size_t i = 0; i < cc->authSecurityPoliciesSize; i++) {
+        UA_SecurityPolicy *sp = &cc->authSecurityPolicies[i];
         sp->generateNonce = reproducibleNonce;
     }
 


### PR DESCRIPTION
Rework of #7769.

Non-X509 user identity tokens (username/password, anonymous) incorrectly searched securityPolicies instead of authSecurityPolicies when resolving the SecurityPolicy for token encryption. This caused authentication failures when the two policy arrays were configured independently.