### PR TITLE
fix(posix): remove non-portable stdio_lim include from 1.5

### DIFF
--- a/arch/posix/eventloop_posix.h
+++ b/arch/posix/eventloop_posix.h
@@ -275,10 +275,6 @@ typedef int SOCKET;
 #endif /* __linux__ */
 #include <sys/stat.h>
 
-#if !defined(__ANDROID__) && !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__OHOS__)
-#include <bits/stdio_lim.h>
-#endif
-
 #define UA_STAT stat
 #define UA_DIR DIR
 #define UA_DIRENT dirent


### PR DESCRIPTION
## What changed

- remove the non-standard `<bits/stdio_lim.h>` include from the POSIX event-loop header
- keep the portable standard headers that already provide the file/path limits used by this header

## Why

`bits/stdio_lim.h` is a glibc implementation detail and is unavailable on FreeBSD. The include is unused and prevents the 1.5 branch from compiling there. This backports the relevant part of #7937 to the 1.5 branch.

Fixes #8197.

## Validation

- `git diff --check`
- `cmake -S . -B build -DUA_BUILD_EXAMPLES=OFF -DUA_BUILD_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j4`