### PR TITLE
fix(core): fix JSON decoding of null QualifiedName values

### DIFF
--- a/src/ua_types_encoding_json.c
+++ b/src/ua_types_encoding_json.c
@@ -1423,6 +1423,7 @@ DECODE_JSON(LocalizedText) {
 
 DECODE_JSON(QualifiedName) {
     UA_QualifiedName *dst = (UA_QualifiedName*)p;
+    CHECK_NULL_SKIP;
     UA_String str;
     UA_String_init(&str);
     status res = String_decodeJson(ctx, &str, NULL);

--- a/tests/check_types_json_decode.c
+++ b/tests/check_types_json_decode.c
@@ -951,6 +951,22 @@ START_TEST(json_decode_statuscode) {
     }
 } END_TEST
 
+/* QualifiedName null */
+START_TEST(json_decode_qualifiedname_null) {
+    UA_QualifiedName val;
+    UA_QualifiedName_init(&val);
+
+    UA_ByteString encode;
+    UA_ByteString_init(&encode);
+    UA_encodeJson(&val, &UA_TYPES[UA_TYPES_QUALIFIEDNAME], &encode, NULL);
+
+    UA_QualifiedName decoded;
+    UA_QualifiedName_init(&decoded);
+    UA_StatusCode res = UA_decodeJson(&encode, &decoded, &UA_TYPES[UA_TYPES_QUALIFIEDNAME], NULL);
+
+    ck_assert_uint_eq(UA_STATUSCODE_GOOD, res);
+} END_TEST
+
 /* ============================================================
  * Suite setup
  * ============================================================ */
@@ -1059,6 +1075,7 @@ int main(void) {
     tcase_add_test(tc_extra, json_decode_diagnosticinfo);
     tcase_add_test(tc_extra, json_decode_diagnosticinfo_null);
     tcase_add_test(tc_extra, json_decode_statuscode);
+    tcase_add_test(tc_extra, json_decode_qualifiedname_null);
     suite_add_tcase(s, tc_extra);
 
     SRunner *sr = srunner_create(s);

--- a/tests/check_types_json_decode.c
+++ b/tests/check_types_json_decode.c
@@ -965,6 +965,7 @@ START_TEST(json_decode_qualifiedname_null) {
     UA_StatusCode res = UA_decodeJson(&encode, &decoded, &UA_TYPES[UA_TYPES_QUALIFIEDNAME], NULL);
 
     ck_assert_uint_eq(UA_STATUSCODE_GOOD, res);
+    UA_ByteString_clear(&encode);
 } END_TEST
 
 /* ============================================================


### PR DESCRIPTION
Related to #7796

UA_encodeJson() already serializes a null UA_QualifiedName as JSON null, but
UA_decodeJson() failed because QualifiedName decoding forwarded the null token
to String_decodeJson().

Handle JSON null values in DECODE_JSON(QualifiedName) and preserve the existing
null state behavior. Add a regression test for the JSON encode/decode
round-trip.