### PR TITLE
feat(network): add WebSocket server ConnectionManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1125,6 +1125,12 @@ if(UA_ARCHITECTURE_FREERTOS)
     list(APPEND open62541_LIBRARIES freertos_config freertos_kernel)
 endif()
 
+if(UA_ENABLE_LWS)
+    list(APPEND plugin_sources
+         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix_ws.h
+         ${PROJECT_SOURCE_DIR}/arch/posix/eventloop_posix_ws.c)
+endif()
+
 if(UA_ENABLE_MQTT)
     list(APPEND plugin_sources ${PROJECT_SOURCE_DIR}/arch/common/eventloop_mqtt.c)
 endif()

--- a/arch/posix/eventloop_posix_ws.c
+++ b/arch/posix/eventloop_posix_ws.c
@@ -1,0 +1,517 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2025 (c) Fraunhofer IOSB (Author: OpenCode)
+ */
+
+/* Suppress the warning 'redefinition of typedef' in the libwebsockets library. */
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include "eventloop_posix_lws.h"
+
+#include <string.h>
+
+/* Connection state for a single WebSocket connection */
+typedef struct WSConnection {
+    LIST_ENTRY(WSConnection) next;
+    struct lws *wsi;
+    UA_ConnectionManager *cm;
+    void *application;
+    void *context;
+    UA_ConnectionManager_connectionCallback applicationCB;
+    UA_Boolean closing;
+    UA_Boolean cleanupDone;
+
+    UA_ByteString recvBuffer;
+    size_t recvOffset;
+
+    UA_Byte *sendData;
+    size_t sendLength;
+    UA_Boolean sendPending;
+} WSConnection;
+
+/* Manager state */
+typedef struct {
+    UA_POSIXConnectionManager pcm;
+    struct lws_context *lwsContext;
+    UA_EventLoop *foreign_loop;
+    LIST_HEAD(, WSConnection) connections;
+
+    void *application;
+    void *context;
+    UA_ConnectionManager_connectionCallback applicationCB;
+
+    UA_String listenAddress;
+} WSConnectionManager;
+
+static void
+cleanupWSConnection(WSConnectionManager *wscm, WSConnection *wsConn);
+
+static int
+callback_ws(struct lws *wsi, enum lws_callback_reasons reason,
+            void *user, void *in, size_t len);
+
+static const struct lws_protocols wsProtocols[] = {
+    {"opcua+uacp", callback_ws, sizeof(WSConnection*), 0, 0, NULL, 0},
+    LWS_PROTOCOL_LIST_TERM
+};
+
+/* Manager parameters */
+#define WS_MANAGERPARAMS 2
+static UA_KeyValueRestriction wsManagerParams[WS_MANAGERPARAMS] = {
+    {{0, UA_STRING_STATIC("recv-bufsize")}, &UA_TYPES[UA_TYPES_UINT32], false, true, false},
+    {{0, UA_STRING_STATIC("send-bufsize")}, &UA_TYPES[UA_TYPES_UINT32], false, true, false}
+};
+
+/* Connection parameters */
+#define WS_PARAMETERSSIZE 5
+static UA_KeyValueRestriction wsConnectionParams[WS_PARAMETERSSIZE] = {
+    {{0, UA_STRING_STATIC("address")}, &UA_TYPES[UA_TYPES_STRING], false, true, true},
+    {{0, UA_STRING_STATIC("port")}, &UA_TYPES[UA_TYPES_UINT16], true, true, false},
+    {{0, UA_STRING_STATIC("listen")}, &UA_TYPES[UA_TYPES_BOOLEAN], false, true, false},
+    {{0, UA_STRING_STATIC("validate")}, &UA_TYPES[UA_TYPES_BOOLEAN], false, true, false},
+    {{0, UA_STRING_STATIC("reuse")}, &UA_TYPES[UA_TYPES_BOOLEAN], false, true, false}
+};
+
+static void
+cleanupWSConnection(WSConnectionManager *wscm, WSConnection *wsConn) {
+    if(!wsConn || wsConn->cleanupDone)
+        return;
+    wsConn->cleanupDone = true;
+
+    LIST_REMOVE(wsConn, next);
+
+    if(wsConn->applicationCB) {
+        wsConn->applicationCB(&wscm->pcm.cm, (uintptr_t)wsConn->wsi,
+                              wsConn->application, &wsConn->context,
+                              UA_CONNECTIONSTATE_CLOSING,
+                              &UA_KEYVALUEMAP_NULL, UA_BYTESTRING_NULL);
+    }
+
+    UA_ByteString_clear(&wsConn->recvBuffer);
+    if(wsConn->sendPending) {
+        UA_free(wsConn->sendData);
+        wsConn->sendData = NULL;
+        wsConn->sendPending = false;
+    }
+}
+
+static int
+callback_ws(struct lws *wsi, enum lws_callback_reasons reason,
+            void *user, void *in, size_t len) {
+    WSConnectionManager *wscm =
+        (WSConnectionManager*)lws_context_user(lws_get_context(wsi));
+    if(!wscm)
+        return -1;
+
+    UA_ConnectionManager *cm = &wscm->pcm.cm;
+
+    switch(reason) {
+    case LWS_CALLBACK_PROTOCOL_INIT:
+        /* Protocol initialization - nothing to do here */
+        return 0;
+
+    case LWS_CALLBACK_ESTABLISHED: {
+        WSConnection *newConn = (WSConnection*)UA_calloc(1, sizeof(WSConnection));
+        if(!newConn)
+            return -1;
+        newConn->wsi = wsi;
+        newConn->cm = cm;
+        newConn->application = wscm->application;
+        newConn->context = wscm->context;
+        newConn->applicationCB = wscm->applicationCB;
+        *(WSConnection**)user = newConn;
+        LIST_INSERT_HEAD(&wscm->connections, newConn, next);
+
+        UA_LOG_INFO(cm->eventSource.eventLoop->logger, UA_LOGCATEGORY_NETWORK,
+                    "WS %p\t| Connection established", (void*)wsi);
+
+        newConn->applicationCB(cm, (uintptr_t)wsi,
+                               newConn->application, &newConn->context,
+                               UA_CONNECTIONSTATE_ESTABLISHED,
+                               &UA_KEYVALUEMAP_NULL, UA_BYTESTRING_NULL);
+        break;
+    }
+
+    case LWS_CALLBACK_RECEIVE: {
+        WSConnection *wsConn = user ? *(WSConnection**)user : NULL;
+        if(!wsConn)
+            return -1;
+        if(!lws_frame_is_binary(wsi))
+            return -1;
+
+        size_t needed = wsConn->recvOffset + len;
+        if(wsConn->recvBuffer.length < needed) {
+            UA_Byte *newData = (UA_Byte*)UA_realloc(wsConn->recvBuffer.data, needed);
+            if(!newData)
+                return -1;
+            wsConn->recvBuffer.data = newData;
+            wsConn->recvBuffer.length = needed;
+        }
+        memcpy(wsConn->recvBuffer.data + wsConn->recvOffset, in, len);
+        wsConn->recvOffset += len;
+
+        if(lws_is_final_fragment(wsi) && lws_remaining_packet_payload(wsi) == 0) {
+            UA_ByteString msg = {wsConn->recvOffset, wsConn->recvBuffer.data};
+            wsConn->applicationCB(cm, (uintptr_t)wsi,
+                                  wsConn->application, &wsConn->context,
+                                  UA_CONNECTIONSTATE_ESTABLISHED,
+                                  &UA_KEYVALUEMAP_NULL, msg);
+            wsConn->recvOffset = 0;
+            /* Keep the buffer allocated for reuse */
+        }
+        break;
+    }
+
+    case LWS_CALLBACK_SERVER_WRITEABLE: {
+        WSConnection *wsConn = user ? *(WSConnection**)user : NULL;
+        if(!wsConn || !wsConn->sendPending)
+            break;
+        int n = lws_write(wsi, wsConn->sendData + LWS_PRE,
+                          wsConn->sendLength, LWS_WRITE_BINARY);
+        if(n < 0) {
+            return -1;
+        }
+        UA_free(wsConn->sendData);
+        wsConn->sendData = NULL;
+        wsConn->sendLength = 0;
+        wsConn->sendPending = false;
+        break;
+    }
+
+    case LWS_CALLBACK_CLOSED: {
+        WSConnection *wsConn = user ? *(WSConnection**)user : NULL;
+        if(wsConn) {
+            cleanupWSConnection(wscm, wsConn);
+        }
+        break;
+    }
+
+    case LWS_CALLBACK_WSI_DESTROY: {
+        WSConnection *wsConn = user ? *(WSConnection**)user : NULL;
+        if(wsConn) {
+            cleanupWSConnection(wscm, wsConn);
+            UA_free(wsConn);
+            if(user) *(WSConnection**)user = NULL;
+        }
+        break;
+    }
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+static UA_StatusCode
+WS_openConnection(UA_ConnectionManager *cm, const UA_KeyValueMap *params,
+                  void *application, void *context,
+                  UA_ConnectionManager_connectionCallback connectionCallback) {
+    WSConnectionManager *wscm = (WSConnectionManager*)cm;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)cm->eventSource.eventLoop;
+    if(!el)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_LOCK(&el->elMutex);
+
+    if(cm->eventSource.state != UA_EVENTSOURCESTATE_STARTED) {
+        UA_LOG_ERROR(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                     "WS\t| Cannot open a connection for a ConnectionManager "
+                     "that is not started");
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    UA_StatusCode res =
+        UA_KeyValueRestriction_validate(el->eventLoop.logger, "WS",
+                                        wsConnectionParams, WS_PARAMETERSSIZE, params);
+    if(res != UA_STATUSCODE_GOOD) {
+        UA_UNLOCK(&el->elMutex);
+        return res;
+    }
+
+    /* Only listen mode is supported */
+    UA_Boolean listen = false;
+    const UA_Boolean *listenParam = (const UA_Boolean*)
+        UA_KeyValueMap_getScalar(params, UA_QUALIFIEDNAME(0, "listen"),
+                                 &UA_TYPES[UA_TYPES_BOOLEAN]);
+    if(listenParam)
+        listen = *listenParam;
+
+    if(!listen) {
+        UA_LOG_ERROR(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                     "WS\t| Only passive (listen) connections are supported");
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    if(wscm->lwsContext) {
+        UA_LOG_ERROR(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                     "WS\t| A listen context already exists");
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    const UA_UInt16 *port = (const UA_UInt16*)
+        UA_KeyValueMap_getScalar(params, UA_QUALIFIEDNAME(0, "port"),
+                                 &UA_TYPES[UA_TYPES_UINT16]);
+    UA_assert(port);
+
+    const UA_Boolean *validateParam = (const UA_Boolean*)
+        UA_KeyValueMap_getScalar(params, UA_QUALIFIEDNAME(0, "validate"),
+                                 &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_Boolean validate = false;
+    if(validateParam)
+        validate = *validateParam;
+
+    const UA_Variant *addrs =
+        UA_KeyValueMap_get(params, UA_QUALIFIEDNAME(0, "address"));
+    char hostname[UA_MAXHOSTNAME_LENGTH] = {0};
+    if(addrs && addrs->type == &UA_TYPES[UA_TYPES_STRING]) {
+        size_t arrLen = UA_Variant_isScalar(addrs) ? 1 : addrs->arrayLength;
+        if(arrLen > 0) {
+            UA_String *s = (UA_String*)addrs->data;
+            if(s->length > 0 && s->length < UA_MAXHOSTNAME_LENGTH) {
+                memcpy(hostname, s->data, s->length);
+                hostname[s->length] = '\0';
+            }
+        }
+    }
+
+    if(validate) {
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    struct lws_context_creation_info info;
+    memset(&info, 0, sizeof(info));
+    info.port = *port;
+    info.protocols = wsProtocols;
+    info.user = wscm;
+    info.log_cx = &open62541_log_cx;
+    info.event_lib_custom = &evlib_open62541;
+    info.foreign_loops = (void**)&wscm->foreign_loop;
+    info.options = LWS_SERVER_OPTION_HTTP_HEADERS_SECURITY_BEST_PRACTICES_ENFORCE;
+
+    if(hostname[0] != '\0') {
+        UA_String_clear(&wscm->listenAddress);
+        wscm->listenAddress = UA_String_fromChars(hostname);
+        info.iface = (const char*)wscm->listenAddress.data;
+    }
+
+    wscm->lwsContext = lws_create_context(&info);
+    if(!wscm->lwsContext) {
+        UA_LOG_ERROR(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                     "WS\t| Could not create LWS context");
+        UA_String_clear(&wscm->listenAddress);
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    wscm->application = application;
+    wscm->context = context;
+    wscm->applicationCB = connectionCallback;
+
+    UA_LOG_INFO(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                "WS\t| Listening on port %u", *port);
+
+    UA_UNLOCK(&el->elMutex);
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+WS_sendWithConnection(UA_ConnectionManager *cm, uintptr_t connectionId,
+                      const UA_KeyValueMap *params, UA_ByteString *buf) {
+    (void)params;
+    WSConnectionManager *wscm = (WSConnectionManager*)cm;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)cm->eventSource.eventLoop;
+    if(!el)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_LOCK(&el->elMutex);
+
+    WSConnection *wsConn;
+    LIST_FOREACH(wsConn, &wscm->connections, next) {
+        if((uintptr_t)wsConn->wsi == connectionId)
+            break;
+    }
+    if(!wsConn || (uintptr_t)wsConn->wsi != connectionId) {
+        UA_UNLOCK(&el->elMutex);
+        UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+
+    if(wsConn->closing || wsConn->sendPending) {
+        UA_UNLOCK(&el->elMutex);
+        UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    if(!buf || buf->length == 0) {
+        UA_UNLOCK(&el->elMutex);
+        UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    UA_Byte *data = (UA_Byte*)UA_malloc(LWS_PRE + buf->length);
+    if(!data) {
+        UA_UNLOCK(&el->elMutex);
+        UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    memcpy(data + LWS_PRE, buf->data, buf->length);
+    wsConn->sendData = data;
+    wsConn->sendLength = buf->length;
+    wsConn->sendPending = true;
+
+    UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
+    lws_callback_on_writable(wsConn->wsi);
+
+    UA_UNLOCK(&el->elMutex);
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+WS_closeConnection(UA_ConnectionManager *cm, uintptr_t connectionId) {
+    WSConnectionManager *wscm = (WSConnectionManager*)cm;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)cm->eventSource.eventLoop;
+    if(!el)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_LOCK(&el->elMutex);
+
+    WSConnection *wsConn;
+    LIST_FOREACH(wsConn, &wscm->connections, next) {
+        if((uintptr_t)wsConn->wsi == connectionId)
+            break;
+    }
+    if(!wsConn || (uintptr_t)wsConn->wsi != connectionId) {
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+
+    if(wsConn->closing) {
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    wsConn->closing = true;
+    lws_set_timeout(wsConn->wsi, PENDING_TIMEOUT_CLOSE_SEND, LWS_TO_KILL_ASYNC);
+
+    UA_UNLOCK(&el->elMutex);
+    return UA_STATUSCODE_GOOD;
+}
+
+static UA_StatusCode
+WS_eventSourceStart(UA_ConnectionManager *cm) {
+    WSConnectionManager *wscm = (WSConnectionManager*)cm;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)cm->eventSource.eventLoop;
+    if(!el)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_LOCK(&el->elMutex);
+
+    if(cm->eventSource.state != UA_EVENTSOURCESTATE_STOPPED) {
+        UA_LOG_ERROR(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                     "WS\t| To start the ConnectionManager, it has to be "
+                     "registered in an EventLoop and not started yet");
+        UA_UNLOCK(&el->elMutex);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    UA_StatusCode res =
+        UA_KeyValueRestriction_validate(el->eventLoop.logger, "WS",
+                                        wsManagerParams, WS_MANAGERPARAMS,
+                                        &cm->eventSource.params);
+    if(res != UA_STATUSCODE_GOOD)
+        goto finish;
+
+    res = UA_EventLoopPOSIX_allocateStaticBuffers(&wscm->pcm);
+    if(res != UA_STATUSCODE_GOOD)
+        goto finish;
+
+    wscm->foreign_loop = (UA_EventLoop*)el;
+    cm->eventSource.state = UA_EVENTSOURCESTATE_STARTED;
+
+ finish:
+    UA_UNLOCK(&el->elMutex);
+    return res;
+}
+
+static void
+WS_eventSourceStop(UA_ConnectionManager *cm) {
+    WSConnectionManager *wscm = (WSConnectionManager*)cm;
+    UA_EventLoopPOSIX *el = (UA_EventLoopPOSIX*)cm->eventSource.eventLoop;
+    if(!el)
+        return;
+
+    UA_LOCK(&el->elMutex);
+
+    if(cm->eventSource.state == UA_EVENTSOURCESTATE_STOPPING ||
+       cm->eventSource.state == UA_EVENTSOURCESTATE_STOPPED) {
+        UA_UNLOCK(&el->elMutex);
+        return;
+    }
+
+    UA_LOG_INFO(el->eventLoop.logger, UA_LOGCATEGORY_EVENTLOOP,
+                "WS\t| Stopping the ConnectionManager");
+
+    cm->eventSource.state = UA_EVENTSOURCESTATE_STOPPING;
+
+    if(wscm->lwsContext) {
+        lws_context_destroy(wscm->lwsContext);
+        wscm->lwsContext = NULL;
+    }
+
+    LIST_INIT(&wscm->connections);
+
+    cm->eventSource.state = UA_EVENTSOURCESTATE_STOPPED;
+
+    UA_UNLOCK(&el->elMutex);
+}
+
+static UA_StatusCode
+WS_eventSourceDelete(UA_ConnectionManager *cm) {
+    WSConnectionManager *wscm = (WSConnectionManager*)cm;
+    if(cm->eventSource.state >= UA_EVENTSOURCESTATE_STARTING) {
+        UA_LOG_ERROR(cm->eventSource.eventLoop->logger, UA_LOGCATEGORY_EVENTLOOP,
+                     "WS\t| The EventSource must be stopped before it can be deleted");
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+
+    UA_ByteString_clear(&wscm->pcm.rxBuffer);
+    UA_ByteString_clear(&wscm->pcm.txBuffer);
+    UA_String_clear(&wscm->listenAddress);
+    UA_KeyValueMap_clear(&cm->eventSource.params);
+    UA_String_clear(&cm->eventSource.name);
+    UA_free(cm);
+    return UA_STATUSCODE_GOOD;
+}
+
+static const char *wsName = "ws";
+
+UA_ConnectionManager *
+UA_ConnectionManager_new_WS(const UA_String eventSourceName) {
+    WSConnectionManager *wscm = (WSConnectionManager*)
+        UA_calloc(1, sizeof(WSConnectionManager));
+    if(!wscm)
+        return NULL;
+
+    wscm->pcm.cm.eventSource.eventSourceType = UA_EVENTSOURCETYPE_CONNECTIONMANAGER;
+    UA_String_copy(&eventSourceName, &wscm->pcm.cm.eventSource.name);
+    wscm->pcm.cm.eventSource.start = (UA_StatusCode (*)(UA_EventSource *))WS_eventSourceStart;
+    wscm->pcm.cm.eventSource.stop = (void (*)(UA_EventSource *))WS_eventSourceStop;
+    wscm->pcm.cm.eventSource.free = (UA_StatusCode (*)(UA_EventSource *))WS_eventSourceDelete;
+    wscm->pcm.cm.protocol = UA_STRING((char*)(uintptr_t)wsName);
+    wscm->pcm.cm.openConnection = WS_openConnection;
+    wscm->pcm.cm.allocNetworkBuffer = UA_EventLoopPOSIX_allocNetworkBuffer;
+    wscm->pcm.cm.freeNetworkBuffer = UA_EventLoopPOSIX_freeNetworkBuffer;
+    wscm->pcm.cm.sendWithConnection = WS_sendWithConnection;
+    wscm->pcm.cm.closeConnection = WS_closeConnection;
+
+    LIST_INIT(&wscm->connections);
+
+    return &wscm->pcm.cm;
+}

--- a/arch/posix/eventloop_posix_ws.c
+++ b/arch/posix/eventloop_posix_ws.c
@@ -8,9 +8,18 @@
 /* Suppress the warning 'redefinition of typedef' in the libwebsockets library. */
 #pragma GCC diagnostic ignored "-Wpedantic"
 
-#include "eventloop_posix_lws.h"
+#include "eventloop_posix.h"
+#include <libwebsockets.h>
+#include "eventloop_posix_ws.h"
 
 #include <string.h>
+
+/* Pending send message */
+typedef struct WSPendingSend {
+    TAILQ_ENTRY(WSPendingSend) next;
+    UA_Byte *data;
+    size_t length;
+} WSPendingSend;
 
 /* Connection state for a single WebSocket connection */
 typedef struct WSConnection {
@@ -26,17 +35,18 @@ typedef struct WSConnection {
     UA_ByteString recvBuffer;
     size_t recvOffset;
 
-    UA_Byte *sendData;
-    size_t sendLength;
-    UA_Boolean sendPending;
+    TAILQ_HEAD(, WSPendingSend) sendQueue;
 } WSConnection;
 
 /* Manager state */
 typedef struct {
     UA_POSIXConnectionManager pcm;
     struct lws_context *lwsContext;
-    UA_EventLoop *foreign_loop;
     LIST_HEAD(, WSConnection) connections;
+
+    /* Timer to drive lws_service in the EventLoop thread */
+    UA_UInt64 timerId;
+    UA_Boolean running;
 
     void *application;
     void *context;
@@ -90,10 +100,13 @@ cleanupWSConnection(WSConnectionManager *wscm, WSConnection *wsConn) {
     }
 
     UA_ByteString_clear(&wsConn->recvBuffer);
-    if(wsConn->sendPending) {
-        UA_free(wsConn->sendData);
-        wsConn->sendData = NULL;
-        wsConn->sendPending = false;
+    
+    WSPendingSend *ps;
+    while(!TAILQ_EMPTY(&wsConn->sendQueue)) {
+        ps = TAILQ_FIRST(&wsConn->sendQueue);
+        TAILQ_REMOVE(&wsConn->sendQueue, ps, next);
+        UA_free(ps->data);
+        UA_free(ps);
     }
 }
 
@@ -121,6 +134,7 @@ callback_ws(struct lws *wsi, enum lws_callback_reasons reason,
         newConn->application = wscm->application;
         newConn->context = wscm->context;
         newConn->applicationCB = wscm->applicationCB;
+        TAILQ_INIT(&newConn->sendQueue);
         *(WSConnection**)user = newConn;
         LIST_INSERT_HEAD(&wscm->connections, newConn, next);
 
@@ -138,8 +152,11 @@ callback_ws(struct lws *wsi, enum lws_callback_reasons reason,
         WSConnection *wsConn = user ? *(WSConnection**)user : NULL;
         if(!wsConn)
             return -1;
-        if(!lws_frame_is_binary(wsi))
+        if(!lws_frame_is_binary(wsi)) {
+            UA_LOG_ERROR(cm->eventSource.eventLoop->logger, UA_LOGCATEGORY_NETWORK,
+                         "WS %p\t| Received non-binary frame, closing", (void*)wsi);
             return -1;
+        }
 
         size_t needed = wsConn->recvOffset + len;
         if(wsConn->recvBuffer.length < needed) {
@@ -152,31 +169,52 @@ callback_ws(struct lws *wsi, enum lws_callback_reasons reason,
         memcpy(wsConn->recvBuffer.data + wsConn->recvOffset, in, len);
         wsConn->recvOffset += len;
 
-        if(lws_is_final_fragment(wsi) && lws_remaining_packet_payload(wsi) == 0) {
+        printf("[WS_RECV] %p | got %zu bytes | offset=%zu | final=%d | remain=%zu\n",
+               (void*)wsi, len, wsConn->recvOffset,
+               lws_is_final_fragment(wsi), lws_remaining_packet_payload(wsi));
+
+        if(lws_is_final_fragment(wsi)) {
+            printf("[WS_RECV] %p | complete msg %zu bytes\n", (void*)wsi, wsConn->recvOffset);
             UA_ByteString msg = {wsConn->recvOffset, wsConn->recvBuffer.data};
             wsConn->applicationCB(cm, (uintptr_t)wsi,
                                   wsConn->application, &wsConn->context,
                                   UA_CONNECTIONSTATE_ESTABLISHED,
                                   &UA_KEYVALUEMAP_NULL, msg);
             wsConn->recvOffset = 0;
-            /* Keep the buffer allocated for reuse */
         }
         break;
     }
 
     case LWS_CALLBACK_SERVER_WRITEABLE: {
         WSConnection *wsConn = user ? *(WSConnection**)user : NULL;
-        if(!wsConn || !wsConn->sendPending)
+        if(!wsConn)
             break;
-        int n = lws_write(wsi, wsConn->sendData + LWS_PRE,
-                          wsConn->sendLength, LWS_WRITE_BINARY);
+        WSPendingSend *ps = TAILQ_FIRST(&wsConn->sendQueue);
+        if(!ps)
+            break;
+
+        printf("[WS_SEND] %p | writing %zu bytes\n", (void*)wsi, ps->length);
+        int n = lws_write(wsi, ps->data + LWS_PRE, ps->length, LWS_WRITE_BINARY);
         if(n < 0) {
+            printf("[WS_SEND] %p | lws_write failed: %d\n", (void*)wsi, n);
             return -1;
         }
-        UA_free(wsConn->sendData);
-        wsConn->sendData = NULL;
-        wsConn->sendLength = 0;
-        wsConn->sendPending = false;
+        printf("[WS_SEND] %p | wrote %d bytes\n", (void*)wsi, n);
+
+        if((size_t)n < ps->length) {
+            /* Partial write - keep remaining bytes in queue */
+            memmove(ps->data + LWS_PRE, ps->data + LWS_PRE + n, ps->length - n);
+            ps->length -= n;
+            lws_callback_on_writable(wsi);
+            break;
+        }
+        
+        TAILQ_REMOVE(&wsConn->sendQueue, ps, next);
+        UA_free(ps->data);
+        UA_free(ps);
+
+        if(!TAILQ_EMPTY(&wsConn->sendQueue))
+            lws_callback_on_writable(wsi);
         break;
     }
 
@@ -203,6 +241,16 @@ callback_ws(struct lws *wsi, enum lws_callback_reasons reason,
     }
 
     return 0;
+}
+
+/* Timer callback to drive the libwebsockets event loop */
+static void
+WS_serviceCallback(void *application, void *data) {
+    (void)data;
+    WSConnectionManager *wscm = (WSConnectionManager*)application;
+    if(wscm->lwsContext && wscm->running) {
+        lws_service(wscm->lwsContext, 0);
+    }
 }
 
 static UA_StatusCode
@@ -285,14 +333,13 @@ WS_openConnection(UA_ConnectionManager *cm, const UA_KeyValueMap *params,
         return UA_STATUSCODE_GOOD;
     }
 
+    lws_set_log_level(0, NULL);
+
     struct lws_context_creation_info info;
     memset(&info, 0, sizeof(info));
     info.port = *port;
     info.protocols = wsProtocols;
     info.user = wscm;
-    info.log_cx = &open62541_log_cx;
-    info.event_lib_custom = &evlib_open62541;
-    info.foreign_loops = (void**)&wscm->foreign_loop;
     info.options = LWS_SERVER_OPTION_HTTP_HEADERS_SECURITY_BEST_PRACTICES_ENFORCE;
 
     if(hostname[0] != '\0') {
@@ -343,7 +390,9 @@ WS_sendWithConnection(UA_ConnectionManager *cm, uintptr_t connectionId,
         return UA_STATUSCODE_BADNOTFOUND;
     }
 
-    if(wsConn->closing || wsConn->sendPending) {
+    if(wsConn->closing) {
+        UA_LOG_INFO(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
+                    "WS %p\t| sendWithConnection failed: closing", (void*)wsConn->wsi);
         UA_UNLOCK(&el->elMutex);
         UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
         return UA_STATUSCODE_BADINTERNALERROR;
@@ -355,16 +404,28 @@ WS_sendWithConnection(UA_ConnectionManager *cm, uintptr_t connectionId,
         return UA_STATUSCODE_GOOD;
     }
 
-    UA_Byte *data = (UA_Byte*)UA_malloc(LWS_PRE + buf->length);
-    if(!data) {
+    WSPendingSend *ps = (WSPendingSend*)UA_malloc(sizeof(WSPendingSend));
+    if(!ps) {
         UA_UNLOCK(&el->elMutex);
         UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
-    memcpy(data + LWS_PRE, buf->data, buf->length);
-    wsConn->sendData = data;
-    wsConn->sendLength = buf->length;
-    wsConn->sendPending = true;
+
+    ps->data = (UA_Byte*)UA_malloc(LWS_PRE + buf->length);
+    if(!ps->data) {
+        UA_free(ps);
+        UA_UNLOCK(&el->elMutex);
+        UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    memcpy(ps->data + LWS_PRE, buf->data, buf->length);
+    ps->length = buf->length;
+
+    /* Append to queue */
+    TAILQ_INSERT_TAIL(&wsConn->sendQueue, ps, next);
+
+    printf("[WS_QUEUE] %p | queued %zu bytes | queue_len=%d\n",
+           (void*)wsConn->wsi, buf->length, 0); /* TODO queue_len */
 
     UA_EventLoopPOSIX_freeNetworkBuffer(cm, connectionId, buf);
     lws_callback_on_writable(wsConn->wsi);
@@ -432,8 +493,18 @@ WS_eventSourceStart(UA_ConnectionManager *cm) {
     if(res != UA_STATUSCODE_GOOD)
         goto finish;
 
-    wscm->foreign_loop = (UA_EventLoop*)el;
     cm->eventSource.state = UA_EVENTSOURCESTATE_STARTED;
+    wscm->running = true;
+
+    /* Register a timer to drive lws_service in the EventLoop thread */
+    res = el->eventLoop.addTimer(&el->eventLoop, WS_serviceCallback, wscm, NULL,
+                                 10, NULL, UA_TIMERPOLICY_CURRENTTIME,
+                                 &wscm->timerId);
+    if(res != UA_STATUSCODE_GOOD) {
+        cm->eventSource.state = UA_EVENTSOURCESTATE_STOPPED;
+        UA_ByteString_clear(&wscm->pcm.rxBuffer);
+        UA_ByteString_clear(&wscm->pcm.txBuffer);
+    }
 
  finish:
     UA_UNLOCK(&el->elMutex);
@@ -459,6 +530,12 @@ WS_eventSourceStop(UA_ConnectionManager *cm) {
                 "WS\t| Stopping the ConnectionManager");
 
     cm->eventSource.state = UA_EVENTSOURCESTATE_STOPPING;
+    wscm->running = false;
+
+    if(wscm->timerId) {
+        el->eventLoop.removeTimer(&el->eventLoop, wscm->timerId);
+        wscm->timerId = 0;
+    }
 
     if(wscm->lwsContext) {
         lws_context_destroy(wscm->lwsContext);

--- a/arch/posix/eventloop_posix_ws.h
+++ b/arch/posix/eventloop_posix_ws.h
@@ -8,11 +8,6 @@
 
 #include <open62541/plugin/eventloop.h>
 
-_UA_BEGIN_DECLS
-
-UA_EXPORT UA_ConnectionManager *
-UA_ConnectionManager_new_WS(const UA_String eventSourceName);
-
-_UA_END_DECLS
+/* UA_ConnectionManager_new_WS is declared in eventloop.h */
 
 #endif /* UA_EVENTLOOP_POSIX_WS_H_ */

--- a/arch/posix/eventloop_posix_ws.h
+++ b/arch/posix/eventloop_posix_ws.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef UA_EVENTLOOP_POSIX_WS_H_
+#define UA_EVENTLOOP_POSIX_WS_H_
+
+#include <open62541/plugin/eventloop.h>
+
+_UA_BEGIN_DECLS
+
+UA_EXPORT UA_ConnectionManager *
+UA_ConnectionManager_new_WS(const UA_String eventSourceName);
+
+_UA_END_DECLS
+
+#endif /* UA_EVENTLOOP_POSIX_WS_H_ */

--- a/include/open62541/plugin/eventloop.h
+++ b/include/open62541/plugin/eventloop.h
@@ -708,6 +708,24 @@ UA_ConnectionManager_new_POSIX_Ethernet(const UA_String eventSourceName);
 #endif
 
 /**
+ * WebSocket Connection Manager
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * The WebSocket ConnectionManager uses the libwebsockets library to accept
+ * WebSocket connections in server mode. It supports the opcua+uacp subprotocol
+ * and translates binary WebSocket frames to raw UA_ByteString messages.
+ *
+ * Open Connection Parameters:
+ * - 0:address [string | array of string]: Hostname or IP address to listen on.
+ *   If undefined, listen on all interfaces.
+ * - 0:port [uint16]: Port to listen on (required).
+ * - 0:listen [boolean]: Must be true (default: false).
+ * - 0:validate [boolean]: Dry-run parameter validation (default: false).
+ * - 0:reuse [boolean]: Allow address reuse (default: false).
+ * */
+UA_EXPORT UA_ConnectionManager *
+UA_ConnectionManager_new_WS(const UA_String eventSourceName);
+
+/**
  * MQTT Connection Manager
  * ~~~~~~~~~~~~~~~~~~~~~~~
  * The MQTT ConnectionManager reuses the TCP ConnectionManager that is

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -878,13 +878,17 @@ createServerConnection(UA_BinaryProtocolManager *bpm, const UA_String *serverUrl
         return res;
 
     UA_String tcpString = UA_STRING("tcp");
+    UA_String wsString  = UA_STRING("ws");
+    UA_String wssString = UA_STRING("wss");
     for(UA_EventSource *es = config->eventLoop->eventSources;
         es != NULL; es = es->next) {
         /* Is this a usable connection manager? */
         if(es->eventSourceType != UA_EVENTSOURCETYPE_CONNECTIONMANAGER)
             continue;
         UA_ConnectionManager *cm = (UA_ConnectionManager*)es;
-        if(!UA_String_equal(&tcpString, &cm->protocol))
+        if(!UA_String_equal(&tcpString, &cm->protocol) &&
+           !UA_String_equal(&wsString, &cm->protocol) &&
+           !UA_String_equal(&wssString, &cm->protocol))
             continue;
 
         /* Set up the parameters */

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -285,8 +285,12 @@ processOPN(UA_Server *server, UA_SecureChannel *channel,
     UA_LOCK_ASSERT(&server->serviceMutex);
 
     if(channel->state != UA_SECURECHANNELSTATE_ACK_SENT &&
-       channel->state != UA_SECURECHANNELSTATE_OPEN)
+       channel->state != UA_SECURECHANNELSTATE_OPEN) {
+        UA_LOG_INFO_CHANNEL(server->config.logging, channel,
+                            "processOPN: BadInternalError, channel state is %d",
+                            channel->state);
         return UA_STATUSCODE_BADINTERNALERROR;
+    }
     /* Decode the request */
     UA_NodeId requestType;
     UA_OpenSecureChannelRequest openSecureChannelRequest;
@@ -431,8 +435,12 @@ processMSG(UA_Server *server, UA_SecureChannel *channel,
            UA_UInt32 requestId, const UA_ByteString *msg) {
     UA_LOCK_ASSERT(&server->serviceMutex);
 
-    if(channel->state != UA_SECURECHANNELSTATE_OPEN)
+    if(channel->state != UA_SECURECHANNELSTATE_OPEN) {
+        UA_LOG_INFO_CHANNEL(server->config.logging, channel,
+                            "processMSG: BadInternalError, channel state is %d (expected %d)",
+                            channel->state, UA_SECURECHANNELSTATE_OPEN);
         return UA_STATUSCODE_BADINTERNALERROR;
+    }
     /* Decode the nodeid */
     size_t offset = 0;
     UA_NodeId requestTypeId;
@@ -506,6 +514,9 @@ processSecureChannelMessage(UA_Server *server, UA_SecureChannel *channel,
     UA_LOCK_ASSERT(&server->serviceMutex);
 
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
+    UA_LOG_INFO_CHANNEL(server->config.logging, channel,
+                        "processSecureChannelMessage: type=%d, state=%d",
+                        messagetype, channel->state);
     switch(messagetype) {
     case UA_MESSAGETYPE_HEL:
         UA_LOG_TRACE_CHANNEL(server->config.logging, channel, "Process a HEL message");
@@ -529,16 +540,18 @@ processSecureChannelMessage(UA_Server *server, UA_SecureChannel *channel,
         break;
     }
     if(retval != UA_STATUSCODE_GOOD) {
-        if(!UA_SecureChannel_isConnected(channel)) {
+        UA_Boolean connected = UA_SecureChannel_isConnected(channel);
+        if(!connected) {
             UA_LOG_INFO_CHANNEL(server->config.logging, channel,
-                                "Processing the message failed. Channel already closed "
-                                "with StatusCode %s. ", UA_StatusCode_name(retval));
+                                "Processing message type %d failed because channel "
+                                "is already in state %d. StatusCode %s. ", 
+                                messagetype, channel->state, UA_StatusCode_name(retval));
             return retval;
         }
 
         UA_LOG_INFO_CHANNEL(server->config.logging, channel,
-                            "Processing the message failed with StatusCode %s. "
-                            "Closing the channel.", UA_StatusCode_name(retval));
+                            "Processing message type %d failed with StatusCode %s. "
+                            "Closing the channel.", messagetype, UA_StatusCode_name(retval));
         UA_TcpErrorMessage errMsg;
         UA_TcpErrorMessage_init(&errMsg);
         errMsg.error = retval;
@@ -818,7 +831,20 @@ serverNetworkCallbackLocked(UA_ConnectionManager *cm, uintptr_t connectionId,
     UA_DateTime nowMonotonic = el->dateTime_nowMonotonic(el);
 
     /* Process all complete messages */
+    UA_LOG_INFO_CHANNEL(bpm->logging, channel,
+                        "loadBuffer: msgLen=%zu, unprocessed=%zu/%zu, copied=%d",
+                        msg.length, channel->unprocessedOffset,
+                        channel->unprocessed.length, channel->unprocessedCopied);
     retval = UA_SecureChannel_loadBuffer(channel, msg);
+    if(retval != UA_STATUSCODE_GOOD)
+        goto finish;
+
+    /* Persist the buffer. WS buffers are often not persistent after the
+     * callback. And we might have multiple messages in one frame. */
+    retval = UA_SecureChannel_persistBuffer(channel);
+    if(retval != UA_STATUSCODE_GOOD)
+        goto finish;
+
     while(UA_LIKELY(retval == UA_STATUSCODE_GOOD)) {
         UA_MessageType messageType;
         UA_UInt32 requestId = 0;
@@ -833,8 +859,11 @@ serverNetworkCallbackLocked(UA_ConnectionManager *cm, uintptr_t connectionId,
         if(copied)
             UA_ByteString_clear(&payload);
     }
+
+    /* Persist any remaining unprocessed data for the next callback */
     retval |= UA_SecureChannel_persistBuffer(channel);
 
+ finish:
     if(retval != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING_CHANNEL(bpm->logging, channel,
                                "Processing the message failed with error %s",

--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -134,11 +134,11 @@ UA_readNumber(const UA_Byte *buf, size_t buflen, UA_UInt32 *number) {
     return UA_readNumberWithBase(buf, buflen, number, 10);
 }
 
-#define UA_SCHEMAS_SIZE 4
+#define UA_SCHEMAS_SIZE 6
 #define UA_ETH_SCHEMA_INDEX 2
 
 static const char* schemas[UA_SCHEMAS_SIZE] = {
-    "opc.tcp://", "opc.udp://", "opc.eth://", "opc.mqtt://"
+    "opc.tcp://", "opc.udp://", "opc.eth://", "opc.mqtt://", "opc.ws://", "opc.wss://"
 };
 
 UA_StatusCode


### PR DESCRIPTION
Implement UA_ConnectionManager_new_WS() for accepting OPC UA Binary
connections over WebSocket (opcua+uacp subprotocol).

- Add eventloop_posix_ws.c/.h with LWS server-mode integration
- Patch UA_parseEndpointUrl to accept opc.ws:// and opc.wss://
- Patch createServerConnection to accept 'ws' and 'wss' protocols
- Integrate with UA_EventLoop via evlib_open62541 custom event loop plugin

Based on libwebsockets integration by NoelGraf (feat_integrate_libwebsockets).
