### PR TITLE
fix(server): guard securityPolicyUriPostfix against empty URI

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -301,6 +301,7 @@ const char *securityModeStrs[4] = {"-invalid", "-none", "-sign", "-sign+encrypt"
 
 UA_String
 securityPolicyUriPostfix(const UA_String uri) {
+    if(uri.length == 0) return uri;
     for(UA_Byte *b = uri.data + uri.length - 1; b >= uri.data; b--) {
         if(*b != '#')
             continue;


### PR DESCRIPTION
securityPolicyUriPostfix iterates backward using raw pointer arithmetic. When uri.length is 0 and uri.data is NULL, the initial pointer wraps to 0xFFFFFFFFFFFFFFFF and the loop dereferences wild memory. Add an early return for empty strings.