### PR TITLE
fix(client): use client ns mapping for decoding response messages

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -505,6 +505,7 @@ processMSGResponse(UA_Client *client, UA_UInt32 requestId,
     UA_DecodeBinaryOptions opt;
     memset(&opt, 0, sizeof(UA_DecodeBinaryOptions));
     opt.customTypes = config->customDataTypes;
+    opt.namespaceMapping = client->channel.namespaceMapping;
     retval = UA_decodeBinaryInternal(msg, &offset, response, responseType, &opt);
 
  process:

--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -790,14 +790,15 @@ responseReadNamespacesArray(UA_Client *client, void *userdata,
         nsMapping->remote2local[i] = nsIndex;
     }
 
-    nsMapping->local2remote = (UA_UInt16*)UA_calloc( nsSize, sizeof(UA_UInt16));
+    size_t l2rSize = client->namespacesSize > nsSize ? client->namespacesSize : nsSize;
+    nsMapping->local2remote = (UA_UInt16*)UA_calloc(l2rSize, sizeof(UA_UInt16));
     if(!nsMapping->local2remote) {
         UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                      "Namespace mapping creation failed. Out of Memory.");
         UA_NamespaceMapping_delete(nsMapping);
         return;
     }
-    nsMapping->local2remoteSize = nsSize;
+    nsMapping->local2remoteSize = l2rSize;
     nsMapping->local2remote[0] = 0;
     nsMapping->local2remote[1] = 1;
 

--- a/tests/nodeset-compiler/check_client_nsMapping.c
+++ b/tests/nodeset-compiler/check_client_nsMapping.c
@@ -46,6 +46,21 @@ static void setup(void) {
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     }
 
+    {
+        UA_VariableAttributes attr = UA_VariableAttributes_default;
+        UA_Boolean value = true;
+        UA_Variant_setScalar(&attr.value, &value, &UA_TYPES[UA_TYPES_BOOLEAN]);
+        attr.dataType = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+        attr.accessLevel = UA_ACCESSLEVELMASK_READ;
+        UA_Server_addVariableNode(server,
+            UA_NODEID_NUMERIC(2, 12345),
+            UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+            UA_QUALIFIEDNAME(2, "CustomVar"),
+            UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+            attr, NULL, NULL);
+    }
+
     UA_Server_run_startup(server);
     THREAD_CREATE(server_thread, serverloop);
 }
@@ -81,6 +96,64 @@ START_TEST(Client_nsMapping){
 
     idx = UA_NamespaceMapping_remote2Local(client->channel.namespaceMapping, 3);
     ck_assert_uint_eq(idx, 3);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_nsMapping_browse_shifted_indices) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_UInt16 extraNsIndex = 0;
+    UA_StatusCode retval = UA_Client_addNamespace(client,
+        UA_STRING("http://example.com/dummy-shift/"),
+        &extraNsIndex);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(extraNsIndex, 2);
+
+    retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    size_t max_stop_iteration_count = 100000;
+    size_t iteration = 0;
+    while(!client->haveNamespaces && iteration < max_stop_iteration_count) {
+        UA_Client_run_iterate(client, 0);
+        iteration++;
+    }
+    ck_assert_uint_ne(client->haveNamespaces, false);
+
+    UA_UInt16 expectedIndex =
+        UA_NamespaceMapping_remote2Local(client->channel.namespaceMapping, 2);
+    ck_assert_uint_ne(expectedIndex, 0);
+    ck_assert_uint_ne(expectedIndex, 2);
+
+    UA_BrowseRequest bReq;
+    UA_BrowseRequest_init(&bReq);
+    bReq.nodesToBrowseSize = 1;
+    bReq.nodesToBrowse = UA_BrowseDescription_new();
+    bReq.nodesToBrowse[0].nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    bReq.nodesToBrowse[0].browseDirection = UA_BROWSEDIRECTION_FORWARD;
+    bReq.nodesToBrowse[0].resultMask = UA_BROWSERESULTMASK_ALL;
+
+    UA_BrowseResponse bResp = UA_Client_Service_browse(client, bReq);
+    ck_assert_uint_eq(bResp.resultsSize, 1);
+
+    UA_NodeId expectedNodeId = UA_NODEID_NUMERIC(expectedIndex, 12345);
+    UA_Boolean found = false;
+    for(size_t i = 0; i < bResp.results[0].referencesSize; i++) {
+        if(UA_ExpandedNodeId_isLocal(&bResp.results[0].references[i].nodeId) &&
+           UA_NodeId_equal(&bResp.results[0].references[i].nodeId.nodeId,
+                           &expectedNodeId)) {
+            found = true;
+            break;
+        }
+    }
+
+    UA_BrowseRequest_clear(&bReq);
+    UA_BrowseResponse_clear(&bResp);
+
+    ck_assert_msg(found,
+        "Expected locally remapped browse target NodeId for shifted namespace index");
 
     UA_Client_disconnect(client);
     UA_Client_delete(client);
@@ -164,6 +237,7 @@ static Suite* testSuite_Client(void) {
     TCase *tc_client = tcase_create("Client Namespace Mapping");
     tcase_add_checked_fixture(tc_client, setup, teardown);
     tcase_add_test(tc_client, Client_nsMapping);
+    tcase_add_test(tc_client, Client_nsMapping_browse_shifted_indices);
 #ifdef UA_ENABLE_MALLOC_SINGLETON
     tcase_add_test(tc_client, Client_nsMapping_alloc_failure);
 #endif


### PR DESCRIPTION
Set the mapping size to max(client->namespacesSize, nsSzie). 
Add a regression test covering browse behavior when local ns indices are actually shifted around.