### PR TITLE
fix(arch): guard sys/inotify.h with #ifdef __linux__

### DIFF
--- a/arch/posix/eventloop_posix.h
+++ b/arch/posix/eventloop_posix.h
@@ -270,9 +270,9 @@ typedef int SOCKET;
 #include <libgen.h>
 #include <limits.h>
 #include <stdio.h>
-#ifndef __APPLE__
+#ifdef __linux__
 # include <sys/inotify.h>
-#endif /* !__APPLE__ */
+#endif /* __linux__ */
 #include <sys/stat.h>
 
 #ifndef __ANDROID__


### PR DESCRIPTION
The inotify is Linux-specific. The current code excluded only macOS  (#ifndef __APPLE__), which broke builds on Cygwin and other non-Linux POSIX platforms. This replaces it with #ifdef __linux__ so the include is only used where it is actually available.