### PR TITLE
fix(core): reject overflowing arrayDimensions product in Variant en/d…

### DIFF
--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -636,8 +636,11 @@ checkAdjustRange(const UA_Variant *v, UA_NumericRange *range) {
     /* Check that the number of elements in the variant matches the array
      * dimensions */
     size_t elements = 1;
-    for(size_t i = 0; i < dims_count; ++i)
+    for(size_t i = 0; i < dims_count; ++i) {
+        if(dims[i] != 0 && elements > SIZE_MAX / dims[i])
+            return UA_STATUSCODE_BADINTERNALERROR;
         elements *= dims[i];
+    }
     if(elements != v->arrayLength)
         return UA_STATUSCODE_BADINTERNALERROR;
 
@@ -700,6 +703,11 @@ computeStrides(const UA_Variant *v, const UA_NumericRange range,
             *block = running_dimssize * dimrange;
             *stride = running_dimssize * dims[k];
         }
+        /* Overflow in running_dimssize is only possible when the Variant has
+         * passed a corrupted state through checkAdjustRange. Guard here as a
+         * defence-in-depth measure. */
+        if(running_dimssize != 0 && dims[k] > SIZE_MAX / running_dimssize)
+            break;
         *first += running_dimssize * range.dimensions[k].min;
         running_dimssize *= dims[k];
     }

--- a/src/ua_types_encoding_binary.c
+++ b/src/ua_types_encoding_binary.c
@@ -1000,8 +1000,17 @@ ENCODE_BINARY(Variant) {
     const UA_Boolean hasDimensions = isArray && src->arrayDimensionsSize > 0;
     if(isArray) {
         encoding |= (u8)UA_VARIANT_ENCODINGMASKTYPE_ARRAY;
-        if(hasDimensions)
+        if(hasDimensions) {
             encoding |= (u8)UA_VARIANT_ENCODINGMASKTYPE_DIMENSIONS;
+            size_t totalRequiredSize = 1;
+            for(size_t i = 0; i < src->arrayDimensionsSize; ++i) {
+                if(src->arrayDimensions[i] != 0 &&
+                   totalRequiredSize > SIZE_MAX / src->arrayDimensions[i])
+                    return UA_STATUSCODE_BADENCODINGERROR;
+                totalRequiredSize *= src->arrayDimensions[i];
+            }
+            if(totalRequiredSize != src->arrayLength) return UA_STATUSCODE_BADENCODINGERROR;
+        }
     }
 
     /* Encode the encoding byte */
@@ -1116,9 +1125,13 @@ DECODE_BINARY(Variant) {
         /* Validate array length against array dimensions */
         size_t totalSize = 1;
         for(size_t i = 0; i < dst->arrayDimensionsSize; ++i) {
-            if(dst->arrayDimensions[i] == 0)
-                return UA_STATUSCODE_BADDECODINGERROR;
-            totalSize *= dst->arrayDimensions[i];
+            if(dst->arrayDimensions[i] == 0) {
+                ret = UA_STATUSCODE_BADDECODINGERROR;
+            } else if(totalSize > SIZE_MAX / dst->arrayDimensions[i]) {
+                ret = UA_STATUSCODE_BADDECODINGERROR;
+            } else {
+                totalSize *= dst->arrayDimensions[i];
+            }
         }
         UA_CHECK(totalSize == dst->arrayLength, ret = UA_STATUSCODE_BADDECODINGERROR);
     }


### PR DESCRIPTION
…ecoding

Multiplying attacker-controlled arrayDimensions values into a size_t accumulator without an overflow check allows the product to wrap and match a small arrayLength. Subsequent ranged read or write operations then access memory outside the allocated array bounds.

Add checked multiplication at all sites where the dimension product is computed: Variant binary decode, Variant binary encode, checkAdjustRange, and computeStrides (as a defence-in-depth measure).

Internal Vulnerability Advisory: open62541-SA-2026-0012 and open62541-SA-2026-0013
Reported by Asher Davila and Malav Vyas from Palo Alto Networks