### PR TITLE
[REVIEW] fix(alarms): clear temporary Variants in limit readers

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -30,6 +30,10 @@ jobs:
           - name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
             cmd_action: unit_tests_alarms
 
+          - name: "Valgrind Build & Unit Tests with Alarms&Conditions (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind
+            cmd_action: unit_tests_alarms_memcheck
+
           - name: "Debug Build & Unit Tests (tcc)"
             cmd_deps: sudo apt-get install -y -qq tcc
             cmd_action: CC=tcc unit_tests

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -2865,10 +2865,13 @@ static UA_StatusCode
 getLowLimit(UA_Server *server, UA_NodeId conditionId, UA_Double *lowLimit) {
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_Variant value;
+    UA_Variant_init(&value);
     UA_StatusCode retval =
         readObjectProperty(server, conditionId,
                            UA_QUALIFIEDNAME(0, CONDITION_FIELD_LOWLIMIT), &value);
-    *lowLimit = *(UA_Double*) value.data;
+    if(retval == UA_STATUSCODE_GOOD)
+        *lowLimit = *(UA_Double*)value.data;
+    UA_Variant_clear(&value);
     return retval;
 }
 
@@ -2876,10 +2879,13 @@ static UA_StatusCode
 getLowLowLimit(UA_Server *server, UA_NodeId conditionId, UA_Double *lowLowLimit) {
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_Variant value;
+    UA_Variant_init(&value);
     UA_StatusCode retval =
         readObjectProperty(server, conditionId,
                            UA_QUALIFIEDNAME(0, CONDITION_FIELD_LOWLOWLIMIT), &value);
-    *lowLowLimit = *(UA_Double*) value.data;
+    if(retval == UA_STATUSCODE_GOOD)
+        *lowLowLimit = *(UA_Double*)value.data;
+    UA_Variant_clear(&value);
     return retval;
 }
 
@@ -2887,10 +2893,13 @@ static UA_StatusCode
 getHighLimit(UA_Server *server, UA_NodeId conditionId, UA_Double *highLimit) {
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_Variant value;
+    UA_Variant_init(&value);
     UA_StatusCode retval =
         readObjectProperty(server, conditionId,
                            UA_QUALIFIEDNAME(0, CONDITION_FIELD_HIGHLIMIT), &value);
-    *highLimit = *(UA_Double*) value.data;
+    if(retval == UA_STATUSCODE_GOOD)
+        *highLimit = *(UA_Double*)value.data;
+    UA_Variant_clear(&value);
     return retval;
 }
 
