### PR TITLE
fix(server): Skip event-field evaluation for subscriptions without an attached session

### DIFF
--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -378,7 +378,7 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
 
 typedef struct {
     UA_Server *server;
-    UA_Session *session;
+    UA_Session *session; /* may be NULL if no session is attached. */
     UA_EventDescription ed; /* shallow copy */
     UA_EventFilter filter;  /* shallow copy */
 

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -1701,10 +1701,11 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
             }
             ctx.filter = *(UA_EventFilter*)mon->parameters.filter.content.decoded.data;
 
-            /* Select the session used to resolve SimpleAttributeOperands. If
-             * the subscription is not bound to a session, use the AdminSession.
-             * TODO: Preserve the access rights of the last connected session? */
-            ctx.session = (sub->session) ? sub->session : &server->adminSession;
+            /* Do not evaluate event fields for detached subscriptions.
+             * Using adminSession would bypass per-session access control. */
+            if(!sub->session)
+                continue;
+            ctx.session = sub->session;
 
             /* Evaluate the where-clause and create a notification */
             res = UA_MonitoredItem_addEvent(mon, &ctx);


### PR DESCRIPTION
When a monitored item on an event subscription outlives the session that created it (e.g. after CloseSession with deleteSubscriptions=false, or before a TransferSubscriptions call), the existing code falls back to evaluating the event filter using the server's adminSession. This bypasses the originating client's per-session access control and can leak event fields that the user is not entitled to read, especially when a subsequent TransferSubscriptions transfers the subscription to a different (less privileged) client.

Do not evaluate event fields while the subscription has no attached session; the monitored item is effectively dormant and is skipped by the surrounding loop. As soon as the subscription is re-bound to a session, event evaluation resumes under that session's access rights.

Internal Vulnerability Advisory: open62541-SA-2026-0007