### PR TITLE
Fix docs generation and upload

### DIFF
--- a/.github/workflows/doc_upload.yml
+++ b/.github/workflows/doc_upload.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y -qq texlive-fonts-recommended texlive-latex-extra texlive-plain-generic texlive-latex-recommended latexmk texlive-fonts-extra
+          sudo apt-get install -y -qq texlive-fonts-recommended texlive-latex-extra texlive-plain-generic texlive-latex-recommended latexmk texlive-fonts-extra graphviz
           pip install -r doc/requirements.txt
       - name: Build Documentation
         run: source tools/ci/linux/ci.sh && build_docs_pdf

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ author = 'The open62541 authors'
 
 extensions = [
     'sphinx_rtd_theme',
+    'sphinx.ext.graphviz',
 ]
 
 templates_path = ['_templates']

--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -297,7 +297,7 @@ typedef struct {
 
 /**
  * PubSub Custom State Machine
- * -----------------
+ * ---------------------------
  * All PubSubComponents (Connection, Reader, ReaderGroup, ...) have a two
  * configuration items in common: A void context-pointer and a callback to
  * override the default state machine with a custom implementation.


### PR DESCRIPTION
The docs generation and upload did fail since the release of v1.5.4 because of formatting and missing packages/extensions. Therefore, no newer documentations for master and 1.5 were released with 1.5.4 still missing.