### PR TITLE
fix(client): extend client coverage + harden QueryNext and highlevel error paths

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -1486,8 +1486,8 @@ UA_Client_Service_queryFirst(UA_Client *client,
 UA_QueryNextResponse
 UA_Client_Service_queryNext(UA_Client *client, const UA_QueryNextRequest request) {
     UA_QueryNextResponse response;
-    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_QUERYFIRSTREQUEST],
-                        &response, &UA_TYPES[UA_TYPES_QUERYFIRSTRESPONSE]);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_QUERYNEXTREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_QUERYNEXTRESPONSE]);
     return response;
 }
 

--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -389,6 +389,7 @@ UA_Client_browse(UA_Client *client, const UA_ViewDescription *view,
     UA_BrowseResult res;
     UA_BrowseRequest request;
     UA_BrowseResponse response;
+    UA_BrowseResponse_init(&response);
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(!nodesToBrowse) {
         retval = UA_STATUSCODE_BADINTERNALERROR;
@@ -460,6 +461,7 @@ UA_Client_translateBrowsePathToNodeIds(UA_Client *client,
     UA_BrowsePathResult res;
     UA_TranslateBrowsePathsToNodeIdsRequest request;
     UA_TranslateBrowsePathsToNodeIdsResponse response;
+    UA_TranslateBrowsePathsToNodeIdsResponse_init(&response);
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if(!browsePath) {
         retval = UA_STATUSCODE_BADINTERNALERROR;

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -757,6 +757,47 @@ START_TEST(Client_setAuthenticationUsername) {
 }
 END_TEST
 
+START_TEST(Client_newWithConfig_NULL) {
+    UA_Client *client = UA_Client_newWithConfig(NULL);
+    ck_assert_ptr_eq(client, NULL);
+}
+END_TEST
+
+START_TEST(Client_getNamespaceUri_outOfBounds) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_String nsUri;
+    UA_String_init(&nsUri);
+    retval = UA_Client_getNamespaceUri(client, UINT16_MAX, &nsUri);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADNOTFOUND);
+    ck_assert_uint_eq(nsUri.length, 0);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_queryNext_emptyContinuation) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_QueryNextRequest request;
+    UA_QueryNextRequest_init(&request);
+    request.releaseContinuationPoint = false;
+    request.continuationPoint = UA_BYTESTRING_NULL;
+
+    UA_QueryNextResponse response = UA_Client_Service_queryNext(client, request);
+    ck_assert_uint_ne(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    UA_QueryNextResponse_clear(&response);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Client");
     TCase *tc_client = tcase_create("Client Basic");
@@ -796,6 +837,9 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_ext, Client_cancelByRequestHandle);
     tcase_add_test(tc_ext, Client_cancelByRequestId_notFound);
     tcase_add_test(tc_ext, Client_setAuthenticationUsername);
+    tcase_add_test(tc_ext, Client_newWithConfig_NULL);
+    tcase_add_test(tc_ext, Client_getNamespaceUri_outOfBounds);
+    tcase_add_test(tc_ext, Client_queryNext_emptyContinuation);
     suite_add_tcase(s, tc_ext);
 
     return s;

--- a/tests/client/check_client.c
+++ b/tests/client/check_client.c
@@ -779,6 +779,7 @@ START_TEST(Client_getNamespaceUri_outOfBounds) {
 }
 END_TEST
 
+#ifdef UA_ENABLE_QUERY
 START_TEST(Client_queryNext_emptyContinuation) {
     UA_Client *client = UA_Client_newForUnitTest();
     UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
@@ -797,6 +798,7 @@ START_TEST(Client_queryNext_emptyContinuation) {
     UA_Client_delete(client);
 }
 END_TEST
+#endif
 
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Client");
@@ -839,7 +841,9 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_ext, Client_setAuthenticationUsername);
     tcase_add_test(tc_ext, Client_newWithConfig_NULL);
     tcase_add_test(tc_ext, Client_getNamespaceUri_outOfBounds);
+#ifdef UA_ENABLE_QUERY
     tcase_add_test(tc_ext, Client_queryNext_emptyContinuation);
+#endif
     suite_add_tcase(s, tc_ext);
 
     return s;

--- a/tests/client/check_client_async_read.c
+++ b/tests/client/check_client_async_read.c
@@ -25,6 +25,7 @@ static UA_Server *server;
 static UA_Boolean running;
 static THREAD_HANDLE server_thread;
 static volatile UA_Boolean asyncCallbackDone;
+static volatile UA_StatusCode asyncServiceStatus;
 
 THREAD_CALLBACK(serverloop) {
     while(running)
@@ -130,6 +131,20 @@ static void disconnectClient(UA_Client *client) {
 static void iterateClient(UA_Client *client) {
     for(int i = 0; i < 30 && !asyncCallbackDone; i++)
         UA_Client_run_iterate(client, 50);
+}
+
+static void cbAsyncCall(UA_Client *c, void *ud, UA_UInt32 rId,
+                        UA_CallResponse *cr) {
+    (void)c; (void)ud; (void)rId;
+    asyncServiceStatus = cr->responseHeader.serviceResult;
+    asyncCallbackDone = true;
+}
+
+static void cbAsyncBrowseNext(UA_Client *c, void *ud, UA_UInt32 rId,
+                              UA_BrowseNextResponse *br) {
+    (void)c; (void)ud; (void)rId;
+    asyncServiceStatus = br->responseHeader.serviceResult;
+    asyncCallbackDone = true;
 }
 
 /* Typed callbacks for each async read function */
@@ -253,6 +268,53 @@ static void cbAsyncWrite(UA_Client *c, void *ud, UA_UInt32 rId,
     (void)c; (void)ud; (void)rId; (void)wr;
     asyncCallbackDone = true;
 }
+
+static void cbAsyncReadNoop(UA_Client *c, void *ud, UA_UInt32 rId,
+                            UA_ReadResponse *response) {
+    (void)c; (void)ud; (void)rId; (void)response;
+}
+
+static void cbAsyncWriteNoop(UA_Client *c, void *ud, UA_UInt32 rId,
+                             UA_WriteResponse *response) {
+    (void)c; (void)ud; (void)rId; (void)response;
+}
+
+START_TEST(async_serviceWrappers_disconnected) {
+    UA_Client *client = UA_Client_newForUnitTest();
+
+    UA_UInt32 reqId = 0;
+    UA_ReadRequest rr;
+    UA_ReadRequest_init(&rr);
+    UA_ReadValueId rvid;
+    UA_ReadValueId_init(&rvid);
+    rvid.nodeId = UA_NODEID_NUMERIC(1, 71001);
+    rvid.attributeId = UA_ATTRIBUTEID_VALUE;
+    rr.nodesToRead = &rvid;
+    rr.nodesToReadSize = 1;
+
+    UA_WriteRequest wr;
+    UA_WriteRequest_init(&wr);
+    UA_WriteValue wv;
+    UA_WriteValue_init(&wv);
+    wv.nodeId = UA_NODEID_NUMERIC(1, 71001);
+    wv.attributeId = UA_ATTRIBUTEID_VALUE;
+    UA_Int32 v = 7;
+    UA_Variant_setScalar(&wv.value.value, &v, &UA_TYPES[UA_TYPES_INT32]);
+    wv.value.hasValue = true;
+    wr.nodesToWrite = &wv;
+    wr.nodesToWriteSize = 1;
+
+    UA_StatusCode res = UA_Client_sendAsyncReadRequest(client, &rr,
+        cbAsyncReadNoop, NULL, &reqId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADSERVERNOTCONNECTED);
+
+    res = UA_Client_sendAsyncWriteRequest(client, &wr,
+        cbAsyncWriteNoop, NULL, &reqId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADSERVERNOTCONNECTED);
+
+    UA_Client_delete(client);
+}
+END_TEST
 
 /* === Async read tests === */
 START_TEST(async_readValue) {
@@ -588,6 +650,46 @@ START_TEST(async_writeWriteMask) {
     disconnectClient(client);
 } END_TEST
 
+START_TEST(async_writeBrowseName) {
+    UA_Client *client = connectClient();
+    asyncCallbackDone = false;
+    UA_UInt32 reqId = 0;
+    UA_QualifiedName qn = UA_QUALIFIEDNAME(1, "AsyncRenamed");
+    UA_StatusCode res = UA_Client_writeBrowseNameAttribute_async(client,
+        UA_NODEID_NUMERIC(1, 71001), &qn, cbAsyncWrite, NULL, &reqId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    iterateClient(client);
+    ck_assert(asyncCallbackDone);
+    disconnectClient(client);
+} END_TEST
+
+START_TEST(async_writeAccessLevel) {
+    UA_Client *client = connectClient();
+    asyncCallbackDone = false;
+    UA_UInt32 reqId = 0;
+    UA_Byte accessLevel = UA_ACCESSLEVELMASK_READ;
+    UA_StatusCode res = UA_Client_writeAccessLevelAttribute_async(client,
+        UA_NODEID_NUMERIC(1, 71001), &accessLevel, cbAsyncWrite, NULL, &reqId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    iterateClient(client);
+    ck_assert(asyncCallbackDone);
+    disconnectClient(client);
+} END_TEST
+
+START_TEST(async_writeIsAbstract) {
+    UA_Client *client = connectClient();
+    asyncCallbackDone = false;
+    UA_UInt32 reqId = 0;
+    UA_Boolean isAbstract = false;
+    UA_StatusCode res = UA_Client_writeIsAbstractAttribute_async(client,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+        &isAbstract, cbAsyncWrite, NULL, &reqId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    iterateClient(client);
+    ck_assert(asyncCallbackDone);
+    disconnectClient(client);
+} END_TEST
+
 /* === Method call === */
 START_TEST(client_callMethod) {
     UA_Client *client = connectClient();
@@ -650,6 +752,79 @@ START_TEST(client_browseNext) {
 
     UA_BrowseRequest_clear(&browseReq);
     UA_BrowseResponse_clear(&browseResp);
+    disconnectClient(client);
+} END_TEST
+
+START_TEST(client_browseNext_async_wrapper) {
+    UA_Client *client = connectClient();
+
+    UA_BrowseRequest browseReq;
+    UA_BrowseRequest_init(&browseReq);
+    UA_BrowseDescription *bd = UA_BrowseDescription_new();
+    UA_BrowseDescription_init(bd);
+    bd->nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    bd->resultMask = UA_BROWSERESULTMASK_ALL;
+    bd->browseDirection = UA_BROWSEDIRECTION_FORWARD;
+    browseReq.nodesToBrowse = bd;
+    browseReq.nodesToBrowseSize = 1;
+    browseReq.requestedMaxReferencesPerNode = 2;
+
+    UA_BrowseResponse browseResp = UA_Client_Service_browse(client, browseReq);
+    ck_assert_uint_eq(browseResp.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert(browseResp.resultsSize > 0);
+
+    if(browseResp.results[0].continuationPoint.length > 0) {
+        UA_ByteString cp;
+        UA_ByteString_copy(&browseResp.results[0].continuationPoint, &cp);
+
+        asyncCallbackDone = false;
+        asyncServiceStatus = UA_STATUSCODE_BADINTERNALERROR;
+
+        UA_BrowseNextRequest nextReq;
+        UA_BrowseNextRequest_init(&nextReq);
+        nextReq.releaseContinuationPoints = false;
+        nextReq.continuationPoints = &cp;
+        nextReq.continuationPointsSize = 1;
+
+        UA_UInt32 reqId = 0;
+        UA_StatusCode res = UA_Client_sendAsyncBrowseNextRequest(
+            client, &nextReq, cbAsyncBrowseNext, NULL, &reqId);
+        ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+        iterateClient(client);
+        ck_assert(asyncCallbackDone);
+        ck_assert_uint_eq(asyncServiceStatus, UA_STATUSCODE_GOOD);
+
+        UA_ByteString_clear(&cp);
+    }
+
+    UA_BrowseRequest_clear(&browseReq);
+    UA_BrowseResponse_clear(&browseResp);
+    disconnectClient(client);
+} END_TEST
+
+START_TEST(client_callMethod_async_wrapper) {
+    UA_Client *client = connectClient();
+
+    UA_Int32 inputVal = 21;
+    UA_Variant input;
+    UA_Variant_setScalar(&input, &inputVal, &UA_TYPES[UA_TYPES_INT32]);
+
+    asyncCallbackDone = false;
+    asyncServiceStatus = UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_UInt32 reqId = 0;
+    UA_StatusCode res = UA_Client_call_async(
+        client,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(1, 71002),
+        1, &input, cbAsyncCall, NULL, &reqId);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+
+    iterateClient(client);
+    ck_assert(asyncCallbackDone);
+    ck_assert_uint_eq(asyncServiceStatus, UA_STATUSCODE_GOOD);
+
     disconnectClient(client);
 } END_TEST
 
@@ -731,6 +906,7 @@ static Suite *testSuite_clientAsync(void) {
     tcase_add_test(tc_asyncRead, async_readUserExecutable);
     tcase_add_test(tc_asyncRead, async_readContainsNoLoops);
     tcase_add_test(tc_asyncRead, async_readAttribute_generic);
+    tcase_add_test(tc_asyncRead, async_serviceWrappers_disconnected);
 
     TCase *tc_asyncWrite = tcase_create("AsyncWrite");
     tcase_add_checked_fixture(tc_asyncWrite, setup, teardown);
@@ -738,12 +914,17 @@ static Suite *testSuite_clientAsync(void) {
     tcase_add_test(tc_asyncWrite, async_writeDisplayName);
     tcase_add_test(tc_asyncWrite, async_writeDescription);
     tcase_add_test(tc_asyncWrite, async_writeWriteMask);
+    tcase_add_test(tc_asyncWrite, async_writeBrowseName);
+    tcase_add_test(tc_asyncWrite, async_writeAccessLevel);
+    tcase_add_test(tc_asyncWrite, async_writeIsAbstract);
 
     TCase *tc_ops = tcase_create("ClientOps");
     tcase_add_checked_fixture(tc_ops, setup, teardown);
     tcase_add_test(tc_ops, client_getState);
     tcase_add_test(tc_ops, client_browseNext);
+    tcase_add_test(tc_ops, client_browseNext_async_wrapper);
     tcase_add_test(tc_ops, client_translateBrowsePath);
+    tcase_add_test(tc_ops, client_callMethod_async_wrapper);
     tcase_add_test(tc_ops, client_disconnectSecureChannel);
 
     Suite *s = suite_create("Client Async and Operations");

--- a/tests/client/check_client_async_read.c
+++ b/tests/client/check_client_async_read.c
@@ -26,6 +26,7 @@ static UA_Boolean running;
 static THREAD_HANDLE server_thread;
 static volatile UA_Boolean asyncCallbackDone;
 static volatile UA_StatusCode asyncServiceStatus;
+static volatile UA_StatusCode asyncOperationStatus;
 
 THREAD_CALLBACK(serverloop) {
     while(running)
@@ -144,6 +145,17 @@ static void cbAsyncBrowseNext(UA_Client *c, void *ud, UA_UInt32 rId,
                               UA_BrowseNextResponse *br) {
     (void)c; (void)ud; (void)rId;
     asyncServiceStatus = br->responseHeader.serviceResult;
+    asyncCallbackDone = true;
+}
+
+static void cbAsyncAddNodes(UA_Client *c, void *ud, UA_UInt32 rId,
+                            UA_AddNodesResponse *ar) {
+    (void)c; (void)ud; (void)rId;
+    asyncServiceStatus = ar->responseHeader.serviceResult;
+    if(asyncServiceStatus == UA_STATUSCODE_GOOD && ar->resultsSize == 1)
+        asyncOperationStatus = ar->results[0].statusCode;
+    else
+        asyncOperationStatus = UA_STATUSCODE_BADUNEXPECTEDERROR;
     asyncCallbackDone = true;
 }
 
@@ -828,6 +840,126 @@ START_TEST(client_callMethod_async_wrapper) {
     disconnectClient(client);
 } END_TEST
 
+#ifdef UA_ENABLE_NODEMANAGEMENT
+START_TEST(client_addVariableNode_async_wrapper) {
+    UA_Client *client = connectClient();
+
+    asyncCallbackDone = false;
+    asyncServiceStatus = UA_STATUSCODE_BADINTERNALERROR;
+    asyncOperationStatus = UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    UA_Int32 initialValue = 123;
+    UA_Variant_setScalar(&attr.value, &initialValue, &UA_TYPES[UA_TYPES_INT32]);
+    attr.displayName = UA_LOCALIZEDTEXT("en", "Async Add Variable");
+
+    UA_NodeId newNodeId = UA_NODEID_NULL;
+    UA_UInt32 reqId = 0;
+    UA_StatusCode res = UA_Client_addVariableNode_async(
+        client,
+        UA_NODEID_NULL,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "AsyncAddVariableNode"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+        attr,
+        &newNodeId,
+        cbAsyncAddNodes,
+        NULL,
+        &reqId);
+
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    iterateClient(client);
+    ck_assert(asyncCallbackDone);
+    ck_assert_uint_eq(asyncServiceStatus, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(asyncOperationStatus, UA_STATUSCODE_GOOD);
+
+    if(!UA_NodeId_isNull(&newNodeId)) {
+        UA_StatusCode del = UA_Client_deleteNode(client, newNodeId, true);
+        ck_assert_uint_eq(del, UA_STATUSCODE_GOOD);
+        UA_NodeId_clear(&newNodeId);
+    }
+
+    disconnectClient(client);
+} END_TEST
+
+START_TEST(client_addMethodNode_async_wrapper) {
+    UA_Client *client = connectClient();
+
+    asyncCallbackDone = false;
+    asyncServiceStatus = UA_STATUSCODE_BADINTERNALERROR;
+    asyncOperationStatus = UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_MethodAttributes attr = UA_MethodAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en", "Async Add Method");
+    attr.executable = true;
+    attr.userExecutable = true;
+
+    UA_NodeId newNodeId = UA_NODEID_NULL;
+    UA_UInt32 reqId = 0;
+    UA_StatusCode res = UA_Client_addMethodNode_async(
+        client,
+        UA_NODEID_NULL,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+        UA_QUALIFIEDNAME(1, "AsyncAddMethodNode"),
+        attr,
+        &newNodeId,
+        cbAsyncAddNodes,
+        NULL,
+        &reqId);
+
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    iterateClient(client);
+    ck_assert(asyncCallbackDone);
+    ck_assert_uint_eq(asyncServiceStatus, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(asyncOperationStatus, UA_STATUSCODE_GOOD);
+
+    if(!UA_NodeId_isNull(&newNodeId)) {
+        UA_StatusCode del = UA_Client_deleteNode(client, newNodeId, true);
+        ck_assert_uint_eq(del, UA_STATUSCODE_GOOD);
+        UA_NodeId_clear(&newNodeId);
+    }
+
+    disconnectClient(client);
+} END_TEST
+
+START_TEST(client_addObjectNode_async_wrapper_invalidParent) {
+    UA_Client *client = connectClient();
+
+    asyncCallbackDone = false;
+    asyncServiceStatus = UA_STATUSCODE_BADINTERNALERROR;
+    asyncOperationStatus = UA_STATUSCODE_BADINTERNALERROR;
+
+    UA_ObjectAttributes attr = UA_ObjectAttributes_default;
+    attr.displayName = UA_LOCALIZEDTEXT("en", "Async Add Object Invalid Parent");
+
+    UA_NodeId newNodeId = UA_NODEID_NULL;
+    UA_UInt32 reqId = 0;
+    UA_StatusCode res = UA_Client_addObjectNode_async(
+        client,
+        UA_NODEID_NULL,
+        UA_NODEID_NUMERIC(1, 99999),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "AsyncAddObjectInvalidParent"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEOBJECTTYPE),
+        attr,
+        &newNodeId,
+        cbAsyncAddNodes,
+        NULL,
+        &reqId);
+
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    iterateClient(client);
+    ck_assert(asyncCallbackDone);
+    ck_assert_uint_eq(asyncServiceStatus, UA_STATUSCODE_GOOD);
+    ck_assert_uint_ne(asyncOperationStatus, UA_STATUSCODE_GOOD);
+
+    UA_NodeId_clear(&newNodeId);
+    disconnectClient(client);
+} END_TEST
+#endif
+
 /* === TranslateBrowsePath === */
 START_TEST(client_translateBrowsePath) {
     UA_Client *client = connectClient();
@@ -925,6 +1057,11 @@ static Suite *testSuite_clientAsync(void) {
     tcase_add_test(tc_ops, client_browseNext_async_wrapper);
     tcase_add_test(tc_ops, client_translateBrowsePath);
     tcase_add_test(tc_ops, client_callMethod_async_wrapper);
+#ifdef UA_ENABLE_NODEMANAGEMENT
+    tcase_add_test(tc_ops, client_addVariableNode_async_wrapper);
+    tcase_add_test(tc_ops, client_addMethodNode_async_wrapper);
+    tcase_add_test(tc_ops, client_addObjectNode_async_wrapper_invalidParent);
+#endif
     tcase_add_test(tc_ops, client_disconnectSecureChannel);
 
     Suite *s = suite_create("Client Async and Operations");

--- a/tests/client/check_client_discovery.c
+++ b/tests/client/check_client_discovery.c
@@ -145,6 +145,72 @@ START_TEST(Client_findServers_connected) {
 }
 END_TEST
 
+START_TEST(Client_findServersOnNetwork) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    size_t serverOnNetworkSize = 0;
+    UA_ServerOnNetwork *servers = NULL;
+
+    UA_StatusCode retval = UA_Client_findServersOnNetwork(client,
+        "opc.tcp://localhost:4840", 0, 0, 0, NULL,
+        &serverOnNetworkSize, &servers);
+
+    if(retval == UA_STATUSCODE_GOOD) {
+        if(serverOnNetworkSize > 0)
+            ck_assert_ptr_ne(servers, NULL);
+        UA_Array_delete(servers, serverOnNetworkSize,
+                        &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
+    } else {
+        ck_assert_uint_eq(serverOnNetworkSize, 0);
+        ck_assert_ptr_eq(servers, NULL);
+    }
+
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_findServersOnNetwork_badUrl_connected) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    size_t serverOnNetworkSize = 123;
+    UA_ServerOnNetwork *servers = (UA_ServerOnNetwork*)(uintptr_t)0x1;
+    retval = UA_Client_findServersOnNetwork(client, "opc.tcp://invalidhost:9999",
+                                            0, 0, 0, NULL,
+                                            &serverOnNetworkSize, &servers);
+    ck_assert_uint_ne(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(serverOnNetworkSize, 0);
+    ck_assert_ptr_eq(servers, NULL);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_getEndpoints_badUrl_connected) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    size_t endpointCount = 0;
+    UA_EndpointDescription *endpoints = NULL;
+    retval = UA_Client_getEndpoints(client, "opc.tcp://invalidhost:9999",
+                                    &endpointCount, &endpoints);
+    if(retval == UA_STATUSCODE_GOOD) {
+        ck_assert(endpointCount > 0);
+        ck_assert_ptr_ne(endpoints, NULL);
+        UA_Array_delete(endpoints, endpointCount,
+                        &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
+    } else {
+        ck_assert_uint_eq(endpointCount, 0);
+        ck_assert_ptr_eq(endpoints, NULL);
+    }
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Client");
     TCase *tc_client = tcase_create("Client Discovery");
@@ -154,6 +220,9 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_client, Client_findServers);
     tcase_add_test(tc_client, Client_getEndpoints_connected);
     tcase_add_test(tc_client, Client_findServers_connected);
+    tcase_add_test(tc_client, Client_findServersOnNetwork);
+    tcase_add_test(tc_client, Client_findServersOnNetwork_badUrl_connected);
+    tcase_add_test(tc_client, Client_getEndpoints_badUrl_connected);
     suite_add_tcase(s,tc_client);
     return s;
 }

--- a/tests/client/check_client_highlevel.c
+++ b/tests/client/check_client_highlevel.c
@@ -1216,6 +1216,33 @@ START_TEST(Highlevel_CallMethod_Error) {
 END_TEST
 #endif
 
+START_TEST(Highlevel_browse_nullDescription) {
+    UA_BrowseResult br = UA_Client_browse(client, NULL, 0, NULL);
+    ck_assert_uint_eq(br.statusCode, UA_STATUSCODE_BADINTERNALERROR);
+    UA_BrowseResult_clear(&br);
+}
+END_TEST
+
+START_TEST(Highlevel_browseNext_emptyContinuation) {
+    UA_BrowseResult br = UA_Client_browseNext(client, false, UA_BYTESTRING_NULL);
+    ck_assert_uint_eq(br.statusCode, UA_STATUSCODE_BADCONTINUATIONPOINTINVALID);
+    UA_BrowseResult_clear(&br);
+}
+END_TEST
+
+START_TEST(Highlevel_translateBrowsePath_null) {
+    UA_BrowsePathResult bpr = UA_Client_translateBrowsePathToNodeIds(client, NULL);
+    ck_assert_uint_eq(bpr.statusCode, UA_STATUSCODE_BADINTERNALERROR);
+    UA_BrowsePathResult_clear(&bpr);
+}
+END_TEST
+
+START_TEST(Highlevel_write_nullWriteValue) {
+    UA_StatusCode retval = UA_Client_write(client, NULL);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADINTERNALERROR);
+}
+END_TEST
+
 static Suite *testSuite_Client(void) {
     Suite *s = suite_create("Client Highlevel");
     TCase *tc_misc = tcase_create("Client Highlevel Misc");
@@ -1275,6 +1302,10 @@ static Suite *testSuite_Client(void) {
     tcase_add_test(tc_ext, Highlevel_ForEachChildNode_InvalidNode);
     tcase_add_test(tc_ext, Highlevel_WriteRead_Direct);
     tcase_add_test(tc_ext, Highlevel_BrowseSimplified);
+    tcase_add_test(tc_ext, Highlevel_browse_nullDescription);
+    tcase_add_test(tc_ext, Highlevel_browseNext_emptyContinuation);
+    tcase_add_test(tc_ext, Highlevel_translateBrowsePath_null);
+    tcase_add_test(tc_ext, Highlevel_write_nullWriteValue);
 #ifdef UA_ENABLE_METHODCALLS
     tcase_add_test(tc_ext, Highlevel_CallMethod_Error);
 #endif


### PR DESCRIPTION
Test-Improvements (as Part of "Project 82" - Coverage 82% +): 

- Increased client test coverage for core client, discovery, highlevel, and async client paths.
- Added new async coverage for service wrappers, operation wrappers, and node-management wrappers.
- Strengthened error-path testing and callback-driven async execution paths.

Fixes:

- Corrected QueryNext request/response type handling in the client service path.
- Initialized response structures in client highlevel error paths to prevent unsafe cleanup behavior.