### PR TITLE
Skip endpoint selection for discovery-only secure-channel connects

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -127,23 +127,25 @@ isFullyConnected(UA_Client *client) {
     if(client->channel.state != UA_SECURECHANNELSTATE_OPEN)
         return false;
 
-    /* GetEndpoints handshake ongoing or not yet done */
-    if(client->endpointsHandshake || endpointUnconfigured(&client->endpoint))
-        return false;
-
     /* FindServers handshake ongoing or not yet done */
     if(client->findServersHandshake || client->discoveryUrl.length == 0)
         return false;
 
-    if(!client->config.noSession) {
-        /* No Session, but is required */
-        if(client->sessionState != UA_SESSIONSTATE_ACTIVATED)
-            return false;
+    /* SecureChannel-only discovery connect is complete */
+    if(client->config.noSession)
+        return true;
 
-        /* NamespaceArray not yet read */
-        if(client->namespacesHandshake || !client->haveNamespaces)
-            return false;
-    }
+    /* GetEndpoints handshake ongoing or not yet done */
+    if(client->endpointsHandshake || endpointUnconfigured(&client->endpoint))
+        return false;
+
+    /* No Session, but is required */
+    if(client->sessionState != UA_SESSIONSTATE_ACTIVATED)
+        return false;
+
+    /* NamespaceArray not yet read */
+    if(client->namespacesHandshake || !client->haveNamespaces)
+        return false;
 
     return true;
 }
@@ -1852,16 +1854,16 @@ connectActivity(UA_Client *client) {
         return;
     }
 
+    /* Have the final SecureChannel but no session */
+    if(client->config.noSession)
+        return;
+
     /* GetEndpoints to identify the remote side and/or reset the SecureChannel
      * with encryption */
     if(endpointUnconfigured(&client->endpoint)) {
         client->connectStatus = requestGetEndpoints(client);
         return;
     }
-
-    /* Have the final SecureChannel but no session */
-    if(client->config.noSession)
-        return;
 
     /* Create and Activate the Session */
     switch(client->sessionState) {


### PR DESCRIPTION
## Summary

 Related to #7998, as this issue affects from version 1.4.x

  Fix discovery-only client connections so `UA_Client_findServers()` can complete without selecting a session endpoint first.

  `connectSecureChannel()` sets `client->config.noSession = true`. In that mode the client only needs to open a SecureChannel, run discovery, and stop before endpoint selection and session setup. That makes `UA_Client_findServers()` fail on servers that allow discovery over a None SecureChannel but do not expose a usable None endpoint.

  ## Why

  `FindServers` is a discovery service. It should not depend on the number of endpoints, endpoint security policies, message security modes, or user token policies. Those are relevant for normal session connections, not for discovery-only secure-channel connects.

  ## Verification

  Tested against Prosys OPC UA Simulation Server:

<img width="337" height="187" alt="image" src="https://github.com/user-attachments/assets/d0ce246d-a6a2-43f5-b4b1-ce1f799d9be7" />


  Before fix:

  ```text
    Rejecting endpoint 0: security policy not available
    No suitable endpoint found
    UA_Client_findServers status=0x80210000 servers=0
```
  After fix:
```
  UA_Client_findServers status=0x00000000 servers=1
  server[0] uri=urn:Username:OPCUA:SimulationServer discoveryUrls=1
  url[0]=opc.tcp://Username:53530
```
