### PR TITLE
fix(docs): declare missing unicode characters

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,6 +82,9 @@ latex_elements = {
 
 # Clean up the header and footer
 'preamble': r"""
+\usepackage{pifont}
+\DeclareUnicodeCharacter{2265}{$\geq$}
+\DeclareUnicodeCharacter{2717}{\ding{55}}
 \fancypagestyle{normal}{
     \fancyhf{}
     \fancyfoot[RO,LE]{\thepage}


### PR DESCRIPTION
With c33c20dac306bcb9b5e0ef768eb1577953ebb5e8 [ecc_security.rst](https://github.com/open62541/open62541/blob/c33c20dac306bcb9b5e0ef768eb1577953ebb5e8/doc/ecc_security.rst) was introduced which contains the Unicode characters ≥ and ✗, which latex compilers can't handle without explicit declarations. Therefore, the Documentation Upload workflow didn't succeed.
This PR correctly declares both characters.