### PR TITLE
test(interop): fail when no .NET ECC test actually runs

### DIFF
--- a/tests/interop/check_interop_client.c
+++ b/tests/interop/check_interop_client.c
@@ -661,19 +661,24 @@ int main(int argc, char *argv[]) {
             struct {
                 const char *label;
                 const char *curve;
+                const char *certName;  /* cert/key file stem; defaults to curve */
                 const char *policyUri;
             } eccTests[] = {
-                {"T-10", "nistP256",
+                {"T-10", "nistP256", "nistP256",
                  "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256"},
-                {"T-11", "nistP384",
+                {"T-11", "nistP256_AesGcm", "nistP256",
+                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256_AesGcm"},
+                {"T-12", "nistP256_ChaChaPoly", "nistP256",
+                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256_ChaChaPoly"},
+                {"T-13", "nistP384", "nistP384",
                  "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP384"},
-                {"T-12", "brainpoolP256r1",
+                {"T-14", "brainpoolP256r1", "brainpoolP256r1",
                  "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP256r1"},
-                {"T-13", "brainpoolP384r1",
+                {"T-15", "brainpoolP384r1", "brainpoolP384r1",
                  "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP384r1"},
-                {"T-14", "curve25519",
+                {"T-16", "curve25519", "curve25519",
                  "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve25519"},
-                {"T-15", "curve448",
+                {"T-17", "curve448", "curve448",
                  "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve448"}
             };
             size_t numEcc = sizeof(eccTests) / sizeof(eccTests[0]);
@@ -681,9 +686,9 @@ int main(int argc, char *argv[]) {
             for(size_t i = 0; i < numEcc; i++) {
                 char certPath[512], keyPath[512];
                 snprintf(certPath, sizeof(certPath),
-                         "%s/client_c_%s.cert.der", eccDir, eccTests[i].curve);
+                         "%s/client_c_%s.cert.der", eccDir, eccTests[i].certName);
                 snprintf(keyPath, sizeof(keyPath),
-                         "%s/client_c_%s.key.der", eccDir, eccTests[i].curve);
+                         "%s/client_c_%s.key.der", eccDir, eccTests[i].certName);
 
                 UA_ByteString eccCert = loadFileFromDisk(certPath);
                 UA_ByteString eccKey = loadFileFromDisk(keyPath);
@@ -708,11 +713,13 @@ int main(int argc, char *argv[]) {
             }
         } else {
             interop_skip("T-10 ECC_nistP256 (no ECC cert dir)");
-            interop_skip("T-11 ECC_nistP384 (no ECC cert dir)");
-            interop_skip("T-12 ECC_brainpoolP256r1 (no ECC cert dir)");
-            interop_skip("T-13 ECC_brainpoolP384r1 (no ECC cert dir)");
-            interop_skip("T-14 ECC_curve25519 (no ECC cert dir)");
-            interop_skip("T-15 ECC_curve448 (no ECC cert dir)");
+            interop_skip("T-11 ECC_nistP256_AesGcm (no ECC cert dir)");
+            interop_skip("T-12 ECC_nistP256_ChaChaPoly (no ECC cert dir)");
+            interop_skip("T-13 ECC_nistP384 (no ECC cert dir)");
+            interop_skip("T-14 ECC_brainpoolP256r1 (no ECC cert dir)");
+            interop_skip("T-15 ECC_brainpoolP384r1 (no ECC cert dir)");
+            interop_skip("T-16 ECC_curve25519 (no ECC cert dir)");
+            interop_skip("T-17 ECC_curve448 (no ECC cert dir)");
         }
 
         /* Safety net: when INTEROP_REQUIRE_ECC is set, at least one ECC
@@ -732,11 +739,13 @@ int main(int argc, char *argv[]) {
     interop_skip("T-8 Username over encrypted (no encryption support)");
     interop_skip("T-9 X509 certificate auth (no encryption support)");
     interop_skip("T-10 ECC_nistP256 (no encryption support)");
-    interop_skip("T-11 ECC_nistP384 (no encryption support)");
-    interop_skip("T-12 ECC_brainpoolP256r1 (no encryption support)");
-    interop_skip("T-13 ECC_brainpoolP384r1 (no encryption support)");
-    interop_skip("T-14 ECC_curve25519 (no encryption support)");
-    interop_skip("T-15 ECC_curve448 (no encryption support)");
+    interop_skip("T-11 ECC_nistP256_AesGcm (no encryption support)");
+    interop_skip("T-12 ECC_nistP256_ChaChaPoly (no encryption support)");
+    interop_skip("T-13 ECC_nistP384 (no encryption support)");
+    interop_skip("T-14 ECC_brainpoolP256r1 (no encryption support)");
+    interop_skip("T-15 ECC_brainpoolP384r1 (no encryption support)");
+    interop_skip("T-16 ECC_curve25519 (no encryption support)");
+    interop_skip("T-17 ECC_curve448 (no encryption support)");
 #endif
 
     /* Cleanup */

--- a/tests/interop/dotnet/InteropClientTest.cs
+++ b/tests/interop/dotnet/InteropClientTest.cs
@@ -38,6 +38,10 @@ namespace Opc.Ua.Interop.Tests
         private ITelemetryContext _telemetry = null!;
         private string _pkiRoot = null!;
 
+        // ECC sessions that connected. Mirrors INTEROP_REQUIRE_ECC in check_interop_client.c.
+        private static int s_eccTestsPassed;
+        private static readonly object s_eccLock = new object();
+
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
@@ -87,6 +91,34 @@ namespace Opc.Ua.Interop.Tests
             await EnsureEccCertificatesAsync().ConfigureAwait(false);
 
             _sessionFactory = new DefaultSessionFactory(_telemetry);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            // Fail when no ECC test actually ran. Mirrors INTEROP_REQUIRE_ECC.
+            var requireEcc = Environment.GetEnvironmentVariable(
+                "INTEROP_REQUIRE_ECC");
+            bool required = requireEcc != null && requireEcc != "0";
+
+            int passed;
+            lock (s_eccLock)
+            {
+                passed = s_eccTestsPassed;
+            }
+
+            TestContext.Out.WriteLine(
+                $"ECC interop summary: {passed} ECC test(s) passed");
+
+            if (required && passed == 0)
+            {
+                Assert.Fail(
+                    "INTEROP_REQUIRE_ECC is set but no ECC security " +
+                    "policy test established a session against the C server. " +
+                    "The open62541 ECC implementation is not being tested. " +
+                    "Check that INTEROP_ECC_CERT_DIR is set and the C server " +
+                    "logs 'Added ECC policy' on startup.");
+            }
         }
 
         private async Task<ConfiguredEndpoint> GetEndpointAsync(bool useSecurity)
@@ -257,47 +289,63 @@ namespace Opc.Ua.Interop.Tests
         {
             await ConnectWithSecurityPolicyAsync(
                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256",
-                "ECC_nistP256").ConfigureAwait(false);
+                "ECC_nistP256", isEcc: true).ConfigureAwait(false);
         }
 
         [Test, Order(31)]
+        public async Task ConnectWithSecurityEccNistP256AesGcm()
+        {
+            await ConnectWithSecurityPolicyAsync(
+                "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256_AesGcm",
+                "ECC_nistP256_AesGcm", isEcc: true).ConfigureAwait(false);
+        }
+
+        [Test, Order(32)]
+        public async Task ConnectWithSecurityEccNistP256ChaChaPoly()
+        {
+            await ConnectWithSecurityPolicyAsync(
+                "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256_ChaChaPoly",
+                "ECC_nistP256_ChaChaPoly", isEcc: true).ConfigureAwait(false);
+        }
+
+        [Test, Order(33)]
         public async Task ConnectWithSecurityEccNistP384()
         {
             await ConnectWithSecurityPolicyAsync(
                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP384",
-                "ECC_nistP384").ConfigureAwait(false);
+                "ECC_nistP384", isEcc: true).ConfigureAwait(false);
         }
 
-        [Test, Order(32)]
+        [Test, Order(34)]
         public async Task ConnectWithSecurityEccBrainpoolP256r1()
         {
             await ConnectWithSecurityPolicyAsync(
                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP256r1",
-                "ECC_brainpoolP256r1").ConfigureAwait(false);
+                "ECC_brainpoolP256r1", isEcc: true).ConfigureAwait(false);
         }
 
-        [Test, Order(33)]
+        [Test, Order(35)]
         public async Task ConnectWithSecurityEccBrainpoolP384r1()
         {
             await ConnectWithSecurityPolicyAsync(
                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP384r1",
-                "ECC_brainpoolP384r1").ConfigureAwait(false);
+                "ECC_brainpoolP384r1", isEcc: true).ConfigureAwait(false);
         }
 
-        [Test, Order(34)]
+        [Test, Order(36)]
         public async Task ConnectWithSecurityEccCurve25519()
         {
             await ConnectWithSecurityPolicyAsync(
                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve25519",
-                "ECC_curve25519").ConfigureAwait(false);
+                "ECC_curve25519", isEcc: true).ConfigureAwait(false);
         }
 
-        [Test, Order(35)]
+        [Test, Order(37)]
         public async Task ConnectWithSecurityEccCurve448()
         {
             await ConnectWithSecurityPolicyAsync(
                 "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve448",
-                "ECC_curve448").ConfigureAwait(false);
+                "ECC_curve448", isEcc: true).ConfigureAwait(false);
         }
 
         [Test, Order(20)]
@@ -454,9 +502,11 @@ namespace Opc.Ua.Interop.Tests
             return null;
         }
 
