### PR TITLE
feat(nc): add --export-macro option to generate_datatypes.py

### DIFF
--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -164,7 +164,7 @@ endfunction()
 function(ua_generate_datatypes)
     find_package(Python3 REQUIRED)
     set(options BUILTIN INTERNAL AUTOLOAD GEN_DOC)
-    set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_XML FILE_CSV)
+    set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_XML FILE_CSV EXPORT_MACRO)
     set(multiValueArgs FILES_BSD IMPORT_BSD FILES_SELECTED)
     cmake_parse_arguments(UA_GEN_DT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -235,6 +235,11 @@ function(ua_generate_datatypes)
         set(FILE_XML "--xml=${UA_GEN_DT_FILE_XML}")
     endif()
 
+    set(EXPORT_MACRO_ARG "")
+    if(UA_GEN_DT_EXPORT_MACRO)
+        set(EXPORT_MACRO_ARG "--export-macro=${UA_GEN_DT_EXPORT_MACRO}")
+    endif()
+
     # Command generating the DataType code files
     add_custom_command(COMMAND ${ARG_CONV_EXCL_ENV} ${Python3_EXECUTABLE}
                                ${open62541_TOOLS_DIR}/generate_datatypes.py
@@ -245,6 +250,7 @@ function(ua_generate_datatypes)
                                --type-csv=${UA_GEN_DT_FILE_CSV}
                                ${UA_GEN_DT_NO_BUILTIN}
                                ${UA_GEN_DT_INTERNAL_ARG}
+                               ${EXPORT_MACRO_ARG}
                                ${UA_GEN_DT_OUTPUT_DIR}/${UA_GEN_DT_NAME}
                                ${UA_GEN_DOC_ARG}
                        OUTPUT  ${UA_GEN_DT_OUTPUT_DIR}/${UA_GEN_DT_NAME}_generated.c

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -89,6 +89,13 @@ parser.add_argument('-i', '--import',
                     default=[],
                     help='combination of TYPE_ARRAY#filepath.bsd with type definitions which should be loaded but not exported/generated')
 
+parser.add_argument('--export-macro',
+                    metavar="<exportMacro>",
+                    type=str,
+                    dest="export_macro",
+                    default="",
+                    help='macro to use in front of extern declarations (default: UA_EXPORT)')
+
 parser.add_argument('outfile',
                     metavar='<outputFile>',
                     help='output file w/o extension')
@@ -181,7 +188,7 @@ def _types_definition_equal(t1, t2):
     return False
 
 class CGenerator:
-    def __init__(self, parser, inname, outfile, is_internal_types, gen_doc, namespaceMap):
+    def __init__(self, parser, inname, outfile, is_internal_types, gen_doc, namespaceMap, export_macro=""):
         self.parser = parser
         self.inname = inname
         self.outfile = outfile
@@ -189,6 +196,7 @@ class CGenerator:
         self.gen_doc = gen_doc
         self.filtered_types = None
         self.namespaceMap = namespaceMap
+        self.export_macro = export_macro if export_macro else "UA_EXPORT"
         self.fh = None
         self.fc = None
         self.fd = None
@@ -589,7 +597,7 @@ _UA_BEGIN_DECLS
         if totalCount > 0:
 
             self.printh(
-                "extern UA_EXPORT UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
+                "extern " + self.export_macro + " UA_DataType UA_" + self.parser.outname.upper() + "[UA_" + self.parser.outname.upper() + "_COUNT];")
 
             for ns in self.filtered_types:
                 for i, t_name in enumerate(self.filtered_types[ns]):
@@ -680,5 +688,5 @@ parser = CSVBSDTypeParser(args.opaque_map, args.selected_types,
                           namespaceMap)
 parser.create_types()
 
-generator = CGenerator(parser, inname, args.outfile, args.internal, args.gen_doc, namespaceMap)
+generator = CGenerator(parser, inname, args.outfile, args.internal, args.gen_doc, namespaceMap, args.export_macro)
 generator.write_definitions()


### PR DESCRIPTION
Adds an optional `--export-macro=<MACRO>` argument to `generate_datatypes.py`, plus a matching `EXPORT_MACRO` argument on the `ua_generate_datatypes` CMake function. It controls the visibility/export macro placed in front of the generated `extern UA_DataType` declarations and defaults to `UA_EXPORT`, so existing builds are unchanged.

Supersedes #5229 