### PR TITLE
ModifyMonitoredItem double buffer

### DIFF
--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -263,7 +263,13 @@ UA_Client_MonitoredItems_deleteSingle(UA_Client *client,
 
 /**
  * The "ClientHandle" is part of the MonitoredItem configuration. The handle is
- * set internally and not exposed to the user. */
+ * set internally and not exposed to the user. A modification uses a new
+ * ClientHandle. Until the first notification with that handle arrives, queued
+ * notifications with the old handle are processed with the old settings.
+ *
+ * If the same MonitoredItem is modified again before a notification with the
+ * pending handle arrives, the newer modification supersedes the pending one.
+ * Notifications with the superseded handle are ignored. */
 
 UA_ModifyMonitoredItemsResponse UA_EXPORT UA_THREADSAFE
 UA_Client_MonitoredItems_modify(UA_Client *client,

--- a/include/open62541/client_subscriptions.h
+++ b/include/open62541/client_subscriptions.h
@@ -272,7 +272,7 @@ UA_Client_MonitoredItems_modify(UA_Client *client,
 typedef void
 (*UA_ClientAsyncModifyMonitoredItemsCallback)(
     UA_Client *client, void *userdata, UA_UInt32 requestId,
-    UA_DeleteMonitoredItemsResponse *response);
+    UA_ModifyMonitoredItemsResponse *response);
 
 UA_StatusCode UA_EXPORT UA_THREADSAFE
 UA_Client_MonitoredItems_modify_async(UA_Client *client,

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -38,6 +38,7 @@ typedef struct UA_Client_MonitoredItem {
     ZIP_ENTRY(UA_Client_MonitoredItem) zipfields;
     UA_UInt32 monitoredItemId;
     UA_MonitoringParameters parameters;
+    UA_MonitoringParameters pendingParameters;
     void *context;
     UA_Client_DeleteMonitoredItemCallback deleteCallback;
     union {
@@ -76,6 +77,12 @@ __Client_Subscriptions_backgroundPublish(UA_Client *client);
 
 void
 __Client_Subscriptions_backgroundPublishInactivityCheck(UA_Client *client);
+
+/* Exposed for unit tests and fuzzing of notification ordering */
+void
+__Client_Subscriptions_processPublishResponse(UA_Client *client,
+                                              UA_PublishRequest *request,
+                                              UA_PublishResponse *response);
 
 /**********/
 /* Client */

--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -37,7 +37,7 @@ typedef struct UA_Client_NotificationsAckNumber {
 typedef struct UA_Client_MonitoredItem {
     ZIP_ENTRY(UA_Client_MonitoredItem) zipfields;
     UA_UInt32 monitoredItemId;
-    UA_UInt32 clientHandle;
+    UA_MonitoringParameters parameters;
     void *context;
     UA_Client_DeleteMonitoredItemCallback deleteCallback;
     union {
@@ -45,8 +45,7 @@ typedef struct UA_Client_MonitoredItem {
         UA_Client_EventNotificationCallback eventCallback;
     } handler;
     UA_Boolean isEventMonitoredItem; /* Otherwise a DataChange MoniitoredItem */
-
-    UA_KeyValueMap eventFields; /* Cached names */
+    UA_KeyValueMap eventFields; /* Lazily cached names for the active filter */
 } UA_Client_MonitoredItem;
 
 ZIP_HEAD(MonitorItemsTree, UA_Client_MonitoredItem);

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -42,6 +42,14 @@ UA_ClientHandle_cmp(const void *a, const void *b) {
 ZIP_FUNCTIONS(MonitorItemsTree, UA_Client_MonitoredItem, zipfields,
               UA_Client_MonitoredItem, zipfields, UA_ClientHandle_cmp)
 
+static UA_Client_MonitoredItem *
+findMonitoredItemByHandle(UA_Client_Subscription *sub, UA_UInt32 clientHandle) {
+    UA_Client_MonitoredItem dummy;
+    memset(&dummy, 0, sizeof(dummy));
+    dummy.clientHandle = clientHandle;
+    return ZIP_FIND(MonitorItemsTree, &sub->monitoredItems, &dummy);
+}
+
 static void
 MonitoredItem_delete(UA_Client *client, UA_Client_Subscription *sub,
                      UA_Client_MonitoredItem *mon);
@@ -791,12 +799,10 @@ MonitoredItems_create_async_handler(UA_Client *client, void *data,
         response->responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
 
     /* Update the MonitoredItems */
-    UA_Client_MonitoredItem dummy;
     for(size_t i = 0; sub && i < monSize; i++) {
         /* Get the MonitoredItem from the ClientHandle */
-        dummy.clientHandle = monHandles[i];
         UA_Client_MonitoredItem *mon =
-            ZIP_FIND(MonitorItemsTree, &sub->monitoredItems, &dummy);
+            findMonitoredItemByHandle(sub, monHandles[i]);
         if(!mon)
             continue;
 
@@ -1324,10 +1330,8 @@ processDataChangeNotification(UA_Client *client, UA_Client_Subscription *sub,
         UA_MonitoredItemNotification *min = &dataChangeNotification->monitoredItems[j];
 
         /* Find the MonitoredItem */
-        UA_Client_MonitoredItem *mon;
-        UA_Client_MonitoredItem dummy;
-        dummy.clientHandle = min->clientHandle;
-        mon = ZIP_FIND(MonitorItemsTree, &sub->monitoredItems, &dummy);
+        UA_Client_MonitoredItem *mon =
+            findMonitoredItemByHandle(sub, min->clientHandle);
 
         if(!mon) {
             UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_CLIENT,
@@ -1362,10 +1366,8 @@ processEventNotification(UA_Client *client, UA_Client_Subscription *sub,
         UA_EventFieldList *efl = &eventNotificationList->events[j];
 
         /* Find the MonitoredItem */
-        UA_Client_MonitoredItem *mon;
-        UA_Client_MonitoredItem dummy;
-        dummy.clientHandle = efl->clientHandle;
-        mon = ZIP_FIND(MonitorItemsTree, &sub->monitoredItems, &dummy);
+        UA_Client_MonitoredItem *mon =
+            findMonitoredItemByHandle(sub, efl->clientHandle);
 
         if(!mon) {
             UA_LOG_DEBUG(client->config.logging, UA_LOGCATEGORY_CLIENT,

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -32,9 +32,9 @@ static enum ZIP_CMP
 UA_ClientHandle_cmp(const void *a, const void *b) {
     const UA_Client_MonitoredItem *aa = (const UA_Client_MonitoredItem *)a;
     const UA_Client_MonitoredItem *bb = (const UA_Client_MonitoredItem *)b;
-    if(aa->clientHandle < bb->clientHandle)
+    if(aa->parameters.clientHandle < bb->parameters.clientHandle)
         return ZIP_CMP_LESS;
-    if(aa->clientHandle > bb->clientHandle)
+    if(aa->parameters.clientHandle > bb->parameters.clientHandle)
         return ZIP_CMP_MORE;
     return ZIP_CMP_EQ;
 }
@@ -46,7 +46,7 @@ static UA_Client_MonitoredItem *
 findMonitoredItemByHandle(UA_Client_Subscription *sub, UA_UInt32 clientHandle) {
     UA_Client_MonitoredItem dummy;
     memset(&dummy, 0, sizeof(dummy));
-    dummy.clientHandle = clientHandle;
+    dummy.parameters.clientHandle = clientHandle;
     return ZIP_FIND(MonitorItemsTree, &sub->monitoredItems, &dummy);
 }
 
@@ -490,6 +490,15 @@ UA_Client_Subscriptions_deleteSingle(UA_Client *client, UA_UInt32 subscriptionId
 /******************/
 
 static void
+EventFields_clear(UA_KeyValueMap *eventFields) {
+    /* The values are borrowed from the PublishResponse. Detach them before
+     * clearing the map-owned field-name keys. */
+    for(size_t i = 0; i < eventFields->mapSize; i++)
+        UA_Variant_init(&eventFields->map[i].value);
+    UA_KeyValueMap_clear(eventFields);
+}
+
+static void
 MonitoredItem_delete(UA_Client *client, UA_Client_Subscription *sub,
                      UA_Client_MonitoredItem *mon) {
     UA_LOCK_ASSERT(&client->clientMutex);
@@ -498,15 +507,13 @@ MonitoredItem_delete(UA_Client *client, UA_Client_Subscription *sub,
     if(mon->deleteCallback)
         mon->deleteCallback(client, sub->subscriptionId, sub->context,
                             mon->monitoredItemId, mon->context);
-    for(size_t i = 0; i < mon->eventFields.mapSize; i++) {
-        UA_Variant_init(&mon->eventFields.map[i].value);
-    }
-    UA_KeyValueMap_clear(&mon->eventFields);
+    EventFields_clear(&mon->eventFields);
+    UA_MonitoringParameters_clear(&mon->parameters);
     UA_free(mon);
 }
 
 static UA_StatusCode
-prepareEventFieldsMap(UA_Client_MonitoredItem *newMon,
+prepareEventFieldsMap(UA_KeyValueMap *eventFields,
                       UA_MonitoringParameters *params) {
     /* Get the EventFilter */
     UA_ExtensionObject *eo = &params->filter;
@@ -520,16 +527,16 @@ prepareEventFieldsMap(UA_Client_MonitoredItem *newMon,
         return UA_STATUSCODE_GOOD;
 
     /* Allocate the map */
-    newMon->eventFields.map = (UA_KeyValuePair*)
+    eventFields->map = (UA_KeyValuePair*)
         UA_calloc(ef->selectClausesSize, sizeof(UA_KeyValuePair));
-    if(!newMon->eventFields.map)
+    if(!eventFields->map)
         return UA_STATUSCODE_BADOUTOFMEMORY;
-    newMon->eventFields.mapSize = ef->selectClausesSize;
+    eventFields->mapSize = ef->selectClausesSize;
 
     /* Create the key-strings for the fields */
-    for(size_t i = 0; i < newMon->eventFields.mapSize; i++) {
+    for(size_t i = 0; i < eventFields->mapSize; i++) {
         res |= UA_SimpleAttributeOperand_print(&ef->selectClauses[i],
-                                               &newMon->eventFields.map[i].key.name);
+                                               &eventFields->map[i].key.name);
     }
 
     return res;
@@ -547,22 +554,20 @@ MonitoredItem_createBegin(UA_Client *client, UA_Client_Subscription *sub,
     if(!mon)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
-    /* Cache the field name map */
-    mon->isEventMonitoredItem =
-        (item->itemToMonitor.attributeId == UA_ATTRIBUTEID_EVENTNOTIFIER);
-    if(mon->isEventMonitoredItem) {
-        UA_StatusCode res = prepareEventFieldsMap(mon, &item->requestedParameters);
-        if(res != UA_STATUSCODE_GOOD) {
-            UA_free(mon);
-            return res;
-        }
+    /* Set a unique ClientHandle and retain the active parameters. */
+    item->requestedParameters.clientHandle = ++client->monitoredItemHandles;
+    UA_StatusCode res =
+        UA_MonitoringParameters_copy(&item->requestedParameters,
+                                     &mon->parameters);
+    if(res != UA_STATUSCODE_GOOD) {
+        UA_free(mon);
+        return res;
     }
 
-    /* Set a unique ClientHandle */
-    item->requestedParameters.clientHandle = ++client->monitoredItemHandles;
+    mon->isEventMonitoredItem =
+        (item->itemToMonitor.attributeId == UA_ATTRIBUTEID_EVENTNOTIFIER);
 
     /* Fill in members and add to the client  */
-    mon->clientHandle = item->requestedParameters.clientHandle;
     mon->context = context;
     mon->deleteCallback = deleteCallback;
     mon->handler.dataChangeCallback =
@@ -571,7 +576,7 @@ MonitoredItem_createBegin(UA_Client *client, UA_Client_Subscription *sub,
 
     UA_LOG_DEBUG(client->config.logging, UA_LOGCATEGORY_CLIENT,
                  "Subscription %" PRIu32 " | Added a MonitoredItem with handle %" PRIu32,
-                 sub->subscriptionId, mon->clientHandle);
+                 sub->subscriptionId, mon->parameters.clientHandle);
 
     *outMon = mon;
     return UA_STATUSCODE_GOOD;
@@ -906,7 +911,7 @@ Client_MonitoredItems_createAsync(UA_Client *client,
     handles[0] = sub->subscriptionId;
     handles[1] = (UA_UInt32)request.itemsToCreateSize;
     for(size_t i = 0; i < request.itemsToCreateSize; i++) {
-        handles[i+2] = mons[i]->clientHandle;
+        handles[i+2] = mons[i]->parameters.clientHandle;
     }
     cc->clientData = handles;
     cc->userCallback = createCallback;
@@ -1382,6 +1387,20 @@ processEventNotification(UA_Client *client, UA_Client_Subscription *sub,
                          "MonitoredItem is configured for DataChanges. But received a "
                          "EventNotification");
             continue;
+        }
+
+        /* Build the callback metadata from the active filter only when it is
+         * first needed. */
+        if(mon->eventFields.mapSize == 0) {
+            UA_StatusCode res =
+                prepareEventFieldsMap(&mon->eventFields, &mon->parameters);
+            if(res != UA_STATUSCODE_GOOD) {
+                EventFields_clear(&mon->eventFields);
+                UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_CLIENT,
+                               "Could not prepare event fields: %s",
+                               UA_StatusCode_name(res));
+                continue;
+            }
         }
 
         if(mon->eventFields.mapSize != efl->eventFieldsSize) {

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -50,6 +50,14 @@ findMonitoredItemByHandle(UA_Client_Subscription *sub, UA_UInt32 clientHandle) {
     return ZIP_FIND(MonitorItemsTree, &sub->monitoredItems, &dummy);
 }
 
+static void *
+MonitoredItem_findPendingByHandle(void *data, UA_Client_MonitoredItem *mon) {
+    UA_UInt32 clientHandle = *(UA_UInt32*)data;
+    if(mon->pendingParameters.clientHandle == clientHandle)
+        return mon;
+    return NULL;
+}
+
 static void
 MonitoredItem_delete(UA_Client *client, UA_Client_Subscription *sub,
                      UA_Client_MonitoredItem *mon);
@@ -509,6 +517,7 @@ MonitoredItem_delete(UA_Client *client, UA_Client_Subscription *sub,
                             mon->monitoredItemId, mon->context);
     EventFields_clear(&mon->eventFields);
     UA_MonitoringParameters_clear(&mon->parameters);
+    UA_MonitoringParameters_clear(&mon->pendingParameters);
     UA_free(mon);
 }
 
@@ -1143,15 +1152,70 @@ findMonitoredItemById(UA_Client_Subscription *sub, UA_UInt32 monitoredItemId) {
                  MonitoredItem_findByID, &monitoredItemId);
 }
 
-static void
-setExistingClientHandles(UA_Client_Subscription *sub,
-                         UA_ModifyMonitoredItemsRequest *request) {
+static UA_StatusCode
+MonitoredItems_prepareModify(UA_Client *client, UA_Client_Subscription *sub,
+                             UA_ModifyMonitoredItemsRequest *request) {
+    UA_STACKARRAY(UA_Client_MonitoredItem*, mons, request->itemsToModifySize);
+    UA_STACKARRAY(UA_MonitoringParameters, preparedParameters,
+                  request->itemsToModifySize);
+    memset(mons, 0, sizeof(UA_Client_MonitoredItem*) *
+           request->itemsToModifySize);
+    memset(preparedParameters, 0, sizeof(UA_MonitoringParameters) *
+           request->itemsToModifySize);
+
+    /* Prepare every settings slot before changing the MonitoredItems. So an
+     * allocation failure leaves all active and pending settings untouched. */
     for(size_t i = 0; i < request->itemsToModifySize; ++i) {
         UA_MonitoredItemModifyRequest *mimr = &request->itemsToModify[i];
+        mimr->requestedParameters.clientHandle = 0;
+        mons[i] = findMonitoredItemById(sub, mimr->monitoredItemId);
+        if(!mons[i])
+            continue;
+
+        mimr->requestedParameters.clientHandle = ++client->monitoredItemHandles;
+        UA_StatusCode res =
+            UA_MonitoringParameters_copy(&mimr->requestedParameters,
+                                         &preparedParameters[i]);
+        if(res != UA_STATUSCODE_GOOD) {
+            for(size_t j = 0; j <= i; j++)
+                UA_MonitoringParameters_clear(&preparedParameters[j]);
+            return res;
+        }
+    }
+
+    /* Commit the prepared settings. A newer modification supersedes a pending
+     * generation that has not produced a notification yet. */
+    for(size_t i = 0; i < request->itemsToModifySize; ++i) {
+        UA_Client_MonitoredItem *mon = mons[i];
+        if(!mon)
+            continue;
+        UA_MonitoringParameters_clear(&mon->pendingParameters);
+        mon->pendingParameters = preparedParameters[i];
+        memset(&preparedParameters[i], 0, sizeof(UA_MonitoringParameters));
+    }
+    return UA_STATUSCODE_GOOD;
+}
+
+static void
+MonitoredItems_reconcileModify(UA_Client_Subscription *sub,
+                               const UA_ModifyMonitoredItemsRequest *request,
+                               UA_ModifyMonitoredItemsResponse *response) {
+    UA_Boolean validResponse = response &&
+        response->responseHeader.serviceResult == UA_STATUSCODE_GOOD &&
+        response->resultsSize == request->itemsToModifySize;
+    if(response && response->responseHeader.serviceResult == UA_STATUSCODE_GOOD &&
+       !validResponse)
+        response->responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
+
+    for(size_t i = 0; i < request->itemsToModifySize; ++i) {
+        if(validResponse && response->results[i].statusCode == UA_STATUSCODE_GOOD)
+            continue;
+        const UA_MonitoredItemModifyRequest *mimr = &request->itemsToModify[i];
         UA_Client_MonitoredItem *mon =
             findMonitoredItemById(sub, mimr->monitoredItemId);
-        if(mon)
-            mimr->requestedParameters.clientHandle = mon->clientHandle;
+        if(mon && mon->pendingParameters.clientHandle ==
+                  mimr->requestedParameters.clientHandle)
+            UA_MonitoringParameters_clear(&mon->pendingParameters);
     }
 }
 
@@ -1165,7 +1229,7 @@ UA_Client_MonitoredItems_modify(UA_Client *client,
     UA_ModifyMonitoredItemsRequest modifiedRequest;
     UA_StatusCode res = UA_ModifyMonitoredItemsRequest_copy(&request, &modifiedRequest);
     if(res != UA_STATUSCODE_GOOD) {
-        response.responseHeader.serviceResult = UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
+        response.responseHeader.serviceResult = res;
         return response;
     }
 
@@ -1180,13 +1244,20 @@ UA_Client_MonitoredItems_modify(UA_Client *client,
         return response;
     }
 
-    /* Reuse the existing ClientHandles for the MonitoredItems */
-    setExistingClientHandles(sub, &modifiedRequest);
+    res = MonitoredItems_prepareModify(client, sub, &modifiedRequest);
+    if(res != UA_STATUSCODE_GOOD) {
+        response.responseHeader.serviceResult = res;
+        unlockClient(client);
+        UA_ModifyMonitoredItemsRequest_clear(&modifiedRequest);
+        return response;
+    }
 
     /* Call the service */
     __Client_Service(client, &modifiedRequest,
                      &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST], &response,
                      &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE]);
+
+    MonitoredItems_reconcileModify(sub, &modifiedRequest, &response);
 
     unlockClient(client);
 
@@ -1195,16 +1266,47 @@ UA_Client_MonitoredItems_modify(UA_Client *client,
     return response;
 }
 
+static void
+MonitoredItems_modify_async_handler(UA_Client *client, void *data,
+                                    UA_UInt32 requestId, void *resp) {
+    CustomCallback *cc = (CustomCallback*)data;
+    UA_ModifyMonitoredItemsRequest *request =
+        (UA_ModifyMonitoredItemsRequest*)cc->clientData;
+    UA_ModifyMonitoredItemsResponse *response =
+        (UA_ModifyMonitoredItemsResponse*)resp;
+
+    lockClient(client);
+    UA_Client_Subscription *sub =
+        findSubscriptionById(client, request->subscriptionId);
+    if(sub)
+        MonitoredItems_reconcileModify(sub, request, response);
+
+    if(cc->userCallback) {
+        UA_ClientAsyncModifyMonitoredItemsCallback cb =
+            (UA_ClientAsyncModifyMonitoredItemsCallback)cc->userCallback;
+        cb(client, cc->userData, requestId, response);
+    }
+
+    UA_ModifyMonitoredItemsRequest_delete(request);
+    UA_free(cc);
+    unlockClient(client);
+}
+
 UA_StatusCode
 UA_Client_MonitoredItems_modify_async(UA_Client *client,
                                       const UA_ModifyMonitoredItemsRequest request,
                                       UA_ClientAsyncModifyMonitoredItemsCallback callback,
                                       void *userdata, UA_UInt32 *requestId) {
-    /* Make a modifiable copy of the request */
-    UA_ModifyMonitoredItemsRequest modifiedRequest;
-    UA_StatusCode res = UA_ModifyMonitoredItemsRequest_copy(&request, &modifiedRequest);
-    if(res != UA_STATUSCODE_GOOD)
+    UA_ModifyMonitoredItemsRequest *requestCopy =
+        UA_ModifyMonitoredItemsRequest_new();
+    if(!requestCopy)
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    UA_StatusCode res =
+        UA_ModifyMonitoredItemsRequest_copy(&request, requestCopy);
+    if(res != UA_STATUSCODE_GOOD) {
+        UA_ModifyMonitoredItemsRequest_delete(requestCopy);
         return res;
+    }
 
     lockClient(client);
 
@@ -1212,23 +1314,41 @@ UA_Client_MonitoredItems_modify_async(UA_Client *client,
     UA_Client_Subscription *sub = findSubscriptionById(client, request.subscriptionId);
     if(!sub) {
         unlockClient(client);
-        UA_ModifyMonitoredItemsRequest_clear(&modifiedRequest);
+        UA_ModifyMonitoredItemsRequest_delete(requestCopy);
         return UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID;
     }
 
-    /* Reuse the existing ClientHandles for the MonitoredItems */
-    setExistingClientHandles(sub, &modifiedRequest);
+    res = MonitoredItems_prepareModify(client, sub, requestCopy);
+    if(res != UA_STATUSCODE_GOOD) {
+        unlockClient(client);
+        UA_ModifyMonitoredItemsRequest_delete(requestCopy);
+        return res;
+    }
+
+    CustomCallback *cc = (CustomCallback*)UA_calloc(1, sizeof(CustomCallback));
+    if(!cc) {
+        MonitoredItems_reconcileModify(sub, requestCopy, NULL);
+        unlockClient(client);
+        UA_ModifyMonitoredItemsRequest_delete(requestCopy);
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+    cc->clientData = requestCopy;
+    cc->userCallback = (UA_ClientAsyncServiceCallback)callback;
+    cc->userData = userdata;
 
     /* Call the service */
     UA_StatusCode statusCode = __Client_AsyncService(
-        client, &modifiedRequest, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST],
-        (UA_ClientAsyncServiceCallback)callback,
-        &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE], userdata, requestId);
+        client, requestCopy, &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSREQUEST],
+        MonitoredItems_modify_async_handler,
+        &UA_TYPES[UA_TYPES_MODIFYMONITOREDITEMSRESPONSE], cc, requestId);
+
+    if(statusCode != UA_STATUSCODE_GOOD) {
+        MonitoredItems_reconcileModify(sub, requestCopy, NULL);
+        UA_ModifyMonitoredItemsRequest_delete(requestCopy);
+        UA_free(cc);
+    }
 
     unlockClient(client);
-
-    /* Clean up */
-    UA_ModifyMonitoredItemsRequest_clear(&modifiedRequest);
     return statusCode;
 }
 
@@ -1326,6 +1446,32 @@ __nextSequenceNumber(UA_UInt32 sequenceNumber) {
     return nextSequenceNumber;
 }
 
+static UA_Client_MonitoredItem *
+findMonitoredItemForNotification(UA_Client_Subscription *sub,
+                                 UA_UInt32 clientHandle) {
+    UA_Client_MonitoredItem *mon =
+        findMonitoredItemByHandle(sub, clientHandle);
+    if(mon)
+        return mon;
+
+    /* A notification is the authoritative signal that the server has started
+     * to use the modified settings. Promote the embedded pending slot and
+     * re-key the existing tree node. */
+    mon = (UA_Client_MonitoredItem*)
+        ZIP_ITER(MonitorItemsTree, &sub->monitoredItems,
+                 MonitoredItem_findPendingByHandle, &clientHandle);
+    if(!mon)
+        return NULL;
+
+    ZIP_REMOVE(MonitorItemsTree, &sub->monitoredItems, mon);
+    UA_MonitoringParameters_clear(&mon->parameters);
+    mon->parameters = mon->pendingParameters;
+    UA_MonitoringParameters_init(&mon->pendingParameters);
+    EventFields_clear(&mon->eventFields);
+    ZIP_INSERT(MonitorItemsTree, &sub->monitoredItems, mon);
+    return mon;
+}
+
 static void
 processDataChangeNotification(UA_Client *client, UA_Client_Subscription *sub,
                               UA_DataChangeNotification *dataChangeNotification) {
@@ -1336,7 +1482,7 @@ processDataChangeNotification(UA_Client *client, UA_Client_Subscription *sub,
 
         /* Find the MonitoredItem */
         UA_Client_MonitoredItem *mon =
-            findMonitoredItemByHandle(sub, min->clientHandle);
+            findMonitoredItemForNotification(sub, min->clientHandle);
 
         if(!mon) {
             UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_CLIENT,
@@ -1372,7 +1518,7 @@ processEventNotification(UA_Client *client, UA_Client_Subscription *sub,
 
         /* Find the MonitoredItem */
         UA_Client_MonitoredItem *mon =
-            findMonitoredItemByHandle(sub, efl->clientHandle);
+            findMonitoredItemForNotification(sub, efl->clientHandle);
 
         if(!mon) {
             UA_LOG_DEBUG(client->config.logging, UA_LOGCATEGORY_CLIENT,
@@ -1390,7 +1536,8 @@ processEventNotification(UA_Client *client, UA_Client_Subscription *sub,
         }
 
         /* Build the callback metadata from the active filter only when it is
-         * first needed. */
+         * first needed. After a promotion the cache is empty and rebuilt from
+         * the newly active parameters. */
         if(mon->eventFields.mapSize == 0) {
             UA_StatusCode res =
                 prepareEventFieldsMap(&mon->eventFields, &mon->parameters);
@@ -1410,12 +1557,12 @@ processEventNotification(UA_Client *client, UA_Client_Subscription *sub,
             continue;
         }
 
-        /* Prepare the key-value map and call the callback  */
-        for(size_t i = 0; i < mon->eventFields.mapSize; i++) {
+        /* Add the borrowed notification values to the cached field names. */
+        for(size_t i = 0; i < mon->eventFields.mapSize; i++)
             mon->eventFields.map[i].value = efl->eventFields[i];
-        }
         mon->handler.eventCallback(client, sub->subscriptionId, sub->context,
-                                   mon->monitoredItemId, mon->context, mon->eventFields);
+                                   mon->monitoredItemId, mon->context,
+                                   mon->eventFields);
     }
 }
 
@@ -1462,7 +1609,7 @@ processNotificationMessage(UA_Client *client, UA_Client_Subscription *sub,
                    "Unknown notification message type");
 }
 
-static void
+void
 __Client_Subscriptions_processPublishResponse(UA_Client *client, UA_PublishRequest *request,
                                               UA_PublishResponse *response) {
     UA_LOCK_ASSERT(&client->clientMutex);

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -125,6 +125,102 @@ deleteMonitoredItemsCallback(UA_Client *client, void *userdata, UA_UInt32 reques
 }
 
 static void
+modifyMonitoredItemsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
+                             UA_ModifyMonitoredItemsResponse *response) {
+    UA_ModifyMonitoredItemsResponse_copy(
+        response, (UA_ModifyMonitoredItemsResponse*)userdata);
+}
+
+static void
+injectNotification(UA_Client *client, UA_Client_Subscription *sub,
+                   const UA_DataType *notificationType, void *notification) {
+    UA_ExtensionObject notificationData;
+    UA_ExtensionObject_init(&notificationData);
+    notificationData.encoding = UA_EXTENSIONOBJECT_DECODED;
+    notificationData.content.decoded.type = notificationType;
+    notificationData.content.decoded.data = notification;
+
+    UA_PublishRequest request;
+    UA_PublishRequest_init(&request);
+    UA_PublishResponse response;
+    UA_PublishResponse_init(&response);
+    response.responseHeader.serviceResult = UA_STATUSCODE_GOOD;
+    response.subscriptionId = sub->subscriptionId;
+    response.notificationMessage.sequenceNumber = sub->sequenceNumber + 1;
+    response.notificationMessage.notificationData = &notificationData;
+    response.notificationMessage.notificationDataSize = 1;
+
+    lockClient(client);
+    client->currentlyOutStandingPublishRequests++;
+    __Client_Subscriptions_processPublishResponse(client, &request, &response);
+    unlockClient(client);
+}
+
+static void
+injectDataChangeNotification(UA_Client *client, UA_Client_Subscription *sub,
+                             UA_UInt32 clientHandle) {
+    UA_MonitoredItemNotification min;
+    UA_MonitoredItemNotification_init(&min);
+    min.clientHandle = clientHandle;
+
+    UA_DataChangeNotification dcn;
+    UA_DataChangeNotification_init(&dcn);
+    dcn.monitoredItems = &min;
+    dcn.monitoredItemsSize = 1;
+    injectNotification(client, sub,
+                       &UA_TYPES[UA_TYPES_DATACHANGENOTIFICATION], &dcn);
+}
+
+static size_t eventFieldsSize;
+
+static void
+eventHandler(UA_Client *client, UA_UInt32 subId, void *subContext,
+             UA_UInt32 monId, void *monContext,
+             const UA_KeyValueMap eventFields) {
+    eventFieldsSize = eventFields.mapSize;
+}
+
+static void
+injectEventNotification(UA_Client *client, UA_Client_Subscription *sub,
+                        UA_UInt32 clientHandle, size_t fieldsSize) {
+    UA_STACKARRAY(UA_Variant, fields, fieldsSize);
+    for(size_t i = 0; i < fieldsSize; i++)
+        UA_Variant_init(&fields[i]);
+
+    UA_EventFieldList efl;
+    UA_EventFieldList_init(&efl);
+    efl.clientHandle = clientHandle;
+    efl.eventFields = fields;
+    efl.eventFieldsSize = fieldsSize;
+
+    UA_EventNotificationList enl;
+    UA_EventNotificationList_init(&enl);
+    enl.events = &efl;
+    enl.eventsSize = 1;
+    injectNotification(client, sub,
+                       &UA_TYPES[UA_TYPES_EVENTNOTIFICATIONLIST], &enl);
+}
+
+static UA_Client_MonitoredItem *
+findTestMonitoredItem(UA_Client_MonitoredItem *mon, UA_UInt32 monitoredItemId) {
+    if(!mon || mon->monitoredItemId == monitoredItemId)
+        return mon;
+    UA_Client_MonitoredItem *found =
+        findTestMonitoredItem(ZIP_LEFT(mon, zipfields), monitoredItemId);
+    if(found)
+        return found;
+    return findTestMonitoredItem(ZIP_RIGHT(mon, zipfields), monitoredItemId);
+}
+
+static size_t
+countTestMonitoredItems(UA_Client_MonitoredItem *mon) {
+    if(!mon)
+        return 0;
+    return 1 + countTestMonitoredItems(ZIP_LEFT(mon, zipfields)) +
+        countTestMonitoredItems(ZIP_RIGHT(mon, zipfields));
+}
+
+static void
 deleteSubscriptionsCallback(UA_Client *client, void *userdata, UA_UInt32 requestId,
                             UA_DeleteSubscriptionsResponse *r) {
     UA_DeleteSubscriptionsResponse_copy(r, (UA_DeleteSubscriptionsResponse *)userdata);
@@ -704,6 +800,437 @@ START_TEST(Client_subscription_modifyMonitoredItem) {
     retval = UA_Client_Subscriptions_deleteSingle(client, subId);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
 
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_subscription_modifyMonitoredItem_doubleBuffer) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    /* Notifications are injected below in a deterministic order. */
+    UA_Client_getConfig(client)->outStandingPublishRequests = 0;
+
+    UA_CreateSubscriptionRequest subRequest =
+        UA_CreateSubscriptionRequest_default();
+    UA_CreateSubscriptionResponse subResponse =
+        UA_Client_Subscriptions_create(client, subRequest, NULL, NULL, NULL);
+    ck_assert_uint_eq(subResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+
+    UA_MonitoredItemCreateRequest monRequest =
+        UA_MonitoredItemCreateRequest_default(
+            UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE));
+    UA_MonitoredItemCreateResult monResponse =
+        UA_Client_MonitoredItems_createDataChange(
+            client, subResponse.subscriptionId, UA_TIMESTAMPSTORETURN_BOTH,
+            monRequest, NULL, dataChangeHandler, NULL);
+    ck_assert_uint_eq(monResponse.statusCode, UA_STATUSCODE_GOOD);
+
+    UA_Client_Subscription *sub = LIST_FIRST(&client->subscriptions);
+    ck_assert_ptr_ne(sub, NULL);
+    UA_Client_MonitoredItem *mon = ZIP_ROOT(&sub->monitoredItems);
+    ck_assert_ptr_ne(mon, NULL);
+    UA_UInt32 oldHandle =
+        mon->parameters.clientHandle;
+    UA_Double oldSamplingInterval = mon->parameters.samplingInterval;
+
+    UA_MonitoredItemModifyRequest item;
+    UA_MonitoredItemModifyRequest_init(&item);
+    item.monitoredItemId = monResponse.monitoredItemId;
+    item.requestedParameters.samplingInterval = 1000.0;
+    item.requestedParameters.queueSize = 1;
+    item.requestedParameters.discardOldest = true;
+
+    UA_ModifyMonitoredItemsRequest request;
+    UA_ModifyMonitoredItemsRequest_init(&request);
+    request.subscriptionId = subResponse.subscriptionId;
+    request.timestampsToReturn = UA_TIMESTAMPSTORETURN_BOTH;
+    request.itemsToModify = &item;
+    request.itemsToModifySize = 1;
+
+    /* First exercise response-before-notification. */
+    UA_ModifyMonitoredItemsResponse response =
+        UA_Client_MonitoredItems_modify(client, request);
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(response.resultsSize, 1);
+    ck_assert_uint_eq(response.results[0].statusCode, UA_STATUSCODE_GOOD);
+    UA_ModifyMonitoredItemsResponse_clear(&response);
+
+    ck_assert(mon->pendingParameters.clientHandle);
+    ck_assert(mon->parameters.samplingInterval == oldSamplingInterval);
+    ck_assert(mon->pendingParameters.samplingInterval == 1000.0);
+    UA_UInt32 newHandle =
+        mon->pendingParameters.clientHandle;
+    ck_assert_uint_ne(oldHandle, newHandle);
+
+    notificationReceived = false;
+    countNotificationReceived = 0;
+    injectDataChangeNotification(client, sub, oldHandle);
+    ck_assert(notificationReceived);
+    ck_assert_uint_eq(countNotificationReceived, 1);
+    ck_assert_uint_eq(mon->parameters.clientHandle, oldHandle);
+    ck_assert(mon->pendingParameters.clientHandle);
+
+    injectDataChangeNotification(client, sub, newHandle);
+    ck_assert_uint_eq(countNotificationReceived, 2);
+    ck_assert_uint_eq(mon->parameters.clientHandle, newHandle);
+    ck_assert(!mon->pendingParameters.clientHandle);
+    ck_assert(mon->parameters.samplingInterval == 1000.0);
+
+    /* Now deliver the new handle before the asynchronous modify response. */
+    pauseServer();
+    item.requestedParameters.samplingInterval = 2000.0;
+    UA_ModifyMonitoredItemsResponse asyncResponse;
+    UA_ModifyMonitoredItemsResponse_init(&asyncResponse);
+    UA_UInt32 requestId = 0;
+    retval = UA_Client_MonitoredItems_modify_async(
+        client, request, modifyMonitoredItemsCallback, &asyncResponse, &requestId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(mon->pendingParameters.clientHandle);
+    UA_UInt32 newestHandle =
+        mon->pendingParameters.clientHandle;
+    ck_assert_uint_ne(newHandle, newestHandle);
+
+    injectDataChangeNotification(client, sub, newestHandle);
+    ck_assert_uint_eq(mon->parameters.clientHandle,
+                      newestHandle);
+    ck_assert(!mon->pendingParameters.clientHandle);
+    ck_assert(mon->parameters.samplingInterval == 2000.0);
+
+    runServer();
+    for(size_t i = 0; i < 1000 && asyncResponse.resultsSize == 0; i++)
+        UA_Client_run_iterate(client, 1);
+    ck_assert_uint_eq(asyncResponse.responseHeader.serviceResult,
+                      UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(asyncResponse.resultsSize, 1);
+    ck_assert_uint_eq(asyncResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(mon->parameters.clientHandle,
+                      newestHandle);
+    UA_ModifyMonitoredItemsResponse_clear(&asyncResponse);
+
+    /* A newer pending generation supersedes the previous one. */
+    item.requestedParameters.samplingInterval = 3000.0;
+    response = UA_Client_MonitoredItems_modify(client, request);
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    UA_ModifyMonitoredItemsResponse_clear(&response);
+    UA_UInt32 supersededHandle =
+        mon->pendingParameters.clientHandle;
+
+    item.requestedParameters.samplingInterval = 4000.0;
+    response = UA_Client_MonitoredItems_modify(client, request);
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    UA_ModifyMonitoredItemsResponse_clear(&response);
+    UA_UInt32 latestHandle =
+        mon->pendingParameters.clientHandle;
+    ck_assert_uint_ne(supersededHandle, latestHandle);
+
+    UA_UInt32 notificationCount = countNotificationReceived;
+    injectDataChangeNotification(client, sub, supersededHandle);
+    ck_assert_uint_eq(countNotificationReceived, notificationCount);
+    ck_assert_uint_eq(mon->parameters.clientHandle,
+                      newestHandle);
+    ck_assert(mon->pendingParameters.clientHandle);
+
+    injectDataChangeNotification(client, sub, latestHandle);
+    ck_assert_uint_eq(countNotificationReceived, notificationCount + 1);
+    ck_assert_uint_eq(mon->parameters.clientHandle,
+                      latestHandle);
+    ck_assert(!mon->pendingParameters.clientHandle);
+
+    /* A rejected modification drops only its matching pending slot. */
+    request.timestampsToReturn = (UA_TimestampsToReturn)100;
+    response = UA_Client_MonitoredItems_modify(client, request);
+    ck_assert_uint_eq(response.responseHeader.serviceResult,
+                      UA_STATUSCODE_BADTIMESTAMPSTORETURNINVALID);
+    ck_assert(!mon->pendingParameters.clientHandle);
+    ck_assert_uint_eq(mon->parameters.clientHandle,
+                      latestHandle);
+    UA_ModifyMonitoredItemsResponse_clear(&response);
+
+    retval = UA_Client_Subscriptions_deleteSingle(client,
+                                                   subResponse.subscriptionId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_subscription_modifyEventFilter_doubleBuffer) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_Client_getConfig(client)->outStandingPublishRequests = 0;
+
+    UA_CreateSubscriptionRequest subRequest =
+        UA_CreateSubscriptionRequest_default();
+    UA_CreateSubscriptionResponse subResponse =
+        UA_Client_Subscriptions_create(client, subRequest, NULL, NULL, NULL);
+    ck_assert_uint_eq(subResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+
+    UA_QualifiedName oldBrowsePath = UA_QUALIFIEDNAME(0, "Message");
+    UA_SimpleAttributeOperand oldClause;
+    UA_SimpleAttributeOperand_init(&oldClause);
+    oldClause.typeDefinitionId =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
+    oldClause.browsePath = &oldBrowsePath;
+    oldClause.browsePathSize = 1;
+    oldClause.attributeId = UA_ATTRIBUTEID_VALUE;
+
+    UA_EventFilter oldFilter;
+    UA_EventFilter_init(&oldFilter);
+    oldFilter.selectClauses = &oldClause;
+    oldFilter.selectClausesSize = 1;
+
+    UA_MonitoredItemCreateRequest monRequest;
+    UA_MonitoredItemCreateRequest_init(&monRequest);
+    monRequest.itemToMonitor.nodeId =
+        UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER);
+    monRequest.itemToMonitor.attributeId = UA_ATTRIBUTEID_EVENTNOTIFIER;
+    monRequest.monitoringMode = UA_MONITORINGMODE_REPORTING;
+    monRequest.requestedParameters.queueSize = 1;
+    monRequest.requestedParameters.discardOldest = true;
+    UA_ExtensionObject_setValueNoDelete(
+        &monRequest.requestedParameters.filter, &oldFilter,
+        &UA_TYPES[UA_TYPES_EVENTFILTER]);
+
+    UA_MonitoredItemCreateResult monResponse =
+        UA_Client_MonitoredItems_createEvent(
+            client, subResponse.subscriptionId, UA_TIMESTAMPSTORETURN_BOTH,
+            monRequest, NULL, eventHandler, NULL);
+    ck_assert_uint_eq(monResponse.statusCode, UA_STATUSCODE_GOOD);
+
+    UA_Client_Subscription *sub = LIST_FIRST(&client->subscriptions);
+    ck_assert_ptr_ne(sub, NULL);
+    UA_Client_MonitoredItem *mon = ZIP_ROOT(&sub->monitoredItems);
+    ck_assert_ptr_ne(mon, NULL);
+    ck_assert_uint_eq(mon->eventFields.mapSize, 0);
+    UA_UInt32 oldHandle =
+        mon->parameters.clientHandle;
+
+    UA_QualifiedName newBrowsePaths[2] = {
+        UA_QUALIFIEDNAME(0, "Severity"),
+        UA_QUALIFIEDNAME(0, "SourceName")
+    };
+    UA_SimpleAttributeOperand newClauses[2];
+    for(size_t i = 0; i < 2; i++) {
+        UA_SimpleAttributeOperand_init(&newClauses[i]);
+        newClauses[i].typeDefinitionId =
+            UA_NODEID_NUMERIC(0, UA_NS0ID_BASEEVENTTYPE);
+        newClauses[i].browsePath = &newBrowsePaths[i];
+        newClauses[i].browsePathSize = 1;
+        newClauses[i].attributeId = UA_ATTRIBUTEID_VALUE;
+    }
+
+    UA_EventFilter newFilter;
+    UA_EventFilter_init(&newFilter);
+    newFilter.selectClauses = newClauses;
+    newFilter.selectClausesSize = 2;
+
+    UA_MonitoredItemModifyRequest item;
+    UA_MonitoredItemModifyRequest_init(&item);
+    item.monitoredItemId = monResponse.monitoredItemId;
+    item.requestedParameters.queueSize = 1;
+    item.requestedParameters.discardOldest = true;
+    UA_ExtensionObject_setValueNoDelete(
+        &item.requestedParameters.filter, &newFilter,
+        &UA_TYPES[UA_TYPES_EVENTFILTER]);
+
+    UA_ModifyMonitoredItemsRequest request;
+    UA_ModifyMonitoredItemsRequest_init(&request);
+    request.subscriptionId = subResponse.subscriptionId;
+    request.timestampsToReturn = UA_TIMESTAMPSTORETURN_BOTH;
+    request.itemsToModify = &item;
+    request.itemsToModifySize = 1;
+    UA_ModifyMonitoredItemsResponse response =
+        UA_Client_MonitoredItems_modify(client, request);
+    ck_assert_uint_eq(response.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(response.resultsSize, 1);
+    ck_assert_uint_eq(response.results[0].statusCode, UA_STATUSCODE_GOOD);
+    UA_ModifyMonitoredItemsResponse_clear(&response);
+
+    ck_assert(mon->pendingParameters.clientHandle);
+    ck_assert_uint_eq(mon->eventFields.mapSize, 0);
+    ck_assert_ptr_eq(mon->parameters.filter.content.decoded.type,
+                     &UA_TYPES[UA_TYPES_EVENTFILTER]);
+    ck_assert_ptr_eq(mon->pendingParameters.filter.content.decoded.type,
+                     &UA_TYPES[UA_TYPES_EVENTFILTER]);
+    UA_EventFilter *activeFilter = (UA_EventFilter*)
+        mon->parameters.filter.content.decoded.data;
+    UA_EventFilter *pendingFilter = (UA_EventFilter*)
+        mon->pendingParameters.filter.content.decoded.data;
+    ck_assert_uint_eq(activeFilter->selectClausesSize, 1);
+    ck_assert_uint_eq(pendingFilter->selectClausesSize, 2);
+    ck_assert_ptr_ne(pendingFilter, &newFilter);
+    UA_UInt32 newHandle =
+        mon->pendingParameters.clientHandle;
+
+    eventFieldsSize = 0;
+    injectEventNotification(client, sub, oldHandle, 1);
+    ck_assert_uint_eq(eventFieldsSize, 1);
+    ck_assert_uint_eq(mon->eventFields.mapSize, 1);
+    ck_assert_uint_eq(mon->parameters.clientHandle, oldHandle);
+    ck_assert(mon->pendingParameters.clientHandle);
+
+    injectEventNotification(client, sub, newHandle, 2);
+    ck_assert_uint_eq(eventFieldsSize, 2);
+    ck_assert_uint_eq(mon->eventFields.mapSize, 2);
+    ck_assert_uint_eq(mon->parameters.clientHandle, newHandle);
+    ck_assert(!mon->pendingParameters.clientHandle);
+    activeFilter = (UA_EventFilter*)mon->parameters.filter.content.decoded.data;
+    ck_assert_uint_eq(activeFilter->selectClausesSize, 2);
+
+    retval = UA_Client_Subscriptions_deleteSingle(client,
+                                                   subResponse.subscriptionId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Client_subscription_modifyMonitoredItem_edgeCases) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    UA_Client_getConfig(client)->outStandingPublishRequests = 0;
+
+    UA_CreateSubscriptionRequest subRequest =
+        UA_CreateSubscriptionRequest_default();
+    UA_CreateSubscriptionResponse subResponse =
+        UA_Client_Subscriptions_create(client, subRequest, NULL, NULL, NULL);
+    ck_assert_uint_eq(subResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    UA_UInt32 subId = subResponse.subscriptionId;
+
+    UA_MonitoredItemCreateRequest items[3] = {
+        UA_MonitoredItemCreateRequest_default(
+            UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STATE)),
+        UA_MonitoredItemCreateRequest_default(
+            UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_CURRENTTIME)),
+        UA_MonitoredItemCreateRequest_default(
+            UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_SECONDSTILLSHUTDOWN))
+    };
+    UA_Client_DataChangeNotificationCallback callbacks[3] = {
+        dataChangeHandler, dataChangeHandler, dataChangeHandler
+    };
+    void *contexts[3] = {NULL, NULL, NULL};
+    UA_Client_DeleteMonitoredItemCallback deleteCallbacks[3] = {
+        NULL, NULL, NULL
+    };
+
+    UA_CreateMonitoredItemsRequest createRequest;
+    UA_CreateMonitoredItemsRequest_init(&createRequest);
+    createRequest.subscriptionId = subId;
+    createRequest.timestampsToReturn = UA_TIMESTAMPSTORETURN_BOTH;
+    createRequest.itemsToCreate = items;
+    createRequest.itemsToCreateSize = 3;
+    UA_CreateMonitoredItemsResponse createResponse =
+        UA_Client_MonitoredItems_createDataChanges(
+            client, createRequest, contexts, callbacks, deleteCallbacks);
+    ck_assert_uint_eq(createResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(createResponse.resultsSize, 3);
+
+    UA_UInt32 monIds[3];
+    for(size_t i = 0; i < 3; i++) {
+        ck_assert_uint_eq(createResponse.results[i].statusCode, UA_STATUSCODE_GOOD);
+        monIds[i] = createResponse.results[i].monitoredItemId;
+    }
+    UA_CreateMonitoredItemsResponse_clear(&createResponse);
+
+    UA_Client_Subscription *sub = LIST_FIRST(&client->subscriptions);
+    ck_assert_ptr_ne(sub, NULL);
+    UA_Client_MonitoredItem *mons[3];
+    for(size_t i = 0; i < 3; i++) {
+        mons[i] = findTestMonitoredItem(ZIP_ROOT(&sub->monitoredItems), monIds[i]);
+        ck_assert_ptr_ne(mons[i], NULL);
+    }
+    ck_assert_uint_eq(countTestMonitoredItems(ZIP_ROOT(&sub->monitoredItems)), 3);
+
+    /* A mixed response keeps the successful item's pending state and rolls
+     * back only the failed item. */
+    UA_MonitoredItemModifyRequest modifyItems[2];
+    for(size_t i = 0; i < 2; i++) {
+        UA_MonitoredItemModifyRequest_init(&modifyItems[i]);
+        modifyItems[i].monitoredItemId = monIds[i];
+        modifyItems[i].requestedParameters.samplingInterval = 1000.0;
+        modifyItems[i].requestedParameters.queueSize = 1;
+        modifyItems[i].requestedParameters.discardOldest = true;
+    }
+    UA_DataChangeFilter unsupportedFilter;
+    UA_DataChangeFilter_init(&unsupportedFilter);
+    unsupportedFilter.deadbandType = (UA_DeadbandType)100;
+    UA_ExtensionObject_setValueNoDelete(
+        &modifyItems[1].requestedParameters.filter, &unsupportedFilter,
+        &UA_TYPES[UA_TYPES_DATACHANGEFILTER]);
+
+    UA_ModifyMonitoredItemsRequest modifyRequest;
+    UA_ModifyMonitoredItemsRequest_init(&modifyRequest);
+    modifyRequest.subscriptionId = subId;
+    modifyRequest.timestampsToReturn = UA_TIMESTAMPSTORETURN_BOTH;
+    modifyRequest.itemsToModify = modifyItems;
+    modifyRequest.itemsToModifySize = 2;
+    UA_ModifyMonitoredItemsResponse modifyResponse =
+        UA_Client_MonitoredItems_modify(client, modifyRequest);
+    ck_assert_uint_eq(modifyResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(modifyResponse.resultsSize, 2);
+    ck_assert_uint_eq(modifyResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_uint_ne(modifyResponse.results[1].statusCode, UA_STATUSCODE_GOOD);
+    UA_ModifyMonitoredItemsResponse_clear(&modifyResponse);
+    ck_assert(mons[0]->pendingParameters.clientHandle);
+    ck_assert(!mons[1]->pendingParameters.clientHandle);
+    ck_assert(!mons[2]->pendingParameters.clientHandle);
+
+    /* Find and promote a pending handle while several monitored items exist. */
+    UA_UInt32 pendingHandle =
+        mons[0]->pendingParameters.clientHandle;
+    UA_UInt32 otherHandles[2] = {
+        mons[1]->parameters.clientHandle,
+        mons[2]->parameters.clientHandle
+    };
+    injectDataChangeNotification(client, sub, pendingHandle);
+    ck_assert_uint_eq(mons[0]->parameters.clientHandle,
+                      pendingHandle);
+    ck_assert_uint_eq(mons[1]->parameters.clientHandle,
+                      otherHandles[0]);
+    ck_assert_uint_eq(mons[2]->parameters.clientHandle,
+                      otherHandles[1]);
+
+    /* Deletion clears both embedded slots while settings are pending. */
+    modifyRequest.itemsToModify = &modifyItems[1];
+    modifyRequest.itemsToModifySize = 1;
+    UA_ExtensionObject_init(&modifyItems[1].requestedParameters.filter);
+    modifyResponse = UA_Client_MonitoredItems_modify(client, modifyRequest);
+    ck_assert_uint_eq(modifyResponse.responseHeader.serviceResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(modifyResponse.results[0].statusCode, UA_STATUSCODE_GOOD);
+    UA_ModifyMonitoredItemsResponse_clear(&modifyResponse);
+    ck_assert(mons[1]->pendingParameters.clientHandle);
+    retval = UA_Client_MonitoredItems_deleteSingle(client, subId, monIds[1]);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_ptr_eq(findTestMonitoredItem(ZIP_ROOT(&sub->monitoredItems), monIds[1]),
+                     NULL);
+    ck_assert_uint_eq(countTestMonitoredItems(ZIP_ROOT(&sub->monitoredItems)), 2);
+
+    /* A local asynchronous submission failure rolls back the prepared slot. */
+    UA_MonitoredItemModifyRequest asyncItem;
+    UA_MonitoredItemModifyRequest_init(&asyncItem);
+    asyncItem.monitoredItemId = monIds[2];
+    asyncItem.requestedParameters.samplingInterval = 2000.0;
+    asyncItem.requestedParameters.queueSize = 1;
+    asyncItem.requestedParameters.discardOldest = true;
+    modifyRequest.itemsToModify = &asyncItem;
+    modifyRequest.itemsToModifySize = 1;
+    UA_SecureChannelState channelState = client->channel.state;
+    client->channel.state = UA_SECURECHANNELSTATE_CLOSED;
+    retval = UA_Client_MonitoredItems_modify_async(
+        client, modifyRequest, NULL, NULL, NULL);
+    client->channel.state = channelState;
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADSERVERNOTCONNECTED);
+    ck_assert(!mons[2]->pendingParameters.clientHandle);
+    ck_assert_uint_eq(mons[2]->parameters.clientHandle,
+                      otherHandles[1]);
+
+    retval = UA_Client_Subscriptions_deleteSingle(client, subId);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     UA_Client_disconnect(client);
     UA_Client_delete(client);
 }
@@ -2139,6 +2666,16 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_client, Client_subscription_modifyAsync_invalidSubscriptionId);
     tcase_add_test(tc_client, Client_renewSecureChannel_returnsGoodCallAgain);
     suite_add_tcase(s,tc_client);
+
+    TCase *tc_doubleBuffer = tcase_create("MonitoredItem Double Buffer");
+    tcase_add_checked_fixture(tc_doubleBuffer, setup, teardown);
+    tcase_add_test(tc_doubleBuffer,
+                   Client_subscription_modifyMonitoredItem_doubleBuffer);
+    tcase_add_test(tc_doubleBuffer,
+                   Client_subscription_modifyEventFilter_doubleBuffer);
+    tcase_add_test(tc_doubleBuffer,
+                   Client_subscription_modifyMonitoredItem_edgeCases);
+    suite_add_tcase(s, tc_doubleBuffer);
 
 #ifdef UA_ENABLE_METHODCALLS
     TCase *tc_client2 = tcase_create("Client Subscription + Method Call of GetMonitoredItmes");


### PR DESCRIPTION
Handle in-between states during ModifyMonitoredItems. Roll over the parameters when the new clienthandle is used for the first time.