### PR TITLE
fix(arch): static rx/tx buffer fast-path and sizing across eventloops

### DIFF
--- a/arch/common/eventloop_common.c
+++ b/arch/common/eventloop_common.c
@@ -53,3 +53,27 @@ UA_KeyValueRestriction_validate(const UA_Logger *logger, const char *logprefix,
 
     return UA_STATUSCODE_GOOD;
 }
+
+UA_StatusCode
+UA_EventLoopCommon_allocStaticBuffer(UA_KeyValueMap *params,
+                                     UA_QualifiedName name,
+                                     UA_UInt32 defaultSize,
+                                     UA_ByteString *buf) {
+    UA_StatusCode res = UA_STATUSCODE_GOOD;
+    UA_UInt32 bufSize = defaultSize;
+    const UA_UInt32 *configBufSize = (const UA_UInt32 *)
+        UA_KeyValueMap_getScalar(params, name, &UA_TYPES[UA_TYPES_UINT32]);
+    if(configBufSize)
+        bufSize = *configBufSize;
+    else
+        /* Write the resolved default back into the params so the
+         * SecureChannel constraint logic in ua_server_binary.c caps the
+         * channel to the actual static-buffer size. */
+        res = UA_KeyValueMap_setScalar(params, name, &bufSize,
+                                       &UA_TYPES[UA_TYPES_UINT32]);
+    if(buf->length != bufSize) {
+        UA_ByteString_clear(buf);
+        res |= UA_ByteString_allocBuffer(buf, bufSize);
+    }
+    return res;
+}

--- a/arch/common/eventloop_common.h
+++ b/arch/common/eventloop_common.h
@@ -32,6 +32,16 @@ UA_KeyValueRestriction_validate(const UA_Logger *logger,
                                 size_t restrictionsSize,
                                 const UA_KeyValueMap *map);
 
+/* (Re)allocate a static network buffer sized by the UInt32 parameter `name`.
+ * If the parameter is not set, use defaultSize and write it back into the
+ * params so that readers of the params (e.g. the SecureChannel constraint
+ * logic in ua_server_binary.c) see the size that was actually allocated. */
+UA_StatusCode
+UA_EventLoopCommon_allocStaticBuffer(UA_KeyValueMap *params,
+                                     UA_QualifiedName name,
+                                     UA_UInt32 defaultSize,
+                                     UA_ByteString *buf);
+
 _UA_END_DECLS
 
 #endif /* UA_EVENTLOOP_COMMON_H_ */

--- a/arch/lwip/eventloop_lwip.c
+++ b/arch/lwip/eventloop_lwip.c
@@ -711,33 +711,19 @@ UA_EventLoopLWIP_freeNetworkBuffer(UA_ConnectionManager *cm,
 
 UA_StatusCode
 UA_EventLoopLWIP_allocateStaticBuffers(UA_LWIPConnectionManager *pcm) {
-    UA_StatusCode res = UA_STATUSCODE_GOOD;
-    UA_UInt32 rxBufSize = 1u << 10; /* The default is 64kb */
-    const UA_UInt32 *configRxBufSize = (const UA_UInt32 *)
-        UA_KeyValueMap_getScalar(&pcm->cm.eventSource.params,
-                                 UA_QUALIFIEDNAME(0, "recv-bufsize"),
-                                 &UA_TYPES[UA_TYPES_UINT32]);
-    if(configRxBufSize)
-        rxBufSize = *configRxBufSize;
-    if(pcm->rxBuffer.length != rxBufSize) {
-        UA_ByteString_clear(&pcm->rxBuffer);
-        res = UA_ByteString_allocBuffer(&pcm->rxBuffer, rxBufSize);
-    }
+    UA_StatusCode res =
+        UA_EventLoopCommon_allocStaticBuffer(&pcm->cm.eventSource.params,
+                                             UA_QUALIFIEDNAME(0, "recv-bufsize"),
+                                             1u << 13, /* The default is 8 kb */
+                                             &pcm->rxBuffer);
 
     /* Default the tx buffer to the rx size so a dedicated static send buffer
      * always exists. This avoids a malloc/free on every send without reusing
      * the rx buffer (which may still hold unprocessed received data). */
-    UA_UInt32 txBufSize = rxBufSize;
-    const UA_UInt32 *configTxBufSize = (const UA_UInt32 *)
-        UA_KeyValueMap_getScalar(&pcm->cm.eventSource.params,
-                                 UA_QUALIFIEDNAME(0, "send-bufsize"),
-                                 &UA_TYPES[UA_TYPES_UINT32]);
-    if(configTxBufSize)
-        txBufSize = *configTxBufSize;
-    if(pcm->txBuffer.length != txBufSize) {
-        UA_ByteString_clear(&pcm->txBuffer);
-        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, txBufSize);
-    }
+    res |= UA_EventLoopCommon_allocStaticBuffer(&pcm->cm.eventSource.params,
+                                                UA_QUALIFIEDNAME(0, "send-bufsize"),
+                                                (UA_UInt32)pcm->rxBuffer.length,
+                                                &pcm->txBuffer);
     return res;
 }
 

