### PR TITLE
fix(client): correct secure channel state output

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -263,8 +263,8 @@ UA_Client_getConfig(UA_Client *client) {
 
 #if UA_LOGLEVEL <= 300
 static const char *channelStateTexts[14] = {
-    "Fresh", "ReverseListening", "Connecting", "Connected", "ReverseConnected", "RHESent", "HELSent", "HELReceived", "ACKSent",
-    "AckReceived", "OPNSent", "Open", "Closing", "Closed"};
+    "Closed", "ReverseListening", "Connecting", "Connected", "ReverseConnected", "RHESent", "HELSent", "HELReceived", "ACKSent",
+    "AckReceived", "OPNSent", "Open", "Closing"};
 static const char *sessionStateTexts[6] =
     {"Closed", "CreateRequested", "Created",
      "ActivateRequested", "Activated", "Closing"};


### PR DESCRIPTION
The enum was changed in b19cc6d but the names weren't.