### PR TITLE
feature(server): Extended the access control plugin to read role permissions

### DIFF
--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -142,6 +142,24 @@ struct UA_AccessControl {
                                                       UA_DateTime endTimestamp,
                                                       bool isDeleteModified);
 #endif
+
+#ifndef UA_ENABLE_RBAC
+    /* Allow reading of RolePermissions attribute */
+    UA_Boolean (*allowReadRolePermissions)(UA_Server *server,  UA_AccessControl *ac,
+                                           const UA_NodeId *sessionId, void *sessionContext,
+                                           const UA_NodeId *nodeId, void *nodeContext);
+
+    /* Fetch the configured / mapped role permissions on the given node */
+    UA_StatusCode (*readRolePermissions)(UA_Server *server,  UA_AccessControl *ac,
+                                         const UA_NodeId *nodeId, void *nodeContext,
+                                         UA_RolePermissionType **entries, size_t *entriesSize);
+
+    /* Fetch the role permissions the user has on the given node */
+    UA_StatusCode (*readUserRolePermissions)(UA_Server *server,  UA_AccessControl *ac,
+                                             const UA_NodeId *sessionId, void *sessionContext,
+                                             const UA_NodeId *nodeId, void *nodeContext,
+                                             UA_RolePermissionType **entries, size_t *entriesSize);
+#endif
 };
 
 _UA_END_DECLS

--- a/include/open62541/plugin/accesscontrol.h
+++ b/include/open62541/plugin/accesscontrol.h
@@ -113,6 +113,22 @@ struct UA_AccessControl {
                                   const UA_NodeId *sessionId, void *sessionContext,
                                   const UA_NodeId *nodeId, void *nodeContext);
 
