### PR TITLE
Decouples WebSocket transport from UA_ENABLE_LWS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ mark_as_advanced(UA_ENABLE_LWS)
 option(UA_ENABLE_LWS_MQTT "Enable the libwebsockets MQTT ConnectionManager" OFF)
 mark_as_advanced(UA_ENABLE_LWS_MQTT)
 
+
 if(UA_ENABLE_LWS_MQTT AND NOT UA_ENABLE_LWS)
     message(FATAL_ERROR "UA_ENABLE_LWS_MQTT requires UA_ENABLE_LWS")
 endif()
@@ -974,9 +975,7 @@ if(UA_ENABLE_RBAC)
     list(APPEND internal_headers ${PROJECT_SOURCE_DIR}/src/server/ua_server_rbac.h)
 endif()
 
-if(UA_ENABLE_LWS)
-    list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_server_ws.c)
-endif()
+list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_server_ws.c)
 
 # Dependencies
 set(lib_sources ${lib_sources}

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -338,6 +338,12 @@ be visible in the cmake GUIs.
 **UA_ENABLE_STATUSCODE_DESCRIPTIONS**
    Compile the human-readable name of the StatusCodes into the binary. Enabled by default.
 
+**UA_ENABLE_LWS**
+   Includes the ``libwebsockets`` library to enable OPC UA over WebSockets transport protocols (``opc.ws://`` for unencrypted WebSockets and ``opc.wss://`` for WebSockets over TLS/SSL).
+
+**UA_ENABLE_LWS_MQTT**
+   Enable the ``libwebsockets`` MQTT ConnectionManager implementation for PubSub MQTT transport protocols (``opc.mqtt://`` and ``opc.mqtts://``). Requires ``UA_ENABLE_LWS`` and ``libwebsockets`` compiled with MQTT support (``LWS_ROLE_MQTT=ON``).
+
 PubSub Build Options
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -2166,6 +2166,13 @@ UA_Role_equal(const UA_Role *r1, const UA_Role *r2);
  *
  * The :ref:`tutorials` provide a good starting point for this. */
 
+/* Encryption mode requirement for OPC UA Binary over WebSockets */
+typedef enum {
+    UA_WEBSOCKET_ENCRYPTION_OPTIONAL = 0, /* Allow both opc.ws:// (unencrypted) and opc.wss:// (TLS) */
+    UA_WEBSOCKET_ENCRYPTION_REQUIRED = 1, /* Allow only opc.wss:// (TLS); reject opc.ws:// */
+    UA_WEBSOCKET_ENCRYPTION_DISABLED = 2  /* Allow only opc.ws:// (unencrypted); reject opc.wss:// */
+} UA_WebSocketEncryptionMode;
+
 struct UA_ServerConfig {
     void *context; /* Used to attach custom data to a server config. This can
                     * then be retrieved e.g. in a callback that forwards a
@@ -2279,13 +2286,13 @@ struct UA_ServerConfig {
                               * (default: 0 -> unbounded) */
     UA_Boolean tcpReuseAddr;
 
-#ifdef UA_ENABLE_LWS
+
     /* The following settings are specific to OPC UA Binary over WebSockets.
-     * The transport is opt-in and requires an opc.wss ServerUrl together with
-     * a TLS certificate/private-key pair. The TLS credentials protect the
-     * WebSocket transport and are independent of OPC UA SecurityPolicies. */
-    UA_Boolean webSocketEnabled; /* Enable the WebSocket listener
-                                   * (default: false) */
+     * The transport is opt-in and controlled via webSocketEnabled (default: false).
+     * TLS credentials protect opc.wss:// endpoints independently of OPC UA SecurityPolicies. */
+    UA_Boolean webSocketEnabled; /* Enable the WebSocket listener (default: false) */
+    UA_Boolean webSocketAllowUnencrypted; /* Allow non-standard unencrypted opc.ws:// endpoints (default: false) */
+    UA_WebSocketEncryptionMode webSocketEncryptionMode; /* Encryption requirement (default: UA_WEBSOCKET_ENCRYPTION_OPTIONAL) */
     UA_UInt32 webSocketBufSize;    /* Max length of sent and received chunks
                                     * (default: 64kB) */
     UA_UInt32 webSocketMaxMsgSize; /* Max length of messages
@@ -2297,7 +2304,6 @@ struct UA_ServerConfig {
     UA_ByteString webSocketCertificate; /* TLS certificate, DER or PEM */
     UA_ByteString webSocketPrivateKey;  /* TLS private key, DER or PEM */
     UA_String webSocketPrivateKeyPassword;
-#endif
 
     /* Security and Encryption
      * ~~~~~~~~~~~~~~~~~~~~~~~ */

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -684,11 +684,11 @@ UA_ServerConfig_setMinimalCustomBuffer(UA_ServerConfig *config, UA_UInt16 portNu
      * intentionally ignored (see the doxygen note on the declaration). */
     (void)sendBufferSize;
     config->tcpBufSize = recvBufferSize;
-#ifdef UA_ENABLE_LWS
     config->webSocketBufSize = recvBufferSize;
+    config->webSocketAllowUnencrypted = false;
+    config->webSocketEncryptionMode = UA_WEBSOCKET_ENCRYPTION_OPTIONAL;
     config->webSocketMaxQueueSize =
         recvBufferSize > UINT32_MAX / 16 ? UINT32_MAX : recvBufferSize * 16;
-#endif
 
     /* Allocate the SecurityPolicies */
     retval = UA_ServerConfig_addSecurityPolicyNone(config, certificate);

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -508,12 +508,10 @@ UA_Server_init(UA_Server *server) {
     res = addDriver(server, server->binaryDriver);
     UA_CHECK_STATUS(res, goto cleanup);
 
-#ifdef UA_ENABLE_LWS
     /* Initialize OPC UA Binary over WebSockets */
     server->webSocketDriver = UA_WebSocketProtocolManager_new();
     res = addDriver(server, server->webSocketDriver);
     UA_CHECK_STATUS(res, goto cleanup);
-#endif
 
     /* Initialize the reverse connect binary protocol support */
     server->reverseBinaryDriver = UA_ReverseBinaryProtocolManager_new();
@@ -964,33 +962,85 @@ UA_Server_run_startup(UA_Server *server) {
     }
     UA_ServerConfig *config = &server->config;
 
-#ifdef UA_ENABLE_LWS
     if(config->webSocketEnabled) {
-        const UA_String prefix = UA_STRING_STATIC("opc.wss://");
+        const UA_String wss = UA_STRING_STATIC("opc.wss://");
+        const UA_String ws  = UA_STRING_STATIC("opc.ws://");
         UA_Boolean haveWebSocketUrl = false;
+        UA_Boolean haveSecureUrl = false;
+        UA_Boolean haveInsecureUrl = false;
         for(size_t i = 0; i < config->serverUrlsSize; i++) {
             const UA_String *url = &config->serverUrls[i];
-            if(url->length >= prefix.length &&
-               memcmp(url->data, prefix.data, prefix.length) == 0) {
+            if(url->length >= wss.length &&
+               memcmp(url->data, wss.data, wss.length) == 0) {
                 haveWebSocketUrl = true;
-                break;
+                haveSecureUrl = true;
+            } else if(url->length >= ws.length &&
+                      memcmp(url->data, ws.data, ws.length) == 0) {
+                haveWebSocketUrl = true;
+                haveInsecureUrl = true;
             }
         }
         if(!haveWebSocketUrl) {
             UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
-                         "WebSocket transport is enabled but no opc.wss "
-                         "ServerUrl is configured");
+                         "WebSocket transport is enabled but no opc.ws:// or "
+                         "opc.wss:// ServerUrl is configured");
             return UA_STATUSCODE_BADCONFIGURATIONERROR;
         }
-        if(config->webSocketCertificate.length == 0 ||
-           config->webSocketPrivateKey.length == 0) {
+
+        /* Check that a "websocket" protocol-provider (ConnectionManager) is registered in the EventLoop */
+        UA_Boolean foundWebSocketManager = false;
+        if(config->eventLoop) {
+            UA_String websocketStr = UA_STRING_STATIC("websocket");
+            for(UA_EventSource *es = config->eventLoop->eventSources;
+                es != NULL; es = es->next) {
+                if(es->eventSourceType != UA_EVENTSOURCETYPE_CONNECTIONMANAGER)
+                    continue;
+                UA_ConnectionManager *cm = (UA_ConnectionManager*)es;
+                if(UA_String_equal(&cm->protocol, &websocketStr)) {
+                    foundWebSocketManager = true;
+                    break;
+                }
+            }
+        }
+        if(!foundWebSocketManager) {
             UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
-                         "WebSocket transport is enabled but its TLS "
+                         "WebSocket transport is enabled (webSocketEnabled=true), "
+                         "but no 'websocket' protocol-provider (ConnectionManager) was found in the EventLoop");
+            return UA_STATUSCODE_BADCONFIGURATIONERROR;
+        }
+
+        /* Encryption mode checks */
+        if(haveInsecureUrl) {
+            if(!config->webSocketAllowUnencrypted) {
+                UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
+                             "opc.ws:// (unencrypted WebSocket) is configured, but webSocketAllowUnencrypted is false. "
+                             "Unencrypted WebSocket transport is non-standard and must be explicitly allowed.");
+                return UA_STATUSCODE_BADCONFIGURATIONERROR;
+            }
+            UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_SERVER,
+                           "opc.ws:// (unencrypted WebSocket) is enabled. "
+                           "Unencrypted WebSocket transport is non-standard and should only be used for testing/debugging!");
+        }
+
+        if(config->webSocketEncryptionMode == UA_WEBSOCKET_ENCRYPTION_REQUIRED && haveInsecureUrl) {
+            UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
+                         "opc.ws:// URL configured but webSocketEncryptionMode is set to REQUIRED");
+            return UA_STATUSCODE_BADCONFIGURATIONERROR;
+        }
+        if(config->webSocketEncryptionMode == UA_WEBSOCKET_ENCRYPTION_DISABLED && haveSecureUrl) {
+            UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
+                         "opc.wss:// URL configured but webSocketEncryptionMode is set to DISABLED");
+            return UA_STATUSCODE_BADCONFIGURATIONERROR;
+        }
+
+        if(haveSecureUrl && (config->webSocketCertificate.length == 0 ||
+                             config->webSocketPrivateKey.length == 0)) {
+            UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
+                         "WebSocket transport is enabled for opc.wss:// but its TLS "
                          "certificate or private key is empty");
             return UA_STATUSCODE_BADCONFIGURATIONERROR;
         }
     }
