### PR TITLE
perf(el): Always allocate a static tx buffer to avoid per-send

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # overwritten with more detailed information if git is available.
 set(OPEN62541_VER_MAJOR 1)
 set(OPEN62541_VER_MINOR 5)
-set(OPEN62541_VER_PATCH 4)
+set(OPEN62541_VER_PATCH 5)
 set(OPEN62541_VER_LABEL "") # like "-rc1" or "-g4538abcd" or "-g4538abcd-dirty"
 set(OPEN62541_VER_COMMIT "unknown-commit")
 

--- a/arch/common/eventloop_mqtt.c
+++ b/arch/common/eventloop_mqtt.c
@@ -784,13 +784,13 @@ MQTT_sendWithConnection(UA_ConnectionManager *cm, uintptr_t connectionId,
     MQTTConnectionManager *mcm = (MQTTConnectionManager*)cm;
     MQTTTopicConnection *tc = findTopicConnection(mcm, connectionId);
     if(!tc) {
-        UA_ByteString_clear(buf);
+        MQTT_freeNetworkBuffer(cm, connectionId, buf);
         return UA_STATUSCODE_BADINTERNALERROR;
     }
 
     MQTTBrokerConnection *bc = tc->brokerConnection;
     if(bc->tcpConnectionState != UA_CONNECTIONSTATE_ESTABLISHED) {
-        UA_ByteString_clear(buf);
+        MQTT_freeNetworkBuffer(cm, connectionId, buf);
         return UA_STATUSCODE_BADCONNECTIONREJECTED;
     }
 
@@ -803,7 +803,7 @@ MQTT_sendWithConnection(UA_ConnectionManager *cm, uintptr_t connectionId,
                                        buf->data, buf->length, 0);
     if(UA_LIKELY(res == MQTT_OK))
         res = (enum MQTTErrors)__mqtt_send(&bc->client);
-    UA_ByteString_clear(buf);
+    MQTT_freeNetworkBuffer(cm, connectionId, buf);
     return (res == MQTT_OK) ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADINTERNALERROR;
 }
 

--- a/arch/lwip/eventloop_lwip.c
+++ b/arch/lwip/eventloop_lwip.c
@@ -690,10 +690,9 @@ UA_EventLoopLWIP_allocNetworkBuffer(UA_ConnectionManager *cm,
                                      UA_ByteString *buf,
                                      size_t bufSize) {
     UA_LWIPConnectionManager *pcm = (UA_LWIPConnectionManager*)cm;
-    if(pcm->txBuffer.length == 0)
-        return UA_ByteString_allocBuffer(buf, bufSize);
+    /* Reuse the static tx buffer; fall back to allocation for larger messages. */
     if(pcm->txBuffer.length < bufSize)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+        return UA_ByteString_allocBuffer(buf, bufSize);
     *buf = pcm->txBuffer;
     buf->length = bufSize;
     return UA_STATUSCODE_GOOD;
@@ -725,13 +724,19 @@ UA_EventLoopLWIP_allocateStaticBuffers(UA_LWIPConnectionManager *pcm) {
         res = UA_ByteString_allocBuffer(&pcm->rxBuffer, rxBufSize);
     }
 
-    const UA_UInt32 *txBufSize = (const UA_UInt32 *)
+    /* Default the tx buffer to the rx size so a dedicated static send buffer
+     * always exists. This avoids a malloc/free on every send without reusing
+     * the rx buffer (which may still hold unprocessed received data). */
+    UA_UInt32 txBufSize = rxBufSize;
+    const UA_UInt32 *configTxBufSize = (const UA_UInt32 *)
         UA_KeyValueMap_getScalar(&pcm->cm.eventSource.params,
                                  UA_QUALIFIEDNAME(0, "send-bufsize"),
                                  &UA_TYPES[UA_TYPES_UINT32]);
-    if(txBufSize && pcm->txBuffer.length != *txBufSize) {
+    if(configTxBufSize)
+        txBufSize = *configTxBufSize;
+    if(pcm->txBuffer.length != txBufSize) {
         UA_ByteString_clear(&pcm->txBuffer);
-        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, *txBufSize);
+        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, txBufSize);
     }
     return res;
 }

