### PR TITLE
fix(server): opt-in stable source timestamps for data source variables

### DIFF
--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -335,6 +335,14 @@ typedef struct {
                            * background. Only dynamic variables conserve source
                            * and server timestamp for the value attribute.
                            * Static variables have timestamps of "now". */
+
+    /* Cached source timestamp for data-source variables
+     * (UA_ServerConfig::stableDataSourceTimestamps). */
+    UA_Variant cachedSourceValue;
+    UA_StatusCode cachedSourceStatus;
+    UA_Boolean cachedSourceHasStatus;
+    UA_DateTime cachedSourceTimestamp;
+    UA_Boolean hasCachedSourceTimestamp;
 } UA_VariableNode;
 
 /**

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -2105,6 +2105,14 @@ struct UA_ServerConfig {
 
     UA_RuleHandling allowAllCertificateUris;
 
+    /* When a data source read callback does not set hasSourceTimestamp, the
+     * server normally fills in the current time on every read. With
+     * StatusValueTimestamp subscriptions this causes spurious notifications
+     * even when the value has not changed. When this flag is set, the server
+     * caches the last value and status per data-source variable node and
+     * only updates the source timestamp when one of them changes. */
+    UA_Boolean stableDataSourceTimestamps;
+
     /* Custom Data Types
      * ~~~~~~~~~~~~~~~~~
      * The following is a linked list of arrays with custom data types. All data

--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -427,6 +427,8 @@ void UA_Node_clear(UA_Node *node) {
         p->arrayDimensionsSize = 0;
         if(p->valueSourceType == UA_VALUESOURCETYPE_INTERNAL)
             UA_DataValue_clear(&p->valueSource.internal.value);
+        if(head->nodeClass == UA_NODECLASS_VARIABLE)
+            UA_Variant_clear(&p->cachedSourceValue);
         break;
     }
     case UA_NODECLASS_REFERENCETYPE: {
@@ -476,6 +478,12 @@ UA_VariableNode_copy(const UA_VariableNode *src, UA_VariableNode *dst) {
     dst->minimumSamplingInterval = src->minimumSamplingInterval;
     dst->historizing = src->historizing;
     dst->isDynamic = src->isDynamic;
+    dst->hasCachedSourceTimestamp = src->hasCachedSourceTimestamp;
+    dst->cachedSourceTimestamp = src->cachedSourceTimestamp;
+    dst->cachedSourceHasStatus = src->cachedSourceHasStatus;
+    dst->cachedSourceStatus = src->cachedSourceStatus;
+    if(src->hasCachedSourceTimestamp)
+        UA_Variant_copy(&src->cachedSourceValue, &dst->cachedSourceValue);
     return UA_CommonVariableNode_copy(src, dst);
 }
 

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -281,7 +281,26 @@ readValueAttributeComplete(UA_Server *server, UA_Session *session,
     /* If not defined return a source timestamp of "now".
      * Static nodes always have the current time as source-time. */
     if(!v->hasSourceTimestamp) {
-        v->sourceTimestamp = el->dateTime_now(el);
+        if(server->config.stableDataSourceTimestamps &&
+           vn->valueSourceType == UA_VALUESOURCETYPE_CALLBACK) {
+            UA_VariableNode *mut_vn = (UA_VariableNode *)(uintptr_t)vn;
+            UA_Boolean changed = !mut_vn->hasCachedSourceTimestamp ||
+                v->hasStatus != mut_vn->cachedSourceHasStatus ||
+                v->status != mut_vn->cachedSourceStatus ||
+                !UA_equal(&v->value, &mut_vn->cachedSourceValue,
+                          &UA_TYPES[UA_TYPES_VARIANT]);
+            if(changed) {
+                mut_vn->cachedSourceTimestamp = el->dateTime_now(el);
+                UA_Variant_clear(&mut_vn->cachedSourceValue);
+                UA_Variant_copy(&v->value, &mut_vn->cachedSourceValue);
+                mut_vn->cachedSourceHasStatus = v->hasStatus;
+                mut_vn->cachedSourceStatus = v->status;
+                mut_vn->hasCachedSourceTimestamp = true;
+            }
+            v->sourceTimestamp = mut_vn->cachedSourceTimestamp;
+        } else {
+            v->sourceTimestamp = el->dateTime_now(el);
+        }
         v->hasSourceTimestamp = true;
     }
 

--- a/tests/server/check_local_monitored_item.c
+++ b/tests/server/check_local_monitored_item.c
@@ -164,6 +164,75 @@ START_TEST(Server_LocalMonitoredItem_dataSource) {
 }
 END_TEST
 
