### PR TITLE
fix(ci): execute Coverity scans only on push to master and exclude dependabot branches explicitly

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,6 +1,11 @@
 name: Coverity Scan
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+    branches-ignore:
+      - 'dependabot/**'
 
 jobs:
   coverity:


### PR DESCRIPTION
Since dependabot creates a new branch directly inside the repository, the Coverity Scans are executed during its PRs but fail due to missing authentication information.
This PR changes the workflow trigger to be only executed on pushes to master and explicitly excludes all dependabot branches.