### PR TITLE
fix(build): repair the debug dump builds and cover untested build options in CI

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -153,6 +153,9 @@ jobs:
           - name: "Build All Companion Specifications"
             cmd_action: build_all_companion_specs
 
+          - name: "Build Option Coverage"
+            cmd_action: build_option_coverage
+
         include:          
           # Clang builds for specific Ubuntu versions
           - os: ubuntu-22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1008,6 +1008,13 @@ if(UA_ENABLE_DRIVER_GDS_RECEIVER)
 endif()
 
 if(UA_ENABLE_RBAC)
+    # RBAC uses the well-known TrustedApplication role and the matching
+    # IdentityCriteriaType value. Both are missing from tools/schema, which is
+    # an older revision than the ua-nodeset submodule used for FULL.
+    # TODO: lift the restriction by aligning tools/schema with that revision.
+    if(NOT UA_NAMESPACE_ZERO STREQUAL "FULL")
+        message(FATAL_ERROR "RBAC requires UA_NAMESPACE_ZERO=FULL")
+    endif()
     list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_server_rbac.c)
     list(APPEND lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_server_ns0_rbac.c)
     list(APPEND internal_headers ${PROJECT_SOURCE_DIR}/src/server/ua_server_rbac.h)
@@ -1056,6 +1063,14 @@ if(UA_ENABLE_SUBSCRIPTIONS_EVENTS)
                             ${PROJECT_SOURCE_DIR}/src/util/ua_eventfilter_parser.c
                             ${PROJECT_SOURCE_DIR}/src/util/ua_eventfilter_lex.c
                             ${PROJECT_SOURCE_DIR}/src/util/ua_eventfilter_grammar.c)
+endif()
+
+if(UA_ENABLE_DIAGNOSTICS)
+    # ua_server_ns0_diagnostics.c looks up struct members by name via
+    # UA_DataType_getStructMember, which only exists with type descriptions
+    if(NOT UA_ENABLE_TYPEDESCRIPTION)
+        message(FATAL_ERROR "Diagnostics require type descriptions to be enabled")
+    endif()
 endif()
 
 if(UA_ENABLE_JSON_ENCODING)

--- a/plugins/ua_debug_dump_pkgs.c
+++ b/plugins/ua_debug_dump_pkgs.c
@@ -5,12 +5,15 @@
  *    Copyright 2017 (c) Stefan Profanter, fortiss GmbH
  */
 
-#include "ua_util_internal.h"
+#include <open62541/types.h>
 
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 
 #ifdef UA_DEBUG_DUMP_PKGS
+void UA_dump_hex_pkg(UA_Byte* buffer, size_t bufferLen);
+
 void UA_dump_hex_pkg(UA_Byte* buffer, size_t bufferLen) {
     printf("--------------- HEX Package Start ---------------\n");
     char ascii[17];

--- a/src/server/ua_transport_tcp.c
+++ b/src/server/ua_transport_tcp.c
@@ -26,8 +26,7 @@
 #include "ua_services.h"
 
 #ifdef UA_DEBUG_DUMP_PKGS_FILE
-void UA_debug_dumpCompleteChunk(UA_Server *const server, UA_Connection *const connection,
-                                UA_ByteString *messageBuffer);
+void UA_debug_dumpCompleteChunk(UA_Server *const server, UA_ByteString *messageBuffer);
 #endif
 
 static void
@@ -720,10 +719,10 @@ serverNetworkCallbackLocked(UA_ConnectionManager *cm, uintptr_t connectionId,
 
     /* Received a message on a normal connection */
 #ifdef UA_DEBUG_DUMP_PKGS
-    UA_dump_hex_pkg(message->data, message->length);
+    UA_dump_hex_pkg(msg.data, msg.length);
 #endif
 #ifdef UA_DEBUG_DUMP_PKGS_FILE
-    UA_debug_dumpCompleteChunk(server, channel->connection, message);
+    UA_debug_dumpCompleteChunk(bpm->drv.server, &msg);
 #endif
 
     UA_EventLoop *el = bpm->drv.server->config.eventLoop;

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -16,7 +16,8 @@ if (UA_BUILD_FUZZING_CORPUS)
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/corpus/custom)
 
     add_executable(corpus_generator ua_debug_dump_pkgs_file.c corpus_generator.c
-                                    ${PROJECT_SOURCE_DIR}/tests/testing-plugins/testing_networklayers.c)
+                                    ${PROJECT_SOURCE_DIR}/tests/testing-plugins/test_helpers.c
+                                    ${PROJECT_SOURCE_DIR}/tests/testing-plugins/testing_clock.c)
     target_link_libraries(corpus_generator open62541 ${open62541_LIBRARIES})
     assign_source_group(corpus_generator)
     set_target_properties(corpus_generator PROPERTIES FOLDER "open62541/corpus_generator")

