### PR TITLE
fix(build): Fix UA_THREAD_LOCAL for MSVC 14.36.32532 (and older?)

### DIFF
--- a/include/open62541/config.h.in
+++ b/include/open62541/config.h.in
@@ -221,12 +221,12 @@
  * Thread-local variables
  * ---------------------- */
 #if UA_MULTITHREADING >= 100
-# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+# if defined(_MSC_VER)
+#  define UA_THREAD_LOCAL __declspec(thread)
+# elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #  define UA_THREAD_LOCAL _Thread_local /* C11 or newer */
 # elif defined(__GNUC__) || defined(__clang__)
 #  define UA_THREAD_LOCAL __thread
-# elif defined(_MSC_VER)
-#  define UA_THREAD_LOCAL __declspec(thread)
 # else
 #  error "No thread-local storage keyword available on this compiler."
 # endif


### PR DESCRIPTION
The existing code works for MSVC 14.43.34808 but 14.36.32532 fails with errors like: C2146: syntax error: missing ';' before identifier 'UA_KeyValuePair'.