--- a/arch/posix/eventloop_posix.c
+++ b/arch/posix/eventloop_posix.c
@@ -624,10 +624,9 @@ UA_EventLoopPOSIX_allocNetworkBuffer(UA_ConnectionManager *cm,
                                      UA_ByteString *buf,
                                      size_t bufSize) {
     UA_POSIXConnectionManager *pcm = (UA_POSIXConnectionManager*)cm;
-    if(pcm->txBuffer.length == 0)
-        return UA_ByteString_allocBuffer(buf, bufSize);
+    /* Reuse the static tx buffer; fall back to allocation for larger messages. */
     if(pcm->txBuffer.length < bufSize)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+        return UA_ByteString_allocBuffer(buf, bufSize);
     *buf = pcm->txBuffer;
     buf->length = bufSize;
     return UA_STATUSCODE_GOOD;
@@ -659,13 +658,19 @@ UA_EventLoopPOSIX_allocateStaticBuffers(UA_POSIXConnectionManager *pcm) {
         res = UA_ByteString_allocBuffer(&pcm->rxBuffer, rxBufSize);
     }
 
-    const UA_UInt32 *txBufSize = (const UA_UInt32 *)
+    /* Default the tx buffer to the rx size so a dedicated static send buffer
+     * always exists. This avoids a malloc/free on every send without reusing
+     * the rx buffer (which may still hold unprocessed received data). */
+    UA_UInt32 txBufSize = rxBufSize;
+    const UA_UInt32 *configTxBufSize = (const UA_UInt32 *)
         UA_KeyValueMap_getScalar(&pcm->cm.eventSource.params,
                                  UA_QUALIFIEDNAME(0, "send-bufsize"),
                                  &UA_TYPES[UA_TYPES_UINT32]);
-    if(txBufSize && pcm->txBuffer.length != *txBufSize) {
+    if(configTxBufSize)
+        txBufSize = *configTxBufSize;
+    if(pcm->txBuffer.length != txBufSize) {
         UA_ByteString_clear(&pcm->txBuffer);
-        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, *txBufSize);
+        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, txBufSize);
     }
     return res;
 }

--- a/arch/zephyr/eventloop_zephyr.c
+++ b/arch/zephyr/eventloop_zephyr.c
@@ -460,10 +460,9 @@ UA_StatusCode
 UA_EventLoopZephyr_allocNetworkBuffer(UA_ConnectionManager *cm, uintptr_t connectionId,
                                       UA_ByteString *buf, size_t bufSize) {
     UA_ZephyrConnectionManager *pcm = (UA_ZephyrConnectionManager *)cm;
-    if(pcm->txBuffer.length == 0)
-        return UA_ByteString_allocBuffer(buf, bufSize);
+    /* Reuse the static tx buffer; fall back to allocation for larger messages. */
     if(pcm->txBuffer.length < bufSize)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+        return UA_ByteString_allocBuffer(buf, bufSize);
     *buf = pcm->txBuffer;
     buf->length = bufSize;
     return UA_STATUSCODE_GOOD;
@@ -493,12 +492,18 @@ UA_EventLoopZephyr_allocateStaticBuffers(UA_ZephyrConnectionManager *pcm) {
         res = UA_ByteString_allocBuffer(&pcm->rxBuffer, rxBufSize);
     }
 
-    const UA_UInt32 *txBufSize = (const UA_UInt32 *)UA_KeyValueMap_getScalar(
+    /* Default the tx buffer to the rx size so a dedicated static send buffer
+     * always exists. This avoids a malloc/free on every send without reusing
+     * the rx buffer (which may still hold unprocessed received data). */
+    UA_UInt32 txBufSize = rxBufSize;
+    const UA_UInt32 *configTxBufSize = (const UA_UInt32 *)UA_KeyValueMap_getScalar(
         &pcm->cm.eventSource.params, UA_QUALIFIEDNAME(0, "send-bufsize"),
         &UA_TYPES[UA_TYPES_UINT32]);
-    if(txBufSize && pcm->txBuffer.length != *txBufSize) {
+    if(configTxBufSize)
+        txBufSize = *configTxBufSize;
+    if(pcm->txBuffer.length != txBufSize) {
         UA_ByteString_clear(&pcm->txBuffer);
-        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, *txBufSize);
+        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, txBufSize);
     }
     return res;
 }

