### PR TITLE
fix(server): support Good_PasswordChangeRequired from AccessControl

### DIFF
--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -354,7 +354,7 @@ sendResponse(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 requestId,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* If the overall service call failed, answer with a ServiceFault */
-    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
+    if(!UA_StatusCode_isGood(response->responseHeader.serviceResult))
         return sendServiceFault(server, channel, requestId,
                                 response->responseHeader.requestHandle,
                                 response->responseHeader.serviceResult);

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -358,7 +358,7 @@ sendResponse(UA_Server *server, UA_SecureChannel *channel, UA_UInt32 requestId,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     /* If the overall service call failed, answer with a ServiceFault */
-    if(response->responseHeader.serviceResult != UA_STATUSCODE_GOOD)
+    if(!UA_StatusCode_isGood(response->responseHeader.serviceResult))
         return sendServiceFault(server, channel, requestId,
                                 response->responseHeader.requestHandle,
                                 response->responseHeader.serviceResult);

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -1093,7 +1093,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         activateSession(server, &server->config.accessControl, ed,
                         &channel->remoteCertificate, &session->sessionId,
                         &req->userIdentityToken, &session->context);
-    if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+    if(!UA_StatusCode_isGood(rh->serviceResult)) {
         UA_LOG_ERROR_SESSION(server->config.logging, session,
                              "ActivateSession: The AccessControl plugin "
                              "denied the activation with the StatusCode %s",
@@ -1111,11 +1111,15 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
                             "ActivateSession: Session attached to new channel");
     }
 
+    /* We must not touch the serviceResult if everything works fine! */
+    UA_StatusCode stepResult = UA_STATUSCODE_BADINTERNALERROR;
+
     /* Generate a new session nonce for the next time ActivateSession is called */
-    rh->serviceResult = UA_Session_generateNonce(session);
-    rh->serviceResult |= UA_ByteString_copy(&session->serverNonce,
-                                            &resp->serverNonce);
-    if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+    stepResult = UA_Session_generateNonce(session);
+    stepResult |= UA_ByteString_copy(&session->serverNonce,
+                                     &resp->serverNonce);
+    if(stepResult != UA_STATUSCODE_GOOD) {
+        rh->serviceResult = stepResult;
         UA_Session_detachFromSecureChannel(server, session);
         UA_LOG_ERROR_SESSION(server->config.logging, session,
                              "ActivateSession: Could not generate the server nonce");
@@ -1129,10 +1133,11 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
          * Session. If it is not specified the Server shall keep using the
          * current localeIds for the Session. */
         UA_String *tmpLocaleIds;
-        rh->serviceResult |=
+        stepResult |=
             UA_Array_copy(req->localeIds, req->localeIdsSize,
                           (void**)&tmpLocaleIds, &UA_TYPES[UA_TYPES_STRING]);
-        if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+        if(stepResult != UA_STATUSCODE_GOOD) {
+            rh->serviceResult = stepResult;
             UA_Session_detachFromSecureChannel(server, session);
             UA_LOG_ERROR_SESSION(server->config.logging, session,
                                  "ActivateSession: Could not store the "
@@ -1155,9 +1160,10 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
     const UA_SecurityPolicy *sessionSp = session->sessionSp;
     if(sessionSp && session->sessionSpContext &&
        sessionSp->policyType == UA_SECURITYPOLICYTYPE_ECC) {
-        rh->serviceResult = addEphemeralKeyAdditionalHeader(server, session,
+        stepResult = addEphemeralKeyAdditionalHeader(server, session,
                                                             &rh->additionalHeader);
-        if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+        if(stepResult != UA_STATUSCODE_GOOD) {
+            rh->serviceResult = stepResult;
             UA_LOG_ERROR_SESSION(server->config.logging, session,
                                  "ActivateSession: Could not prepare the "
                                  "ephemeral key (%s)",

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -1191,7 +1191,7 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         activateSession(server, &server->config.accessControl, ed,
                         &channel->remoteCertificate, &session->sessionId,
                         &req->userIdentityToken, &session->context);
-    if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+    if(!UA_StatusCode_isGood(rh->serviceResult)) {
         UA_LOG_ERROR_SESSION(server->config.logging, session,
                              "ActivateSession: The AccessControl plugin "
                              "denied the activation with the StatusCode %s",
@@ -1209,11 +1209,15 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
                             "ActivateSession: Session attached to new channel");
     }
 
+    /* We must not touch the serviceResult if everything works fine! */
+    UA_StatusCode stepResult = UA_STATUSCODE_BADINTERNALERROR;
+
     /* Generate a new session nonce for the next time ActivateSession is called */
-    rh->serviceResult = UA_Session_generateNonce(session);
-    rh->serviceResult |= UA_ByteString_copy(&session->serverNonce,
-                                            &resp->serverNonce);
-    if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+    stepResult = UA_Session_generateNonce(session);
+    stepResult |= UA_ByteString_copy(&session->serverNonce,
+                                     &resp->serverNonce);
+    if(stepResult != UA_STATUSCODE_GOOD) {
+        rh->serviceResult = stepResult;
         UA_Session_detachFromSecureChannel(server, session);
         UA_LOG_ERROR_SESSION(server->config.logging, session,
                              "ActivateSession: Could not generate the server nonce");
@@ -1227,10 +1231,11 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
          * Session. If it is not specified the Server shall keep using the
          * current localeIds for the Session. */
         UA_String *tmpLocaleIds;
-        rh->serviceResult |=
+        stepResult |=
             UA_Array_copy(req->localeIds, req->localeIdsSize,
                           (void**)&tmpLocaleIds, &UA_TYPES[UA_TYPES_STRING]);
-        if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+        if(stepResult != UA_STATUSCODE_GOOD) {
+            rh->serviceResult = stepResult;
             UA_Session_detachFromSecureChannel(server, session);
             UA_LOG_ERROR_SESSION(server->config.logging, session,
                                  "ActivateSession: Could not store the "
@@ -1254,9 +1259,10 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
     if(sessionSp && session->sessionSpContext &&
        UA_SecurityPolicy_isEcc(sessionSp) &&
        clientRequestedEphemeralKey(&req->requestHeader.additionalHeader)) {
-        rh->serviceResult = addEphemeralKeyAdditionalHeader(server, session,
-                                                            &rh->additionalHeader);
-        if(rh->serviceResult != UA_STATUSCODE_GOOD) {
+        stepResult = addEphemeralKeyAdditionalHeader(server, session,
+                                                     &rh->additionalHeader);
+        if(stepResult != UA_STATUSCODE_GOOD) {
+            rh->serviceResult = stepResult;
             UA_LOG_ERROR_SESSION(server->config.logging, session,
                                  "ActivateSession: Could not prepare the "
                                  "ephemeral key (%s)",


### PR DESCRIPTION
The fixes the issue where Service_ActivateSession() overwrites the serviceResult after activateSession() from the AccessControl plugin returned either Good or Good_PasswordChangeRequired.

Only in case of an error in any subsequent step will the serviceResult be properly adjusted.