+static size_t stableCallbackCount = 0;
+
+static void
+stableDataChangeCallback(UA_Server *thisServer,
+                         UA_UInt32 monitoredItemId,
+                         void *monitoredItemContext,
+                         const UA_NodeId *nodeId,
+                         void *nodeContext,
+                         UA_UInt32 attributeId,
+                         const UA_DataValue *value) {
+    stableCallbackCount++;
+}
+
+/* stableDataSourceTimestamps: no spurious notifications when value is unchanged */
+START_TEST(Server_LocalMonitoredItem_stableDataSourceTimestamp) {
+    stableCallbackCount = 0;
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    config->stableDataSourceTimestamps = true;
+
+    UA_DataSource ds = {readDataSource, NULL};
+    UA_Server_setVariableNode_dataSource(server, outNodeId, ds);
+
+    UA_MonitoredItemCreateRequest monitorRequest =
+            UA_MonitoredItemCreateRequest_default(outNodeId);
+    monitorRequest.requestedParameters.samplingInterval = (double)100;
+    monitorRequest.monitoringMode = UA_MONITORINGMODE_REPORTING;
+
+    UA_DataChangeFilter filter;
+    UA_DataChangeFilter_init(&filter);
+    filter.trigger = UA_DATACHANGETRIGGER_STATUSVALUETIMESTAMP;
+    monitorRequest.requestedParameters.filter.encoding = UA_EXTENSIONOBJECT_DECODED;
+    monitorRequest.requestedParameters.filter.content.decoded.type =
+        &UA_TYPES[UA_TYPES_DATACHANGEFILTER];
+    monitorRequest.requestedParameters.filter.content.decoded.data = &filter;
+
+    UA_MonitoredItemCreateResult result =
+            UA_Server_createDataChangeMonitoredItem(server,
+                                                    UA_TIMESTAMPSTORETURN_BOTH,
+                                                    monitorRequest,
+                                                    NULL,
+                                                    &stableDataChangeCallback);
+    ASSERT_STATUSCODE(result.statusCode, UA_STATUSCODE_GOOD);
+    UA_Server_run_iterate(server, false);
+    ck_assert_uint_eq(stableCallbackCount, 1);
+
+    /* 10 sampling intervals with unchanged value: no extra notifications */
+    for(size_t i = 0; i < 10; i++) {
+        UA_fakeSleep(100);
+        UA_Server_run_iterate(server, 1);
+    }
+    ck_assert_uint_eq(stableCallbackCount, 1);
+
+    /* Change the value: exactly one new notification */
+    staticUInt32 = 9999;
+    UA_fakeSleep(100);
+    UA_Server_run_iterate(server, 1);
+    ck_assert_uint_eq(stableCallbackCount, 2);
+
+    /* Another 5 intervals unchanged: still 2 */
+    for(size_t i = 0; i < 5; i++) {
+        UA_fakeSleep(100);
+        UA_Server_run_iterate(server, 1);
+    }
+    ck_assert_uint_eq(stableCallbackCount, 2);
+
+    config->stableDataSourceTimestamps = false;
+}
+END_TEST
+
 /* Custom datatype with a String NodeId */
 typedef struct {
     UA_Float p;
@@ -329,6 +398,7 @@ static Suite * testSuite_Client(void) {
     tcase_add_checked_fixture(tc_server, setup, teardown);
     tcase_add_test(tc_server, Server_LocalMonitoredItem);
     tcase_add_test(tc_server, Server_LocalMonitoredItem_dataSource);
+    tcase_add_test(tc_server, Server_LocalMonitoredItem_stableDataSourceTimestamp);
     tcase_add_test(tc_server, Server_LocalMonitoredItem_CustomType);
     suite_add_tcase(s, tc_server);
 


### PR DESCRIPTION
## Context

Reopening (from the application side) a problem first reported in #5882.

When a data source read callback does not set `hasSourceTimestamp`, the server fills in `dateTime_now()` on every read (`readValueAttributeComplete`, line 283 in `ua_services_attribute.c`). With `UA_DATACHANGETRIGGER_STATUSVALUETIMESTAMP` subscriptions this causes a flood of spurious notifications even when neither value nor status have changed.

This has bitten us again, this time specifically with **data source variables** (not just nodeset-imported ones). Our OPC UA server exposes ~80 data source variables to an external SCADA system. Each read callback returns the current process value but does not set a source timestamp (because the source has no meaningful timestamp to provide). With the current behavior, every sampling interval produces a notification, flooding the SCADA client.

## Fix

Add `UA_ServerConfig::stableDataSourceTimestamps` (default `false`). When enabled, the server caches the last value and status per data-source variable node and only updates the source timestamp when one of them actually changes.

This is fully backward compatible: the default behavior is unchanged. Applications that want stable timestamps opt in with a single config flag.

### Changes

- **`include/open62541/server.h`**: new `UA_Boolean stableDataSourceTimestamps` field on `UA_ServerConfig`
- **`include/open62541/plugin/nodestore.h`**: cache fields on `UA_VariableNode` (`cachedSourceValue`, `cachedSourceStatus`, etc.)
- **`src/server/ua_services_attribute.c`**: in `readValueAttributeComplete`, compare against cached state before stamping
- **`src/server/ua_nodes.c`**: cleanup in `UA_Node_clear`, deep copy in `UA_VariableNode_copy`

## Workaround (current)

We work around this in our application layer by caching value + status + sourceTimestamp in the data source read callback itself and setting `hasSourceTimestamp = true` only when something changes. This works but pushes a concern into every application that uses data source variables with timestamp-sensitive subscriptions. A server-level opt-in is cleaner.

## Test plan

- [ ] Existing unit tests pass (no behavior change with flag off)
- [ ] Manual verification with UaExpert: subscribe to a data source variable with StatusValueTimestamp trigger, confirm no spurious notifications when value is unchanged