### PR TITLE
fix(core): fix the case where the last chunk may exceed the max message size.

### DIFF
--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -949,7 +949,7 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
 
     /* Validate the assembled message size */
     if(channel->config.localMaxMessageSize != 0 &&
-       channel->chunksLength > channel->config.localMaxMessageSize) {
+       messageSize > channel->config.localMaxMessageSize) {
         if(chunk.copied)
             UA_ByteString_clear(&chunk.bytes);
         return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;


### PR DESCRIPTION
If a transferred message exceeds the configured tcpMaxMsgSize, the server must return UA_STATUSCODE_BADTCPMESSAGETOOLARGE. This did not occur in our tests with a slightly oversized message. This modification ensures that the final chunk is correctly validated against the maximum message size.