### PR TITLE
fix(pubsub): keep delta frame field count consistent

### DIFF
--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -480,7 +480,6 @@ UA_PubSubDataSetWriter_generateDeltaFrameMessage(UA_PubSubManager *psm,
     if(!deltaFields)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    dsm->fieldCount = counter;
     dsm->data.deltaFrameFields = deltaFields;
 
     size_t currentDeltaField = 0;

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -483,7 +483,6 @@ UA_PubSubDataSetWriter_generateDeltaFrameMessage(UA_PubSubManager *psm,
     if(!deltaFields)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    dsm->fieldCount = counter;
     dsm->data.deltaFrameFields = deltaFields;
 
     size_t currentDeltaField = 0;

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -623,6 +623,14 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
                           UA_DATASETMESSAGE_DATAKEYFRAME);
         UA_DataSetMessage_clear(&keyFrame);
 
+        UA_DataSetMessage secondKeyFrame;
+        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
+        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &secondKeyFrame);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(secondKeyFrame.header.dataSetMessageType,
+                          UA_DATASETMESSAGE_DATAKEYFRAME);
+        UA_DataSetMessage_clear(&secondKeyFrame);
+
         value2 = 201;
         UA_Variant updatedValue;
         UA_Variant_init(&updatedValue);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -616,7 +616,7 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         dsw->config.keyFrameCount = 3;
 
         UA_DataSetMessage keyFrame;
-        UA_DataSetMessage_init(&keyFrame);
+        memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &keyFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
@@ -631,7 +631,7 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         UA_DataSetMessage deltaFrame;
-        UA_DataSetMessage_init(&deltaFrame);
+        memset(&deltaFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &deltaFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(deltaFrame.header.dataSetMessageType,

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -571,25 +571,27 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         UA_Int32 value1 = 100;
         UA_Variant_setScalar(&attr.value, &value1, &UA_TYPES[UA_TYPES_INT32]);
-        UA_NodeId node1 = UA_NODEID_NUMERIC(1, 50010);
+        UA_NodeId node1;
+        UA_NodeId_init(&node1);
         UA_StatusCode retVal =
-            UA_Server_addVariableNode(server, node1,
+            UA_Server_addVariableNode(server, UA_NODEID_NULL,
                                       UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                       UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                                       UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount1"),
                                       UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
-                                      attr, NULL, NULL);
+                                      attr, NULL, &node1);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         UA_Int32 value2 = 200;
         UA_Variant_setScalar(&attr.value, &value2, &UA_TYPES[UA_TYPES_INT32]);
-        UA_NodeId node2 = UA_NODEID_NUMERIC(1, 50011);
-        retVal |= UA_Server_addVariableNode(server, node2,
+        UA_NodeId node2;
+        UA_NodeId_init(&node2);
+        retVal |= UA_Server_addVariableNode(server, UA_NODEID_NULL,
                                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                             UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                                             UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount2"),
                                             UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
-                                            attr, NULL, NULL);
+                                            attr, NULL, &node2);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         UA_DataSetFieldConfig dataSetFieldConfig;
@@ -652,6 +654,8 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         ck_assert_int_eq(*(UA_Int32 *)deltaFrame.data.deltaFrameFields[0].value.value.data,
                          value2);
         UA_DataSetMessage_clear(&deltaFrame);
+        UA_NodeId_clear(&node1);
+        UA_NodeId_clear(&node2);
     } END_TEST
 
 

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -612,25 +612,29 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         retVal = UA_Server_enableAllPubSubComponents(server);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
+        UA_DataSetMessage keyFrame;
+        memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
+        UA_DataSetMessage secondKeyFrame;
+        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
+
+        lockServer(server);
         UA_PubSubManager *psm = getPSM(server);
         UA_DataSetWriter *dsw = UA_DataSetWriter_find(psm, dataSetWriter1);
         ck_assert_ptr_nonnull(dsw);
         dsw->config.keyFrameCount = 3;
 
-        UA_DataSetMessage keyFrame;
-        memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &keyFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
                           UA_DATASETMESSAGE_DATAKEYFRAME);
