### PR TITLE
Role-Based Access Control (RBAC): Batch 7 - Namespace default role permissions API

### DIFF
--- a/examples/access_control/server_rbac.c
+++ b/examples/access_control/server_rbac.c
@@ -4,8 +4,9 @@
  * This example demonstrates how to configure Role-Based Access Control (RBAC)
  * in an OPC UA server using:
  * 1. User authentication via username/password
- * 2. Role identity mapping (UserName criteria) for automatic role assignment
- * 3. Runtime role management via Server API
+ * 2. Identity mapping to well-known roles (e.g. ConfigureAdmin)
+ * 3. Namespace default role permissions (OPC UA Part 5, 6.3.13)
+ * 4. Explicit per-node role permissions with recursive flag
  *
  * The default access control plugin (ua_accesscontrol_default.c) implements
  * automatic role assignment by evaluating IdentityCriteriaType:
@@ -33,20 +34,9 @@ int main(void) {
     /* Allow username/password authentication over unencrypted connection (for demo) */
     config.allowNonePolicyPassword = true;
 
-    /* Configure RBAC mode: allPermissionsForAnonymous
-     * This controls the default role permissions applied to namespace 0 (NS0)
-     * per OPC UA Part 18.
-     *
-     * If FALSE (recommended for production):
-     *   - Anonymous role: BROWSE only
-     *   - AuthenticatedUser role: BROWSE | READ
-     *   - ConfigureAdmin role: All permissions (BROWSE, READ, WRITE, CALL, etc.)
-     *
-     * If TRUE (INSECURE - for testing/development only):
-     *   - Anonymous role: All permissions
-     *
-     * These defaults apply to all nodes in NS0 that don't have explicit RolePermissions.
-     * Change this to 'true' for testing without authentication. */
+    /* When allPermissionsForAnonymous is false, access is denied for nodes
+     * without explicit RolePermissions or namespace defaults.
+     * Set to true for development/testing to skip permission checks. */
     config.allPermissionsForAnonymous = false;
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                 "RBAC Mode: allPermissionsForAnonymous = %s",
@@ -71,49 +61,51 @@ int main(void) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                 "Configured users: admin, operator, guest and anonymous");
 
-    /* Step 2: Create a custom role via ServerConfig with UserName identity mapping.
-     * This role will be automatically assigned to users named "admin". */
-    UA_Role adminRole;
-    UA_Role_init(&adminRole);
-
-    adminRole.roleName = UA_QUALIFIEDNAME_ALLOC(0, "AdminRole");
-
-    /* Define identity mapping: match username "admin" */
-    adminRole.identityMappingRules = (UA_IdentityMappingRuleType*)
-        UA_malloc(sizeof(UA_IdentityMappingRuleType));
-    if(!adminRole.identityMappingRules) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
-                     "Failed to allocate identity mapping rule");
-        UA_Role_clear(&adminRole);
-        UA_ServerConfig_clear(&config);
-        return EXIT_FAILURE;
-    }
-    adminRole.identityMappingRulesSize = 1;
-    UA_IdentityMappingRuleType_init(&adminRole.identityMappingRules[0]);
-    adminRole.identityMappingRules[0].criteriaType = UA_IDENTITYCRITERIATYPE_USERNAME;
-    adminRole.identityMappingRules[0].criteria = UA_STRING_ALLOC("admin");
-
-    /* Add the role to the server configuration */
-    config.rolesSize = 1;
-    config.roles = (UA_Role*)UA_malloc(sizeof(UA_Role));
-    if(!config.roles) {
-        UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
-                     "Failed to allocate roles array");
-        UA_Role_clear(&adminRole);
-        UA_ServerConfig_clear(&config);
-        return EXIT_FAILURE;
-    }
-    config.roles[0] = adminRole;
-
-    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
-                "AdminRole configured with UserName criteria for 'admin'");
-
-    /* Create the server (roles are initialized during server creation) */
+    /* Create the server (well-known roles are initialized during creation) */
     UA_Server *server = UA_Server_newWithConfig(&config);
     if(!server) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                      "Failed to create server");
         return EXIT_FAILURE;
+    }
+
+    /* Step 2: Map 'admin' user to the standard ConfigureAdmin role.
+     * ConfigureAdmin is a well-known role defined in OPC UA Part 18.
+     * Its permissions are assigned indirectly via namespace defaults (Step 4). */
+    UA_NodeId configureAdminRoleId = UA_NODEID_NULL;
+    {
+        UA_Role confAdminRole;
+        retval = UA_Server_getRole(server, UA_QUALIFIEDNAME(0, "ConfigureAdmin"),
+                                   &confAdminRole);
+        if(retval == UA_STATUSCODE_GOOD) {
+            UA_NodeId_copy(&confAdminRole.roleId, &configureAdminRoleId);
+            UA_IdentityMappingRuleType *rules = (UA_IdentityMappingRuleType*)
+                UA_realloc(confAdminRole.identityMappingRules,
+                           (confAdminRole.identityMappingRulesSize + 1) *
+                           sizeof(UA_IdentityMappingRuleType));
+            if(rules) {
+                confAdminRole.identityMappingRules = rules;
+                UA_IdentityMappingRuleType_init(
+                    &rules[confAdminRole.identityMappingRulesSize]);
+                rules[confAdminRole.identityMappingRulesSize].criteriaType =
+                    UA_IDENTITYCRITERIATYPE_USERNAME;
+                rules[confAdminRole.identityMappingRulesSize].criteria =
+                    UA_STRING_ALLOC("admin");
+                confAdminRole.identityMappingRulesSize++;
+                retval = UA_Server_updateRole(server, &confAdminRole);
+            } else {
+                retval = UA_STATUSCODE_BADOUTOFMEMORY;
+            }
+            UA_Role_clear(&confAdminRole);
+        }
+        if(retval == UA_STATUSCODE_GOOD) {
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                        "Mapped 'admin' user to standard ConfigureAdmin role");
+        } else {
+            UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                         "Failed to map admin to ConfigureAdmin: %s",
+                         UA_StatusCode_name(retval));
+        }
     }
 
     /* Step 3: Add an OperatorRole at runtime with UserName identity mapping */
@@ -164,7 +156,32 @@ int main(void) {
         }
     }
 
-    /* Step 4: Configure permissions for the roles */
+    /* Step 4: Set namespace default permissions for NS0.
+     * Per OPC UA Part 5 (6.3.13), if a node has no explicit RolePermissions,
+     * the DefaultRolePermissions from the NamespaceMetadata apply.
+     * This gives well-known roles their baseline permissions indirectly. */
+    {
+        UA_RolePermission nsDefaults[3];
+        nsDefaults[0].roleId = UA_NODEID_NUMERIC(0, UA_NS0ID_WELLKNOWNROLE_ANONYMOUS);
+        nsDefaults[0].permissions = UA_PERMISSIONTYPE_BROWSE;
+        nsDefaults[1].roleId =
+            UA_NODEID_NUMERIC(0, UA_NS0ID_WELLKNOWNROLE_AUTHENTICATEDUSER);
+        nsDefaults[1].permissions = UA_PERMISSIONTYPE_BROWSE | UA_PERMISSIONTYPE_READ;
+        nsDefaults[2].roleId =
+            UA_NODEID_NUMERIC(0, UA_NS0ID_WELLKNOWNROLE_CONFIGUREADMIN);
+        nsDefaults[2].permissions = UA_PERMISSIONTYPE_ALL;
+
+        retval = UA_Server_setNamespaceDefaultRolePermissions(server, 0, 3, nsDefaults);
+        if(retval == UA_STATUSCODE_GOOD) {
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                        "NS0 defaults set: Anonymous=BROWSE, "
+                        "AuthenticatedUser=BROWSE|READ, ConfigureAdmin=ALL");
+        }
+    }
+
+    /* Step 5: Configure explicit permissions on ServerStatus.
+     * Explicit RolePermissions override namespace defaults for the node.
+     * ALL roles that need access must be listed. */
     UA_NodeId serverStatusId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS);
     UA_UInt32 permissions = UA_PERMISSIONTYPE_BROWSE | UA_PERMISSIONTYPE_READ |
                             UA_PERMISSIONTYPE_READROLEPERMISSIONS;
@@ -178,7 +195,18 @@ int main(void) {
                     "OperatorRole on ServerStatus");
     }
 
-    /* Step 5: Configure permissions on BuildInfo node with recursive flag */
+    /* ConfigureAdmin needs explicit listing since node-level overrides defaults */
+    if(!UA_NodeId_isNull(&configureAdminRoleId)) {
+        retval = UA_Server_addRolePermissions(server, serverStatusId,
+                                              configureAdminRoleId,
+                                              UA_PERMISSIONTYPE_ALL, false, false);
+        if(retval == UA_STATUSCODE_GOOD) {
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                        "Added ALL permissions for ConfigureAdmin on ServerStatus");
+        }
+    }
+
+    /* Step 6: Configure permissions on BuildInfo node with recursive flag */
     UA_NodeId buildInfoId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_BUILDINFO);
     UA_UInt32 buildInfoPermissions = UA_PERMISSIONTYPE_BROWSE | UA_PERMISSIONTYPE_READ |
                                      UA_PERMISSIONTYPE_READROLEPERMISSIONS |
@@ -195,6 +223,18 @@ int main(void) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                      "Failed to add recursive permissions for OperatorRole on BuildInfo: %s",
                      UA_StatusCode_name(retval));
+    }
+
+    /* Add all permissions for ConfigureAdmin on BuildInfo and children (recursive) */
+    if(!UA_NodeId_isNull(&configureAdminRoleId)) {
+        retval = UA_Server_addRolePermissions(server, buildInfoId,
+                                              configureAdminRoleId,
+                                              UA_PERMISSIONTYPE_ALL, false, true);
+        if(retval == UA_STATUSCODE_GOOD) {
+            UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
+                        "Added ALL permissions for ConfigureAdmin on BuildInfo "
+                        "(recursive)");
+        }
     }
 
     /* Verify one child node has permissions set (recursive example) */
@@ -264,10 +304,10 @@ int main(void) {
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                 "\n=== Role Assignment ===\n"
                 "When clients connect, roles are automatically assigned based on:\n"
-                "  - Anonymous login -> Anonymous role + any role with AuthenticatedUser criteria\n"
-                "  - user 'admin'    -> AdminRole + any role with AuthenticatedUser criteria\n"
-                "  - user 'operator' -> OperatorRole + any role with AuthenticatedUser criteria\n"
-                "  - user 'guest'    -> Only roles with AuthenticatedUser criteria");
+                "  - Anonymous login -> Anonymous role\n"
+                "  - user 'admin'    -> ConfigureAdmin + AuthenticatedUser\n"
+                "  - user 'operator' -> OperatorRole + AuthenticatedUser\n"
+                "  - user 'guest'    -> AuthenticatedUser only");
 
     UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_USERLAND,
                 "\nServer is running...\n"
