### PR TITLE
[REVIEW] fix(gds): avoid stack-use-after-scope in removeCertificate

### DIFF
--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -583,6 +583,8 @@ removeCertificate(UA_Server *server,
     UA_ByteString *crls = NULL;
     size_t crlsSize = 0;
 
+    UA_ByteString certificate = UA_BYTESTRING_NULL;
+
     UA_String thumbpr = UA_STRING_NULL;
     thumbpr.length = (UA_SHA1_LENGTH * 2);
     thumbpr.data = (UA_Byte*)UA_malloc(sizeof(UA_Byte)*thumbpr.length);
@@ -593,7 +595,7 @@ removeCertificate(UA_Server *server,
         if(!UA_String_equal_ignorecase(&thumbprint, &thumbpr))
             continue;
 
-        UA_ByteString certificate = certificates[i];
+        certificate = certificates[i];
         retval = certGroup->getCertificateCrls(certGroup, &certificate, isTrustedCertificate,
                                                &crls, &crlsSize);
         /* Tolerate "Bad_NoMatch" to support removing CA certificates that do


### PR DESCRIPTION
Possible fix for #7807

removeCertificate stored the address of a loop-local UA_ByteString in the temporary TrustList passed to removeFromTrustList(). The pointer was then used after the loop-local variable went out of scope, triggering ASan in RemoveCertificate. Move the temporary certificate variable to the outer scope.