### PR TITLE
fix(client): use getEndpointUrl in initConnect

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -2288,10 +2288,11 @@ initConnect(UA_Client *client) {
     UA_String path = UA_STRING_NULL;
     UA_UInt16 port = 4840;
 
-    res = UA_parseEndpointUrl(&client->config.endpointUrl, &hostname, &port, &path);
+    UA_String endpointUrl = getEndpointUrl(client);
+    res = UA_parseEndpointUrl(&endpointUrl, &hostname, &port, &path);
     if(res != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_NETWORK,
-                       "Endpoint URL is invalid: %S", client->config.endpointUrl);
+                       "Endpoint URL is invalid: %S", endpointUrl);
         setConnectStatus(client, res);
         return;
     }


### PR DESCRIPTION
initConnect parsed client->config.endpointUrl directly, ignoring an endpoint URL provided by discovery/reverse-connect. Every other connect path (HEL message, GetEndpoints request) already routes through getEndpointUrl, which prefers client->endpoint.endpointUrl when set. Use the helper here too so initConnect connects to the correct URL after a GetEndpoints/discovery exchange.

Supersedes the original PR #6973, which read client->config.endpointUrl instead of getEndpointUrl(client).