### PR TITLE
fix(discovery): filter before limiting FindServersOnNetwork

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -357,17 +357,16 @@ process_FindServersOnNetwork(UA_Server *server, UA_Session *session,
             break;
     }
 
-    /* Compute the max number of records to return */
+    /* Compute the number of candidate records after the record id cutoff */
     size_t recordCount = server->serversOnNetworkSize - recordOffset;
-    if(maxRecordsToReturn > 0 && maxRecordsToReturn < recordCount)
-        recordCount = maxRecordsToReturn;
     UA_assert(recordCount <= server->serversOnNetworkSize);
 
     /* Nothing to do */
     if(recordCount == 0)
         return UA_STATUSCODE_GOOD;
 
-    /* Iterate over all records and add to filtered list */
+    /* Iterate over all candidate records, apply the capability filter first
+     * and only then enforce the response size limit. */
     UA_UInt32 filteredCount = 0;
     UA_STACKARRAY(UA_ServerOnNetwork*, filtered, recordCount);
     for(size_t i = 0; i < recordCount; i++) {
@@ -376,6 +375,8 @@ process_FindServersOnNetwork(UA_Server *server, UA_Session *session,
                                          serverCapabilityFilter, son))
             continue;
         filtered[filteredCount++] = son;
+        if(maxRecordsToReturn > 0 && filteredCount >= maxRecordsToReturn)
+            break;
     }
 
     /* Nothing to do */

--- a/tests/server/check_discovery_mdnsd.c
+++ b/tests/server/check_discovery_mdnsd.c
@@ -1759,6 +1759,42 @@ START_TEST(PublicApiFindServersOnNetworkListsRegisteredServers) {
 }
 END_TEST
 
+START_TEST(PublicApiFindServersOnNetworkAppliesLimitAfterCapabilityFilter) {
+    UA_Server *localServer = UA_Server_newForUnitTest();
+    ck_assert_ptr_ne(localServer, NULL);
+
+    UA_ServerConfig *localConfig = UA_Server_getConfig(localServer);
+    localConfig->serversOnNetworkEnabled = true;
+    ck_assert_uint_eq(UA_Server_run_startup(localServer), UA_STATUSCODE_GOOD);
+
+    const char *capsDa[] = {"DA"};
+    const char *capsLds[] = {"LDS"};
+    registerServerOnNetwork(localServer, "candidate-da",
+                            "opc.tcp://localhost:4841", capsDa, 1);
+    registerServerOnNetwork(localServer, "candidate-lds",
+                            "opc.tcp://localhost:4842", capsLds, 1);
+
+    UA_String filter = UA_STRING("LDS");
+    UA_DateTime lastCounterResetTime = 0;
+    size_t serverOnNetworkSize = 0;
+    UA_ServerOnNetwork *serverOnNetwork = NULL;
+    UA_StatusCode retval =
+        UA_Server_findServersOnNetwork(localServer, UA_STRING_NULL, 0, 1, 1,
+                                       &filter, &lastCounterResetTime,
+                                       &serverOnNetworkSize, &serverOnNetwork);
+
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(serverOnNetworkSize, 1);
+    UA_String expectedName = UA_STRING("candidate-lds");
+    ck_assert(UA_String_equal(&serverOnNetwork[0].serverName, &expectedName));
+
+    UA_Array_delete(serverOnNetwork, serverOnNetworkSize,
+                    &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
+    UA_Server_run_shutdown(localServer);
+    UA_Server_delete(localServer);
+}
+END_TEST
+
 START_TEST(MdnsDriverParamCopiessettingsOnStartup) {
     UA_Server *localServer = UA_Server_newForUnitTest();
     ck_assert_ptr_ne(localServer, NULL);
@@ -2352,6 +2388,11 @@ testSuite_DiscoveryMdnsd(void) {
     */
     (void)tc_config;
     suite_add_tcase(s, tc_config);
+
+    TCase *tc_public_api_core = tcase_create("Public discovery API core");
+    tcase_add_test(tc_public_api_core,
+                   PublicApiFindServersOnNetworkAppliesLimitAfterCapabilityFilter);
+    suite_add_tcase(s, tc_public_api_core);
 
     TCase *tc_integration = tcase_create("Public discovery API integration");
     tcase_add_unchecked_fixture(tc_integration,


### PR DESCRIPTION
### Summary

This PR fixes `FindServersOnNetwork` so `maxRecordsToReturn` is applied after capability filtering, and adds a regression test that covers the case where matching servers appear only after earlier non-matching records.

### Problem

According to OPC UA Specification, `FindServersOnNetwork` first considers all records with `recordId > startingRecordId`, then filters that candidate set with `serverCapabilityFilter[]`, and finally limits the response to at most `maxRecordsToReturn` matching entries.

Previously, `process_FindServersOnNetwork()` truncated the candidate window to `maxRecordsToReturn` before calling `entryMatchesCapabilityFilter()`. As a result, the implementation only scanned the first N raw records after `startingRecordId` instead of the full candidate set. If those early records did not match the requested capabilities, later matching entries were skipped entirely and never made it into the response.

### Changes

- Keep scanning all candidate `ServerOnNetwork` records after the `startingRecordId` cutoff.
- Apply `entryMatchesCapabilityFilter()` before enforcing the `maxRecordsToReturn` response limit.
- Add a regression test in `check_discovery_mdnsd` that verifies a later matching record is still returned even when an earlier non-matching record consumes the first raw slot.