--- a/tests/fuzz/corpus_generator.c
+++ b/tests/fuzz/corpus_generator.c
@@ -414,15 +414,20 @@ subscriptionRequests(UA_Client *client) {
     monId = monResponse.monitoredItemId;
 
     // publishRequest
+    // Both helpers are internal and require the client lock to be held.
     UA_PublishRequest publishRequest;
     UA_PublishRequest_init(&publishRequest);
-    ASSERT_GOOD(UA_Client_preparePublishRequest(client, &publishRequest));
-    __UA_Client_AsyncService(client, &publishRequest,
-                             &UA_TYPES[UA_TYPES_PUBLISHREQUEST], NULL,
-                             &UA_TYPES[UA_TYPES_PUBLISHRESPONSE], NULL, NULL);
-    // here we don't care about the return value since it may be UA_STATUSCODE_BADMESSAGENOTAVAILABLE
-    // ASSERT_GOOD(publishResponse.responseHeader.serviceResult);
+    lockClient(client);
+    UA_StatusCode publishRetval = __Client_preparePublishRequest(client, &publishRequest);
+    if(publishRetval == UA_STATUSCODE_GOOD)
+        __Client_AsyncService(client, &publishRequest,
+                              &UA_TYPES[UA_TYPES_PUBLISHREQUEST], NULL,
+                              &UA_TYPES[UA_TYPES_PUBLISHRESPONSE], NULL, NULL);
+    unlockClient(client);
+    // here we don't care about the async return value since it may be
+    // UA_STATUSCODE_BADMESSAGENOTAVAILABLE
     UA_PublishRequest_clear(&publishRequest);
+    ASSERT_GOOD(publishRetval);
 
     // republishRequest
     UA_RepublishRequest republishRequest;

--- a/tests/fuzz/ua_debug_dump_pkgs_file.c
+++ b/tests/fuzz/ua_debug_dump_pkgs_file.c
@@ -16,9 +16,8 @@
 #include <open62541/types.h>
 
 #include "server/ua_server_internal.h"
-#include "testing_networklayers.h"
-
-#define RECEIVE_BUFFER_SIZE 65535
+#include "ua_securechannel.h"
+#include "ua_types_encoding_binary.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,8 +39,7 @@ struct UA_dump_filename {
     char serviceName[100];
 };
 
-void UA_debug_dumpCompleteChunk(UA_Server *const server, UA_Connection *const connection,
-                                UA_ByteString *messageBuffer);
+void UA_debug_dumpCompleteChunk(UA_Server *const server, UA_ByteString *messageBuffer);
 
 /**
  * Gets a pointer to the string representing the given message type from UA_dump_messageTypes.
@@ -105,56 +103,61 @@ UA_debug_dumpSetServiceName(const UA_ByteString *msg, char serviceNameTarget[100
 }
 
 /**
- * We need to decode the given binary message to get the name of the called service.
- * This method is used if the connection an established secure channel.
+ * Derive the file name from the first chunk in the received buffer.
  *
- * message is the decoded message starting at the nodeid of the content type.
+ * The message type is taken from the chunk header, which is never encrypted.
+ * The service name additionally requires the request body, which is readable
+ * because the corpus is generated over an unencrypted channel (see
+ * corpus_generator.c). With SecurityMode Sign/SignAndEncrypt the body stays
+ * opaque here and the name is left empty.
  */
