### PR TITLE
fix(server): revalidate active secure channels on trustlist changes

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -681,8 +681,8 @@ secureChannel_delayedCloseTrustList(void *application, void *context) {
     UA_CertificateGroup *certGroup = &server->config.secureChannelPKI;
     UA_SecureChannel *channel;
     TAILQ_FOREACH(channel, &server->channels, serverEntry) {
-        if(channel->state != UA_SECURECHANNELSTATE_CLOSED &&
-           channel->state != UA_SECURECHANNELSTATE_CLOSING)
+        if(channel->state == UA_SECURECHANNELSTATE_CLOSED ||
+           channel->state == UA_SECURECHANNELSTATE_CLOSING)
             continue;
         if(channel->remoteCertificate.length == 0)
             continue; /* SecureChannels w/o security */


### PR DESCRIPTION
### Summary

This PR fixes TrustList updates so active SecureChannels are revalidated against the new trust state.

### Problem

According to OPC UA PushManagement / TrustList semantics, changes to the TrustList must affect not only future connections but also already active SecureChannels. If a peer certificate is no longer trusted after a TrustList update, the server needs to re-check that channel and close it.

Previously, `secureChannel_delayedCloseTrustList()` used the channel state filter in the wrong direction. The callback skipped all non-closed channels and only continued with channels that were already `CLOSED` or `CLOSING`. As a result, the revalidation logic never ran for active SecureChannels, so connections that should have become untrusted could remain usable until they disconnected naturally.

### Changes

- Fix the SecureChannel state check in `secureChannel_delayedCloseTrustList()` so only already closing or closed channels are skipped.
- Keep revalidating active SecureChannels after `UA_Server_addCertificates(..., appendCertificates=false)` and `UA_Server_removeCertificates()`.
