### PR TITLE
fix: eliminate uninitialized-variable and potential overflow warnings under GCC LTO

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -2218,7 +2218,7 @@ __Client_networkCallback(UA_ConnectionManager *cm, uintptr_t connectionId,
     /* Received a message. Process the message with the SecureChannel. */
     UA_StatusCode res = UA_SecureChannel_loadBuffer(&client->channel, msg);
     while(UA_LIKELY(res == UA_STATUSCODE_GOOD)) {
-        UA_MessageType messageType;
+        UA_MessageType messageType = UA_MESSAGETYPE_INVALID;
         UA_UInt32 requestId = 0;
         UA_ByteString payload = UA_BYTESTRING_NULL;
         UA_Boolean copied = false;

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -2137,6 +2137,17 @@ removeDataSetWriterAction(UA_Server *server,
 /**********************************************/
 
 static void
+freeNodeContext(UA_Server *server, const UA_NodeId *nodeId) {
+    if(UA_NodeId_isNull(nodeId))
+        return;
+
+    void *context = NULL;
+    UA_StatusCode res = getNodeContext(server, *nodeId, &context);
+    if(res == UA_STATUSCODE_GOOD)
+        UA_free(context);
+}
+
+static void
 connectionTypeDestructor(UA_Server *server,
                          const UA_NodeId *sessionId, void *sessionContext,
                          const UA_NodeId *typeId, void *typeContext,
@@ -2147,10 +2158,7 @@ connectionTypeDestructor(UA_Server *server,
     UA_NodeId publisherIdNode =
         findSingleChildNode(server, UA_QUALIFIEDNAME(0, "PublisherId"),
                             UA_NS0ID(HASPROPERTY), *nodeId);
-    UA_NodePropertyContext *ctx;
-    getNodeContext(server, publisherIdNode, (void **)&ctx);
-    if(!UA_NodeId_isNull(&publisherIdNode))
-        UA_free(ctx);
+    freeNodeContext(server, &publisherIdNode);
 }
 
 static void
@@ -2165,10 +2173,7 @@ writerGroupTypeDestructor(UA_Server *server,
         findSingleChildNode(server, UA_QUALIFIEDNAME(0, "PublishingInterval"),
                             UA_NS0ID(HASPROPERTY), *nodeId);
 
-    UA_NodePropertyContext *ctx;
-    getNodeContext(server, intervalNode, (void **)&ctx);
-    if(!UA_NodeId_isNull(&intervalNode))
-        UA_free(ctx);
+    freeNodeContext(server, &intervalNode);
 }
 
 static void
@@ -2192,10 +2197,7 @@ dataSetWriterTypeDestructor(UA_Server *server,
         findSingleChildNode(server, UA_QUALIFIEDNAME(0, "DataSetWriterId"),
                             UA_NS0ID(HASPROPERTY), *nodeId);
 
-    UA_NodePropertyContext *ctx;
-    getNodeContext(server, dataSetWriterIdNode, (void **)&ctx);
-    if(!UA_NodeId_isNull(&dataSetWriterIdNode))
-        UA_free(ctx);
+    freeNodeContext(server, &dataSetWriterIdNode);
 }
 
 static void
@@ -2210,10 +2212,7 @@ dataSetReaderTypeDestructor(UA_Server *server,
         findSingleChildNode(server, UA_QUALIFIEDNAME(0, "PublisherId"),
                             UA_NS0ID(HASPROPERTY), *nodeId);
 
-    UA_NodePropertyContext *ctx;
-    getNodeContext(server, publisherIdNode, (void **)&ctx);
-    if(!UA_NodeId_isNull(&publisherIdNode))
-        UA_free(ctx);
+    freeNodeContext(server, &publisherIdNode);
 }
 
 static void
@@ -2224,27 +2223,17 @@ publishedDataItemsTypeDestructor(UA_Server *server,
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_LOG_INFO(server->config.logging, UA_LOGCATEGORY_PUBSUB,
                 "PublishedDataItems destructor called!");
-    void *childContext;
     UA_NodeId node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "PublishedData"),
                                          UA_NS0ID(HASPROPERTY), *nodeId);
-    if(!UA_NodeId_isNull(&node)) {
-        getNodeContext(server, node, (void**)&childContext);
-        UA_free(childContext);
-    }
+    freeNodeContext(server, &node);
 
     node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "ConfigurationVersion"),
                                UA_NS0ID(HASPROPERTY), *nodeId);
-    if(!UA_NodeId_isNull(&node)) {
-        getNodeContext(server, node, (void**)&childContext);
-        UA_free(childContext);
-    }
+    freeNodeContext(server, &node);
 
     node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "DataSetMetaData"),
                                UA_NS0ID(HASPROPERTY), *nodeId);
