### PR TITLE
fix(server): Skip event-field evaluation for subscriptions without an attached session

### DIFF
--- a/src/server/ua_subscription_events.c
+++ b/src/server/ua_subscription_events.c
@@ -191,6 +191,16 @@ UA_MonitoredItem_addEvent(UA_Server *server, UA_MonitoredItem *mon,
      * not taken for local MonitoredItems (once they are enabled for Events). */
     UA_assert(mon->subscription);
     UA_Subscription *sub = mon->subscription;
+
+    /* Do not evaluate event fields for detached subscriptions. A NULL
+     * sub->session means the subscription outlived its session (e.g. after
+     * CloseSession with deleteSubscriptions=false, or before a
+     * TransferSubscriptions call). Filter resolution later in this function
+     * dereferences the session; using &server->adminSession here would bypass
+     * per-session access control and could leak event fields to a less
+     * privileged client that subsequently transfers the subscription. */
+    if(!sub->session)
+        return UA_STATUSCODE_GOOD;
     UA_Session *session = sub->session;
 
     UA_EventFilterResult res; /* FilterResult contains only statuscodes. Ignored


### PR DESCRIPTION
When an event subscription outlives the session that created it (e.g. after CloseSession with deleteSubscriptions=false, or before a TransferSubscriptions call), sub->session is NULL. The function then passes a NULL session to filterEvent()/readWithSession(), which dereferences the session when resolving SimpleAttributeOperands, leading to a NULL pointer dereference and immediate process termination. A subsequent TransferSubscriptions could also let a less-privileged client inherit the queued event notifications.

Do not evaluate event fields while the subscription has no attached session. The monitored item is effectively dormant and is skipped by this guard; as soon as the subscription is re-bound to a session, event evaluation resumes under that session's access rights.

Internal Vulnerability Advisory: open62541-SA-2026-0007