### PR TITLE
fix(server): prevent infinite loop in UA_ServerConfig_clear

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -1222,6 +1222,14 @@ setServerLifecycleState(UA_Server *server, UA_LifecycleState state) {
     if(server->state == state)
         return;
 
+    /* Refuse to mark STOPPED while the EventLoop is still draining */
+    if(state == UA_LIFECYCLESTATE_STOPPED) {
+        UA_EventLoop *el = server->config.eventLoop;
+        if(el && el->state != UA_EVENTLOOPSTATE_STOPPED &&
+           el->state != UA_EVENTLOOPSTATE_FRESH)
+            return;
+    }
+
     server->state = state; /* Apply the state change */
 
     /* Call the application notification callback */

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -930,6 +930,14 @@ setServerLifecycleState(UA_Server *server, UA_LifecycleState state) {
     if(server->state == state)
         return;
 
+    /* Refuse to mark STOPPED while the EventLoop is still draining */
+    if(state == UA_LIFECYCLESTATE_STOPPED) {
+        UA_EventLoop *el = server->config.eventLoop;
+        if(el && el->state != UA_EVENTLOOPSTATE_STOPPED &&
+           el->state != UA_EVENTLOOPSTATE_FRESH)
+            return;
+    }
+
     server->state = state; /* Apply the state change */
 
     /* Call the application notification callback */


### PR DESCRIPTION
`UA_Server_run_shutdown` unconditionally sets `server->state = STOPPED` after its drain loops, even when those loops bailed early (`res != GOOD`). This lets `UA_Server_delete` reach `UA_ServerConfig_clear`, whose unbounded `while(el->state != STOPPED) el->run(el, 100)` loop spins forever if the EventLoop is stuck in STOPPING.

Fix: `setServerLifecycleState()` now refuses the transition to STOPPED while the EventLoop is still draining. Companion to the client-side fix in #7856.