### PR TITLE
fix(server): Enforce default message and chunk size limits to prevent DoS

### DIFF
--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -1114,6 +1114,15 @@ createServerSecureChannel(UA_BinaryProtocolManager *bpm, UA_ConnectionManager *c
     if(connConfig.sendBufferSize == 0)
         connConfig.sendBufferSize = 1 << 16; /* 64kB */
 
+    if(connConfig.localMaxMessageSize == 0)
+        connConfig.localMaxMessageSize = 1 << 29; /* 512 MB */
+    if(connConfig.remoteMaxMessageSize == 0)
+        connConfig.remoteMaxMessageSize = 1 << 29; /* 512 MB */
+    if(connConfig.localMaxChunkCount == 0)
+        connConfig.localMaxChunkCount = 1 << 14; /* 16384 */
+    if(connConfig.remoteMaxChunkCount == 0)
+        connConfig.remoteMaxChunkCount = 1 << 14; /* 16384 */
+
     /* Set up the new SecureChannel */
     UA_SecureChannel_init(&entry->channel);
     entry->channel.config = connConfig;


### PR DESCRIPTION
When tcpMaxMsgSize or tcpMaxChunks are configured as 0, the server treats the limit as truly unbounded. A remote attacker can exploit this by sending arbitrarily large messages or an unbounded number of chunks, exhausting server memory and causing a denial of service.

Set safe defaults (512 MB per message, 16384 chunks) whenever the configured value is zero, mirroring the existing behaviour for recv/sendBufferSize.

See: open62541-SA-2026-0002