### PR TITLE
fix(client): include endpointUrl in FindServers request

### DIFF
--- a/src/client/ua_client_discovery.c
+++ b/src/client/ua_client_discovery.c
@@ -117,6 +117,7 @@ UA_Client_findServers(UA_Client *client, const char *serverUrl,
     }
 
     UA_StatusCode retval;
+    const UA_String url = UA_STRING((char*)(uintptr_t)serverUrl);
     if(!connected) {
         retval = connectSecureChannel(client, serverUrl);
         if(retval != UA_STATUSCODE_GOOD) {
@@ -128,6 +129,7 @@ UA_Client_findServers(UA_Client *client, const char *serverUrl,
     /* Prepare the request */
     UA_FindServersRequest request;
     UA_FindServersRequest_init(&request);
+    request.endpointUrl = url;
     request.serverUrisSize = serverUrisSize;
     request.serverUris = serverUris;
     request.localeIdsSize = localeIdsSize;

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -112,7 +112,6 @@ process_FindServers(UA_Server *server, UA_Session *session, UA_String endpointUr
     }
 
     /* Direct access to the out-variables */
-    size_t serversSize;
     UA_ApplicationDescription *servers;
 
 #ifndef UA_ENABLE_DISCOVERY
@@ -124,7 +123,6 @@ process_FindServers(UA_Server *server, UA_Session *session, UA_String endpointUr
         return res;
     *outServersSize = 1;
 
-    serversSize = 1;
     servers = *outServers;
 #else
     /* Allocate enough memory, including memory for the "self" response */
@@ -184,26 +182,23 @@ process_FindServers(UA_Server *server, UA_Session *session, UA_String endpointUr
     }
 
     *outServersSize = pos;
-    serversSize = pos;
 #endif /* UA_ENABLE_DISCOVERY */
 
-    /* Mirror back the expected EndpointUrl */
-    if(endpointUrl.length > 0) {
-        for(size_t i = 0; i < serversSize; i++) {
-            UA_ApplicationDescription *ad = &servers[i];
-            UA_Array_delete(ad->discoveryUrls, ad->discoveryUrlsSize,
+    /* Mirror back the expected EndpointUrl for the local server only.
+     * Registered servers retain the DiscoveryUrls they registered with. */
+    if(endpointUrl.length > 0 && foundSelf) {
+        UA_ApplicationDescription *ad = &servers[0];
+        UA_Array_delete(ad->discoveryUrls, ad->discoveryUrlsSize,
+                        &UA_TYPES[UA_TYPES_STRING]);
+        ad->discoveryUrls = NULL;
+        ad->discoveryUrlsSize = 0;
+        res = UA_Array_copy(&endpointUrl, 1, (void**)&ad->discoveryUrls,
                             &UA_TYPES[UA_TYPES_STRING]);
-            ad->discoveryUrls = NULL;
-            ad->discoveryUrlsSize = 0;
-            res = UA_Array_copy(&endpointUrl, 1, (void**)&ad->discoveryUrls,
-                                &UA_TYPES[UA_TYPES_STRING]);
-            if(res != UA_STATUSCODE_GOOD)
-                break;
+        if(res == UA_STATUSCODE_GOOD)
             ad->discoveryUrlsSize = 1;
-        }
     }
 
-    return UA_STATUSCODE_GOOD;
+    return res;
 }
 
 UA_Boolean

--- a/tests/client/check_client_discovery.c
+++ b/tests/client/check_client_discovery.c
@@ -86,16 +86,20 @@ END_TEST
 
 START_TEST(Client_findServers) {
     UA_Client *client = UA_Client_newForUnitTest();
+    const char *serverUrl = "opc.tcp://127.0.0.1:4840";
+    const UA_String requestedUrl = UA_STRING((char*)(uintptr_t)serverUrl);
 
     size_t serverCount = 0;
     UA_ApplicationDescription *servers = NULL;
     UA_StatusCode retval = UA_Client_findServers(client,
-                                "opc.tcp://localhost:4840",
+                                serverUrl,
                                 0, NULL, 0, NULL,
                                 &serverCount, &servers);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert(serverCount > 0);
     ck_assert_ptr_ne(servers, NULL);
+    ck_assert_uint_eq(servers[0].discoveryUrlsSize, 1);
+    ck_assert(UA_String_equal(&servers[0].discoveryUrls[0], &requestedUrl));
 
     UA_Array_delete(servers, serverCount,
                     &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);

--- a/tests/server/check_discovery.c
+++ b/tests/server/check_discovery.c
@@ -121,6 +121,9 @@ UA_Boolean *running_register;
 THREAD_HANDLE server_thread_register;
 UA_UInt64 periodicRegisterCallbackId;
 
+static const UA_String registeredDiscoveryUrl =
+    UA_STRING_STATIC("opc.tcp://third-party.example:16664");
+
 THREAD_CALLBACK(serverloop_register) {
     while(*running_register)
         UA_Server_run_iterate(server_register, true);
@@ -160,6 +163,11 @@ setup_register(void) {
     UA_LocalizedText_clear(&config_register->applicationDescription.applicationName);
     config_register->applicationDescription.applicationName =
         UA_LOCALIZEDTEXT_ALLOC("de", "Anmeldungsserver");
+    UA_StatusCode res = UA_Array_appendCopy(
+        (void**)&config_register->applicationDescription.discoveryUrls,
+        &config_register->applicationDescription.discoveryUrlsSize,
+        &registeredDiscoveryUrl, &UA_TYPES[UA_TYPES_STRING]);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
     UA_Server_run_startup(server_register);
     THREAD_CREATE(server_thread_register, serverloop_register);
 }
@@ -352,7 +360,9 @@ FindAndCheck(const UA_String expectedUris[], size_t expectedUrisSize,
 
 static UA_Boolean
 FindAndCheckDiscoveryUrls(const char *requestedEndpointUrl,
-                          size_t expectedSize) {
+                          const char *filterUri,
+                          UA_Boolean expectSelf,
+                          UA_Boolean expectRegistered) {
     UA_Client *client = UA_Client_newForUnitTest();
 
     UA_StatusCode retval = UA_Client_connect(client, requestedEndpointUrl);
@@ -364,6 +374,12 @@ FindAndCheckDiscoveryUrls(const char *requestedEndpointUrl,
     UA_FindServersRequest request;
     UA_FindServersRequest_init(&request);
     request.endpointUrl = UA_STRING((char*)(uintptr_t)requestedEndpointUrl);
+    UA_String filter = UA_STRING_NULL;
+    if(filterUri) {
+        filter = UA_STRING((char*)(uintptr_t)filterUri);
+        request.serverUrisSize = 1;
+        request.serverUris = &filter;
+    }
 
     UA_ApplicationDescription *applicationDescriptionArray = NULL;
     size_t applicationDescriptionArraySize = 0;
@@ -378,21 +394,47 @@ FindAndCheckDiscoveryUrls(const char *requestedEndpointUrl,
 
     UA_Boolean ok = true;
     UA_String requested = UA_STRING((char*)(uintptr_t)requestedEndpointUrl);
-
+    UA_String selfUri =
+        UA_STRING("urn:open62541.test.local_discovery_server");
+    UA_String registeredUri =
+        UA_STRING("urn:open62541.test.server_register");
+    UA_Boolean foundSelf = false;
+    UA_Boolean foundRegistered = false;
+    size_t expectedSize = (size_t)expectSelf + (size_t)expectRegistered;
     if(applicationDescriptionArraySize != expectedSize)
         ok = false;
 
     for(size_t i = 0; ok && i < applicationDescriptionArraySize; i++) {
         UA_ApplicationDescription *ad = &applicationDescriptionArray[i];
-        if(ad->discoveryUrlsSize != 1) {
-            ok = false;
-            break;
+        if(UA_String_equal(&ad->applicationUri, &selfUri)) {
+            foundSelf = true;
+            if(ad->discoveryUrlsSize != 1 ||
+               !UA_String_equal(&ad->discoveryUrls[0], &requested))
+                ok = false;
+            continue;
         }
-        if(!UA_String_equal(&ad->discoveryUrls[0], &requested)) {
-            ok = false;
-            break;
+
+        if(UA_String_equal(&ad->applicationUri, &registeredUri)) {
+            foundRegistered = true;
+            UA_Boolean foundUrl = false;
+            for(size_t j = 0; j < ad->discoveryUrlsSize; j++) {
+                if(UA_String_equal(&ad->discoveryUrls[j],
+                                   &registeredDiscoveryUrl)) {
+                    foundUrl = true;
+                    break;
+                }
+            }
+            if(!foundUrl)
+                ok = false;
+            continue;
         }
+
+        /* No other server was registered in this test. */
+        ok = false;
     }
+
+    if(foundSelf != expectSelf || foundRegistered != expectRegistered)
+        ok = false;
 
     UA_FindServersResponse_clear(&response);
     UA_Client_disconnect(client);
@@ -586,19 +628,23 @@ START_TEST(Server_registerTimeout) {
 }
 END_TEST
 
-START_TEST(Server_findServers_mirrors_endpointUrl) {
+START_TEST(Server_findServers_preserves_registered_discoveryUrls) {
     while(!Client_find_discovery()) {}
 
     registerServer();
 
     while(!Client_find_registered()) {}
 
-    /* Wait until FindServers returns exactly the two servers, each mirroring the
-     * requested discovery URL. Busy-wait (like the checks above) instead of a
-     * one-shot assert: under slow execution (valgrind) the registered entry can
-     * briefly age out between periodic re-registrations, so retry until the
-     * expected state is observed. */
-    while(!FindAndCheckDiscoveryUrls("opc.tcp://localhost:4840", 2)) {}
+    /* The local server mirrors the requested DiscoveryUrl. The registered
+     * server retains its own URLs. */
+    while(!FindAndCheckDiscoveryUrls("opc.tcp://localhost:4840", NULL,
+                                     true, true)) {}
+
+    /* Filtering out the local server must not cause the first registered
+     * server entry to be overwritten with the LDS URL. */
+    while(!FindAndCheckDiscoveryUrls(
+        "opc.tcp://localhost:4840", "urn:open62541.test.server_register",
+        false, true)) {}
 
     unregisterServer();
 
@@ -639,7 +685,8 @@ static Suite* testSuite_Client(void) {
     tcase_add_unchecked_fixture(tc_register, setup_lds, teardown_lds);
     tcase_add_unchecked_fixture(tc_register, setup_register, teardown_register);
     tcase_add_test(tc_register, Server_registerUnregister);
-    tcase_add_test(tc_register, Server_findServers_mirrors_endpointUrl);
+    tcase_add_test(tc_register,
+                   Server_findServers_preserves_registered_discoveryUrls);
     suite_add_tcase(s,tc_register);
 
     TCase *tc_register_find = tcase_create("RegisterServer and FindServers");


### PR DESCRIPTION
### Summary

This PR propagates the requested Discovery Endpoint URL in `UA_Client_findServers()` and add a unit test that verifies the returned `discoveryUrls` mirror the URL used by the client.

### Problem

According to the OPC UA specification, the client should pass the Discovery Endpoint URL it used in `FindServersRequest.endpointUrl`, and servers may use that value to return matching `discoveryUrls`.

Previously, `UA_Client_findServers()` did not set `FindServersRequest.endpointUrl`. As a result, servers could fall back to their default discovery URL selection logic and return `discoveryUrls` that did not match the actual Discovery Endpoint URL used by the client.

### Changes

- Set `request.endpointUrl` from the `serverUrl` argument in `UA_Client_findServers()`.
- Extend `check_client_discovery` to assert that the returned `discoveryUrls` match the requested URL.
