### PR TITLE
fix(pubsub): Guard DataSetPayload JSON field count against UA_UInt16 overflow

### DIFF
--- a/src/pubsub/ua_pubsub_networkmessage_json.c
+++ b/src/pubsub/ua_pubsub_networkmessage_json.c
@@ -286,6 +286,8 @@ DataSetPayload_decodeJsonInternal(void* dsmP, const UA_DataType *type,
     }
 
     size_t length = (size_t)parseCtx->tokenArray[parseCtx->index].size;
+    if(length > UA_UINT16_MAX)
+        return UA_STATUSCODE_BADDECODINGERROR;
     UA_String *fieldNames = (UA_String*)UA_calloc(length, sizeof(UA_String));
     dsm->data.keyFrameData.fieldNames = fieldNames;
     dsm->data.keyFrameData.fieldCount = (UA_UInt16)length;


### PR DESCRIPTION
The JSON decoder for PubSub DataSetPayload casts the token count to UA_UInt16 without bounds checking. If a malicious or malformed message provides more than UA_UINT16_MAX/2 tokens, the cast silently truncates to a smaller value while the actual allocation uses the full (large) length. This can lead to heap buffer overflows and memory corruption.

Add an explicit bounds check before the cast, rejecting messages with a field count that exceeds UA_UINT16_MAX.

See: open62541-SA-2026-0001