### PR TITLE
fix(pubsub): reject unsupported standalone subscribed dataset mirrors

### DIFF
--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -646,13 +646,14 @@ UA_StatusCode
 UA_SubscribedDataSetConfig_copy(const UA_SubscribedDataSetConfig *src,
                                 UA_SubscribedDataSetConfig *dst) {
     UA_StatusCode res = UA_STATUSCODE_GOOD;
+    if(src->subscribedDataSetType != UA_PUBSUB_SDS_TARGET)
+        return UA_STATUSCODE_BADNOTIMPLEMENTED;
+
     memcpy(dst, src, sizeof(UA_SubscribedDataSetConfig));
     res = UA_DataSetMetaDataType_copy(&src->dataSetMetaData, &dst->dataSetMetaData);
     res |= UA_String_copy(&src->name, &dst->name);
-    if(src->subscribedDataSetType == UA_PUBSUB_SDS_TARGET) {
-        res |= UA_TargetVariablesDataType_copy(&src->subscribedDataSet.target,
-                                               &dst->subscribedDataSet.target);
-    }
+    res |= UA_TargetVariablesDataType_copy(&src->subscribedDataSet.target,
+                                           &dst->subscribedDataSet.target);
     if(res != UA_STATUSCODE_GOOD)
         UA_SubscribedDataSetConfig_clear(dst);
     return res;
@@ -678,6 +679,13 @@ addSubscribedDataSet(UA_PubSubManager *psm,
         UA_LOG_ERROR(psm->logging, UA_LOGCATEGORY_PUBSUB,
                      "SubscribedDataSet creation failed. No config passed in.");
         return UA_STATUSCODE_BADINVALIDARGUMENT;
+    }
+
+    if(sdsConfig->subscribedDataSetType != UA_PUBSUB_SDS_TARGET) {
+        UA_LOG_ERROR(psm->logging, UA_LOGCATEGORY_PUBSUB,
+                     "SubscribedDataSet creation failed. Currently only "
+                     "TargetVariables are implemented.");
+        return UA_STATUSCODE_BADNOTIMPLEMENTED;
     }
 
     UA_SubscribedDataSetConfig tmpSubscribedDataSetConfig;

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -2004,6 +2004,24 @@ START_TEST(ValidDataSetConfigurationAddAndRemove) {
 
 } END_TEST
 
+START_TEST(RejectUnsupportedStandaloneSubscribedDataSetMirror) {
+    UA_PubSubManager *psm = getPSM(server);
+    UA_SubscribedDataSetConfig cfg;
+    UA_NodeId ret = UA_NODEID_NULL;
+    memset(&cfg, 0, sizeof(UA_SubscribedDataSetConfig));
+
+    UA_DataSetMetaDataType_init(&cfg.dataSetMetaData);
+    cfg.dataSetMetaData.name = UA_STRING("UnsupportedMirrorSDS");
+    cfg.name = UA_STRING("UnsupportedMirrorSDS");
+    cfg.subscribedDataSetType = UA_PUBSUB_SDS_MIRROR;
+
+    UA_StatusCode retVal = UA_Server_addSubscribedDataSet(server, &cfg, &ret);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_BADNOTIMPLEMENTED);
+    ck_assert(UA_NodeId_equal(&ret, &UA_NODEID_NULL));
+    ck_assert_ptr_eq(UA_SubscribedDataSet_findByName(psm, UA_STRING("UnsupportedMirrorSDS")), NULL);
+}
+END_TEST
+
 START_TEST(AddAndRemoveReaderUsingDataSet) {
     UA_PubSubManager *psm = getPSM(server);
     addTargetVariable();
@@ -2550,8 +2568,9 @@ int main(void) {
 
     /*Test cases for the subscribed datasets */
     TCase *tc_pubsub_datasets = tcase_create("Subscriber using subscribed datasets");
-    tcase_add_test(tc_pubsub_publish_subscribe, ValidDataSetConfigurationAddAndRemove);
-    tcase_add_test(tc_pubsub_publish_subscribe, AddAndRemoveReaderUsingDataSet);
+    tcase_add_test(tc_pubsub_datasets, ValidDataSetConfigurationAddAndRemove);
+    tcase_add_test(tc_pubsub_datasets, RejectUnsupportedStandaloneSubscribedDataSetMirror);
+    tcase_add_test(tc_pubsub_datasets, AddAndRemoveReaderUsingDataSet);
 
     TCase *tc_dataSetMessage_padding = tcase_create("PubSub DataSetMessage padding");
     tcase_add_checked_fixture(tc_dataSetMessage_padding, setup, teardown);

--- a/tests/pubsub/check_pubsub_subscribe.c
+++ b/tests/pubsub/check_pubsub_subscribe.c
@@ -2565,12 +2565,13 @@ int main(void) {
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishSubscribeWithoutPayloadHeader);
     tcase_add_test(tc_pubsub_publish_subscribe, MultiPublishSubscribeInt32);
     tcase_add_test(tc_pubsub_publish_subscribe, SinglePublishOnDemand);
+    tcase_add_test(tc_pubsub_publish_subscribe, ValidDataSetConfigurationAddAndRemove);
+    tcase_add_test(tc_pubsub_publish_subscribe, AddAndRemoveReaderUsingDataSet);
 
     /*Test cases for the subscribed datasets */
     TCase *tc_pubsub_datasets = tcase_create("Subscriber using subscribed datasets");
-    tcase_add_test(tc_pubsub_datasets, ValidDataSetConfigurationAddAndRemove);
+    tcase_add_checked_fixture(tc_pubsub_datasets, setup, teardown);
     tcase_add_test(tc_pubsub_datasets, RejectUnsupportedStandaloneSubscribedDataSetMirror);
-    tcase_add_test(tc_pubsub_datasets, AddAndRemoveReaderUsingDataSet);
 
     TCase *tc_dataSetMessage_padding = tcase_create("PubSub DataSetMessage padding");
     tcase_add_checked_fixture(tc_dataSetMessage_padding, setup, teardown);


### PR DESCRIPTION
### Summary

This PR rejects unsupported standalone `SubscribedDataSetMirror` configurations during standalone `SubscribedDataSet` creation.

### Problem

According to the OPC UA specification, standard `SubscribedDataSet` types should only be accepted when the implementation provides a matching runtime path for them.

Previously, the standalone `SubscribedDataSet` creation path accepted `UA_PUBSUB_SDS_MIRROR` and registered it in the runtime configuration, even though the later `DataSetReader` binding path only supports `UA_PUBSUB_SDS_TARGET` and returns `BadNotImplemented` for other types. As a result, the API could report successful configuration creation for an object that could never be connected or used.

### Changes

- Reject non-`UA_PUBSUB_SDS_TARGET` types in `UA_SubscribedDataSetConfig_copy()`.
- Reject unsupported standalone `SubscribedDataSet` types in `addSubscribedDataSet()` before registering them in the `PubSubManager`.
- Add a regression test that verifies `UA_PUBSUB_SDS_MIRROR` is rejected during creation.
