### PR TITLE
[Review] Fix the checks for writing the StatusCode and SourceTimestamp of a value

### DIFF
--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1780,8 +1780,12 @@ copyAttributeIntoNode(UA_Server *server, UA_Session *session,
                 retval = UA_STATUSCODE_BADUSERACCESSDENIED;
                 break;
             }
-            /* Writing the StatusCode requires the StatusWrite bit */
-            if(wvalue->value.hasStatus) {
+            /* Writing a StatusCode different to "Good" requires the
+             * StatusWrite bit (see OPC specification 10000-3: AccessLevelType;
+             * https://reference.opcfoundation.org/specs/OPC-10000-3/v1.05.06/8.57)
+             */
+            if(   (wvalue->value.hasStatus)
+               && (wvalue->value.status != UA_STATUSCODE_GOOD)) {
                 accessLevel = getAccessLevel(server, session, &node->variableNode);
                 if(!(accessLevel & UA_ACCESSLEVELMASK_STATUSWRITE)) {
                     retval = UA_STATUSCODE_BADWRITENOTSUPPORTED;
@@ -1793,8 +1797,13 @@ copyAttributeIntoNode(UA_Server *server, UA_Session *session,
                     break;
                 }
             }
-            /* Writing the SourceTimestamp requires the TimestampWrite bit */
-            if(wvalue->value.hasSourceTimestamp) {
+            /* Writing a SourceTimestamp different to NULL requires the
+             * TimestampWrite bit (see OPC specification 10000-3:
+             * AccessLevelType;
+             * https://reference.opcfoundation.org/specs/OPC-10000-3/v1.05.06/8.57)
+             */
+            if(   (wvalue->value.hasSourceTimestamp)
+               && (wvalue->value.sourceTimestamp != (UA_DateTime)(0))) {
                 accessLevel = getAccessLevel(server, session, &node->variableNode);
                 if(!(accessLevel & UA_ACCESSLEVELMASK_TIMESTAMPWRITE)) {
                     retval = UA_STATUSCODE_BADWRITENOTSUPPORTED;


### PR DESCRIPTION
Commit 59d47fc introduced checks for writing the StatusCode and SourceTimestamp of a Variable. However, these checks are currently implemented too restrictive, as they only allow writing these fields when the corresponding AccessLevelType bits are set.

The OPC specification, however, states for the AccessLevelType bits:
- `StatusWrite`: "Indicates if the current StatusCode of the value is writeable (*0 means only StatusCode Good is writeable*, 1 means any StatusCode is writeable)."
- `TimestampWrite`: "Indicates if the current SourceTimestamp is writeable (*0 means only null timestamps are writeable*, 1 means any timestamp value is writeable)."

(see https://reference.opcfoundation.org/specs/OPC-10000-3/v1.05.06/8.57)

Thus, according to the specification, writing a StatusCode of "Good" and a "null" timestamp must always be possible, even when the `StatusWrite` and `TimestampWrite` are not set.

This PR completes the checks such that they behave in an OPC-conforming way and fixes issue #8062.