### PR TITLE
fix(core): copy membersSize to destination in UA_DataType_copy

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -167,6 +167,7 @@ UA_DataType_copy(const UA_DataType *t1, UA_DataType *t2) {
             *(void**)(uintptr_t)&m2->memberName = mName;
 #endif
         }
+        t2->membersSize = t1->membersSize;
     }
 
  errout:


### PR DESCRIPTION
`UA_DataType_copy` zeroed `membersSize` but never updated it after successfully copying members. This left the destination struct in an inconsistent state where members pointed to valid allocated memory but `membersSize` was 0.
This fixes #7999.