### PR TITLE
fix(server): Cap default outstanding PublishRequest count per session

### DIFF
--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -470,6 +470,7 @@ setDefaultConfig(UA_ServerConfig *conf, UA_UInt16 portNumber) {
     conf->maxNotificationsPerPublish = 1000;
     conf->enableRetransmissionQueue = true;
     conf->maxRetransmissionQueueSize = 0; /* unlimited */
+    conf->maxPublishReqPerSession = 512; /* limit outstanding publish requests per session */
 # ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
     conf->maxEventsPerNode = 0; /* unlimited */
 # endif


### PR DESCRIPTION
The default server configuration zero-initialises
maxPublishReqPerSession, which disables the per-session cap on outstanding PublishRequest entries. A remote client that is allowed to create a session and a subscription can therefore send an unbounded number of PublishRequest messages, each of which allocates a UA_PublishResponseEntry and appends it to the session's publish queue. The resulting monotonic heap growth causes process memory exhaustion and a denial of service.

Set a safe finite default of 512 outstanding PublishRequests per session in setDefaultConfig() so that the cap enforced by UA_Session_ensurePublishQueueSpace() is active in the default profile, while still allowing deployers to override it.

Internal Vulnerability Advisory: open62541-SA-2026-0010