### PR TITLE
feat(ci): Split the Valgrind unit tests across parallel jobs

### DIFF
--- a/.github/actions/linux-ci-setup/action.yml
+++ b/.github/actions/linux-ci-setup/action.yml
@@ -1,0 +1,37 @@
+name: "Linux CI setup"
+description: >
+  Enable IPv6 on the container network and install the build dependencies
+  shared by all Linux CI jobs. Requires the repository to be checked out
+  already, because this is a local action.
+
+inputs:
+  extra-deps:
+    description: >
+      Shell snippet installing the additional packages a specific job needs.
+      Passed through verbatim, so it may span multiple lines.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Work around disabled ipv6 on actions container networks
+      shell: bash
+      run: |
+        IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+        echo "Current IPv6 status on eth0: $IPV6"
+        # Nothing to do if IPv6 is already enabled. Plain "exit" would
+        # propagate the failed test as exit status 1 and fail the step.
+        [ "$IPV6" = "1" ] || exit 0
+
+        echo 0 | sudo tee /proc/sys/net/ipv6/conf/eth0/disable_ipv6 > /dev/null
+        IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
+        echo "New IPv6 status on eth0: $IPV6"
+        [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential cmake curl libcap2-bin pkg-config libssl-dev python3-sphinx check libxml2-dev libpcap-dev libreadline-dev
+        ${{ inputs.extra-deps }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,6 +1,16 @@
 name: Linux Build & Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Only supersede runs of the same pull request, never pushes to master/1.x.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -29,10 +39,6 @@ jobs:
 
           - name: "Debug Build & Unit Tests with Alarms&Conditions (gcc)"
             cmd_action: unit_tests_alarms
-
-          - name: "Valgrind Build & Unit Tests with Alarms&Conditions (gcc)"
-            cmd_deps: sudo apt-get install -y -qq valgrind
-            cmd_action: unit_tests_alarms_memcheck
 
           - name: "Debug Build & Unit Tests (tcc)"
             cmd_deps: sudo apt-get install -y -qq tcc
@@ -242,31 +248,6 @@ jobs:
               cmd_deps: sudo apt-get install -y -qq libmbedtls-dev python3-netifaces
               cmd_action: run_examples MBEDTLS MDNSD
 
-          # Valgrind tests for specific Ubuntu versions
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Build & Unit Tests with MbedTLS (gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev
-              cmd_action: unit_tests_valgrind MBEDTLS          
-
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Build & Unit Tests with OpenSSL (gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind openssl
-              cmd_action: unit_tests_valgrind OPENSSL          
-
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Examples with MbedTLS and mDNSD (gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev python3-netifaces
-              cmd_action: examples_valgrind MBEDTLS MDNSD          
-
-          - os: ubuntu-24.04
-            build:
-              name: "Valgrind Examples with OpenSSL and avahi-mdns(gcc)"
-              cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev python3-netifaces libavahi-client-dev libavahi-common-dev
-              cmd_action: examples_valgrind OPENSSL AVAHI          
-
           # Clang Static Analyzer Builds
           - os: ubuntu-20.04
             build:
@@ -291,24 +272,12 @@ jobs:
       image: ghcr.io/marwinglaser/ci:${{ matrix.os }}
       options: --privileged
     steps:
-      - name: Work around disabled ipv6 on actions container networks
-        run: |
-          IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
-          echo "Current IPv6 status on eth0: $IPV6"
-          [ "$IPV6" = "1" ] || exit
-
-          echo 0 | sudo tee /proc/sys/net/ipv6/conf/eth0/disable_ipv6 > /dev/null
-          IPV6="$(cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6)"
-          echo "New IPv6 status on eth0: $IPV6"
-          [ "$IPV6" = "0" ] || { echo "Failed to enable IPv6 on eth0"; exit 1; }      
       - uses: actions/checkout@v5
         with:
           submodules: true
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential cmake curl libcap2-bin pkg-config libssl-dev python3-sphinx check libxml2-dev libpcap-dev libreadline-dev
-          ${{ matrix.build.cmd_deps }}
+      - uses: ./.github/actions/linux-ci-setup
+        with:
+          extra-deps: ${{ matrix.build.cmd_deps }}
       - name: ${{ matrix.build.name }}
         shell: bash
         run: source tools/ci/linux/ci.sh && ${{ matrix.build.cmd_action }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,111 @@
+name: Valgrind
+
+# Running the unit tests under Valgrind takes hours. The suite is therefore
+# split round-robin over several runners via CTEST_SHARDS/CTEST_SHARD, which
+# tools/ci/linux/ci.sh turns into "ctest -I <shard>,,<shards>". Every test is
+# still executed, just spread over parallel jobs.
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Only supersede runs of the same pull request. Pushes to master/1.x must not
+  # cancel each other, otherwise a quick series of merges leaves release
+  # branches without a completed Valgrind run.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  unit-tests:
+    name: "Valgrind ${{ matrix.config.os }}-${{ matrix.config.name }} (shard ${{ matrix.shard }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: ghcr.io/open62541/open62541-ci:${{ matrix.config.os }}
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep this list in sync with CTEST_SHARDS below: it has to contain
+        # exactly the values 1..CTEST_SHARDS, otherwise tests are skipped.
+        shard: [1, 2, 3, 4, 5, 6]
+        # The Ubuntu version is part of the config instead of a separate matrix
+        # dimension, so that the coverage matches what build_linux.yml ran
+        # before: MbedTLS and OpenSSL on ubuntu-24.04 only, Alarms&Conditions
+        # on every supported version. GitHub Actions has no YAML anchors, so
+        # the repeated entry has to be spelled out.
+        config:
+          - os: ubuntu-24.04
+            name: "Unit Tests with MbedTLS (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev
+            cmd_action: unit_tests_valgrind MBEDTLS
+
+          - os: ubuntu-24.04
+            name: "Unit Tests with OpenSSL (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind openssl
+            cmd_action: unit_tests_valgrind OPENSSL
+
+          - os: ubuntu-20.04
+            name: "Unit Tests with Alarms&Conditions (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind
+            cmd_action: unit_tests_alarms_memcheck
+
+          - os: ubuntu-22.04
+            name: "Unit Tests with Alarms&Conditions (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind
+            cmd_action: unit_tests_alarms_memcheck
+
+          - os: ubuntu-24.04
+            name: "Unit Tests with Alarms&Conditions (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind
+            cmd_action: unit_tests_alarms_memcheck
+    env:
+      CTEST_SHARDS: 6
+      CTEST_SHARD: ${{ matrix.shard }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+      - uses: ./.github/actions/linux-ci-setup
+        with:
+          extra-deps: ${{ matrix.config.cmd_deps }}
+      - name: ${{ matrix.config.name }}
+        shell: bash
+        run: source tools/ci/linux/ci.sh && ${{ matrix.config.cmd_action }}
+        env:
+          ETHERNET_INTERFACE: eth0
+
+  examples:
+    name: "Valgrind ${{ matrix.config.name }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/open62541/open62541-ci:ubuntu-24.04
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Examples with MbedTLS and mDNSD (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind libmbedtls-dev python3-netifaces
+            cmd_action: examples_valgrind MBEDTLS MDNSD
+
+          - name: "Examples with OpenSSL and avahi-mdns (gcc)"
+            cmd_deps: sudo apt-get install -y -qq valgrind openssl libmbedtls-dev python3-netifaces libavahi-client-dev libavahi-common-dev
+            cmd_action: examples_valgrind OPENSSL AVAHI
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+      - uses: ./.github/actions/linux-ci-setup
+        with:
+          extra-deps: ${{ matrix.config.cmd_deps }}
+      - name: ${{ matrix.config.name }}
+        shell: bash
+        run: source tools/ci/linux/ci.sh && ${{ matrix.config.cmd_action }}
+        env:
+          ETHERNET_INTERFACE: eth0

--- a/tools/ci/linux/ci.sh
+++ b/tools/ci/linux/ci.sh
@@ -19,6 +19,47 @@ fi
 # Allow to reuse TIME-WAIT sockets for new connections
 sudo sysctl -w net.ipv4.tcp_tw_reuse=1
 
+# CTest arguments for the memcheck jobs. Running the full unit test suite under
+# Valgrind takes hours, so the CI splits it round-robin over several runners
+# (ctest -I <start>,,<stride>). CTEST_SHARDS is the number of runners and
+# CTEST_SHARD the 1-based index of this one. Both default to running the
+# complete suite, so a local "source ci.sh && unit_tests_valgrind MBEDTLS"
+# behaves as before.
+#
+# Two things to keep in mind when reusing this helper:
+#
+#  - "-I" selects tests by their index in the *unfiltered* list. Sharding must
+#    therefore not be combined with a "-R" name filter, or the shards silently
+#    end up covering only part of the filtered set.
+#  - "--no-tests=error" catches a shard that ends up selecting no test at all.
+#    It requires CMake >= 3.18 and is therefore only passed when the installed
+#    ctest advertises it; ubuntu-20.04 still ships CMake 3.16.
+function ctest_args {
+    local args="--output-on-failure"
+    local shards="${CTEST_SHARDS:-1}"
+    local shard="${CTEST_SHARD:-1}"
+    if [ "${shards}" != "1" ]; then
+        # Fail loudly on a misconfigured matrix. Falling back to the full suite
+        # would run the complete multi-hour testsuite in every single shard.
+        case "${shards}:${shard}" in
+            *[!0-9:]*|:*|*:)
+                echo "ci.sh: CTEST_SHARDS/CTEST_SHARD must be positive integers," \
+                     "got '${shards}'/'${shard}'" >&2
+                return 1
+                ;;
+        esac
+        # Probed instead of piped into grep, so that neither "set -o pipefail"
+        # nor a SIGPIPE from an early-exiting reader can flip the result.
+        local help_output
+        help_output="$(ctest --help 2>/dev/null || true)"
+        case "${help_output}" in
+            *--no-tests=*) args="${args} --no-tests=error" ;;
+        esac
+        args="${args} -I ${shard},,${shards}"
+    fi
+    printf '%s' "${args}"
+}
+
 #####################################
 # Build Documentation including PDF #
 #####################################
@@ -360,7 +401,8 @@ function unit_tests_alarms_memcheck {
 
     make ${MAKEOPTS}
     # set_capabilities not possible with valgrind
-    sudo -E bash -c "make test ARGS=\"-V\""
+    local args; args="$(ctest_args)"
+    sudo -E bash -c "make test ARGS=\"${args}\""
 }
 
 function unit_tests_encryption {
@@ -412,7 +454,9 @@ function unit_tests_pubsub_sks {
           -DUA_FORCE_WERROR=ON \
           ..
     make ${MAKEOPTS}
-    sudo -E bash -c "make test ARGS=\"-V -R sks\""
+    # Never sharded: "-I" would index into the unfiltered list, not into "-R sks"
+    local args; args="$(CTEST_SHARDS=1 ctest_args)"
+    sudo -E bash -c "make test ARGS=\"${args} -R sks\""
     make gcov
 }
 
@@ -437,7 +481,8 @@ function unit_tests_valgrind {
           ..
     make ${MAKEOPTS}
     # set_capabilities not possible with valgrind
-    sudo -E bash -c "make test ARGS=\"-V\""
+    local args; args="$(ctest_args)"
+    sudo -E bash -c "make test ARGS=\"${args}\""
 }
 
 ##########################


### PR DESCRIPTION
The Valgrind jobs take close to three hours, and they're the usual reason a PR sits un-green long after everything else has finished. The work is serial by construction: every one of the ~180 registered tests gets wrapped individually in valgrind, and then `make test` runs them one after another on a single runner. Meanwhile there are free runners sitting idle.

This splits the suite across several jobs. Every test still runs — just not all on the same machine.
