### PR TITLE
fix(server): check for NULL in _UA_dirname_minimal()

### DIFF
--- a/plugins/crypto/ua_filestore_common.c
+++ b/plugins/crypto/ua_filestore_common.c
@@ -16,7 +16,11 @@
  * implementation working with correct input data. */
 char *
 _UA_dirname_minimal(char *path) {
+    if(path == NULL || *path == '\0')
+        return ".";
     char *lastSlash = strrchr(path, '/');
+    if(lastSlash == NULL)
+        return ".";
     *lastSlash = 0;
     return path;
 }


### PR DESCRIPTION
Dereferenceing the return value of strrchr() without a NULL check caused a crash when the provided filestore path contained no directory separator or was NULL/empty. Guard both the path argument and the strrchr() result, returning '.' in those cases to match POSIX dirname() behaviour.