### PR TITLE
fix(client): use getEndpointUrl in initConnect

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -2298,10 +2298,11 @@ initConnect(UA_Client *client) {
     UA_String path = UA_STRING_NULL;
     UA_UInt16 port = 4840;
 
-    res = UA_parseEndpointUrl(&client->config.endpointUrl, &hostname, &port, &path);
+    UA_String endpointUrl = getEndpointUrl(client);
+    res = UA_parseEndpointUrl(&endpointUrl, &hostname, &port, &path);
     if(res != UA_STATUSCODE_GOOD) {
         UA_LOG_WARNING(client->config.logging, UA_LOGCATEGORY_NETWORK,
-                       "Endpoint URL is invalid: %S", client->config.endpointUrl);
+                       "Endpoint URL is invalid: %S", endpointUrl);
         setConnectStatus(client, res);
         return;
     }


### PR DESCRIPTION
initConnect parses client->config.endpointUrl directly, ignoring a discovery-provided endpoint URL. Every other place in the connect code — the HEL message and the GetEndpoints request — already goes through the getEndpointUrl helper, which prefers client->endpoint.endpointUrl when it is set.

Use the helper here too, so initConnect connects to the same URL as the rest of the handshake (e.g. for reverse connect and discovered endpoints).

Supersedes #6973.