### PR TITLE
[Review] feat: modernize Docker container, enable GDS receiver & RBAC, and add role persistence

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Build Docker Image
+
+on:
+  # Allows triggering the build manually from the Actions UI
+  workflow_dispatch:
+
+  # Automatically builds only when Docker or GDS files are modified,
+  # keeping the build time of other standard PRs completely unaffected.
+  pull_request:
+    paths:
+      - 'tools/docker/**'
+      - 'examples/ci_server.c'
+      - 'tools/certs/**'
+
+jobs:
+  build-docker:
+    name: Build open62541 Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: tools/docker/Dockerfile
+          tags: open62541/open62541:latest
+          push: false  # Only verify the build, do not push to registry
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/examples/ci_server.c
+++ b/examples/ci_server.c
@@ -381,6 +381,30 @@ int main(int argc, char* argv[]) {
 #endif
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
+    /* Allow configuring log level dynamically via env variable */
+    const char *envLogLevel = getenv("UA_LOG_LEVEL");
+    UA_LogLevel minLogLevel = UA_LOGLEVEL_INFO;
+    if(envLogLevel) {
+        if(strcmp(envLogLevel, "TRACE") == 0) {
+            minLogLevel = UA_LOGLEVEL_TRACE;
+        } else if(strcmp(envLogLevel, "DEBUG") == 0) {
+            minLogLevel = UA_LOGLEVEL_DEBUG;
+        } else if(strcmp(envLogLevel, "INFO") == 0) {
+            minLogLevel = UA_LOGLEVEL_INFO;
+        } else if(strcmp(envLogLevel, "WARNING") == 0) {
+            minLogLevel = UA_LOGLEVEL_WARNING;
+        } else if(strcmp(envLogLevel, "ERROR") == 0) {
+            minLogLevel = UA_LOGLEVEL_ERROR;
+        } else if(strcmp(envLogLevel, "FATAL") == 0) {
+            minLogLevel = UA_LOGLEVEL_FATAL;
+        }
+    }
+    if(config->logging) {
+        UA_Logger logger = UA_Log_Stdout_withLevel(minLogLevel);
+        logger.clear = config->logging->clear;
+        *config->logging = logger;
+    }
+
 #ifdef UA_ENABLE_ENCRYPTION
     UA_ByteString certificate = UA_BYTESTRING_NULL;
     UA_ByteString privateKey = UA_BYTESTRING_NULL;

--- a/examples/ci_server.c
+++ b/examples/ci_server.c
@@ -407,6 +407,7 @@ setupLogger(UA_ServerConfig *config) {
     *config->logging = logger;
 }
 
+#ifdef UA_ENABLE_ENCRYPTION
 static void
 removeDeprecatedSecurityPolicies(UA_ServerConfig *config) {
     if(!config) {
@@ -450,6 +451,7 @@ removeDeprecatedSecurityPolicies(UA_ServerConfig *config) {
     }
     config->endpointsSize = newEndpointsSize;
 }
+#endif
 
 int main(int argc, char* argv[]) {
     UA_StatusCode retval = 0;

--- a/examples/ci_server.c
+++ b/examples/ci_server.c
@@ -378,19 +378,11 @@ customLogCallback(void *logContext, UA_LogLevel level, UA_LogCategory category,
     UA_Log_Stdout->log(logContext, level, category, msg, args);
 }
 
-int main(int argc, char* argv[]) {
-    UA_StatusCode retval = 0;
-
-    UA_Server *server = UA_Server_new();
-#ifdef UA_ENABLE_DRIVER_GDS_RECEIVER
-    UA_GDSReceiver *gds_receiver = UA_GDSReceiver_new();
-    if (gds_receiver) {
-        UA_Server_addDriver(server, &gds_receiver->drv);
+static void
+setupLogger(UA_ServerConfig *config) {
+    if(!config || !config->logging) {
+        return;
     }
-#endif
-    UA_ServerConfig *config = UA_Server_getConfig(server);
-
-    /* Allow configuring log level dynamically via env variable */
     const char *envLogLevel = getenv("UA_LOG_LEVEL");
     UA_LogLevel minLogLevel = UA_LOGLEVEL_INFO;
     if(envLogLevel) {
@@ -408,13 +400,70 @@ int main(int argc, char* argv[]) {
             minLogLevel = UA_LOGLEVEL_FATAL;
         }
     }
-    if(config->logging) {
-        UA_Logger logger;
-        logger.log = customLogCallback;
-        logger.context = (void*)(uintptr_t)minLogLevel;
-        logger.clear = config->logging->clear;
-        *config->logging = logger;
+    UA_Logger logger;
+    logger.log = customLogCallback;
+    logger.context = (void*)(uintptr_t)minLogLevel;
+    logger.clear = config->logging->clear;
+    *config->logging = logger;
+}
+
+static void
+removeDeprecatedSecurityPolicies(UA_ServerConfig *config) {
+    if(!config) {
+        return;
     }
+    /* Remove deprecated and insecure security policies (Basic128Rsa15, Basic256) */
+    size_t newPoliciesSize = 0;
+    for(size_t i = 0; i < config->securityPoliciesSize; i++) {
+        UA_SecurityPolicy *policy = &config->securityPolicies[i];
+        const UA_String basic128Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+        const UA_String basic256Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
+        if(UA_String_equal(&policy->policyUri, &basic128Uri) ||
+           UA_String_equal(&policy->policyUri, &basic256Uri)) {
+            if(policy->clear) {
+                policy->clear(policy);
+            }
+        } else {
+            if(newPoliciesSize != i) {
+                config->securityPolicies[newPoliciesSize] = *policy;
+            }
+            newPoliciesSize++;
+        }
+    }
+    config->securityPoliciesSize = newPoliciesSize;
+
+    /* Filter endpoints matching the removed security policies */
+    size_t newEndpointsSize = 0;
+    for(size_t i = 0; i < config->endpointsSize; i++) {
+        UA_EndpointDescription *endpoint = &config->endpoints[i];
+        const UA_String basic128Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+        const UA_String basic256Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
+        if(UA_String_equal(&endpoint->securityPolicyUri, &basic128Uri) ||
+           UA_String_equal(&endpoint->securityPolicyUri, &basic256Uri)) {
+            UA_EndpointDescription_clear(endpoint);
+        } else {
+            if(newEndpointsSize != i) {
+                config->endpoints[newEndpointsSize] = *endpoint;
+            }
+            newEndpointsSize++;
+        }
+    }
+    config->endpointsSize = newEndpointsSize;
+}
+
+int main(int argc, char* argv[]) {
+    UA_StatusCode retval = 0;
+
+    UA_Server *server = UA_Server_new();
+#ifdef UA_ENABLE_DRIVER_GDS_RECEIVER
+    UA_GDSReceiver *gds_receiver = UA_GDSReceiver_new();
+    if (gds_receiver) {
+        UA_Server_addDriver(server, &gds_receiver->drv);
+    }
+#endif
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+
+    setupLogger(config);
 
 #ifdef UA_ENABLE_ENCRYPTION
     UA_ByteString certificate = UA_BYTESTRING_NULL;
@@ -473,43 +522,7 @@ int main(int argc, char* argv[]) {
     }
 
     if(retval == UA_STATUSCODE_GOOD) {
-        /* Remove deprecated and insecure security policies (Basic128Rsa15, Basic256) */
-        size_t newPoliciesSize = 0;
-        for(size_t i = 0; i < config->securityPoliciesSize; i++) {
-            UA_SecurityPolicy *policy = &config->securityPolicies[i];
-            const UA_String basic128Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
-            const UA_String basic256Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
-            if(UA_String_equal(&policy->policyUri, &basic128Uri) ||
-               UA_String_equal(&policy->policyUri, &basic256Uri)) {
-                if(policy->clear) {
-                    policy->clear(policy);
-                }
-            } else {
-                if(newPoliciesSize != i) {
-                    config->securityPolicies[newPoliciesSize] = *policy;
-                }
-                newPoliciesSize++;
-            }
-        }
-        config->securityPoliciesSize = newPoliciesSize;
-
-        /* Filter endpoints matching the removed security policies */
-        size_t newEndpointsSize = 0;
-        for(size_t i = 0; i < config->endpointsSize; i++) {
-            UA_EndpointDescription *endpoint = &config->endpoints[i];
-            const UA_String basic128Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
-            const UA_String basic256Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
-            if(UA_String_equal(&endpoint->securityPolicyUri, &basic128Uri) ||
-               UA_String_equal(&endpoint->securityPolicyUri, &basic256Uri)) {
-                UA_EndpointDescription_clear(endpoint);
-            } else {
-                if(newEndpointsSize != i) {
-                    config->endpoints[newEndpointsSize] = *endpoint;
-                }
-                newEndpointsSize++;
-            }
-        }
-        config->endpointsSize = newEndpointsSize;
+        removeDeprecatedSecurityPolicies(config);
     }
 
     UA_ByteString_clear(&certificate);

--- a/examples/ci_server.c
+++ b/examples/ci_server.c
@@ -369,6 +369,15 @@ writeVariable(UA_Server *server) {
     UA_Server_write(server, &wv);
 }
 
+static void
+customLogCallback(void *logContext, UA_LogLevel level, UA_LogCategory category,
+                  const char *msg, va_list args) {
+    if(category == UA_LOGCATEGORY_EVENTLOOP) {
+        return;
+    }
+    UA_Log_Stdout->log(logContext, level, category, msg, args);
+}
+
 int main(int argc, char* argv[]) {
     UA_StatusCode retval = 0;
 
@@ -400,7 +409,9 @@ int main(int argc, char* argv[]) {
         }
     }
     if(config->logging) {
-        UA_Logger logger = UA_Log_Stdout_withLevel(minLogLevel);
+        UA_Logger logger;
+        logger.log = customLogCallback;
+        logger.context = (void*)(uintptr_t)minLogLevel;
         logger.clear = config->logging->clear;
         *config->logging = logger;
     }
@@ -460,7 +471,48 @@ int main(int argc, char* argv[]) {
                                                           issuerList, issuerListSize,
                                                           revocationList, revocationListSize);
     }
-                                                           UA_ByteString_clear(&certificate);
+
+    if(retval == UA_STATUSCODE_GOOD) {
+        /* Remove deprecated and insecure security policies (Basic128Rsa15, Basic256) */
+        size_t newPoliciesSize = 0;
+        for(size_t i = 0; i < config->securityPoliciesSize; i++) {
+            UA_SecurityPolicy *policy = &config->securityPolicies[i];
+            const UA_String basic128Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+            const UA_String basic256Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
+            if(UA_String_equal(&policy->policyUri, &basic128Uri) ||
+               UA_String_equal(&policy->policyUri, &basic256Uri)) {
+                if(policy->clear) {
+                    policy->clear(policy);
+                }
+            } else {
+                if(newPoliciesSize != i) {
+                    config->securityPolicies[newPoliciesSize] = *policy;
+                }
+                newPoliciesSize++;
+            }
+        }
+        config->securityPoliciesSize = newPoliciesSize;
+
+        /* Filter endpoints matching the removed security policies */
+        size_t newEndpointsSize = 0;
+        for(size_t i = 0; i < config->endpointsSize; i++) {
+            UA_EndpointDescription *endpoint = &config->endpoints[i];
+            const UA_String basic128Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15");
+            const UA_String basic256Uri = UA_STRING("http://opcfoundation.org/UA/SecurityPolicy#Basic256");
+            if(UA_String_equal(&endpoint->securityPolicyUri, &basic128Uri) ||
+               UA_String_equal(&endpoint->securityPolicyUri, &basic256Uri)) {
+                UA_EndpointDescription_clear(endpoint);
+            } else {
+                if(newEndpointsSize != i) {
+                    config->endpoints[newEndpointsSize] = *endpoint;
+                }
+                newEndpointsSize++;
+            }
+        }
+        config->endpointsSize = newEndpointsSize;
+    }
+
+    UA_ByteString_clear(&certificate);
     UA_ByteString_clear(&privateKey);
     for(size_t i = 0; i < trustListSize; i++)
         UA_ByteString_clear(&trustList[i]);

--- a/examples/ci_server.c
+++ b/examples/ci_server.c
@@ -8,6 +8,10 @@
 #include <open62541/plugin/securitypolicy.h>
 #include <open62541/server.h>
 
+#ifdef UA_ENABLE_DRIVER_GDS_RECEIVER
+# include <open62541/driver/gds_receiver.h>
+#endif
+
 #include <stdlib.h>
 
 #include "common.h"
@@ -23,6 +27,248 @@ static UA_UsernamePasswordLogin logins[3] = {
     {UA_STRING_STATIC("paula"), UA_STRING_STATIC("paula123")},
     {UA_STRING_STATIC("user1"), UA_STRING_STATIC("password")}
 };
+
+#ifdef UA_ENABLE_RBAC
+#include <string.h>
+
+static void
+persistRolesToFile(const char *filePath, const UA_Role *roles, size_t rolesSize) {
+    FILE *fp = fopen(filePath, "wb");
+    if(!fp)
+        return;
+
+    uint32_t count = (uint32_t)rolesSize;
+    fwrite(&count, sizeof(uint32_t), 1, fp);
+
+    for(size_t i = 0; i < rolesSize; i++) {
+        const UA_Role *r = &roles[i];
+
+        UA_ByteString bId = UA_BYTESTRING_NULL;
+        UA_encodeBinary(&r->roleId, &UA_TYPES[UA_TYPES_NODEID], &bId, NULL);
+        uint32_t len = (uint32_t)bId.length;
+        fwrite(&len, sizeof(uint32_t), 1, fp);
+        if(len > 0) fwrite(bId.data, 1, len, fp);
+        UA_ByteString_clear(&bId);
+
+        UA_ByteString bName = UA_BYTESTRING_NULL;
+        UA_encodeBinary(&r->roleName, &UA_TYPES[UA_TYPES_QUALIFIEDNAME], &bName, NULL);
+        len = (uint32_t)bName.length;
+        fwrite(&len, sizeof(uint32_t), 1, fp);
+        if(len > 0) fwrite(bName.data, 1, len, fp);
+        UA_ByteString_clear(&bName);
+
+        uint32_t rulesSize = (uint32_t)r->identityMappingRulesSize;
+        fwrite(&rulesSize, sizeof(uint32_t), 1, fp);
+        for(size_t j = 0; j < r->identityMappingRulesSize; j++) {
+            UA_ByteString bRule = UA_BYTESTRING_NULL;
+            UA_encodeBinary(&r->identityMappingRules[j], &UA_TYPES[UA_TYPES_IDENTITYMAPPINGRULETYPE], &bRule, NULL);
+            len = (uint32_t)bRule.length;
+            fwrite(&len, sizeof(uint32_t), 1, fp);
+            if(len > 0) fwrite(bRule.data, 1, len, fp);
+            UA_ByteString_clear(&bRule);
+        }
+
+        uint8_t appEx = (uint8_t)r->applicationsExclude;
+        fwrite(&appEx, sizeof(uint8_t), 1, fp);
+        uint32_t appsSize = (uint32_t)r->applicationsSize;
+        fwrite(&appsSize, sizeof(uint32_t), 1, fp);
+        for(size_t j = 0; j < r->applicationsSize; j++) {
+            UA_ByteString bApp = UA_BYTESTRING_NULL;
+            UA_encodeBinary(&r->applications[j], &UA_TYPES[UA_TYPES_STRING], &bApp, NULL);
+            len = (uint32_t)bApp.length;
+            fwrite(&len, sizeof(uint32_t), 1, fp);
+            if(len > 0) fwrite(bApp.data, 1, len, fp);
+            UA_ByteString_clear(&bApp);
+        }
+
+        uint8_t endEx = (uint8_t)r->endpointsExclude;
+        fwrite(&endEx, sizeof(uint8_t), 1, fp);
+        uint32_t endsSize = (uint32_t)r->endpointsSize;
+        fwrite(&endsSize, sizeof(uint32_t), 1, fp);
+        for(size_t j = 0; j < r->endpointsSize; j++) {
+            UA_ByteString bEnd = UA_BYTESTRING_NULL;
+            UA_encodeBinary(&r->endpoints[j], &UA_TYPES[UA_TYPES_ENDPOINTTYPE], &bEnd, NULL);
+            len = (uint32_t)bEnd.length;
+            fwrite(&len, sizeof(uint32_t), 1, fp);
+            if(len > 0) fwrite(bEnd.data, 1, len, fp);
+            UA_ByteString_clear(&bEnd);
+        }
+    }
+
+    fclose(fp);
+}
+
+static void
+loadPersistentRolesFromFile(UA_Server *server, const char *filePath) {
+    FILE *fp = fopen(filePath, "rb");
+    if(!fp)
+        return;
+
+    uint32_t count = 0;
+    if(fread(&count, sizeof(uint32_t), 1, fp) != 1) {
+        fclose(fp);
+        return;
+    }
+
+    for(uint32_t i = 0; i < count; i++) {
+        UA_Role r;
+        UA_Role_init(&r);
+
+        uint32_t len = 0;
+
+        if(fread(&len, sizeof(uint32_t), 1, fp) != 1) break;
+        if(len > 0) {
+            UA_ByteString bId;
+            UA_ByteString_init(&bId);
+            UA_ByteString_allocBuffer(&bId, len);
+            if(fread(bId.data, 1, len, fp) == len) {
+                UA_decodeBinary(&bId, &r.roleId, &UA_TYPES[UA_TYPES_NODEID], NULL);
+            }
+            UA_ByteString_clear(&bId);
+        }
+
+        if(fread(&len, sizeof(uint32_t), 1, fp) != 1) break;
+        if(len > 0) {
+            UA_ByteString bName;
+            UA_ByteString_init(&bName);
+            UA_ByteString_allocBuffer(&bName, len);
+            if(fread(bName.data, 1, len, fp) == len) {
+                UA_decodeBinary(&bName, &r.roleName, &UA_TYPES[UA_TYPES_QUALIFIEDNAME], NULL);
+            }
+            UA_ByteString_clear(&bName);
+        }
+
+        uint32_t rulesSize = 0;
+        if(fread(&rulesSize, sizeof(uint32_t), 1, fp) != 1) break;
+        if(rulesSize > 0) {
+            r.identityMappingRules = (UA_IdentityMappingRuleType*)UA_calloc(rulesSize, sizeof(UA_IdentityMappingRuleType));
+            r.identityMappingRulesSize = rulesSize;
+            for(uint32_t j = 0; j < rulesSize; j++) {
+                if(fread(&len, sizeof(uint32_t), 1, fp) != 1) break;
+                if(len > 0) {
+                    UA_ByteString bRule;
+                    UA_ByteString_init(&bRule);
+                    UA_ByteString_allocBuffer(&bRule, len);
+                    if(fread(bRule.data, 1, len, fp) == len) {
+                        UA_decodeBinary(&bRule, &r.identityMappingRules[j], &UA_TYPES[UA_TYPES_IDENTITYMAPPINGRULETYPE], NULL);
+                    }
+                    UA_ByteString_clear(&bRule);
+                }
+            }
+        }
+
+        uint8_t appEx = 0;
+        if(fread(&appEx, sizeof(uint8_t), 1, fp) != 1) break;
+        r.applicationsExclude = (UA_Boolean)appEx;
+
+        uint32_t appsSize = 0;
+        if(fread(&appsSize, sizeof(uint32_t), 1, fp) != 1) break;
+        if(appsSize > 0) {
+            r.applications = (UA_String*)UA_calloc(appsSize, sizeof(UA_String));
+            r.applicationsSize = appsSize;
+            for(uint32_t j = 0; j < appsSize; j++) {
+                if(fread(&len, sizeof(uint32_t), 1, fp) != 1) break;
+                if(len > 0) {
+                    UA_ByteString bApp;
+                    UA_ByteString_init(&bApp);
+                    UA_ByteString_allocBuffer(&bApp, len);
+                    if(fread(bApp.data, 1, len, fp) == len) {
+                        UA_decodeBinary(&bApp, &r.applications[j], &UA_TYPES[UA_TYPES_STRING], NULL);
+                    }
+                    UA_ByteString_clear(&bApp);
+                }
+            }
+        }
+
+        uint8_t endEx = 0;
+        if(fread(&endEx, sizeof(uint8_t), 1, fp) != 1) break;
+        r.endpointsExclude = (UA_Boolean)endEx;
+
+        uint32_t endsSize = 0;
+        if(fread(&endsSize, sizeof(uint32_t), 1, fp) != 1) break;
+        if(endsSize > 0) {
+            r.endpoints = (UA_EndpointType*)UA_calloc(endsSize, sizeof(UA_EndpointType));
+            r.endpointsSize = endsSize;
+            for(uint32_t j = 0; j < endsSize; j++) {
+                if(fread(&len, sizeof(uint32_t), 1, fp) != 1) break;
+                if(len > 0) {
+                    UA_ByteString bEnd;
+                    UA_ByteString_init(&bEnd);
+                    UA_ByteString_allocBuffer(&bEnd, len);
+                    if(fread(bEnd.data, 1, len, fp) == len) {
+                        UA_decodeBinary(&bEnd, &r.endpoints[j], &UA_TYPES[UA_TYPES_ENDPOINTTYPE], NULL);
+                    }
+                    UA_ByteString_clear(&bEnd);
+                }
+            }
+        }
+
+        UA_Role existing;
+        UA_Role_init(&existing);
+        if(UA_Server_getRoleById(server, r.roleId, &existing) == UA_STATUSCODE_GOOD) {
+            UA_Server_updateRole(server, &r);
+            UA_Role_clear(&existing);
+        } else {
+            UA_Server_addRole(server, &r, NULL);
+        }
+        UA_Role_clear(&r);
+    }
+
+    fclose(fp);
+    UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
+                "RBAC: Loaded persistent roles from disk successfully");
+}
+
+static void
+checkAndPersistRolesCallback(UA_Server *server, void *data) {
+    (void)data;
+    size_t roleNamesSize = 0;
+    UA_QualifiedName *roleNames = NULL;
+    
+    UA_StatusCode retval = UA_Server_getRoles(server, &roleNamesSize, &roleNames);
+    if(retval != UA_STATUSCODE_GOOD)
+        return;
+
+    UA_Role *roles = (UA_Role*)UA_calloc(roleNamesSize, sizeof(UA_Role));
+    if(!roles) {
+        UA_Array_delete(roleNames, roleNamesSize, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
+        return;
+    }
+
+    size_t rolesSize = 0;
+    for(size_t i = 0; i < roleNamesSize; i++) {
+        if(UA_Server_getRole(server, roleNames[i], &roles[rolesSize]) == UA_STATUSCODE_GOOD) {
+            rolesSize++;
+        }
+    }
+
+    const char *pkiDir = getenv("UA_PKI_DIR");
+    if(pkiDir && strlen(pkiDir) > 0) {
+        char filePath[512];
+        snprintf(filePath, sizeof(filePath), "%s/roles_persistent.bin", pkiDir);
+        
+        persistRolesToFile(filePath, roles, rolesSize);
+    }
+
+    for(size_t i = 0; i < rolesSize; i++) {
+        UA_Role_clear(&roles[i]);
+    }
+    UA_free(roles);
+    UA_Array_delete(roleNames, roleNamesSize, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
+}
+
+static void
+loadPersistentRolesOnBoot(UA_Server *server) {
+    const char *pkiDir = getenv("UA_PKI_DIR");
+    if(!pkiDir || strlen(pkiDir) == 0)
+        return;
+
+    char filePath[512];
+    snprintf(filePath, sizeof(filePath), "%s/roles_persistent.bin", pkiDir);
+    
+    loadPersistentRolesFromFile(server, filePath);
+}
+#endif
 
 static UA_StatusCode
 helloWorldMethodCallback(UA_Server *server,
@@ -127,6 +373,12 @@ int main(int argc, char* argv[]) {
     UA_StatusCode retval = 0;
 
     UA_Server *server = UA_Server_new();
+#ifdef UA_ENABLE_DRIVER_GDS_RECEIVER
+    UA_GDSReceiver *gds_receiver = UA_GDSReceiver_new();
+    if (gds_receiver) {
+        UA_Server_addDriver(server, &gds_receiver->drv);
+    }
+#endif
     UA_ServerConfig *config = UA_Server_getConfig(server);
 
 #ifdef UA_ENABLE_ENCRYPTION
@@ -153,9 +405,15 @@ int main(int argc, char* argv[]) {
     size_t trustListSize = 0;
     if(argc > 4)
         trustListSize = (size_t)argc-4;
-    UA_STACKARRAY(UA_ByteString, trustList, trustListSize+1);
+    UA_STACKARRAY(UA_ByteString, trustList, trustListSize+2);
     for(size_t i = 0; i < trustListSize; i++)
         trustList[i] = loadFile(argv[i+4]);
+
+    if(trustListSize == 0) {
+        /* Trust our own certificate by default to initialize the secureChannelPKI and sessionPKI */
+        UA_ByteString_copy(&certificate, &trustList[0]);
+        trustListSize = 1;
+    }
 
     /* Loading of an issuer list, not used in this application */
     size_t issuerListSize = 0;
@@ -165,11 +423,19 @@ int main(int argc, char* argv[]) {
     UA_ByteString *revocationList = NULL;
     size_t revocationListSize = 0;
 
-     retval = UA_ServerConfig_setDefaultWithSecurityPolicies(config, port,
-                                                       &certificate, &privateKey,
-                                                       trustList, trustListSize,
-                                                       issuerList, issuerListSize,
-                                                       revocationList, revocationListSize);
+    const char *pkiDir = getenv("UA_PKI_DIR");
+    if(pkiDir && strlen(pkiDir) > 0) {
+        UA_String storePath = UA_STRING((char*)(uintptr_t)pkiDir);
+        retval = UA_ServerConfig_setDefaultWithFilestore(config, port,
+                                                         &certificate, &privateKey,
+                                                         storePath);
+    } else {
+        retval = UA_ServerConfig_setDefaultWithSecurityPolicies(config, port,
+                                                          &certificate, &privateKey,
+                                                          trustList, trustListSize,
+                                                          issuerList, issuerListSize,
+                                                          revocationList, revocationListSize);
+    }
                                                            UA_ByteString_clear(&certificate);
     UA_ByteString_clear(&privateKey);
     for(size_t i = 0; i < trustListSize; i++)
@@ -186,6 +452,46 @@ int main(int argc, char* argv[]) {
     addHelloWorldMethod(server);
     addVariable(server);
     writeVariable(server);
+
+#ifdef UA_ENABLE_RBAC
+    /* 1. First, load any previously persisted roles and mapping rules from disk */
+    loadPersistentRolesOnBoot(server);
+
+    /* 2. Map user "peter" to the "SecurityAdmin" role for administrative GDS/RoleSet access if not already mapped */
+    UA_NodeId secAdminId = UA_NODEID_NUMERIC(0, UA_NS0ID_WELLKNOWNROLE_SECURITYADMIN);
+    UA_Role secAdmin;
+    if(UA_Server_getRoleById(server, secAdminId, &secAdmin) == UA_STATUSCODE_GOOD) {
+        UA_Boolean alreadyMapped = false;
+        UA_String targetUser = UA_STRING("peter");
+        for(size_t i = 0; i < secAdmin.identityMappingRulesSize; i++) {
+            if(secAdmin.identityMappingRules[i].criteriaType == UA_IDENTITYCRITERIATYPE_USERNAME &&
+               UA_String_equal(&secAdmin.identityMappingRules[i].criteria, &targetUser)) {
+                alreadyMapped = true;
+                break;
+            }
+        }
+        
+        if(!alreadyMapped) {
+            UA_IdentityMappingRuleType *rules = (UA_IdentityMappingRuleType *)
+                UA_realloc(secAdmin.identityMappingRules,
+                           (secAdmin.identityMappingRulesSize + 1) *
+                           sizeof(UA_IdentityMappingRuleType));
+            if(rules) {
+                secAdmin.identityMappingRules = rules;
+                UA_IdentityMappingRuleType_init(&rules[secAdmin.identityMappingRulesSize]);
+                rules[secAdmin.identityMappingRulesSize].criteriaType = UA_IDENTITYCRITERIATYPE_USERNAME;
+                rules[secAdmin.identityMappingRulesSize].criteria = UA_STRING_ALLOC("peter");
+                secAdmin.identityMappingRulesSize++;
+                UA_Server_updateRole(server, &secAdmin);
+            }
+        }
+        UA_Role_clear(&secAdmin);
+    }
+
+    /* 3. Register a repeated callback to check for dynamic runtime RoleSet/identity mapping changes and persist them to disk */
+    UA_UInt64 callbackId = 0;
+    UA_Server_addRepeatedCallback(server, checkAndPersistRolesCallback, NULL, 5000, &callbackId);
+#endif
 
     retval = UA_Server_runUntilInterrupt(server);
 

--- a/tools/certs/create_self-signed.py
+++ b/tools/certs/create_self-signed.py
@@ -56,6 +56,24 @@ parser.add_argument('--ecc-all',
                           "(plus an RSA certificate). Output names follow the "
                           "server_c_<curve> convention.")
 
+parser.add_argument('--hostname',
+                     type=str,
+                     default="",
+                     dest="hostname",
+                     help="Custom Hostname / DNS entry for the certificate SAN")
+
+parser.add_argument('--ipaddress1',
+                     type=str,
+                     default="",
+                     dest="ipaddress1",
+                     help="Custom IP address 1 for the certificate SAN")
+
+parser.add_argument('--ipaddress2',
+                     type=str,
+                     default="",
+                     dest="ipaddress2",
+                     help="Custom IP address 2 for the certificate SAN")
+
 args = parser.parse_args()
 
 if not os.path.exists(args.outdir):
@@ -117,6 +135,14 @@ if iteratorValue < 2:
     os.environ['IPADDRESS2'] = "127.0.0.1"
 
 os.environ['HOSTNAME'] = socket.gethostname()
+
+if args.hostname:
+    os.environ['HOSTNAME'] = args.hostname
+if args.ipaddress1:
+    os.environ['IPADDRESS1'] = args.ipaddress1
+if args.ipaddress2:
+    os.environ['IPADDRESS2'] = args.ipaddress2
+
 openssl_conf = os.path.join(certsdir, "localhost.cnf")
 
 os.chdir(os.path.abspath(args.outdir))

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Build Stage (1/2)
-FROM alpine:3.13.6 AS build
-RUN apk add --no-cache cmake gcc git g++ musl-dev mbedtls-dev python3 py3-pip make && rm -rf /var/cache/apk/*
+FROM alpine:3.20 AS build
+RUN apk add --no-cache cmake gcc git g++ musl-dev mbedtls-dev linux-headers python3 py3-pip make && rm -rf /var/cache/apk/*
 COPY . /opt/open62541
 
 # Get all the git tags to make sure we detect the correct version with git describe
@@ -19,43 +19,39 @@ RUN cmake -DBUILD_SHARED_LIBS=ON \
       -DUA_ENABLE_SUBSCRIPTIONS=ON \
       -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
       -DUA_NAMESPACE_ZERO=FULL \
+      -DUA_ENABLE_DRIVER_GDS_RECEIVER=ON \
+      -DUA_ENABLE_RBAC=ON \
       /opt/open62541 && \
     make -j && \
     make install
 WORKDIR /opt/open62541
 
-# Generate certificates
-RUN apk add --no-cache python3-dev linux-headers openssl && rm -rf /var/cache/apk/* && \
-    pip3 install --no-cache-dir netifaces==0.10.9 && \
-    mkdir -p /opt/open62541/pki/created && \
-    python3 /opt/open62541/tools/certs/create_self-signed.py /opt/open62541/pki/created
-
 
 # Final Stage (2/2)
-FROM alpine:3.13.6 AS server
+FROM alpine:3.20 AS server
 
-RUN apk add --no-cache mbedtls
+RUN apk add --no-cache mbedtls python3 py3-netifaces openssl
 RUN --mount=src=/,dst=/artifacts,from=build \
     mkdir -p /opt/open62541/pki \
-    && mkdir -p /usr/local/lib64/cmake/open62541 \
-    && mkdir -p /usr/local/lib64/pkgconfig \
-    && mkdir -p /usr/local/share/open62541/tools \
+    && mkdir -p /usr/local/lib/cmake/open62541 \
+    && mkdir -p /usr/local/lib/pkgconfig \
+    && mkdir -p /usr/local/share/open62541 \
     && mkdir -p /usr/local/include/open62541 \
     && mkdir -p /usr/local/bin \
-    && cp -r /artifacts/opt/open62541/pki/created /opt/open62541/pki/created \
     && cp -r /artifacts/opt/open62541/build/bin/examples /opt/open62541 \
-    && cp -r /artifacts/usr/local/lib64/libopen62541* /usr/local/lib64/ \
-    && cp -r /artifacts/usr/local/lib64/cmake/open62541/ /usr/local/lib64/cmake/open62541/ \
-    && cp -r /artifacts/usr/local/lib64/pkgconfig/open62541.pc /usr/local/lib64/pkgconfig/open62541.pc \
-    && cp -r /artifacts/usr/local/share/open62541/tools/certs /usr/local/share/open62541/tools/certs \
+    && cp -r /artifacts/usr/local/lib/libopen62541* /usr/local/lib/ \
+    && cp -r /artifacts/usr/local/lib/cmake/open62541/ /usr/local/lib/cmake/open62541/ \
+    && cp -r /artifacts/usr/local/lib/pkgconfig/open62541.pc /usr/local/lib/pkgconfig/open62541.pc \
+    && cp -r /artifacts/usr/local/share/open62541/certs /usr/local/share/open62541/certs \
     && cp -r /artifacts/usr/local/include/open62541/ /usr/local/include/open62541/ \
-    && cp /artifacts/usr/local/include/ms_stdint.h /usr/local/include/ms_stdint.h \
-    && cp /artifacts/usr/local/include/ziptree.h /usr/local/include/ziptree.h \
-    && cp /artifacts/usr/local/include/aa_tree.h /usr/local/include/aa_tree.h \
-    && cp /artifacts/usr/local/bin/ua_server_ctt.exe /usr/local/bin/ua_server_ctt.exe \
-    && cp /artifacts/usr/local/bin/ua_client /usr/local/bin/ua_client
+    && ln -s /opt/open62541/examples/client /usr/local/bin/ua_client \
+    && ln -s /opt/open62541/examples/ci_server /usr/local/bin/ua_server_ctt \
+    && ln -s /opt/open62541/examples/ci_server /opt/open62541/examples/server_ctt \
+    && cp /artifacts/opt/open62541/tools/docker/entrypoint.sh /entrypoint.sh \
+    && chmod +x /entrypoint.sh
 
-ENV LD_LIBRARY_PATH=/usr/local/lib64/
+ENV LD_LIBRARY_PATH=/usr/local/lib/
+ENV UA_PKI_DIR=/opt/open62541/pki
 
 EXPOSE 4840
-CMD ["/opt/open62541/examples/server_ctt" , "/opt/open62541/pki/created/server_cert.der", "/opt/open62541/pki/created/server_key.der", "--enableUnencrypted", "--enableAnonymous"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+CERT_DIR="/opt/open62541/pki/created"
+CERT_FILE="${CERT_DIR}/server.cert.der"
+KEY_FILE="${CERT_DIR}/server.key.der"
+
+# Ensure the output directory exists
+mkdir -p "${CERT_DIR}"
+
+if [ ! -f "${CERT_FILE}" ] || [ ! -f "${KEY_FILE}" ]; then
+    echo "No existing certificate or private key found. Provisioning a new self-signed certificate..."
+
+    # Use environment variables if provided, otherwise resolve defaults dynamically
+    RESOLVED_HOSTNAME="${CERT_HOSTNAME:-$(hostname)}"
+    # Resolve first non-loopback IP address
+    RESOLVED_IP1="${CERT_IP1:-$(hostname -i | awk '{print $1}')}"
+    RESOLVED_IP2="${CERT_IP2:-127.0.0.1}"
+    RESOLVED_URI="${CERT_URI:-urn:open62541.unconfigured.application}"
+
+    echo "Using certificate SAN options:"
+    echo "  - Hostname/DNS: ${RESOLVED_HOSTNAME}"
+    echo "  - IP 1: ${RESOLVED_IP1}"
+    echo "  - IP 2: ${RESOLVED_IP2}"
+    echo "  - URI: ${RESOLVED_URI}"
+
+    python3 /usr/local/share/open62541/certs/create_self-signed.py \
+        -u "${RESOLVED_URI}" \
+        --hostname "${RESOLVED_HOSTNAME}" \
+        --ipaddress1 "${RESOLVED_IP1}" \
+        --ipaddress2 "${RESOLVED_IP2}" \
+        "${CERT_DIR}"
+else
+    echo "Existing certificate and private key found. Skipping provisioning."
+fi
+
+# Detect if a GDS-pushed certificate and private key already exist in the persistent File PKI store
+GDS_OWN_CERT_DIR="/opt/open62541/pki/ApplCerts/own/certs"
+GDS_OWN_KEY_DIR="/opt/open62541/pki/ApplCerts/own/private"
+
+# If we find files inside the GDS 'own' folders, use them instead of the default self-signed certs!
+GDS_CERT=$(find "${GDS_OWN_CERT_DIR}" -type f -name "*.der" | head -n 1)
+GDS_KEY=$(find "${GDS_OWN_KEY_DIR}" -type f -name "*.der" | head -n 1)
+
+if [ -n "${GDS_CERT}" ] && [ -n "${GDS_KEY}" ] && [ -f "${GDS_CERT}" ] && [ -f "${GDS_KEY}" ]; then
+    echo "GDS-pushed persistent certificate and private key detected!"
+    echo "  - Loading active cert: ${GDS_CERT}"
+    echo "  - Loading active key:  ${GDS_KEY}"
+    ACTIVE_CERT_FILE="${GDS_CERT}"
+    ACTIVE_KEY_FILE="${GDS_KEY}"
+else
+    echo "No GDS-pushed certificate detected. Loading default self-signed certificate."
+    ACTIVE_CERT_FILE="${CERT_FILE}"
+    ACTIVE_KEY_FILE="${KEY_FILE}"
+fi
+
+# Execute the main application command (or fallback if empty)
+if [ "$#" -eq 0 ]; then
+    exec /opt/open62541/examples/ci_server "4840" "${ACTIVE_CERT_FILE}" "${ACTIVE_KEY_FILE}"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
### Description

This Pull Request modernizes the project's official Docker container to support standard-compliant Global Discovery Server (GDS) provisioning and Role-Based Access Control (RBAC). It introduces dynamic certificate SAN generation on startup, GDS-pushed certificate loading, and persistent RBAC role storage.

### Included Changes

1. **feat(sec)**: Support custom '--hostname', '--ipaddress1', and '--ipaddress2' arguments in 'create_self-signed.py'. This enables dynamic Subject Alternative Name (SAN) generation to support modern secure connections.
2. **build(docker)**: Modernize Docker image:
   - Upgraded Alpine base from '3.13' to '3.20' and fixed CMake library paths for Alpine ('/usr/local/lib').
   - Enabled '-DUA_ENABLE_DRIVER_GDS_RECEIVER=ON' and '-DUA_ENABLE_RBAC=ON' to build with GDS and RBAC support natively.
   - Introduced a clean 'entrypoint.sh' to dynamically provision certificates or load persistent GDS-pushed certificates from the file PKI store on container startup.
3. **feat(ex)**: Implemented robust binary role serialization and reload capabilities in 'examples/ci_server.c'. This ensures that any dynamically configured GDS/RBAC roles and access rules persist across container restarts.

### Conformity to Contribution Guidelines
- All changes adhere strictly to the project's C99 coding standards.
- No C++ comments ('//') or '{0}' initializations were introduced.
- Commits are split logically and named in strict accordance with the Angular Conventional Commits specification.