-    if(!UA_NodeId_isNull(&node)) {
-        getNodeContext(server, node, (void**)&childContext);
-        UA_free(childContext);
-    }
+    freeNodeContext(server, &node);
 }
 
 static void
@@ -2255,20 +2244,13 @@ subscribedDataSetTypeDestructor(UA_Server *server,
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_LOG_INFO(server->config.logging, UA_LOGCATEGORY_PUBSUB,
                 "Standalone SubscribedDataSet destructor called!");
-    void *childContext;
     UA_NodeId node =
         findSingleChildNode(server, UA_QUALIFIEDNAME(0, "DataSetMetaData"),
                             UA_NS0ID(HASPROPERTY), *nodeId);
-    if(!UA_NodeId_isNull(&node)) {
-        getNodeContext(server, node, (void**)&childContext);
-        UA_free(childContext);
-    }
+    freeNodeContext(server, &node);
     node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "IsConnected"),
                                UA_NS0ID(HASPROPERTY), *nodeId);
-    if(!UA_NodeId_isNull(&node)) {
-        getNodeContext(server, node, (void**)&childContext);
-        UA_free(childContext);
-    }
+    freeNodeContext(server, &node);
 }
 
 /*************************************/

--- a/src/server/ua_server_ws.c
+++ b/src/server/ua_server_ws.c
@@ -104,6 +104,8 @@ createWebSocketServerConnection(UA_BinaryProtocolManager *bpm,
     if(res != UA_STATUSCODE_GOOD)
         return res;
 
+    if(path.length == SIZE_MAX)
+        return UA_STATUSCODE_BADOUTOFMEMORY;
     UA_String websocketPath = UA_STRING_NULL;
     res = UA_ByteString_allocBuffer((UA_ByteString*)&websocketPath,
                                     path.length + 1);


### PR DESCRIPTION
#### Background

When open62541 is built with GCC optimization and link-time optimization (LTO), the compiler reports several warnings in the Client, WebSocket Server, and PubSub NS0 code paths:

- `-Wmaybe-uninitialized`
- `-Wstringop-overflow`

The affected code includes a potentially uninitialized `UA_MessageType`, PubSub node-context pointers, and a theoretical integer wraparound in `path.length + 1` when allocating the WebSocket path buffer.

These warnings create noise for downstream projects using strict compiler-warning settings and may hide unrelated issues in the same build log.

#### Changes

- Explicitly initialize the message type with `UA_MESSAGETYPE_INVALID` in the Client network callback so that the value passed to `processServiceResponse` always has a defined state.
- Check for `SIZE_MAX` before incrementing the WebSocket path length, preventing the allocation size from wrapping to zero. Continue to use `UA_ByteString_allocBuffer` and preserve the existing out-of-memory status code.
- Add a shared node-context cleanup helper for the PubSub NS0 destructors. A context is released only when the NodeId is valid and `getNodeContext` succeeds.
- Preserve the behavior of successful execution paths while making state and resource ownership explicit on error paths.

#### Impact

- No public API or ABI changes.
- No intended behavioral changes on successful code paths.
- More robust handling of error paths.
- Removes the corresponding GCC optimization/LTO warnings.

#### Verification

- Completed a Release + LTO build with GCC 15.2.0.
- Built with the Client, PubSub, and PubSub Information Model enabled, including compilation of the WebSocket Server source.
- Completed the final LTO link of `tutorial_client_firststeps` and `tutorial_server_firststeps`.
- Confirmed that the reported `-Wmaybe-uninitialized` and `-Wstringop-overflow` warnings no longer occur.