@@ -2898,10 +2907,13 @@ static UA_StatusCode
 getHighHighLimit(UA_Server *server, UA_NodeId conditionId, UA_Double *highHighLimit) {
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_Variant value;
+    UA_Variant_init(&value);
     UA_StatusCode retval =
         readObjectProperty(server, conditionId,
                            UA_QUALIFIEDNAME(0, CONDITION_FIELD_HIGHHIGHLIMIT), &value);
-    *highHighLimit = *(UA_Double*) value.data;
+    if(retval == UA_STATUSCODE_GOOD)
+        *highHighLimit = *(UA_Double*)value.data;
+    UA_Variant_clear(&value);
     return retval;
 }
 

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -2922,7 +2922,7 @@ setLimitState(UA_Server *server, const UA_NodeId conditionId,
               UA_Double limitValue) {
     UA_LOCK_ASSERT(&server->serviceMutex);
 
-    UA_NodeId limitState;
+    UA_NodeId limitState = UA_NODEID_NULL;
     UA_Double lowLowLimit;
     UA_Double lowLimit;
     UA_Double highLimit;
@@ -2936,7 +2936,7 @@ setLimitState(UA_Server *server, const UA_NodeId conditionId,
     retval |= getHighHighLimit(server, conditionId, &highHighLimit);
     if(retval == UA_STATUSCODE_GOOD) {
         if(limitValue >= highHighLimit) {
-            UA_NodeId highHighLimitId;
+            UA_NodeId highHighLimitId = UA_NODEID_NULL;
             retval |= getConditionFieldNodeId(server, &conditionId,
                                               &fieldHighHighLimitQN, &highHighLimitId);
             UA_LocalizedText text = UA_LOCALIZEDTEXT(LOCALE, ACTIVE_HIGHHIGH_TEXT);
@@ -2952,7 +2952,7 @@ setLimitState(UA_Server *server, const UA_NodeId conditionId,
     retval |= getHighLimit(server, conditionId, &highLimit);
     if(retval == UA_STATUSCODE_GOOD) {
         if(limitValue >= highLimit) {
-            UA_NodeId highLimitId;
+            UA_NodeId highLimitId = UA_NODEID_NULL;
             retval |= getConditionFieldNodeId(server, &conditionId, &fieldHighLimitQN, &highLimitId);
             UA_LocalizedText text = UA_LOCALIZEDTEXT(LOCALE, ACTIVE_HIGH_TEXT);
             UA_Variant_setScalar(&value, &text, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
@@ -2969,7 +2969,7 @@ setLimitState(UA_Server *server, const UA_NodeId conditionId,
     retval |= getLowLowLimit(server, conditionId, &lowLowLimit);
     if(retval == UA_STATUSCODE_GOOD) {
         if(limitValue <= lowLowLimit) {
-            UA_NodeId lowLowLimitId;
+            UA_NodeId lowLowLimitId = UA_NODEID_NULL;
             retval |= getConditionFieldNodeId(server, &conditionId,
                                               &fieldLowLowLimitQN, &lowLowLimitId);
             UA_LocalizedText text = UA_LOCALIZEDTEXT(LOCALE, ACTIVE_LOWLOW_TEXT);
@@ -2986,7 +2986,7 @@ setLimitState(UA_Server *server, const UA_NodeId conditionId,
     retval |= getLowLimit(server, conditionId, &lowLimit);
     if(retval == UA_STATUSCODE_GOOD) {
         if(limitValue <= lowLimit) {
-            UA_NodeId lowLimitId;
+            UA_NodeId lowLimitId = UA_NODEID_NULL;
             retval |= getConditionFieldNodeId(server, &conditionId, &fieldLowLimitQN, &lowLimitId);
             UA_LocalizedText text = UA_LOCALIZEDTEXT(LOCALE, ACTIVE_LOW_TEXT);
             UA_Variant_setScalar(&value, &text, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);

--- a/tests/server/check_server_alarmsconditions.c
+++ b/tests/server/check_server_alarmsconditions.c
@@ -73,6 +73,43 @@ readConditionField(UA_Server *s, const UA_NodeId conditionId,
     return retval;
 }
 
+static UA_NodeId
+createConfiguredExclusiveLimitAlarm(UA_Server *s, const char *name,
+                                    const UA_NodeId source) {
+    UA_NodeId cond = createTestCondition(
+        s, UA_NODEID_NUMERIC(0, UA_NS0ID_EXCLUSIVELIMITALARMTYPE),
+        name, source);
+
+    UA_Variant val;
+    UA_StatusCode retval;
+
+    UA_Double highHighLimit = 100.0;
+    UA_Variant_setScalar(&val, &highHighLimit, &UA_TYPES[UA_TYPES_DOUBLE]);
+    retval = UA_Server_setConditionField(s, cond, &val,
+                                         UA_QUALIFIEDNAME(0, "HighHighLimit"));
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Double highLimit = 80.0;
+    UA_Variant_setScalar(&val, &highLimit, &UA_TYPES[UA_TYPES_DOUBLE]);
+    retval = UA_Server_setConditionField(s, cond, &val,
+                                         UA_QUALIFIEDNAME(0, "HighLimit"));
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Double lowLimit = 20.0;
+    UA_Variant_setScalar(&val, &lowLimit, &UA_TYPES[UA_TYPES_DOUBLE]);
+    retval = UA_Server_setConditionField(s, cond, &val,
+                                         UA_QUALIFIEDNAME(0, "LowLimit"));
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Double lowLowLimit = 5.0;
+    UA_Variant_setScalar(&val, &lowLowLimit, &UA_TYPES[UA_TYPES_DOUBLE]);
+    retval = UA_Server_setConditionField(s, cond, &val,
+                                         UA_QUALIFIEDNAME(0, "LowLowLimit"));
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    return cond;
+}
+
 START_TEST(createDelete) {
     UA_StatusCode retval;
     // Loop to increase the chance of capturing dead pointers
@@ -1277,6 +1314,45 @@ START_TEST(setLimitState_nonLimitCondition) {
     UA_Server_deleteCondition(server_ac, cond, source);
 } END_TEST
 
+/* Regression test for limit getter paths (HighHigh, High, LowLow, Low)
+ * Ensures no crash and correct behavior. Leak detection relies on ASan/LSan. */
+START_TEST(limitAlarm_limitGetter_regression) {
+    UA_NodeId source = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER);
+    UA_StatusCode retval;
+
+    {
+        UA_NodeId cond = createConfiguredExclusiveLimitAlarm(
+            server_ac, "LimitGetterHighHigh", source);
+        retval = UA_Server_setLimitState(server_ac, cond, 110.0);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        UA_Server_deleteCondition(server_ac, cond, source);
+    }
+
+    {
+        UA_NodeId cond = createConfiguredExclusiveLimitAlarm(
+            server_ac, "LimitGetterHigh", source);
+        retval = UA_Server_setLimitState(server_ac, cond, 90.0);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        UA_Server_deleteCondition(server_ac, cond, source);
+    }
+
+    {
+        UA_NodeId cond = createConfiguredExclusiveLimitAlarm(
+            server_ac, "LimitGetterLowLow", source);
+        retval = UA_Server_setLimitState(server_ac, cond, 3.0);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        UA_Server_deleteCondition(server_ac, cond, source);
+    }
+
+    {
+        UA_NodeId cond = createConfiguredExclusiveLimitAlarm(
+            server_ac, "LimitGetterLow", source);
+        retval = UA_Server_setLimitState(server_ac, cond, 15.0);
+        ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+        UA_Server_deleteCondition(server_ac, cond, source);
+    }
+} END_TEST
+
 /* Test reading Comment field on condition */
 START_TEST(conditionField_comment) {
     UA_NodeId source = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER);
@@ -1764,6 +1840,7 @@ int main(void) {
     tcase_add_test(tc_limit, limitAlarm_setLimitState);
     tcase_add_test(tc_limit, limitAlarm_exactBoundaries);
     tcase_add_test(tc_limit, setLimitState_nonLimitCondition);
+    tcase_add_test(tc_limit, limitAlarm_limitGetter_regression);
     tcase_add_test(tc_limit, exclusiveLimitAlarm_test);
 #endif
     tcase_add_checked_fixture(tc_limit, setup, teardown);

--- a/tools/ci/linux/ci.sh
+++ b/tools/ci/linux/ci.sh
@@ -342,6 +342,25 @@ function unit_tests_alarms {
     make gcov
 }
 
+function unit_tests_alarms_memcheck {
+    mkdir -p build; cd build; rm -rf *
+    cmake -DCMAKE_BUILD_TYPE=Debug \
+          -DUA_BUILD_UNIT_TESTS=ON \
+          -DUA_ENABLE_DA=ON \
+          -DUA_ENABLE_NODESETLOADER=ON \
+          -DUA_ENABLE_XML_ENCODING=ON \
+          -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+          -DUA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS=ON \
+          -DUA_ENABLE_UNIT_TESTS_MEMCHECK=ON \
+          -DUA_FORCE_WERROR=ON \
+          -DUA_NAMESPACE_ZERO=FULL \
+          ..
+
+    make ${MAKEOPTS}
+    # set_capabilities not possible with valgrind
+    sudo -E bash -c "make test ARGS=\"-V\""
+}
+
 function unit_tests_encryption {
     mkdir -p build; cd build; rm -rf *
     cmake -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
fix for #7844

The reported leak is visible through getHighLimit in the issue trace, but the same temporary-Variant pattern is used by all four limit readers (LowLimit/LowLowLimit/HighLimit/HighHighLimit). This patch clears the local UA_Variant in each helper and keeps the change minimal.