### PR TITLE
fix(doc): repair the PDF docs build — nested list in common.h exceeded LaTeX limits

### DIFF
--- a/include/open62541/common.h
+++ b/include/open62541/common.h
@@ -423,30 +423,43 @@ typedef uint64_t UA_ApplicationNotificationType;
  * Properties from the super-type are inherited.
  *
  * - AuditEventType
+ *
  *   - AuditSecurityEventType
+ *
  *     - AuditChannelEventType
+ *
  *       - AuditOpenSecureChannelEventType
+ *
  *     - AuditSessionEventType
+ *
  *       - AuditCreateSessionEventType
  *       - AuditActivateSessionEventType
  *       - AuditCancelEventType
+ *
  *     - AuditCertificateEventType
+ *
  *       - AuditCertificateDataMismatchEventType
  *       - AuditCertificateExpiredEventType
  *       - AuditCertificateInvalidEventType
  *       - AuditCertificateUntrustedEventType
  *       - AuditCertificateRevokedEventType
  *       - AuditCertificateMismatchEventType
+ *
  *   - AuditNodeManagementEventType
+ *
  *     - AuditAddNodesEventType
  *     - AuditDeleteNodesEventType
  *     - AuditAddReferencesEventType
  *     - AuditDeleteReferencesEventType
+ *
  *   - AuditUpdateEventType
+ *
  *     - AuditWriteUpdateEventType
  *     - AuditHistoryUpdateEventType
+ *
  *   - AuditUpdateMethodEventType
  *   - AuditClientEventType
+ *
  *     - AuditClientUpdateMethodResultEventType */
 #define UA_APPLICATIONNOTIFICATIONTYPE_AUDIT                                   \
     (0x40ULL << 32)

--- a/tools/c2rst.py
+++ b/tools/c2rst.py
@@ -25,15 +25,6 @@ def clean_comment(line):
         return "\n"
     return m.group(2) + "\n"
 
-# Double the indent of RST bullet lines so docutils >= 0.21 accepts nested lists.
-bullet_re = re.compile(r"^(\s*)([-*+]|\d+\.)\s")
-
-def reindent_bullet(line):
-    m = bullet_re.match(line)
-    if not m:
-        return line
-    return (" " * (len(m.group(1)) * 2)) + line.lstrip()
-
 def clean_line(line):
     for keyword in remove_keyword:
         line = line.replace(keyword, "")
@@ -108,8 +99,6 @@ with open(sys.argv[args-1], 'w') as rst:
             if not ((doc_start or doc_end) and line == "\n"):
                 if not in_doc:
                     line = "   " + line
-                else:
-                    line = reindent_bullet(line)
                 rst.write(clean_line(line))
 
             if doc_end and i < last:


### PR DESCRIPTION
The doc_upload job kept failing after #(preamble fix) — this time inside the lualatex PDF compile with "Too deeply nested". 