### PR TITLE
feat(server): exclude client code from build when UA_ENABLE_DISCOVERY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,13 +913,6 @@ set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_services_monitoreditem.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_services_securechannel.c
                 ${PROJECT_SOURCE_DIR}/src/server/ua_services_nodemanagement.c
-                # client
-                ${PROJECT_SOURCE_DIR}/src/client/ua_client.c
-                ${PROJECT_SOURCE_DIR}/src/client/ua_client_connect.c
-                ${PROJECT_SOURCE_DIR}/src/client/ua_client_discovery.c
-                ${PROJECT_SOURCE_DIR}/src/client/ua_client_highlevel.c
-                ${PROJECT_SOURCE_DIR}/src/client/ua_client_subscriptions.c
-                ${PROJECT_SOURCE_DIR}/src/client/ua_client_util.c
                 # dependencies
                 ${PROJECT_SOURCE_DIR}/deps/libc_time.c
                 ${PROJECT_SOURCE_DIR}/deps/pcg_basic.c
@@ -935,6 +928,15 @@ set(lib_sources ${PROJECT_SOURCE_DIR}/src/ua_types.c
 if(UA_GENERATED_NAMESPACE_ZERO)
     list(APPEND lib_headers ${PROJECT_BINARY_DIR}/src_generated/open62541/namespace0_generated.h)
     list(APPEND lib_sources ${PROJECT_BINARY_DIR}/src_generated/open62541/namespace0_generated.c)
+endif()
+
+if(UA_ENABLE_DISCOVERY)
+    list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/client/ua_client.c
+                            ${PROJECT_SOURCE_DIR}/src/client/ua_client_connect.c
+                            ${PROJECT_SOURCE_DIR}/src/client/ua_client_discovery.c
+                            ${PROJECT_SOURCE_DIR}/src/client/ua_client_highlevel.c
+                            ${PROJECT_SOURCE_DIR}/src/client/ua_client_subscriptions.c
+                            ${PROJECT_SOURCE_DIR}/src/client/ua_client_util.c)
 endif()
 
 if(UA_ENABLE_SUBSCRIPTIONS_EVENTS)

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -21,7 +21,9 @@
 #include <open62541/common.h>
 #include <open62541/util.h>
 #include <open62541/types.h>
+#ifdef UA_ENABLE_DISCOVERY
 #include <open62541/client.h>
+#endif
 
 #include <open62541/plugin/log.h>
 #include <open62541/plugin/certificategroup.h>

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -14,14 +14,16 @@
  *    Copyright 2024 (c) Siemens AG (Authors: Tin Raic, Thomas Zeschg)
  */
 
-#include <open62541/client.h>
-#include <open62541/client_config_default.h>
 #include <open62541/plugin/accesscontrol_default.h>
 #include <open62541/plugin/nodestore_default.h>
 #include <open62541/plugin/log_stdout.h>
 #include <open62541/plugin/certificategroup_default.h>
 #include <open62541/plugin/securitypolicy_default.h>
 #include <open62541/server_config_default.h>
+#ifdef UA_ENABLE_DISCOVERY
+#include <open62541/client.h>
+#include <open62541/client_config_default.h>
+#endif
 
 #include "../deps/mp_printf.h"
 
@@ -1662,6 +1664,8 @@ UA_ServerConfig_setDefaultWithFilestore(UA_ServerConfig *conf,
 
 #endif /* UA_ENABLE_ENCRYPTION */
 
+#ifdef UA_ENABLE_DISCOVERY
+
 /***************************/
 /* Default Client Settings */
 /***************************/
@@ -1975,3 +1979,5 @@ UA_ClientConfig_setAuthenticationCert(UA_ClientConfig *config,
     return clientConfig_setAuthenticationSecurityPolicies(config, certificateAuth, privateKeyAuth);
 }
 #endif
+
+#endif /* UA_ENABLE_DISCOVERY */


### PR DESCRIPTION
When UA_ENABLE_DISCOVERY=OFF, the OPC UA client subsystem is unnecessary for a server-only build. 