### PR TITLE
feat(nc): optionally place generated *_members arrays in external RAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,16 @@ if(UA_ENABLE_TPM2_KEYSTORE)
     endif()
 endif()
 
+# Generated *_members arrays (UA_DataTypeMember[]) placement. Empty
+# (default): compile-time-initialized as always. Set to an attribute macro
+# name (e.g. EXT_RAM_BSS_ATTR on ESP-IDF, with
+# CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY enabled) to instead declare
+# them zero-initialized with that attribute and fill them in via a
+# generated __attribute__((constructor)) function -- lets embedded targets
+# place them in external RAM, since only zero-initialized (.bss) data can
+# be attribute-placed there. See tools/generate_datatypes.py.
+set(UA_TYPES_MEMBERS_EXTRAM_ATTR "" CACHE STRING "Attribute macro to zero-init-declare and runtime-populate generated *_members arrays with (e.g. EXT_RAM_BSS_ATTR); empty disables this and keeps them compile-time-initialized")
+
 # Namespace Zero
 set(UA_NAMESPACE_ZERO "REDUCED" CACHE STRING "Completeness of the generated namespace zero (none/minimal/reduced/full)")
 SET_PROPERTY(CACHE UA_NAMESPACE_ZERO PROPERTY STRINGS "NONE" "MINIMAL" "REDUCED" "FULL")
@@ -1603,14 +1613,16 @@ include(open62541Macros)
 ua_generate_datatypes(BUILTIN GEN_DOC NAME "types" TARGET_SUFFIX "types" NAMESPACE_IDX 0
                       FILE_CSV "${UA_NS0_NODEIDS}"
                       FILES_BSD "${UA_NS0_TYPES_BSD}"
-                      FILES_SELECTED ${UA_NS0_DATATYPES})
+                      FILES_SELECTED ${UA_NS0_DATATYPES}
+                      MEMBERS_EXTRAM_ATTR "${UA_TYPES_MEMBERS_EXTRAM_ATTR}")
 
 # transport data types
 ua_generate_datatypes(INTERNAL NAME "transport" TARGET_SUFFIX "transport" NAMESPACE_IDX 1
                       FILE_CSV "${UA_NS0_NODEIDS}"
                       IMPORT_BSD "TYPES#${UA_NS0_TYPES_BSD}"
                       FILES_BSD "${PROJECT_SOURCE_DIR}/tools/schema/Custom.Opc.Ua.Transport.bsd"
-                      FILES_SELECTED "${PROJECT_SOURCE_DIR}/tools/schema/datatypes_transport.txt")
+                      FILES_SELECTED "${PROJECT_SOURCE_DIR}/tools/schema/datatypes_transport.txt"
+                      MEMBERS_EXTRAM_ATTR "${UA_TYPES_MEMBERS_EXTRAM_ATTR}")
 
 # statuscode explanation
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src_generated/open62541/statuscodes.h

--- a/tools/cmake/open62541Macros.cmake
+++ b/tools/cmake/open62541Macros.cmake
@@ -164,7 +164,7 @@ endfunction()
 function(ua_generate_datatypes)
     find_package(Python3 REQUIRED)
     set(options BUILTIN INTERNAL AUTOLOAD GEN_DOC)
