### PR TITLE
[Review] Fix coverity issues and compiler warnings

### DIFF
--- a/arch/posix/eventloop_posix_udp.c
+++ b/arch/posix/eventloop_posix_udp.c
@@ -1181,6 +1181,7 @@ UDP_openSendConnection(UA_POSIXConnectionManager *pcm, const UA_KeyValueMap *par
     if(!conn) {
         UA_LOG_WARNING(el->eventLoop.logger, UA_LOGCATEGORY_NETWORK,
                        "UDP\t| Error allocating memory for the socket, closing");
+        UA_freeaddrinfo(info);
         return UA_STATUSCODE_BADOUTOFMEMORY;
     }
 

--- a/plugins/crypto/mbedtls/certificategroup.c
+++ b/plugins/crypto/mbedtls/certificategroup.c
@@ -1085,7 +1085,12 @@ UA_CertificateUtils_decryptPrivateKey(const UA_ByteString privateKey,
 
     /* Write the DER-encoded key into a local buffer */
     unsigned char buf[1 << 14];
-    size_t pos = (size_t)mbedtls_pk_write_key_der(&ctx, buf, sizeof(buf));
+    int written = mbedtls_pk_write_key_der(&ctx, buf, sizeof(buf));
+    if(written <= 0) {
+        mbedtls_pk_free(&ctx);
+        return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+    }
+    size_t pos = (size_t)written;
 
     /* Allocate memory */
     UA_StatusCode res = UA_ByteString_allocBuffer(outDerKey, pos);

--- a/plugins/crypto/mbedtls/create_certificate.c
+++ b/plugins/crypto/mbedtls/create_certificate.c
@@ -253,9 +253,9 @@ UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
 
         /* split into SAN type and value */
         char *sanType = NULL;
-        for(char *pos = subAlt; *pos != 0; pos++) {
-            if(*pos == ':') {
-                *pos = '\0';
+        for(char *char_pos = subAlt; *char_pos != 0; char_pos++) {
+            if(*char_pos == ':') {
+                *char_pos = '\0';
                 sanType = subAlt;
                 break;
             }

--- a/plugins/crypto/mbedtls/securitypolicy_common.c
+++ b/plugins/crypto/mbedtls/securitypolicy_common.c
@@ -110,12 +110,16 @@ mbedtls_generateKey(mbedtls_md_context_t *context,
         if(retval != UA_STATUSCODE_GOOD){
             UA_ByteString_clear(&A_and_seed);
             UA_ByteString_clear(&ANext_and_seed);
+            if(bufferAllocated)
+                UA_ByteString_clear(&outSegment);
             return retval;
         }
         retval = mbedtls_hmac(context, secret, &A, ANext.data);
         if(retval != UA_STATUSCODE_GOOD){
             UA_ByteString_clear(&A_and_seed);
             UA_ByteString_clear(&ANext_and_seed);
+            if(bufferAllocated)
+                UA_ByteString_clear(&outSegment);
             return retval;
         }
 

--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -787,7 +787,6 @@ PARSE_JSON(SecurityPkiField) {
 #if defined(__linux__) || defined(UA_ARCHITECTURE_WIN32)
     /* Currently not supported! */
     (void)config;
-    return UA_STATUSCODE_GOOD;
 #else
     /* Set up the parameters */
     UA_KeyValuePair params[2];

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -486,22 +486,28 @@ implicitCastTargetType(const UA_DataType *t1, const UA_DataType *t2) {
  * - Converting a value that is outside the range of the target type causes a
  *   conversion error. */
 
-#define UA_CAST_SIGNED(t, T)                                         \
-    if(i < (UA_Int64)T##_MIN || i > (UA_Int64)T##_MAX)               \
-        return;                                                      \
-    *(t*)data = (t)i;                                                \
+#define UA_CAST_SIGNED(t, T)                                           \
+    if(i < (UA_Int64)T##_MIN || i > (UA_Int64)T##_MAX) {               \
+        UA_free(data);                                                 \
+        return;                                                        \
+    }                                                                  \
+    *(t*)data = (t)i;                                                  \
     do { } while(0)
 
-#define UA_CAST_UNSIGNED(t, T)                                       \
-    if(u > T##_MAX)                                                  \
-        return;                                                      \
-    *(t*)data = (t)u;                                                \
+#define UA_CAST_UNSIGNED(t, T)                                         \
+    if(u > T##_MAX) {                                                  \
+        UA_free(data);                                                 \
+        return;                                                        \
+    }                                                                  \
+    *(t*)data = (t)u;                                                  \
     do { } while(0)
 
-#define UA_CAST_FLOAT(t, T)                                          \
-    if(f + 0.5 < (UA_Double)T##_MIN || f + 0.5 > (UA_Double)T##_MAX) \
-        return;                                                      \
-    *(t*)data = (t)(f + 0.5);                                        \
+#define UA_CAST_FLOAT(t, T)                                            \
+    if(f + 0.5 < (UA_Double)T##_MIN || f + 0.5 > (UA_Double)T##_MAX) { \
+        UA_free(data);                                                 \
+        return;                                                        \
+    }                                                                  \
+    *(t*)data = (t)(f + 0.5);                                          \
     do { } while(0)
 
 /* We can cast between any numerical type. So this can be reused for explicit casting. */

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -109,6 +109,8 @@ xml_tokenize(const char *xml, unsigned int len,
             break;
         case YXML_ELEMEND:
         case YXML_ATTREND:
+            if(top == 0)
+                goto errout; /* more closes than opens */
             if(val_begin > 0) {
                 stack[top]->content.data = (UA_Byte*)(uintptr_t)xml + val_begin;
                 stack[top]->content.length = stack[top]->end + 1 - val_begin;


### PR DESCRIPTION
Fix some issues reported by Coverity as high impact:
 - Memory leaks in error cases
 - top decremented from zero in xml_tokenize
 - Handle error (-1) from mbedtls_pk_write_key_der instead of casting the return value directly to size_t

And couple of compiler warnings:
 - C4702: unreachable code in the end of the function
 - C4456: declaration of 'pos' hides previous local declaration