### PR TITLE
[Draft] Check return values of getTrustList in GDS code

### DIFF
--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -569,7 +569,11 @@ removeCertificate(UA_Server *server,
 
     UA_ByteString *certificates;
     size_t certificatesSize = 0;
-    certGroup->getTrustList(certGroup, &trustList);
+    retval = certGroup->getTrustList(certGroup, &trustList);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_TrustListDataType_clear(&trustList);
+        return retval;
+    }
 
     if(isTrustedCertificate) {
         certificates = trustList.trustedCertificates;
@@ -708,7 +712,11 @@ openTrustList(UA_Server *server,
     UA_TrustListDataType trustList;
     memset(&trustList, 0, sizeof(UA_TrustListDataType));
     trustList.specifiedLists = UA_TRUSTLISTMASKS_ALL;
-    certGroup->getTrustList(certGroup, &trustList);
+    retval = certGroup->getTrustList(certGroup, &trustList);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_TrustListDataType_clear(&trustList);
+        return retval;
+    }
 
     UA_ByteString encTrustList = UA_BYTESTRING_NULL;
     retval = UA_encodeBinary(&trustList, &UA_TYPES[UA_TYPES_TRUSTLISTDATATYPE], &encTrustList, NULL);
@@ -775,7 +783,11 @@ openTrustListWithMask(UA_Server *server,
     UA_TrustListDataType trustList;
     memset(&trustList, 0, sizeof(UA_TrustListDataType));
     trustList.specifiedLists = mask;
-    certGroup->getTrustList(certGroup, &trustList);
+    retval = certGroup->getTrustList(certGroup, &trustList);
+    if(retval != UA_STATUSCODE_GOOD) {
+        UA_TrustListDataType_clear(&trustList);
+        return retval;
+    }
 
     UA_ByteString encTrustList = UA_BYTESTRING_NULL;
     retval = UA_encodeBinary(&trustList, &UA_TYPES[UA_TYPES_TRUSTLISTDATATYPE], &encTrustList, NULL);
@@ -1163,7 +1175,11 @@ applyChangesToServer(UA_Server *server) {
         UA_TrustListDataType trustList;
         UA_TrustListDataType_init(&trustList);
         trustList.specifiedLists = UA_TRUSTLISTMASKS_ALL;
-        transactionCertGroup.getTrustList(&transactionCertGroup, &trustList);
+        retval = transactionCertGroup.getTrustList(&transactionCertGroup, &trustList);
+        if(retval != UA_STATUSCODE_GOOD) {
+            UA_TrustListDataType_clear(&trustList);
+            goto cleanup;
+        }
 
         UA_CertificateGroup *certGroup = getCertGroup(server, &transactionCertGroup.certificateGroupId);
         if(!certGroup) {


### PR DESCRIPTION
In ua_server_ns0_gds.c, the "getTrustList" function of the CertificateGroup is called without checking its return value.

This leads to errors being suppressed when the backend accessing the Certificate Store fails to read the TrustList (e.g. because the medium on which it is stored is unavailable or has a physical error).

Steps to reproduce the problem:
1. Create a CertificateGroup implementation that returns an error (e.g. "Bad_NotReadble") when getTrustList() is called.
2. Compile a Server using this CertificateGroup implementation.
3. Run the Server and connect with a Client, e.g. UaExpert.
4. Call "Server->ServerConfiguration->CertificateGroups->DefaultApplicationGroup->TrustList->Open" with Mode=1 ("open for read"). This should fail with an error (e.g. "Bad_NotReadable"), but returns "Good".
5. Now you can even call "Read" on the returned FileHandle, which returns an empty TrustListDataType object.

IMHO this is misleading behavior - I would have expected the Server to return e.g. "Bad_NotReadble" or "Bad_NotFound", as specified for Open and Read of the FileType parent type:
https://reference.opcfoundation.org/Core/Part20/v105/docs/4.2.2
