### PR TITLE
feature(server): Allow to limit the max size of untrusted messages

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -2158,6 +2158,11 @@ struct UA_ServerConfig {
                               * (default: 0 -> unbounded) */
     UA_UInt32 tcpMaxChunks;  /* Max number of chunks per message
                               * (default: 0 -> unbounded) */
+    /* Additional limitation of messages that are sent over an unsecured SecureChannel.
+     * This will target mainly the Discovery Service Set and prevents an unauthenticated
+     * and untrusted client to block too many server resources. */
+    UA_UInt32 tcpMaxUntrustedMsgSize; /* (default: 0 -> unbounded) */
+
     UA_Boolean tcpReuseAddr;
 
     /* Security and Encryption

--- a/include/open62541/util.h
+++ b/include/open62541/util.h
@@ -207,6 +207,10 @@ typedef struct {
     UA_UInt32 remoteMaxMessageSize; /* (0 = unbounded) */
     UA_UInt32 localMaxChunkCount;   /* (0 = unbounded) */
     UA_UInt32 remoteMaxChunkCount;  /* (0 = unbounded) */
+    /* Additional limitation of messages that are sent over an unsecured SecureChannel.
+     * This will target mainly the Discovery Service Set and prevents an unauthenticated
+     * and untrusted client to block too many server resources. */
+    UA_UInt32 localMaxUntrustedMessageSize; /* (0 = unbounded) */
 } UA_ConnectionConfig;
 
 /**

--- a/plugins/ua_config_default.c
+++ b/plugins/ua_config_default.c
@@ -201,7 +201,8 @@ const UA_ConnectionConfig UA_ConnectionConfig_default = {
     1 << 29, /* .localMaxMessageSize, 512 MB */
     1 << 29, /* .remoteMaxMessageSize, 512 MB */
     1 << 14, /* .localMaxChunkCount, 16k */
-    1 << 14  /* .remoteMaxChunkCount, 16k */
+    1 << 14,  /* .remoteMaxChunkCount, 16k */
+    1 << 17  /* .localMaxUntrustedMessageSize 128 kB*/
 };
 
 /***************************/

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -614,6 +614,7 @@ createServerSecureChannel(UA_BinaryProtocolManager *bpm, UA_ConnectionManager *c
     connConfig.remoteMaxMessageSize = config->tcpMaxMsgSize;
     connConfig.localMaxChunkCount = config->tcpMaxChunks;
     connConfig.remoteMaxChunkCount = config->tcpMaxChunks;
+    connConfig.localMaxUntrustedMessageSize = config->tcpMaxUntrustedMsgSize;
 
     /* Further constrain the bufsize if the ConnectionManager has static rx/tx
      * buffers configured. Also applies when tcpBufSize is unset (0), so that
@@ -648,6 +649,8 @@ createServerSecureChannel(UA_BinaryProtocolManager *bpm, UA_ConnectionManager *c
         connConfig.localMaxChunkCount = 1 << 14; /* 16384 */
     if(connConfig.remoteMaxChunkCount == 0)
         connConfig.remoteMaxChunkCount = 1 << 14; /* 16384 */
+    if(connConfig.localMaxUntrustedMessageSize == 0)
+        connConfig.localMaxUntrustedMessageSize = 1 << 17; /* 128 kB */
 
     /* Set up the new SecureChannel */
     UA_SecureChannel_init(channel);

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -953,6 +953,17 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
             return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;
         }
 
+        /* Now validate whether the channel is unsecured AND the message size
+         * exceeds what is configured */
+        if((channel->securityMode != UA_MESSAGESECURITYMODE_SIGN &&
+            channel->securityMode != UA_MESSAGESECURITYMODE_SIGNANDENCRYPT) &&
+           (channel->config.localMaxUntrustedMessageSize != 0 &&
+            channel->chunksLength + chunk.bytes.length > channel->config.localMaxUntrustedMessageSize)) {
+            if(chunk.copied)
+                UA_ByteString_clear(&chunk.bytes);
+            return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;
+        }
+
         /* Add the chunk to the queue. Then continue extracting more chunks. */
         pchunk = (UA_Chunk*)UA_malloc(sizeof(UA_Chunk));
         if(!pchunk) {


### PR DESCRIPTION
"Untrusted" messages are hereby messages that are sent over an unsecured Secure Channel (neither encrypted nor signed).

This complements PR #8142 to provide a separate knob for untrusted messages.