### PR TITLE
fix(core): Do not pass the empty-array sentinel to realloc when appending

### DIFF
--- a/src/server/ua_services_discovery.c
+++ b/src/server/ua_services_discovery.c
@@ -424,7 +424,9 @@ updateEndpointUserIdentityToken(UA_Server *server,
             postfix = securityPolicyUriPostfix(ed->securityPolicyUri);
         size_t newLen = utp->policyId.length + postfix.length +
             strlen(securityModeStrs[ed->securityMode]);
-        UA_Byte *newString = (UA_Byte*)UA_realloc(utp->policyId.data, newLen);
+        UA_Byte *newString = (UA_Byte*)
+            UA_realloc((void*)((uintptr_t)utp->policyId.data &
+                               ~(uintptr_t)UA_EMPTY_ARRAY_SENTINEL), newLen);
         if(!newString)
             continue;
         size_t pos = utp->policyId.length;

--- a/src/ua_types.c
+++ b/src/ua_types.c
@@ -299,7 +299,9 @@ UA_StatusCode
 UA_String_append(UA_String *s, const UA_String s2) {
     if(s2.length == 0)
         return UA_STATUSCODE_GOOD;
-    UA_Byte *buf = (UA_Byte*)UA_realloc(s->data, s->length + s2.length);
+    UA_Byte *buf = (UA_Byte*)
+        UA_realloc((void*)((uintptr_t)s->data & ~(uintptr_t)UA_EMPTY_ARRAY_SENTINEL),
+                   s->length + s2.length);
     if(!buf)
         return UA_STATUSCODE_BADOUTOFMEMORY;
     memcpy(buf + s->length, s2.data, s2.length);

--- a/src/util/ua_util.c
+++ b/src/util/ua_util.c
@@ -956,7 +956,8 @@ UA_String_escapeAppend(UA_String *s, const UA_String s2, UA_Escaping esc) {
     /* Allocate memory for the additional escaped string */
     size_t escapedLength = UA_String_escapedSize(s2, esc);
     UA_Byte *buf = (UA_Byte*)
-        UA_realloc(s->data, s->length + s2.length + escapedLength);
+        UA_realloc((void*)((uintptr_t)s->data & ~(uintptr_t)UA_EMPTY_ARRAY_SENTINEL),
+                   s->length + s2.length + escapedLength);
     if(!buf)
         return UA_STATUSCODE_BADOUTOFMEMORY;
 

--- a/tests/check_types_print.c
+++ b/tests/check_types_print.c
@@ -7,6 +7,7 @@
 #include <open62541/types.h>
 #include <open62541/types_generated.h>
 #include <open62541/util.h>
+#include "util/ua_util_internal.h"
 #include <check.h>
 #include <stdlib.h>
 #include <string.h>
@@ -106,6 +107,30 @@ START_TEST(string_append_to_empty) {
     UA_StatusCode res = UA_String_append(&s, s2);
     ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
     ck_assert_uint_eq(s.length, 5);
+    UA_String_clear(&s);
+} END_TEST
+
+/* An empty (but not null) string carries the UA_EMPTY_ARRAY_SENTINEL in the
+ * data pointer. That must not be handed over to realloc. */
+START_TEST(string_append_to_empty_sentinel) {
+    UA_String s = UA_STRING_ALLOC("");
+    ck_assert_ptr_eq(s.data, (UA_Byte*)UA_EMPTY_ARRAY_SENTINEL);
+    UA_String s2 = UA_STRING("World");
+    UA_StatusCode res = UA_String_append(&s, s2);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(s.length, 5);
+    ck_assert(memcmp(s.data, "World", 5) == 0);
+    UA_String_clear(&s);
+} END_TEST
+
+START_TEST(string_escapeAppend_to_empty_sentinel) {
+    UA_String s = UA_STRING_ALLOC("");
+    ck_assert_ptr_eq(s.data, (UA_Byte*)UA_EMPTY_ARRAY_SENTINEL);
+    UA_String s2 = UA_STRING("a/b");
+    UA_StatusCode res = UA_String_escapeAppend(&s, s2, UA_ESCAPING_AND);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(s.length, 4);
+    ck_assert(memcmp(s.data, "a&/b", 4) == 0);
     UA_String_clear(&s);
 } END_TEST
 
@@ -424,6 +449,8 @@ static Suite *testSuite_typesExtra3(void) {
     tcase_add_test(tc_string, string_append_normal);
     tcase_add_test(tc_string, string_append_empty);
     tcase_add_test(tc_string, string_append_to_empty);
+    tcase_add_test(tc_string, string_append_to_empty_sentinel);
+    tcase_add_test(tc_string, string_escapeAppend_to_empty_sentinel);
     tcase_add_test(tc_string, string_format_test);
 
     TCase *tc_print = tcase_create("TypePrint");


### PR DESCRIPTION
UA_String_append, UA_String_escapeAppend and the PolicyId update in GetEndpoints crashed when the target string was empty but not null.