### PR TITLE
fix(util): Avoid a dangling pointer.

### DIFF
--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -550,7 +550,7 @@ UA_KeyValueMap_clear(UA_KeyValueMap *map) {
         UA_Array_delete(map->map, map->mapSize, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
     }
     map->map = NULL;
-    map->mapSize = 0
+    map->mapSize = 0;
 }
 
 void

--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -548,8 +548,9 @@ UA_KeyValueMap_clear(UA_KeyValueMap *map) {
         return;
     if(map->mapSize > 0) {
         UA_Array_delete(map->map, map->mapSize, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-        map->mapSize = 0;
     }
+    map->map = NULL;
+    map->mapSize = 0
 }
 
 void


### PR DESCRIPTION
Calling UA_KeyValueMap_clear directly leaves a dangling pointer. Reusing the map via UA_KeyValueMap_set passes a stale non-NULL pointer to UA_Array_appendCopy.