### PR TITLE
fix(ex): fix key copy and memory leaks in pubsub TPM keystore subscriber

### DIFF
--- a/examples/pubsub/pubsub_subscribe_encrypted_tpm_keystore.c
+++ b/examples/pubsub/pubsub_subscribe_encrypted_tpm_keystore.c
@@ -670,16 +670,36 @@ int main(int argc, char **argv) {
     rv = decrypt(slotId, userpin, keyLabel, &encrypt_in_data, &encrypt_out_data);
     if (rv != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SECURITYPOLICY, "Decrypt failed for encryption key");
+        if (sign_out_data) {
+            if (sign_out_data->data)
+                UA_free(sign_out_data->data);
+            UA_free(sign_out_data);
+        }
+        if (encrypt_out_data) {
+            if (encrypt_out_data->data)
+                UA_free(encrypt_out_data->data);
+            UA_free(encrypt_out_data);
+        }
         return EXIT_FAILURE;
     }
     rv = decrypt(slotId, userpin, keyLabel, &sign_in_data, &sign_out_data);
     if (rv != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SECURITYPOLICY, "Decrypt failed for signing key");
+        if (sign_out_data) {
+            if (sign_out_data->data)
+                UA_free(sign_out_data->data);
+            UA_free(sign_out_data);
+        }
+        if (encrypt_out_data) {
+            if (encrypt_out_data->data)
+                UA_free(encrypt_out_data->data);
+            UA_free(encrypt_out_data);
+        }
         return EXIT_FAILURE;
     }
 
-    signingKey[UA_AES128CTR_SIGNING_KEY_LENGTH] = *(UA_Byte*)sign_out_data->data;
-    encryptingKey[UA_AES128CTR_KEY_LENGTH] = *(UA_Byte*)encrypt_out_data->data;
+    memcpy(signingKey, sign_out_data->data, UA_AES128CTR_SIGNING_KEY_LENGTH);
+    memcpy(encryptingKey, encrypt_out_data->data, UA_AES128CTR_KEY_LENGTH);
 
     UA_ByteString_clear(&encrypt_in_data);
     UA_ByteString_clear(&sign_in_data);


### PR DESCRIPTION
Similar to #7814.

The clean-up part could be simplified but I think it is worth to have this file similar to `pubsub_publish_encrypted_tpm_keystore.c`.

I missed that while creating #7809.