### PR TITLE
fix(arch): fix monotonic clock unit on zephyr

### DIFF
--- a/arch/zephyr/clock_zephyr.c
+++ b/arch/zephyr/clock_zephyr.c
@@ -39,7 +39,7 @@ UA_DateTime_localTimeUtcOffset(void) {
 
 UA_DateTime
 UA_DateTime_nowMonotonic(void) {
-    return k_uptime_get();
+    return (UA_DateTime)(k_ticks_to_ns_floor64(k_uptime_ticks()) / 100);
 }
 
 #endif


### PR DESCRIPTION
k_uptime_get() returns milliseconds, but UA_DateTime is measured in 100ns intervals, so the monotonic clock ran 10000x slow.
Derive the value from k_uptime_ticks() converted to nanoseconds instead.

See https://docs.zephyrproject.org/latest/kernel/services/timing/clocks.html