### PR TITLE
fix(server): validate AddReferences target node class

### DIFF
--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -2317,6 +2317,17 @@ Operation_addReference(UA_Server *server, UA_Session *session, void *context,
             *retval = UA_STATUSCODE_BADTARGETNODEIDINVALID;
             return;
         }
+        if(item->targetNodeClass != UA_NODECLASS_UNSPECIFIED &&
+           item->targetNodeClass != targetNode->head.nodeClass) {
+            UA_LOG_DEBUG_SESSION(server->config.logging, session,
+                                 "Cannot add reference - target %N has NodeClass %u "
+                                 "but request expects %u",
+                                 item->targetNodeId.nodeId, (unsigned)targetNode->head.nodeClass,
+                                 (unsigned)item->targetNodeClass);
+            UA_NODESTORE_RELEASE(server, targetNode);
+            *retval = UA_STATUSCODE_BADNODECLASSINVALID;
+            return;
+        }
     }
 
     UA_Node *sourceNode =

--- a/tests/client/check_client_highlevel.c
+++ b/tests/client/check_client_highlevel.c
@@ -213,7 +213,7 @@ START_TEST(Node_Add) {
 
     // Add 'Top' to view
     retval = UA_Client_addReference(client, newViewId, UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
-                                    UA_TRUE, UA_STRING_NULL, target, UA_NODECLASS_VARIABLE);
+                                    UA_TRUE, UA_STRING_NULL, target, UA_NODECLASS_OBJECT);
 
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 

--- a/tests/server/check_services_nodemanagement.c
+++ b/tests/server/check_services_nodemanagement.c
@@ -925,6 +925,42 @@ START_TEST(AddReference_InvalidRefType) {
     ck_assert_int_ne(st, UA_STATUSCODE_GOOD);
 } END_TEST
 
+START_TEST(AddReference_InvalidTargetNodeClass) {
+    UA_NodeId refTypeId = registerRefType("HasTypedRef", "IsTypedRefOf");
+    UA_NodeId objectsNodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    UA_NodeId sourceId = addObjInstance(objectsNodeId, "typedRefSrc");
+    UA_NodeId targetId = addObjInstance(objectsNodeId, "typedRefTgt");
+
+    UA_AddReferencesItem item;
+    UA_AddReferencesItem_init(&item);
+    item.sourceNodeId = sourceId;
+    item.referenceTypeId = refTypeId;
+    item.isForward = true;
+    item.targetNodeId.nodeId = targetId;
+    item.targetNodeClass = UA_NODECLASS_VARIABLE;
+
+    UA_AddReferencesRequest request;
+    UA_AddReferencesRequest_init(&request);
+    request.referencesToAddSize = 1;
+    request.referencesToAdd = &item;
+
+    UA_AddReferencesResponse response;
+    UA_AddReferencesResponse_init(&response);
+
+    lockServer(server);
+    Service_AddReferences(server, &server->adminSession, &request, &response);
+    unlockServer(server);
+
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(response.resultsSize, 1);
+    ck_assert_uint_eq(response.results[0], UA_STATUSCODE_BADNODECLASSINVALID);
+
+    UA_NodeId targetCheckId = findReference(sourceId, refTypeId);
+    ck_assert(UA_NodeId_isNull(&targetCheckId));
+
+    UA_AddReferencesResponse_clear(&response);
+} END_TEST
+
 START_TEST(SetNodeTypeLifecycle) {
     /* Set a lifecycle callback on BaseObjectType */
     UA_NodeTypeLifecycle nlc;
@@ -1019,6 +1055,7 @@ int main(void) {
     tcase_add_test(tc_addreferences, AddDoubleReference);
     tcase_add_test(tc_addreferences, DeleteReference);
     tcase_add_test(tc_addreferences, AddReference_InvalidRefType);
+    tcase_add_test(tc_addreferences, AddReference_InvalidTargetNodeClass);
     suite_add_tcase(s, tc_addreferences);
 
     TCase *tc_ext = tcase_create("extendedCoverage");


### PR DESCRIPTION
This PR adds validation for `targetNodeClass` in AddReferences when the target node is local.

Previously, AddReferences could succeed even if the provided `targetNodeClass` did not match the actual NodeClass of the target node. This change returns `UA_STATUSCODE_BADNODECLASSINVALID` for such requests.

The OPC UA AddReferences definition expects `targetNodeClass` to match the TargetNode NodeClass for local targets. To avoid changing existing helper paths that do not set this field, the check is only applied when a non-zero `targetNodeClass` is provided.

A regression test is included to cover this case.