### PR TITLE
fix(nc): improve QualifiedName handling in nodeset compiler

### DIFF
--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -36,7 +36,9 @@ def makeCIdentifier(value):
 
 # Escape C strings:
 def makeCLiteral(value):
-    return re.sub(r'(?<!\\)"', r'\\"', value.replace('\\', r'\\').replace('"', r'\"').replace('\n', r'\n').replace('\r', r'\r'))
+    if value is None:
+        return ""
+    return value.replace('\\', r'\\').replace('"', r'\"').replace('\n', r'\n').replace('\r', r'\r')
 
 def splitStringLiterals(value, splitLength=500):
     """
@@ -62,6 +64,8 @@ def generateLocalizedTextCode(value, alloc=False):
     return "UA_LOCALIZEDTEXT{}(\"{}\", {})".format("_ALLOC" if alloc else "", '' if value.locale is None else value.locale, splitStringLiterals(vt))
 
 def generateQualifiedNameCode(value, alloc=False,):
+    if value.name is None:
+        value.name = ""
     vn = makeCLiteral(value.name)
     return "UA_QUALIFIEDNAME{}(UA_NamespaceMapping_local2Remote(nsMapping, {}), {})".format("_ALLOC" if alloc else "", str(value.ns), splitStringLiterals(vn))
 


### PR DESCRIPTION
In tools/nodeset_compiler/backend_open62541.py, makeCLiteral() has no guard for
value=None and crashes with an AttributeError on the value.replace(...) chain.

This adds `if value is None: return ""` to makeCLiteral and `if value.name is None: value.name = ""` to
generateQualifiedNameCode, preventing the crash on empty/None QualifiedName
values. Only affects the code-generation tool, not the library.

Supersedes #6719.