### PR TITLE
fix(pubsub): Implicit declaration of pthread_create

### DIFF
--- a/examples/pubsub_realtime/server_pubsub_subscribe_rt_state_machine.c
+++ b/examples/pubsub_realtime/server_pubsub_subscribe_rt_state_machine.c
@@ -19,6 +19,7 @@
 #include <poll.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <pthread.h>
 
 #define PUBSUB_CONFIG_FIELD_COUNT 10
 


### PR DESCRIPTION
## Description
Hello!

When building Master Yocto for a Aarch32 device, I am running into a Implicit declaration error. Recreated this PR to fix the extra merge commit.

## Background Information / Reproduction Steps
Yocto setup info: 
- Overall setup: https://git.ti.com/cgit/arago-project/oe-layersetup/tree/ using the arago-master-config.txt config file. 
- MACHINE: am62pxx-evm

Cross Compiler: 
- arm-oe-linux-gnueabi-gcc (GCC) 15.2.0

## Error Log 

```bash
examples/pubsub_realtime/server_pubsub_subscribe_rt_state_machine.c:198:23: error: implicit declaration of function 'pthread_create' [-Wimplicit-function-declaration]
   78 |     pthread_create(&pubSubELThread, NULL, runPubSubEL, NULL);
      |     ^~~~~~~~~~~~~~
```

## Used CMake options:

Using the default ones setup by the upstream recipe found within meta-openembedded layer. 

## Fix 

Include the right header file. 