--- a/arch/lwip/eventloop_lwip_tcp.c
+++ b/arch/lwip/eventloop_lwip_tcp.c
@@ -13,6 +13,13 @@
 #if defined(UA_ARCHITECTURE_LWIP)
 
 /* Configuration parameters */
+#define TCP_MANAGERPARAMS 2
+
+static UA_KeyValueRestriction tcpManagerParams[TCP_MANAGERPARAMS] = {
+    {{0, UA_STRING_STATIC("recv-bufsize")}, &UA_TYPES[UA_TYPES_UINT32], false, true, false},
+    {{0, UA_STRING_STATIC("send-bufsize")}, &UA_TYPES[UA_TYPES_UINT32], false, true, false}
+};
+
 #define TCP_PARAMETERSSIZE 7
 #define TCP_PARAMINDEX_RECVBUF 0
 #define TCP_PARAMINDEX_ADDR 1
@@ -1039,7 +1046,7 @@ TCP_eventSourceStart(UA_ConnectionManager *cm) {
     /* Check the parameters */
     UA_StatusCode res =
         UA_KeyValueRestriction_validate(el->eventLoop.logger, "TCP",
-                                        TCPConfigParameters, 1,
+                                        tcpManagerParams, TCP_MANAGERPARAMS,
                                         &cm->eventSource.params);
     if(res != UA_STATUSCODE_GOOD)
         goto finish;

--- a/arch/lwip/eventloop_lwip_udp.c
+++ b/arch/lwip/eventloop_lwip_udp.c
@@ -20,6 +20,13 @@
 #endif
 
 /* Configuration parameters */
+#define UDP_MANAGERPARAMS 2
+
+static UA_KeyValueRestriction udpManagerParams[UDP_MANAGERPARAMS] = {
+    {{0, UA_STRING_STATIC("recv-bufsize")}, &UA_TYPES[UA_TYPES_UINT32], false, true, false},
+    {{0, UA_STRING_STATIC("send-bufsize")}, &UA_TYPES[UA_TYPES_UINT32], false, true, false}
+};
+
 #define UDP_PARAMETERSSIZE 10
 #define UDP_PARAMINDEX_RECVBUF 0
 #define UDP_PARAMINDEX_LISTEN 1
@@ -1301,7 +1308,7 @@ UDP_eventSourceStart(UA_ConnectionManager *cm) {
     /* Check the parameters */
     UA_StatusCode res =
         UA_KeyValueRestriction_validate(el->eventLoop.logger, "UDP",
-                                        UDPConfigParameters, 1,
+                                        udpManagerParams, UDP_MANAGERPARAMS,
                                         &cm->eventSource.params);
     if(res != UA_STATUSCODE_GOOD)
         goto finish;

--- a/arch/posix/eventloop_posix.c
+++ b/arch/posix/eventloop_posix.c
@@ -645,33 +645,19 @@ UA_EventLoopPOSIX_freeNetworkBuffer(UA_ConnectionManager *cm,
 
 UA_StatusCode
 UA_EventLoopPOSIX_allocateStaticBuffers(UA_POSIXConnectionManager *pcm) {
-    UA_StatusCode res = UA_STATUSCODE_GOOD;
-    UA_UInt32 rxBufSize = 2u << 16; /* The default is 64kb */
-    const UA_UInt32 *configRxBufSize = (const UA_UInt32 *)
-        UA_KeyValueMap_getScalar(&pcm->cm.eventSource.params,
-                                 UA_QUALIFIEDNAME(0, "recv-bufsize"),
-                                 &UA_TYPES[UA_TYPES_UINT32]);
-    if(configRxBufSize)
-        rxBufSize = *configRxBufSize;
-    if(pcm->rxBuffer.length != rxBufSize) {
-        UA_ByteString_clear(&pcm->rxBuffer);
-        res = UA_ByteString_allocBuffer(&pcm->rxBuffer, rxBufSize);
-    }
+    UA_StatusCode res =
+        UA_EventLoopCommon_allocStaticBuffer(&pcm->cm.eventSource.params,
+                                             UA_QUALIFIEDNAME(0, "recv-bufsize"),
+                                             1u << 16, /* The default is 64 kb */
+                                             &pcm->rxBuffer);
 
     /* Default the tx buffer to the rx size so a dedicated static send buffer
      * always exists. This avoids a malloc/free on every send without reusing
      * the rx buffer (which may still hold unprocessed received data). */
-    UA_UInt32 txBufSize = rxBufSize;
-    const UA_UInt32 *configTxBufSize = (const UA_UInt32 *)
-        UA_KeyValueMap_getScalar(&pcm->cm.eventSource.params,
-                                 UA_QUALIFIEDNAME(0, "send-bufsize"),
-                                 &UA_TYPES[UA_TYPES_UINT32]);
-    if(configTxBufSize)
-        txBufSize = *configTxBufSize;
-    if(pcm->txBuffer.length != txBufSize) {
-        UA_ByteString_clear(&pcm->txBuffer);
-        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, txBufSize);
-    }
+    res |= UA_EventLoopCommon_allocStaticBuffer(&pcm->cm.eventSource.params,
+                                                UA_QUALIFIEDNAME(0, "send-bufsize"),
+                                                (UA_UInt32)pcm->rxBuffer.length,
+                                                &pcm->txBuffer);
     return res;
 }
 

--- a/arch/zephyr/eventloop_zephyr.c
+++ b/arch/zephyr/eventloop_zephyr.c
@@ -480,31 +480,19 @@ UA_EventLoopZephyr_freeNetworkBuffer(UA_ConnectionManager *cm, uintptr_t connect
 
 UA_StatusCode
 UA_EventLoopZephyr_allocateStaticBuffers(UA_ZephyrConnectionManager *pcm) {
-    UA_StatusCode res = UA_STATUSCODE_GOOD;
-    UA_UInt32 rxBufSize = 2u << 13; /* The default is 64kb */
-    const UA_UInt32 *configRxBufSize = (const UA_UInt32 *)UA_KeyValueMap_getScalar(
-        &pcm->cm.eventSource.params, UA_QUALIFIEDNAME(0, "recv-bufsize"),
-        &UA_TYPES[UA_TYPES_UINT32]);
-    if(configRxBufSize)
-        rxBufSize = *configRxBufSize;
-    if(pcm->rxBuffer.length != rxBufSize) {
-        UA_ByteString_clear(&pcm->rxBuffer);
-        res = UA_ByteString_allocBuffer(&pcm->rxBuffer, rxBufSize);
-    }
+    UA_StatusCode res =
+        UA_EventLoopCommon_allocStaticBuffer(&pcm->cm.eventSource.params,
+                                             UA_QUALIFIEDNAME(0, "recv-bufsize"),
+                                             1u << 13, /* The default is 8 kb */
+                                             &pcm->rxBuffer);
 
     /* Default the tx buffer to the rx size so a dedicated static send buffer
      * always exists. This avoids a malloc/free on every send without reusing
      * the rx buffer (which may still hold unprocessed received data). */
-    UA_UInt32 txBufSize = rxBufSize;
-    const UA_UInt32 *configTxBufSize = (const UA_UInt32 *)UA_KeyValueMap_getScalar(
-        &pcm->cm.eventSource.params, UA_QUALIFIEDNAME(0, "send-bufsize"),
-        &UA_TYPES[UA_TYPES_UINT32]);
-    if(configTxBufSize)
-        txBufSize = *configTxBufSize;
-    if(pcm->txBuffer.length != txBufSize) {
-        UA_ByteString_clear(&pcm->txBuffer);
-        res |= UA_ByteString_allocBuffer(&pcm->txBuffer, txBufSize);
-    }
+    res |= UA_EventLoopCommon_allocStaticBuffer(&pcm->cm.eventSource.params,
+                                                UA_QUALIFIEDNAME(0, "send-bufsize"),
+                                                (UA_UInt32)pcm->rxBuffer.length,
+                                                &pcm->txBuffer);
     return res;
 }
 

--- a/plugins/include/open62541/server_config_default.h
+++ b/plugins/include/open62541/server_config_default.h
@@ -33,13 +33,20 @@ UA_ConnectionConfig UA_ConnectionConfig_default;
  * endpoint with the security policy ``SecurityPolicy#None`` to the server.
  * If the port is set to 0, it will be dynamically assigned.
  * A server certificate may be supplied but is optional.
- * Additionally you can define a custom buffer size for send and receive buffer.
+ *
+ * Note: only ``recvBufferSize`` is used; it is stored in ``config->tcpBufSize``
+ * and drives both ``connConfig.recvBufferSize`` and ``connConfig.sendBufferSize``.
+ * ``sendBufferSize`` is kept in the signature for compatibility but ignored.
+ * A value of 0 lets the underlying ConnectionManager choose its default
+ * (architecture-dependent, see the recv-bufsize/send-bufsize CM parameters).
  *
  * @param portNumber The port number for the tcp network layer
  * @param certificate Optional certificate for the server endpoint. Can be
  *        ``NULL``.
- * @param sendBufferSize The size in bytes for the network send buffer
- * @param recvBufferSize The size in bytes for the network receive buffer
+ * @param sendBufferSize Ignored (kept for compatibility); pass the same value
+ *        as ``recvBufferSize``.
+ * @param recvBufferSize The size in bytes for the network send AND receive
+ *        buffer (0 = architecture-dependent default).
  *
  */
 UA_EXPORT UA_StatusCode

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -668,7 +668,10 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
         return retval;
     }
 
-    /* Set the TCP settings */
+    /* Set the TCP settings. Only recvBufferSize is stored; it drives both
+     * connConfig.recvBufferSize and connConfig.sendBufferSize. sendBufferSize is
+     * intentionally ignored (see the doxygen note on the declaration). */
+    (void)sendBufferSize;
     config->tcpBufSize = recvBufferSize;
 
     /* Allocate the SecurityPolicies */

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -616,18 +616,23 @@ createServerSecureChannel(UA_BinaryProtocolManager *bpm, UA_ConnectionManager *c
     connConfig.remoteMaxChunkCount = config->tcpMaxChunks;
 
     /* Further constrain the bufsize if the ConnectionManager has static rx/tx
-     * buffers configured */
+     * buffers configured. Also applies when tcpBufSize is unset (0), so that
+     * chunks always fit into the static buffers. Never constrain below 8192
+     * bytes: the transport buffer must be at least that size to fit a single
+     * MessageChunk (OPC UA Part 6 v1.05.07 §6.7.1 and §6.7.2.4). */
     const UA_UInt32 *bufSize = (const UA_UInt32 *)
         UA_KeyValueMap_getScalar(&cm->eventSource.params,
                                  UA_QUALIFIEDNAME(0, "recv-bufsize"),
                                  &UA_TYPES[UA_TYPES_UINT32]);
-    if(bufSize && *bufSize < connConfig.recvBufferSize)
+    if(bufSize && *bufSize >= 8192 &&
+       (connConfig.recvBufferSize == 0 || *bufSize < connConfig.recvBufferSize))
         connConfig.recvBufferSize = *bufSize;
     bufSize = (const UA_UInt32 *)
         UA_KeyValueMap_getScalar(&cm->eventSource.params,
                                  UA_QUALIFIEDNAME(0, "send-bufsize"),
                                  &UA_TYPES[UA_TYPES_UINT32]);
-    if(bufSize && *bufSize < connConfig.sendBufferSize)
+    if(bufSize && *bufSize >= 8192 &&
+       (connConfig.sendBufferSize == 0 || *bufSize < connConfig.sendBufferSize))
         connConfig.sendBufferSize = *bufSize;
 
     /* Set upper bounds if not configured */

--- a/tests/check_eventloop_tcp.c
+++ b/tests/check_eventloop_tcp.c
@@ -246,6 +246,30 @@ START_TEST(staticSendBuffer) {
     /* Run once so the ConnectionManager eventSource starts its static buffers */
     el->run(el, 1);
 
+    /* The resolved rx default was written back into the CM params (so the
+     * SecureChannel logic can cap to the static-buffer size); the explicitly
+     * configured send-bufsize is untouched. The rx default is
+     * architecture-dependent and must match the default passed to
+     * UA_EventLoopCommon_allocStaticBuffer in each eventloop porting
+     * (64 KiB on POSIX/Win32, 8 KiB on lwip and Zephyr). */
+#if defined(UA_ARCHITECTURE_LWIP) || defined(UA_ARCHITECTURE_ZEPHYR)
+    UA_UInt32 expectedRxBufSize = 1u << 13;
+#else
+    UA_UInt32 expectedRxBufSize = 1u << 16;
+#endif
+    const UA_UInt32 *rxParam = (const UA_UInt32 *)
+        UA_KeyValueMap_getScalar(&cm->eventSource.params,
+                                 UA_QUALIFIEDNAME(0, "recv-bufsize"),
+                                 &UA_TYPES[UA_TYPES_UINT32]);
+    ck_assert_ptr_ne(rxParam, NULL);
+    ck_assert_uint_eq(*rxParam, expectedRxBufSize);
+    const UA_UInt32 *txParam = (const UA_UInt32 *)
+        UA_KeyValueMap_getScalar(&cm->eventSource.params,
+                                 UA_QUALIFIEDNAME(0, "send-bufsize"),
+                                 &UA_TYPES[UA_TYPES_UINT32]);
+    ck_assert_ptr_ne(txParam, NULL);
+    ck_assert_uint_eq(*txParam, sendBufSize);
+
     /* A message that fits is served from the static send buffer */
     UA_ByteString a = UA_BYTESTRING_NULL;
     UA_StatusCode retval = cm->allocNetworkBuffer(cm, 0, &a, sendBufSize);


### PR DESCRIPTION
The static tx-buffer optimization from #8156 didn't fire on lwip/zephyr: the default was too small, lwip couldn't configure send-bufsize, and the SecureChannel never capped to the real static-buffer size, so every send malloc'd. Raise the lwip default to 8 KiB, expose send-bufsize on lwip, write the resolved buffer sizes back into the CM params so the channel is capped correctly, and fix the misleading "default is 64kb" comments plus the setMinimalCustomBuffer single-buffer contract.
