### PR TITLE
fix(client): propagate browse operation status in child iterator

### DIFF
--- a/src/client/ua_client_highlevel.c
+++ b/src/client/ua_client_highlevel.c
@@ -71,13 +71,18 @@ UA_Client_forEachChildNodeCall(UA_Client *client, UA_NodeId parentNodeId,
     UA_BrowseResponse bResp = UA_Client_Service_browse(client, bReq);
 
     UA_StatusCode retval = bResp.responseHeader.serviceResult;
+    if(retval == UA_STATUSCODE_GOOD && bResp.resultsSize != 1)
+        retval = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    if(retval == UA_STATUSCODE_GOOD)
+        retval = bResp.results[0].statusCode;
+
     if(retval == UA_STATUSCODE_GOOD) {
-        for(size_t i = 0; i < bResp.resultsSize; ++i) {
-            for(size_t j = 0; j < bResp.results[i].referencesSize; ++j) {
-                UA_ReferenceDescription *ref = &bResp.results[i].references[j];
-                retval |= callback(ref->nodeId.nodeId, !ref->isForward,
-                                   ref->referenceTypeId, handle);
-            }
+        UA_BrowseResult *result = &bResp.results[0];
+        for(size_t j = 0; j < result->referencesSize; ++j) {
+            UA_ReferenceDescription *ref = &result->references[j];
+            retval |= callback(ref->nodeId.nodeId, !ref->isForward,
+                               ref->referenceTypeId, handle);
         }
     }
 

--- a/tests/client/check_client_highlevel.c
+++ b/tests/client/check_client_highlevel.c
@@ -1131,11 +1131,12 @@ END_TEST
 #endif
 
 START_TEST(Highlevel_ForEachChildNode_InvalidNode) {
-    /* forEachChildNodeCall with non-existent node — exercises the browse path.
-     * The server may return GOOD with empty results for unknown nodes. */
+    /* Operation-level Browse failures must be propagated to the helper caller. */
     UA_NodeId invalidNode = UA_NODEID_NUMERIC(99, 99999);
     unsigned int prevCount = iteratedNodeCount;
-    UA_Client_forEachChildNodeCall(client, invalidNode, nodeIter, NULL);
+    UA_StatusCode retval =
+        UA_Client_forEachChildNodeCall(client, invalidNode, nodeIter, NULL);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADNODEIDUNKNOWN);
     /* No children should have been iterated */
     ck_assert_uint_eq(iteratedNodeCount, prevCount);
 }


### PR DESCRIPTION
### Summary

This PR makes `UA_Client_forEachChildNodeCall()` propagate operation-level `BrowseResult.statusCode` values and adds a regression test for the invalid-node case.

### Problem

According to the OPC UA specification, a successful `Browse` service call and the status of each individual `BrowseResult` are separate layers of result semantics.

Previously, `UA_Client_forEachChildNodeCall()` only checked `responseHeader.serviceResult` and then iterated over the returned references without checking the operation-level `BrowseResult.statusCode`. As a result, a browse failure such as `BadNodeIdUnknown` could be silently treated as success by the helper.

### Changes

- Check that the `Browse` response contains exactly one result and propagate `results[0].statusCode` before iterating references.
- Extend `check_client_highlevel` with a regression test that verifies `UA_Client_forEachChildNodeCall()` returns `BadNodeIdUnknown` for an invalid node and does not invoke the iterator callback.
