### PR TITLE
feat(server): Add const option for generated UA_DataType

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,7 @@ The `types` field in `UA_DataTypeArray` changed from `UA_DataType *` to
 them `const` makes this explicit in the API, protects against accidental
 modification and allows the toolchain to place the definitions in
 read-only memory. DataType arrays generated for additional nodesets
-remain mutable, as their NamespaceIndex gets adjusted when the nodeset
-is loaded into a server.
+remain mutable by default (see below).
 
 The `members` field in `UA_DataType` changed from `UA_DataTypeMember *`
 to `const UA_DataTypeMember *`. Generated member arrays are declared
@@ -31,6 +30,31 @@ namespace-dependent data, so this also applies to type arrays generated
 for additional nodesets. Code that builds DataType definitions at
 runtime must populate the members array through its own mutable pointer
 before assigning it to the `members` field.
+
+### Const DataType arrays for additional nodesets (companion specifications)
+
+Type arrays generated for additional nodesets (e.g. companion
+specifications like DI) can now also be declared `const` and placed in
+read-only memory. Pass the new `NAMESPACE_MAP` argument to the CMake
+generation macros (`--namespaceMap` to generate_datatypes.py) to pin the
+namespace indices at generation time, e.g.
+`NAMESPACE_MAP "2:http://opcfoundation.org/UA/DI/"`. The generated init
+code then verifies at runtime that the server assigned exactly the
+pinned indices (i.e. the nodesets are loaded in the generation order)
+and fails with `UA_STATUSCODE_BADINTERNALERROR` otherwise. The check
+covers the nodeset's own type array; arrays of dependency nodesets are
+verified by their own generated init functions, which must be called in
+dependency order (as already required for the nodes). Without pinning,
+the generated array remains mutable and its namespace indices continue
+to be adjusted in-place when the nodeset is loaded (unchanged behavior;
+the `xmlEncodingId` is now adjusted as well, and null encoding NodeIds
+are left untouched instead of receiving the namespace index).
+
+The namespace index baked into a generated type array is now always
+derived from the namespace URI of the type (via `--namespaceMap`, or
+ascending assignment for unpinned URIs). Explicit `ns=` prefixes in the
+NodeId strings of the type definition files are ignored, as they carry
+file-local indices without a defined runtime meaning.
 
 ### PubSub DataSetOrdering Support (OPC UA Part 14)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,14 @@ read-only memory. DataType arrays generated for additional nodesets
 remain mutable, as their NamespaceIndex gets adjusted when the nodeset
 is loaded into a server.
 
+The `members` field in `UA_DataType` changed from `UA_DataTypeMember *`
+to `const UA_DataTypeMember *`. Generated member arrays are declared
+`const` for all type arrays. Member definitions carry no
+namespace-dependent data, so this also applies to type arrays generated
+for additional nodesets. Code that builds DataType definitions at
+runtime must populate the members array through its own mutable pointer
+before assigning it to the `members` field.
+
 ### PubSub DataSetOrdering Support (OPC UA Part 14)
 
 Support for DataSetOrdering mechanism as defined in OPC UA Part 14, section

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,17 @@ Property. Semantic changes also set the `SemanticsChanged` StatusCode bit on
 the next DataChange notification for Value MonitoredItems on the affected
 Variable.
 
+### UA_DataTypeArray.types is const
+
+The `types` field in `UA_DataTypeArray` changed from `UA_DataType *` to
+`const UA_DataType *`. The built-in `UA_TYPES` array is now declared
+`const` as well. DataType definitions are immutable at runtime; declaring
+them `const` makes this explicit in the API, protects against accidental
+modification and allows the toolchain to place the definitions in
+read-only memory. DataType arrays generated for additional nodesets
+remain mutable, as their NamespaceIndex gets adjusted when the nodeset
+is loaded into a server.
+
 ### PubSub DataSetOrdering Support (OPC UA Part 14)
 
 Support for DataSetOrdering mechanism as defined in OPC UA Part 14, section

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,8 +65,9 @@ array must be pinned, otherwise the load-time rewrite would overwrite the
 pinned indices again. Namespaces that are only imported (they contribute
 no type to this array) do not need to be pinned. An incomplete
 `NAMESPACE_MAP`, a namespace URI that matches no namespace of the type
-array, one index pinned to two namespaces, or an index outside the UInt16
-range is reported as an error at generation time.
+array, one index pinned to two namespaces, one namespace pinned to conflicting
+indices, or an index outside the UInt16 range is reported as an error at
+generation time.
 
 For a pinned namespace the pinned index takes precedence over an
 explicit `ns=` prefix in the NodeId strings of the type definition files.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,12 +49,12 @@ read-only memory. Pass the new `NAMESPACE_MAP` argument to the CMake
 generation macros (`--namespaceMap` to generate_datatypes.py) to pin the
 namespace indices at generation time, e.g.
 `NAMESPACE_MAP "2:http://opcfoundation.org/UA/DI/"`. The generated init
