### PR TITLE
fix(build): Fix amalgamation build for win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -881,7 +881,7 @@ set(lib_headers ${PROJECT_SOURCE_DIR}/deps/open62541_queue.h
                 ${PROJECT_SOURCE_DIR}/src/server/ua_server_internal.h
                 ${PROJECT_SOURCE_DIR}/src/client/ua_client_internal.h)
 
-if(UA_ENABLE_ENCRYPTION AND (UA_ARCHITECTURE_WIN32 OR UA_ENABLE_AMALGAMATION))
+if(UA_ENABLE_AMALGAMATION OR (UA_ENABLE_ENCRYPTION AND UA_ARCHITECTURE_WIN32))
     list(APPEND lib_headers ${PROJECT_SOURCE_DIR}/deps/tr_dirent.h)
 endif()
 


### PR DESCRIPTION
The file tr_dirent.h should always be included in the amalgamation or setting UA_ENABLE_ENCRYPTION later will result in build errors.