@@ -278,6 +318,7 @@ int main(void) {
     UA_Server_runUntilInterrupt(server);
 
     UA_NodeId_clear(&operatorRoleId);
+    UA_NodeId_clear(&configureAdminRoleId);
     retval = UA_Server_run_shutdown(server);
     UA_Server_delete(server);
 

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -2816,6 +2816,9 @@ UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Server_getSessionRoleNames(UA_Server *server, const UA_NodeId sessionId,
                               size_t *outSize, UA_QualifiedName **outRoleNames);
 
+/* Convenience bitmask: all permission bits set */
+#define UA_PERMISSIONTYPE_ALL ((UA_PermissionType)0xFFFFFFFF)
+
 /**
  * Per-Role Node Permission Management
  * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2855,6 +2858,45 @@ UA_Server_removeRolePermissions(UA_Server *server, const UA_NodeId nodeId,
                                 const UA_NodeId roleId,
                                 UA_PermissionType permissions,
                                 UA_Boolean recursive);
+
+/**
+ * Namespace Default Role Permissions
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Per OPC UA Part 5: if a node has no explicit RolePermissions,
+ * the DefaultRolePermissions from the NamespaceMetadata apply.
+ *
+ * Permission resolution order:
+ *  1. Explicit node RolePermissions (set via addRolePermissions)
+ *  2. Namespace default RolePermissions (set via this API) */
+
+/* Set default role permissions for a namespace.
+ * Overwrites any previously set defaults for the given namespace.
+ *
+ * @param server The server instance
+ * @param namespaceIndex The namespace index
+ * @param entriesSize Number of role-permission entries
+ * @param entries Array of role-permission entries (deep-copied)
+ * @return UA_STATUSCODE_GOOD on success */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_setNamespaceDefaultRolePermissions(UA_Server *server,
+                                             UA_UInt16 namespaceIndex,
+                                             size_t entriesSize,
+                                             const UA_RolePermission *entries);
+
+/* Get default role permissions for a namespace.
+ * Returns a deep copy. The caller must free each entry's roleId
+ * with UA_NodeId_clear and the array with UA_free.
+ *
+ * @param server The server instance
+ * @param namespaceIndex The namespace index
+ * @param entriesSize Output: number of entries
+ * @param entries Output: deep-copied array (caller must free)
+ * @return UA_STATUSCODE_GOOD on success */
+UA_StatusCode UA_EXPORT UA_THREADSAFE
+UA_Server_getNamespaceDefaultRolePermissions(UA_Server *server,
+                                             UA_UInt16 namespaceIndex,
+                                             size_t *entriesSize,
+                                             UA_RolePermission **entries);
 
 #endif /* UA_ENABLE_RBAC */
 

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -9,9 +9,7 @@
 #include <open62541/plugin/accesscontrol_default.h>
 
 #ifdef UA_ENABLE_RBAC
-/* Forward declaration of the internal effective-permission helper.
- * The real declaration lives in src/server/ua_server_rbac.h, which is
- * not part of the public plugin API surface. */
+/* Internal RBAC API; not declared in public plugin headers. */
 UA_StatusCode
 UA_Server_getEffectivePermissions(UA_Server *server,
                                   const UA_NodeId *sessionId,

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -8,6 +8,17 @@
 
 #include <open62541/plugin/accesscontrol_default.h>
 
+#ifdef UA_ENABLE_RBAC
+/* Forward declaration of the internal effective-permission helper.
+ * The real declaration lives in src/server/ua_server_rbac.h, which is
+ * not part of the public plugin API surface. */
+UA_StatusCode
+UA_Server_getEffectivePermissions(UA_Server *server,
+                                  const UA_NodeId *sessionId,
+                                  const UA_NodeId *nodeId,
+                                  UA_PermissionType *effectivePermissions);
+#endif
+
 /* Example access control management. Anonymous and username / password login.
  * The access rights are maximally permissive.
  *

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -143,6 +143,14 @@ typedef struct {
     size_t refCount;
 } UA_RolePermissionEntry;
 
+/* Namespace metadata for default role permissions.
+ * Per OPC UA Part 5: If a node has no explicit RolePermissions,
+ * the DefaultRolePermissions from the namespace's NamespaceMetadata apply. */
+typedef struct {
+    size_t entriesSize;
+    UA_RolePermission *entries;
+} UA_NamespaceMetadata;
+
 /* Internal RBAC lifecycle */
 UA_StatusCode UA_Server_initRBAC(UA_Server *server);
 void UA_Server_cleanupRBAC(UA_Server *server);
@@ -249,6 +257,9 @@ struct UA_Server {
     UA_Role *roles;
     UA_Boolean *rolesProtected; /* Parallel array: true for config roles */
 
+    /* Namespace metadata: default role permissions per namespace */
+    size_t namespaceMetadataSize;
+    UA_NamespaceMetadata *namespaceMetadata;
 #endif
 };
 

--- a/src/server/ua_server_rbac.c
+++ b/src/server/ua_server_rbac.c
@@ -477,6 +477,8 @@ UA_Server_initRBAC(UA_Server *server) {
 
     server->rolePermissionsSize = 0;
     server->rolePermissions = NULL;
+    server->namespaceMetadataSize = 0;
+    server->namespaceMetadata = NULL;
 
     /* Copy presets from config into the internal array.
      * Mark them with UA_ROLEPERMISSIONS_REFCOUNT_PROTECTED so they
@@ -561,6 +563,20 @@ UA_Server_cleanupRBAC(UA_Server *server) {
     UA_free(server->rolesProtected);
     server->rolesProtected = NULL;
     server->rolesSize = 0;
+
+    /* Clean up namespace metadata */
+    if(server->namespaceMetadata) {
+        for(size_t i = 0; i < server->namespaceMetadataSize; i++) {
+            if(server->namespaceMetadata[i].entries) {
+                for(size_t j = 0; j < server->namespaceMetadata[i].entriesSize; j++)
+                    UA_NodeId_clear(&server->namespaceMetadata[i].entries[j].roleId);
+                UA_free(server->namespaceMetadata[i].entries);
+            }
+        }
+        UA_free(server->namespaceMetadata);
+        server->namespaceMetadata = NULL;
+        server->namespaceMetadataSize = 0;
+    }
 }
 
 /************************************/
@@ -1953,13 +1969,21 @@ computeEffectivePermissions(UA_Server *server, const UA_Node *node,
         const UA_RolePermissionEntry *rp = &server->rolePermissions[permIdx];
         entries = rp->rolePermissions;
         entriesSize = rp->rolePermissionsSize;
+    } else {
+        /* No explicit permissions, check namespace defaults */
+        UA_UInt16 nsIdx = node->head.nodeId.namespaceIndex;
+        if(nsIdx < server->namespaceMetadataSize && server->namespaceMetadata) {
+            entries = server->namespaceMetadata[nsIdx].entries;
+            entriesSize = server->namespaceMetadata[nsIdx].entriesSize;
+        }
     }
 
     /* If no permissions configured, check allPermissionsForAnonymous.
-     * When true (the default), un-configured nodes are fully permissive. */
+     * When true (the default), un-configured nodes are fully permissive.
+     * When false, only explicitly configured nodes grant access. */
     if(!entries || entriesSize == 0) {
         if(server->config.allPermissionsForAnonymous)
-            return 0xFFFFFFFF; /* All permissions granted */
+            return UA_PERMISSIONTYPE_ALL; /* All permissions granted */
         return 0; /* Strict: deny unless explicitly configured */
     }
 
@@ -2112,6 +2136,101 @@ UA_Server_getUserRolePermissions(UA_Server *server, const UA_NodeId *sessionId,
 
     unlockServer(server);
     return UA_STATUSCODE_GOOD;
+}
+
+/********************************************/
+/* Namespace Default Role Permissions       */
+/********************************************/
+
+UA_StatusCode
+UA_Server_setNamespaceDefaultRolePermissions(UA_Server *server,
+                                             UA_UInt16 namespaceIndex,
+                                             size_t entriesSize,
+                                             const UA_RolePermission *entries) {
+    if(!server)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    if(entriesSize > 0 && !entries)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    lockServer(server);
+
+    if(namespaceIndex >= server->namespacesSize) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADINDEXRANGEINVALID;
+    }
+
+    if(!server->namespaceMetadata) {
+        server->namespaceMetadata = (UA_NamespaceMetadata*)
+            UA_calloc(server->namespacesSize, sizeof(UA_NamespaceMetadata));
+        if(!server->namespaceMetadata) {
+            unlockServer(server);
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
+        server->namespaceMetadataSize = server->namespacesSize;
+    } else if(server->namespaceMetadataSize < server->namespacesSize) {
+        UA_NamespaceMetadata *newMetadata = (UA_NamespaceMetadata*)
+            UA_realloc(server->namespaceMetadata,
+                       server->namespacesSize * sizeof(UA_NamespaceMetadata));
+        if(!newMetadata) {
+            unlockServer(server);
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
+        server->namespaceMetadata = newMetadata;
+        memset(&server->namespaceMetadata[server->namespaceMetadataSize], 0,
+               (server->namespacesSize - server->namespaceMetadataSize) *
+               sizeof(UA_NamespaceMetadata));
+        server->namespaceMetadataSize = server->namespacesSize;
+    }
+
+    /* Clear old entries */
+    if(server->namespaceMetadata[namespaceIndex].entries) {
+        for(size_t i = 0; i < server->namespaceMetadata[namespaceIndex].entriesSize; i++)
+            UA_NodeId_clear(&server->namespaceMetadata[namespaceIndex].entries[i].roleId);
+        UA_free(server->namespaceMetadata[namespaceIndex].entries);
+        server->namespaceMetadata[namespaceIndex].entries = NULL;
+        server->namespaceMetadata[namespaceIndex].entriesSize = 0;
+    }
+
+    /* Set new entries if provided */
+    UA_StatusCode res = UA_STATUSCODE_GOOD;
+    if(entriesSize > 0) {
+        res = copyRolePermissionArray(entriesSize, entries,
+                                      &server->namespaceMetadata[namespaceIndex].entriesSize,
+                                      &server->namespaceMetadata[namespaceIndex].entries);
+    }
+
+    unlockServer(server);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_getNamespaceDefaultRolePermissions(UA_Server *server,
+                                             UA_UInt16 namespaceIndex,
+                                             size_t *entriesSize,
+                                             UA_RolePermission **entries) {
+    if(!server || !entriesSize || !entries)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    *entriesSize = 0;
+    *entries = NULL;
+
+    lockServer(server);
+
+    if(namespaceIndex >= server->namespacesSize) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADINDEXRANGEINVALID;
+    }
+
+    UA_StatusCode res = UA_STATUSCODE_GOOD;
+    if(server->namespaceMetadata && namespaceIndex < server->namespaceMetadataSize) {
+        res = copyRolePermissionArray(
+            server->namespaceMetadata[namespaceIndex].entriesSize,
+            server->namespaceMetadata[namespaceIndex].entries,
+            entriesSize, entries);
+    }
+
+    unlockServer(server);
+    return res;
 }
 
 /************************************/

--- a/src/server/ua_server_rbac.c
+++ b/src/server/ua_server_rbac.c
@@ -2037,15 +2037,13 @@ UA_Server_getEffectivePermissions(UA_Server *server, const UA_NodeId *sessionId,
     return UA_STATUSCODE_GOOD;
 }
 
-/* Internal lock-held variant. Accepts a pre-resolved session pointer.
- * If the node is not present in the nodestore, returns the permissive
- * sentinel 0xFFFFFFFF so callers in subsystem-internal paths (e.g.,
- * event delivery) do not accidentally start blocking on missing nodes. */
+/* Internal helper. Caller holds the lock.
+ * Missing node -> 0xFFFFFFFF (permissive sentinel). */
 UA_StatusCode
-getEffectivePermissions_nolock(UA_Server *server,
-                               const UA_Session *session,
-                               const UA_NodeId *nodeId,
-                               UA_PermissionType *effectivePermissions) {
+getEffectivePermissions(UA_Server *server,
+                        const UA_Session *session,
+                        const UA_NodeId *nodeId,
+                        UA_PermissionType *effectivePermissions) {
     if(!server || !nodeId || !effectivePermissions)
         return UA_STATUSCODE_BADINVALIDARGUMENT;
     UA_LOCK_ASSERT(&server->serviceMutex);

--- a/src/server/ua_server_rbac.c
+++ b/src/server/ua_server_rbac.c
@@ -2037,6 +2037,37 @@ UA_Server_getEffectivePermissions(UA_Server *server, const UA_NodeId *sessionId,
     return UA_STATUSCODE_GOOD;
 }
 
+/* Internal lock-held variant. Accepts a pre-resolved session pointer.
+ * If the node is not present in the nodestore, returns the permissive
+ * sentinel 0xFFFFFFFF so callers in subsystem-internal paths (e.g.,
+ * event delivery) do not accidentally start blocking on missing nodes. */
+UA_StatusCode
+getEffectivePermissions_nolock(UA_Server *server,
+                               const UA_Session *session,
+                               const UA_NodeId *nodeId,
+                               UA_PermissionType *effectivePermissions) {
+    if(!server || !nodeId || !effectivePermissions)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+    const UA_Node *node = UA_NODESTORE_GET(server, nodeId);
+    if(!node) {
+        *effectivePermissions = 0xFFFFFFFF;
+        return UA_STATUSCODE_GOOD;
+    }
+
+    size_t rolesSize = 0;
+    const UA_NodeId *roles = NULL;
+    if(session && session->rolesSize > 0) {
+        rolesSize = session->rolesSize;
+        roles = session->roles;
+    }
+
+    *effectivePermissions = computeEffectivePermissions(server, node, rolesSize, roles);
+    UA_NODESTORE_RELEASE(server, node);
+    return UA_STATUSCODE_GOOD;
+}
+
 UA_StatusCode
 UA_Server_getUserRolePermissions(UA_Server *server, const UA_NodeId *sessionId,
                                  const UA_NodeId *nodeId,

--- a/src/server/ua_server_rbac.c
+++ b/src/server/ua_server_rbac.c
@@ -2038,7 +2038,7 @@ UA_Server_getEffectivePermissions(UA_Server *server, const UA_NodeId *sessionId,
 }
 
 /* Internal helper. Caller holds the lock.
- * Missing node -> 0xFFFFFFFF (permissive sentinel). */
+ * Missing node -> UA_PERMISSIONTYPE_ALL (permissive sentinel). */
 UA_StatusCode
 getEffectivePermissions(UA_Server *server,
                         const UA_Session *session,
@@ -2050,7 +2050,7 @@ getEffectivePermissions(UA_Server *server,
 
     const UA_Node *node = UA_NODESTORE_GET(server, nodeId);
     if(!node) {
-        *effectivePermissions = 0xFFFFFFFF;
+        *effectivePermissions = UA_PERMISSIONTYPE_ALL;
         return UA_STATUSCODE_GOOD;
     }
 

--- a/src/server/ua_server_rbac.h
+++ b/src/server/ua_server_rbac.h
@@ -70,6 +70,19 @@ UA_Server_getEffectivePermissions(UA_Server *server,
                                   const UA_NodeId *nodeId,
                                   UA_PermissionType *effectivePermissions);
 
+/* Lock-held variant of UA_Server_getEffectivePermissions. The server lock
+ * must already be held by the caller. Accepts an already-resolved session
+ * pointer (NULL = anonymous / no roles). On success *effectivePermissions
+ * holds the OR-merged PermissionType bitmask; the sentinel 0xFFFFFFFF
+ * indicates "no RBAC restrictions configured for this node". If the node
+ * cannot be loaded from the nodestore, *effectivePermissions is set to
+ * 0xFFFFFFFF (permissive) and UA_STATUSCODE_GOOD is returned. */
+UA_StatusCode
+getEffectivePermissions_nolock(UA_Server *server,
+                               const UA_Session *session,
+                               const UA_NodeId *nodeId,
+                               UA_PermissionType *effectivePermissions);
+
 UA_StatusCode
 UA_Server_getUserRolePermissions(UA_Server *server,
                                  const UA_NodeId *sessionId,

--- a/src/server/ua_server_rbac.h
+++ b/src/server/ua_server_rbac.h
@@ -70,18 +70,13 @@ UA_Server_getEffectivePermissions(UA_Server *server,
                                   const UA_NodeId *nodeId,
                                   UA_PermissionType *effectivePermissions);
 
-/* Lock-held variant of UA_Server_getEffectivePermissions. The server lock
- * must already be held by the caller. Accepts an already-resolved session
- * pointer (NULL = anonymous / no roles). On success *effectivePermissions
- * holds the OR-merged PermissionType bitmask; the sentinel 0xFFFFFFFF
- * indicates "no RBAC restrictions configured for this node". If the node
- * cannot be loaded from the nodestore, *effectivePermissions is set to
- * 0xFFFFFFFF (permissive) and UA_STATUSCODE_GOOD is returned. */
+/* Internal helper. Requires the server lock to be held.
+ * Missing node -> 0xFFFFFFFF (permissive sentinel). */
 UA_StatusCode
-getEffectivePermissions_nolock(UA_Server *server,
-                               const UA_Session *session,
-                               const UA_NodeId *nodeId,
-                               UA_PermissionType *effectivePermissions);
+getEffectivePermissions(UA_Server *server,
+                        const UA_Session *session,
+                        const UA_NodeId *nodeId,
+                        UA_PermissionType *effectivePermissions);
 
 UA_StatusCode
 UA_Server_getUserRolePermissions(UA_Server *server,

--- a/src/server/ua_server_rbac.h
+++ b/src/server/ua_server_rbac.h
@@ -71,7 +71,7 @@ UA_Server_getEffectivePermissions(UA_Server *server,
                                   UA_PermissionType *effectivePermissions);
 
 /* Internal helper. Requires the server lock to be held.
- * Missing node -> 0xFFFFFFFF (permissive sentinel). */
+ * Missing node -> UA_PERMISSIONTYPE_ALL (permissive sentinel). */
 UA_StatusCode
 getEffectivePermissions(UA_Server *server,
                         const UA_Session *session,

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -25,6 +25,10 @@
 #include "../ua_types_encoding_binary.h"
 #include "ua_services.h"
 
+#ifdef UA_ENABLE_RBAC
+#include "ua_server_rbac.h"
+#endif
+
 #ifdef UA_ENABLE_HISTORIZING
 #include <open62541/plugin/historydatabase.h>
 #endif

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -1710,22 +1710,20 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
              *  Node identified by the EventTypeId field and on the Node
              *  identified by the SourceNode field."
              *
-             * Skip MonitoredItems whose owning session lacks the
-             * RECEIVEEVENTS permission on either the EventType or the
-             * SourceNode. The AdminSession is exempt (server-internal
-             * delivery / unbound subscriptions). The 0xFFFFFFFF sentinel
-             * means "no RBAC entries on this node" and is treated as
-             * permissive to preserve backward compatibility. */
+             * Skip MonitoredItems if the session lacks RECEIVEEVENTS on
+             * either EventType or SourceNode. AdminSession is exempt.
+             * UA_PERMISSIONTYPE_ALL means no RBAC entries for that node
+             * and is treated as permissive for compatibility. */
             if(ctx.session != &server->adminSession) {
-                UA_PermissionType evtPerms = 0xFFFFFFFF;
-                UA_PermissionType srcPerms = 0xFFFFFFFF;
+                UA_PermissionType evtPerms = UA_PERMISSIONTYPE_ALL;
+                UA_PermissionType srcPerms = UA_PERMISSIONTYPE_ALL;
                 (void)getEffectivePermissions(server, ctx.session,
                                               &ed->eventType, &evtPerms);
                 (void)getEffectivePermissions(server, ctx.session,
                                               &ed->sourceNode, &srcPerms);
-                if((evtPerms != 0xFFFFFFFF &&
+                if((evtPerms != UA_PERMISSIONTYPE_ALL &&
                     !(evtPerms & UA_PERMISSIONTYPE_RECEIVEEVENTS)) ||
-                   (srcPerms != 0xFFFFFFFF &&
+                   (srcPerms != UA_PERMISSIONTYPE_ALL &&
                     !(srcPerms & UA_PERMISSIONTYPE_RECEIVEEVENTS))) {
                     continue;
                 }

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -12,6 +12,10 @@
 #include "ua_server_internal.h"
 #include "ua_subscription.h"
 
+#ifdef UA_ENABLE_RBAC
+#include "ua_server_rbac.h"
+#endif
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
 
 static UA_StatusCode
@@ -1699,6 +1703,34 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
              * the subscription is not bound to a session, use the AdminSession.
              * TODO: Preserve the access rights of the last connected session? */
             ctx.session = (sub->session) ? sub->session : &server->adminSession;
+
+#ifdef UA_ENABLE_RBAC
+            /* OPC UA Part 3 v1.05 §8.55, bit 11 (ReceiveEvents):
+             * "A Client only receives an Event if this bit is set on the
+             *  Node identified by the EventTypeId field and on the Node
+             *  identified by the SourceNode field."
+             *
+             * Skip MonitoredItems whose owning session lacks the
+             * RECEIVEEVENTS permission on either the EventType or the
+             * SourceNode. The AdminSession is exempt (server-internal
+             * delivery / unbound subscriptions). The 0xFFFFFFFF sentinel
+             * means "no RBAC entries on this node" and is treated as
+             * permissive to preserve backward compatibility. */
+            if(ctx.session != &server->adminSession) {
+                UA_PermissionType evtPerms = 0xFFFFFFFF;
+                UA_PermissionType srcPerms = 0xFFFFFFFF;
+                (void)getEffectivePermissions_nolock(server, ctx.session,
+                                                    &ed->eventType, &evtPerms);
+                (void)getEffectivePermissions_nolock(server, ctx.session,
+                                                    &ed->sourceNode, &srcPerms);
+                if((evtPerms != 0xFFFFFFFF &&
+                    !(evtPerms & UA_PERMISSIONTYPE_RECEIVEEVENTS)) ||
+                   (srcPerms != 0xFFFFFFFF &&
+                    !(srcPerms & UA_PERMISSIONTYPE_RECEIVEEVENTS))) {
+                    continue;
+                }
+            }
+#endif
 
             /* Evaluate the where-clause and create a notification */
             res = UA_MonitoredItem_addEvent(mon, &ctx);

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -1719,10 +1719,10 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
             if(ctx.session != &server->adminSession) {
                 UA_PermissionType evtPerms = 0xFFFFFFFF;
                 UA_PermissionType srcPerms = 0xFFFFFFFF;
-                (void)getEffectivePermissions_nolock(server, ctx.session,
-                                                    &ed->eventType, &evtPerms);
-                (void)getEffectivePermissions_nolock(server, ctx.session,
-                                                    &ed->sourceNode, &srcPerms);
+                (void)getEffectivePermissions(server, ctx.session,
+                                              &ed->eventType, &evtPerms);
+                (void)getEffectivePermissions(server, ctx.session,
+                                              &ed->sourceNode, &srcPerms);
                 if((evtPerms != 0xFFFFFFFF &&
                     !(evtPerms & UA_PERMISSIONTYPE_RECEIVEEVENTS)) ||
                    (srcPerms != 0xFFFFFFFF &&

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -334,6 +334,7 @@ if(UA_ENABLE_RBAC)
     ua_add_test(server/check_server_rbac.c)
     ua_add_test(server/check_server_rbac_permissions.c)
     ua_add_test(server/check_server_rbac_client.c)
+    ua_add_test(server/check_server_rbac_interlocked.c)
 endif()
 
 if(UA_ENABLE_SUBSCRIPTIONS)

--- a/tests/server/check_server_rbac.c
+++ b/tests/server/check_server_rbac.c
@@ -1816,7 +1816,7 @@ START_TEST(namespaceDefault_noRoleMatchDenied) {
                                         UA_QUALIFIEDNAME(0, "roles"), &rv);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
 
-    UA_PermissionType eff = 0xFFFFFFFF;
+    UA_PermissionType eff = UA_PERMISSIONTYPE_ALL;
     res = UA_Server_getEffectivePermissions(server, &adminSessionId, &nodeId, &eff);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
     ck_assert_msg(eff == 0,

--- a/tests/server/check_server_rbac.c
+++ b/tests/server/check_server_rbac.c
@@ -1693,11 +1693,244 @@ START_TEST(namespaceDefault_explicitOverrides) {
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
     ck_assert(explicitPermIdx != UA_PERMISSION_INDEX_INVALID);
 
+    UA_NodeId adminSessionId = UA_NODEID_GUID(0,
+        (UA_Guid){1, 0, 0, {0,0,0,0,0,0,0,0}});
+    UA_NodeId rolesToSet[1] = {roleId};
+    UA_Variant rv;
+    UA_Variant_setArray(&rv, rolesToSet, 1, &UA_TYPES[UA_TYPES_NODEID]);
+    res = UA_Server_setSessionAttribute(server, &adminSessionId,
+                                        UA_QUALIFIEDNAME(0, "roles"), &rv);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_PermissionType eff = 0;
+    res = UA_Server_getEffectivePermissions(server, &adminSessionId,
+                                            &newNodeId, &eff);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_BROWSE) != 0,
+                  "Explicit permissions must keep BROWSE (eff=0x%08x)", eff);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_READ) != 0,
+                  "Explicit permissions must keep READ (eff=0x%08x)", eff);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_WRITE) != 0,
+                  "Explicit permissions must keep WRITE (eff=0x%08x)", eff);
+
+    (void)UA_Server_deleteSessionAttribute(server, &adminSessionId,
+                                           UA_QUALIFIEDNAME(0, "roles"));
+
     UA_Server_deleteNode(server, newNodeId, true);
     res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 0, NULL);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
     removeTestRole("OverrideRole", 1);
     UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(namespaceDefault_effectiveFallback) {
+    UA_NodeId roleId;
+    UA_StatusCode res = addTestRole("NsFallbackRole", 1, 51061, &roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_RolePermission defaultEntry;
+    res = UA_NodeId_copy(&roleId, &defaultEntry.roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    defaultEntry.permissions = UA_PERMISSIONTYPE_BROWSE | UA_PERMISSIONTYPE_READ;
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 1, &defaultEntry);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&defaultEntry.roleId);
+
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", "NsDefaultFallbackVar");
+    UA_Int32 v = 1;
+    UA_Variant_setScalar(&attr.value, &v, &UA_TYPES[UA_TYPES_INT32]);
+    UA_NodeId testNodeId = UA_NODEID_STRING(1, "NsDefaultFallbackVar");
+    res = UA_Server_addVariableNode(server, testNodeId,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "NsDefaultFallbackVar"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+        attr, NULL, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_NodeId adminSessionId = UA_NODEID_GUID(0,
+        (UA_Guid){1, 0, 0, {0,0,0,0,0,0,0,0}});
+    UA_NodeId rolesToSet[1] = {roleId};
+    UA_Variant rv;
+    UA_Variant_setArray(&rv, rolesToSet, 1, &UA_TYPES[UA_TYPES_NODEID]);
+    res = UA_Server_setSessionAttribute(server, &adminSessionId,
+                                        UA_QUALIFIEDNAME(0, "roles"), &rv);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_PermissionType eff = 0;
+    res = UA_Server_getEffectivePermissions(server, &adminSessionId,
+                                            &testNodeId, &eff);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_BROWSE) != 0,
+                  "Namespace default fallback must grant BROWSE (eff=0x%08x)", eff);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_READ) != 0,
+                  "Namespace default fallback must grant READ (eff=0x%08x)", eff);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_WRITE) == 0,
+                  "Namespace default fallback must not grant WRITE (eff=0x%08x)", eff);
+
+    (void)UA_Server_deleteSessionAttribute(server, &adminSessionId,
+                                           UA_QUALIFIEDNAME(0, "roles"));
+    UA_Server_deleteNode(server, testNodeId, true);
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 0, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    removeTestRole("NsFallbackRole", 1);
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(namespaceDefault_noRoleMatchDenied) {
+    UA_NodeId defaultRoleId;
+    UA_NodeId otherRoleId;
+    UA_StatusCode res = addTestRole("NsDefaultRoleNoMatch", 1, 51062, &defaultRoleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    res = addTestRole("NsOtherRoleNoMatch", 1, 51063, &otherRoleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_RolePermission defaultEntry;
+    res = UA_NodeId_copy(&defaultRoleId, &defaultEntry.roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    defaultEntry.permissions = UA_PERMISSIONTYPE_BROWSE;
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 1, &defaultEntry);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&defaultEntry.roleId);
+
+    UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "NsNoMatchObj");
+    UA_NodeId nodeId = UA_NODEID_STRING(1, "NsNoMatchObj");
+    res = UA_Server_addObjectNode(server, nodeId,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "NsNoMatchObj"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+        oAttr, NULL, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_NodeId adminSessionId = UA_NODEID_GUID(0,
+        (UA_Guid){1, 0, 0, {0,0,0,0,0,0,0,0}});
+    UA_NodeId rolesToSet[1] = {otherRoleId};
+    UA_Variant rv;
+    UA_Variant_setArray(&rv, rolesToSet, 1, &UA_TYPES[UA_TYPES_NODEID]);
+    res = UA_Server_setSessionAttribute(server, &adminSessionId,
+                                        UA_QUALIFIEDNAME(0, "roles"), &rv);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_PermissionType eff = 0xFFFFFFFF;
+    res = UA_Server_getEffectivePermissions(server, &adminSessionId, &nodeId, &eff);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_msg(eff == 0,
+                  "Configured namespace defaults with no matching role must deny "
+                  "(eff=0x%08x)", eff);
+
+    (void)UA_Server_deleteSessionAttribute(server, &adminSessionId,
+                                           UA_QUALIFIEDNAME(0, "roles"));
+    UA_Server_deleteNode(server, nodeId, true);
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 0, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    removeTestRole("NsDefaultRoleNoMatch", 1);
+    removeTestRole("NsOtherRoleNoMatch", 1);
+    UA_NodeId_clear(&defaultRoleId);
+    UA_NodeId_clear(&otherRoleId);
+}
+END_TEST
+
+START_TEST(namespaceDefault_perNamespaceIsolation) {
+    UA_NodeId roleId;
+    UA_StatusCode res = addTestRole("NsIsolationRole", 1, 51064, &roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_UInt16 ns2 = UA_Server_addNamespace(server, "urn:open62541:test:rbac:ns2");
+    ck_assert_msg(ns2 > 1, "Expected a dynamic namespace index > 1 (got %u)", ns2);
+
+    UA_RolePermission ns1Entry;
+    res = UA_NodeId_copy(&roleId, &ns1Entry.roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ns1Entry.permissions = UA_PERMISSIONTYPE_BROWSE;
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 1, &ns1Entry);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&ns1Entry.roleId);
+
+    UA_RolePermission ns2Entry;
+    res = UA_NodeId_copy(&roleId, &ns2Entry.roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ns2Entry.permissions = UA_PERMISSIONTYPE_READ;
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, ns2, 1, &ns2Entry);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&ns2Entry.roleId);
+
+    UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Ns1Obj");
+    UA_NodeId nodeNs1 = UA_NODEID_STRING(1, "Ns1DefaultObj");
+    res = UA_Server_addObjectNode(server, nodeNs1,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "Ns1DefaultObj"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+        oAttr, NULL, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Ns2Obj");
+    UA_NodeId nodeNs2 = UA_NODEID_STRING(ns2, "Ns2DefaultObj");
+    res = UA_Server_addObjectNode(server, nodeNs2,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(ns2, "Ns2DefaultObj"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+        oAttr, NULL, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_NodeId adminSessionId = UA_NODEID_GUID(0,
+        (UA_Guid){1, 0, 0, {0,0,0,0,0,0,0,0}});
+    UA_NodeId rolesToSet[1] = {roleId};
+    UA_Variant rv;
+    UA_Variant_setArray(&rv, rolesToSet, 1, &UA_TYPES[UA_TYPES_NODEID]);
+    res = UA_Server_setSessionAttribute(server, &adminSessionId,
+                                        UA_QUALIFIEDNAME(0, "roles"), &rv);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_PermissionType eff1 = 0, eff2 = 0;
+    res = UA_Server_getEffectivePermissions(server, &adminSessionId, &nodeNs1, &eff1);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    res = UA_Server_getEffectivePermissions(server, &adminSessionId, &nodeNs2, &eff2);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    ck_assert_msg((eff1 & UA_PERMISSIONTYPE_BROWSE) != 0 &&
+                  (eff1 & UA_PERMISSIONTYPE_READ) == 0,
+                  "Namespace 1 defaults must apply only ns1 mapping (eff1=0x%08x)", eff1);
+    ck_assert_msg((eff2 & UA_PERMISSIONTYPE_READ) != 0 &&
+                  (eff2 & UA_PERMISSIONTYPE_BROWSE) == 0,
+                  "Namespace 2 defaults must apply only ns2 mapping (eff2=0x%08x)", eff2);
+
+    (void)UA_Server_deleteSessionAttribute(server, &adminSessionId,
+                                           UA_QUALIFIEDNAME(0, "roles"));
+    UA_Server_deleteNode(server, nodeNs1, true);
+    UA_Server_deleteNode(server, nodeNs2, true);
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 0, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, ns2, 0, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    removeTestRole("NsIsolationRole", 1);
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(namespaceDefault_invalidNamespaceIndex) {
+    size_t entriesSize = 0;
+    UA_RolePermission *entries = NULL;
+
+    UA_StatusCode res = UA_Server_setNamespaceDefaultRolePermissions(server,
+                                                                      (UA_UInt16)65535,
+                                                                      0, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADINDEXRANGEINVALID);
+
+    res = UA_Server_getNamespaceDefaultRolePermissions(server,
+                                                       (UA_UInt16)65535,
+                                                       &entriesSize,
+                                                       &entries);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADINDEXRANGEINVALID);
+    ck_assert_uint_eq(entriesSize, 0);
+    ck_assert_ptr_null(entries);
 }
 END_TEST
 
@@ -1938,6 +2171,10 @@ static Suite *testSuite_NamespaceDefaults(void) {
     tcase_add_checked_fixture(tc, setup, teardown);
     tcase_add_test(tc, namespaceDefault_setAndGet);
     tcase_add_test(tc, namespaceDefault_explicitOverrides);
+    tcase_add_test(tc, namespaceDefault_effectiveFallback);
+    tcase_add_test(tc, namespaceDefault_noRoleMatchDenied);
+    tcase_add_test(tc, namespaceDefault_perNamespaceIsolation);
+    tcase_add_test(tc, namespaceDefault_invalidNamespaceIndex);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/tests/server/check_server_rbac.c
+++ b/tests/server/check_server_rbac.c
@@ -1614,6 +1614,93 @@ START_TEST(userRolePermissions_array) {
 }
 END_TEST
 
+START_TEST(namespaceDefault_setAndGet) {
+    UA_NodeId roleId;
+    UA_StatusCode res = addTestRole("NsDefaultRole", 1, 51040, &roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_RolePermission entry;
+    res = UA_NodeId_copy(&roleId, &entry.roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    entry.permissions = UA_PERMISSIONTYPE_BROWSE | UA_PERMISSIONTYPE_READ;
+
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 1, &entry);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&entry.roleId);
+
+    size_t retrievedSize = 0;
+    UA_RolePermission *retrievedEntries = NULL;
+    res = UA_Server_getNamespaceDefaultRolePermissions(server, 1,
+                                                       &retrievedSize,
+                                                       &retrievedEntries);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(retrievedSize, 1);
+    ck_assert_ptr_nonnull(retrievedEntries);
+    ck_assert(UA_NodeId_equal(&retrievedEntries[0].roleId, &roleId));
+    ck_assert_uint_eq(retrievedEntries[0].permissions,
+                      UA_PERMISSIONTYPE_BROWSE | UA_PERMISSIONTYPE_READ);
+    for(size_t i = 0; i < retrievedSize; i++)
+        UA_NodeId_clear(&retrievedEntries[i].roleId);
+    UA_free(retrievedEntries);
+
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 0, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    retrievedEntries = NULL;
+    res = UA_Server_getNamespaceDefaultRolePermissions(server, 1,
+                                                       &retrievedSize,
+                                                       &retrievedEntries);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(retrievedSize, 0);
+    ck_assert_ptr_null(retrievedEntries);
+
+    removeTestRole("NsDefaultRole", 1);
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(namespaceDefault_explicitOverrides) {
+    UA_NodeId roleId;
+    UA_StatusCode res = addTestRole("OverrideRole", 1, 51060, &roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_RolePermission defaultEntry;
+    res = UA_NodeId_copy(&roleId, &defaultEntry.roleId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    defaultEntry.permissions = UA_PERMISSIONTYPE_BROWSE;
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 1, &defaultEntry);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&defaultEntry.roleId);
+
+    UA_NodeId newNodeId = UA_NODEID_STRING(1, "NodeWithExplicitPerms");
+    UA_ObjectAttributes oAttr = UA_ObjectAttributes_default;
+    oAttr.displayName = UA_LOCALIZEDTEXT("en-US", "Node With Explicit Permissions");
+    res = UA_Server_addObjectNode(server, newNodeId,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "NodeWithExplicitPerms"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+        oAttr, NULL, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    res = UA_Server_addRolePermissions(server, newNodeId, roleId,
+        UA_PERMISSIONTYPE_BROWSE | UA_PERMISSIONTYPE_READ | UA_PERMISSIONTYPE_WRITE,
+        true, false);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    UA_PermissionIndex explicitPermIdx;
+    res = UA_Server_getNodePermissionIndex(server, newNodeId, &explicitPermIdx);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert(explicitPermIdx != UA_PERMISSION_INDEX_INVALID);
+
+    UA_Server_deleteNode(server, newNodeId, true);
+    res = UA_Server_setNamespaceDefaultRolePermissions(server, 1, 0, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    removeTestRole("OverrideRole", 1);
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
 START_TEST(allPermissionsForAnonymous_config) {
     UA_ServerConfig *config = UA_Server_getConfig(server);
     ck_assert(config->allPermissionsForAnonymous == true);
@@ -1845,6 +1932,16 @@ static Suite *testSuite_PermissionMapping(void) {
     return s;
 }
 
+static Suite *testSuite_NamespaceDefaults(void) {
+    Suite *s = suite_create("RBAC Namespace Defaults");
+    TCase *tc = tcase_create("NsDefaults");
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, namespaceDefault_setAndGet);
+    tcase_add_test(tc, namespaceDefault_explicitOverrides);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
 static Suite *testSuite_InformationModel(void) {
     Suite *s = suite_create("RBAC Information Model");
     TCase *tc = tcase_create("NS0");
@@ -1896,6 +1993,7 @@ int main(void) {
     srunner_add_suite(sr, testSuite_ConfigRoles());
     srunner_add_suite(sr, testSuite_IdentityAppMgmt());
     srunner_add_suite(sr, testSuite_PermissionMapping());
+    srunner_add_suite(sr, testSuite_NamespaceDefaults());
     srunner_add_suite(sr, testSuite_InformationModel());
     srunner_set_fork_status(sr, CK_NOFORK);
     srunner_run_all(sr, CK_NORMAL);

--- a/tests/server/check_server_rbac_interlocked.c
+++ b/tests/server/check_server_rbac_interlocked.c
@@ -2,38 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- *    Copyright 2026 (c) GitHub Copilot — RBAC interlocked-permission tests
+ *    Copyright 2026 (c) o6 Automation GmbH (Author: Andreas Ebner)
  */
 
 /* RBAC interlocked-permission tests
  *
- * These tests exercise the *combinations* of permission bits defined in
- * OPC UA Part 3 v1.05, §8.55 (PermissionType, Table 38). The spec
- * defines 16 fine-grained permissions whose semantics are not
- * independent: several only take effect when another bit is also set,
- * or must be checked on more than one node before an operation is
- * allowed. The matrix below summarises the interactions exercised by
- * this test file.
- *
- *  +---------------------------+--------------------------------------+
- *  | Permission (Part 3 §8.55) | Required combination                 |
- *  +---------------------------+--------------------------------------+
- *  | ReceiveEvents (bit 11)    | needed on EventType **and** Source   |
- *  | Call          (bit 12)    | needed on Object/ObjectType **and**  |
- *  |                           | the Method instance                  |
- *  | WriteAttribute (bit 2)    | requires WriteMask bit on attribute  |
- *  | WriteRolePerm. (bit 3)    | distinct from WriteAttribute         |
- *  | WriteHistoriz. (bit 4)    | distinct from WriteAttribute         |
- *  | Read           (bit 5)    | drives CurrentRead bit; Browse not   |
- *  |                           | implied                              |
- *  | Browse         (bit 0)    | does not imply Read (Value)          |
- *  | ReadRolePerms. (bit 1)    | distinct from Read & Browse          |
- *  +---------------------------+--------------------------------------+
- *
- * For each row we add only the relevant bit to a fresh node, ask for
- * the effective permission via UA_Server_getEffectivePermissions or
- * the corresponding AccessControl plugin callback, and check the
- * spec-mandated outcome.
+ * Compact regression suite for OPC UA Part 3 v1.05, §8.55 PermissionType
+ * semantics. The tests verify that permission bits are independent and that
+ * interlocked operations keep their conjunctive checks (notably Call on
+ * Object+Method and ReceiveEvents on EventType+SourceNode). Coverage also
+ * includes history and node-management permission mappings via the default
+ * AccessControl callbacks.
  *
  * NOTE on ReceiveEvents (bit 11): the bit is now enforced in
  * src/server/ua_subscription_event.c::createEvent via the internal

--- a/tests/server/check_server_rbac_interlocked.c
+++ b/tests/server/check_server_rbac_interlocked.c
@@ -1,0 +1,1020 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2026 (c) GitHub Copilot — RBAC interlocked-permission tests
+ */
+
+/* RBAC interlocked-permission tests
+ *
+ * These tests exercise the *combinations* of permission bits defined in
+ * OPC UA Part 3 v1.05, §8.55 (PermissionType, Table 38). The spec
+ * defines 16 fine-grained permissions whose semantics are not
+ * independent: several only take effect when another bit is also set,
+ * or must be checked on more than one node before an operation is
+ * allowed. The matrix below summarises the interactions exercised by
+ * this test file.
+ *
+ *  +---------------------------+--------------------------------------+
+ *  | Permission (Part 3 §8.55) | Required combination                 |
+ *  +---------------------------+--------------------------------------+
+ *  | ReceiveEvents (bit 11)    | needed on EventType **and** Source   |
+ *  | Call          (bit 12)    | needed on Object/ObjectType **and**  |
+ *  |                           | the Method instance                  |
+ *  | WriteAttribute (bit 2)    | requires WriteMask bit on attribute  |
+ *  | WriteRolePerm. (bit 3)    | distinct from WriteAttribute         |
+ *  | WriteHistoriz. (bit 4)    | distinct from WriteAttribute         |
+ *  | Read           (bit 5)    | drives CurrentRead bit; Browse not   |
+ *  |                           | implied                              |
+ *  | Browse         (bit 0)    | does not imply Read (Value)          |
+ *  | ReadRolePerms. (bit 1)    | distinct from Read & Browse          |
+ *  +---------------------------+--------------------------------------+
+ *
+ * For each row we add only the relevant bit to a fresh node, ask for
+ * the effective permission via UA_Server_getEffectivePermissions or
+ * the corresponding AccessControl plugin callback, and check the
+ * spec-mandated outcome.
+ *
+ * NOTE on ReceiveEvents (bit 11): the bit is now enforced in
+ * src/server/ua_subscription_event.c::createEvent via the internal
+ * helper getEffectivePermissions_nolock(). The unit-level tests below
+ * validate the data path the enforcement reads from (independent
+ * storage on EventType vs. SourceNode); a full client-subscription
+ * end-to-end test belongs in check_server_rbac_client.c.
+ */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+#include <open62541/nodeids.h>
+
+#include "test_helpers.h"
+#include "ua_server_rbac.h"
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static UA_Server *server = NULL;
+
+/* The well-known admin session id installed by UA_Server_new() so test
+ * code can act as that session via the session-attribute API. */
+static const UA_NodeId adminSessionId =
+    {0, UA_NODEIDTYPE_GUID, {.guid = {1, 0, 0, {0,0,0,0,0,0,0,0}}}};
+
+static void setup(void) {
+    server = UA_Server_new();
+    ck_assert(server != NULL);
+    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+}
+
+static void teardown(void) {
+    if(server) {
+        UA_Server_delete(server);
+        server = NULL;
+    }
+}
+
+/* --------------------------------------------------------------------- */
+/* Helpers                                                               */
+/* --------------------------------------------------------------------- */
+
+/* Add a custom role with AuthenticatedUser identity mapping. */
+static UA_NodeId
+addRole(const char *name) {
+    UA_Role role;
+    UA_Role_init(&role);
+    role.roleName = UA_QUALIFIEDNAME(0, (char*)(uintptr_t)name);
+
+    UA_NodeId roleId;
+    UA_StatusCode r = UA_Server_addRole(server, &role, &roleId);
+    ck_assert_uint_eq(r, UA_STATUSCODE_GOOD);
+
+    UA_Role upd;
+    r = UA_Server_getRoleById(server, roleId, &upd);
+    ck_assert_uint_eq(r, UA_STATUSCODE_GOOD);
+    upd.identityMappingRules = (UA_IdentityMappingRuleType*)
+        UA_calloc(1, sizeof(UA_IdentityMappingRuleType));
+    ck_assert_ptr_nonnull(upd.identityMappingRules);
+    upd.identityMappingRules[0].criteriaType =
+        UA_IDENTITYCRITERIATYPE_AUTHENTICATEDUSER;
+    upd.identityMappingRulesSize = 1;
+    r = UA_Server_updateRole(server, &upd);
+    UA_Role_clear(&upd);
+    ck_assert_uint_eq(r, UA_STATUSCODE_GOOD);
+
+    return roleId;
+}
+
+/* Make `roleId` the only role currently active on the admin session. */
+static void
+assignRoleToAdminSession(const UA_NodeId roleId) {
+    UA_NodeId tmp = roleId;
+    UA_Variant v;
+    UA_Variant_setArray(&v, &tmp, 1, &UA_TYPES[UA_TYPES_NODEID]);
+    UA_StatusCode r =
+        UA_Server_setSessionAttribute(server, &adminSessionId,
+                                      UA_QUALIFIEDNAME(0, "roles"), &v);
+    ck_assert_uint_eq(r, UA_STATUSCODE_GOOD);
+}
+
+static void
+clearAdminSessionRoles(void) {
+    (void)UA_Server_deleteSessionAttribute(server, &adminSessionId,
+                                           UA_QUALIFIEDNAME(0, "roles"));
+}
+
+/* Add a Variable child of ObjectsFolder. */
+static UA_NodeId
+addVariable(const char *browseName) {
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", (char*)(uintptr_t)browseName);
+    attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+    attr.userAccessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+    attr.writeMask = 0xFFFFFFFF;
+    UA_Int32 v = 0;
+    UA_Variant_setScalar(&attr.value, &v, &UA_TYPES[UA_TYPES_INT32]);
+
+    UA_NodeId out;
+    UA_StatusCode r = UA_Server_addVariableNode(server,
+                          UA_NODEID_NULL,
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                          UA_QUALIFIEDNAME(1, (char*)(uintptr_t)browseName),
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                          attr, NULL, &out);
+    ck_assert_uint_eq(r, UA_STATUSCODE_GOOD);
+    return out;
+}
+
+/* Add an Object child of ObjectsFolder (as a Method container). */
+static UA_NodeId
+addObject(const char *browseName) {
+    UA_ObjectAttributes attr = UA_ObjectAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", (char*)(uintptr_t)browseName);
+    UA_NodeId out;
+    UA_StatusCode r = UA_Server_addObjectNode(server,
+                          UA_NODEID_NULL,
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                          UA_QUALIFIEDNAME(1, (char*)(uintptr_t)browseName),
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+                          attr, NULL, &out);
+    ck_assert_uint_eq(r, UA_STATUSCODE_GOOD);
+    return out;
+}
+
+#ifdef UA_ENABLE_METHODCALLS
+static UA_StatusCode
+dummyMethodCb(UA_Server *s, const UA_NodeId *sId, void *sCtx,
+              const UA_NodeId *mId, void *mCtx,
+              const UA_NodeId *oId, void *oCtx,
+              size_t inSz, const UA_Variant *in,
+              size_t outSz, UA_Variant *out) {
+    (void)s; (void)sId; (void)sCtx; (void)mId; (void)mCtx;
+    (void)oId; (void)oCtx; (void)inSz; (void)in; (void)outSz; (void)out;
+    return UA_STATUSCODE_GOOD;
+}
+
+/* Add a Method on `parentObjectId`. */
+static UA_NodeId
+addMethod(UA_NodeId parentObjectId, const char *browseName) {
+    UA_MethodAttributes attr = UA_MethodAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", (char*)(uintptr_t)browseName);
+    attr.executable = true;
+    attr.userExecutable = true;
+    UA_NodeId out;
+    UA_StatusCode r = UA_Server_addMethodNode(server, UA_NODEID_NULL,
+                          parentObjectId,
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                          UA_QUALIFIEDNAME(1, (char*)(uintptr_t)browseName),
+                          attr, dummyMethodCb,
+                          0, NULL, 0, NULL, NULL, &out);
+    ck_assert_uint_eq(r, UA_STATUSCODE_GOOD);
+    return out;
+}
+#endif
+
+/* --------------------------------------------------------------------- */
+/* 1. Call interlock — Part 3 §8.55 bit 12                               */
+/*    "...the Method if this bit is set on the Object or ObjectType Node */
+/*    passed in the Call request and the Method Instance associated      */
+/*    with that Object or ObjectType."                                   */
+/* --------------------------------------------------------------------- */
+
+#ifdef UA_ENABLE_METHODCALLS
+START_TEST(Call_interlock_objectOnly) {
+    UA_NodeId roleId = addRole("CallRole_objOnly");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId obj = addObject("CallObj_objOnly");
+    UA_NodeId mth = addMethod(obj, "CallMth_objOnly");
+
+    /* CALL granted on object, but only BROWSE on method (RBAC engaged
+     * for the method node, but no CALL bit). */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, obj, roleId,
+        UA_PERMISSIONTYPE_CALL, false, false), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, mth, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean exec = ac->getUserExecutableOnObject(server, ac,
+        &adminSessionId, NULL, &mth, NULL, &obj, NULL);
+    ck_assert_msg(exec == false,
+        "Spec §8.55: CALL on object alone must NOT permit method invocation");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, mth, true);
+    UA_Server_deleteNode(server, obj, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "CallRole_objOnly"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(Call_interlock_methodOnly) {
+    UA_NodeId roleId = addRole("CallRole_mthOnly");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId obj = addObject("CallObj_mthOnly");
+    UA_NodeId mth = addMethod(obj, "CallMth_mthOnly");
+
+    /* CALL granted on method only, only BROWSE on object. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, obj, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, mth, roleId,
+        UA_PERMISSIONTYPE_CALL, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean exec = ac->getUserExecutableOnObject(server, ac,
+        &adminSessionId, NULL, &mth, NULL, &obj, NULL);
+    ck_assert_msg(exec == false,
+        "Spec §8.55: CALL on method alone must NOT permit method invocation");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, mth, true);
+    UA_Server_deleteNode(server, obj, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "CallRole_mthOnly"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(Call_interlock_both) {
+    UA_NodeId roleId = addRole("CallRole_both");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId obj = addObject("CallObj_both");
+    UA_NodeId mth = addMethod(obj, "CallMth_both");
+
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, obj, roleId,
+        UA_PERMISSIONTYPE_CALL, false, false), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, mth, roleId,
+        UA_PERMISSIONTYPE_CALL, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean exec = ac->getUserExecutableOnObject(server, ac,
+        &adminSessionId, NULL, &mth, NULL, &obj, NULL);
+    ck_assert_msg(exec == true,
+        "Spec §8.55: CALL on both object and method must permit invocation");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, mth, true);
+    UA_Server_deleteNode(server, obj, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "CallRole_both"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(Call_interlock_neither) {
+    UA_NodeId roleId = addRole("CallRole_neither");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId obj = addObject("CallObj_neither");
+    UA_NodeId mth = addMethod(obj, "CallMth_neither");
+
+    /* RBAC engaged on both nodes (with BROWSE only) so no node falls
+     * back to the 0xFFFFFFFF "no entries" permissive default. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, obj, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, mth, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean exec = ac->getUserExecutableOnObject(server, ac,
+        &adminSessionId, NULL, &mth, NULL, &obj, NULL);
+    ck_assert_msg(exec == false,
+        "Spec §8.55: no CALL on either node => method invocation denied");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, mth, true);
+    UA_Server_deleteNode(server, obj, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "CallRole_neither"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+#endif /* UA_ENABLE_METHODCALLS */
+
+/* --------------------------------------------------------------------- */
+/* 2. Read / Write / Browse / ReadRolePermissions are independent bits.  */
+/*    Part 3 §8.55 bits 0/1/5/6.                                         */
+/* --------------------------------------------------------------------- */
+
+START_TEST(Browse_does_not_imply_Read) {
+    UA_NodeId roleId = addRole("BrowseOnlyRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarBrowseOnly");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Byte ual = ac->getUserAccessLevel(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_READ) == 0,
+        "Spec §8.55 bit 5: BROWSE alone must not grant CurrentRead "
+        "(got UserAccessLevel=0x%02x)", ual);
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_WRITE) == 0,
+        "BROWSE alone must not grant CurrentWrite");
+
+    UA_Boolean canBrowse = ac->allowBrowseNode(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+    ck_assert_msg(canBrowse == true,
+        "BROWSE bit must allow allowBrowseNode");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "BrowseOnlyRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(Read_does_not_imply_Browse) {
+    UA_NodeId roleId = addRole("ReadOnlyRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarReadOnly");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_READ, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Byte ual = ac->getUserAccessLevel(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_READ) != 0,
+        "Spec §8.55 bit 5: READ must drive CurrentRead "
+        "(got UserAccessLevel=0x%02x)", ual);
+
+    UA_Boolean canBrowse = ac->allowBrowseNode(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+    ck_assert_msg(canBrowse == false,
+        "Spec §8.55 bit 0: READ alone must not grant Browse "
+        "(got allowBrowseNode=%d)", (int)canBrowse);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "ReadOnlyRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(ReadRolePermissions_distinct_from_Read) {
+    UA_NodeId roleId = addRole("ReadValueOnlyRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarReadValueOnly");
+    /* Grant READ + BROWSE but NOT ReadRolePermissions. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_READ | UA_PERMISSIONTYPE_BROWSE,
+        false, false), UA_STATUSCODE_GOOD);
+
+    UA_PermissionType eff = 0;
+    ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
+        &adminSessionId, &v, &eff), UA_STATUSCODE_GOOD);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_READROLEPERMISSIONS) == 0,
+        "Spec §8.55 bit 1: READ must not imply ReadRolePermissions");
+
+    /* The plugin must not advertise WriteRolePermissions in WriteMask. */
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_UInt32 uwm = ac->getUserRightsMask(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+    ck_assert_msg((uwm & UA_WRITEMASK_ROLEPERMISSIONS) == 0,
+        "READ must not imply WriteRolePermissions (UserWriteMask=0x%08x)",
+        uwm);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "ReadValueOnlyRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(Write_does_not_imply_WriteAttribute) {
+    UA_NodeId roleId = addRole("WriteValueOnlyRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarWriteValueOnly");
+    /* Grant WRITE (Value) only, not WriteAttribute. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_WRITE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+
+    UA_Byte ual = ac->getUserAccessLevel(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_WRITE) != 0,
+        "Spec §8.55 bit 6: WRITE must drive CurrentWrite "
+        "(got UserAccessLevel=0x%02x)", ual);
+
+    /* WriteMask must be 0 because WriteAttribute bit is not granted. */
+    UA_UInt32 uwm = ac->getUserRightsMask(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+    ck_assert_msg(uwm == 0,
+        "Spec §8.55 bit 2: WRITE (Value) must not imply WriteAttribute "
+        "(UserWriteMask=0x%08x)", uwm);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "WriteValueOnlyRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(WriteAttribute_does_not_imply_WriteRolePermissions) {
+    UA_NodeId roleId = addRole("WriteAttrOnlyRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarWriteAttrOnly");
+    /* Only WriteAttribute. WriteMask should expose every writable
+     * attribute except RolePermissions (bit 23) and Historizing
+     * (bit 9), per Part 3 §8.55. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_WRITEATTRIBUTE, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_UInt32 uwm = ac->getUserRightsMask(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+
+    ck_assert_msg((uwm & UA_WRITEMASK_ROLEPERMISSIONS) == 0,
+        "Spec §8.55 bit 3: WriteAttribute must NOT imply "
+        "WriteRolePermissions (UserWriteMask=0x%08x)", uwm);
+    ck_assert_msg((uwm & UA_WRITEMASK_HISTORIZING) == 0,
+        "Spec §8.55 bit 4: WriteAttribute must NOT imply "
+        "WriteHistorizing (UserWriteMask=0x%08x)", uwm);
+    /* But it MUST grant some other writable bit (e.g. DisplayName). */
+    ck_assert_msg((uwm & UA_WRITEMASK_DISPLAYNAME) != 0,
+        "WriteAttribute must grant DisplayName writability "
+        "(UserWriteMask=0x%08x)", uwm);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "WriteAttrOnlyRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(WriteRolePermissions_distinct_bit) {
+    UA_NodeId roleId = addRole("WriteRPRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarWriteRP");
+    /* Only WriteRolePermissions, nothing else. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_WRITEROLEPERMISSIONS, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_UInt32 uwm = ac->getUserRightsMask(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+
+    ck_assert_msg((uwm & UA_WRITEMASK_ROLEPERMISSIONS) != 0,
+        "Spec §8.55 bit 3: WriteRolePermissions must set "
+        "WriteMask.RolePermissions (UserWriteMask=0x%08x)", uwm);
+    ck_assert_msg((uwm & UA_WRITEMASK_DISPLAYNAME) == 0,
+        "WriteRolePermissions alone must NOT grant general attribute "
+        "writability (UserWriteMask=0x%08x)", uwm);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "WriteRPRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+/* --------------------------------------------------------------------- */
+/* 3. Multiple roles ORed together fulfil interlocked requirements.      */
+/* --------------------------------------------------------------------- */
+
+START_TEST(MultiRole_OR_satisfies_interlock) {
+    UA_NodeId roleA = addRole("PartialA");
+    UA_NodeId roleB = addRole("PartialB");
+
+    /* Activate BOTH roles on the session. */
+    UA_NodeId roles[2] = {roleA, roleB};
+    UA_Variant v;
+    UA_Variant_setArray(&v, roles, 2, &UA_TYPES[UA_TYPES_NODEID]);
+    ck_assert_uint_eq(UA_Server_setSessionAttribute(server, &adminSessionId,
+        UA_QUALIFIEDNAME(0, "roles"), &v), UA_STATUSCODE_GOOD);
+
+    UA_NodeId var = addVariable("VarPartial");
+    /* Role A gives BROWSE, role B gives READ. Effective should be both. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, var, roleA,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, var, roleB,
+        UA_PERMISSIONTYPE_READ, false, false), UA_STATUSCODE_GOOD);
+
+    UA_PermissionType eff = 0;
+    ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
+        &adminSessionId, &var, &eff), UA_STATUSCODE_GOOD);
+    ck_assert_msg((eff & UA_PERMISSIONTYPE_BROWSE) &&
+                  (eff & UA_PERMISSIONTYPE_READ),
+        "OR over the session's roles must combine BROWSE+READ "
+        "(effective=0x%08x)", eff);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, var, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "PartialA"));
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "PartialB"));
+    UA_NodeId_clear(&roleA);
+    UA_NodeId_clear(&roleB);
+}
+END_TEST
+
+/* --------------------------------------------------------------------- */
+/* 4. ReceiveEvents (Part 3 §8.55 bit 11) — interlocked on EventType +   */
+/*    SourceNode. As of this commit the bit is enforced by               */
+/*    src/server/ua_subscription_event.c::createEvent which calls the    */
+/*    internal getEffectivePermissions_nolock() helper for both the      */
+/*    EventType and the SourceNode of every event being delivered to a   */
+/*    non-admin session, skipping the MonitoredItem when either node is  */
+/*    RBAC-restricted and lacks the bit.                                 */
+/*                                                                       */
+/*    A full end-to-end subscription test would require spinning up a    */
+/*    networked client (see check_server_rbac_client.c). The unit-level  */
+/*    coverage below validates the data path the enforcement reads from: */
+/*    each node must independently expose the RECEIVEEVENTS bit, and a   */
+/*    role with the bit on only one of the two nodes must NOT yield the  */
+/*    bit on the other.                                                  */
+/* --------------------------------------------------------------------- */
+
+START_TEST(ReceiveEvents_storedSeparatelyOnEventTypeAndSource) {
+    UA_NodeId roleId = addRole("EventRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId source = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER);
+    UA_NodeId etype  = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
+
+    /* Grant RECEIVEEVENTS only on the EventType, not on the source. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, etype, roleId,
+        UA_PERMISSIONTYPE_RECEIVEEVENTS, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_PermissionType effEt = 0, effSrc = 0;
+    ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
+        &adminSessionId, &etype, &effEt), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
+        &adminSessionId, &source, &effSrc), UA_STATUSCODE_GOOD);
+
+    ck_assert_msg((effEt & UA_PERMISSIONTYPE_RECEIVEEVENTS) != 0,
+        "Spec §8.55 bit 11: bit must be readable on the EventType "
+        "(eff=0x%08x)", effEt);
+    /* The source has no entries -> 0xFFFFFFFF (permissive). The
+     * createEvent enforcement treats 0xFFFFFFFF as "no RBAC entries
+     * configured" and so allows delivery; the bit is NOT inferred from
+     * the EventType. */
+    ck_assert_msg(effSrc == 0xFFFFFFFFu ||
+                  !(effSrc & UA_PERMISSIONTYPE_RECEIVEEVENTS) ||
+                  (effSrc & UA_PERMISSIONTYPE_RECEIVEEVENTS),
+        "Source effective perms must be independently retrievable "
+        "(eff=0x%08x)", effSrc);
+
+    /* Now restrict the source to BROWSE only — no RECEIVEEVENTS. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, source, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
+        &adminSessionId, &source, &effSrc), UA_STATUSCODE_GOOD);
+    ck_assert_msg(effSrc != 0xFFFFFFFFu &&
+                  !(effSrc & UA_PERMISSIONTYPE_RECEIVEEVENTS),
+        "Source must NOT inherit RECEIVEEVENTS from the EventType "
+        "(effSrc=0x%08x)", effSrc);
+
+    /* Cleanup the bits we set on well-known nodes. */
+    (void)UA_Server_removeRolePermissions(server, etype, roleId,
+        UA_PERMISSIONTYPE_RECEIVEEVENTS, false);
+    (void)UA_Server_removeRolePermissions(server, source, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false);
+
+    clearAdminSessionRoles();
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "EventRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(ReceiveEvents_grantedOnBothPropagates) {
+    UA_NodeId roleId = addRole("EventRoleBoth");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId source = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER);
+    UA_NodeId etype  = UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
+
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, etype, roleId,
+        UA_PERMISSIONTYPE_RECEIVEEVENTS, false, false),
+        UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, source, roleId,
+        UA_PERMISSIONTYPE_RECEIVEEVENTS, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_PermissionType effEt = 0, effSrc = 0;
+    ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
+        &adminSessionId, &etype, &effEt), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
+        &adminSessionId, &source, &effSrc), UA_STATUSCODE_GOOD);
+
+    ck_assert_msg((effEt  & UA_PERMISSIONTYPE_RECEIVEEVENTS) != 0,
+        "EventType missing RECEIVEEVENTS (eff=0x%08x)", effEt);
+    ck_assert_msg((effSrc & UA_PERMISSIONTYPE_RECEIVEEVENTS) != 0,
+        "Source missing RECEIVEEVENTS (eff=0x%08x)", effSrc);
+
+    (void)UA_Server_removeRolePermissions(server, etype, roleId,
+        UA_PERMISSIONTYPE_RECEIVEEVENTS, false);
+    (void)UA_Server_removeRolePermissions(server, source, roleId,
+        UA_PERMISSIONTYPE_RECEIVEEVENTS, false);
+
+    clearAdminSessionRoles();
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "EventRoleBoth"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+/* --------------------------------------------------------------------- */
+/* 5. WriteHistorizing (Part 3 §8.55 bit 4) — exposes the Historizing    */
+/*    bit in the WriteMask, distinct from WriteAttribute (bit 2).        */
+/* --------------------------------------------------------------------- */
+
+START_TEST(WriteHistorizing_distinct_bit) {
+    UA_NodeId roleId = addRole("WriteHistRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarWriteHist");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_WRITEHISTORIZING, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_UInt32 uwm = ac->getUserRightsMask(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+
+    ck_assert_msg((uwm & UA_WRITEMASK_HISTORIZING) != 0,
+        "Spec §8.55 bit 4: WriteHistorizing must set "
+        "WriteMask.Historizing (UserWriteMask=0x%08x)", uwm);
+    ck_assert_msg((uwm & UA_WRITEMASK_DISPLAYNAME) == 0,
+        "WriteHistorizing alone must NOT grant general WriteAttribute "
+        "(UserWriteMask=0x%08x)", uwm);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "WriteHistRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+/* --------------------------------------------------------------------- */
+/* 6. History permission bits (Part 3 §8.55 bits 7..10).                 */
+/*    ReadHistory drives UserAccessLevel.HistoryRead;                    */
+/*    Insert/Modify/DeleteHistory drive UserAccessLevel.HistoryWrite.    */
+/* --------------------------------------------------------------------- */
+
+START_TEST(ReadHistory_setsHistoryReadAccessLevel) {
+    UA_NodeId roleId = addRole("HistReadRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarHistRead");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_READHISTORY, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Byte ual = ac->getUserAccessLevel(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_HISTORYREAD) != 0,
+        "Spec §8.55 bit 7: ReadHistory must set HistoryRead "
+        "(UserAccessLevel=0x%02x)", ual);
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_HISTORYWRITE) == 0,
+        "ReadHistory must NOT set HistoryWrite "
+        "(UserAccessLevel=0x%02x)", ual);
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_READ) == 0,
+        "ReadHistory must NOT imply CurrentRead "
+        "(UserAccessLevel=0x%02x)", ual);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "HistReadRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(InsertHistory_setsHistoryWriteAccessLevel) {
+    UA_NodeId roleId = addRole("HistInsertRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarHistInsert");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_INSERTHISTORY, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Byte ual = ac->getUserAccessLevel(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_HISTORYWRITE) != 0,
+        "Spec §8.55 bit 8: InsertHistory must set HistoryWrite "
+        "(UserAccessLevel=0x%02x)", ual);
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_HISTORYREAD) == 0,
+        "InsertHistory must NOT set HistoryRead "
+        "(UserAccessLevel=0x%02x)", ual);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "HistInsertRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(ModifyHistory_setsHistoryWriteAccessLevel) {
+    UA_NodeId roleId = addRole("HistModifyRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarHistModify");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_MODIFYHISTORY, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Byte ual = ac->getUserAccessLevel(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_HISTORYWRITE) != 0,
+        "Spec §8.55 bit 9: ModifyHistory must set HistoryWrite "
+        "(UserAccessLevel=0x%02x)", ual);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "HistModifyRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(DeleteHistory_setsHistoryWriteAccessLevel) {
+    UA_NodeId roleId = addRole("HistDeleteRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarHistDelete");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_DELETEHISTORY, false, false),
+        UA_STATUSCODE_GOOD);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Byte ual = ac->getUserAccessLevel(server, ac,
+        &adminSessionId, NULL, &v, NULL);
+
+    ck_assert_msg((ual & UA_ACCESSLEVELMASK_HISTORYWRITE) != 0,
+        "Spec §8.55 bit 10: DeleteHistory must set HistoryWrite "
+        "(UserAccessLevel=0x%02x)", ual);
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "HistDeleteRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+/* --------------------------------------------------------------------- */
+/* 7. Node-management permissions (Part 3 §8.55 bits 13..16).            */
+/*    AddReference / RemoveReference are checked on the source node,     */
+/*    DeleteNode on the node itself, AddNode on the parent node.         */
+/* --------------------------------------------------------------------- */
+
+START_TEST(AddReference_checked_on_source) {
+    UA_NodeId roleId = addRole("AddRefRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId src = addVariable("AddRefSource");
+    UA_NodeId tgt = addVariable("AddRefTarget");
+
+    /* Only BROWSE on source — no AddReference bit. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, src, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AddReferencesItem item;
+    UA_AddReferencesItem_init(&item);
+    item.sourceNodeId = src;
+    item.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    item.isForward = true;
+    item.targetNodeId.nodeId = tgt;
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean allowed = ac->allowAddReference(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == false,
+        "Spec §8.55 bit 13: AddReference must be denied without bit "
+        "on source (allowAddReference returned true)");
+
+    /* Now grant AddReference — should be allowed. */
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, src, roleId,
+        UA_PERMISSIONTYPE_ADDREFERENCE, false, false),
+        UA_STATUSCODE_GOOD);
+    allowed = ac->allowAddReference(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == true,
+        "AddReference must be allowed once bit 13 is granted on source");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, src, true);
+    UA_Server_deleteNode(server, tgt, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "AddRefRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(RemoveReference_checked_on_source) {
+    UA_NodeId roleId = addRole("RemRefRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId src = addVariable("RemRefSource");
+    UA_NodeId tgt = addVariable("RemRefTarget");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, src, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_DeleteReferencesItem item;
+    UA_DeleteReferencesItem_init(&item);
+    item.sourceNodeId = src;
+    item.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    item.isForward = true;
+    item.targetNodeId.nodeId = tgt;
+    item.deleteBidirectional = true;
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean allowed = ac->allowDeleteReference(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == false,
+        "Spec §8.55 bit 14: RemoveReference must be denied without bit "
+        "on source (allowDeleteReference returned true)");
+
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, src, roleId,
+        UA_PERMISSIONTYPE_REMOVEREFERENCE, false, false),
+        UA_STATUSCODE_GOOD);
+    allowed = ac->allowDeleteReference(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == true,
+        "RemoveReference must be allowed once bit 14 is granted");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, src, true);
+    UA_Server_deleteNode(server, tgt, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "RemRefRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(DeleteNode_checked_on_target) {
+    UA_NodeId roleId = addRole("DelNodeRole");
+    assignRoleToAdminSession(roleId);
+
+    UA_NodeId v = addVariable("VarToDelete");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_DeleteNodesItem item;
+    UA_DeleteNodesItem_init(&item);
+    item.nodeId = v;
+    item.deleteTargetReferences = true;
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean allowed = ac->allowDeleteNode(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == false,
+        "Spec §8.55 bit 15: DeleteNode must be denied without bit "
+        "on the target node (allowDeleteNode returned true)");
+
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, v, roleId,
+        UA_PERMISSIONTYPE_DELETENODE, false, false),
+        UA_STATUSCODE_GOOD);
+    allowed = ac->allowDeleteNode(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == true,
+        "DeleteNode must be allowed once bit 15 is granted");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, v, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "DelNodeRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+START_TEST(AddNode_checked_on_parent) {
+    UA_NodeId roleId = addRole("AddNodeRole");
+    assignRoleToAdminSession(roleId);
+
+    /* Parent is an Object child of ObjectsFolder, RBAC engaged with
+     * BROWSE only. */
+    UA_NodeId parent = addObject("AddNodeParent");
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, parent, roleId,
+        UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
+
+    UA_AddNodesItem item;
+    UA_AddNodesItem_init(&item);
+    item.parentNodeId.nodeId = parent;
+    item.referenceTypeId = UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT);
+    item.requestedNewNodeId.nodeId = UA_NODEID_NULL;
+    item.browseName = UA_QUALIFIEDNAME(1, "ChildVar");
+    item.nodeClass = UA_NODECLASS_VARIABLE;
+    item.typeDefinition.nodeId =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE);
+
+    UA_AccessControl *ac = &UA_Server_getConfig(server)->accessControl;
+    UA_Boolean allowed = ac->allowAddNode(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == false,
+        "Spec §8.55 bit 16: AddNode must be denied without bit on the "
+        "parent (allowAddNode returned true)");
+
+    ck_assert_uint_eq(UA_Server_addRolePermissions(server, parent, roleId,
+        UA_PERMISSIONTYPE_ADDNODE, false, false),
+        UA_STATUSCODE_GOOD);
+    allowed = ac->allowAddNode(server, ac,
+        &adminSessionId, NULL, &item);
+    ck_assert_msg(allowed == true,
+        "AddNode must be allowed once bit 16 is granted on parent");
+
+    clearAdminSessionRoles();
+    UA_Server_deleteNode(server, parent, true);
+    UA_Server_removeRole(server, UA_QUALIFIEDNAME(0, "AddNodeRole"));
+    UA_NodeId_clear(&roleId);
+}
+END_TEST
+
+/* --------------------------------------------------------------------- */
+/* Suite                                                                 */
+/* --------------------------------------------------------------------- */
+
+static Suite *testSuite(void) {
+    Suite *s = suite_create("Server RBAC Interlocked Permissions");
+
+#ifdef UA_ENABLE_METHODCALLS
+    TCase *tc_call = tcase_create("Call interlock (object + method)");
+    tcase_add_unchecked_fixture(tc_call, setup, teardown);
+    tcase_add_test(tc_call, Call_interlock_objectOnly);
+    tcase_add_test(tc_call, Call_interlock_methodOnly);
+    tcase_add_test(tc_call, Call_interlock_both);
+    tcase_add_test(tc_call, Call_interlock_neither);
+    suite_add_tcase(s, tc_call);
+#endif
+
+    TCase *tc_bits = tcase_create("Permission bits are independent");
+    tcase_add_unchecked_fixture(tc_bits, setup, teardown);
+    tcase_add_test(tc_bits, Browse_does_not_imply_Read);
+    tcase_add_test(tc_bits, Read_does_not_imply_Browse);
+    tcase_add_test(tc_bits, ReadRolePermissions_distinct_from_Read);
+    tcase_add_test(tc_bits, Write_does_not_imply_WriteAttribute);
+    tcase_add_test(tc_bits, WriteAttribute_does_not_imply_WriteRolePermissions);
+    tcase_add_test(tc_bits, WriteRolePermissions_distinct_bit);
+    tcase_add_test(tc_bits, WriteHistorizing_distinct_bit);
+    suite_add_tcase(s, tc_bits);
+
+    TCase *tc_hist = tcase_create("History permission bits");
+    tcase_add_unchecked_fixture(tc_hist, setup, teardown);
+    tcase_add_test(tc_hist, ReadHistory_setsHistoryReadAccessLevel);
+    tcase_add_test(tc_hist, InsertHistory_setsHistoryWriteAccessLevel);
+    tcase_add_test(tc_hist, ModifyHistory_setsHistoryWriteAccessLevel);
+    tcase_add_test(tc_hist, DeleteHistory_setsHistoryWriteAccessLevel);
+    suite_add_tcase(s, tc_hist);
+
+    TCase *tc_nm = tcase_create("Node-management permission bits");
+    tcase_add_unchecked_fixture(tc_nm, setup, teardown);
+    tcase_add_test(tc_nm, AddReference_checked_on_source);
+    tcase_add_test(tc_nm, RemoveReference_checked_on_source);
+    tcase_add_test(tc_nm, DeleteNode_checked_on_target);
+    tcase_add_test(tc_nm, AddNode_checked_on_parent);
+    suite_add_tcase(s, tc_nm);
+
+    TCase *tc_multi = tcase_create("Multi-role OR semantics");
+    tcase_add_unchecked_fixture(tc_multi, setup, teardown);
+    tcase_add_test(tc_multi, MultiRole_OR_satisfies_interlock);
+    suite_add_tcase(s, tc_multi);
+
+    TCase *tc_evt = tcase_create("ReceiveEvents interlock");
+    tcase_add_unchecked_fixture(tc_evt, setup, teardown);
+    tcase_add_test(tc_evt, ReceiveEvents_storedSeparatelyOnEventTypeAndSource);
+    tcase_add_test(tc_evt, ReceiveEvents_grantedOnBothPropagates);
+    suite_add_tcase(s, tc_evt);
+
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    int failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/server/check_server_rbac_interlocked.c
+++ b/tests/server/check_server_rbac_interlocked.c
@@ -16,7 +16,7 @@
  *
  * NOTE on ReceiveEvents (bit 11): the bit is now enforced in
  * src/server/ua_subscription_event.c::createEvent via the internal
- * helper getEffectivePermissions_nolock(). The unit-level tests below
+ * helper getEffectivePermissions(). The unit-level tests below
  * validate the data path the enforcement reads from (independent
  * storage on EventType vs. SourceNode); a full client-subscription
  * end-to-end test belongs in check_server_rbac_client.c.
@@ -520,7 +520,7 @@ END_TEST
 /* 4. ReceiveEvents (Part 3 §8.55 bit 11) — interlocked on EventType +   */
 /*    SourceNode. As of this commit the bit is enforced by               */
 /*    src/server/ua_subscription_event.c::createEvent which calls the    */
-/*    internal getEffectivePermissions_nolock() helper for both the      */
+/*    internal getEffectivePermissions() helper for both the             */
 /*    EventType and the SourceNode of every event being delivered to a   */
 /*    non-admin session, skipping the MonitoredItem when either node is  */
 /*    RBAC-restricted and lacks the bit.                                 */

--- a/tests/server/check_server_rbac_interlocked.c
+++ b/tests/server/check_server_rbac_interlocked.c
@@ -554,11 +554,11 @@ START_TEST(ReceiveEvents_storedSeparatelyOnEventTypeAndSource) {
     ck_assert_msg((effEt & UA_PERMISSIONTYPE_RECEIVEEVENTS) != 0,
         "Spec §8.55 bit 11: bit must be readable on the EventType "
         "(eff=0x%08x)", effEt);
-    /* The source has no entries -> 0xFFFFFFFF (permissive). The
-     * createEvent enforcement treats 0xFFFFFFFF as "no RBAC entries
+    /* The source has no entries -> UA_PERMISSIONTYPE_ALL (permissive). The
+     * createEvent enforcement treats UA_PERMISSIONTYPE_ALL as "no RBAC entries
      * configured" and so allows delivery; the bit is NOT inferred from
      * the EventType. */
-    ck_assert_msg(effSrc == 0xFFFFFFFFu ||
+    ck_assert_msg(effSrc == UA_PERMISSIONTYPE_ALL ||
                   !(effSrc & UA_PERMISSIONTYPE_RECEIVEEVENTS) ||
                   (effSrc & UA_PERMISSIONTYPE_RECEIVEEVENTS),
         "Source effective perms must be independently retrievable "
@@ -569,7 +569,7 @@ START_TEST(ReceiveEvents_storedSeparatelyOnEventTypeAndSource) {
         UA_PERMISSIONTYPE_BROWSE, false, false), UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(UA_Server_getEffectivePermissions(server,
         &adminSessionId, &source, &effSrc), UA_STATUSCODE_GOOD);
-    ck_assert_msg(effSrc != 0xFFFFFFFFu &&
+    ck_assert_msg(effSrc != UA_PERMISSIONTYPE_ALL &&
                   !(effSrc & UA_PERMISSIONTYPE_RECEIVEEVENTS),
         "Source must NOT inherit RECEIVEEVENTS from the EventType "
         "(effSrc=0x%08x)", effSrc);


### PR DESCRIPTION
Warning: This PR currently also includes the changes from Batch 6. #7929 

Work on implementing Role-Based Access Control according to Part 18 of the OPC UA specification began in PR #7458. As this is a substantial subsystem, the mechanism will be merged into the main branch over a series of ~7 PRs


Batch 1: Configuration option, core RBAC types and initialisation. (merged)
Batch 2: Add Roles and Permissions confugration structures and handling API.
Batch 3: Role Management and RBAC initialization
Batch 4: RBAC Information Model
Batch 5: Roles and Permssions Node Attribute
Batch 6: Session role auto-assignment
Batch 7: Namespace default role permissions API