### PR TITLE
fix(encoding): avoid null-pointer UB in calcSize and enforce Extension

### DIFF
--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -85,6 +85,16 @@ ctxClearNodeId(Ctx *ctx, UA_NodeId *p) {
             return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED; \
     } else                                                  \
 
+static UA_INLINE UA_Boolean
+ctxHasEnoughSpace(const Ctx *ctx, size_t length) {
+    return ((uintptr_t)ctx->pos + length <= (uintptr_t)ctx->end);
+}
+
+static UA_INLINE void
+ctxAdvance(Ctx *ctx, size_t length) {
+    ctx->pos = (u8*)((uintptr_t)ctx->pos + length);
+}
+
 /* Send the current chunk and replace the buffer */
 static status exchangeBuffer(Ctx *ctx) {
     if(!ctx->exchangeBufferCallback)
@@ -181,10 +191,10 @@ UA_decode64(const u8 buf[8], u64 *v) {
  * is disabled in those cases. */
 FUNC_ENCODE_BINARY(Boolean) {
     const UA_Boolean *src = (const UA_Boolean*)_src;
-    IF_CHECK_BUFSIZE(ctx->pos + 1 <= ctx->end) {
+    IF_CHECK_BUFSIZE(ctxHasEnoughSpace(ctx, 1)) {
         *ctx->pos = *(const u8*)src;
     }
-    ++ctx->pos;
+    ctxAdvance(ctx, 1);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -199,10 +209,10 @@ FUNC_DECODE_BINARY(Boolean) {
 /* Byte */
 FUNC_ENCODE_BINARY(Byte) {
     const UA_Byte *src = (const UA_Byte*)_src;
-    IF_CHECK_BUFSIZE(ctx->pos + sizeof(u8) <= ctx->end) {
+    IF_CHECK_BUFSIZE(ctxHasEnoughSpace(ctx, sizeof(u8))) {
         *ctx->pos = *(const u8*)src;
     }
-    ++ctx->pos;
+    ctxAdvance(ctx, 1);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -218,14 +228,14 @@ FUNC_DECODE_BINARY(Byte) {
 /* UInt16 */
 FUNC_ENCODE_BINARY(UInt16) {
     const UA_UInt16 *src = (const UA_UInt16*)_src;
-    IF_CHECK_BUFSIZE(ctx->pos + sizeof(u16) <= ctx->end) {
+    IF_CHECK_BUFSIZE(ctxHasEnoughSpace(ctx, sizeof(u16))) {
 #if UA_BINARY_OVERLAYABLE_INTEGER
         memcpy(ctx->pos, src, sizeof(u16));
 #else
         UA_encode16(*src, ctx->pos);
 #endif
     }
-    ctx->pos += 2;
+    ctxAdvance(ctx, 2);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -245,14 +255,14 @@ FUNC_DECODE_BINARY(UInt16) {
 /* UInt32 */
 FUNC_ENCODE_BINARY(UInt32) {
     const UA_UInt32 *src = (const UA_UInt32*)_src;
-    IF_CHECK_BUFSIZE(ctx->pos + sizeof(u32) <= ctx->end) {
+    IF_CHECK_BUFSIZE(ctxHasEnoughSpace(ctx, sizeof(u32))) {
 #if UA_BINARY_OVERLAYABLE_INTEGER
         memcpy(ctx->pos, src, sizeof(u32));
 #else
         UA_encode32(*src, ctx->pos);
 #endif
     }
-    ctx->pos += 4;
+    ctxAdvance(ctx, 4);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -272,14 +282,14 @@ FUNC_DECODE_BINARY(UInt32) {
 /* UInt64 */
 FUNC_ENCODE_BINARY(UInt64) {
     const UA_UInt64 *src = (const UA_UInt64*)_src;
-    IF_CHECK_BUFSIZE(ctx->pos + sizeof(u64) <= ctx->end) {
+    IF_CHECK_BUFSIZE(ctxHasEnoughSpace(ctx, sizeof(u64))) {
 #if UA_BINARY_OVERLAYABLE_INTEGER
         memcpy(ctx->pos, src, sizeof(u64));
 #else
         UA_encode64(*src, ctx->pos);
 #endif
     }
-    ctx->pos += 8;
+    ctxAdvance(ctx, 8);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -439,7 +449,7 @@ static status
 Array_encodeBinaryOverlayable(Ctx *ctx, uintptr_t ptr, size_t memSize) {
     /* CalcSize only */
     if(ctx->end == NULL) {
-        ctx->pos += memSize;
+        ctxAdvance(ctx, memSize);
         return UA_STATUSCODE_GOOD;
     }
 
@@ -585,10 +595,10 @@ FUNC_ENCODE_BINARY(Guid) {
     ret |= ENCODE_DIRECT(&src->data1, UInt32);
     ret |= ENCODE_DIRECT(&src->data2, UInt16);
     ret |= ENCODE_DIRECT(&src->data3, UInt16);
-    IF_CHECK_BUFSIZE(ctx->pos + (8*sizeof(u8)) <= ctx->end) {
+    IF_CHECK_BUFSIZE(ctxHasEnoughSpace(ctx, 8 * sizeof(u8))) {
         memcpy(ctx->pos, src->data4, 8*sizeof(u8));
     }
-    ctx->pos += 8;
+    ctxAdvance(ctx, 8);
     return ret;
 }
 


### PR DESCRIPTION
# Binary encoding: avoid calc-size UB and enforce ExtensionObject body bounds

`UA_calcSizeBinary()` and known `ExtensionObject` decoding both rely on binary
encoding cursor state. This patch hardens those paths in two places:

- size calculation now uses an explicit byte counter instead of advancing a
  null pointer;
- known `ExtensionObject` bodies are decoded inside their declared ByteString
  length instead of decoding against the full remaining input buffer.

Both paths are reachable through the existing `fuzz_binary_decode` OSS-Fuzz
target.

## Bug

### 1. Size calculation advances a null cursor

`UA_calcSizeBinary()` enters binary encoding in size-calculation mode by passing
`pos == NULL` and `end == NULL`:

```c
u8 *pos = NULL;
const u8 *posEnd = NULL;
UA_StatusCode res = UA_encodeBinaryInternal(p, type, &pos, &posEnd, options, NULL, NULL);
```

Several encoder helpers then advance `ctx->pos` directly:

```c
++ctx->pos;
ctx->pos += 2;
ctx->pos += 4;
ctx->pos += memSize;
```

With UBSan enabled, this is reported as undefined behavior:

```text
runtime error: applying non-zero offset 1 to null pointer
Byte_encodeBinary
encodeWithExchangeBuffer
UA_encodeBinaryInternal
UA_calcSizeBinary
tests/fuzz/fuzz_binary_decode.cc:80
```

The patch adds an explicit `calcSize` field to `Ctx` and routes encoder cursor
advances through `ctxAdvance()`. Normal encoding still advances `ctx->pos`;
size-calculation mode increments `ctx->calcSize`.

### 2. Known ExtensionObject body length is skipped, not enforced

Known `ExtensionObject` bodies are encoded as a ByteString with a declared body
length. Before this patch, decoding known types skipped the length field and
decoded the known type against the full remaining input:

```c
/* Jump over the length field */
ctx->pos += 4;
return decodeBinaryJumpTable[type->typeKind](ctx, dst->content.decoded.data, type);
```

The same pattern existed in `Variant` unwrapping paths for scalar and array
`ExtensionObject` values. A malformed input could declare a one-byte body, append
a complete known `ViewDescription` body after it, and still be accepted as a
decoded `ViewDescription`.

The patch decodes the declared ByteString length, temporarily bounds `ctx->end`
to that body, and rejects successful decodes that do not consume exactly the
declared body length.

## Repro

Built baseline and patched trees with Clang sanitizers:

```sh
cmake -S . -B build-asan-fuzz-clang \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_BUILD_TYPE=Debug \
  -DUA_BUILD_FUZZING=ON \
  -DUA_ENABLE_ENCRYPTION=OFF \
  -DUA_BUILD_EXAMPLES=OFF \
  -DUA_ENABLE_AMALGAMATION=OFF

cmake --build build-asan-fuzz-clang --target fuzz_binary_decode -j2
```

Sanitizer settings:

```sh
ASAN_OPTIONS=abort_on_error=1:detect_leaks=0
UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1
```

### Calc-size UBSan artifact

The existing `fuzz_binary_decode` target produced a minimized artifact that
crashes baseline with UBSan:

```text
Base64: AAAVAAEAAAAAAAAAAAAAAI8CAf8AAAAAAAB/
```

Baseline stack:

```text
runtime error: applying non-zero offset 1 to null pointer
    #0 Byte_encodeBinary                 src/ua_types_encoding_binary.c
    #1 encodeWithExchangeBuffer          src/ua_types_encoding_binary.c
    #2 UA_encodeBinaryInternal           src/ua_types_encoding_binary.c
    #3 UA_calcSizeBinary                 src/ua_types_encoding_binary.c
    #4 LLVMFuzzerTestOneInput            tests/fuzz/fuzz_binary_decode.cc:80
```

### ExtensionObject boundary regression

A defensive regression input declares an `ExtensionObject` body length of 1 byte
for known binary type `ViewDescription` (`i=513`), then appends a full
`ViewDescription` body. The same pattern is covered for:

- direct `ExtensionObject` decode;
- scalar `Variant` unwrapping an `ExtensionObject`;
- array `Variant` unwrapping `ExtensionObject` elements.

Baseline accepted all three malformed inputs:

```text
extensionobject ret=0x00000000 decodedLength=23 encoding=3 knownView=1
variant-scalar ret=0x00000000 decodedLength=24 typeKind=27 knownView=1 arrayLength=0
variant-array ret=0x00000000 decodedLength=28 typeKind=27 knownView=1 arrayLength=1
```

Patched behavior rejects all three:

```text
extensionobject ret=0x80070000 decodedLength=0
variant-scalar ret=0x80070000 decodedLength=0
variant-array ret=0x80070000 decodedLength=0
```

## Verification

| Check | Pre-patch | Post-patch |
|---|---|---|
| `fuzz_binary_decode` UBSan artifact | UBSan crash in `UA_calcSizeBinary` | exits cleanly |
| direct malformed known `ExtensionObject` | accepted as `ViewDescription` | `BADDECODINGERROR` |
| malformed scalar `Variant` ExtensionObject unwrap | accepted as `ViewDescription` | `BADDECODINGERROR` |
| malformed array `Variant` ExtensionObject unwrap | accepted as `ViewDescription[]` | `BADDECODINGERROR` |
| targeted `fuzz_binary_decode` pass | not applicable | `23,851,932` runs in `61s`, no sanitizer crash |

The new regression tests cover the declared-length checks in
`tests/check_encoding_roundtrip.c`.


