### PR TITLE
fix(arch): remove bits/stdio_lim.h

### DIFF
--- a/arch/posix/eventloop_posix.h
+++ b/arch/posix/eventloop_posix.h
@@ -275,12 +275,6 @@ typedef int SOCKET;
 #endif /* !__APPLE__ */
 #include <sys/stat.h>
 
-#ifndef __ANDROID__
-#ifndef __APPLE__
-#include <bits/stdio_lim.h>
-#endif /* !__APPLE__ */
-#endif /* !__ANDROID__ */
-
 #define UA_STAT stat
 #define UA_DIR DIR
 #define UA_DIRENT dirent


### PR DESCRIPTION
Fix #7936


if there are some obscure or old systems that require this header we could wrap the include with `#ifdef __GLIBC__`