-#endif
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     /* Prominently warn user that fuzzing build is enabled. This will tamper

--- a/src/server/ua_server_config.c
+++ b/src/server/ua_server_config.c
@@ -39,11 +39,9 @@ UA_ServerConfig_clear(UA_ServerConfig *config) {
     config->serverUrls = NULL;
     config->serverUrlsSize = 0;
 
-#ifdef UA_ENABLE_LWS
     UA_ByteString_clear(&config->webSocketCertificate);
     UA_ByteString_clear(&config->webSocketPrivateKey);
     UA_String_clear(&config->webSocketPrivateKeyPassword);
-#endif
 
     /* Security Policies */
     for(size_t i = 0; i < config->securityPoliciesSize; ++i) {

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -139,9 +139,7 @@ struct UA_Server {
      * have direct pointers for fast access below. */
     UA_Driver *drivers; /* linked-list of all SC */
     UA_Driver *binaryDriver;
-#ifdef UA_ENABLE_LWS
     UA_Driver *webSocketDriver;
-#endif
     UA_Driver *reverseBinaryDriver;
     UA_Driver *discoveryDriver;
     UA_Driver *pubSubDriver;
@@ -831,9 +829,7 @@ UA_BinaryConnectionConfig_set(UA_ConnectionConfig *connectionConfig,
 
 UA_Driver * UA_BinaryProtocolManager_new(void);
 
-#ifdef UA_ENABLE_LWS
 UA_Driver * UA_WebSocketProtocolManager_new(void);
-#endif
 
 UA_Driver * UA_ReverseBinaryProtocolManager_new(void);
 

--- a/src/server/ua_server_ws.c
+++ b/src/server/ua_server_ws.c
@@ -5,13 +5,21 @@
 #include "ua_server_internal.h"
 #include "mp_printf.h"
 
-#ifdef UA_ENABLE_LWS
-
 static UA_Boolean
 isWebSocketUrl(const UA_String *url) {
-    const UA_String prefix = UA_STRING_STATIC("opc.wss://");
-    return url->length >= prefix.length &&
-        memcmp(url->data, prefix.data, prefix.length) == 0;
+    const UA_String wss = UA_STRING_STATIC("opc.wss://");
+    const UA_String ws  = UA_STRING_STATIC("opc.ws://");
+    return (url->length >= wss.length &&
+            memcmp(url->data, wss.data, wss.length) == 0) ||
+           (url->length >= ws.length &&
+            memcmp(url->data, ws.data, ws.length) == 0);
+}
+
+static UA_Boolean
+isSecureWebSocketUrl(const UA_String *url) {
+    const UA_String wss = UA_STRING_STATIC("opc.wss://");
+    return url->length >= wss.length &&
+           memcmp(url->data, wss.data, wss.length) == 0;
 }
 
 static void
@@ -54,24 +62,26 @@ addWebSocketDiscoveryUrls(UA_BinaryProtocolManager *bpm,
         if(!isWebSocketUrl(serverUrl))
             continue;
 
+        const UA_Boolean secure = isSecureWebSocketUrl(serverUrl);
         UA_String hostname = UA_STRING_NULL;
         UA_String path = UA_STRING_NULL;
-        UA_UInt16 port = 443;
+        UA_UInt16 port = secure ? 443 : 4840;
         UA_StatusCode res =
             UA_parseEndpointUrl(serverUrl, &hostname, &port, &path);
         if(res != UA_STATUSCODE_GOOD ||
            (port != 0 && port != *listenPort))
             continue;
 
+        const char *scheme = secure ? "opc.wss" : "opc.ws";
         const UA_String advertisedHost =
             hostname.length > 0 ? hostname : *listenAddress;
         char urlstr[1024];
         if(path.length > 0) {
-            mp_snprintf(urlstr, sizeof(urlstr), "opc.wss://%S:%u/%S",
-                        advertisedHost, (unsigned)*listenPort, path);
+            mp_snprintf(urlstr, sizeof(urlstr), "%s://%S:%u/%S",
+                        scheme, advertisedHost, (unsigned)*listenPort, path);
         } else {
-            mp_snprintf(urlstr, sizeof(urlstr), "opc.wss://%S:%u",
-                        advertisedHost, (unsigned)*listenPort);
+            mp_snprintf(urlstr, sizeof(urlstr), "%s://%S:%u",
+                        scheme, advertisedHost, (unsigned)*listenPort);
         }
         appendDiscoveryUrl(server, UA_STRING(urlstr));
     }
@@ -85,9 +95,10 @@ createWebSocketServerConnection(UA_BinaryProtocolManager *bpm,
 
     UA_LOCK_ASSERT(&bpm->drv.server->serviceMutex);
 
+    UA_Boolean secure = isSecureWebSocketUrl(serverUrl);
     UA_String hostname = UA_STRING_NULL;
     UA_String path = UA_STRING_NULL;
-    UA_UInt16 port = 443;
+    UA_UInt16 port = secure ? 443 : 4840;
     UA_StatusCode res =
         UA_parseEndpointUrl(serverUrl, &hostname, &port, &path);
     if(res != UA_STATUSCODE_GOOD)
@@ -128,9 +139,8 @@ createWebSocketServerConnection(UA_BinaryProtocolManager *bpm,
         UA_Variant_setScalar(&params[paramsSize++].value, &listen,
                              &UA_TYPES[UA_TYPES_BOOLEAN]);
 
-        UA_Boolean useSSL = true;
         params[paramsSize].key = UA_QUALIFIEDNAME(0, "useSSL");
-        UA_Variant_setScalar(&params[paramsSize++].value, &useSSL,
+        UA_Variant_setScalar(&params[paramsSize++].value, &secure,
                              &UA_TYPES[UA_TYPES_BOOLEAN]);
 
         params[paramsSize].key = UA_QUALIFIEDNAME(0, "path");
@@ -166,32 +176,35 @@ createWebSocketServerConnection(UA_BinaryProtocolManager *bpm,
                                  &UA_TYPES[UA_TYPES_STRING]);
         }
 
-        /* TLS credentials are configured on the WebSocket ConnectionManager.
-         * They are separate from the keys used by the UACP SecurityPolicies.
-         * Do not forward empty values. The TLS listener requires a non-empty
-         * certificate/private-key pair. */
-        UA_ByteString *certificate = &config->webSocketCertificate;
-        UA_ByteString *privateKey = &config->webSocketPrivateKey;
-        if(certificate->length == 0 || privateKey->length == 0) {
-            UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
-                         "The WebSocket server requires a non-empty TLS "
-                         "certificate and private key");
-            openResult = UA_STATUSCODE_BADINVALIDARGUMENT;
-            continue;
-        }
-        params[paramsSize].key = UA_QUALIFIEDNAME(0, "certificate");
-        UA_Variant_setScalar(&params[paramsSize++].value, certificate,
-                             &UA_TYPES[UA_TYPES_BYTESTRING]);
-        params[paramsSize].key = UA_QUALIFIEDNAME(0, "private-key");
-        UA_Variant_setScalar(&params[paramsSize++].value, privateKey,
-                             &UA_TYPES[UA_TYPES_BYTESTRING]);
+        /* TLS credentials — only required for opc.wss:// */
+        if(secure) {
+            /* TLS credentials are configured on the WebSocket ConnectionManager.
+             * They are separate from the keys used by the UACP SecurityPolicies.
+             * Do not forward empty values. The TLS listener requires a non-empty
+             * certificate/private-key pair. */
+            UA_ByteString *certificate = &config->webSocketCertificate;
+            UA_ByteString *privateKey = &config->webSocketPrivateKey;
+            if(certificate->length == 0 || privateKey->length == 0) {
+                UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
+                             "The WebSocket server (opc.wss://) requires a "
+                             "non-empty TLS certificate and private key");
+                openResult = UA_STATUSCODE_BADINVALIDARGUMENT;
+                continue;
+            }
+            params[paramsSize].key = UA_QUALIFIEDNAME(0, "certificate");
+            UA_Variant_setScalar(&params[paramsSize++].value, certificate,
+                                 &UA_TYPES[UA_TYPES_BYTESTRING]);
+            params[paramsSize].key = UA_QUALIFIEDNAME(0, "private-key");
+            UA_Variant_setScalar(&params[paramsSize++].value, privateKey,
+                                 &UA_TYPES[UA_TYPES_BYTESTRING]);
 
-        if(config->webSocketPrivateKeyPassword.length > 0) {
-            params[paramsSize].key =
-                UA_QUALIFIEDNAME(0, "private-key-password");
-            UA_Variant_setScalar(&params[paramsSize++].value,
-                                 &config->webSocketPrivateKeyPassword,
-                                 &UA_TYPES[UA_TYPES_STRING]);
+            if(config->webSocketPrivateKeyPassword.length > 0) {
+                params[paramsSize].key =
+                    UA_QUALIFIEDNAME(0, "private-key-password");
+                UA_Variant_setScalar(&params[paramsSize++].value,
+                                     &config->webSocketPrivateKeyPassword,
+                                     &UA_TYPES[UA_TYPES_STRING]);
+            }
         }
 
         UA_KeyValueMap paramsMap = {paramsSize, params};
@@ -220,12 +233,18 @@ startWebSocketTransport(UA_BinaryProtocolManager *bpm) {
     if(!config->webSocketEnabled)
         return UA_STATUSCODE_GOOD;
 
-    if(config->webSocketCertificate.length == 0 ||
-       config->webSocketPrivateKey.length == 0) {
-        UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
-                     "WebSocket transport is enabled but its TLS certificate "
-                     "or private key is empty");
-        return UA_STATUSCODE_BADCONFIGURATIONERROR;
+    /* Fail early if any opc.wss:// URL is configured without TLS credentials */
+    for(size_t i = 0; i < config->serverUrlsSize; i++) {
+        if(!isSecureWebSocketUrl(&config->serverUrls[i]))
+            continue;
+        if(config->webSocketCertificate.length == 0 ||
+           config->webSocketPrivateKey.length == 0) {
+            UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
+                         "WebSocket transport is enabled but its TLS certificate "
+                         "or private key is empty");
+            return UA_STATUSCODE_BADCONFIGURATIONERROR;
+        }
+        break;
     }
 
     UA_BinaryConnectionConfig_set(&bpm->connectionConfig,
@@ -255,8 +274,8 @@ startWebSocketTransport(UA_BinaryProtocolManager *bpm) {
 
     if(!haveWebSocketUrl) {
         UA_LOG_ERROR(config->logging, UA_LOGCATEGORY_SERVER,
-                     "WebSocket transport is enabled but no opc.wss ServerUrl "
-                     "is configured");
+                     "WebSocket transport is enabled but no opc.ws:// or "
+                     "opc.wss:// ServerUrl is configured");
         return UA_STATUSCODE_BADCONFIGURATIONERROR;
     }
     if(haveServerSocket)
@@ -280,5 +299,3 @@ UA_WebSocketProtocolManager_new(void) {
                                   addWebSocketDiscoveryUrls);
     return &bpm->drv;
 }
-
-#endif /* UA_ENABLE_LWS */

--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -700,17 +700,24 @@ updateEndpointUserIdentityToken(UA_Server *server,
 
 /* Also reused to create the EndpointDescription array in the
  * CreateSessionResponse */
-#ifdef UA_ENABLE_LWS
+static const UA_String wsBinaryTransportProfile = UA_STRING_STATIC(
+    "http://opcfoundation.org/UA-Profile/Transport/ws-uasc-uabinary");
 static const UA_String wssBinaryTransportProfile = UA_STRING_STATIC(
     "http://opcfoundation.org/UA-Profile/Transport/wss-uasc-uabinary");
 
 static UA_Boolean
-isWebSocketEndpointUrl(const UA_String *url) {
+isSecureWebSocketEndpointUrl(const UA_String *url) {
     const UA_String prefix = UA_STRING_STATIC("opc.wss://");
     return url->length >= prefix.length &&
         memcmp(url->data, prefix.data, prefix.length) == 0;
 }
-#endif
+
+static UA_Boolean
+isInsecureWebSocketEndpointUrl(const UA_String *url) {
+    const UA_String prefix = UA_STRING_STATIC("opc.ws://");
+    return url->length >= prefix.length &&
+        memcmp(url->data, prefix.data, prefix.length) == 0;
+}
 
 UA_StatusCode
 setCurrentEndpointsArray(UA_Server *server, const UA_String endpointUrl,
@@ -752,10 +759,10 @@ setCurrentEndpointsArray(UA_Server *server, const UA_String endpointUrl,
                 currentEndpointUrl = &sc->applicationDescription.discoveryUrls[i];
 
             const UA_String *transportProfileUri = &ep->transportProfileUri;
-#ifdef UA_ENABLE_LWS
-            if(isWebSocketEndpointUrl(currentEndpointUrl))
+            if(isSecureWebSocketEndpointUrl(currentEndpointUrl))
                 transportProfileUri = &wssBinaryTransportProfile;
-#endif
+            else if(isInsecureWebSocketEndpointUrl(currentEndpointUrl))
+                transportProfileUri = &wsBinaryTransportProfile;
 
             /* Test if the effective transport profile shall be returned */
             UA_Boolean usable = (profileUrisSize == 0);

--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -134,27 +134,26 @@ UA_readNumber(const UA_Byte *buf, size_t buflen, UA_UInt32 *number) {
     return UA_readNumberWithBase(buf, buflen, number, 10);
 }
 
-#define UA_SCHEMAS_SIZE 5
+#define UA_SCHEMAS_SIZE 6
 #define UA_ETH_SCHEMA_INDEX 2
 
 static const char* schemas[UA_SCHEMAS_SIZE] = {
-    "opc.tcp://", "opc.udp://", "opc.eth://", "opc.mqtt://", "opc.wss://"
+    "opc.tcp://", "opc.udp://", "opc.eth://", "opc.mqtt://", "opc.wss://", "opc.ws://"
 };
 
 UA_StatusCode
 UA_parseEndpointUrl(const UA_String *endpointUrl, UA_String *outHostname,
                     UA_UInt16 *outPort, UA_String *outPath) {
-    /* Url must begin with a supported OPC UA URL scheme */
-    if(endpointUrl->length < 11) {
+    if(!endpointUrl || !endpointUrl->data)
         return UA_STATUSCODE_BADTCPENDPOINTURLINVALID;
-    }
 
     /* Which type of schema is this? */
     unsigned schemaType = 0;
+    size_t schemaLen = 0;
     for(; schemaType < UA_SCHEMAS_SIZE; schemaType++) {
-        if(strncmp((char*)endpointUrl->data,
-                   schemas[schemaType],
-                   strlen(schemas[schemaType])) == 0)
+        schemaLen = strlen(schemas[schemaType]);
+        if(endpointUrl->length >= schemaLen &&
+           strncmp((char*)endpointUrl->data, schemas[schemaType], schemaLen) == 0)
             break;
     }
     if(schemaType == UA_SCHEMAS_SIZE)
@@ -197,8 +196,11 @@ UA_parseEndpointUrl(const UA_String *endpointUrl, UA_String *outHostname,
         outHostname->data = NULL;
 
     /* Already at the end */
-    if(curr == endpointUrl->length)
+    if(curr == endpointUrl->length) {
+        if(outHostname->length == 0)
+            return UA_STATUSCODE_BADTCPENDPOINTURLINVALID;
         return UA_STATUSCODE_GOOD;
+    }
 
     /* Set the port - and for ETH set the VID.PCP postfix in the outpath string.
      * We have to parse that externally. */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,10 @@ endif()
 find_package(Check REQUIRED)
 set(LIBS ${CHECK_LIBRARIES} ${open62541_LIBRARIES})
 if(NOT WIN32 AND NOT APPLE AND NOT (CMAKE_HOST_SYSTEM_NAME MATCHES "OpenBSD") AND NOT (CMAKE_HOST_SYSTEM_NAME MATCHES "FreeBSD"))
-    list(APPEND LIBS subunit)
+    find_library(SUBUNIT_LIB subunit)
+    if(SUBUNIT_LIB)
+        list(APPEND LIBS subunit)
+    endif()
 endif()
 include_directories(${CHECK_INCLUDE_DIRS})
 link_directories(${CHECK_LIBRARY_DIRS})
@@ -88,9 +91,12 @@ set(test_plugin_sources
 # Network replay tests currently require a Linux environment.
 # Also only do it for 64bit builds, as there is a bug in the Debian multi-arch installation.
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT UA_FORCE_32BIT)
-    list(APPEND test_plugin_sources
-                ${PROJECT_SOURCE_DIR}/tests/testing-plugins/testing_networklayers_pcap.c)
-    list(APPEND LIBS pcap)
+    find_path(PCAP_INCLUDE_DIR pcap.h)
+    if(PCAP_INCLUDE_DIR)
+        list(APPEND test_plugin_sources
+                    ${PROJECT_SOURCE_DIR}/tests/testing-plugins/testing_networklayers_pcap.c)
+        list(APPEND LIBS pcap)
+    endif()
 endif()
 
 if(UA_ENABLE_PUBSUB)

--- a/tests/check_eventloop_websocket_lws.c
+++ b/tests/check_eventloop_websocket_lws.c
@@ -955,6 +955,68 @@ START_TEST(clientServerTlsCaCertificate) {
 }
 END_TEST
 
+START_TEST(serverStartupWithoutWebSocketProvider) {
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_ne(server, NULL);
+
+    /* By default webSocketEnabled is false, so startup succeeds */
+    UA_StatusCode res = UA_Server_run_startup(server);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_Server_run_shutdown(server);
+    UA_Server_delete(server);
+
+    /* If webSocketEnabled is true and no websocket provider in EventLoop, startup fails */
+    server = UA_Server_new();
+    ck_assert_ptr_ne(server, NULL);
+    UA_EventLoop *el = UA_EventLoop_new_POSIX(server->config.logging);
+    server->config.eventLoop = el;
+    server->config.webSocketEnabled = true;
+    server->config.webSocketAllowUnencrypted = true;
+    UA_String wsUrl = UA_STRING("opc.ws://localhost:4840");
+    UA_Array_copy(&wsUrl, 1, (void**)&server->config.serverUrls, &UA_TYPES[UA_TYPES_STRING]);
+    server->config.serverUrlsSize = 1;
+
+    res = UA_Server_run_startup(server);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADCONFIGURATIONERROR);
+    UA_Server_delete(server);
+}
+END_TEST
+
+START_TEST(serverWebSocketEncryptionMode) {
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_ne(server, NULL);
+    UA_EventLoop *el = UA_EventLoop_new_POSIX(server->config.logging);
+    server->config.eventLoop = el;
+    UA_ConnectionManager *cm = UA_ConnectionManager_new_LWS_WebSocket(UA_STRING("websocket"));
+    el->registerEventSource(el, &cm->eventSource);
+    server->config.webSocketEnabled = true;
+
+    /* opc.ws:// fails if webSocketAllowUnencrypted is false (default) */
+    server->config.webSocketAllowUnencrypted = false;
+    UA_String wsUrl = UA_STRING("opc.ws://localhost:4840");
+    UA_Array_copy(&wsUrl, 1, (void**)&server->config.serverUrls, &UA_TYPES[UA_TYPES_STRING]);
+    server->config.serverUrlsSize = 1;
+    UA_StatusCode res = UA_Server_run_startup(server);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADCONFIGURATIONERROR);
+
+    /* REQUIRED mode rejects opc.ws:// even when allowUnencrypted is true */
+    server->config.webSocketAllowUnencrypted = true;
+    server->config.webSocketEncryptionMode = UA_WEBSOCKET_ENCRYPTION_REQUIRED;
+    res = UA_Server_run_startup(server);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADCONFIGURATIONERROR);
+
+    /* DISABLED mode rejects opc.wss:// */
+    server->config.webSocketEncryptionMode = UA_WEBSOCKET_ENCRYPTION_DISABLED;
+    UA_String wssUrl = UA_STRING("opc.wss://localhost:443");
+    UA_Array_copy(&wssUrl, 1, (void**)&server->config.serverUrls, &UA_TYPES[UA_TYPES_STRING]);
+    server->config.serverUrlsSize = 1;
+    res = UA_Server_run_startup(server);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADCONFIGURATIONERROR);
+
+    UA_Server_delete(server);
+}
+END_TEST
+
 int main(void) {
     Suite *s = suite_create("LWS WebSocket ConnectionManager");
     TCase *tc = tcase_create("integration");
@@ -973,6 +1035,8 @@ int main(void) {
 #endif
     tcase_add_test(tc, clientServerRejectsPolicyMismatch);
     tcase_add_test(tc, clientServerTlsCaCertificate);
+    tcase_add_test(tc, serverStartupWithoutWebSocketProvider);
+    tcase_add_test(tc, serverWebSocketEncryptionMode);
     suite_add_tcase(s, tc);
     SRunner *sr = srunner_create(s); srunner_set_fork_status(sr, CK_NOFORK);
     srunner_run_all(sr, CK_NORMAL); int failed = srunner_ntests_failed(sr);

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -86,6 +86,20 @@ START_TEST(EndpointUrl_split) {
     ck_assert_uint_eq(port, 1234);
     ck_assert(UA_String_equal(&path, &expectedPath));
 
+    // short WebSocket URLs (e.g. opc.ws://a)
+    endPointUrl = UA_STRING("opc.ws://a");
+    port = 4840;
+    path = UA_STRING_NULL;
+    ck_assert_uint_eq(UA_parseEndpointUrl(&endPointUrl, &hostname, &port, &path), UA_STATUSCODE_GOOD);
+    expected = UA_STRING("a");
+    ck_assert(UA_String_equal(&hostname, &expected));
+
+    endPointUrl = UA_STRING("opc.wss://a");
+    port = 443;
+    path = UA_STRING_NULL;
+    ck_assert_uint_eq(UA_parseEndpointUrl(&endPointUrl, &hostname, &port, &path), UA_STATUSCODE_GOOD);
+    ck_assert(UA_String_equal(&hostname, &expected));
+
     // invalid IPv6: missing ]
     endPointUrl = UA_STRING("opc.tcp://[2001:0db8:85a3::8a2e:0370:7334");
     ck_assert_uint_eq(UA_parseEndpointUrl(&endPointUrl, &hostname, &port, &path), UA_STATUSCODE_BADTCPENDPOINTURLINVALID);


### PR DESCRIPTION
Separates server-side WebSocket transport wiring from reliance on UA_ENABLE_LWS.

Adds support for plain opc.ws:// WebSocket server, enabling non-TLS WebSocket connections alongside the existing opc.wss:// support. This enhancement allows non-POSIX platforms to implement a custom "websocket" UA_ConnectionManager using native HTTP/WS stacks.

Adressing: https://github.com/o6-automation/open62541-dev/pull/2#issuecomment-5175143291 

