### PR TITLE
fix(rbac): use RoleType method objectId instead of sessionId

### DIFF
--- a/src/server/ua_server_ns0_rbac.c
+++ b/src/server/ua_server_ns0_rbac.c
@@ -303,9 +303,9 @@ removeRoleMethodCallback(UA_Server *server,
 
 static UA_StatusCode
 addIdentityMethodCallback(UA_Server *server,
-                          const UA_NodeId *objectId, void *objectContext,
+                          const UA_NodeId *sessionId, void *sessionContext,
                           const UA_NodeId *methodId, void *methodContext,
-                          const UA_NodeId *inputType, void *inputContext,
+                          const UA_NodeId *objectId, void *objectContext,
                           size_t inputSize, const UA_Variant *input,
                           size_t outputSize, UA_Variant *output) {
     if(inputSize != 1 || input[0].type != &UA_TYPES[UA_TYPES_EXTENSIONOBJECT])
@@ -348,9 +348,9 @@ addIdentityMethodCallback(UA_Server *server,
 
 static UA_StatusCode
 removeIdentityMethodCallback(UA_Server *server,
-                             const UA_NodeId *objectId, void *objectContext,
+                             const UA_NodeId *sessionId, void *sessionContext,
                              const UA_NodeId *methodId, void *methodContext,
-                             const UA_NodeId *inputType, void *inputContext,
+                             const UA_NodeId *objectId, void *objectContext,
                              size_t inputSize, const UA_Variant *input,
                              size_t outputSize, UA_Variant *output) {
     if(inputSize != 1 || input[0].type != &UA_TYPES[UA_TYPES_EXTENSIONOBJECT])
@@ -397,9 +397,9 @@ removeIdentityMethodCallback(UA_Server *server,
 
 static UA_StatusCode
 addApplicationMethodCallback(UA_Server *server,
-                             const UA_NodeId *objectId, void *objectContext,
+                             const UA_NodeId *sessionId, void *sessionContext,
                              const UA_NodeId *methodId, void *methodContext,
-                             const UA_NodeId *inputType, void *inputContext,
+                             const UA_NodeId *objectId, void *objectContext,
                              size_t inputSize, const UA_Variant *input,
                              size_t outputSize, UA_Variant *output) {
     if(inputSize != 1 || input[0].type != &UA_TYPES[UA_TYPES_STRING])
@@ -433,9 +433,9 @@ addApplicationMethodCallback(UA_Server *server,
 
 static UA_StatusCode
 removeApplicationMethodCallback(UA_Server *server,
-                                const UA_NodeId *objectId, void *objectContext,
+                                const UA_NodeId *sessionId, void *sessionContext,
                                 const UA_NodeId *methodId, void *methodContext,
-                                const UA_NodeId *inputType, void *inputContext,
+                                const UA_NodeId *objectId, void *objectContext,
                                 size_t inputSize, const UA_Variant *input,
                                 size_t outputSize, UA_Variant *output) {
     if(inputSize != 1 || input[0].type != &UA_TYPES[UA_TYPES_STRING])
@@ -473,9 +473,9 @@ removeApplicationMethodCallback(UA_Server *server,
 
 static UA_StatusCode
 addEndpointMethodCallback(UA_Server *server,
-                          const UA_NodeId *objectId, void *objectContext,
+                          const UA_NodeId *sessionId, void *sessionContext,
                           const UA_NodeId *methodId, void *methodContext,
-                          const UA_NodeId *inputType, void *inputContext,
+                          const UA_NodeId *objectId, void *objectContext,
                           size_t inputSize, const UA_Variant *input,
                           size_t outputSize, UA_Variant *output) {
     if(inputSize != 1 || input[0].type != &UA_TYPES[UA_TYPES_EXTENSIONOBJECT])
@@ -514,9 +514,9 @@ addEndpointMethodCallback(UA_Server *server,
 
 static UA_StatusCode
 removeEndpointMethodCallback(UA_Server *server,
-                             const UA_NodeId *objectId, void *objectContext,
+                             const UA_NodeId *sessionId, void *sessionContext,
                              const UA_NodeId *methodId, void *methodContext,
-                             const UA_NodeId *inputType, void *inputContext,
+                             const UA_NodeId *objectId, void *objectContext,
                              size_t inputSize, const UA_Variant *input,
                              size_t outputSize, UA_Variant *output) {
     if(inputSize != 1 || input[0].type != &UA_TYPES[UA_TYPES_EXTENSIONOBJECT])


### PR DESCRIPTION
## Summary

Fix the `RoleType` management method callbacks to use the called role `objectId` instead of the `sessionId`.

The bug is caused by several callbacks in `src/server/ua_server_ns0_rbac.c` using the second `UA_MethodCallback` parameter as if it were the target role object id. According to `UA_MethodCallback`, however, the second parameter is `sessionId`, while the called object is passed as the sixth parameter.

From `include/open62541/server.h`:

```c
typedef UA_StatusCode
(*UA_MethodCallback)(UA_Server *server,
                     const UA_NodeId *sessionId, void *sessionContext,
                     const UA_NodeId *methodId, void *methodContext,
                     const UA_NodeId *objectId, void *objectContext,
                     size_t inputSize, const UA_Variant *input,
                     size_t outputSize, UA_Variant *output);
```

Affected code before this change:

```c
static UA_StatusCode
addIdentityMethodCallback(UA_Server *server,
                          const UA_NodeId *objectId, void *objectContext,
                          const UA_NodeId *methodId, void *methodContext,
                          const UA_NodeId *inputType, void *inputContext,
                          size_t inputSize, const UA_Variant *input,
                          size_t outputSize, UA_Variant *output) {
    ...
    UA_Role role;
    UA_StatusCode res = UA_Server_getRoleById(server, *objectId, &role);
    ...
}
```

In this implementation, `objectId` actually refers to the second callback parameter, which is the `sessionId`. As a result, remote calls to `AddIdentity`, `RemoveIdentity`, `AddApplication`, `RemoveApplication`, `AddEndpoint`, and `RemoveEndpoint` could look up the wrong role or fail with `Bad_NotFound`.

## Changes

- update the `RoleType` method callback signatures in `src/server/ua_server_ns0_rbac.c`
- use the correct `objectId` / `objectContext` callback parameters