### PR TITLE
fix(server): return runtime auditing state in Server.Auditing

### DIFF
--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -473,7 +473,7 @@ readAuditing(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext
     UA_Boolean *boolean = UA_Boolean_new();
     if(!boolean)
         return UA_STATUSCODE_BADOUTOFMEMORY;
-    *boolean = false;
+    *boolean = server->config.auditingEnabled;
     value->value.data = boolean;
     value->value.arrayDimensionsSize = 0;
     value->value.arrayDimensions = NULL;
@@ -1411,4 +1411,3 @@ initNS0_dataSources(UA_Server *server) {
 
     return UA_STATUSCODE_GOOD;
 }
-

--- a/tests/server/check_server_ns0_diagnostics.c
+++ b/tests/server/check_server_ns0_diagnostics.c
@@ -184,7 +184,17 @@ START_TEST(read_auditing) {
     UA_StatusCode res = readNodeValue(
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_AUDITING), &out);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
-    ck_assert(out.type == &UA_TYPES[UA_TYPES_BOOLEAN]);
+    ck_assert(UA_Variant_hasScalarType(&out, &UA_TYPES[UA_TYPES_BOOLEAN]));
+    ck_assert_uint_eq(*(UA_Boolean*)out.data, false);
+    UA_Variant_clear(&out);
+
+    UA_Server_getConfig(server)->auditingEnabled = true;
+
+    UA_Variant_init(&out);
+    res = readNodeValue(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_AUDITING), &out);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert(UA_Variant_hasScalarType(&out, &UA_TYPES[UA_TYPES_BOOLEAN]));
+    ck_assert_uint_eq(*(UA_Boolean*)out.data, true);
     UA_Variant_clear(&out);
 } END_TEST
 


### PR DESCRIPTION
This PR updates `Server.Auditing` to reflect the runtime auditing configuration.

Previously, `readAuditing()` always returned `false`, even when auditing was enabled in the server configuration. This could make the standard `Server.Auditing` variable report a disabled auditing state while the server was actually configured to emit audit events.

The OPC UA Part 5 definition of `Server.Auditing` says that it is a Boolean specifying whether the Server is currently generating audit events, and that it shall be set to `TRUE` if the Server generates audit events, otherwise `false`. This change returns `server->config.auditingEnabled` instead of a constant `false`, so the exposed state matches the runtime configuration more closely.

A regression test is included to verify that `Server.Auditing` returns `false` with the default configuration and `true` after auditing is enabled.