### PR TITLE
fix(server): A&C - do not return BadInternalError when clients call ConditionRefresh.

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -1260,6 +1260,14 @@ UA_Server_run_startup(UA_Server *server) {
     /* Take the server lock */
     lockServer(server);
 
+#ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
+    /* Set callbacks for condition method fields (needs to be set only once!). */
+    retVal = UA_setConditionMethodCallbacks(server);
+    UA_CHECK_STATUS_ERROR(retVal, unlockServer(server); return retVal,
+                          config->logging, UA_LOGCATEGORY_SERVER,
+                          "Could not set method callbacks for conditions");
+#endif
+
     /* Does the ApplicationUri match the local certificates? */
     verifyServerApplicationUri(server);
 

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -460,6 +460,9 @@ isConditionOrBranch(UA_Server *server,
                     const UA_NodeId *conditionSource,
                     UA_Boolean *isCallerAC);
 
+UA_StatusCode
+UA_setConditionMethodCallbacks(UA_Server *server);
+
 #endif /* UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS */
 
 /* Returns the first "HasTypeDefinition" or "HasSubtype" reference to the

--- a/src/server/ua_subscription_alarms_conditions.c
+++ b/src/server/ua_subscription_alarms_conditions.c
@@ -2298,9 +2298,8 @@ setConditionVariableCallbacks(UA_Server *server, const UA_NodeId *condition,
 /* Set callbacks for Method Fields of a condition. The current implementation
  * references methods without copying them when creating objects. So the
  * callbacks will be attached to the methods of the conditionType. */
-static UA_StatusCode
-setConditionMethodCallbacks(UA_Server *server, const UA_NodeId* condition,
-                            const UA_NodeId* conditionType) {
+UA_StatusCode
+UA_setConditionMethodCallbacks(UA_Server *server) {
     UA_LOCK_ASSERT(&server->serviceMutex);
 
     UA_NodeId methodId[7] = {
@@ -2339,12 +2338,6 @@ setStandardConditionCallbacks(UA_Server *server, const UA_NodeId* condition,
 
     retval = setConditionVariableCallbacks(server, condition, conditionType);
     CONDITION_ASSERT_RETURN_RETVAL(retval, "Set ConditionVariable Callback failed",);
-
-    /* Set callbacks for Method Components (needs to be set only once!) */
-    if(LIST_EMPTY(&server->conditionSources)) {
-        retval = setConditionMethodCallbacks(server, condition, conditionType);
-        CONDITION_ASSERT_RETURN_RETVAL(retval, "Set Method Callback failed",);
-    }
 
     return retval;
 }


### PR DESCRIPTION
When a client calls ConditionRefresh before the condition has been initialized, the server currently responds with BadInternalError.
Since this situation does not represent an actual internal server failure, the returned status code is misleading.
Either a more specific error code should be used, or the error scenario should be avoided altogether.
In general, BadInternalError should be avoided for client-facing situations whenever a more appropriate status code is available.

This change addresses the issue by moving the initialization of the method callbacks to an earlier stage, ensuring that the generic callbacks are already available when ConditionRefresh is invoked.
As a result, the erroneous BadInternalError response is avoided.