### PR TITLE
fix(server): guard against union aliasing direct calls

### DIFF
--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -871,15 +871,18 @@ UA_Server_setAsyncCallMethodResult(UA_Server *server, UA_Variant *output,
     UA_AsyncManager *am = &server->asyncManager;
     UA_AsyncOperation *op = NULL;
     TAILQ_FOREACH(op, &am->waitingOps, pointers) {
-        if(op->output.call->outputArguments == output) {
-            op->output.call->statusCode = result;
-            processOperationResult(server, op);
-            break;
-        }
-        if(op->output.directCall.outputArguments == output) {
-            op->output.directCall.statusCode = result;
-            processOperationResult(server, op);
-            break;
+        if(op->asyncOperationType == UA_ASYNCOPERATIONTYPE_CALL_REQUEST) {
+            if(op->output.call->outputArguments == output) {
+                op->output.call->statusCode = result;
+                processOperationResult(server, op);
+                break;
+            }
+        } else if(op->asyncOperationType == UA_ASYNCOPERATIONTYPE_CALL_DIRECT) {
+            if(op->output.directCall.outputArguments == output) {
+                op->output.directCall.statusCode = result;
+                processOperationResult(server, op);
+                break;
+            }
         }
     }
     unlockServer(server);


### PR DESCRIPTION
`output.call` and `output.directCall` share the same memory in the async operation union.

`output.call` is a pointer at the same union offset as `directCall.statusCode`. After `UA_CallMethodResult_init`, `directCall.statusCode == 0`. Because `call` and `directCall` share the same union memory, the bytes at offset 0 are interpreted as a NULL pointer when reading `op->output.call`.

So the bad path is:

- `op->output.directCall` is the valid inline output object for `CALL_DIRECT`
- `op->output.call` is incorrectly dereferenced first
- `op->output.call` reads as NULL
- `op->output.call->outputArguments` crashes immediately
