### PR TITLE
fix(pubsub): use component ref for standalone subscribed dataset

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -2459,7 +2459,7 @@ connectDataSetReaderToDataSet(UA_Server *server, UA_NodeId dsrId, UA_NodeId sdsI
     UA_StatusCode retVal = UA_STATUSCODE_GOOD;
     retVal |= addRef(server, dsrId, UA_NS0ID(HASPROPERTY),
                      dataSetMetaDataOnSdsId, true);
-    retVal |= addRef(server, dsrId, UA_NS0ID(HASPROPERTY),
+    retVal |= addRef(server, dsrId, UA_NS0ID(HASCOMPONENT),
                      subscribedDataSetOnSdsId, true);
     return retVal;
 }


### PR DESCRIPTION
This PR fixes the use of `HasProperty` instead of `HasComponent` when rebinding a `DataSetReader` to a standalone `SubscribedDataSet`.