### PR TITLE
fix(plugins): sanitize CN in getCertFileName

### DIFF
--- a/plugins/crypto/ua_certificategroup_filestore.c
+++ b/plugins/crypto/ua_certificategroup_filestore.c
@@ -162,8 +162,16 @@ getCertFileName(const char *path, const UA_ByteString *certificate,
 
     if(ptr != NULL) {
         subName = ptr + 3;
+        char *endName = strchr(subName, ',');
+        if(endName != NULL)
+            *endName = '\0';
     } else {
         subName = subjectNameBuffer;
+    }
+
+    for(char *c = subName; *c; c++) {
+        if(*c == '/' || *c == '\\')
+            *c = '_';
     }
 
     if(mp_snprintf(fileNameBuf, fileNameLen, "%s/%s[%s]", path, subName,


### PR DESCRIPTION
getCertFileName() extracts the certificate subject's CN field via strstr() and inserts it directly into the rejected-certificate file path without sanitization or truncation at the trailing RDN comma. A remote peer presenting a certificate with a subject such as CN=../../tmp/evil can make the FileCertStore plugin write the rejected certificate DER outside the configured rejected-certificate directory, into any existing directory reachable via the traversal sequence. The untruncated CN also lets subsequent RDN components leak into the generated filename.

Truncate subName at the first ',' to drop trailing RDN components, and replace '/' and '\' in the extracted CN with '_' before it is used to build the file path.

Internal Vulnerability Advisory: open62541-SA-2026-0011
Reported by: Tomer Dricker