--- a/include/open62541/plugin/eventloop.h
+++ b/include/open62541/plugin/eventloop.h
@@ -505,9 +505,12 @@ UA_EventLoop_new_POSIX(const UA_Logger *logger);
  *    (default 64kB).
  *
  * 0:send-bufsize [uint32]
- *    Size of the statically allocated buffer for sending messages. This then
- *    becomes an upper bound for the message size. If undefined a fresh buffer
- *    is allocated for every `allocNetworkBuffer` (default: no buffer).
+ *    Size of the statically allocated buffer for sending messages. The buffer
+ *    is reused for every `allocNetworkBuffer` to avoid a heap allocation per
+ *    message; a message larger than the buffer falls back to a fresh
+ *    allocation. A dedicated send buffer is used (never the recv buffer), so
+ *    sending while received data is still being processed is safe. If
+ *    undefined, the send buffer defaults to the recv-bufsize.
  *
  * **Open Connection Parameters:**
  *
@@ -561,9 +564,12 @@ UA_ConnectionManager_new_POSIX_TCP(const UA_String eventSourceName);
  *    (default 64kB).
  *
  * 0:send-bufsize [uint32]
- *    Size of the statically allocated buffer for sending messages. This then
- *    becomes an upper bound for the message size. If undefined a fresh buffer
- *    is allocated for every `allocNetworkBuffer` (default: no buffer).
+ *    Size of the statically allocated buffer for sending messages. The buffer
+ *    is reused for every `allocNetworkBuffer` to avoid a heap allocation per
+ *    message; a message larger than the buffer falls back to a fresh
+ *    allocation. A dedicated send buffer is used (never the recv buffer), so
+ *    sending while received data is still being processed is safe. If
+ *    undefined, the send buffer defaults to the recv-bufsize.
  *
  * **Open Connection Parameters:**
  *
@@ -636,9 +642,12 @@ UA_ConnectionManager_new_POSIX_UDP(const UA_String eventSourceName);
  *    (default 64kB).
  *
  * 0:send-bufsize [uint32]
- *    Size of the statically allocated buffer for sending messages. This then
- *    becomes an upper bound for the message size. If undefined a fresh buffer
- *    is allocated for every `allocNetworkBuffer` (default: no buffer).
+ *    Size of the statically allocated buffer for sending messages. The buffer
+ *    is reused for every `allocNetworkBuffer` to avoid a heap allocation per
+ *    message; a message larger than the buffer falls back to a fresh
+ *    allocation. A dedicated send buffer is used (never the recv buffer), so
+ *    sending while received data is still being processed is safe. If
+ *    undefined, the send buffer defaults to the recv-bufsize.
  *
  * **Open Connection Parameters:**
  *
