### PR TITLE
feat(monitored items): provide sampling interval to the application

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -2418,6 +2418,32 @@ struct UA_ServerConfig {
                                           void *nodeContext,
                                           UA_UInt32 attibuteId,
                                           UA_Boolean removed);
+
+    /* Register MonitoredItem in Userland with sampling interval report
+     *
+     * Extended version of monitoredItemRegisterCallback
+     *
+     * @param server Allows the access to the server object
+     * @param sessionId The session id, represented as an node id
+     * @param sessionContext An optional pointer to user-defined data for the
+     *        specific data source
+     * @param nodeid Id of the node in question
+     * @param nodeidContext An optional pointer to user-defined data, associated
+     *        with the node in the nodestore. Note that, if the node has already
+     *        been removed, this value contains a NULL pointer.
+     * @param attributeId Identifies which attribute (value, data type etc.) is
+     *        monitored
+     * @param samplingInterval Sampling interval of the node id
+     * @param removed Determines if the MonitoredItem was removed or created. */
+
+    void (*monitoredItemRegisterCallbackEx)(UA_Server *server,
+                                            const UA_NodeId *sessionId,
+                                            void *sessionContext,
+                                            const UA_NodeId *nodeId,
+                                            void *nodeContext,
+                                            UA_UInt32 attibuteId,
+                                            UA_Double samplingInterval,
+                                            UA_Boolean removed);
 #endif
 
     /* PubSub

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -1302,6 +1302,19 @@ UA_MonitoredItem_register(UA_Server *server, UA_MonitoredItem *mon) {
                                                      targetContext,
                                                      mon->itemToMonitor.attributeId, false);
     }
+    /* Register the MonitoredItem in userland with the sampling interval */
+    if(server->config.monitoredItemRegisterCallbackEx) {
+        UA_Session *session = sub->session;
+        void *targetContext = NULL;
+        getNodeContext(server, mon->itemToMonitor.nodeId, &targetContext);
+        server->config.monitoredItemRegisterCallbackEx(server,
+                                                       session ? &session->sessionId : NULL,
+                                                       session ? session->context : NULL,
+                                                       &mon->itemToMonitor.nodeId,
+                                                       targetContext,
+                                                       mon->itemToMonitor.attributeId,
+                                                       mon->parameters.samplingInterval, false);
+    }
 }
 
 static void


### PR DESCRIPTION
### Summary
Currently (up to the openstack v1.5.3) `UA_ServerConfig` structure allows the application to be notified when a node is added (or removed) to a monitor items list. The signature is as follows :

```c
    /* Register MonitoredItem in Userland
     *
     * @param server Allows the access to the server object
     * @param sessionId The session id, represented as an node id
     * @param sessionContext An optional pointer to user-defined data for the
     *        specific data source
     * @param nodeid Id of the node in question
     * @param nodeidContext An optional pointer to user-defined data, associated
     *        with the node in the nodestore. Note that, if the node has already
     *        been removed, this value contains a NULL pointer.
     * @param attributeId Identifies which attribute (value, data type etc.) is
     *        monitored
     * @param removed Determines if the MonitoredItem was removed or created. */
    void (*monitoredItemRegisterCallback)(UA_Server *server,
                                          const UA_NodeId *sessionId,
                                          void *sessionContext,
                                          const UA_NodeId *nodeId,
                                          void *nodeContext,
                                          UA_UInt32 attibuteId,
                                          UA_Boolean removed);
```
here in the [HTML documentation](https://open62541.org/doc/1.5/server.html#server-configuration)

The current callback signature does not allows to notify the application about the sampling interval the node is monitored. This is a missing information that could be useful at application level.

So, the main idea is to propose a second API, called `monitoredItemRegisterCallbackEx` which acts as extension of the original one, providing this information to the application.

### Why this PR
This PR try to resolve some issues, like this: #5131 and the intent is to collect your feedback in order to be, I think, better implemented
