### PR TITLE
[Review] Coverity issue fixes

### DIFF
--- a/plugins/crypto/ua_filestore_common.c
+++ b/plugins/crypto/ua_filestore_common.c
@@ -38,7 +38,12 @@ readFileToByteString(const char *const path, UA_ByteString *data) {
 
     /* Get the file length, allocate the data and read */
     UA_fseek(fp, 0, UA_SEEK_END);
-    UA_StatusCode retval = UA_ByteString_allocBuffer(data, (size_t)UA_ftell(fp));
+    long fileSize = UA_ftell(fp);
+    if(fileSize < 0) {
+        UA_fclose(fp);
+        return UA_STATUSCODE_BADINTERNALERROR;
+    }
+    UA_StatusCode retval = UA_ByteString_allocBuffer(data, (size_t)fileSize);
     if(retval == UA_STATUSCODE_GOOD) {
         UA_fseek(fp, 0, UA_SEEK_SET);
         size_t read = UA_fread(data->data, sizeof(UA_Byte), data->length * sizeof(UA_Byte), fp);

--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -253,6 +253,8 @@ checkSessionActive(UA_Server *server, void *data) {
         removingCallback = false;
 
         UA_CertificateGroup *certGroup = getCertGroup(server, &fileInfoContext->certificateGroupId);
+        if(!certGroup)
+            continue;
 
         UA_FileContext *fileContext, *fileContextTmp;
         LIST_FOREACH_SAFE(fileContext, &fileInfo.fileContext, listEntry, fileContextTmp) {

--- a/src/server/ua_server_ns0_gds.c
+++ b/src/server/ua_server_ns0_gds.c
@@ -1348,6 +1348,9 @@ openFile(UA_Server *server,
          size_t outputSize, UA_Variant *output) {
 
     const UA_Node *object = UA_NODESTORE_GET(server, objectId);
+    if(!object)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+
     const UA_Node *objectType =
         getNodeType(server, &object->head, ~(UA_UInt32)0,
                     UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
@@ -1379,6 +1382,9 @@ readFile(UA_Server *server,
          size_t outputSize, UA_Variant *output) {
 
     const UA_Node *object = UA_NODESTORE_GET(server, objectId);
+    if(!object)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+
     const UA_Node *objectType =
         getNodeType(server, &object->head, ~(UA_UInt32)0,
                     UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
@@ -1410,6 +1416,9 @@ writeFile(UA_Server *server,
          size_t outputSize, UA_Variant *output) {
 
     const UA_Node *object = UA_NODESTORE_GET(server, objectId);
+    if(!object)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+
     const UA_Node *objectType =
         getNodeType(server, &object->head, ~(UA_UInt32)0,
                     UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
@@ -1441,6 +1450,9 @@ closeFile(UA_Server *server,
          size_t outputSize, UA_Variant *output) {
 
     const UA_Node *object = UA_NODESTORE_GET(server, objectId);
+    if(!object)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+
     const UA_Node *objectType =
         getNodeType(server, &object->head, ~(UA_UInt32)0,
                     UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
@@ -1472,6 +1484,9 @@ getPositionFile(UA_Server *server,
          size_t outputSize, UA_Variant *output) {
 
     const UA_Node *object = UA_NODESTORE_GET(server, objectId);
+    if(!object)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+
     const UA_Node *objectType =
         getNodeType(server, &object->head, ~(UA_UInt32)0,
                     UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
@@ -1503,6 +1518,9 @@ setPositionFile(UA_Server *server,
          size_t outputSize, UA_Variant *output) {
 
     const UA_Node *object = UA_NODESTORE_GET(server, objectId);
+    if(!object)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+
     const UA_Node *objectType =
         getNodeType(server, &object->head, ~(UA_UInt32)0,
                     UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);

--- a/src/ua_securechannel_crypto.c
+++ b/src/ua_securechannel_crypto.c
@@ -184,6 +184,7 @@ prependHeadersAsym(UA_SecureChannel *const channel, UA_Byte *header_pos,
             getRemoteBlockSize(sp, cc);
 
         /* Padding always fills up the last block */
+        UA_assert(plainTextBlockSize > 0);
         UA_assert(dataToEncryptLength % plainTextBlockSize == 0);
         size_t blocks = dataToEncryptLength / plainTextBlockSize;
         *encryptedLength = totalLength + blocks * (encryptedBlockSize - plainTextBlockSize);
@@ -248,6 +249,7 @@ hideBytesAsym(const UA_SecureChannel *channel, UA_Byte **buf_start,
         sp->asymEncryptionAlgorithm.getRemoteBlockSize(sp, cc);
 
     size_t max_encrypted = (size_t)(*buf_end - *buf_start);
+    UA_assert(encryptedBlockSize > 0);
     size_t max_blocks = max_encrypted / encryptedBlockSize;
     size_t max_plaintext = max_blocks * plainTextBlockSize;
 
@@ -280,6 +282,7 @@ padChunk(UA_SecureChannel *channel,
     UA_Boolean extraPadding = (ea->getRemoteKeyLength(sp, cc) > 2048);
     size_t paddingBytes = (UA_LIKELY(!extraPadding)) ? 1u : 2u;
 
+    UA_assert(plainTextBlockSize > 0);
     size_t lastBlock = ((bytesToWrite + signatureSize + paddingBytes) % plainTextBlockSize);
     size_t paddingLength = (lastBlock != 0) ? plainTextBlockSize - lastBlock : 0;
 
@@ -457,6 +460,7 @@ setBufPos(UA_MessageContext *mc) {
 
     /* Leave enough space for the signature and padding */
     mc->buf_end -= sigsize;
+    UA_assert(plainBlockSize > 0);
     mc->buf_end -= mc->messageBuffer.length % plainBlockSize;
 
     if(channel->securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT) {

--- a/src/util/ua_eventfilter_parser.c
+++ b/src/util/ua_eventfilter_parser.c
@@ -115,8 +115,11 @@ create_operator(EFParseContext *ctx, UA_FilterOperator fo) {
 void
 append_operand(Operand *op, Operand *on) {
     Operator *optr = &op->operand.op;
-    optr->children = (Operand**)
+    Operand **children_tmp = (Operand **)
         UA_realloc(optr->children, (optr->childrenSize + 1) * sizeof(Operand*));
+    if(!children_tmp)
+        return;
+    optr->children = children_tmp;
     optr->children[optr->childrenSize] = on;
     optr->childrenSize++;
 }


### PR DESCRIPTION
Fixes for some medium impact Coverity issues reported in our internal Coverity runs:

- Check UA_NODESTORE_GET and getCertGroup return values in ua_server_ns0_gds.c like elsewhere (Deference null return value)
- Check return value of UA_realloc in append_operand (Deference null return value)
- Check return value of UA_ftell in readFileToByteString to avoid -1 to be cast to size_t for buffer allocation (Improper use of negative value)
- Add some asserts to protect against Division or module by zero issues in ua_securechannel_crypto.c

Are the asserts enough in ua_securechannel_crypto.c? At least there are some other asserts in the same functions.