@@ -860,9 +869,12 @@ UA_EventLoop_new_LWIP(const UA_Logger *logger, UA_EventLoopConfiguration *config
  *    (default 64kB).
  *
  * 0:send-bufsize [uint32]
- *    Size of the statically allocated buffer for sending messages. This then
- *    becomes an upper bound for the message size. If undefined a fresh buffer
- *    is allocated for every `allocNetworkBuffer` (default: no buffer).
+ *    Size of the statically allocated buffer for sending messages. The buffer
+ *    is reused for every `allocNetworkBuffer` to avoid a heap allocation per
+ *    message; a message larger than the buffer falls back to a fresh
+ *    allocation. A dedicated send buffer is used (never the recv buffer), so
+ *    sending while received data is still being processed is safe. If
+ *    undefined, the send buffer defaults to the recv-bufsize.
  *
  * **Open Connection Parameters:**
  *
@@ -916,9 +928,12 @@ UA_ConnectionManager_new_LWIP_TCP(const UA_String eventSourceName);
  *    (default 64kB).
  *
  * 0:send-bufsize [uint32]
- *    Size of the statically allocated buffer for sending messages. This then
- *    becomes an upper bound for the message size. If undefined a fresh buffer
- *    is allocated for every `allocNetworkBuffer` (default: no buffer).
+ *    Size of the statically allocated buffer for sending messages. The buffer
+ *    is reused for every `allocNetworkBuffer` to avoid a heap allocation per
+ *    message; a message larger than the buffer falls back to a fresh
+ *    allocation. A dedicated send buffer is used (never the recv buffer), so
+ *    sending while received data is still being processed is safe. If
+ *    undefined, the send buffer defaults to the recv-bufsize.
  *
  * **Open Connection Parameters:**
  *

--- a/tests/check_eventloop_tcp.c
+++ b/tests/check_eventloop_tcp.c
@@ -231,11 +231,64 @@ START_TEST(connectTCP) {
     el = NULL;
 } END_TEST
 
+/* The connection manager keeps a static send buffer (defaulting to the
+ * recv-bufsize). allocNetworkBuffer reuses it instead of allocating per send,
+ * and falls back to a fresh allocation for messages larger than the buffer. */
+START_TEST(staticSendBuffer) {
+    setupEL();
+
+    /* Configure a small static send buffer */
+    UA_UInt32 sendBufSize = 16;
+    UA_KeyValueMap_setScalar(&cm->eventSource.params, UA_QUALIFIEDNAME(0, "send-bufsize"),
+                             &sendBufSize, &UA_TYPES[UA_TYPES_UINT32]);
+
+    el->start(el);
+    /* Run once so the ConnectionManager eventSource starts its static buffers */
+    el->run(el, 1);
+
+    /* A message that fits is served from the static send buffer */
+    UA_ByteString a = UA_BYTESTRING_NULL;
+    UA_StatusCode retval = cm->allocNetworkBuffer(cm, 0, &a, sendBufSize);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(a.length, sendBufSize);
+    UA_Byte *reused = a.data;
+    cm->freeNetworkBuffer(cm, 0, &a);
+
+    /* The next fitting allocation reuses the same static buffer (no per-send
+     * allocation) */
+    UA_ByteString b = UA_BYTESTRING_NULL;
+    retval = cm->allocNetworkBuffer(cm, 0, &b, sendBufSize);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_ptr_eq(b.data, reused);
+    cm->freeNetworkBuffer(cm, 0, &b);
+
+    /* A message larger than the static buffer falls back to a fresh allocation
+     * instead of failing with BadOutOfMemory */
+    UA_ByteString big = UA_BYTESTRING_NULL;
+    retval = cm->allocNetworkBuffer(cm, 0, &big, sendBufSize * 64);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(big.length, sendBufSize * 64);
+    cm->freeNetworkBuffer(cm, 0, &big);
+
+    /* Stop the EventLoop */
+    int iteration = 0;
+    el->stop(el);
+    while(el->state != UA_EVENTLOOPSTATE_STOPPED && iteration < 10) {
+        UA_DateTime next = el->run(el, 1);
+        UA_fakeSleep((UA_UInt32)((next - UA_DateTime_now()) / UA_DATETIME_MSEC));
+        iteration++;
+    }
+    ck_assert(el->state == UA_EVENTLOOPSTATE_STOPPED);
+    el->free(el);
+    el = NULL;
+} END_TEST
+
 int main(void) {
     Suite *s  = suite_create("Test TCP EventLoop");
     TCase *tc = tcase_create("test cases");
     tcase_add_test(tc, listenTCP);
     tcase_add_test(tc, connectTCP);
+    tcase_add_test(tc, staticSendBuffer);
     suite_add_tcase(s, tc);
 
     SRunner *sr = srunner_create(s);


### PR DESCRIPTION
When send-bufsize isn't set, allocNetworkBuffer mallocs a fresh buffer on every
send. On small targets (we ran into this on an ESP32) the constant malloc/free
fragments the heap until sends start failing with BadOutOfMemory.

So just keep a static send buffer around, defaulting to the recv-bufsize, and
reuse it — with a malloc fallback for messages bigger than the buffer. It's a
separate buffer from the rx one on purpose: a response can be sent while a later
pipelined request still sits in the rx buffer, so reusing rx would corrupt it.
