### PR TITLE
fix(client): distinguish secure channel renewal from sending requests

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -364,11 +364,6 @@ sendRequest(UA_Client *client, const void *request,
             const UA_DataType *requestType, UA_UInt32 *requestId) {
     UA_LOCK_ASSERT(&client->clientMutex);
 
-    /* Renew SecureChannel if necessary */
-    __Client_renewSecureChannel(client);
-    if(client->connectStatus != UA_STATUSCODE_GOOD)
-        return client->connectStatus;
-
     UA_EventLoop *el = client->config.eventLoop;
 
     /* Adjusting the request header. The const attribute is violated, but we
@@ -677,6 +672,14 @@ __Client_Service(UA_Client *client, const void *request,
      * reconnection within the EventLoop run method. */
     UA_UInt32 channelId = client->channel.securityToken.channelId;
 
+    /* Renew SecureChannel if necessary */
+    __Client_renewSecureChannel(client);
+    if(client->connectStatus != UA_STATUSCODE_GOOD) {
+        notifyClientState(client);
+        respHeader->serviceResult = client->connectStatus;
+        return;
+    }
+
     /* Send the request */
     UA_UInt32 requestId = 0;
     UA_StatusCode retval = sendRequest(client, request, requestType, &requestId);
@@ -819,6 +822,13 @@ __Client_AsyncService(UA_Client *client, const void *request,
         UA_LOG_ERROR(client->config.logging, UA_LOGCATEGORY_CLIENT,
                      "SecureChannel must be connected to send request");
         return UA_STATUSCODE_BADSERVERNOTCONNECTED;
+    }
+
+    /* Renew SecureChannel if necessary */
+    __Client_renewSecureChannel(client);
+    if(client->connectStatus != UA_STATUSCODE_GOOD) {
+        notifyClientState(client);
+        return client->connectStatus;
     }
 
     /* Prepare the entry for the linked list */

--- a/tests/client/check_client_securechannel.c
+++ b/tests/client/check_client_securechannel.c
@@ -4,6 +4,7 @@
 
 #include <open62541/client.h>
 #include <open62541/client_config_default.h>
+#include <open62541/client_highlevel_async.h>
 #include <open62541/client_highlevel.h>
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
@@ -222,6 +223,66 @@ START_TEST(SecureChannel_cableunplugged) {
 }
 END_TEST
 
+START_TEST(SecureChannel_sync_badconnectstatus) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    ck_assert(isFullyConnected(client));
+    ck_assert_uint_eq(client->channel.state, UA_SECURECHANNELSTATE_OPEN);
+
+    /* Reproduce the split state where the logical client status is bad but the
+     * SecureChannel still appears open. */
+    client->connectStatus = UA_STATUSCODE_BADTIMEOUT;
+
+    UA_Variant val;
+    UA_Variant_init(&val);
+    UA_NodeId nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
+    retval = UA_Client_readValueAttribute(client, nodeId, &val);
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADTIMEOUT);
+    ck_assert_uint_eq(client->channel.state, UA_SECURECHANNELSTATE_OPEN);
+
+    UA_Variant_clear(&val);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(SecureChannel_async_badconnectstatus) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    ck_assert(isFullyConnected(client));
+    ck_assert_uint_eq(client->channel.state, UA_SECURECHANNELSTATE_OPEN);
+
+    /* Reproduce the split state where the logical client status is bad but the
+     * SecureChannel still appears open. */
+    client->connectStatus = UA_STATUSCODE_BADTIMEOUT;
+
+    UA_ReadValueId rvi;
+    UA_ReadValueId_init(&rvi);
+    rvi.attributeId = UA_ATTRIBUTEID_VALUE;
+    rvi.nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE);
+
+    UA_ReadRequest request;
+    UA_ReadRequest_init(&request);
+    request.nodesToRead = &rvi;
+    request.nodesToReadSize = 1;
+
+    retval = __UA_Client_AsyncService(client, &request,
+                                      &UA_TYPES[UA_TYPES_READREQUEST],
+                                      NULL,
+                                      &UA_TYPES[UA_TYPES_READRESPONSE],
+                                      NULL, NULL);
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADTIMEOUT);
+    ck_assert_uint_eq(client->channel.state, UA_SECURECHANNELSTATE_OPEN);
+
+    UA_Client_delete(client);
+}
+END_TEST
+
 /* Some servers have a certificate in their endpoint which they do not use for
  * #None SecureChannels. To be compatible with them, only check if the
  * certificate matches IF it gets sent in th asymHeader of the OPN message. */
@@ -284,6 +345,8 @@ int main(void) {
     tcase_add_test(tc_sc, SecureChannel_networkfail);
     tcase_add_test(tc_sc, SecureChannel_reconnect);
     tcase_add_test(tc_sc, SecureChannel_cableunplugged);
+    tcase_add_test(tc_sc, SecureChannel_sync_badconnectstatus);
+    tcase_add_test(tc_sc, SecureChannel_async_badconnectstatus);
     tcase_add_test(tc_sc, SecureChannel_serverCert);
     tcase_add_test(tc_sc, SecureChannel_differentMonotonicClock);
 


### PR DESCRIPTION
Closes #8046

## Summary
- Move SecureChannel renewal and subsequent `connectStatus` check out of `sendRequest()` and into the sync/async service callers.
- Keep `sendRequest()` focused on the actual service-message send, so a non-good return from it still means the send path failed and the SecureChannel
  should be closing or closed.
- Fix the async assertion failure that can occur when the client has a stale logical connection status while the SecureChannel state still appears open.

## Details
`sendRequest()` could previously return a pre-existing `client->connectStatus` before attempting `UA_SecureChannel_sendMSG()`. The async caller then asserted that any non-good return meant the SecureChannel was already closing or closed, which is not true for pre-send client status failures.

This change performs the renewal/status preflight before calling `sendRequest()` in both `__Client_Service()` and `__Client_AsyncService()`.

<!-- closes CON-2350 -->