-        // Helper: connect with a given security policy (T-5/6/7)
+        // When isEcc, count successful sessions for the safety net.
+        // Curves the C server does not offer (e.g. curve25519 on mbedTLS)
+        // or the .NET SDK cannot connect to still IGNORE gracefully.
         private async Task ConnectWithSecurityPolicyAsync(
-            string policyUri, string policyName)
+            string policyUri, string policyName, bool isEcc = false)
         {
             var secureEndpoint = await FindSecureEndpointAsync(policyUri)
                 .ConfigureAwait(false);
@@ -518,6 +568,14 @@ namespace Opc.Ua.Interop.Tests
                 TestContext.Out.WriteLine(
                     $"Secure session established with {session.Endpoint.SecurityPolicyUri}");
 
+                if (isEcc)
+                {
+                    lock (s_eccLock)
+                    {
+                        s_eccTestsPassed++;
+                    }
+                }
+
                 await session.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
@@ -540,7 +598,8 @@ namespace Opc.Ua.Interop.Tests
                         out var curve, out var hashAlg))
                     continue;
 
-                var existing = await certId.Find(true).ConfigureAwait(false);
+                var existing = await certId.FindAsync(true, telemetry: _telemetry)
+                    .ConfigureAwait(false);
                 if (existing != null && existing.HasPrivateKey)
                 {
                     TestContext.Out.WriteLine(
@@ -655,7 +714,7 @@ namespace Opc.Ua.Interop.Tests
                 DateTimeOffset.UtcNow.AddYears(1));
 
             // Re-import so the private key is exportable
-            return new X509Certificate2(
+            return X509CertificateLoader.LoadPkcs12(
                 cert.Export(X509ContentType.Pfx, (string?)null),
                 (string?)null,
                 X509KeyStorageFlags.Exportable);

--- a/tests/interop/interop_server.c
+++ b/tests/interop/interop_server.c
@@ -250,10 +250,10 @@ int main(int argc, char *argv[]) {
         goto cleanup;
 
     /* --- ECC security policies (optional) ---
-     * ECC policy APIs are only available with OpenSSL, LibreSSL or
-     * mbedTLS >= 3.0.  Guard with the same condition as the
-     * implementation in ua_config_default.c. */
-#if defined(UA_ENABLE_ENCRYPTION_OPENSSL) || defined(UA_ENABLE_ENCRYPTION_LIBRESSL) || \
+     * The ECC policy APIs are only available with OpenSSL or mbedTLS >= 3.0.
+     * Guard with the same condition as the implementation in
+     * ua_config_default.c. */
+#if defined(UA_ENABLE_ENCRYPTION_OPENSSL) || \
     (defined(UA_ENABLE_ENCRYPTION_MBEDTLS) && defined(MBEDTLS_VERSION_NUMBER) && \
      MBEDTLS_VERSION_NUMBER >= 0x03000000)
     {
@@ -261,25 +261,34 @@ int main(int argc, char *argv[]) {
         if(eccDir) {
             struct {
                 const char *curve;
+                const char *certName;  /* cert/key file stem; defaults to curve */
                 UA_StatusCode (*addPolicy)(UA_ServerConfig *,
                                           const UA_ByteString *,
                                           const UA_ByteString *);
             } eccPolicies[] = {
-                {"nistP256",        UA_ServerConfig_addSecurityPolicyEccNistP256},
-                {"nistP384",        UA_ServerConfig_addSecurityPolicyEccNistP384},
-                {"brainpoolP256r1", UA_ServerConfig_addSecurityPolicyEccBrainpoolP256r1},
-                {"brainpoolP384r1", UA_ServerConfig_addSecurityPolicyEccBrainpoolP384r1},
-                {"curve25519",      UA_ServerConfig_addSecurityPolicyEccCurve25519},
-                {"curve448",        UA_ServerConfig_addSecurityPolicyEccCurve448}
+                {"nistP256",            "nistP256", UA_ServerConfig_addSecurityPolicyEccNistP256},
+/* The AEAD (AesGcm/ChaChaPoly) and Curve25519/448 policies are only
+ * implemented in the OpenSSL backend. */
+#if defined(UA_ENABLE_ENCRYPTION_OPENSSL)
+                {"nistP256_AesGcm",     "nistP256", UA_ServerConfig_addSecurityPolicyEccNistP256AesGcm},
+                {"nistP256_ChaChaPoly", "nistP256", UA_ServerConfig_addSecurityPolicyEccNistP256ChaChaPoly},
+#endif
+                {"nistP384",            "nistP384", UA_ServerConfig_addSecurityPolicyEccNistP384},
+                {"brainpoolP256r1",     "brainpoolP256r1", UA_ServerConfig_addSecurityPolicyEccBrainpoolP256r1},
+                {"brainpoolP384r1",     "brainpoolP384r1", UA_ServerConfig_addSecurityPolicyEccBrainpoolP384r1},
+#if defined(UA_ENABLE_ENCRYPTION_OPENSSL)
+                {"curve25519",          "curve25519", UA_ServerConfig_addSecurityPolicyEccCurve25519},
+                {"curve448",            "curve448", UA_ServerConfig_addSecurityPolicyEccCurve448}
+#endif
             };
             size_t numEcc = sizeof(eccPolicies) / sizeof(eccPolicies[0]);
 
             for(size_t i = 0; i < numEcc; i++) {
                 char certPath[512], keyPath[512];
                 snprintf(certPath, sizeof(certPath),
-                         "%s/server_c_%s.cert.der", eccDir, eccPolicies[i].curve);
+                         "%s/server_c_%s.cert.der", eccDir, eccPolicies[i].certName);
                 snprintf(keyPath, sizeof(keyPath),
-                         "%s/server_c_%s.key.der", eccDir, eccPolicies[i].curve);
+                         "%s/server_c_%s.key.der", eccDir, eccPolicies[i].certName);
 
                 UA_ByteString eccCert = loadFile(certPath);
                 UA_ByteString eccKey  = loadFile(keyPath);

--- a/tests/interop/node-opcua/client.mjs
+++ b/tests/interop/node-opcua/client.mjs
@@ -454,16 +454,19 @@ async function t9() {
 }
 
 // ---------------------------------------------------------------------------
-// T-10..T-15: ECC Security Policies (expected to SKIP in node-opcua)
+// T-10..T-17: ECC Security Policies (expected to SKIP in node-opcua).
+// Labels and ordering match check_interop_client.c.
 // ---------------------------------------------------------------------------
 
 const eccPolicies = [
     { label: "T-10", name: "ECC_nistP256", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256" },
-    { label: "T-11", name: "ECC_nistP384", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP384" },
-    { label: "T-12", name: "ECC_brainpoolP256r1", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP256r1" },
-    { label: "T-13", name: "ECC_brainpoolP384r1", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP384r1" },
-    { label: "T-14", name: "ECC_curve25519", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve25519" },
-    { label: "T-15", name: "ECC_curve448", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve448" },
+    { label: "T-11", name: "ECC_nistP256_AesGcm", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256_AesGcm" },
+    { label: "T-12", name: "ECC_nistP256_ChaChaPoly", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP256_ChaChaPoly" },
+    { label: "T-13", name: "ECC_nistP384", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_nistP384" },
+    { label: "T-14", name: "ECC_brainpoolP256r1", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP256r1" },
+    { label: "T-15", name: "ECC_brainpoolP384r1", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_brainpoolP384r1" },
+    { label: "T-16", name: "ECC_curve25519", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve25519" },
+    { label: "T-17", name: "ECC_curve448", uri: "http://opcfoundation.org/UA/SecurityPolicy#ECC_curve448" },
 ];
 
 async function runEccTests() {

--- a/tools/ci/cross-sdk/interop_test.sh
+++ b/tools/ci/cross-sdk/interop_test.sh
@@ -176,9 +176,8 @@ if ! wait_for_server "localhost:$C_PORT"; then
     RESULT=1
 else
     echo "Running C interop client against C server (self-test)..."
-    # Only require ECC tests to pass when the server actually loaded
-    # ECC policies (e.g. not when built with mbedTLS < 3.0 which does
-    # not support ECC security policies).
+    # Set when the C server offers ECC. Honoured by both the C and .NET
+    # clients so neither side can silently skip all ECC tests.
     if grep -q "Added ECC policy" "$C_LOG"; then
         export INTEROP_REQUIRE_ECC=1
     fi
@@ -192,7 +191,6 @@ else
         echo "FAIL: Scenario A - C client self-test failed"
         RESULT=1
     fi
-    unset INTEROP_REQUIRE_ECC 2>/dev/null || true
 
     echo ""
     echo "Running .NET interop tests against C server..."
@@ -208,6 +206,7 @@ else
     fi
     unset OPCUA_INTEROP_SERVER_URL
     unset OPCUA_INTEROP_CERT_DIR
+    unset INTEROP_REQUIRE_ECC 2>/dev/null || true
 
     echo ""
     echo "Running node-opcua interop client against C server..."


### PR DESCRIPTION
Cover the new ECC_nistP256_AesGcm/_ChaChaPoly policies in C server, C client and .NET tests and fail instead of silently skipping when no ECC session is established.
