### PR TITLE
fix(pubsub): Don't treat zero-element allocations as out-of-memory

### DIFF
--- a/src/pubsub/ua_pubsub_config.c
+++ b/src/pubsub/ua_pubsub_config.c
@@ -123,9 +123,12 @@ updatePubSubConfig(UA_PubSubManager *psm,
 
     /* Configuration of Published DataSets: */
     UA_UInt32 pdsCount = (UA_UInt32)configurationParameters->publishedDataSetsSize;
-    UA_NodeId *publishedDataSetIdent = (UA_NodeId*)UA_calloc(pdsCount, sizeof(UA_NodeId));
-    if(!publishedDataSetIdent)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    UA_NodeId *publishedDataSetIdent = NULL;
+    if(pdsCount > 0) {
+        publishedDataSetIdent = (UA_NodeId*)UA_calloc(pdsCount, sizeof(UA_NodeId));
+        if(!publishedDataSetIdent)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
 
     for(UA_UInt32 i = 0; i < pdsCount; i++) {
         res = createPublishedDataSet(psm,
@@ -153,10 +156,14 @@ updatePubSubConfig(UA_PubSubManager *psm,
                 "[UA_PubSubManager_updatePubSubConfig] START CONNECTIONS (Phase 1: Creation)");
 
     /* Store connection NodeIds for Phase 2 */
-    UA_NodeId *connectionIdents = (UA_NodeId*)UA_calloc(configurationParameters->connectionsSize, sizeof(UA_NodeId));
-    if(!connectionIdents) {
-        UA_free(publishedDataSetIdent);
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    UA_NodeId *connectionIdents = NULL;
+    if(configurationParameters->connectionsSize > 0) {
+        connectionIdents = (UA_NodeId*)
+            UA_calloc(configurationParameters->connectionsSize, sizeof(UA_NodeId));
+        if(!connectionIdents) {
+            UA_free(publishedDataSetIdent);
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
     }
 
     for(size_t i = 0; i < configurationParameters->connectionsSize; i++) {
@@ -888,13 +895,15 @@ generateWriterGroupDataType(const UA_WriterGroup *src,
         UA_WriterGroupDataType_clear(dst);
         return res;
     }
-    dst->groupPropertiesSize = src->config.groupProperties.mapSize,
+    dst->groupPropertiesSize = src->config.groupProperties.mapSize;
 
-    dst->dataSetWriters = (UA_DataSetWriterDataType*)
-        UA_calloc(src->writersCount, sizeof(UA_DataSetWriterDataType));
-    if(!dst->dataSetWriters) {
-        UA_WriterGroupDataType_clear(dst);
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    if(src->writersCount > 0) {
+        dst->dataSetWriters = (UA_DataSetWriterDataType*)
+            UA_calloc(src->writersCount, sizeof(UA_DataSetWriterDataType));
+        if(!dst->dataSetWriters) {
+            UA_WriterGroupDataType_clear(dst);
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
     }
 
     dst->dataSetWritersSize = src->writersCount;
@@ -933,10 +942,12 @@ generateDataSetReaderDataType(const UA_DataSetReader *src,
         return UA_STATUSCODE_BADOUTOFMEMORY;
 
     const UA_TargetVariablesDataType *targets = &src->config.subscribedDataSet.target;
-    tmpTarget->targetVariables = (UA_FieldTargetDataType *)
-        UA_calloc(targets->targetVariablesSize, sizeof(UA_FieldTargetDataType));
-    if(!tmpTarget->targetVariables)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    if(targets->targetVariablesSize > 0) {
+        tmpTarget->targetVariables = (UA_FieldTargetDataType *)
+            UA_calloc(targets->targetVariablesSize, sizeof(UA_FieldTargetDataType));
+        if(!tmpTarget->targetVariables)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
     tmpTarget->targetVariablesSize = targets->targetVariablesSize;
     for(size_t i = 0; i < tmpTarget->targetVariablesSize; i++) {
         res |= UA_FieldTargetDataType_copy(&targets->targetVariables[i],
@@ -955,10 +966,12 @@ generateReaderGroupDataType(const UA_ReaderGroup *src,
     memset(dst, 0, sizeof(UA_ReaderGroupDataType));
 
     UA_String_copy(&src->config.name, &dst->name);
-    dst->dataSetReaders = (UA_DataSetReaderDataType*)
-        UA_calloc(src->readersCount, sizeof(UA_DataSetReaderDataType));
-    if(dst->dataSetReaders == NULL)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    if(src->readersCount > 0) {
+        dst->dataSetReaders = (UA_DataSetReaderDataType*)
+            UA_calloc(src->readersCount, sizeof(UA_DataSetReaderDataType));
+        if(dst->dataSetReaders == NULL)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
     dst->dataSetReadersSize = src->readersCount;
 
     size_t i = 0;
@@ -1048,11 +1061,13 @@ generatePubSubConnectionDataType(UA_PubSubManager *psm,
         }
     }
 
-    dst->writerGroups = (UA_WriterGroupDataType*)
-        UA_calloc(src->writerGroupsSize, sizeof(UA_WriterGroupDataType));
-    if(!dst->writerGroups) {
-        UA_PubSubConnectionDataType_clear(dst);
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    if(src->writerGroupsSize > 0) {
+        dst->writerGroups = (UA_WriterGroupDataType*)
+            UA_calloc(src->writerGroupsSize, sizeof(UA_WriterGroupDataType));
+        if(!dst->writerGroups) {
+            UA_PubSubConnectionDataType_clear(dst);
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
     }
 
     dst->writerGroupsSize = src->writerGroupsSize;
@@ -1067,11 +1082,13 @@ generatePubSubConnectionDataType(UA_PubSubManager *psm,
         wgIndex++;
     }
 
-    dst->readerGroups = (UA_ReaderGroupDataType*)
-        UA_calloc(src->readerGroupsSize, sizeof(UA_ReaderGroupDataType));
-    if(dst->readerGroups == NULL) {
-        UA_PubSubConnectionDataType_clear(dst);
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    if(src->readerGroupsSize > 0) {
+        dst->readerGroups = (UA_ReaderGroupDataType*)
+            UA_calloc(src->readerGroupsSize, sizeof(UA_ReaderGroupDataType));
+        if(dst->readerGroups == NULL) {
+            UA_PubSubConnectionDataType_clear(dst);
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
     }
 
     dst->readerGroupsSize = src->readerGroupsSize;

--- a/src/pubsub/ua_pubsub_networkmessage_json.c
+++ b/src/pubsub/ua_pubsub_networkmessage_json.c
@@ -565,10 +565,12 @@ NetworkMessage_decodeJsonInternal(PubSubDecodeJsonCtx *ctx,
     if(!isUaData)
         return UA_STATUSCODE_BADNOTIMPLEMENTED;
 
-    dst->payload.dataSetMessages = (UA_DataSetMessage*)
-        UA_calloc(messageCount, sizeof(UA_DataSetMessage));
-    if(!dst->payload.dataSetMessages)
-        return UA_STATUSCODE_BADOUTOFMEMORY;
+    if(messageCount > 0) {
+        dst->payload.dataSetMessages = (UA_DataSetMessage*)
+            UA_calloc(messageCount, sizeof(UA_DataSetMessage));
+        if(!dst->payload.dataSetMessages)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
     dst->messageCount = (UA_Byte)messageCount;
 
     /* Network Message */

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -482,8 +482,17 @@ ReadCallback(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext
             return UA_STATUSCODE_BADNOTFOUND;
         switch(nodeContext->elementClassiefier) {
         case UA_NS0ID_PUBLISHEDDATAITEMSTYPE_PUBLISHEDDATA: {
-            UA_PublishedVariableDataType *pvd = (UA_PublishedVariableDataType *)
-                UA_calloc(publishedDataSet->fieldSize, sizeof(UA_PublishedVariableDataType));
+            /* Return an empty array if the PublishedDataSet has no fields.
+             * UA_calloc is allowed to return NULL for zero elements. */
+            UA_PublishedVariableDataType *pvd =
+                (UA_PublishedVariableDataType *)UA_EMPTY_ARRAY_SENTINEL;
+            if(publishedDataSet->fieldSize > 0) {
+                pvd = (UA_PublishedVariableDataType *)
+                    UA_calloc(publishedDataSet->fieldSize,
+                              sizeof(UA_PublishedVariableDataType));
+                if(!pvd)
+                    return UA_STATUSCODE_BADOUTOFMEMORY;
+            }
             size_t counter = 0;
             UA_DataSetField *field;
             TAILQ_FOREACH(field, &publishedDataSet->fields, listEntry) {

--- a/src/pubsub/ua_pubsub_securitygroup.c
+++ b/src/pubsub/ua_pubsub_securitygroup.c
@@ -193,8 +193,16 @@ initializeKeyStorageWithKeys(UA_PubSubManager *psm, UA_SecurityGroup *sg) {
     retval = UA_ByteString_allocBuffer(&currentKey, keyLength);
     retval = generateKeyData(ks->policy, &currentKey);
 
-    UA_ByteString *futurekeys = (UA_ByteString *)
-        UA_calloc(sg->config.maxFutureKeyCount, sizeof(UA_ByteString));
+    UA_ByteString *futurekeys = NULL;
+    if(sg->config.maxFutureKeyCount > 0) {
+        futurekeys = (UA_ByteString *)
+            UA_calloc(sg->config.maxFutureKeyCount, sizeof(UA_ByteString));
+        if(!futurekeys) {
+            UA_ByteString_clear(&currentKey);
+            UA_PubSubKeyStorage_delete(psm, ks);
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        }
+    }
     for(size_t i = 0; i < sg->config.maxFutureKeyCount; i++) {
         retval = UA_ByteString_allocBuffer(&futurekeys[i], keyLength);
         retval = generateKeyData(ks->policy, &futurekeys[i]);

--- a/tests/pubsub/check_pubsub_configuration.c
+++ b/tests/pubsub/check_pubsub_configuration.c
@@ -10,6 +10,7 @@
 #include "../common.h"
 
 #include "test_helpers.h"
+#include "pubsub_test_helpers.h"
 #include "ua_pubsub_internal.h"
 #include "ua_server_internal.h"
 
@@ -115,6 +116,66 @@ START_TEST(SaveEmptyConfiguration) {
                                                        &savedConfiguration);
     ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     ck_assert_uint_gt(savedConfiguration.length, 0);
+
+    /* A configuration without PublishedDataSets and Connections must also be
+     * loadable again. */
+    retVal = UA_Server_loadPubSubConfigFromByteString(server, savedConfiguration);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+    UA_ByteString_clear(&savedConfiguration);
+} END_TEST
+
+START_TEST(SaveConfigurationWithEmptyComponents) {
+    /* A Connection without groups, a WriterGroup without DataSetWriters, a
+     * ReaderGroup without DataSetReaders and a DataSetReader without
+     * TargetVariables must be serializable. */
+    UA_PubSubConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(UA_PubSubConnectionConfig));
+    connectionConfig.name = UA_STRING("UADP Connection");
+    UA_NetworkAddressUrlDataType networkAddressUrl =
+        UA_PUBSUB_TEST_NETWORKADDRESSURL(UA_PUBSUB_TEST_UDP_MULTICAST_URL_4840);
+    UA_Variant_setScalar(&connectionConfig.address, &networkAddressUrl,
+                         &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    connectionConfig.transportProfileUri =
+        UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
+
+    /* The first Connection stays without any group */
+    UA_NodeId connection;
+    UA_StatusCode retVal =
+        UA_Server_addPubSubConnection(server, &connectionConfig, NULL);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+    retVal = UA_Server_addPubSubConnection(server, &connectionConfig, &connection);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+    UA_WriterGroupConfig writerGroupConfig;
+    memset(&writerGroupConfig, 0, sizeof(writerGroupConfig));
+    writerGroupConfig.name = UA_STRING("WriterGroup without writers");
+    writerGroupConfig.publishingInterval = 100;
+    retVal = UA_Server_addWriterGroup(server, connection, &writerGroupConfig, NULL);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+    UA_ReaderGroupConfig readerGroupConfig;
+    memset(&readerGroupConfig, 0, sizeof(readerGroupConfig));
+    readerGroupConfig.name = UA_STRING("ReaderGroup without readers");
+    UA_NodeId readerGroup;
+    retVal = UA_Server_addReaderGroup(server, connection, &readerGroupConfig,
+                                      &readerGroup);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+    UA_DataSetReaderConfig readerConfig;
+    memset(&readerConfig, 0, sizeof(readerConfig));
+    readerConfig.name = UA_STRING("DataSetReader without target variables");
+    retVal = UA_Server_addDataSetReader(server, readerGroup, &readerConfig, NULL);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+
+    UA_ByteString savedConfiguration = UA_BYTESTRING_NULL;
+    retVal = UA_Server_writePubSubConfigurationToByteString(server,
+                                                            &savedConfiguration);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
+    ck_assert_uint_gt(savedConfiguration.length, 0);
+
+    UA_Server_disableAllPubSubComponents(server);
+    retVal = UA_Server_loadPubSubConfigFromByteString(server, savedConfiguration);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_GOOD);
     UA_ByteString_clear(&savedConfiguration);
 } END_TEST
 
@@ -124,6 +185,7 @@ int main(void) {
     tcase_add_test(tc_pubsub_file_configuration, AddPublisherUsingBinaryFile);
     tcase_add_test(tc_pubsub_file_configuration, AddSubscriberUsingBinaryFile);
     tcase_add_test(tc_pubsub_file_configuration, SaveEmptyConfiguration);
+    tcase_add_test(tc_pubsub_file_configuration, SaveConfigurationWithEmptyComponents);
 
     Suite *s = suite_create("PubSub file configuration");
     suite_add_tcase(s, tc_pubsub_file_configuration);


### PR DESCRIPTION
Some UA_calloc calls in the PubSub code request zero elements and then treat the NULL result as an out-of-memory error. That breaks saving a configuration with an empty connection/group, decoding a JSON NetworkMessage with an empty Messages array, and reading PublishedData of a PDS without fields. This guards the 11 affected allocations and adds a round-trip test for empty PubSub components.