-    set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_XML FILE_CSV EXPORT_MACRO)
+    set(oneValueArgs NAME TARGET_SUFFIX TARGET_PREFIX OUTPUT_DIR FILE_XML FILE_CSV EXPORT_MACRO MEMBERS_EXTRAM_ATTR)
     set(multiValueArgs FILES_BSD IMPORT_BSD FILES_SELECTED)
     cmake_parse_arguments(UA_GEN_DT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -240,6 +240,11 @@ function(ua_generate_datatypes)
         set(EXPORT_MACRO_ARG "--export-macro=${UA_GEN_DT_EXPORT_MACRO}")
     endif()
 
+    set(MEMBERS_EXTRAM_ATTR_ARG "")
+    if(UA_GEN_DT_MEMBERS_EXTRAM_ATTR)
+        set(MEMBERS_EXTRAM_ATTR_ARG "--members-extram-attr=${UA_GEN_DT_MEMBERS_EXTRAM_ATTR}")
+    endif()
+
     # Command generating the DataType code files
     add_custom_command(COMMAND ${ARG_CONV_EXCL_ENV} ${Python3_EXECUTABLE}
                                ${open62541_TOOLS_DIR}/generate_datatypes.py
@@ -251,6 +256,7 @@ function(ua_generate_datatypes)
                                ${UA_GEN_DT_NO_BUILTIN}
                                ${UA_GEN_DT_INTERNAL_ARG}
                                ${EXPORT_MACRO_ARG}
+                               ${MEMBERS_EXTRAM_ATTR_ARG}
                                ${UA_GEN_DT_OUTPUT_DIR}/${UA_GEN_DT_NAME}
                                ${UA_GEN_DOC_ARG}
                        OUTPUT  ${UA_GEN_DT_OUTPUT_DIR}/${UA_GEN_DT_NAME}_generated.c

--- a/tools/generate_datatypes.py
+++ b/tools/generate_datatypes.py
@@ -97,6 +97,20 @@ parser.add_argument('--export-macro',
                     default="",
                     help='macro to use in front of extern declarations (default: UA_EXPORT)')
 
+parser.add_argument('--members-extram-attr',
+                    metavar="<attrMacro>",
+                    type=str,
+                    dest="members_extram_attr",
+                    default="",
+                    help='if set, declare the per-type *_members arrays (UA_DataTypeMember[]) '
+                         'zero-initialized with this attribute macro and fill them in via a '
+                         'generated __attribute__((constructor)) function instead of a '
+                         'compile-time initializer, so they can be attribute-placed in external '
+                         'RAM on targets where only zero-initialized (.bss) data can be (e.g. '
+                         'pass EXT_RAM_BSS_ATTR on ESP-IDF with '
+                         'CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY). Default: unset, arrays '
+                         'stay compile-time-initialized as before.')
+
 parser.add_argument('outfile',
                     metavar='<outputFile>',
                     help='output file w/o extension')
@@ -188,7 +202,7 @@ def _types_definition_equal(t1, t2):
     return False
 
 class CGenerator:
-    def __init__(self, parser, inname, outfile, is_internal_types, gen_doc, namespaceMap, export_macro=""):
+    def __init__(self, parser, inname, outfile, is_internal_types, gen_doc, namespaceMap, export_macro="", members_extram_attr=""):
         self.parser = parser
         self.inname = inname
         self.outfile = outfile
@@ -197,6 +211,15 @@ class CGenerator:
         self.filtered_types = None
         self.namespaceMap = namespaceMap
         self.export_macro = export_macro if export_macro else "UA_EXPORT"
+        # If set, the *_members arrays (UA_DataTypeMember[]) are declared
+        # zero-initialized with this attribute macro and filled in by a
+        # generated __attribute__((constructor)) function instead of a
+        # compile-time initializer -- see print_members(). Intended for
+        # e.g. "EXT_RAM_BSS_ATTR" on ESP-IDF, to place them in external
+        # PSRAM (only .bss/zero-initialized data can be attribute-placed
+        # in PSRAM there) instead of internal RAM. Empty/default: no
+        # change from the plain compile-time-initialized array.
+        self.members_extram_attr = members_extram_attr
         self.fh = None
         self.fc = None
         self.fd = None
@@ -280,33 +303,34 @@ class CGenerator:
                "    %s_members" % idName + "  /* .members */\n" + \
                "}"
 
-    @staticmethod
-    def print_members(datatype):
+    def print_members(self, datatype):
         idName = makeCIdentifier(datatype.name)
         # TODO: OptionSet is omitted because the type description is not generated as UA_DATATYPEKIND_ENUM
         isEnum = isinstance(datatype, EnumerationType) and not datatype.isOptionSet
         if (not isEnum and len(datatype.members) == 0) or (isEnum and len(datatype.elements) == 0):
-            return "#define %s_members NULL" % (idName)
+            return "#define %s_members NULL" % (idName), None
         isUnion = isinstance(datatype, StructType) and datatype.is_union
-        members = "static UA_DataTypeMember {}_members[{}] = {{".format(idName, len(datatype.elements) if isEnum else len(datatype.members))
-        before = None
         size = len(datatype.elements) if isEnum else len(datatype.members)
+
+        # Build the per-element initializer bodies ("{ ... }", no trailing
+        # comma). Used verbatim both for the plain aggregate initializer
+        # (default) and, one element at a time, for the runtime init
+        # function (self.members_extram_attr set -- see below).
+        bodies = []
+        before = None
         if isEnum:
             # Print all enumerators as UA_DataTypeMember
-            for i, (name, value) in enumerate(datatype.elements.items()):
-                m = "\n{\n"
+            for name, value in datatype.elements.items():
+                m = "{\n"
                 m += "    UA_TYPENAME(\"%s\") /* .memberName */\n" % name
                 m += "    (const UA_DataType *)(uintptr_t)({}), /* .memberType */\n".format(value)
                 m += "    0, /* .padding */\n"
                 m += "    false, /* .isArray */\n"
                 m += "    false /* .isOptional */\n}"
-                # Don't add a trailing comma for the last entry
-                if i != size - 1:
-                    m += ","
-                members += m
+                bodies.append(m)
         else:
             # Print all structure fields as UA_DataTypeMember
-            for i, member in enumerate(datatype.members):
+            for member in datatype.members:
 
                 # Build the type name for the current field
                 if not member.member_type.members and isinstance(member.member_type, StructType):
@@ -326,7 +350,7 @@ class CGenerator:
                 member_name_capital = member_name
                 if len(member_name) > 0:
                     member_name_capital = member_name[0].upper() + member_name[1:]
-                m = "\n{\n"
+                m = "{\n"
                 m += "    UA_TYPENAME(\"%s\") /* .memberName */\n" % member_name_capital
                 m += "    &UA_{}[UA_{}_{}], /* .memberType */\n".format(
                     member.member_type.outname.upper(), member.member_type.outname.upper(),
@@ -350,12 +374,34 @@ class CGenerator:
                 m += " /* .padding */\n"
                 m += ("    true" if member.is_array else "    false") + ", /* .isArray */\n"
                 m += ("    true" if member.is_optional else "    false") + "  /* .isOptional */\n}"
-                # Don't add a trailing comma for the last entry
-                if i != size - 1:
-                    m += ","
-                members += m
+                bodies.append(m)
                 before = member
-        return members + "};"
+
+        if not self.members_extram_attr:
+            # Default: a single plain aggregate initializer, exactly as before.
+            members = "static UA_DataTypeMember {}_members[{}] = {{".format(idName, size)
+            members += ",".join("\n" + b for b in bodies)
+            return members + "};", None
+
+        # --members-extram-attr set: declare as a zero-initialized array
+        # tagged with the given attribute (e.g. EXT_RAM_BSS_ATTR on
+        # ESP-IDF, to place it in external PSRAM instead of internal RAM)
+        # and fill it in via a generated one-time init function instead of
+        # a compile-time initializer. Zero-initialized (.bss) placement is
+        # the only form ESP-IDF's EXT_RAM_BSS_ATTR supports; a regular
+        # non-zero initializer would stay internal (.data) regardless of
+        # the attribute. The values themselves are unchanged (still
+        # link-time constants -- pointers into the const UA_TYPES-style
+        # arrays and offsetof()/sizeof() expressions), just written via
+        # assignment instead of aggregate-initialized.
+        decl = "static {} UA_DataTypeMember {}_members[{}];".format(
+            self.members_extram_attr, idName, size)
+        init_fn_name = "{}_members_init".format(idName)
+        init_fn = "static void {}(void) {{\n".format(init_fn_name)
+        for i, b in enumerate(bodies):
+            init_fn += "    {}_members[{}] = (UA_DataTypeMember){};\n".format(idName, i, b)
+        init_fn += "}"
+        return decl + "\n" + init_fn, init_fn_name
 
     @staticmethod
     def print_datatype_ptr(datatype):
@@ -647,14 +693,30 @@ _UA_END_DECLS
 
 #include "''' + self.parser.outname + '''_generated.h"''')
 
+        if self.members_extram_attr:
+            # Portable fallback so this file compiles standalone even where
+            # the attribute macro isn't otherwise defined (e.g. non-ESP-IDF
+            # builds): downstream builds that actually want the placement
+            # define it (via their own config header included before this
+            # file, or a compiler -D flag) to something real, such as
+            # EXT_RAM_BSS_ATTR from ESP-IDF's esp_attr.h.
+            self.printc('''
+#ifndef ''' + self.members_extram_attr + '''
+#define ''' + self.members_extram_attr + '''
+#endif''')
+
         totalCount = 0
+        memberInitFns = []
         for ns in self.filtered_types:
             totalCount += len(self.filtered_types[ns])
             for _, t_name in enumerate(self.filtered_types[ns]):
                 t = self.filtered_types[ns][t_name]
                 self.printc("")
                 self.printc("/* " + t.name + " */")
-                self.printc(CGenerator.print_members(t))
+                code, initFnName = self.print_members(t)
+                self.printc(code)
+                if initFnName:
+                    memberInitFns.append(initFnName)
 
         if totalCount > 0:
             self.printc(
@@ -666,6 +728,22 @@ _UA_END_DECLS
                     self.printc("/* " + t.name + " */")
                     self.printc(self.print_datatype(t) + ",")
             self.printc("};\n")
+
+        if memberInitFns:
+            # Members arrays above were declared zero-initialized (see
+            # print_members()); populate them once, automatically, before
+            # anything in the program can run -- no explicit call required
+            # by servers, clients, or standalone type encode/decode users.
+            # Order between these doesn't matter: each function only
+            # writes to its own array, using values (pointers into the
+            # const UA_TYPES-style arrays, offsetof()/sizeof() constants)
+            # that don't depend on any other member array being populated
+            # yet.
+            self.printc("__attribute__((constructor))")
+            self.printc("static void UA_{}_members_init(void) {{".format(self.parser.outname.upper()))
+            for fn in memberInitFns:
+                self.printc("    {}();".format(fn))
+            self.printc("}\n")
 
 ###########################################
 # Execute with the command line arguments #
@@ -687,5 +765,5 @@ parser = CSVBSDTypeParser(args.opaque_map, args.selected_types,
                           namespaceMap)
 parser.create_types()
 
-generator = CGenerator(parser, inname, args.outfile, args.internal, args.gen_doc, namespaceMap, args.export_macro)
+generator = CGenerator(parser, inname, args.outfile, args.internal, args.gen_doc, namespaceMap, args.export_macro, args.members_extram_attr)
 generator.write_definitions()


### PR DESCRIPTION
Adds a --members-extram-attr <attrMacro> option to generate_datatypes.py
(wired through ua_generate_datatypes()'s new MEMBERS_EXTRAM_ATTR
argument, and a UA_TYPES_MEMBERS_EXTRAM_ATTR CMake cache option for
the two builtin invocations -- "types"/UA_TYPES and
"transport"/UA_TRANSPORT).

Default (unset): no change, *_members arrays stay exactly as before --
a plain compile-time-initialized static array.

When set (e.g. to EXT_RAM_BSS_ATTR on ESP-IDF, with
CONFIG_SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY enabled): the array is
instead declared zero-initialized with the given attribute, and a
generated per-type init function assigns each element -- the exact
same link-time-constant values (pointers into the const
UA_TYPES-style arrays, offsetof()/sizeof() expressions) as before,
just via assignment instead of an aggregate initializer. All the
per-type init functions are called once from a single
__attribute__((constructor)) function per output file, so they run
automatically before any code (server, client, or standalone type
encode/decode) executes -- no explicit call required from any
existing or new open62541 user. Order between the init functions
doesn't matter: each only writes to its own array.

This exists because ESP-IDF's EXT_RAM_BSS_ATTR (the mechanism to
attribute-place a static variable in external PSRAM) only supports
zero-initialized (.bss) data; a regular non-zero initializer stays in
internal RAM regardless of the attribute. Companion to the earlier
`const UA_TYPES` fix: that one is free (no runtime cost, works
everywhere) and gets UA_TYPES itself (32592 bytes on our target) into
flash-mapped .rodata; the *_members arrays can't take that path since
UA_DataType.members is a non-const pointer (needed for legitimate
runtime custom-type registration), so moving them requires this
opt-in, runtime-init approach instead.

Verified on an ESP32-S3 embedded build using the generated
amalgamation with --members-extram-attr=EXT_RAM_BSS_ATTR: compiles
and links cleanly, a new 220KB .ext_ram.bss section appears (confirms
the real ESP-IDF attribute resolved, not the portable no-op
fallback), internal .dram0.data drops by a further 16912 bytes on top
of the const-UA_TYPES savings, and UA_TYPES_members_init is emitted
as .text.startup.UA_TYPES_members_init (GCC's constructor-function
naming convention) alongside the toolchain's normal
__libc_init_array/init_array machinery, confirming it runs
automatically at startup.
