### PR TITLE
fix(tools): ignore build-* folders in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ doc_src/
 /src_generated/
 **/build
 **/build_*
+**/build-*
 /cmake-build*
 /tools/certs/certs/*
 Pipfile


### PR DESCRIPTION
The .gitignore already covers `**/build` and `**/build_*` but not folders using a dash separator such as `build-debug/` or `build-gds-current/`. Add `**/build-*` to match those.