### PR TITLE
fix(core): use correct size in memset after moving Variant array elements

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -931,7 +931,7 @@ Variant_setRange(UA_Variant *v, void *array, size_t arraySize,
 
     /* If members were moved, initialize original array to prevent reuse */
     if(!copy && !v->type->pointerFree)
-        memset(array, 0, sizeof(elem_size)*arraySize);
+        memset(array, 0, elem_size*arraySize);
 
     return retval;
 }


### PR DESCRIPTION
Variant_setRange uses sizeof(elem_size) instead of elem_size in the memset that zeros moved array elements. sizeof(elem_size) always evaluates to sizeof(size_t) (8 on 64-bit), not the actual element size. For types with memSize > 8 (like UA_String at 16 bytes), only half the struct is zeroed, leaving heap data pointers dangling. This causes a double-free when both the source array and the variant are later cleared.

Confirmed with AddressSanitizer.