-static UA_StatusCode
-UA_debug_dump_setName(void *application, UA_SecureChannel *channel,
-                      UA_MessageType messagetype, UA_UInt32 requestId,
-                      UA_ByteString *message) {
-    struct UA_dump_filename *dump_filename = (struct UA_dump_filename *)application;
-    dump_filename->messageType = UA_debug_dumpGetMessageTypePrefix(messagetype);
-    if(messagetype == UA_MESSAGETYPE_MSG)
-        UA_debug_dumpSetServiceName(message, dump_filename->serviceName);
-    return UA_STATUSCODE_GOOD;
+static void
+UA_debug_dumpSetNames(const UA_ByteString *buffer, struct UA_dump_filename *dump_filename) {
+    if(buffer->length < UA_SECURECHANNEL_MESSAGEHEADER_LENGTH)
+        return;
+
+    size_t offset = 0;
+    UA_TcpMessageHeader header;
+    UA_StatusCode res =
+        UA_decodeBinaryInternal(buffer, &offset, &header,
+                                &UA_TRANSPORT[UA_TRANSPORT_TCPMESSAGEHEADER], NULL);
+    if(res != UA_STATUSCODE_GOOD)
+        return;
+
+    UA_MessageType messageType =
+        (UA_MessageType)(header.messageTypeAndChunkType & 0x00ffffff);
+    dump_filename->messageType = UA_debug_dumpGetMessageTypePrefix(messageType);
+
+    /* Only MSG chunks carry a service request. Skip the symmetric security and
+     * sequence headers to get to the request body. */
+    if(messageType != UA_MESSAGETYPE_MSG ||
+       buffer->length <= UA_SECURECHANNEL_SYMMETRIC_HEADER_TOTALLENGTH)
+        return;
+
+    UA_ByteString body;
+    body.data = buffer->data + UA_SECURECHANNEL_SYMMETRIC_HEADER_TOTALLENGTH;
+    body.length = buffer->length - UA_SECURECHANNEL_SYMMETRIC_HEADER_TOTALLENGTH;
+    UA_debug_dumpSetServiceName(&body, dump_filename->serviceName);
 }
 
 /**
- * Called in processCompleteChunk for every complete chunk which is received by the server.
+ * Called for every buffer which is received by the server.
  *
- * It will first try to decode the message to get the name of the called service.
- * When we have a name the message is dumped as binary to that file.
- * If the file already exists a new file will be created with a counter at the end.
+ * The name of the file is derived from the first chunk in the buffer. The
+ * buffer is then dumped verbatim, as that is what the server consumes and
+ * therefore what the fuzzer has to replay. If the file already exists a new
+ * file will be created with a counter at the end.
  */
 void
-UA_debug_dumpCompleteChunk(UA_Server *const server, UA_Connection *const connection,
-                           UA_ByteString *messageBuffer) {
+UA_debug_dumpCompleteChunk(UA_Server *const server, UA_ByteString *messageBuffer) {
+    /* The first callback of a connection carries no data yet */
+    if(messageBuffer->length == 0)
+        return;
+
     struct UA_dump_filename dump_filename;
     dump_filename.messageType = NULL;
     dump_filename.serviceName[0] = 0;
-
-    UA_Connection c = createDummyConnection(RECEIVE_BUFFER_SIZE, NULL);
-    UA_SecureChannel dummy;
-    UA_SecureChannel_init(&dummy, &connection->channel->config);
-    dummy.securityPolicy = connection->channel->securityPolicy;
-    dummy.state = connection->channel->state;
-    dummy.securityMode = connection->channel->securityMode;
-    dummy.connection = &c;
-    UA_ChannelSecurityToken_copy(&connection->channel->securityToken,
-                                 &dummy.securityToken);
-    UA_ChannelSecurityToken_copy(&connection->channel->altSecurityToken,
-                                 &dummy.altSecurityToken);
-
-    UA_ByteString messageBufferCopy;
-    UA_ByteString_copy(messageBuffer, &messageBufferCopy);
-    UA_SecureChannel_processBuffer(&dummy, &dump_filename, UA_debug_dump_setName, &messageBufferCopy);
-    UA_ByteString_clear(&messageBufferCopy);
-
-    dummy.securityPolicy = NULL;
-    UA_SecureChannel_deleteBuffered(&dummy);
-    c.close(&c);
+    UA_debug_dumpSetNames(messageBuffer, &dump_filename);
 
     char fileName[250];
     snprintf(fileName, sizeof(fileName), "%s/%05u_%s%s", UA_CORPUS_OUTPUT_DIR, ++UA_dump_chunkCount,

--- a/tools/ci/linux/ci.sh
+++ b/tools/ci/linux/ci.sh
@@ -827,3 +827,69 @@ UAFX-Data\;UAFX-AC\;UAFX-CM\;Robotics \
           ..
     make ${MAKEOPTS}
 }
+
+#########################
+# Build option coverage #
+#########################
+
+# Compile the library once per build option that no other job configures:
+# options that are off by default, and default-on features in their off state.
+# Only the library is built, so a configuration costs about a minute.
+#
+# Failures are collected instead of aborting, so one run reports every broken
+# configuration. "set -e" does not apply here: the CI step runs
+# "source ci.sh && <action>", and errexit is suspended inside an && list.
+
+function build_option_coverage {
+    local failed=()
+
+    # Usage: build_option_cfg <name> <cmake options...>
+    build_option_cfg() {
+        local name=$1; shift
+        echo "::group::${name}"
+        rm -rf build; mkdir -p build; cd build
+        if cmake -DCMAKE_BUILD_TYPE=Debug \
+                 -DUA_BUILD_EXAMPLES=OFF \
+                 -DUA_FORCE_WERROR=ON \
+                 "$@" \
+                 .. && make ${MAKEOPTS}; then
+            echo "::endgroup::"
+        else
+            echo "::endgroup::"
+            echo "::error::build_option_coverage: ${name} failed"
+            failed+=("${name}")
+        fi
+        cd ..
+    }
+
+    # Debug instrumentation
+    build_option_cfg "UA_DEBUG"                -DUA_DEBUG=ON -DUA_DEBUG_FILE_LINE_INFO=ON
+    build_option_cfg "UA_DEBUG_DUMP_PKGS"      -DUA_DEBUG_DUMP_PKGS=ON
+    # Defines UA_DEBUG_DUMP_PKGS_FILE and builds the corpus generator
+    build_option_cfg "UA_BUILD_FUZZING_CORPUS"  -DUA_BUILD_FUZZING_CORPUS=ON
+
+    # Off by default
+    build_option_cfg "UA_ENABLE_QUERY"             -DUA_ENABLE_QUERY=ON
+    build_option_cfg "UA_ENABLE_DETERMINISTIC_RNG" -DUA_ENABLE_DETERMINISTIC_RNG=ON
+    build_option_cfg "UA_ENABLE_RBAC"              -DUA_ENABLE_RBAC=ON -DUA_NAMESPACE_ZERO=FULL
+
+    # On by default, so only ever compiled in the enabled state
+    # The PubSub information model twin exposes methods, so it has to go as well
+    build_option_cfg "no UA_ENABLE_METHODCALLS"    -DUA_ENABLE_METHODCALLS=OFF \
+                     -DUA_ENABLE_PUBSUB_INFORMATIONMODEL=OFF
+    build_option_cfg "no UA_ENABLE_NODEMANAGEMENT" -DUA_ENABLE_NODEMANAGEMENT=OFF
+    build_option_cfg "no UA_ENABLE_AUDITING"       -DUA_ENABLE_AUDITING=OFF
+    build_option_cfg "no UA_ENABLE_STATUSCODE_DESCRIPTIONS" -DUA_ENABLE_STATUSCODE_DESCRIPTIONS=OFF
+    build_option_cfg "no UA_ENABLE_NODESET_COMPILER_DESCRIPTIONS" -DUA_ENABLE_NODESET_COMPILER_DESCRIPTIONS=OFF
+    # Type descriptions are required by the diagnostics, the JSON encoding and
+    # the event filter parser
+    build_option_cfg "no UA_ENABLE_TYPEDESCRIPTION" -DUA_ENABLE_TYPEDESCRIPTION=OFF \
+                     -DUA_ENABLE_DIAGNOSTICS=OFF -DUA_ENABLE_JSON_ENCODING=OFF \
+                     -DUA_ENABLE_XML_ENCODING=OFF -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=OFF
+
+    if [ ${#failed[@]} -ne 0 ]; then
+        echo "Failed configurations: ${failed[*]}"
+        return 1
+    fi
+    echo "All build option configurations compiled"
+}


### PR DESCRIPTION
The EventLoop/ConnectionManager refactor left the two package dump options
behind, and nothing noticed because no CI job ever compiles them.

`UA_DEBUG_DUMP_PKGS` referenced `message->data`, but the message is now passed
by value as `msg`. The plugin also included `ua_util_internal.h`, which it
cannot reach from `plugins/`; it only needs `UA_Byte` and `memset`.

`UA_DEBUG_DUMP_PKGS_FILE` was in worse shape: the dump hook built a dummy
`UA_Connection` and drove it through `UA_SecureChannel_processBuffer`, none of
which exists any more. The dummy channel only served to recover the message
type and service name for the file name, and the corpus is generated over an
unencrypted channel, so both can be read straight from the chunk header. The
hook now takes neither a channel nor a connection. The corpus generator itself
called two client internals that were renamed and now require the client lock,
and its CMake target linked the wrong test helper. Verified by generating a
corpus: hel, opn, clo and msg_<ServiceName> entries all come out named
correctly.

Two more options silently required another one to be enabled: RBAC needs the
TrustedApplication role, which only exists in the ua-nodeset schema used for
`UA_NAMESPACE_ZERO=FULL`, and the diagnostics need `UA_ENABLE_TYPEDESCRIPTION`
for `UA_DataType_getStructMember`. Both are now reported at configure time.

To keep this from happening again, a `build_option_coverage` job compiles the
library once per option that no other job configures - options that are off by
default, and default-on features in their off state. Only the library is built,
so a configuration costs about a minute, and failures are collected so one run
lists every broken configuration.

Supersedes #7401.