### PR TITLE
fix(pubsub): check message length before signature size subtraction

### DIFF
--- a/src/pubsub/ua_pubsub_security.c
+++ b/src/pubsub/ua_pubsub_security.c
@@ -84,6 +84,11 @@ verifyAndDecrypt(const UA_Logger *logger, UA_ByteString *buffer,
     if(doValidate) {
         size_t sigSize = securityPolicy->symmetricModule.cryptoModule.
             signatureAlgorithm.getLocalSignatureSize(channelContext);
+        if(buffer->length < sigSize) {
+            UA_LOG_WARNING(logger, UA_LOGCATEGORY_SECURITYPOLICY,
+                           "PubSub receive. Message too short for signature");
+            return UA_STATUSCODE_BADSECURITYCHECKSFAILED;
+        }
         UA_ByteString toBeVerified = {buffer->length - sigSize, buffer->data};
         UA_ByteString signature = {sigSize, buffer->data + buffer->length - sigSize};
 


### PR DESCRIPTION
Add bounds check in verifyAndDecrypt() to prevent unsigned integer underflow when buffer->length is smaller than the expected signature size. Without this check, the subtraction wraps around producing a large size_t that causes mbedtls to read unmapped memory.

Internal Vulnerability Advisory: open62541-SA-2026-0014
Reported by Abhinar Avagarwal