### PR TITLE
[Review] ci: add manual and path-filtered Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Build Docker Image
+
+on:
+  # Allows triggering the build manually from the Actions UI
+  workflow_dispatch:
+
+  # Automatically builds only when Docker or GDS files are modified,
+  # keeping the build time of other standard PRs completely unaffected.
+  pull_request:
+    paths:
+      - 'tools/docker/**'
+      - 'examples/ci_server.c'
+      - 'tools/certs/**'
+
+jobs:
+  build-docker:
+    name: Build open62541 Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: tools/docker/Dockerfile
+          tags: open62541/open62541:latest
+          push: false  # Only verify the build, do not push to registry
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
### Description

This Pull Request introduces a dedicated, path-filtered, and manual GitHub Actions workflow ('.github/workflows/docker.yml') to verify that the official open62541 Docker image compiles successfully.

### Key Features
1. **Manual Execution (workflow_dispatch)**: Allows repository maintainers to manually trigger a Docker build on any branch via the Actions UI.
2. **Selective Auto-trigger (pull_request path filtering)**: Automatically triggers a Docker image build ONLY when files under 'tools/docker/', 'tools/certs/', or the example server 'ci_server.c' are changed. It will **not** trigger on standard core PRs, maintaining 100% build efficiency.

### Empirical Demonstration of Broken State
Upon opening this PR, the newly added workflow will automatically trigger on the base code of 'master'. **It is expected to fail**, because the existing 'master' Dockerfile has unresolved Alpine 3.13 library path and build errors. 

This failure provides clear, objective proof to the community that the current master Docker configuration is broken.
Our corresponding PR #8325 (which contains the Dockerfile, GDS, and RBAC fixes) will include this exact workflow and show a successful green build, confirming the validity of those fixes.