-        UA_DataSetMessage_clear(&keyFrame);
 
-        UA_DataSetMessage secondKeyFrame;
-        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &secondKeyFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(secondKeyFrame.header.dataSetMessageType,
                           UA_DATASETMESSAGE_DATAKEYFRAME);
+        unlockServer(server);
+
+        UA_DataSetMessage_clear(&keyFrame);
         UA_DataSetMessage_clear(&secondKeyFrame);
 
         value2 = 201;
@@ -642,6 +646,10 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         UA_DataSetMessage deltaFrame;
         memset(&deltaFrame, 0, sizeof(UA_DataSetMessage));
+        lockServer(server);
+        psm = getPSM(server);
+        dsw = UA_DataSetWriter_find(psm, dataSetWriter1);
+        ck_assert_ptr_nonnull(dsw);
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &deltaFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(deltaFrame.header.dataSetMessageType,
@@ -653,6 +661,7 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
                          &UA_TYPES[UA_TYPES_INT32]);
         ck_assert_int_eq(*(UA_Int32 *)deltaFrame.data.deltaFrameFields[0].value.value.data,
                          value2);
+        unlockServer(server);
         UA_DataSetMessage_clear(&deltaFrame);
         UA_NodeId_clear(&node1);
         UA_NodeId_clear(&node2);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -563,7 +563,6 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         UA_ServerConfig *config = UA_Server_getConfig(server);
         config->pubSubConfig.enableDeltaFrames = true;
-        setupDataSetFieldTestEnvironment();
 
         UA_VariableAttributes attr = UA_VariableAttributes_default;
         attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
