### PR TITLE
fix(plugin): invoke login callback for anonymous user authentication

### DIFF
--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -64,6 +64,15 @@ activateSession_default(UA_Server *server, UA_AccessControl *ac,
         /* Anonymous login */
         if(!context->allowAnonymous)
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+        if(context->loginCallback) {
+            UA_StatusCode res =
+                context->loginCallback(&UA_STRING_NULL, &UA_BYTESTRING_NULL,
+                                       context->usernamePasswordLoginSize,
+                                       context->usernamePasswordLogin,
+                                       sessionContext, context->loginContext);
+            if(res != UA_STATUSCODE_GOOD)
+                return UA_STATUSCODE_BADUSERACCESSDENIED;
+        }
     } else if(tokenType == &UA_TYPES[UA_TYPES_USERNAMEIDENTITYTOKEN]) {
         /* Username and password */
         const UA_UserNameIdentityToken *userToken = (UA_UserNameIdentityToken*)


### PR DESCRIPTION
The anonymous branch in activateSession_default returned before calling context->loginCallback, so registered callbacks were never notified on anonymous activation. Invoke it with empty user/password, guarded by if(context->loginCallback), mapping non-Good to BadUserAccessDenied. Supersedes the original PR #7209.