+    /* Allow reading of RolePermissions attribute */
+    UA_Boolean (*allowReadRolePermissions)(UA_Server *server,  UA_AccessControl *ac,
+                                           const UA_NodeId *sessionId, void *sessionContext,
+                                           const UA_NodeId *nodeId, void *nodeContext);
+
+    /* Fetch the configured / mapped role permissions on the given node */
+    UA_StatusCode (*readRolePermissions)(UA_Server *server,  UA_AccessControl *ac,
+                                         const UA_NodeId *nodeId, void *nodeContext,
+                                         size_t *entriesSize, UA_RolePermissionType **entries);
+
+    /* Fetch the role permissions the user has on the given node */
+    UA_StatusCode (*readUserRolePermissions)(UA_Server *server,  UA_AccessControl *ac,
+                                             const UA_NodeId *sessionId, void *sessionContext,
+                                             const UA_NodeId *nodeId, void *nodeContext,
+                                             size_t *entriesSize, UA_RolePermissionType **entries);
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /* Allow creating a subscription */
     UA_Boolean (*allowCreateSubscription)(UA_Server *server, UA_AccessControl *ac,

--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -16,6 +16,18 @@ UA_Server_getEffectivePermissions(UA_Server *server,
                                   const UA_NodeId *sessionId,
                                   const UA_NodeId *nodeId,
                                   UA_PermissionType *effectivePermissions);
+
+UA_StatusCode
+UA_Server_getUserRolePermissions(UA_Server *server,
+                                 const UA_NodeId *sessionId,
+                                 const UA_NodeId *nodeId,
+                                 size_t *entriesSize, UA_RolePermissionType **entries);
+
+UA_StatusCode
+UA_Server_getRolePermissions(UA_Server *server,
+                             const UA_NodeId *nodeId,
+                             size_t *entriesSize, UA_RolePermissionType **entries);
+
 #endif
 
 /* Example access control management. Anonymous and username / password login.
@@ -363,6 +375,39 @@ allowBrowseNode_default(UA_Server *server, UA_AccessControl *ac,
 #endif
 }
 
+static UA_Boolean
+allowReadRolePermissions_default(UA_Server *server,  UA_AccessControl *ac,
+                                 const UA_NodeId *sessionId, void *sessionContext,
+                                 const UA_NodeId *nodeId, void *nodeContext) {
+#ifdef UA_ENABLE_RBAC
+    UA_PermissionType effectivePerms = 0;
+    UA_StatusCode res = UA_Server_getEffectivePermissions(server, sessionId,
+                                                          nodeId, &effectivePerms);
+    if(res != UA_STATUSCODE_GOOD)
+        return false;
+    return (effectivePerms & UA_PERMISSIONTYPE_READROLEPERMISSIONS) != 0;
+#else
+    return false;
+#endif
+}
+
+#ifdef UA_ENABLE_RBAC
+static UA_StatusCode
+readRolePermissions_default(UA_Server *server,  UA_AccessControl *ac,
+                            const UA_NodeId *nodeId, void *nodeContext,
+                            size_t *entriesSize, UA_RolePermissionType **entries) {
+    return UA_Server_getRolePermissions(server, nodeId, entriesSize, entries);
+}
+
+static UA_StatusCode
+readUserRolePermissions_default(UA_Server *server,  UA_AccessControl *ac,
+                                const UA_NodeId *sessionId, void *sessionContext,
+                                const UA_NodeId *nodeId, void *nodeContext,
+                                size_t *entriesSize, UA_RolePermissionType **entries) {
+    return UA_Server_getUserRolePermissions(server, sessionId, nodeId, entriesSize, entries);
+}
+#endif
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 static UA_Boolean
 allowCreateSubscription_default(UA_Server *server, UA_AccessControl *ac,
@@ -579,6 +624,15 @@ UA_AccessControl_default(UA_ServerConfig *config,
     ac->allowAddNode = allowAddNode_default;
     ac->allowAddReference = allowAddReference_default;
     ac->allowBrowseNode = allowBrowseNode_default;
+    ac->allowReadRolePermissions = allowReadRolePermissions_default;
+
+#ifdef UA_ENABLE_RBAC
+    ac->readRolePermissions = readRolePermissions_default;
+    ac->readUserRolePermissions = readUserRolePermissions_default;
+#else
+    ac->readRolePermissions = NULL;
+    ac->readUserRolePermissions = NULL;
+#endif
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     ac->allowCreateSubscription = allowCreateSubscription_default;

--- a/src/server/ua_server_rbac.c
+++ b/src/server/ua_server_rbac.c
@@ -2291,6 +2291,72 @@ getEffectivePermissions(UA_Server *server,
 }
 
 UA_StatusCode
+UA_Server_getRolePermissions(UA_Server *server,
+                             const UA_NodeId *nodeId,
+                             size_t *entriesSize,
+                             UA_RolePermissionType **entries)
+{
+    if(!server || !nodeId || !entriesSize || !entries)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+
+    *entriesSize = 0;
+    *entries = NULL;
+
+    lockServer(server);
+
+    const UA_Node *node = UA_NODESTORE_GET(server, nodeId);
+    if(!node) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+    }
+
+    /* If node has no permission configuration, return empty array */
+    if(node->head.permissionIndex == UA_PERMISSION_INDEX_INVALID ||
+       node->head.permissionIndex >= server->rolePermissionsSize) {
+        UA_NODESTORE_RELEASE(server, node);
+        unlockServer(server);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    const UA_RolePermissionEntry *rp = &server->rolePermissions[node->head.permissionIndex];
+    if(!rp->rolePermissions || rp->rolePermissionsSize == 0) {
+        UA_NODESTORE_RELEASE(server, node);
+        unlockServer(server);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    /* Allocate result array */
+    UA_RolePermissionType *result = (UA_RolePermissionType*)
+        UA_Array_new(rp->rolePermissionsSize, &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+    if(!result) {
+        UA_NODESTORE_RELEASE(server, node);
+        unlockServer(server);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
+    /* Fill result array */
+    UA_StatusCode res = UA_STATUSCODE_GOOD;
+    for(size_t i = 0; i < rp->rolePermissionsSize; i++) {
+        res = UA_NodeId_copy(&rp->rolePermissions[i].roleId, &result[i].roleId);
+        if(res != UA_STATUSCODE_GOOD) {
+            UA_Array_delete(result, i, &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+            UA_NODESTORE_RELEASE(server, node);
+            unlockServer(server);
+            return res;
+        }
+        result[i].permissions = rp->rolePermissions[i].permissions;
+    }
+
+    *entriesSize = rp->rolePermissionsSize;
+    *entries = result;
+
+    UA_NODESTORE_RELEASE(server, node);
+
+    unlockServer(server);
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
 UA_Server_getUserRolePermissions(UA_Server *server, const UA_NodeId *sessionId,
                                  const UA_NodeId *nodeId,
                                  size_t *entriesSize,

--- a/src/server/ua_server_rbac.h
+++ b/src/server/ua_server_rbac.h
@@ -105,6 +105,12 @@ getEffectivePermissions(UA_Server *server,
                         UA_PermissionType *effectivePermissions);
 
 UA_StatusCode
+UA_Server_getRolePermissions(UA_Server *server,
+                             const UA_NodeId *nodeId,
+                             size_t *entriesSize,
+                             UA_RolePermissionType **entries);
+
+UA_StatusCode
 UA_Server_getUserRolePermissions(UA_Server *server,
                                  const UA_NodeId *sessionId,
                                  const UA_NodeId *nodeId,

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -19,6 +19,7 @@
  *    Copyright 2020 (c) Christian von Arnim, ISW University of Stuttgart  (for VDW and umati)
  *    Copyright 2026 (c) o6 Automation GmbH (Author: Julius Pfrommer)
  *    Copyright 2026 (c) o6 Automation GmbH (Author: Andreas Ebner)
+ *    Copyright (c) 2026 Pilz GmbH & Co. KG, Author: Marcel Patzlaff
  */
 
 #include "ua_server_internal.h"
@@ -199,6 +200,76 @@ readUserRolePermissions(UA_Server *server, UA_Session *session,
 
     UA_Variant_setArray(&v->value, entries, entriesSize,
                        &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+    return UA_STATUSCODE_GOOD;
+}
+#else
+static UA_StatusCode
+readRolePermissions(UA_Server *server, UA_Session *session,
+                    const UA_Node *node, UA_DataValue *v) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+    if(session == NULL || !server->config.accessControl.readRolePermissions
+                       || !server->config.accessControl.allowReadRolePermissions)
+        return UA_STATUSCODE_BADATTRIBUTEIDINVALID;
+
+    if(session != &server->adminSession) {
+        UA_Boolean readable = server->config.accessControl.
+            allowReadRolePermissions(server, &server->config.accessControl,
+                &session->sessionId, session->context,
+                &node->head.nodeId, node->head.context
+            );
+        if(!readable)
+            return UA_STATUSCODE_BADUSERACCESSDENIED;
+    }
+    size_t entriesSize = 0;
+    UA_RolePermissionType *entries = NULL;
+
+    UA_StatusCode retval = server->config.accessControl.readRolePermissions(
+        server, &server->config.accessControl,
+        &node->head.nodeId, node->head.context,
+        &entries, &entriesSize
+    );
+
+    if(UA_StatusCode_isGood(retval))
+        UA_Variant_setArray(&v->value, entries, entriesSize,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+
+    return retval;
+}
+
+static UA_StatusCode
+readUserRolePermissions(UA_Server *server, UA_Session *session,
+                        const UA_Node *node, UA_DataValue *v) {
+
+    if(session == NULL || !server->config.accessControl.readUserRolePermissions) {
+        // just return empty array
+        UA_Variant_setArray(&v->value, NULL, 0,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    if(session == &server->adminSession) {
+        // admin session sees all role permissions
+        return readRolePermissions(server, session, node, v);
+    }
+
+    size_t entriesSize = 0;
+    UA_RolePermissionType *entries = NULL;
+
+    UA_StatusCode retval = server->config.accessControl.readUserRolePermissions(
+        server, &server->config.accessControl,
+        &session->sessionId, session->context,
+        &node->head.nodeId, node->head.context,
+        &entries, &entriesSize
+    );
+
+    if(UA_StatusCode_isGood(retval))
+        UA_Variant_setArray(&v->value, entries, entriesSize,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+    else
+        UA_Variant_setArray(&v->value, NULL, 0,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+
     return UA_STATUSCODE_GOOD;
 }
 #endif /* UA_ENABLE_RBAC */
@@ -645,21 +716,10 @@ ReadWithNodeMaybeAsync(const UA_Node *node, UA_Server *server, UA_Session *sessi
         break;
     }
     case UA_ATTRIBUTEID_ROLEPERMISSIONS:
-#ifdef UA_ENABLE_RBAC
         retval = readRolePermissions(server, session, node, v);
-#else
-        retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
-#endif
         break;
     case UA_ATTRIBUTEID_USERROLEPERMISSIONS:
-#ifdef UA_ENABLE_RBAC
         retval = readUserRolePermissions(server, session, node, v);
-#else
-        /* Without RBAC, return empty array */
-        UA_Variant_setArray(&v->value, NULL, 0,
-                           &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-        retval = UA_STATUSCODE_GOOD;
-#endif
         break;
     case UA_ATTRIBUTEID_ACCESSRESTRICTIONS:
         /* TODO: Add support for AccessRestrictions from the 1.04 spec */

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -20,6 +20,7 @@
  *    Copyright 2026 (c) o6 Automation GmbH (Author: Julius Pfrommer)
  *    Copyright 2026 (c) o6 Automation GmbH (Author: Andreas Ebner)
  *    Copyright 2026 (c) Precitec GmbH & Co. KG (Author: Eric Supernok)
+ *    Copyright (c) 2026 Pilz GmbH & Co. KG, Author: Marcel Patzlaff
  */
 
 #include "ua_server_internal.h"
@@ -129,76 +130,74 @@ getUserExecutable(UA_Server *server, const UA_Session *session,
 /* Read Service */
 /****************/
 
-#ifdef UA_ENABLE_RBAC
 static UA_StatusCode
 readRolePermissions(UA_Server *server, UA_Session *session,
                     const UA_Node *node, UA_DataValue *v) {
-    /* Check if the user has ReadRolePermissions permission on this node */
-    UA_UInt32 effectivePerms = 0;
-    UA_StatusCode retval = UA_Server_getEffectivePermissions(
-        server, &session->sessionId, &node->head.nodeId, &effectivePerms);
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
+    UA_LOCK_ASSERT(&server->serviceMutex);
+    if(session == NULL || !server->config.accessControl.readRolePermissions
+                       || !server->config.accessControl.allowReadRolePermissions)
+        return UA_STATUSCODE_BADATTRIBUTEIDINVALID;
 
-    if(!(effectivePerms & UA_PERMISSIONTYPE_READROLEPERMISSIONS))
-        return UA_STATUSCODE_BADUSERACCESSDENIED;
-
-    /* Check if node has a valid permission index */
-    if(node->head.permissionIndex == UA_PERMISSION_INDEX_INVALID) {
-        UA_Variant_setArray(&v->value, NULL, 0,
-                           &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-        return UA_STATUSCODE_GOOD;
+    if(session != &server->adminSession) {
+        UA_Boolean readable = server->config.accessControl.
+            allowReadRolePermissions(server, &server->config.accessControl,
+                &session->sessionId, session->context,
+                &node->head.nodeId, node->head.context
+            );
+        if(!readable)
+            return UA_STATUSCODE_BADUSERACCESSDENIED;
     }
+    size_t entriesSize = 0;
+    UA_RolePermissionType *entries = NULL;
 
-    const UA_RolePermissionEntry *rp =
-        &server->rolePermissions[node->head.permissionIndex];
+    UA_StatusCode retval = server->config.accessControl.readRolePermissions(
+        server, &server->config.accessControl,
+        &node->head.nodeId, node->head.context,
+        &entriesSize, &entries
+    );
 
-    /* If no entries -> return empty array */
-    if(rp->rolePermissionsSize == 0 || !rp->rolePermissions) {
-        UA_Variant_setArray(&v->value, NULL, 0,
-                           &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-        return UA_STATUSCODE_GOOD;
-    }
+    if(UA_StatusCode_isGood(retval))
+        UA_Variant_setArray(&v->value, entries, entriesSize,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
 
-    UA_RolePermissionType *permissions = (UA_RolePermissionType*)
-        UA_Array_new(rp->rolePermissionsSize, &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-    if(!permissions)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
-
-    retval = UA_STATUSCODE_GOOD;
-    for(size_t i = 0; i < rp->rolePermissionsSize; i++) {
-        retval = UA_NodeId_copy(&rp->rolePermissions[i].roleId, &permissions[i].roleId);
-        if(retval != UA_STATUSCODE_GOOD) {
-            UA_Array_delete(permissions, i, &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-            return retval;
-        }
-        permissions[i].permissions = rp->rolePermissions[i].permissions;
-    }
-
-    UA_Variant_setArray(&v->value, permissions, rp->rolePermissionsSize,
-                       &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-    return UA_STATUSCODE_GOOD;
+    return retval;
 }
 
 static UA_StatusCode
 readUserRolePermissions(UA_Server *server, UA_Session *session,
                         const UA_Node *node, UA_DataValue *v) {
-    /* Return only the roles that the current session has been granted */
+    UA_LOCK_ASSERT(&server->serviceMutex);
+    if(session == NULL || !server->config.accessControl.readUserRolePermissions) {
+        // just return empty array
+        UA_Variant_setArray(&v->value, NULL, 0,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+        return UA_STATUSCODE_GOOD;
+    }
+
+    if(session == &server->adminSession) {
+        // admin session sees all role permissions
+        return readRolePermissions(server, session, node, v);
+    }
+
     size_t entriesSize = 0;
     UA_RolePermissionType *entries = NULL;
 
-    UA_StatusCode retval = UA_Server_getUserRolePermissions(
-        server, &session->sessionId, &node->head.nodeId,
-        &entriesSize, &entries);
+    UA_StatusCode retval = server->config.accessControl.readUserRolePermissions(
+        server, &server->config.accessControl,
+        &session->sessionId, session->context,
+        &node->head.nodeId, node->head.context,
+        &entriesSize, &entries
+    );
 
-    if(retval != UA_STATUSCODE_GOOD)
-        return retval;
+    if(UA_StatusCode_isGood(retval))
+        UA_Variant_setArray(&v->value, entries, entriesSize,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
+    else
+        UA_Variant_setArray(&v->value, NULL, 0,
+                            &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
 
-    UA_Variant_setArray(&v->value, entries, entriesSize,
-                       &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
     return UA_STATUSCODE_GOOD;
 }
-#endif /* UA_ENABLE_RBAC */
 
 static UA_StatusCode
 readIsAbstractAttribute(const UA_Node *node, UA_Variant *v) {
@@ -763,21 +762,10 @@ Operation_ReadWithNode(UA_Server *server, UA_Session *session,
         break;
     }
     case UA_ATTRIBUTEID_ROLEPERMISSIONS:
-#ifdef UA_ENABLE_RBAC
         retval = readRolePermissions(server, session, node, v);
-#else
-        retval = UA_STATUSCODE_BADATTRIBUTEIDINVALID;
-#endif
         break;
     case UA_ATTRIBUTEID_USERROLEPERMISSIONS:
-#ifdef UA_ENABLE_RBAC
         retval = readUserRolePermissions(server, session, node, v);
-#else
-        /* Without RBAC, return empty array */
-        UA_Variant_setArray(&v->value, NULL, 0,
-                           &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-        retval = UA_STATUSCODE_GOOD;
-#endif
         break;
     case UA_ATTRIBUTEID_ACCESSRESTRICTIONS:
         /* TODO: Add support for AccessRestrictions from the 1.04 spec */


### PR DESCRIPTION
This allows a vendor specific Role Permission model to be mapped to the standard attributes.