@@ -608,6 +607,8 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = node2;
         retVal = UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        setupDataSetFieldTestEnvironment();
 
         retVal = UA_Server_enableAllPubSubComponents(server);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -560,10 +560,10 @@ START_TEST(PublishDataSetFieldAsDeltaFrame){
 
 START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         setupPublishedDataSetTestEnvironment();
-        setupDataSetFieldTestEnvironment();
 
         UA_ServerConfig *config = UA_Server_getConfig(server);
         config->pubSubConfig.enableDeltaFrames = true;
+        setupDataSetFieldTestEnvironment();
 
         UA_VariableAttributes attr = UA_VariableAttributes_default;
         attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -558,6 +558,94 @@ START_TEST(PublishDataSetFieldAsDeltaFrame){
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
+START_TEST(DeltaFrameFieldCountMatchesChangedFields){
+        setupPublishedDataSetTestEnvironment();
+        setupDataSetFieldTestEnvironment();
+
+        UA_ServerConfig *config = UA_Server_getConfig(server);
+        config->pubSubConfig.enableDeltaFrames = true;
+
+        UA_VariableAttributes attr = UA_VariableAttributes_default;
+        attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+        attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
+
+        UA_Int32 value1 = 100;
+        UA_Variant_setScalar(&attr.value, &value1, &UA_TYPES[UA_TYPES_INT32]);
+        UA_NodeId node1 = UA_NODEID_NUMERIC(1, 50010);
+        UA_StatusCode retVal =
+            UA_Server_addVariableNode(server, node1,
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                      UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount1"),
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                      attr, NULL, NULL);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_Int32 value2 = 200;
+        UA_Variant_setScalar(&attr.value, &value2, &UA_TYPES[UA_TYPES_INT32]);
+        UA_NodeId node2 = UA_NODEID_NUMERIC(1, 50011);
+        retVal |= UA_Server_addVariableNode(server, node2,
+                                            UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                            UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount2"),
+                                            UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                            attr, NULL, NULL);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_DataSetFieldConfig dataSetFieldConfig;
+        memset(&dataSetFieldConfig, 0, sizeof(dataSetFieldConfig));
+        dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
+        dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
+
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("field 1");
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = node1;
+        retVal = UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("field 2");
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = node2;
+        retVal = UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        retVal = UA_Server_enableAllPubSubComponents(server);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_PubSubManager *psm = getPSM(server);
+        UA_DataSetWriter *dsw = UA_DataSetWriter_find(psm, dataSetWriter1);
+        ck_assert_ptr_nonnull(dsw);
+        dsw->config.keyFrameCount = 3;
+
+        UA_DataSetMessage keyFrame;
+        UA_DataSetMessage_init(&keyFrame);
+        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &keyFrame);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
+                          UA_DATASETMESSAGE_DATAKEYFRAME);
+        UA_DataSetMessage_clear(&keyFrame);
+
+        value2 = 201;
+        UA_Variant updatedValue;
+        UA_Variant_init(&updatedValue);
+        UA_Variant_setScalar(&updatedValue, &value2, &UA_TYPES[UA_TYPES_INT32]);
+        retVal = UA_Server_writeValue(server, node2, updatedValue);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_DataSetMessage deltaFrame;
+        UA_DataSetMessage_init(&deltaFrame);
+        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &deltaFrame);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(deltaFrame.header.dataSetMessageType,
+                          UA_DATASETMESSAGE_DATADELTAFRAME);
+        ck_assert_uint_eq(deltaFrame.fieldCount, 1);
+        ck_assert_ptr_nonnull(deltaFrame.data.deltaFrameFields);
+        ck_assert_uint_eq(deltaFrame.data.deltaFrameFields[0].index, 1);
+        ck_assert_ptr_eq(deltaFrame.data.deltaFrameFields[0].value.value.type,
+                         &UA_TYPES[UA_TYPES_INT32]);
+        ck_assert_int_eq(*(UA_Int32 *)deltaFrame.data.deltaFrameFields[0].value.value.data,
+                         value2);
+        UA_DataSetMessage_clear(&deltaFrame);
+    } END_TEST
+
 
 /* Test DataSetOrdering reconfiguration (OPC UA Part 14, section 6.3.1.1.3) 
  * 
@@ -707,6 +795,7 @@ int main(void) {
     tcase_add_checked_fixture(tc_pubsub_publish, setup, teardown);
     tcase_add_test(tc_pubsub_publish, SinglePublishDataSetFieldAndPublishTimestampTest);
     tcase_add_test(tc_pubsub_publish, PublishDataSetFieldAsDeltaFrame);
+    tcase_add_test(tc_pubsub_publish, DeltaFrameFieldCountMatchesChangedFields);
 
     TCase *tc_pubsub_datasetordering = tcase_create("PubSub DataSetOrdering (OPC UA Part 14)");
     tcase_add_checked_fixture(tc_pubsub_datasetordering, setup, teardown);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -610,13 +610,8 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         setupDataSetFieldTestEnvironment();
 
-        retVal = UA_Server_enableAllPubSubComponents(server);
-        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-
         UA_DataSetMessage keyFrame;
         memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
-        UA_DataSetMessage secondKeyFrame;
-        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
 
         lockServer(server);
         UA_PubSubManager *psm = getPSM(server);
@@ -628,15 +623,9 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
                           UA_DATASETMESSAGE_DATAKEYFRAME);
-
-        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &secondKeyFrame);
-        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-        ck_assert_uint_eq(secondKeyFrame.header.dataSetMessageType,
-                          UA_DATASETMESSAGE_DATAKEYFRAME);
         unlockServer(server);
 
         UA_DataSetMessage_clear(&keyFrame);
-        UA_DataSetMessage_clear(&secondKeyFrame);
 
         value2 = 201;
         UA_Variant updatedValue;

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -611,13 +611,8 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         setupDataSetFieldTestEnvironment();
 
-        retVal = UA_Server_enableAllPubSubComponents(server);
-        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-
         UA_DataSetMessage keyFrame;
         memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
-        UA_DataSetMessage secondKeyFrame;
-        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
 
         lockServer(server);
         UA_PubSubManager *psm = getPSM(server);
@@ -629,15 +624,9 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
                           UA_DATASETMESSAGE_DATAKEYFRAME);
-
-        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &secondKeyFrame);
-        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
-        ck_assert_uint_eq(secondKeyFrame.header.dataSetMessageType,
-                          UA_DATASETMESSAGE_DATAKEYFRAME);
         unlockServer(server);
 
         UA_DataSetMessage_clear(&keyFrame);
-        UA_DataSetMessage_clear(&secondKeyFrame);
 
         value2 = 201;
         UA_Variant updatedValue;

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -624,6 +624,14 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
                           UA_DATASETMESSAGE_DATAKEYFRAME);
         UA_DataSetMessage_clear(&keyFrame);
 
+        UA_DataSetMessage secondKeyFrame;
+        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
+        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &secondKeyFrame);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(secondKeyFrame.header.dataSetMessageType,
+                          UA_DATASETMESSAGE_DATAKEYFRAME);
+        UA_DataSetMessage_clear(&secondKeyFrame);
+
         value2 = 201;
         UA_Variant updatedValue;
         UA_Variant_init(&updatedValue);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -561,10 +561,10 @@ START_TEST(PublishDataSetFieldAsDeltaFrame){
 
 START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         setupPublishedDataSetTestEnvironment();
-        setupDataSetFieldTestEnvironment();
 
         UA_ServerConfig *config = UA_Server_getConfig(server);
         config->pubSubConfig.enableDeltaFrames = true;
+        setupDataSetFieldTestEnvironment();
 
         UA_VariableAttributes attr = UA_VariableAttributes_default;
         attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -559,6 +559,94 @@ START_TEST(PublishDataSetFieldAsDeltaFrame){
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     } END_TEST
 
+START_TEST(DeltaFrameFieldCountMatchesChangedFields){
+        setupPublishedDataSetTestEnvironment();
+        setupDataSetFieldTestEnvironment();
+
+        UA_ServerConfig *config = UA_Server_getConfig(server);
+        config->pubSubConfig.enableDeltaFrames = true;
+
+        UA_VariableAttributes attr = UA_VariableAttributes_default;
+        attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+        attr.dataType = UA_TYPES[UA_TYPES_INT32].typeId;
+
+        UA_Int32 value1 = 100;
+        UA_Variant_setScalar(&attr.value, &value1, &UA_TYPES[UA_TYPES_INT32]);
+        UA_NodeId node1 = UA_NODEID_NUMERIC(1, 50010);
+        UA_StatusCode retVal =
+            UA_Server_addVariableNode(server, node1,
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                      UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount1"),
+                                      UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                      attr, NULL, NULL);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_Int32 value2 = 200;
+        UA_Variant_setScalar(&attr.value, &value2, &UA_TYPES[UA_TYPES_INT32]);
+        UA_NodeId node2 = UA_NODEID_NUMERIC(1, 50011);
+        retVal |= UA_Server_addVariableNode(server, node2,
+                                            UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                            UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+                                            UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount2"),
+                                            UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+                                            attr, NULL, NULL);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_DataSetFieldConfig dataSetFieldConfig;
+        memset(&dataSetFieldConfig, 0, sizeof(dataSetFieldConfig));
+        dataSetFieldConfig.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
+        dataSetFieldConfig.field.variable.publishParameters.attributeId = UA_ATTRIBUTEID_VALUE;
+
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("field 1");
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = node1;
+        retVal = UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        dataSetFieldConfig.field.variable.fieldNameAlias = UA_STRING("field 2");
+        dataSetFieldConfig.field.variable.publishParameters.publishedVariable = node2;
+        retVal = UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        retVal = UA_Server_enableAllPubSubComponents(server);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_PubSubManager *psm = getPSM(server);
+        UA_DataSetWriter *dsw = UA_DataSetWriter_find(psm, dataSetWriter1);
+        ck_assert_ptr_nonnull(dsw);
+        dsw->config.keyFrameCount = 3;
+
+        UA_DataSetMessage keyFrame;
+        UA_DataSetMessage_init(&keyFrame);
+        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &keyFrame);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
+                          UA_DATASETMESSAGE_DATAKEYFRAME);
+        UA_DataSetMessage_clear(&keyFrame);
+
+        value2 = 201;
+        UA_Variant updatedValue;
+        UA_Variant_init(&updatedValue);
+        UA_Variant_setScalar(&updatedValue, &value2, &UA_TYPES[UA_TYPES_INT32]);
+        retVal = UA_Server_writeValue(server, node2, updatedValue);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        UA_DataSetMessage deltaFrame;
+        UA_DataSetMessage_init(&deltaFrame);
+        retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &deltaFrame);
+        ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(deltaFrame.header.dataSetMessageType,
+                          UA_DATASETMESSAGE_DATADELTAFRAME);
+        ck_assert_uint_eq(deltaFrame.fieldCount, 1);
+        ck_assert_ptr_nonnull(deltaFrame.data.deltaFrameFields);
+        ck_assert_uint_eq(deltaFrame.data.deltaFrameFields[0].index, 1);
+        ck_assert_ptr_eq(deltaFrame.data.deltaFrameFields[0].value.value.type,
+                         &UA_TYPES[UA_TYPES_INT32]);
+        ck_assert_int_eq(*(UA_Int32 *)deltaFrame.data.deltaFrameFields[0].value.value.data,
+                         value2);
+        UA_DataSetMessage_clear(&deltaFrame);
+    } END_TEST
+
 
 /* Test DataSetOrdering reconfiguration (OPC UA Part 14, section 6.3.1.1.3) 
  * 
@@ -1032,6 +1120,7 @@ int main(void) {
     tcase_add_checked_fixture(tc_pubsub_publish, setup, teardown);
     tcase_add_test(tc_pubsub_publish, SinglePublishDataSetFieldAndPublishTimestampTest);
     tcase_add_test(tc_pubsub_publish, PublishDataSetFieldAsDeltaFrame);
+    tcase_add_test(tc_pubsub_publish, DeltaFrameFieldCountMatchesChangedFields);
 
     TCase *tc_pubsub_datasetordering = tcase_create("PubSub DataSetOrdering (OPC UA Part 14)");
     tcase_add_checked_fixture(tc_pubsub_datasetordering, setup, teardown);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -613,25 +613,29 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         retVal = UA_Server_enableAllPubSubComponents(server);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
+        UA_DataSetMessage keyFrame;
+        memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
+        UA_DataSetMessage secondKeyFrame;
+        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
+
+        lockServer(server);
         UA_PubSubManager *psm = getPSM(server);
         UA_DataSetWriter *dsw = UA_DataSetWriter_find(psm, dataSetWriter1);
         ck_assert_ptr_nonnull(dsw);
         dsw->config.keyFrameCount = 3;
 
-        UA_DataSetMessage keyFrame;
-        memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &keyFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
                           UA_DATASETMESSAGE_DATAKEYFRAME);
-        UA_DataSetMessage_clear(&keyFrame);
 
-        UA_DataSetMessage secondKeyFrame;
-        memset(&secondKeyFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &secondKeyFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(secondKeyFrame.header.dataSetMessageType,
                           UA_DATASETMESSAGE_DATAKEYFRAME);
+        unlockServer(server);
+
+        UA_DataSetMessage_clear(&keyFrame);
         UA_DataSetMessage_clear(&secondKeyFrame);
 
         value2 = 201;
@@ -643,6 +647,10 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         UA_DataSetMessage deltaFrame;
         memset(&deltaFrame, 0, sizeof(UA_DataSetMessage));
+        lockServer(server);
+        psm = getPSM(server);
+        dsw = UA_DataSetWriter_find(psm, dataSetWriter1);
+        ck_assert_ptr_nonnull(dsw);
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &deltaFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(deltaFrame.header.dataSetMessageType,
@@ -654,6 +662,7 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
                          &UA_TYPES[UA_TYPES_INT32]);
         ck_assert_int_eq(*(UA_Int32 *)deltaFrame.data.deltaFrameFields[0].value.value.data,
                          value2);
+        unlockServer(server);
         UA_DataSetMessage_clear(&deltaFrame);
         UA_NodeId_clear(&node1);
         UA_NodeId_clear(&node2);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -564,7 +564,6 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         UA_ServerConfig *config = UA_Server_getConfig(server);
         config->pubSubConfig.enableDeltaFrames = true;
-        setupDataSetFieldTestEnvironment();
 
         UA_VariableAttributes attr = UA_VariableAttributes_default;
         attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
@@ -609,6 +608,8 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         dataSetFieldConfig.field.variable.publishParameters.publishedVariable = node2;
         retVal = UA_Server_addDataSetField(server, publishedDataSet1, &dataSetFieldConfig, NULL).result;
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+        setupDataSetFieldTestEnvironment();
 
         retVal = UA_Server_enableAllPubSubComponents(server);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -617,7 +617,7 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         dsw->config.keyFrameCount = 3;
 
         UA_DataSetMessage keyFrame;
-        UA_DataSetMessage_init(&keyFrame);
+        memset(&keyFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &keyFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(keyFrame.header.dataSetMessageType,
@@ -632,7 +632,7 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         UA_DataSetMessage deltaFrame;
-        UA_DataSetMessage_init(&deltaFrame);
+        memset(&deltaFrame, 0, sizeof(UA_DataSetMessage));
         retVal = UA_DataSetWriter_generateDataSetMessage(psm, dsw, &deltaFrame);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
         ck_assert_uint_eq(deltaFrame.header.dataSetMessageType,

--- a/tests/pubsub/check_pubsub_publish.c
+++ b/tests/pubsub/check_pubsub_publish.c
@@ -572,25 +572,27 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
 
         UA_Int32 value1 = 100;
         UA_Variant_setScalar(&attr.value, &value1, &UA_TYPES[UA_TYPES_INT32]);
-        UA_NodeId node1 = UA_NODEID_NUMERIC(1, 50010);
+        UA_NodeId node1;
+        UA_NodeId_init(&node1);
         UA_StatusCode retVal =
-            UA_Server_addVariableNode(server, node1,
+            UA_Server_addVariableNode(server, UA_NODEID_NULL,
                                       UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                       UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                                       UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount1"),
                                       UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
-                                      attr, NULL, NULL);
+                                      attr, NULL, &node1);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         UA_Int32 value2 = 200;
         UA_Variant_setScalar(&attr.value, &value2, &UA_TYPES[UA_TYPES_INT32]);
-        UA_NodeId node2 = UA_NODEID_NUMERIC(1, 50011);
-        retVal |= UA_Server_addVariableNode(server, node2,
+        UA_NodeId node2;
+        UA_NodeId_init(&node2);
+        retVal |= UA_Server_addVariableNode(server, UA_NODEID_NULL,
                                             UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
                                             UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
                                             UA_QUALIFIEDNAME(1, "DeltaFrameFieldCount2"),
                                             UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
-                                            attr, NULL, NULL);
+                                            attr, NULL, &node2);
         ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
 
         UA_DataSetFieldConfig dataSetFieldConfig;
@@ -653,6 +655,8 @@ START_TEST(DeltaFrameFieldCountMatchesChangedFields){
         ck_assert_int_eq(*(UA_Int32 *)deltaFrame.data.deltaFrameFields[0].value.value.data,
                          value2);
         UA_DataSetMessage_clear(&deltaFrame);
+        UA_NodeId_clear(&node1);
+        UA_NodeId_clear(&node2);
     } END_TEST
 
 


### PR DESCRIPTION
### Summary

This PR preserves the actual number of changed fields when generating UADP `DataDeltaFrame` messages.

### Problem

According to the OPC UA specification, a `DataDeltaFrame` only carries the subset of fields that changed since the last key frame, and `FieldCount` must match the number of encoded delta fields.

Previously, `UA_PubSubDataSetWriter_generateDeltaFrameMessage()` correctly counted changed fields first, but later overwrote `fieldCount` with the total number of fields in the `PublishedDataSet`. As a result, the generated `FieldCount` could exceed the number of valid delta entries, and later encoding logic could process uninitialized tail elements as if they were part of the delta frame.

### Changes

Keep `fieldCount` equal to the actual number of changed fields in `UA_PubSubDataSetWriter_generateDeltaFrameMessage()`.