-code then verifies at runtime that the server assigned exactly the
-pinned indices (i.e. the nodesets are loaded in the generation order)
-and fails with `UA_STATUSCODE_BADINTERNALERROR` otherwise. The check
-covers the nodeset's own type array; arrays of dependency nodesets are
-verified by their own generated init functions, which must be called in
-dependency order (as already required for the nodes). Without pinning,
+code then verifies each contributing namespace URI against its pinned
+index and fails with `UA_STATUSCODE_BADINTERNALERROR` otherwise, before
+registering any type arrays or adding nodes. This checks all supplied
+const arrays, including dependency arrays and arrays spanning multiple
+namespaces, independently of the generated nodeset's filename. Dependency
+nodesets must still be initialized before their dependent nodes. Without pinning,
 the generated array remains mutable and its namespace indices continue
 to be adjusted in-place when the nodeset is loaded (unchanged behavior;
 the `xmlEncodingId` is now adjusted as well, and null encoding NodeIds
@@ -65,8 +65,8 @@ array must be pinned, otherwise the load-time rewrite would overwrite the
 pinned indices again. Namespaces that are only imported (they contribute
 no type to this array) do not need to be pinned. An incomplete
 `NAMESPACE_MAP`, a namespace URI that matches no namespace of the type
-array, or one index pinned to two namespaces is reported as an error at
-generation time instead of silently producing a mutable array.
+array, one index pinned to two namespaces, or an index outside the UInt16
+range is reported as an error at generation time.
 
 For a pinned namespace the pinned index takes precedence over an
 explicit `ns=` prefix in the NodeId strings of the type definition files.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,25 @@ Property. Semantic changes also set the `SemanticsChanged` StatusCode bit on
 the next DataChange notification for Value MonitoredItems on the affected
 Variable.
 
+### UA_DataTypeArray.types is const
+
+The `types` field in `UA_DataTypeArray` changed from `UA_DataType *` to
+`const UA_DataType *`. The built-in `UA_TYPES` array is now declared
+`const` as well. DataType definitions are immutable at runtime; declaring
+them `const` makes this explicit in the API, protects against accidental
+modification and allows the toolchain to place the definitions in
+read-only memory. DataType arrays generated for additional nodesets
+remain mutable, as their NamespaceIndex gets adjusted when the nodeset
+is loaded into a server.
+
+The `members` field in `UA_DataType` changed from `UA_DataTypeMember *`
+to `const UA_DataTypeMember *`. Generated member arrays are declared
+`const` for all type arrays. Member definitions carry no
+namespace-dependent data, so this also applies to type arrays generated
+for additional nodesets. Code that builds DataType definitions at
+runtime must populate the members array through its own mutable pointer
+before assigning it to the `members` field.
+
 ### PubSub DataSetOrdering Support (OPC UA Part 14)
 
 Support for DataSetOrdering mechanism as defined in OPC UA Part 14, section

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,8 +31,7 @@ The `types` field in `UA_DataTypeArray` changed from `UA_DataType *` to
 them `const` makes this explicit in the API, protects against accidental
 modification and allows the toolchain to place the definitions in
 read-only memory. DataType arrays generated for additional nodesets
-remain mutable, as their NamespaceIndex gets adjusted when the nodeset
-is loaded into a server.
+remain mutable by default (see below).
 
 The `members` field in `UA_DataType` changed from `UA_DataTypeMember *`
 to `const UA_DataTypeMember *`. Generated member arrays are declared
@@ -41,6 +40,38 @@ namespace-dependent data, so this also applies to type arrays generated
 for additional nodesets. Code that builds DataType definitions at
 runtime must populate the members array through its own mutable pointer
 before assigning it to the `members` field.
+
+### Const DataType arrays for additional nodesets (companion specifications)
+
+Type arrays generated for additional nodesets (e.g. companion
+specifications like DI) can now also be declared `const` and placed in
+read-only memory. Pass the new `NAMESPACE_MAP` argument to the CMake
+generation macros (`--namespaceMap` to generate_datatypes.py) to pin the
+namespace indices at generation time, e.g.
+`NAMESPACE_MAP "2:http://opcfoundation.org/UA/DI/"`. The generated init
+code then verifies at runtime that the server assigned exactly the
+pinned indices (i.e. the nodesets are loaded in the generation order)
+and fails with `UA_STATUSCODE_BADINTERNALERROR` otherwise. The check
+covers the nodeset's own type array; arrays of dependency nodesets are
+verified by their own generated init functions, which must be called in
+dependency order (as already required for the nodes). Without pinning,
+the generated array remains mutable and its namespace indices continue
+to be adjusted in-place when the nodeset is loaded (unchanged behavior;
+the `xmlEncodingId` is now adjusted as well, and null encoding NodeIds
+are left untouched instead of receiving the namespace index).
+
+Pinning is all-or-nothing: every namespace that contributes a type to the
+array must be pinned, otherwise the load-time rewrite would overwrite the
+pinned indices again. Namespaces that are only imported (they contribute
+no type to this array) do not need to be pinned. An incomplete
+`NAMESPACE_MAP`, a namespace URI that matches no namespace of the type
+array, or one index pinned to two namespaces is reported as an error at
+generation time instead of silently producing a mutable array.
+
+For a pinned namespace the pinned index takes precedence over an
+explicit `ns=` prefix in the NodeId strings of the type definition files.
+Unpinned namespaces keep the previous behavior (the `ns=` prefix if
+present, otherwise 0).
 
 ### PubSub DataSetOrdering Support (OPC UA Part 14)
 

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1056,7 +1056,7 @@ UA_DataType_copy(const UA_DataType *t1, UA_DataType *t2);
 typedef struct UA_DataTypeArray {
     struct UA_DataTypeArray *next;
     size_t typesSize;
-    UA_DataType *types;
+    const UA_DataType *types;
     UA_Boolean cleanup; /* Free the array structure and its content when the
                          * client or server configuration containing it is
                          * cleaned up */

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1041,7 +1041,7 @@ struct UA_DataType {
     UA_UInt32 overlayable : 1;  /* The type has the identical memory layout
                                  * in memory and on the binary stream. */
     UA_UInt32 membersSize : 8;  /* How many members does the type have? */
-    UA_DataTypeMember *members;
+    const UA_DataTypeMember *members;
 };
 
 /* Clean up type definition with heap-allocated data */

--- a/include/open62541/types.h
+++ b/include/open62541/types.h
@@ -1047,7 +1047,7 @@ struct UA_DataType {
     UA_UInt32 overlayable : 1;  /* The type has the identical memory layout
                                  * in memory and on the binary stream. */
     UA_UInt32 membersSize : 9;  /* How many members does the type have? */
-    UA_DataTypeMember *members;
+    const UA_DataTypeMember *members;
 };
 
 /* Clean up type definition with heap-allocated data */
@@ -1062,7 +1062,7 @@ UA_DataType_copy(const UA_DataType *t1, UA_DataType *t2);
 typedef struct UA_DataTypeArray {
     struct UA_DataTypeArray *next;
     size_t typesSize;
-    UA_DataType *types;
+    const UA_DataType *types;
     UA_Boolean cleanup; /* Free the array structure and its content when the
                          * client or server configuration containing it is
                          * cleaned up */

--- a/src/client/ua_client_util.c
+++ b/src/client/ua_client_util.c
@@ -113,8 +113,9 @@ getRemoteDataTypes(UA_Client *client, UA_ReadRequest *req,
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     dta->cleanup = true;
-    dta->types = (UA_DataType*)UA_calloc(typesSize, sizeof(UA_DataType));
-    if(!dta->types) {
+    UA_DataType *newTypes = (UA_DataType*)UA_calloc(typesSize, sizeof(UA_DataType));
+    dta->types = newTypes;
+    if(!newTypes) {
         UA_ReadResponse_clear(&rr);
         UA_cleanupDataTypeWithCustom(dta);
         return UA_STATUSCODE_BADOUTOFMEMORY;
@@ -147,7 +148,7 @@ getRemoteDataTypes(UA_Client *client, UA_ReadRequest *req,
         UA_DataTypeArray lookupTypes = *dta;
         lookupTypes.next = client->config.customDataTypes;
 
-        res = UA_DataType_fromDescription(&dta->types[dta->typesSize], &eo,
+        res = UA_DataType_fromDescription(&newTypes[dta->typesSize], &eo,
                                           &lookupTypes);
         if(res != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
@@ -167,7 +168,7 @@ getRemoteDataTypes(UA_Client *client, UA_ReadRequest *req,
     UA_ReadResponse_clear(&rr);
     UA_ReadRequest_clear(req);
     if(dta->typesSize == 0) {
-        UA_free(dta->types);
+        UA_free(newTypes);
         dta->types = NULL;
     }
     return UA_STATUSCODE_GOOD;

--- a/src/client/ua_client_util.c
+++ b/src/client/ua_client_util.c
@@ -127,8 +127,9 @@ getRemoteDataTypes(UA_Client *client, UA_ReadRequest *req,
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
     dta->cleanup = true;
-    dta->types = (UA_DataType*)UA_calloc(typesSize, sizeof(UA_DataType));
-    if(!dta->types) {
+    UA_DataType *newTypes = (UA_DataType*)UA_calloc(typesSize, sizeof(UA_DataType));
+    dta->types = newTypes;
+    if(!newTypes) {
         UA_ReadResponse_clear(&rr);
         UA_cleanupDataTypeWithCustom(dta);
         return UA_STATUSCODE_BADOUTOFMEMORY;
@@ -161,7 +162,7 @@ getRemoteDataTypes(UA_Client *client, UA_ReadRequest *req,
         UA_DataTypeArray lookupTypes = *dta;
         lookupTypes.next = client->config.customDataTypes;
 
-        res = UA_DataType_fromDescription(&dta->types[dta->typesSize], &eo,
+        res = UA_DataType_fromDescription(&newTypes[dta->typesSize], &eo,
                                           &lookupTypes);
         if(res != UA_STATUSCODE_GOOD) {
             UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
@@ -181,7 +182,7 @@ getRemoteDataTypes(UA_Client *client, UA_ReadRequest *req,
     UA_ReadResponse_clear(&rr);
     UA_ReadRequest_clear(req);
     if(dta->typesSize == 0) {
-        UA_free(dta->types);
+        UA_free(newTypes);
         dta->types = NULL;
     }
     return UA_STATUSCODE_GOOD;

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -383,8 +383,8 @@ UA_Server_delete(UA_Server *server) {
         for(size_t i = 0; i < server->customTypes_internalSize; i++) {
             UA_DataTypeArray *curr = &server->customTypes_internal[i];
             for(size_t j = 0; j < curr->typesSize; j++)
-                UA_DataType_clear(&curr->types[j]);
-            UA_free(curr->types);
+                UA_DataType_clear((UA_DataType*)(uintptr_t)&curr->types[j]);
+            UA_free((void*)(uintptr_t)curr->types);
         }
         UA_free(server->customTypes_internal);
     }

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -381,8 +381,8 @@ UA_Server_delete(UA_Server *server) {
         for(size_t i = 0; i < server->customTypes_internalSize; i++) {
             UA_DataTypeArray *curr = &server->customTypes_internal[i];
             for(size_t j = 0; j < curr->typesSize; j++)
-                UA_DataType_clear(&curr->types[j]);
-            UA_free(curr->types);
+                UA_DataType_clear((UA_DataType*)(uintptr_t)&curr->types[j]);
+            UA_free((void*)(uintptr_t)curr->types);
         }
         UA_free(server->customTypes_internal);
     }

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -73,7 +73,7 @@ addDataType(UA_Server *server, UA_DataType *dt) {
     }
 
     /* Move the datatype into the stable location in the server */
-    current->types[current->typesSize] = *dt;
+    ((UA_DataType*)(uintptr_t)current->types)[current->typesSize] = *dt;
     current->typesSize++;
     return UA_STATUSCODE_GOOD;
 }

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -149,11 +149,12 @@ addDataType(UA_Server *server, UA_DataType *dt) {
     /* Move the datatype into the stable location in the server. Repair
      * self-referential members because their source pointer is about to go
      * out of scope. */
-    UA_DataType *target = &current->types[current->typesSize];
+    UA_DataType *target = (UA_DataType*)(uintptr_t)&current->types[current->typesSize];
     *target = *dt;
+    UA_DataTypeMember *members = (UA_DataTypeMember*)(uintptr_t)target->members;
     for(size_t i = 0; i < target->membersSize; i++) {
-        if(target->members[i].memberType == dt)
-            target->members[i].memberType = target;
+        if(members[i].memberType == dt)
+            members[i].memberType = target;
     }
     current->typesSize++;
     return UA_STATUSCODE_GOOD;

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -181,10 +181,10 @@ UA_cleanupDataTypeWithCustom(UA_DataTypeArray *customTypes) {
         UA_DataTypeArray *next = customTypes->next;
         if(customTypes->cleanup) {
             for(size_t i = 0; i < customTypes->typesSize; ++i) {
-                UA_DataType *type = &customTypes->types[i];
+                UA_DataType *type = (UA_DataType*)(uintptr_t)&customTypes->types[i];
                 UA_DataType_clear(type);
             }
-            UA_free(customTypes->types);
+            UA_free((void*)(uintptr_t)customTypes->types);
             UA_free(customTypes);
         }
         customTypes = next;

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -112,14 +112,14 @@ UA_DataType_clear(UA_DataType *type) {
 #ifdef UA_ENABLE_TYPEDESCRIPTION
     UA_free((void*)(uintptr_t)type->typeName);
     for(size_t j = 0; j < type->membersSize; ++j) {
-        UA_DataTypeMember *m = &type->members[j];
+        const UA_DataTypeMember *m = &type->members[j];
         UA_free((void*)(uintptr_t)m->memberName);
     }
 #endif
     UA_NodeId_clear(&type->typeId);
     UA_NodeId_clear(&type->binaryEncodingId);
     UA_NodeId_clear(&type->xmlEncodingId);
-    UA_free(type->members);
+    UA_free((void*)(uintptr_t)type->members);
     memset(type, 0, sizeof(UA_DataType));
 }
 
@@ -145,15 +145,16 @@ UA_DataType_copy(const UA_DataType *t1, UA_DataType *t2) {
 
     /* Copy the members */
     if(t1->membersSize > 0) {
-        t2->members = (UA_DataTypeMember*)
+        UA_DataTypeMember *newMembers = (UA_DataTypeMember*)
             UA_calloc(t1->membersSize, sizeof(UA_DataTypeMember));
-        if(!t2->members) {
+        if(!newMembers) {
             res = UA_STATUSCODE_BADOUTOFMEMORY;
             goto errout;
         }
+        t2->members = newMembers;
         for(size_t i = 0; i < t1->membersSize; i++) {
             const UA_DataTypeMember *m1 = &t1->members[i];
-            UA_DataTypeMember *m2 = &t2->members[i];
+            UA_DataTypeMember *m2 = &newMembers[i];
             memcpy(m2, m1, sizeof(UA_DataTypeMember));
 #ifdef UA_ENABLE_TYPEDESCRIPTION
             nameLen = strlen(m1->memberName) + 1;

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -113,14 +113,14 @@ UA_DataType_clear(UA_DataType *type) {
 #ifdef UA_ENABLE_TYPEDESCRIPTION
     UA_free((void*)(uintptr_t)type->typeName);
     for(size_t j = 0; j < type->membersSize; ++j) {
-        UA_DataTypeMember *m = &type->members[j];
+        const UA_DataTypeMember *m = &type->members[j];
         UA_free((void*)(uintptr_t)m->memberName);
     }
 #endif
     UA_NodeId_clear(&type->typeId);
     UA_NodeId_clear(&type->binaryEncodingId);
     UA_NodeId_clear(&type->xmlEncodingId);
-    UA_free(type->members);
+    UA_free((void*)(uintptr_t)type->members);
     memset(type, 0, sizeof(UA_DataType));
 }
 
@@ -146,16 +146,17 @@ UA_DataType_copy(const UA_DataType *t1, UA_DataType *t2) {
 
     /* Copy the members */
     if(t1->membersSize > 0) {
-        t2->members = (UA_DataTypeMember*)
+        UA_DataTypeMember *newMembers = (UA_DataTypeMember*)
             UA_calloc(t1->membersSize, sizeof(UA_DataTypeMember));
-        if(!t2->members) {
+        if(!newMembers) {
             res = UA_STATUSCODE_BADOUTOFMEMORY;
             goto errout;
         }
+        t2->members = newMembers;
         t2->membersSize = t1->membersSize;
         for(size_t i = 0; i < t1->membersSize; i++) {
             const UA_DataTypeMember *m1 = &t1->members[i];
-            UA_DataTypeMember *m2 = &t2->members[i];
+            UA_DataTypeMember *m2 = &newMembers[i];
             memcpy(m2, m1, sizeof(UA_DataTypeMember));
             if(m1->memberType == t1)
                 m2->memberType = t2;
@@ -184,10 +185,10 @@ UA_cleanupDataTypeWithCustom(UA_DataTypeArray *customTypes) {
         UA_DataTypeArray *next = customTypes->next;
         if(customTypes->cleanup) {
             for(size_t i = 0; i < customTypes->typesSize; ++i) {
-                UA_DataType *type = &customTypes->types[i];
+                UA_DataType *type = (UA_DataType*)(uintptr_t)&customTypes->types[i];
                 UA_DataType_clear(type);
             }
-            UA_free(customTypes->types);
+            UA_free((void*)(uintptr_t)customTypes->types);
             UA_free(customTypes);
         }
         customTypes = next;

--- a/src/ua_types_definition.c
+++ b/src/ua_types_definition.c
@@ -177,12 +177,13 @@ UA_DataType_fromStructureDescription(UA_DataType *type,
     UA_CHECK_STATUS(res, UA_DataType_clear(type); return res);
 
     /* Allocate the members array */
-    type->members = (UA_DataTypeMember *)
+    UA_DataTypeMember *newMembers = (UA_DataTypeMember *)
         UA_calloc(sd->fieldsSize, sizeof(UA_DataTypeMember));
-    if((sd->fieldsSize > 0) && !type->members) {
+    if((sd->fieldsSize > 0) && !newMembers) {
         UA_DataType_clear(type);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
+    type->members = newMembers;
     type->membersSize = (UA_Byte)sd->fieldsSize;
 
     /* Try to get pointerFree and overlayable handling shortcuts.
@@ -197,7 +198,7 @@ UA_DataType_fromStructureDescription(UA_DataType *type,
     /* Populate the members array */
     for(size_t i = 0; i < sd->fieldsSize; i++) {
         const UA_StructureField *sf = &sd->fields[i];
-        UA_DataTypeMember *dtm = &type->members[i];
+        UA_DataTypeMember *dtm = &newMembers[i];
 
         /* A datatype can contain itself only indirectly. Resolve a direct
          * self-reference against the type currently being constructed instead
@@ -401,17 +402,18 @@ UA_DataType_fromEnumDescription(UA_DataType *type,
     type->overlayable = true;
 
     /* Allocate the members array */
-    type->members = (UA_DataTypeMember *)
+    UA_DataTypeMember *newMembers = (UA_DataTypeMember *)
         UA_calloc(descr->enumDefinition.fieldsSize, sizeof(UA_DataTypeMember));
-    if((descr->enumDefinition.fieldsSize > 0) && !type->members) {
+    if((descr->enumDefinition.fieldsSize > 0) && !newMembers) {
         UA_DataType_clear(type);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
+    type->members = newMembers;
     type->membersSize = (UA_Byte)descr->enumDefinition.fieldsSize;
 
     /* Copy the enum fields into the members array */
     for(size_t i = 0; i < type->membersSize; i++) {
-        UA_DataTypeMember *dtm = &type->members[i];
+        UA_DataTypeMember *dtm = &newMembers[i];
         const UA_EnumField *ef = &descr->enumDefinition.fields[i];
         dtm->memberType = (const UA_DataType*)(uintptr_t)ef->value;
 #ifdef UA_ENABLE_TYPEDESCRIPTION

--- a/src/ua_types_definition.c
+++ b/src/ua_types_definition.c
@@ -185,12 +185,13 @@ UA_DataType_fromStructureDescription(UA_DataType *type,
     }
 
     /* Allocate the members array */
-    type->members = (UA_DataTypeMember *)
+    UA_DataTypeMember *newMembers = (UA_DataTypeMember *)
         UA_calloc(sd->fieldsSize, sizeof(UA_DataTypeMember));
-    if((sd->fieldsSize > 0) && !type->members) {
+    if((sd->fieldsSize > 0) && !newMembers) {
         UA_DataType_clear(type);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
+    type->members = newMembers;
     type->membersSize = (UA_UInt32)sd->fieldsSize;
 
     /* Try to get pointerFree and overlayable handling shortcuts.
@@ -216,7 +217,7 @@ UA_DataType_fromStructureDescription(UA_DataType *type,
     /* Populate the members array */
     for(size_t i = 0; i < sd->fieldsSize; i++) {
         const UA_StructureField *sf = &sd->fields[i];
-        UA_DataTypeMember *dtm = &type->members[i];
+        UA_DataTypeMember *dtm = &newMembers[i];
 
         /* A datatype can contain itself only indirectly. Resolve a direct
          * self-reference against the type currently being constructed instead
@@ -439,17 +440,18 @@ UA_DataType_fromEnumDescription(UA_DataType *type,
     }
 
     /* Allocate the members array */
-    type->members = (UA_DataTypeMember *)
+    UA_DataTypeMember *newMembers = (UA_DataTypeMember *)
         UA_calloc(descr->enumDefinition.fieldsSize, sizeof(UA_DataTypeMember));
-    if((descr->enumDefinition.fieldsSize > 0) && !type->members) {
+    if((descr->enumDefinition.fieldsSize > 0) && !newMembers) {
         UA_DataType_clear(type);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
+    type->members = newMembers;
     type->membersSize = (UA_UInt32)descr->enumDefinition.fieldsSize;
 
     /* Copy the enum fields into the members array */
     for(size_t i = 0; i < type->membersSize; i++) {
-        UA_DataTypeMember *dtm = &type->members[i];
+        UA_DataTypeMember *dtm = &newMembers[i];
         const UA_EnumField *ef = &descr->enumDefinition.fields[i];
         dtm->memberType = (const UA_DataType*)(uintptr_t)ef->value;
 #ifdef UA_ENABLE_TYPEDESCRIPTION

--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -8,11 +8,16 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
     set(GENERATE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/src_generated/tests")
 
-    # Generate types and namespace for DI
+    # Generate types and namespace for DI. The namespace index is pinned via
+    # NAMESPACE_MAP, so the generated type array is const and the tests
+    # exercise the const type array path including the generated runtime
+    # namespace-order check (DI is always the first namespace added to the
+    # test servers -> index 2).
     ua_generate_nodeset_and_datatypes(
         NAME "tests-di"
         FILE_CSV "${UA_NODESET_DIR}/DI/Opc.Ua.Di.NodeIds.csv"
         FILE_BSD "${UA_NODESET_DIR}/DI/Opc.Ua.Di.Types.bsd"
+        NAMESPACE_MAP "2:http://opcfoundation.org/UA/DI/"
         OUTPUT_DIR "${GENERATE_OUTPUT_DIR}"
         FILE_NS "${UA_NODESET_DIR}/DI/Opc.Ua.Di.NodeSet2.xml"
         INTERNAL

--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -8,15 +8,27 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
     set(GENERATE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/src_generated/tests")
 
-    # Generate types and namespace for DI
+    # Generate types and namespace for DI. The namespace index is pinned via
+    # NAMESPACE_MAP, so the generated type array is const and the tests
+    # exercise the const type array path including the generated runtime
+    # namespace-order check (DI is always the first namespace added to the
+    # test servers -> index 2).
     ua_generate_nodeset_and_datatypes(
         NAME "tests-di"
         FILE_CSV "${UA_NODESET_DIR}/DI/Opc.Ua.Di.NodeIds.csv"
         FILE_BSD "${UA_NODESET_DIR}/DI/Opc.Ua.Di.Types.bsd"
+        NAMESPACE_MAP "2:http://opcfoundation.org/UA/DI/"
         OUTPUT_DIR "${GENERATE_OUTPUT_DIR}"
         FILE_NS "${UA_NODESET_DIR}/DI/Opc.Ua.Di.NodeSet2.xml"
         INTERNAL
     )
+
+    # Covers both outcomes of the generated namespace-order check: the pinned
+    # index matching the server, and the mismatch that must be rejected.
+    ua_add_test(check_nodeset_compiler_di_pinned_ns.c EXTRASOURCES
+                ${UA_NODESET_TESTS_DI_SOURCES}
+                ${UA_TYPES_TESTS_DI_SOURCES})
+    add_dependencies(check_nodeset_compiler_di_pinned_ns open62541-generator-ns-tests-di)
 
     # Generate types and namespace for ADI
     ua_generate_nodeset_and_datatypes(

--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -8,6 +8,31 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
     set(GENERATE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/src_generated/tests")
 
+    # One const array containing two namespaces, used by nodesets with both
+    # a matching name and an independently chosen name.
+    ua_generate_datatypes(
+        NAME "types-tests-pinned-multi"
+        TARGET_SUFFIX "types-tests-pinned-multi"
+        FILE_CSV "${CMAKE_CURRENT_SOURCE_DIR}/pinned_namespaces.csv"
+        FILES_BSD "${CMAKE_CURRENT_SOURCE_DIR}/pinned_namespaces_a.bsd"
+                  "${CMAKE_CURRENT_SOURCE_DIR}/pinned_namespaces_b.bsd"
+        NAMESPACE_MAP "2:urn:open62541:test:pinned-a"
+                      "3:urn:open62541:test:pinned-b"
+        OUTPUT_DIR "${GENERATE_OUTPUT_DIR}")
+    foreach(name tests-pinned-multi tests-pinned-renamed)
+        ua_generate_nodeset(
+            NAME "${name}"
+            FILE "${CMAKE_CURRENT_SOURCE_DIR}/pinned_namespaces.xml"
+            TYPES_ARRAY "UA_TYPES_TESTS_PINNED_MULTI"
+            DEPENDS_NS ${open62541_NS0_NODESETS}
+            DEPENDS_TYPES "UA_TYPES"
+            OUTPUT_DIR "${GENERATE_OUTPUT_DIR}")
+    endforeach()
+    ua_add_test(check_nodeset_compiler_pinned_namespaces.c EXTRASOURCES
+                ${UA_TYPES_TESTS_PINNED_MULTI_SOURCES}
+                ${UA_NODESET_TESTS_PINNED_MULTI_SOURCES}
+                ${UA_NODESET_TESTS_PINNED_RENAMED_SOURCES})
+
     # Generate types and namespace for DI. The namespace index is pinned via
     # NAMESPACE_MAP, so the generated type array is const and the tests
     # exercise the const type array path including the generated runtime

--- a/tests/nodeset-compiler/check_nodeset_compiler_di_pinned_ns.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_di_pinned_ns.c
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+
+#include "check.h"
+#include "namespace_tests_di_generated.h"
+#include "test_helpers.h"
+#include "types_tests_di_generated.h"
+
+/* The tests-di nodeset is generated with NAMESPACE_MAP (see CMakeLists.txt),
+ * which bakes the namespace index into the type array and makes it const.
+ * This test only covers that configuration. */
+#ifndef UA_TYPES_TESTS_DI_IS_CONST
+#error "tests-di must be generated with NAMESPACE_MAP to cover the const DataType array"
+#endif
+
+#define DI_NAMESPACE_URI "http://opcfoundation.org/UA/DI/"
+
+/* Namespace index pinned via NAMESPACE_MAP. NS0 is 0 and the server
+ * application URI takes 1, so the first namespace added is 2. */
+#define DI_PINNED_NS_INDEX 2
+
+static UA_Server *server = NULL;
+
+static void setup(void) {
+    server = UA_Server_newForUnitTest();
+    ck_assert(server != NULL);
+}
+
+static void teardown(void) {
+    UA_Server_delete(server);
+    server = NULL;
+}
+
+/* DI is the first namespace added, so it gets the pinned index and the
+ * namespace-order check in the generated init code passes. */
+START_TEST(Server_pinnedNamespaceMatches) {
+    UA_StatusCode retval = namespace_tests_di_generated(server);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    size_t nsIndex = 0;
+    retval = UA_Server_getNamespaceByName(server, UA_STRING(DI_NAMESPACE_URI), &nsIndex);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(nsIndex, DI_PINNED_NS_INDEX);
+
+    /* The const array is not patched at load time. Its typeIds already carry
+     * the runtime namespace index and are directly usable for lookups. */
+    ck_assert_uint_gt(UA_TYPES_TESTS_DI_COUNT, 0);
+    for(size_t i = 0; i < UA_TYPES_TESTS_DI_COUNT; i++) {
+        const UA_DataType *dt = &UA_TYPES_TESTS_DI[i];
+        ck_assert_uint_eq(dt->typeId.namespaceIndex, DI_PINNED_NS_INDEX);
+        ck_assert_ptr_ne(UA_Server_findDataType(server, &dt->typeId), NULL);
+    }
+}
+END_TEST
+
+/* Adding an unrelated namespace first shifts DI to index 3, so the indices
+ * baked into the const array no longer match the server. The generated init
+ * code must refuse the nodeset instead of registering unusable typeIds. This
+ * logs the expected "does not match" error. */
+START_TEST(Server_pinnedNamespaceMismatch) {
+    UA_UInt16 otherNs = UA_Server_addNamespace(server, "urn:open62541.tests:not-di");
+    ck_assert_uint_eq(otherNs, DI_PINNED_NS_INDEX);
+
+    UA_StatusCode retval = namespace_tests_di_generated(server);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADINTERNALERROR);
+
+    /* The namespace is registered before the check, but at the wrong index */
+    size_t nsIndex = 0;
+    retval = UA_Server_getNamespaceByName(server, UA_STRING(DI_NAMESPACE_URI), &nsIndex);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_ne(nsIndex, DI_PINNED_NS_INDEX);
+
+    /* The check aborts before the types are added to the server config.
+     * Neither the baked nor the actual runtime index resolves. */
+    UA_NodeId typeId = UA_TYPES_TESTS_DI[0].typeId;
+    ck_assert_ptr_eq(UA_Server_findDataType(server, &typeId), NULL);
+    typeId.namespaceIndex = (UA_UInt16)nsIndex;
+    ck_assert_ptr_eq(UA_Server_findDataType(server, &typeId), NULL);
+}
+END_TEST
+
+static Suite* testSuite_pinnedNamespace(void) {
+    Suite *s = suite_create("Nodeset Compiler Pinned Namespace");
+    TCase *tc = tcase_create("const DataType array");
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_test(tc, Server_pinnedNamespaceMatches);
+    tcase_add_test(tc, Server_pinnedNamespaceMismatch);
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main(void) {
+    Suite *s = testSuite_pinnedNamespace();
+    SRunner *sr = srunner_create(s);
+    srunner_set_fork_status(sr, CK_NOFORK);
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-compiler/check_nodeset_compiler_di_pinned_ns.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_di_pinned_ns.c
@@ -60,7 +60,7 @@ END_TEST
 /* Adding an unrelated namespace first shifts DI to index 3, so the indices
  * baked into the const array no longer match the server. The generated init
  * code must refuse the nodeset instead of registering unusable typeIds. This
- * logs the expected "does not match" error. */
+ * logs the expected pinned-index error. */
 START_TEST(Server_pinnedNamespaceMismatch) {
     UA_UInt16 otherNs = UA_Server_addNamespace(server, "urn:open62541.tests:not-di");
     ck_assert_uint_eq(otherNs, DI_PINNED_NS_INDEX);

--- a/tests/nodeset-compiler/check_nodeset_compiler_pinned_namespaces.c
+++ b/tests/nodeset-compiler/check_nodeset_compiler_pinned_namespaces.c
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "namespace_tests_pinned_multi_generated.h"
+#include "namespace_tests_pinned_renamed_generated.h"
+#include "test_helpers.h"
+
+#include <check.h>
+
+#ifndef UA_TYPES_TESTS_PINNED_MULTI_IS_CONST
+#error "The namespace validation tests require a const datatype array"
+#endif
+
+#define NS_A "urn:open62541:test:pinned-a"
+#define NS_B "urn:open62541:test:pinned-b"
+
+static UA_Server *server;
+
+static void
+setup(void) {
+    server = UA_Server_newForUnitTest();
+    ck_assert_ptr_nonnull(server);
+}
+
+static void
+teardown(void) {
+    UA_Server_delete(server);
+}
+
+/* Exercise the same array with both the conventional output name and an
+ * independently named nodeset using the explicit TYPES_ARRAY argument. */
+static UA_StatusCode
+loadNodeset(int renamed) {
+    return renamed ? namespace_tests_pinned_renamed_generated(server) :
+        namespace_tests_pinned_multi_generated(server);
+}
+
+START_TEST(matchingNamespaces) {
+    ck_assert_uint_eq(loadNodeset(_i), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_TYPES_TESTS_PINNED_MULTI[
+        UA_TYPES_TESTS_PINNED_MULTI_PINNEDA].typeId.identifier.numeric, 1001);
+    ck_assert_uint_eq(UA_TYPES_TESTS_PINNED_MULTI[
+        UA_TYPES_TESTS_PINNED_MULTI_PINNEDB].typeId.identifier.numeric, 2001);
+    for(size_t i = 0; i < UA_TYPES_TESTS_PINNED_MULTI_COUNT; i++) {
+        const UA_DataType *type = &UA_TYPES_TESTS_PINNED_MULTI[i];
+        ck_assert_ptr_eq(UA_Server_findDataType(server, &type->typeId), type);
+        UA_NodeClass nodeClass;
+        ck_assert_uint_eq(UA_Server_readNodeClass(server, type->typeId, &nodeClass),
+                          UA_STATUSCODE_GOOD);
+        ck_assert_int_eq(nodeClass, UA_NODECLASS_DATATYPE);
+    }
+}
+END_TEST
+
+START_TEST(swappedNamespaces) {
+    ck_assert_uint_eq(UA_Server_addNamespace(server, NS_B), 2);
+    ck_assert_uint_eq(UA_Server_addNamespace(server, NS_A), 3);
+    ck_assert_uint_eq(loadNodeset(_i), UA_STATUSCODE_BADINTERNALERROR);
+    ck_assert_ptr_null(UA_Server_getConfig(server)->customDataTypes);
+}
+END_TEST
+
+START_TEST(secondNamespaceMismatch) {
+    ck_assert_uint_eq(UA_Server_addNamespace(server, NS_A), 2);
+    ck_assert_uint_eq(UA_Server_addNamespace(server, "urn:unrelated"), 3);
+    ck_assert_uint_eq(loadNodeset(_i), UA_STATUSCODE_BADINTERNALERROR);
+    ck_assert_ptr_null(UA_Server_getConfig(server)->customDataTypes);
+}
+END_TEST
+
+START_TEST(firstNamespaceMismatch) {
+    ck_assert_uint_eq(UA_Server_addNamespace(server, "urn:unrelated"), 2);
+    ck_assert_uint_eq(UA_Server_addNamespace(server, NS_B), 3);
+    ck_assert_uint_eq(loadNodeset(_i), UA_STATUSCODE_BADINTERNALERROR);
+    ck_assert_ptr_null(UA_Server_getConfig(server)->customDataTypes);
+}
+END_TEST
+
+int
+main(void) {
+    Suite *suite = suite_create("Nodeset compiler namespace validation");
+    TCase *tc = tcase_create("Pinned namespaces and explicit array names");
+    tcase_add_checked_fixture(tc, setup, teardown);
+    tcase_add_loop_test(tc, matchingNamespaces, 0, 2);
+    tcase_add_loop_test(tc, swappedNamespaces, 0, 2);
+    tcase_add_loop_test(tc, secondNamespaceMismatch, 0, 2);
+    tcase_add_loop_test(tc, firstNamespaceMismatch, 0, 2);
+    suite_add_tcase(suite, tc);
+    SRunner *runner = srunner_create(suite);
+    srunner_set_fork_status(runner, CK_NOFORK);
+    srunner_run_all(runner, CK_NORMAL);
+    int failed = srunner_ntests_failed(runner);
+    srunner_free(runner);
+    return failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/nodeset-compiler/pinned_namespaces.csv
+++ b/tests/nodeset-compiler/pinned_namespaces.csv
@@ -1,0 +1,2 @@
+PinnedA,1001,DataType
+PinnedB,2001,DataType

--- a/tests/nodeset-compiler/pinned_namespaces.xml
+++ b/tests/nodeset-compiler/pinned_namespaces.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>urn:open62541:test:pinned-a</Uri>
+    <Uri>urn:open62541:test:pinned-b</Uri>
+  </NamespaceUris>
+  <UADataType NodeId="ns=1;i=1001" BrowseName="1:PinnedA">
+    <DisplayName>PinnedA</DisplayName>
+    <References>
+      <Reference ReferenceType="i=45" IsForward="false">i=29</Reference>
+    </References>
+    <Definition Name="PinnedA">
+      <Field Name="Zero" Value="0"/>
+    </Definition>
+  </UADataType>
+  <UADataType NodeId="ns=2;i=2001" BrowseName="2:PinnedB">
+    <DisplayName>PinnedB</DisplayName>
+    <References>
+      <Reference ReferenceType="i=45" IsForward="false">i=29</Reference>
+    </References>
+    <Definition Name="PinnedB">
+      <Field Name="One" Value="1"/>
+    </Definition>
+  </UADataType>
+</UANodeSet>

--- a/tests/nodeset-compiler/pinned_namespaces_a.bsd
+++ b/tests/nodeset-compiler/pinned_namespaces_a.bsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<opc:TypeDictionary xmlns:opc="http://opcfoundation.org/BinarySchema/"
+                    TargetNamespace="urn:open62541:test:pinned-a">
+  <opc:EnumeratedType Name="PinnedA" LengthInBits="32">
+    <opc:EnumeratedValue Name="Zero" Value="0"/>
+  </opc:EnumeratedType>
+</opc:TypeDictionary>

--- a/tests/nodeset-compiler/pinned_namespaces_b.bsd
+++ b/tests/nodeset-compiler/pinned_namespaces_b.bsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<opc:TypeDictionary xmlns:opc="http://opcfoundation.org/BinarySchema/"
+                    TargetNamespace="urn:open62541:test:pinned-b">
+  <opc:EnumeratedType Name="PinnedB" LengthInBits="32">
+    <opc:EnumeratedValue Name="One" Value="1"/>
+  </opc:EnumeratedType>
+</opc:TypeDictionary>

--- a/tests/nodeset-compiler/test_cross_ns_types.py
+++ b/tests/nodeset-compiler/test_cross_ns_types.py
@@ -3,14 +3,23 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Test cross-namespace type-name collision handling in generate_datatypes.py.
+# Standalone tests for generate_datatypes.py. Does not need a built library.
 #
-# Two scenarios are exercised:
+# Cross-namespace type-name collisions:
 #   1. Same-name type with IDENTICAL definition across namespaces
 #      -> generator must succeed (exit 0).
 #   2. Same-name type with DIFFERENT definition across namespaces
 #      -> generator must fail (non-zero exit), because the same C typedef
 #         cannot represent two different structures/enums.
+#
+# --namespaceMap (pins namespace indices, makes the type array const):
+#   3. Pinning every namespace that contributes types is enough, even when
+#      other namespaces are imported -> succeeds and the array is const.
+#   4. A namespace uri that matches nothing -> must fail instead of silently
+#      shifting the remaining indices.
+#   5. A partially pinned array -> must fail, because the nodeset compiler
+#      would overwrite the pinned indices at load time.
+#   6. One index pinned to two namespaces -> must fail.
 
 import os
 import sys
@@ -26,42 +35,139 @@ SAME_CSV = os.path.join(HERE, "cross_ns_same.csv")
 DIFF_BSD = os.path.join(HERE, "cross_ns_diff.bsd")
 DIFF_CSV = os.path.join(HERE, "cross_ns_diff.csv")
 
+BASE_NS = "http://test.org/CrossNsBase/"
+SAME_NS = "http://test.org/CrossNsSame/"
+DIFF_NS = "http://test.org/CrossNsDiff/"
 
-def run_generator(spec_bsd, spec_csv, outdir, outname):
-    cmd = [
-        sys.executable, GENERATOR,
-        f"--import=CROSS_NS_BASE#{BASE_BSD}",
-        f"--type-bsd={spec_bsd}",
+
+def run_generator(outdir, outname, type_bsd, spec_csv, extra_args=(), import_base=True):
+    cmd = [sys.executable, GENERATOR]
+    if import_base:
+        cmd.append(f"--import=CROSS_NS_BASE#{BASE_BSD}")
+    for f in type_bsd:
+        cmd.append(f"--type-bsd={f}")
+    cmd += [
         f"--type-csv={spec_csv}",
         "--no-builtin",
+        *extra_args,
         os.path.join(outdir, outname),
     ]
     return subprocess.run(cmd, capture_output=True, text=True)
 
 
+def is_const_array(outdir, outname):
+    """Whether the generated type array was emitted const."""
+    with open(os.path.join(outdir, outname + "_generated.h")) as f:
+        return "_IS_CONST 1" in f.read()
+
+
 def main():
     failures = 0
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-
-        # --- Test 1: same definition → must succeed ---
-        r = run_generator(SAME_BSD, SAME_CSV, tmpdir, "cross_ns_same")
+    def expect_ok(label, r):
+        nonlocal failures
         if r.returncode != 0:
-            print("FAIL: same-definition cross-namespace type should be accepted, "
-                  f"but generator exited {r.returncode}")
+            print(f"FAIL: {label}, but generator exited {r.returncode}")
+            print(r.stderr)
+            failures += 1
+            return False
+        print(f"PASS: {label}")
+        return True
+
+    def expect_fail(label, r, expect_in_stderr):
+        nonlocal failures
+        if r.returncode == 0:
+            print(f"FAIL: {label}, but generator succeeded")
+            failures += 1
+        elif expect_in_stderr not in r.stderr:
+            print(f"FAIL: {label}, but the error did not mention "
+                  f"{expect_in_stderr!r}:")
             print(r.stderr)
             failures += 1
         else:
-            print("PASS: same-definition cross-namespace type accepted")
+            print(f"PASS: {label}")
 
-        # --- Test 2: different definition → must fail ---
-        r = run_generator(DIFF_BSD, DIFF_CSV, tmpdir, "cross_ns_diff")
-        if r.returncode == 0:
-            print("FAIL: different-definition cross-namespace type should be "
-                  "rejected, but generator succeeded")
-            failures += 1
-        else:
-            print("PASS: different-definition cross-namespace type rejected")
+    with tempfile.TemporaryDirectory() as tmpdir:
+
+        # --- Test 1: same definition -> must succeed ---
+        r = run_generator(tmpdir, "cross_ns_same", [SAME_BSD], SAME_CSV)
+        expect_ok("same-definition cross-namespace type accepted", r)
+
+        # --- Test 2: different definition -> must fail ---
+        r = run_generator(tmpdir, "cross_ns_diff", [DIFF_BSD], DIFF_CSV)
+        expect_fail("different-definition cross-namespace type rejected", r,
+                    "different definition")
+
+        # --- Test 3: pinning the contributing namespace is enough ---
+        # The imported base namespace contributes no type to this array, so it
+        # does not need to be pinned for the array to become const.
+        r = run_generator(tmpdir, "ns_pinned", [SAME_BSD], SAME_CSV,
+                          extra_args=[f"--namespaceMap=2:{SAME_NS}"])
+        if expect_ok("pinning the contributing namespace accepted", r):
+            if not is_const_array(tmpdir, "ns_pinned"):
+                print("FAIL: fully pinned type array was not emitted const")
+                failures += 1
+            else:
+                print("PASS: fully pinned type array is const")
+
+        # Without pinning the same array stays mutable
+        r = run_generator(tmpdir, "ns_unpinned", [SAME_BSD], SAME_CSV)
+        if expect_ok("unpinned generation accepted", r):
+            if is_const_array(tmpdir, "ns_unpinned"):
+                print("FAIL: unpinned type array must not be const")
+                failures += 1
+            else:
+                print("PASS: unpinned type array is mutable")
+
+        # --- Test 4: namespace uri that matches nothing ---
+        r = run_generator(tmpdir, "ns_unknown", [SAME_BSD], SAME_CSV,
+                          extra_args=["--namespaceMap=2:http://test.org/Nope/"])
+        expect_fail("unmatched --namespaceMap namespace rejected", r,
+                    "do not appear in the generated type array")
+
+        # --- Test 5: partially pinned array (two contributing namespaces) ---
+        r = run_generator(tmpdir, "ns_partial", [BASE_BSD, DIFF_BSD], DIFF_CSV,
+                          extra_args=[f"--namespaceMap=2:{BASE_NS}"],
+                          import_base=False)
+        expect_fail("partial --namespaceMap rejected", r,
+                    "--namespaceMap is incomplete")
+
+        # Pinning both contributing namespaces is accepted and const
+        r = run_generator(tmpdir, "ns_both", [BASE_BSD, DIFF_BSD], DIFF_CSV,
+                          extra_args=[f"--namespaceMap=2:{BASE_NS}",
+                                      f"--namespaceMap=3:{DIFF_NS}"],
+                          import_base=False)
+        if expect_ok("fully pinned multi-namespace array accepted", r):
+            if not is_const_array(tmpdir, "ns_both"):
+                print("FAIL: fully pinned multi-namespace array was not const")
+                failures += 1
+            else:
+                print("PASS: fully pinned multi-namespace array is const")
+
+        # --- Test 6: one index pinned to two namespaces ---
+        r = run_generator(tmpdir, "ns_dup", [BASE_BSD, DIFF_BSD], DIFF_CSV,
+                          extra_args=[f"--namespaceMap=2:{BASE_NS}",
+                                      f"--namespaceMap=2:{DIFF_NS}"],
+                          import_base=False)
+        expect_fail("duplicate pinned index rejected", r,
+                    "more than one namespace")
+
+        # --- Test 7: namespace 0 pinned somewhere other than index 0 ---
+        r = run_generator(tmpdir, "ns_zero", [SAME_BSD], SAME_CSV,
+                          extra_args=["--namespaceMap=5:http://opcfoundation.org/UA/"])
+        expect_fail("relocating namespace 0 rejected", r,
+                    "Namespace 0 is always at index 0")
+
+        # Spelling out the default namespace 0 mapping stays valid
+        r = run_generator(tmpdir, "ns_zero_ok", [SAME_BSD], SAME_CSV,
+                          extra_args=["--namespaceMap=0:http://opcfoundation.org/UA/",
+                                      f"--namespaceMap=2:{SAME_NS}"])
+        if expect_ok("explicit namespace 0 mapping accepted", r):
+            if not is_const_array(tmpdir, "ns_zero_ok"):
+                print("FAIL: explicit namespace 0 mapping lost const")
+                failures += 1
+            else:
+                print("PASS: explicit namespace 0 mapping is const")
 
     sys.exit(failures)
 

--- a/tests/nodeset-compiler/test_cross_ns_types.py
+++ b/tests/nodeset-compiler/test_cross_ns_types.py
@@ -152,6 +152,14 @@ def main():
         expect_fail("duplicate pinned index rejected", r,
                     "more than one namespace")
 
+        # Namespace indices must fit into UA_NodeId.namespaceIndex. Otherwise
+        # the generated initializer can truncate the promised pinned index.
+        for index in (-1, 65536):
+            r = run_generator(tmpdir, "ns_out_of_range", [SAME_BSD], SAME_CSV,
+                              extra_args=[f"--namespaceMap={index}:{SAME_NS}"])
+            expect_fail(f"out-of-range namespace index {index} rejected", r,
+                        "outside the UInt16 range")
+
         # --- Test 7: namespace 0 pinned somewhere other than index 0 ---
         r = run_generator(tmpdir, "ns_zero", [SAME_BSD], SAME_CSV,
                           extra_args=["--namespaceMap=5:http://opcfoundation.org/UA/"])

--- a/tests/nodeset-compiler/test_cross_ns_types.py
+++ b/tests/nodeset-compiler/test_cross_ns_types.py
@@ -152,6 +152,18 @@ def main():
         expect_fail("duplicate pinned index rejected", r,
                     "more than one namespace")
 
+        # A repeated URI must not silently discard an earlier pinned index.
+        r = run_generator(tmpdir, "ns_conflict", [SAME_BSD], SAME_CSV,
+                          extra_args=[f"--namespaceMap=2:{SAME_NS}",
+                                      f"--namespaceMap=3:{SAME_NS}"])
+        expect_fail("conflicting indices for one namespace rejected", r,
+                    "conflicting indices")
+
+        r = run_generator(tmpdir, "ns_repeated", [SAME_BSD], SAME_CSV,
+                          extra_args=[f"--namespaceMap=2:{SAME_NS}",
+                                      f"--namespaceMap=2:{SAME_NS}"])
+        expect_ok("repeating an identical namespace mapping accepted", r)
+
         # Namespace indices must fit into UA_NodeId.namespaceIndex. Otherwise
         # the generated initializer can truncate the promised pinned index.
         for index in (-1, 65536):
@@ -164,7 +176,7 @@ def main():
         r = run_generator(tmpdir, "ns_zero", [SAME_BSD], SAME_CSV,
                           extra_args=["--namespaceMap=5:http://opcfoundation.org/UA/"])
         expect_fail("relocating namespace 0 rejected", r,
-                    "Namespace 0 is always at index 0")
+                    "conflicting indices")
 
         # Spelling out the default namespace 0 mapping stays valid
         r = run_generator(tmpdir, "ns_zero_ok", [SAME_BSD], SAME_CSV,

--- a/tests/nodeset-loader/CMakeLists.txt
+++ b/tests/nodeset-loader/CMakeLists.txt
@@ -17,11 +17,15 @@ if(UA_NAMESPACE_ZERO STREQUAL "FULL")
 
     set(GENERATE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/src_generated/tests")
 
-    # Generate types and namespace for DI
+    # Generate types and namespace for DI. The namespace index is pinned via
+    # NAMESPACE_MAP, so the generated type array is const and its NodeIds are
+    # directly comparable with the types the nodeset loader creates at runtime
+    # (DI is the first namespace added to the test server -> index 2).
     ua_generate_nodeset_and_datatypes(
         NAME "nodesetloader-di"
         FILE_CSV "${UA_NODESET_DIR}/DI/Opc.Ua.Di.NodeIds.csv"
         FILE_BSD "${UA_NODESET_DIR}/DI/Opc.Ua.Di.Types.bsd"
+        NAMESPACE_MAP "2:http://opcfoundation.org/UA/DI/"
         OUTPUT_DIR "${GENERATE_OUTPUT_DIR}"
         FILE_NS "${UA_NODESET_DIR}/DI/Opc.Ua.Di.NodeSet2.xml"
         INTERNAL)

--- a/tests/nodeset-loader/check_nodeset_loader_compare_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_compare_di.c
@@ -32,11 +32,13 @@ START_TEST(Server_compareDiNodeset) {
     UA_UInt16 nsIndex = UA_Server_addNamespace(server, "http://opcfoundation.org/UA/DI/");
 
     for(int i = 0; i < UA_TYPES_NODESETLOADER_DI_COUNT; ++i) {
-        UA_TYPES_NODESETLOADER_DI[i].typeId.namespaceIndex = nsIndex;
-        UA_TYPES_NODESETLOADER_DI[i].binaryEncodingId.namespaceIndex = nsIndex;
-
+        /* Do not patch the generated array in place. Translate the
+         * generation-time namespace index to the runtime index in a
+         * local copy of the id. */
         const UA_DataType *compiledType = &UA_TYPES_NODESETLOADER_DI[i];
-        const UA_DataType *loadedType = UA_Server_findDataType(server, &compiledType->typeId);
+        UA_NodeId typeId = compiledType->typeId;
+        typeId.namespaceIndex = nsIndex;
+        const UA_DataType *loadedType = UA_Server_findDataType(server, &typeId);
 
         ck_assert(loadedType != NULL);
         ck_assert_uint_eq(compiledType->typeKind, loadedType->typeKind);
@@ -51,9 +53,15 @@ START_TEST(Server_compareDiNodeset) {
             const UA_DataTypeMember *loadMember = &loadedType->members[j];
 
             ck_assert(compMember->isArray == loadMember->isArray);
-            if(compiledType->typeKind != UA_DATATYPEKIND_ENUM)
-                ck_assert(UA_NodeId_equal(&compMember->memberType->typeId,
+            if(compiledType->typeKind != UA_DATATYPEKIND_ENUM) {
+                /* Member types in the DI namespace carry the baked
+                 * generation-time namespace index; translate for comparison */
+                UA_NodeId memberTypeId = compMember->memberType->typeId;
+                if(memberTypeId.namespaceIndex != 0)
+                    memberTypeId.namespaceIndex = nsIndex;
+                ck_assert(UA_NodeId_equal(&memberTypeId,
                                           &loadMember->memberType->typeId));
+            }
             ck_assert(compMember->padding == loadMember->padding);
             ck_assert(compMember->isOptional == loadMember->isOptional);
         }

--- a/tests/nodeset-loader/check_nodeset_loader_compare_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_compare_di.c
@@ -11,6 +11,10 @@
 #include "testing_clock.h"
 #include "test_helpers.h"
 
+#ifndef UA_TYPES_NODESETLOADER_DI_IS_CONST
+#error "DI types must be const to check compatibility with the runtime loader"
+#endif
+
 UA_Server *server = NULL;
 
 static void setup(void) {
@@ -40,6 +44,10 @@ START_TEST(Server_compareDiNodeset) {
         const UA_DataType *loadedType = UA_Server_findDataType(server, &compiledType->typeId);
 
         ck_assert(loadedType != NULL);
+        ck_assert(UA_NodeId_equal(&compiledType->binaryEncodingId,
+                                  &loadedType->binaryEncodingId));
+        ck_assert(UA_NodeId_equal(&compiledType->xmlEncodingId,
+                                  &loadedType->xmlEncodingId));
         ck_assert_uint_eq(compiledType->typeKind, loadedType->typeKind);
         ck_assert_uint_eq(compiledType->membersSize, loadedType->membersSize);
         ck_assert_uint_eq(compiledType->memSize, loadedType->memSize);
@@ -62,11 +70,43 @@ START_TEST(Server_compareDiNodeset) {
 }
 END_TEST
 
+START_TEST(Server_loadWithConstTypes) {
+    UA_StatusCode retVal = namespace_nodesetloader_di_generated(server);
+    ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
+
+    /* The loader must reuse the registered const definitions and still be
+     * able to add owned, mutable definitions alongside them. */
+    retVal = loadNodesetFile(server,
+        OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
+    ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
+    retVal = loadNodesetFile(server,
+        OPEN62541_TESTNODESET_DIR "datatype_edge_cases.xml", NULL);
+    ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
+
+    for(size_t i = 0; i < UA_TYPES_NODESETLOADER_DI_COUNT; i++) {
+        const UA_DataType *type = &UA_TYPES_NODESETLOADER_DI[i];
+        ck_assert_ptr_eq(UA_Server_findDataType(server, &type->typeId), type);
+    }
+
+    size_t nsIndex = 0;
+    retVal = UA_Server_getNamespaceByName(server,
+        UA_STRING("http://open62541.org/test/datatype-edge-cases/"), &nsIndex);
+    ck_assert_uint_eq(retVal, UA_STATUSCODE_GOOD);
+    UA_NodeId recursiveId = UA_NODEID_NUMERIC((UA_UInt16)nsIndex, 9001);
+    const UA_DataType *recursive = UA_Server_findDataType(server, &recursiveId);
+    ck_assert_ptr_nonnull(recursive);
+    ck_assert_uint_eq(recursive->membersSize, 1);
+    ck_assert(recursive->members[0].isArray);
+    ck_assert_ptr_eq(recursive->members[0].memberType, recursive);
+}
+END_TEST
+
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Server Nodeset Loader");
     TCase *tc_server = tcase_create("Compare DI Nodeset");
-    tcase_add_unchecked_fixture(tc_server, setup, teardown);
+    tcase_add_checked_fixture(tc_server, setup, teardown);
     tcase_add_test(tc_server, Server_compareDiNodeset);
+    tcase_add_test(tc_server, Server_loadWithConstTypes);
     suite_add_tcase(s, tc_server);
     return s;
 }

--- a/tests/nodeset-loader/check_nodeset_loader_compare_di.c
+++ b/tests/nodeset-loader/check_nodeset_loader_compare_di.c
@@ -28,12 +28,14 @@ START_TEST(Server_compareDiNodeset) {
         OPEN62541_NODESET_DIR "DI/Opc.Ua.Di.NodeSet2.xml", NULL);
     ck_assert(UA_StatusCode_isGood(retVal));
 
+    /* The generated array is const with the DI namespace index pinned at
+     * generation time (NAMESPACE_MAP in CMakeLists.txt). The nodeset loader
+     * must have registered DI at exactly that index for the NodeIds to be
+     * comparable without patching the array. */
     UA_UInt16 nsIndex = UA_Server_addNamespace(server, "http://opcfoundation.org/UA/DI/");
+    ck_assert_uint_eq(nsIndex, UA_TYPES_NODESETLOADER_DI[0].typeId.namespaceIndex);
 
     for(int i = 0; i < UA_TYPES_NODESETLOADER_DI_COUNT; ++i) {
-        UA_TYPES_NODESETLOADER_DI[i].typeId.namespaceIndex = nsIndex;
-        UA_TYPES_NODESETLOADER_DI[i].binaryEncodingId.namespaceIndex = nsIndex;
-
         const UA_DataType *compiledType = &UA_TYPES_NODESETLOADER_DI[i];
         const UA_DataType *loadedType = UA_Server_findDataType(server, &compiledType->typeId);
 

--- a/tests/server/check_datachange_deadband_typekinds.c
+++ b/tests/server/check_datachange_deadband_typekinds.c
@@ -87,7 +87,7 @@ static void teardown(void) {
  * the given absolute deadband, and prime the lastReportedValue so
  * the next delivery is the post-prime one. */
 static void
-addMonitoredVariable(UA_DataType *type, UA_Int32 deadband) {
+addMonitoredVariable(const UA_DataType *type, UA_Int32 deadband) {
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     UA_Variant value;
     UA_Variant_init(&value);

--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -160,12 +160,18 @@ endfunction()
 #                   of types which should be included in the generation. The
 #                   file should contain one type per line. Multiple files can be
 #                   passed to this argument.
+#   [NAMESPACE_MAP] Optional list of "<idx>:<namespace uri>" entries that bake
+#                   fixed namespace indices into the generated type array. If
+#                   all namespace indices are pinned, the array is const and
+#                   can reside in read-only memory. The server must assign
+#                   exactly these indices at runtime.
+#                   E.g. "2:http://opcfoundation.org/UA/DI/"
 
 function(ua_generate_datatypes)
     find_package(Python3 REQUIRED)
     set(options BUILTIN INTERNAL AUTOLOAD GEN_DOC)
     set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_XML FILE_CSV)
-    set(multiValueArgs FILES_BSD IMPORT_BSD FILES_SELECTED)
+    set(multiValueArgs FILES_BSD IMPORT_BSD FILES_SELECTED NAMESPACE_MAP)
     cmake_parse_arguments(UA_GEN_DT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
     # Argument checking
@@ -223,6 +229,11 @@ function(ua_generate_datatypes)
         set(IMPORT_BSD_TMP ${IMPORT_BSD_TMP} "--import=${f}")
     endforeach()
 
+    set(NAMESPACE_MAP_TMP "")
+    foreach(f ${UA_GEN_DT_NAMESPACE_MAP})
+        set(NAMESPACE_MAP_TMP ${NAMESPACE_MAP_TMP} "--namespaceMap=${f}")
+    endforeach()
+
     if((MINGW) AND (DEFINED ENV{SHELL}))
         # fix issue 4156 that MINGW will do automatic Windows Path Conversion
         # powershell handles Windows Path correctly
@@ -241,6 +252,7 @@ function(ua_generate_datatypes)
                                ${SELECTED_TYPES_TMP}
                                ${BSD_FILES_TMP}
                                ${IMPORT_BSD_TMP}
+                               ${NAMESPACE_MAP_TMP}
                                ${FILE_XML}
                                --type-csv=${UA_GEN_DT_FILE_CSV}
                                ${UA_GEN_DT_NO_BUILTIN}
@@ -548,12 +560,19 @@ endfunction()
 #                   These names must match any name from a previous call to this
 #                   funtion. E.g. 'di' if you are generating the 'plcopen'
 #                   nodeset
+#   [NAMESPACE_MAP] Optional list of "<idx>:<namespace uri>" entries that bake
+#                   fixed namespace indices into the generated type array. The
+#                   array is then const and can reside in read-only memory. The
+#                   server must assign exactly these indices at runtime (i.e.
+#                   the nodesets must be loaded in the generation order); this
+#                   is verified by the generated init code.
+#                   E.g. "2:http://opcfoundation.org/UA/DI/"
 
 function(ua_generate_nodeset_and_datatypes)
     find_package(Python3 REQUIRED)
     set(options INTERNAL AUTOLOAD)
     set(oneValueArgs NAME FILE_NS FILE_CSV FILE_BSD OUTPUT_DIR TARGET_PREFIX BLACKLIST)
-    set(multiValueArgs DEPENDS IMPORT_BSD)
+    set(multiValueArgs DEPENDS IMPORT_BSD NAMESPACE_MAP)
     cmake_parse_arguments(UA_GEN "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
     # Argument checking
@@ -631,6 +650,7 @@ function(ua_generate_nodeset_and_datatypes)
                               FILES_BSD "${UA_GEN_FILE_BSD}"
                               ${NODESET_AUTOLOAD}
                               IMPORT_BSD "${UA_GEN_IMPORT_BSD}"
+                              NAMESPACE_MAP "${UA_GEN_NAMESPACE_MAP}"
                               OUTPUT_DIR "${UA_GEN_OUTPUT_DIR}")
 
         # Generates target ${UA_GEN_TARGET_PREFIX}-ids-${UA_GEN_NAME}

--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -160,12 +160,20 @@ endfunction()
 #                   of types which should be included in the generation. The
 #                   file should contain one type per line. Multiple files can be
 #                   passed to this argument.
+#   [NAMESPACE_MAP] Optional list of "<idx>:<namespace uri>" entries that bake
+#                   fixed namespace indices into the generated type array. The
+#                   array is then const and can reside in read-only memory.
+#                   The server must assign exactly these indices at runtime.
+#                   Every namespace that contributes a type must be pinned;
+#                   purely imported namespaces need not be. An incomplete or
+#                   inconsistent map is an error.
+#                   E.g. "2:http://opcfoundation.org/UA/DI/"
 
 function(ua_generate_datatypes)
     find_package(Python3 REQUIRED)
     set(options BUILTIN INTERNAL AUTOLOAD GEN_DOC)
     set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_XML FILE_CSV EXPORT_MACRO)
-    set(multiValueArgs FILES_BSD IMPORT_BSD FILES_SELECTED)
+    set(multiValueArgs FILES_BSD IMPORT_BSD FILES_SELECTED NAMESPACE_MAP)
     cmake_parse_arguments(UA_GEN_DT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
     # Argument checking
@@ -223,6 +231,11 @@ function(ua_generate_datatypes)
         set(IMPORT_BSD_TMP ${IMPORT_BSD_TMP} "--import=${f}")
     endforeach()
 
+    set(NAMESPACE_MAP_TMP "")
+    foreach(f ${UA_GEN_DT_NAMESPACE_MAP})
+        set(NAMESPACE_MAP_TMP ${NAMESPACE_MAP_TMP} "--namespaceMap=${f}")
+    endforeach()
+
     if((MINGW) AND (DEFINED ENV{SHELL}))
         # fix issue 4156 that MINGW will do automatic Windows Path Conversion
         # powershell handles Windows Path correctly
@@ -246,6 +259,7 @@ function(ua_generate_datatypes)
                                ${SELECTED_TYPES_TMP}
                                ${BSD_FILES_TMP}
                                ${IMPORT_BSD_TMP}
+                               ${NAMESPACE_MAP_TMP}
                                ${FILE_XML}
                                --type-csv=${UA_GEN_DT_FILE_CSV}
                                ${UA_GEN_DT_NO_BUILTIN}
@@ -554,12 +568,23 @@ endfunction()
 #                   These names must match any name from a previous call to this
 #                   funtion. E.g. 'di' if you are generating the 'plcopen'
 #                   nodeset
+#   [NAMESPACE_MAP] Optional list of "<idx>:<namespace uri>" entries that bake
+#                   fixed namespace indices into the generated type array. The
+#                   array is then const and can reside in read-only memory. The
+#                   server must assign exactly these indices at runtime (i.e.
+#                   the nodesets must be loaded in the generation order); this
+#                   is verified by the generated init code.
+#                   Every namespace that contributes a type must be pinned;
+#                   purely imported namespaces (e.g. the types of a dependency
+#                   nodeset) need not be. An incomplete or inconsistent map is
+#                   an error.
+#                   E.g. "2:http://opcfoundation.org/UA/DI/"
 
 function(ua_generate_nodeset_and_datatypes)
     find_package(Python3 REQUIRED)
     set(options INTERNAL AUTOLOAD)
     set(oneValueArgs NAME FILE_NS FILE_CSV FILE_BSD OUTPUT_DIR TARGET_PREFIX BLACKLIST)
-    set(multiValueArgs DEPENDS IMPORT_BSD)
+    set(multiValueArgs DEPENDS IMPORT_BSD NAMESPACE_MAP)
     cmake_parse_arguments(UA_GEN "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
     # Argument checking
@@ -637,6 +662,7 @@ function(ua_generate_nodeset_and_datatypes)
                               FILES_BSD "${UA_GEN_FILE_BSD}"
                               ${NODESET_AUTOLOAD}
                               IMPORT_BSD "${UA_GEN_IMPORT_BSD}"
+                              NAMESPACE_MAP "${UA_GEN_NAMESPACE_MAP}"
                               OUTPUT_DIR "${UA_GEN_OUTPUT_DIR}")
 
         # Generates target ${UA_GEN_TARGET_PREFIX}-ids-${UA_GEN_NAME}

--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -571,9 +571,9 @@ endfunction()
 #   [NAMESPACE_MAP] Optional list of "<idx>:<namespace uri>" entries that bake
 #                   fixed namespace indices into the generated type array. The
 #                   array is then const and can reside in read-only memory. The
-#                   server must assign exactly these indices at runtime (i.e.
-#                   the nodesets must be loaded in the generation order); this
-#                   is verified by the generated init code.
+#                   server must assign exactly these indices to the namespace
+#                   URIs at runtime; the generated init code verifies this for
+#                   all supplied const arrays before registering any of them.
 #                   Every namespace that contributes a type must be pinned;
 #                   purely imported namespaces (e.g. the types of a dependency
 #                   nodeset) need not be. An incomplete or inconsistent map is

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -285,7 +285,7 @@ class CGenerator:
         if (not isEnum and len(datatype.members) == 0) or (isEnum and len(datatype.elements) == 0):
             return "#define %s_members NULL" % (idName)
         isUnion = isinstance(datatype, StructType) and datatype.is_union
-        members = "static UA_DataTypeMember {}_members[{}] = {{".format(idName, len(datatype.elements) if isEnum else len(datatype.members))
+        members = "static const UA_DataTypeMember {}_members[{}] = {{".format(idName, len(datatype.elements) if isEnum else len(datatype.members))
         before = None
         size = len(datatype.elements) if isEnum else len(datatype.members)
         if isEnum:

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -192,12 +192,31 @@ class CGenerator:
         self.fd = None
         self.fe = None
 
+    def _build_ns_index_map(self):
+        """Assign a fixed ("baked") namespace index to every namespace URI
+        that appears in the generated type array. Index 0 is always the
+        OPC UA namespace. Additional namespaces get the index provided via
+        --namespaceMap, otherwise ascending indices starting at 1."""
+        nsIndexMap = dict(self.namespaceMap)  # URI -> baked index (has ns0 -> 0)
+        used = set(nsIndexMap.values())
+        nextIdx = 1
+        for ns in self.filtered_types:
+            if ns in nsIndexMap:
+                continue
+            while nextIdx in used:
+                nextIdx += 1
+            nsIndexMap[ns] = nextIdx
+            used.add(nextIdx)
+        self.nsIndexMap = nsIndexMap
+
     def _can_be_const(self):
-        """The base UA_TYPES array (outname 'types', namespace 0) is never
-        modified at runtime and can therefore be declared const. Type arrays
-        generated for additional nodesets get their NamespaceIndex adjusted
-        at runtime and must remain mutable."""
-        return self.parser.outname == "types"
+        """The type array can be declared const (and reside in read-only
+        memory) when the namespace index of every contained type is fixed at
+        generation time: either the type belongs to namespace 0 or its
+        namespace index was pinned via --namespaceMap. Without pinning, the
+        namespace indices get rewritten in-place when the nodeset is loaded
+        into a server, so the array must remain mutable."""
+        return all(ns in self.namespaceMap for ns in self.filtered_types)
 
     @staticmethod
     def get_type_index(datatype):
@@ -254,12 +273,21 @@ class CGenerator:
         raise RuntimeError("Unknown datatype")
 
     def print_datatype(self, datatype):
-        nsIdx, bareNodeId = splitNodeidNs(datatype.nodeId)
-        typeid = "{{{}, {}}}".format(nsIdx, getNodeidTypeAndId(bareNodeId))
-        binNs, bareBinId = splitNodeidNs(datatype.binaryEncodingId)
-        binaryEncodingId = "{{{}, {}}}".format(binNs, getNodeidTypeAndId(bareBinId))
-        xmlNs, bareXmlId = splitNodeidNs(datatype.xmlEncodingId)
-        xmlEncodingId = "{{{}, {}}}".format(xmlNs, getNodeidTypeAndId(bareXmlId))
+        # The namespace index is derived from the namespace URI of the type
+        # (see _build_ns_index_map). Null NodeIds (e.g. missing encoding
+        # ids) stay in namespace 0. Explicit ns= prefixes in the id strings
+        # are ignored; they carry file-local indices without a defined
+        # runtime meaning.
+        nsIdx = self.nsIndexMap.get(datatype.namespaceUri, 0)
+        _, bareNodeId = splitNodeidNs(datatype.nodeId)
+        typeid = "{{{}, {}}}".format(nsIdx if bareNodeId else 0,
+                                     getNodeidTypeAndId(bareNodeId))
+        _, bareBinId = splitNodeidNs(datatype.binaryEncodingId)
+        binaryEncodingId = "{{{}, {}}}".format(nsIdx if bareBinId else 0,
+                                               getNodeidTypeAndId(bareBinId))
+        _, bareXmlId = splitNodeidNs(datatype.xmlEncodingId)
+        xmlEncodingId = "{{{}, {}}}".format(nsIdx if bareXmlId else 0,
+                                            getNodeidTypeAndId(bareXmlId))
         idName = makeCIdentifier(datatype.name)
         pointerfree = "true" if datatype.pointerfree else "false"
         # TODO: OptionSet is omitted because the type description is not generated as UA_DATATYPEKIND_ENUM
@@ -470,6 +498,7 @@ class CGenerator:
         self.fc = open(self.outfile + "_generated.c", 'w')
 
         self.filtered_types = self.iter_types(self.parser.types)
+        self._build_ns_index_map()
 
         self.print_header()
         self.print_description_array()
@@ -591,9 +620,17 @@ _UA_BEGIN_DECLS
         self.printh("#define UA_" + self.parser.outname.upper() + "_COUNT %s" % (str(totalCount)))
 
         if totalCount > 0:
+            outUpper = self.parser.outname.upper()
             const_q = "const " if self._can_be_const() else ""
+            if self._can_be_const():
+                self.printh("""
+/* All namespace indices in the type array are fixed at generation time
+ * (--namespaceMap). The array is const and can reside in read-only memory.
+ * The server must assign exactly the baked namespace indices at runtime,
+ * i.e. the nodesets must be loaded in the generation order. */""")
+                self.printh("#define UA_" + outUpper + "_IS_CONST 1")
             self.printh(
-                "extern UA_EXPORT " + const_q + "UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
+                "extern UA_EXPORT " + const_q + "UA_DataType UA_" + outUpper + "[UA_" + outUpper + "_COUNT];")
 
             for ns in self.filtered_types:
                 for i, t_name in enumerate(self.filtered_types[ns]):
@@ -654,9 +691,10 @@ _UA_END_DECLS
                 self.printc(CGenerator.print_members(t))
 
         if totalCount > 0:
+            outUpper = self.parser.outname.upper()
             const_q = "const " if self._can_be_const() else ""
             self.printc(
-                "{}UA_DataType UA_{}[UA_{}_COUNT] = {{".format(const_q, self.parser.outname.upper(), self.parser.outname.upper()))
+                "{}UA_DataType UA_{}[UA_{}_COUNT] = {{".format(const_q, outUpper, outUpper))
 
             for ns in self.filtered_types:
                 for _, t_name in enumerate(self.filtered_types[ns]):

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -192,6 +192,13 @@ class CGenerator:
         self.fd = None
         self.fe = None
 
+    def _can_be_const(self):
+        """The base UA_TYPES array (outname 'types', namespace 0) is never
+        modified at runtime and can therefore be declared const. Type arrays
+        generated for additional nodesets get their NamespaceIndex adjusted
+        at runtime and must remain mutable."""
+        return self.parser.outname == "types"
+
     @staticmethod
     def get_type_index(datatype):
         if isinstance(datatype,  BuiltinType):
@@ -584,9 +591,9 @@ _UA_BEGIN_DECLS
         self.printh("#define UA_" + self.parser.outname.upper() + "_COUNT %s" % (str(totalCount)))
 
         if totalCount > 0:
-
+            const_q = "const " if self._can_be_const() else ""
             self.printh(
-                "extern UA_EXPORT UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
+                "extern UA_EXPORT " + const_q + "UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
 
             for ns in self.filtered_types:
                 for i, t_name in enumerate(self.filtered_types[ns]):
@@ -647,8 +654,9 @@ _UA_END_DECLS
                 self.printc(CGenerator.print_members(t))
 
         if totalCount > 0:
+            const_q = "const " if self._can_be_const() else ""
             self.printc(
-                "UA_DataType UA_{}[UA_{}_COUNT] = {{".format(self.parser.outname.upper(), self.parser.outname.upper()))
+                "{}UA_DataType UA_{}[UA_{}_COUNT] = {{".format(const_q, self.parser.outname.upper(), self.parser.outname.upper()))
 
             for ns in self.filtered_types:
                 for _, t_name in enumerate(self.filtered_types[ns]):

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -202,6 +202,13 @@ class CGenerator:
         self.fd = None
         self.fe = None
 
+    def _can_be_const(self):
+        """The base UA_TYPES array (outname 'types', namespace 0) is never
+        modified at runtime and can therefore be declared const. Type arrays
+        generated for additional nodesets get their NamespaceIndex adjusted
+        at runtime and must remain mutable."""
+        return self.parser.outname == "types"
+
     @staticmethod
     def get_type_index(datatype):
         if isinstance(datatype,  BuiltinType):
@@ -288,7 +295,7 @@ class CGenerator:
         if (not isEnum and len(datatype.members) == 0) or (isEnum and len(datatype.elements) == 0):
             return "#define %s_members NULL" % (idName)
         isUnion = isinstance(datatype, StructType) and datatype.is_union
-        members = "static UA_DataTypeMember {}_members[{}] = {{".format(idName, len(datatype.elements) if isEnum else len(datatype.members))
+        members = "static const UA_DataTypeMember {}_members[{}] = {{".format(idName, len(datatype.elements) if isEnum else len(datatype.members))
         before = None
         size = len(datatype.elements) if isEnum else len(datatype.members)
         if isEnum:
@@ -594,9 +601,9 @@ _UA_BEGIN_DECLS
         self.printh("#define UA_" + self.parser.outname.upper() + "_COUNT %s" % (str(totalCount)))
 
         if totalCount > 0:
-
+            const_q = "const " if self._can_be_const() else ""
             self.printh(
-                "extern " + self.export_macro + " UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
+                "extern " + self.export_macro + " " + const_q + "UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
 
             for ns in self.filtered_types:
                 for i, t_name in enumerate(self.filtered_types[ns]):
@@ -657,8 +664,9 @@ _UA_END_DECLS
                 self.printc(CGenerator.print_members(t))
 
         if totalCount > 0:
+            const_q = "const " if self._can_be_const() else ""
             self.printc(
-                "UA_DataType UA_{}[UA_{}_COUNT] = {{".format(self.parser.outname.upper(), self.parser.outname.upper()))
+                "{}UA_DataType UA_{}[UA_{}_COUNT] = {{".format(const_q, self.parser.outname.upper(), self.parser.outname.upper()))
 
             for ns in self.filtered_types:
                 for _, t_name in enumerate(self.filtered_types[ns]):

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -41,7 +41,9 @@ parser.add_argument('--namespaceMap',
                     action='append',
                     default=["0:http://opcfoundation.org/UA/"],
                     help='Mapping of namespace uri to the resulting namespace index in the server. Default only contains Namespace 0: "0:http://opcfoundation.org/UA/". '
-                         'Parameter can be used multiple times to define multiple mappings.')
+                         'Parameter can be used multiple times to define multiple mappings. '
+                         'Pinning the index of every namespace that contributes a type makes the generated type array const. '
+                         'Purely imported namespaces need not be pinned. An incomplete or inconsistent mapping is an error.')
 
 parser.add_argument('-s', '--selected-types',
                     metavar="<selectedTypes>",
@@ -104,6 +106,9 @@ parser.add_argument('outfile',
 ###################
 # Code Generation #
 ###################
+
+# Namespace 0, always at index 0 in a server
+OPC_UA_NAMESPACE = "http://opcfoundation.org/UA/"
 
 # Some types can be memcpy'd off the binary stream. That's especially important
 # for arrays. But we need to check if they contain padding and whether the
@@ -202,12 +207,71 @@ class CGenerator:
         self.fd = None
         self.fe = None
 
+    def _contributing_namespaces(self):
+        """The namespaces that actually contribute types to the generated
+        array. iter_types drops types that come from imported bsd files but
+        keeps the (then empty) namespace entry, so filtered_types can list
+        namespaces that own no type in this array. Those do not constrain the
+        baked namespace indices."""
+        return [ns for ns, types in self.filtered_types.items() if len(types) > 0]
+
+    def _validate_namespace_map(self):
+        """Sanity-check a user-provided --namespaceMap.
+
+        Pinning is all-or-nothing: with an unpinned namespace the array cannot
+        be const, and the nodeset compiler then rewrites the namespace index of
+        every entry when the nodeset is loaded -- silently discarding the
+        pinned indices. Rather than generate such a half-honored array, fail
+        here so the mistake surfaces at build time."""
+        if self.namespaceMap == {OPC_UA_NAMESPACE: 0}:
+            return  # Nothing pinned, only the implicit namespace 0 entry
+
+        if self.namespaceMap.get(OPC_UA_NAMESPACE, 0) != 0:
+            raise RuntimeError(
+                "--namespaceMap pins {} to index {}. Namespace 0 is always at "
+                "index 0.".format(OPC_UA_NAMESPACE,
+                                  self.namespaceMap[OPC_UA_NAMESPACE]))
+
+        byIndex = {}
+        for ns in sorted(self.namespaceMap):
+            idx = self.namespaceMap[ns]
+            if idx in byIndex:
+                raise RuntimeError(
+                    "--namespaceMap pins index {} to more than one namespace:\n"
+                    "  {}\n  {}".format(idx, byIndex[idx], ns))
+            byIndex[idx] = ns
+
+        unknown = [ns for ns in self.namespaceMap
+                   if ns != OPC_UA_NAMESPACE and ns not in self.filtered_types]
+        if unknown:
+            raise RuntimeError(
+                "--namespaceMap contains namespaces that do not appear in the "
+                "generated type array:\n" +
+                "".join("  {}\n".format(ns) for ns in sorted(unknown)) +
+                "Namespaces of this type array:\n" +
+                "".join("  {}\n".format(ns) for ns in sorted(self.filtered_types)))
+
+        missing = [ns for ns in self._contributing_namespaces()
+                   if ns not in self.namespaceMap]
+        if missing:
+            raise RuntimeError(
+                "--namespaceMap is incomplete. Pinning is all-or-nothing: as "
+                "long as one namespace is unpinned the type array cannot be "
+                "const, and loading the nodeset overwrites the namespace index "
+                "of every entry -- including the pinned ones. Either pin all "
+                "namespaces that contribute types or drop --namespaceMap.\n"
+                "Not pinned:\n" +
+                "".join("  {}\n".format(ns) for ns in sorted(missing)))
+
     def _can_be_const(self):
-        """The base UA_TYPES array (outname 'types', namespace 0) is never
-        modified at runtime and can therefore be declared const. Type arrays
-        generated for additional nodesets get their NamespaceIndex adjusted
-        at runtime and must remain mutable."""
-        return self.parser.outname == "types"
+        """The type array can be declared const (and reside in read-only
+        memory) when the namespace index of every contained type is fixed at
+        generation time: either the type belongs to namespace 0 or its
+        namespace index was pinned via --namespaceMap. Only namespaces that
+        contribute a type are relevant. Without pinning, the namespace indices
+        get rewritten in-place when the nodeset is loaded into a server, so the
+        array must remain mutable."""
+        return all(ns in self.namespaceMap for ns in self._contributing_namespaces())
 
     @staticmethod
     def get_type_index(datatype):
@@ -263,12 +327,28 @@ class CGenerator:
             return self.get_struct_overlayable(datatype)
         raise RuntimeError("Unknown datatype")
 
+    def _baked_nodeid(self, datatype, nodeIdStr):
+        """Split a NodeId string of a type definition into the namespace index
+        baked into the generated array and the bare id. Pinned namespaces
+        (--namespaceMap) get the pinned index, which is what allows the array
+        to be const. Otherwise the index of an explicit ns= prefix is kept and
+        defaults to 0; the nodeset compiler rewrites it when the nodeset is
+        loaded. Null NodeIds (e.g. a missing encoding id) stay in namespace
+        0."""
+        nsPrefix, bareId = splitNodeidNs(nodeIdStr)
+        if not bareId:
+            return "0", bareId
+        pinned = self.namespaceMap.get(datatype.namespaceUri)
+        if pinned is not None:
+            return str(pinned), bareId
+        return nsPrefix, bareId
+
     def print_datatype(self, datatype):
-        nsIdx, bareNodeId = splitNodeidNs(datatype.nodeId)
+        nsIdx, bareNodeId = self._baked_nodeid(datatype, datatype.nodeId)
         typeid = "{{{}, {}}}".format(nsIdx, getNodeidTypeAndId(bareNodeId))
-        binNs, bareBinId = splitNodeidNs(datatype.binaryEncodingId)
+        binNs, bareBinId = self._baked_nodeid(datatype, datatype.binaryEncodingId)
         binaryEncodingId = "{{{}, {}}}".format(binNs, getNodeidTypeAndId(bareBinId))
-        xmlNs, bareXmlId = splitNodeidNs(datatype.xmlEncodingId)
+        xmlNs, bareXmlId = self._baked_nodeid(datatype, datatype.xmlEncodingId)
         xmlEncodingId = "{{{}, {}}}".format(xmlNs, getNodeidTypeAndId(bareXmlId))
         idName = makeCIdentifier(datatype.name)
         pointerfree = "true" if datatype.pointerfree else "false"
@@ -480,6 +560,7 @@ class CGenerator:
         self.fc = open(self.outfile + "_generated.c", 'w')
 
         self.filtered_types = self.iter_types(self.parser.types)
+        self._validate_namespace_map()
 
         self.print_header()
         self.print_description_array()
@@ -601,9 +682,17 @@ _UA_BEGIN_DECLS
         self.printh("#define UA_" + self.parser.outname.upper() + "_COUNT %s" % (str(totalCount)))
 
         if totalCount > 0:
+            outUpper = self.parser.outname.upper()
             const_q = "const " if self._can_be_const() else ""
+            if self._can_be_const():
+                self.printh("""
+/* All namespace indices in the type array are fixed at generation time
+ * (--namespaceMap). The array is const and can reside in read-only memory.
+ * The server must assign exactly the baked namespace indices at runtime,
+ * i.e. the nodesets must be loaded in the generation order. */""")
+                self.printh("#define UA_" + outUpper + "_IS_CONST 1")
             self.printh(
-                "extern " + self.export_macro + " " + const_q + "UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
+                "extern " + self.export_macro + " " + const_q + "UA_DataType UA_" + outUpper + "[UA_" + outUpper + "_COUNT];")
 
             for ns in self.filtered_types:
                 for i, t_name in enumerate(self.filtered_types[ns]):
@@ -664,9 +753,10 @@ _UA_END_DECLS
                 self.printc(CGenerator.print_members(t))
 
         if totalCount > 0:
+            outUpper = self.parser.outname.upper()
             const_q = "const " if self._can_be_const() else ""
             self.printc(
-                "{}UA_DataType UA_{}[UA_{}_COUNT] = {{".format(const_q, self.parser.outname.upper(), self.parser.outname.upper()))
+                "{}UA_DataType UA_{}[UA_{}_COUNT] = {{".format(const_q, outUpper, outUpper))
 
             for ns in self.filtered_types:
                 for _, t_name in enumerate(self.filtered_types[ns]):
@@ -684,7 +774,7 @@ args = parser.parse_args()
 outname = args.outfile.split("/")[-1]
 inname = ', '.join(list(map(lambda x: x.name.split("/")[-1], args.type_bsd)))
 
-namespaceMap = {"http://opcfoundation.org/UA/": 0}
+namespaceMap = {OPC_UA_NAMESPACE: 0}
 for m in args.namespace_map:
     [idx, ns] = m.split(':', 1)
     namespaceMap[ns] = int(idx)

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -235,6 +235,10 @@ class CGenerator:
         byIndex = {}
         for ns in sorted(self.namespaceMap):
             idx = self.namespaceMap[ns]
+            if not 0 <= idx <= 65535:
+                raise RuntimeError(
+                    "--namespaceMap index {} for {} is outside the UInt16 "
+                    "range (0..65535).".format(idx, ns))
             if idx in byIndex:
                 raise RuntimeError(
                     "--namespaceMap pins index {} to more than one namespace:\n"
@@ -688,14 +692,24 @@ _UA_BEGIN_DECLS
                 self.printh("""
 /* All namespace indices in the type array are fixed at generation time
  * (--namespaceMap). The array is const and can reside in read-only memory.
- * The server must assign exactly the baked namespace indices at runtime,
- * i.e. the nodesets must be loaded in the generation order. */""")
+ * The server must assign exactly the baked indices to these namespace URIs
+ * at runtime. The nodeset initializer verifies the URI/index pairs below. */""")
                 self.printh("#define UA_" + outUpper + "_IS_CONST 1")
+                # Preserve the URI/index association for nodeset initialization.
+                # Array order and the nodeset output filename do not identify
+                # which namespace a type belongs to.
+                entries = [
+                    '{{{}, UA_STRING_STATIC("{}")}}'.format(
+                        self.namespaceMap[ns], makeCLiteral(ns))
+                    for ns in self._contributing_namespaces()]
+                self.printh("#define UA_" + outUpper + "_NAMESPACE_MAP {" +
+                            ", ".join(entries) + "}")
             self.printh(
                 "extern " + self.export_macro + " " + const_q + "UA_DataType UA_" + outUpper + "[UA_" + outUpper + "_COUNT];")
 
+            typeIndex = 0
             for ns in self.filtered_types:
-                for i, t_name in enumerate(self.filtered_types[ns]):
+                for t_name in self.filtered_types[ns]:
                     t = self.filtered_types[ns][t_name]
                     is_cross_ns_dup = t_name in self.cross_ns_duplicate_types
                     if t.description == "":
@@ -709,7 +723,8 @@ _UA_BEGIN_DECLS
                     if not is_cross_ns_dup:
                         if not isinstance(t, BuiltinType):
                             self.printh(self.print_datatype_typedef(t) + "\n")
-                    self.printh("#define UA_" + makeCIdentifier(self.parser.outname.upper() + "_" + t.name.upper()) + " " + str(i))
+                    self.printh("#define UA_" + makeCIdentifier(self.parser.outname.upper() + "_" + t.name.upper()) + " " + str(typeIndex))
+                    typeIndex += 1
                     self.printh("")
                     if not is_cross_ns_dup:
                         self.printh(self.print_functions(t))

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -226,12 +226,6 @@ class CGenerator:
         if self.namespaceMap == {OPC_UA_NAMESPACE: 0}:
             return  # Nothing pinned, only the implicit namespace 0 entry
 
-        if self.namespaceMap.get(OPC_UA_NAMESPACE, 0) != 0:
-            raise RuntimeError(
-                "--namespaceMap pins {} to index {}. Namespace 0 is always at "
-                "index 0.".format(OPC_UA_NAMESPACE,
-                                  self.namespaceMap[OPC_UA_NAMESPACE]))
-
         byIndex = {}
         for ns in sorted(self.namespaceMap):
             idx = self.namespaceMap[ns]
@@ -792,7 +786,11 @@ inname = ', '.join(list(map(lambda x: x.name.split("/")[-1], args.type_bsd)))
 namespaceMap = {OPC_UA_NAMESPACE: 0}
 for m in args.namespace_map:
     [idx, ns] = m.split(':', 1)
-    namespaceMap[ns] = int(idx)
+    idx = int(idx)
+    if ns in namespaceMap and namespaceMap[ns] != idx:
+        parser.error("--namespaceMap pins {} to conflicting indices {} and {}."
+                     .format(ns, namespaceMap[ns], idx))
+    namespaceMap[ns] = idx
 
 parser = CSVBSDTypeParser(args.opaque_map, args.selected_types,
                           args.no_builtin, outname, args.import_bsd,

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -649,20 +649,43 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
     writec("nsMapping.remote2local = nsMappingTable;")
     writec(f"nsMapping.remote2localSize = {len(mapping)};")
 
-    # Change namespaceIndex from the current namespace,
-    # but only if it defines its own data types, otherwise it is not necessary.
+    # Change namespaceIndex from the current namespace, but only if the
+    # nodeset defines its own data types and the array is mutable. For const
+    # arrays (namespace indices pinned at generation time via --namespaceMap)
+    # verify instead that the runtime namespace order matches the pinning.
     if len(typesArray) > 0:
         typeArr = typesArray[-1]
         # Build the name of the TypeArray to compare if the current nodeset defines data types.
         currentTypeArr = '_'.join(outfilebase.upper().split('_')[1:-1])
         if typeArr != "UA_TYPES" and typeArr != "ns0" and typeArr == "UA_TYPES_"+currentTypeArr:
+            nsIdx = "ns[" + str(len(nodeset.namespaces)-1) + "]"
+            writec("#ifndef " + typeArr + "_IS_CONST")
             writec("/* Change namespaceIndex from current namespace */")
             writec("#if " + typeArr + "_COUNT" + " > 0")
             writec("for(int i = 0; i < " + typeArr + "_COUNT" + "; i++) {")
-            writec(typeArr + "[i]" + ".typeId.namespaceIndex = ns[" + str(len(nodeset.namespaces)-1) + "];")
-            writec(typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = ns[" + str(len(nodeset.namespaces)-1) + "];")
+            writec(typeArr + "[i]" + ".typeId.namespaceIndex = " + nsIdx + ";")
+            writec("if(!UA_NodeId_isNull(&" + typeArr + "[i]" + ".binaryEncodingId))")
+            writec("    " + typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = " + nsIdx + ";")
+            writec("if(!UA_NodeId_isNull(&" + typeArr + "[i]" + ".xmlEncodingId))")
+            writec("    " + typeArr + "[i]" + ".xmlEncodingId.namespaceIndex = " + nsIdx + ";")
             writec("}")
             writec("#endif")
+            writec("#else")
+            writec("/* Namespace indices are baked into the const type array. Verify that")
+            writec(" * the runtime namespace order matches the generation-time pinning. */")
+            writec("#if " + typeArr + "_COUNT" + " > 0")
+            writec("if(" + nsIdx + " != " + typeArr + "[0].typeId.namespaceIndex) {")
+            writec("    UA_LOG_ERROR(UA_Server_getConfig(server)->logging, UA_LOGCATEGORY_SERVER,")
+            writec("                 \"The runtime namespace index (%u) does not match the index \"")
+            writec("                 \"baked into the const DataType array " + typeArr + " (%u). \"")
+            writec("                 \"Load the nodesets in the generation order or regenerate \"")
+            writec("                 \"without NAMESPACE_MAP.\",")
+            writec("                 (unsigned)" + nsIdx + ",")
+            writec("                 (unsigned)" + typeArr + "[0].typeId.namespaceIndex);")
+            writec("    return UA_STATUSCODE_BADINTERNALERROR;")
+            writec("}")
+            writec("#endif")
+            writec("#endif /* " + typeArr + "_IS_CONST */")
 
     # Add generated types to the server
     writec("\n/* Load custom datatype definitions into the server */")

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -653,20 +653,43 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
     writec("nsMapping.remote2local = nsMappingTable;")
     writec(f"nsMapping.remote2localSize = {len(mapping)};")
 
-    # Change namespaceIndex from the current namespace,
-    # but only if it defines its own data types, otherwise it is not necessary.
+    # Change namespaceIndex from the current namespace, but only if the
+    # nodeset defines its own data types and the array is mutable. For const
+    # arrays (namespace indices pinned at generation time via --namespaceMap)
+    # verify instead that the runtime namespace order matches the pinning.
     if len(typesArray) > 0:
         typeArr = typesArray[-1]
         # Build the name of the TypeArray to compare if the current nodeset defines data types.
         currentTypeArr = '_'.join(outfilebase.upper().split('_')[1:-1])
         if typeArr != "UA_TYPES" and typeArr != "ns0" and typeArr == "UA_TYPES_"+currentTypeArr:
+            nsIdx = "ns[" + str(len(nodeset.namespaces)-1) + "]"
+            writec("#ifndef " + typeArr + "_IS_CONST")
             writec("/* Change namespaceIndex from current namespace */")
             writec("#if " + typeArr + "_COUNT" + " > 0")
             writec("for(int i = 0; i < " + typeArr + "_COUNT" + "; i++) {")
-            writec(typeArr + "[i]" + ".typeId.namespaceIndex = ns[" + str(len(nodeset.namespaces)-1) + "];")
-            writec(typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = ns[" + str(len(nodeset.namespaces)-1) + "];")
+            writec(typeArr + "[i]" + ".typeId.namespaceIndex = " + nsIdx + ";")
+            writec("if(!UA_NodeId_isNull(&" + typeArr + "[i]" + ".binaryEncodingId))")
+            writec("    " + typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = " + nsIdx + ";")
+            writec("if(!UA_NodeId_isNull(&" + typeArr + "[i]" + ".xmlEncodingId))")
+            writec("    " + typeArr + "[i]" + ".xmlEncodingId.namespaceIndex = " + nsIdx + ";")
             writec("}")
             writec("#endif")
+            writec("#else")
+            writec("/* Namespace indices are baked into the const type array. Verify that")
+            writec(" * the runtime namespace order matches the generation-time pinning. */")
+            writec("#if " + typeArr + "_COUNT" + " > 0")
+            writec("if(" + nsIdx + " != " + typeArr + "[0].typeId.namespaceIndex) {")
+            writec("    UA_LOG_ERROR(UA_Server_getConfig(server)->logging, UA_LOGCATEGORY_SERVER,")
+            writec("                 \"The runtime namespace index (%u) does not match the index \"")
+            writec("                 \"baked into the const DataType array " + typeArr + " (%u). \"")
+            writec("                 \"Load the nodesets in the generation order or regenerate \"")
+            writec("                 \"without NAMESPACE_MAP.\",")
+            writec("                 (unsigned)" + nsIdx + ",")
+            writec("                 (unsigned)" + typeArr + "[0].typeId.namespaceIndex);")
+            writec("    return UA_STATUSCODE_BADINTERNALERROR;")
+            writec("}")
+            writec("#endif")
+            writec("#endif /* " + typeArr + "_IS_CONST */")
 
     # Add generated types to the server
     writec("\n/* Load custom datatype definitions into the server */")

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -653,13 +653,38 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
     writec("nsMapping.remote2local = nsMappingTable;")
     writec(f"nsMapping.remote2localSize = {len(mapping)};")
 
-    # Change namespaceIndex from the current namespace, but only if the
-    # nodeset defines its own data types and the array is mutable. For const
-    # arrays (namespace indices pinned at generation time via --namespaceMap)
-    # verify instead that the runtime namespace order matches the pinning.
+    # Validate every const array before registering any types. The datatype
+    # generator supplies the URI/index pairs, including arrays spanning multiple
+    # namespaces and arrays whose names differ from this nodeset's output name.
+    for arr in typesArray:
+        if arr == "UA_TYPES":
+            continue
+        writec("#ifdef " + arr + "_IS_CONST")
+        writec("{")
+        writec("    static const struct {")
+        writec("        UA_UInt16 index;")
+        writec("        UA_String uri;")
+        writec("    } namespaces[] = " + arr + "_NAMESPACE_MAP;")
+        writec("    for(size_t i = 0; i < sizeof(namespaces) / sizeof(namespaces[0]); i++) {")
+        writec("        size_t runtimeIndex = 0;")
+        writec("        UA_StatusCode res = UA_Server_getNamespaceByName(")
+        writec("            server, namespaces[i].uri, &runtimeIndex);")
+        writec("        if(res != UA_STATUSCODE_GOOD || runtimeIndex != namespaces[i].index) {")
+        writec("            UA_LOG_ERROR(UA_Server_getConfig(server)->logging, UA_LOGCATEGORY_SERVER,")
+        writec('                 "Namespace %.*s does not have the pinned index %u required by "')
+        writec('                 "the const DataType array ' + arr + '. Load the namespaces at "')
+        writec('                 "their pinned indices or regenerate without NAMESPACE_MAP.",')
+        writec("                 (int)namespaces[i].uri.length, (char*)namespaces[i].uri.data,")
+        writec("                 (unsigned)namespaces[i].index);")
+        writec("            return UA_STATUSCODE_BADINTERNALERROR;")
+        writec("        }")
+        writec("    }")
+        writec("}")
+        writec("#endif /* " + arr + "_IS_CONST */")
+
+    # Preserve the existing namespace rewrite for the nodeset's mutable array.
     if len(typesArray) > 0:
         typeArr = typesArray[-1]
-        # Build the name of the TypeArray to compare if the current nodeset defines data types.
         currentTypeArr = '_'.join(outfilebase.upper().split('_')[1:-1])
         if typeArr != "UA_TYPES" and typeArr != "ns0" and typeArr == "UA_TYPES_"+currentTypeArr:
             nsIdx = "ns[" + str(len(nodeset.namespaces)-1) + "]"
@@ -672,21 +697,6 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
             writec("    " + typeArr + "[i]" + ".binaryEncodingId.namespaceIndex = " + nsIdx + ";")
             writec("if(!UA_NodeId_isNull(&" + typeArr + "[i]" + ".xmlEncodingId))")
             writec("    " + typeArr + "[i]" + ".xmlEncodingId.namespaceIndex = " + nsIdx + ";")
-            writec("}")
-            writec("#endif")
-            writec("#else")
-            writec("/* Namespace indices are baked into the const type array. Verify that")
-            writec(" * the runtime namespace order matches the generation-time pinning. */")
-            writec("#if " + typeArr + "_COUNT" + " > 0")
-            writec("if(" + nsIdx + " != " + typeArr + "[0].typeId.namespaceIndex) {")
-            writec("    UA_LOG_ERROR(UA_Server_getConfig(server)->logging, UA_LOGCATEGORY_SERVER,")
-            writec("                 \"The runtime namespace index (%u) does not match the index \"")
-            writec("                 \"baked into the const DataType array " + typeArr + " (%u). \"")
-            writec("                 \"Load the nodesets in the generation order or regenerate \"")
-            writec("                 \"without NAMESPACE_MAP.\",")
-            writec("                 (unsigned)" + nsIdx + ",")
-            writec("                 (unsigned)" + typeArr + "[0].typeId.namespaceIndex);")
-            writec("    return UA_STATUSCODE_BADINTERNALERROR;")
             writec("}")
             writec("#endif")
             writec("#endif /* " + typeArr + "_IS_CONST */")


### PR DESCRIPTION
UA_DataTypeArray.types and UA_DataType.members become const; UA_TYPES and all generated member arrays are const. Type arrays of additional nodesets can be made const by pinning their namespace indices at generation time
(NAMESPACE_MAP / --namespaceMap). The generated init code verifies the runtime namespace order and fails with BadInternalError on mismatch. Unpinned arrays keep the existing load-time rewrite.