### PR TITLE
fix(server) monitoreditem: allow samplingInterval=0 and restore value change notifications

### DIFF
--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -307,14 +307,12 @@ checkAdjustMonitoredItemParams(UA_Server *server, UA_Session *session,
     if(mon->subscription && params->samplingInterval < 0.0)
         params->samplingInterval = mon->subscription->publishingInterval;
 
-    /* Adjust non-null sampling interval to lie within the configured limits */
-    if(params->samplingInterval != 0.0) {
-        UA_BOUNDEDVALUE_SETWBOUNDS(server->config.samplingIntervalLimits,
-                                   params->samplingInterval, params->samplingInterval);
-        /* Check for NaN */
-        if(mon->parameters.samplingInterval != mon->parameters.samplingInterval)
-            params->samplingInterval = server->config.samplingIntervalLimits.min;
-    }
+    /* Adjust sampling interval to lie within the configured limits */
+    UA_BOUNDEDVALUE_SETWBOUNDS(server->config.samplingIntervalLimits,
+                               params->samplingInterval, params->samplingInterval);
+    /* Check for NaN */
+    if(mon->parameters.samplingInterval != mon->parameters.samplingInterval)
+        params->samplingInterval = server->config.samplingIntervalLimits.min;
 
     /* Adjust the maximum queue size */
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS


### PR DESCRIPTION
According to the OPC UA specification, a sampling interval of 0 means "fastest practical rate" and should be revised by the server to the minimum supported sampling interval.

Currently, due to a check introduced in https://github.com/open62541/open62541/commit/9b759bbfb7a9d267ac097c1542ff387a7553a79f, a samplingInterval of 0 prevents proper monitoring behavior. In particular, value changes are no longer reported when samplingInterval is set to 0.

This patch restores the expected behavior by allowing samplingInterval=0 and ensuring it is revised to a valid minimum interval, so that monitored items continue to report value changes.

Reproducible using UaExpert by creating a subscription with samplingInterval=0.

Fixes #8000