### PR TITLE
fix(server): Ensure non-zero condition event Time across all state callbacks

### DIFF
--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -962,8 +962,11 @@ afterWriteCallbackAckedStateChange(UA_Server *server,
      * That check makes it possible to set ackedState/Id to false, without triggering an event */
     if(*((UA_Boolean *)data->value.data) == false) {
         /* Set unacknowledging time */
+        UA_DateTime eventTime = data->sourceTimestamp;
+        if (eventTime == 0)
+            eventTime = UA_DateTime_now();
         retval = UA_Server_writeObjectProperty_scalar(server, conditionNode, fieldTimeQN,
-                                                      &data->sourceTimestamp,
+                                                      &eventTime,
                                                       &UA_TYPES[UA_TYPES_DATETIME]);
         CONDITION_ASSERT_RETURN_VOID(retval, "Set deactivating Time failed",
                                      UA_NodeId_clear(&conditionNode););
@@ -1055,8 +1058,11 @@ afterWriteCallbackConfirmedStateChange(UA_Server *server,
      * That check makes it possible to set ConfirmedState/Id to false, without triggering an event */
     if(*((UA_Boolean *)data->value.data) == false) {
         /* Set unconfirming time */
+        UA_DateTime eventTime = data->sourceTimestamp;
+        if (eventTime == 0)
+            eventTime = UA_DateTime_now();
         retval = UA_Server_writeObjectProperty_scalar(server, conditionNode, fieldTimeQN,
-                                                      &data->sourceTimestamp,
+                                                      &eventTime,
                                                       &UA_TYPES[UA_TYPES_DATETIME]);
         CONDITION_ASSERT_RETURN_VOID(retval, "Set deactivating Time failed",
                                      UA_NodeId_clear(&conditionNode););
@@ -1084,8 +1090,11 @@ afterWriteCallbackConfirmedStateChange(UA_Server *server,
     }
 
     /* Set confirming time */
+    UA_DateTime confirmingTime = data->sourceTimestamp;
+    if (confirmingTime == 0)
+        confirmingTime = UA_DateTime_now();
     retval = UA_Server_writeObjectProperty_scalar(server, conditionNode, fieldTimeQN,
-                                                  &data->sourceTimestamp, &UA_TYPES[UA_TYPES_DATETIME]);
+                                                  &confirmingTime, &UA_TYPES[UA_TYPES_DATETIME]);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set Confirming Time failed",
                                  UA_NodeId_clear(&conditionNode););
 
@@ -1194,8 +1203,11 @@ afterWriteCallbackActiveStateChange(UA_Server *server,
         if(UA_Server_isTwoStateVariableInTrueState(server, &conditionNode, &fieldEnabledStateQN) &&
            UA_Server_isRetained(server, &conditionNode)) {
             /* Set activating time */
+            UA_DateTime activatingTime = data->sourceTimestamp;
+            if (activatingTime == 0)
+                activatingTime = UA_DateTime_now();
             retval = UA_Server_writeObjectProperty_scalar(server, conditionNode, fieldTimeQN,
-                                                          &data->sourceTimestamp,
+                                                          &activatingTime,
                                                           &UA_TYPES[UA_TYPES_DATETIME]);
             CONDITION_ASSERT_RETURN_VOID(retval, "Set activating Time failed",
                                          UA_NodeId_clear(&conditionNode);
@@ -1250,8 +1262,11 @@ afterWriteCallbackActiveStateChange(UA_Server *server,
                                      UA_NodeId_clear(&conditionSource););
 
         /* Set deactivating time */
+        UA_DateTime deactivatingTime = data->sourceTimestamp;
+        if (deactivatingTime == 0)
+            deactivatingTime = UA_DateTime_now();
         retval = UA_Server_writeObjectProperty_scalar(server, conditionNode, fieldTimeQN,
-                                                      &data->sourceTimestamp,
+                                                      &deactivatingTime,
                                                       &UA_TYPES[UA_TYPES_DATETIME]);
         CONDITION_ASSERT_RETURN_VOID(retval, "Set deactivating Time failed",
                                      UA_NodeId_clear(&conditionNode);
@@ -1334,8 +1349,10 @@ afterWriteCallbackSeverityChange(UA_Server *server,
     UA_NodeId_clear(&conditionSource););
 
     /* Set Time (Time of Value Change) */
-    UA_Variant_setScalar(&value, (void*)(uintptr_t)((const UA_DateTime*)&data->sourceTimestamp),
-                         &UA_TYPES[UA_TYPES_DATETIME]);
+    UA_DateTime severityTime = data->sourceTimestamp;
+    if (severityTime == 0)
+        severityTime = UA_DateTime_now();
+    UA_Variant_setScalar(&value, &severityTime, &UA_TYPES[UA_TYPES_DATETIME]);
     retval = UA_Server_setConditionField(server, condition, &value, fieldTimeQN);
     CONDITION_ASSERT_RETURN_VOID(retval, "Set Condition Time failed",
                                  UA_NodeId_clear(&condition););


### PR DESCRIPTION
PR #7555 fixed the Time fallback for the EnabledState/Disabled callback. The same root cause exists in five other condition state-change callbacks: when the application updates a condition state via the high- level helpers (setConditionVariableFieldProperty / setConditionField), the resulting DataValue carries sourceTimestamp = 0. Each after-write callback then copies that 0 into the condition's Time property, which propagates into every event subsequently fired -- both the events that auto-fire on state change and explicit UA_Server_triggerConditionEvent calls. Clients render this as the OPC UA epoch (1601-01-01).

Apply the same `if (sourceTimestamp == 0) eventTime = UA_DateTime_now();` guard that #7555 introduced to the remaining call sites:

  * afterWriteCallbackAckedStateChange      (Acked -> false)
  * afterWriteCallbackConfirmedStateChange  (Confirmed -> false, -> true)
  * afterWriteCallbackActiveStateChange     (Active -> true, -> false)
  * afterWriteCallbackSeverityChange        (Severity change)

After this change, condition events fired via the standard ActiveState toggle carry a wall-clock Time matching the activation moment, both for auto-fired events (severity-changed, active-changed) and for explicit triggerConditionEvent calls.

Verification (live capture against a server with this patch applied):

  Before:                                              After:
    severity has increased  Time=1601-01-01             Time=2026-04-28 18:49:41.646663+00:00
    Fault active            Time=1601-01-01             Time=2026-04-28 18:49:41.646892+00:00
    severity has decreased  Time=1601-01-01             Time=2026-04-28 18:49:36.646521+00:00
    Fault cleared           Time=1601-01-01             Time=2026-04-28 18:49:36.646521+00:00

Closes #6391