### PR TITLE
fix(server/types): enable retaining of ServerLog object and honor optional fields in NodeSets 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,14 +131,6 @@ endif()
 
 if(UA_INFORMATION_MODEL_AUTOLOAD AND NOT UA_BUILD_FUZZING)
     set(UA_ENABLE_NODESET_INJECTOR ON)
-
-    # Detect whether any loaded companion spec requires the RoleSet node
-    set(UA_NODESET_INJECTOR_NEEDS_ROLESET OFF)
-    foreach(_model ${UA_INFORMATION_MODEL_AUTOLOAD})
-        if(_model STREQUAL "GDS" OR _model STREQUAL "Onboarding" OR _model STREQUAL "UAFX-Data")
-            set(UA_NODESET_INJECTOR_NEEDS_ROLESET ON)
-        endif()
-    endforeach()
 endif()
 
 set(MULTITHREADING_DEFAULT 0)
@@ -1801,13 +1793,6 @@ add_library(open62541::open62541 ALIAS open62541)
 target_compile_definitions(open62541-object PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
 target_compile_definitions(open62541-plugins PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
 target_compile_definitions(open62541 PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
-if(UA_NODESET_INJECTOR_NEEDS_ROLESET)
-    target_compile_definitions(open62541-object PRIVATE -DUA_NODESET_INJECTOR_NEEDS_ROLESET)
-endif()
-if(UA_NODESET_INJECTOR_NEEDS_SERVERLOG)
-    target_compile_definitions(open62541-object PRIVATE -DUA_NODESET_INJECTOR_NEEDS_SERVERLOG)
-endif()
-
 # Prevent Wincrypt override warning.
 if(UA_ENABLE_ENCRYPTION_LIBRESSL)
     target_compile_definitions(open62541-plugins PUBLIC NOCRYPT=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1804,6 +1804,9 @@ target_compile_definitions(open62541 PRIVATE -DUA_DYNAMIC_LINKING_EXPORT)
 if(UA_NODESET_INJECTOR_NEEDS_ROLESET)
     target_compile_definitions(open62541-object PRIVATE -DUA_NODESET_INJECTOR_NEEDS_ROLESET)
 endif()
+if(UA_NODESET_INJECTOR_NEEDS_SERVERLOG)
+    target_compile_definitions(open62541-object PRIVATE -DUA_NODESET_INJECTOR_NEEDS_SERVERLOG)
+endif()
 
 # Prevent Wincrypt override warning.
 if(UA_ENABLE_ENCRYPTION_LIBRESSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1504,6 +1504,7 @@ set(UA_NS0_NODESETS)
 if(UA_NAMESPACE_ZERO STREQUAL "FULL")
     # Use the "full" schema files also for datatypes and statuscodes
     set(UA_SCHEMA_DIR ${UA_NODESET_DIR}/Schema CACHE INTERNAL "")
+    set(UA_NS0_TYPES_XML ${UA_SCHEMA_DIR}/Opc.Ua.NodeSet2.xml)
 
     # Set the full ns0 nodeset
     list(APPEND UA_NS0_NODESETS Opc.Ua.NodeSet2.xml)
@@ -1602,6 +1603,7 @@ include(open62541Macros)
 # standard-defined data types
 ua_generate_datatypes(BUILTIN GEN_DOC NAME "types" TARGET_SUFFIX "types" NAMESPACE_IDX 0
                       FILE_CSV "${UA_NS0_NODEIDS}"
+                      FILE_XML "${UA_NS0_TYPES_XML}"
                       FILES_BSD "${UA_NS0_TYPES_BSD}"
                       FILES_SELECTED ${UA_NS0_DATATYPES})
 

--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -306,7 +306,9 @@ UA_Server_delete(UA_Server *server) {
     LIST_FOREACH_SAFE(current, &server->sessions, pointers, temp) {
         UA_Session_remove(server, &current->session, UA_SHUTDOWNREASON_CLOSE);
     }
-    UA_Array_delete(server->namespaces, server->namespacesSize, &UA_TYPES[UA_TYPES_STRING]);
+    UA_Array_delete(server->namespaces, server->namespacesSize,
+                    &UA_TYPES[UA_TYPES_STRING]);
+    UA_free(server->ns0CleanupSignatures);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /* Remove subscriptions without a session */
@@ -486,6 +488,8 @@ UA_Server_init(UA_Server *server) {
     res = initNS0_dataSources(server);
 #endif
     UA_CHECK_STATUS(res, goto cleanup);
+
+    snapshotNS0CleanupReferences(server);
 
 #ifdef UA_ENABLE_NODESET_INJECTOR
     res = UA_Server_injectNodesets(server);
@@ -1143,6 +1147,9 @@ UA_Server_run_startup(UA_Server *server) {
     UA_NodeId startTime =
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERSTATUS_STARTTIME);
     writeValueAttribute(server, startTime, &var);
+
+    /* Remove NS0 cleanup candidates that remain unused. */
+    removeUnusedNS0Nodes(server);
 
     /* Start all drivers */
     for(UA_Driver *drv = server->drivers; drv; drv = drv->next) {

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -103,6 +103,12 @@ typedef struct session_list_entry {
     UA_Session session;
 } session_list_entry;
 
+typedef struct {
+    UA_UInt64 hash;
+    size_t nodesSize;
+    size_t referencesSize;
+} UA_NS0ReferenceSignature;
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
 
 /* Internal accumulator marker. Reserved ModelChange verb bits must never be
@@ -172,6 +178,9 @@ struct UA_Server {
     /* Namespaces */
     size_t namespacesSize;
     UA_String *namespaces;
+
+    size_t ns0CleanupSignaturesSize;
+    UA_NS0ReferenceSignature *ns0CleanupSignatures;
 
     /* For bootstrapping, omit some consistency checks, creating a reference to
      * the parent and member instantiation */
@@ -1135,6 +1144,10 @@ UA_StatusCode initNS0(UA_Server *server);
 
 /* Connect data sources to existing NS0 nodes */
 UA_StatusCode initNS0_dataSources(UA_Server *server);
+
+void snapshotNS0CleanupReferences(UA_Server *server);
+
+void removeUnusedNS0Nodes(UA_Server *server);
 
 #ifdef UA_ENABLE_DIAGNOSTICS
 void createSessionObject(UA_Server *server, UA_Session *session);

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -971,7 +971,7 @@ initNS0(UA_Server *server) {
     return UA_STATUSCODE_GOOD;
 }
 
-/* Configure NS0 nodes: write values, delete unused nodes, add references.
+/* Configure NS0 nodes: write values and add references.
  * This is called after nodes are created (initNS0) or loaded from ROM.
  * Shared between initNS0() and initNS0_dataSources() to avoid duplication. */
 static UA_StatusCode
@@ -1025,22 +1025,6 @@ configureNS0(UA_Server *server) {
     UA_RedundancySupport redundancySupport = UA_REDUNDANCYSUPPORT_NONE;
     retVal |= writeNs0Variable(server, UA_NS0ID_SERVER_SERVERREDUNDANCY_REDUNDANCYSUPPORT,
                                &redundancySupport, &UA_TYPES[UA_TYPES_REDUNDANCYSUPPORT]);
-    /* Remove unused subtypes of ServerRedundancy */
-    deleteNode(server, UA_NS0ID(SERVER_SERVERREDUNDANCY_CURRENTSERVERID), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERREDUNDANCY_REDUNDANTSERVERARRAY), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERREDUNDANCY_SERVERURIARRAY), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERREDUNDANCY_SERVERNETWORKGROUPS), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_CONFORMANCEUNITS), true);
-    deleteNode(server, UA_NS0ID(SERVER_URISVERSION), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_CONFORMANCEUNITS), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXMONITOREDITEMS), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXMONITOREDITEMSPERSUBSCRIPTION), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXSELECTCLAUSEPARAMETERS), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXSESSIONS), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXSUBSCRIPTIONS), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXSUBSCRIPTIONSPERSESSION), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXWHERECLAUSEPARAMETERS), true);
-
     /* ServerCapabilities - LocaleIdArray */
     UA_LocaleId locale_en = UA_STRING("en");
     retVal |= writeNs0VariableArray(server, UA_NS0ID_SERVER_SERVERCAPABILITIES_LOCALEIDARRAY,
@@ -1075,62 +1059,6 @@ configureNS0(UA_Server *server) {
     retVal |= writeNs0Variable(server, UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXHISTORYCONTINUATIONPOINTS,
                                &maxHistoryContinuationPoints, &UA_TYPES[UA_TYPES_UINT16]);
 
-    /* Remove unused operation limit components */
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYREADDATA), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYREADEVENTS), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYUPDATEDATA), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYUPDATEEVENTS), true);
-#if !defined(UA_NODESET_INJECTOR_NEEDS_ROLESET) && !defined(UA_ENABLE_RBAC)
-    /* With RBAC the RoleSet with the well-known Role Objects and their
-     * standard NodeIds (Part 18 v1.05 §4.3) is kept; initNS0RBAC only fills
-     * the gaps and connects the data sources. */
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_ROLESET), true);
-#endif
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXSTRINGLENGTH), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXARRAYLENGTH), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERCAPABILITIES_MAXBYTESTRINGLENGTH), true);
-
-    /* Remove not supported server configurations */
-    deleteNode(server, UA_NS0ID(SERVER_ESTIMATEDRETURNTIME), true);
-    deleteNode(server, UA_NS0ID(SERVER_LOCALTIME), true);
-    deleteNode(server, UA_NS0ID(SERVER_REQUESTSERVERSTATECHANGE), true);
-    deleteNode(server, UA_NS0ID(SERVER_SETSUBSCRIPTIONDURABLE), true);
-    deleteNode(server, UA_NS0ID(SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTHTTPSGROUP), true);
-#if defined(UA_NS0ID_SERVERLOG) && !defined(UA_NODESET_INJECTOR_NEEDS_SERVERLOG)
-    deleteNode(server, UA_NS0ID(SERVERLOG), true);
-#endif
-#ifdef UA_NS0ID_LLDP
-    deleteNode(server, UA_NS0ID(LLDP), true);
-#endif
-    deleteNode(server, UA_NS0ID(PROVISIONABLEDEVICE), true);
-    deleteNode(server, UA_NS0ID(USERMANAGEMENT), true);
-    deleteNode(server, UA_NS0ID(SERVERCONFIGURATION_TRANSACTIONDIAGNOSTICS), true);
-#ifdef UA_NS0ID_SERVERCONFIGURATION_CONFIGURATIONFILE
-    deleteNode(server, UA_NS0ID(SERVERCONFIGURATION_CONFIGURATIONFILE), true);
-#endif
-#ifndef UA_ENABLE_DRIVER_GDS_RECEIVER
-    deleteNode(server, UA_NS0ID(SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTAPPLICATIONGROUP), true);
-    deleteNode(server, UA_NS0ID(SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTUSERTOKENGROUP), true);
-#endif
-
-#ifndef UA_ENABLE_DIAGNOSTICS
-    /* Removing these NodeIds make Server Object to be non-complaint with UA
-     * 1.03 in CTT (Base Inforamtion/Base Info Core Structure/ 001.js) In the
-     * 1.04 specification this has been resolved by allowing to remove these
-     * static nodes as well */
-    deleteNode(server, UA_NS0ID(SERVER_SERVERDIAGNOSTICS_SESSIONSDIAGNOSTICSSUMMARY), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERDIAGNOSTICS_SERVERDIAGNOSTICSSUMMARY), true);
-    deleteNode(server, UA_NS0ID(SERVER_SERVERDIAGNOSTICS_SUBSCRIPTIONDIAGNOSTICSARRAY), true);
-#endif
-
-    /* The sampling diagnostics array is optional
-     * TODO: Add support for this diagnostics */
-    deleteNode(server, UA_NS0ID(SERVER_SERVERDIAGNOSTICS_SAMPLINGINTERVALDIAGNOSTICSARRAY), true);
-
-#ifndef UA_ENABLE_PUBSUB
-    deleteNode(server, UA_NS0ID(PUBLISHSUBSCRIBE), true);
-#endif
-
     /* ServerConfiguration - MulticastDnsEnabled */
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
     retVal |= writeNs0Variable(server, UA_NS0ID_SERVERCONFIGURATION_MULTICASTDNSENABLED,
@@ -1157,12 +1085,7 @@ configureNS0(UA_Server *server) {
                                    &UA_TYPES[UA_TYPES_ACCESSRESTRICTIONTYPE]);
     }
 #endif
-#ifndef UA_ENABLE_HISTORIZING
-    deleteNode(server, UA_NS0ID(HISTORYSERVERCAPABILITIES), true);
-#ifdef UA_NS0ID_DEFAULTHACONFIGURATION
-    deleteNode(server, UA_NS0ID(DEFAULTHACONFIGURATION), true);
-#endif
-#else
+#ifdef UA_ENABLE_HISTORIZING
     /* ServerCapabilities - HistoryServerCapabilities - AccessHistoryDataCapability */
     retVal |= writeNs0Variable(server, UA_NS0ID_HISTORYSERVERCAPABILITIES_ACCESSHISTORYDATACAPABILITY,
                                &server->config.accessHistoryDataCapability, &UA_TYPES[UA_TYPES_BOOLEAN]);
@@ -1388,20 +1311,314 @@ connectNS0_dataSources(UA_Server *server) {
     return retVal;
 }
 
+#ifdef UA_GENERATED_NAMESPACE_ZERO
+
+static UA_Boolean
+variableNodeHasCallbacks(const UA_VariableNode *node) {
+    if(node->valueSourceType == UA_VALUESOURCETYPE_CALLBACK)
+        return (node->valueSource.callback.read != NULL ||
+                node->valueSource.callback.write != NULL);
+
+    const UA_ValueSourceNotifications *notifications =
+        (node->valueSourceType == UA_VALUESOURCETYPE_EXTERNAL) ?
+        &node->valueSource.external.notifications :
+        &node->valueSource.internal.notifications;
+    return (notifications->onRead != NULL || notifications->onWrite != NULL);
+}
+
+static UA_Boolean
+nodeHasRuntimeConfiguration(const UA_Node *node) {
+    if(node->head.context != NULL)
+        return true;
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    if(node->head.monitoredItems != NULL)
+        return true;
+#endif
+
+    if(node->head.nodeClass == UA_NODECLASS_METHOD)
+        return node->methodNode.method != NULL;
+    if(node->head.nodeClass == UA_NODECLASS_VARIABLE)
+        return variableNodeHasCallbacks(&node->variableNode);
+    return false;
+}
+
+typedef struct {
+    UA_NS0ReferenceSignature *signature;
+    UA_UInt32 sourceHash;
+    UA_Byte referenceTypeIndex;
+    UA_Boolean isInverse;
+} NS0ReferenceSignatureContext;
+
+static UA_UInt64
+mixReferenceHash(UA_UInt64 value) {
+    value ^= value >> 30;
+    value *= 0xbf58476d1ce4e5b9ULL;
+    value ^= value >> 27;
+    value *= 0x94d049bb133111ebULL;
+    return value ^ (value >> 31);
+}
+
+static void *
+addReferenceToSignature(void *context, UA_ReferenceTarget *target) {
+    NS0ReferenceSignatureContext *ctx =
+        (NS0ReferenceSignatureContext*)context;
+    UA_ExpandedNodeId targetId =
+        UA_NodePointer_toExpandedNodeId(target->targetId);
+    UA_UInt64 value = ((UA_UInt64)ctx->sourceHash << 32) |
+        UA_ExpandedNodeId_hash(&targetId);
+    value ^= ((UA_UInt64)ctx->referenceTypeIndex << 1);
+    value ^= ctx->isInverse;
+    ctx->signature->hash += mixReferenceHash(value);
+    ctx->signature->referencesSize++;
+    return NULL;
+}
+
+static UA_StatusCode
+inspectNS0Hierarchy(UA_Server *server, UA_UInt32 nodeId,
+                    UA_NS0ReferenceSignature *signature,
+                    UA_Boolean *configured) {
+    *signature = (UA_NS0ReferenceSignature){0};
+    *configured = false;
+
+    UA_NodeId rootId = UA_NODEID_NUMERIC(0, nodeId);
+    const UA_Node *root = UA_NODESTORE_GET(server, &rootId);
+    if(!root)
+        return UA_STATUSCODE_GOOD;
+    UA_NODESTORE_RELEASE(server, root);
+
+    UA_ReferenceTypeSet hierarchicalRefs;
+    UA_NodeId hierarchicalReferences = UA_NS0ID(HIERARCHICALREFERENCES);
+    UA_StatusCode res =
+        referenceTypeIndices(server, &hierarchicalReferences,
+                             &hierarchicalRefs, true);
+    if(res != UA_STATUSCODE_GOOD)
+        return res;
+
+    size_t nodesSize = 0;
+    UA_ExpandedNodeId *nodes = NULL;
+    res = browseRecursive(server, 1, &rootId, UA_BROWSEDIRECTION_FORWARD,
+                          &hierarchicalRefs, 0, true, &nodesSize, &nodes);
+    if(res != UA_STATUSCODE_GOOD)
+        return res;
+
+    signature->nodesSize = nodesSize;
+    for(size_t i = 0; i < nodesSize; i++) {
+        if(!UA_ExpandedNodeId_isLocal(&nodes[i]))
+            continue;
+
+        const UA_Node *node = UA_NODESTORE_GET(server, &nodes[i].nodeId);
+        if(!node) {
+            res = UA_STATUSCODE_BADNODEIDUNKNOWN;
+            break;
+        }
+
+        *configured |= nodeHasRuntimeConfiguration(node);
+        for(size_t j = 0; j < node->head.referencesSize; j++) {
+            UA_NodeReferenceKind *reference = &node->head.references[j];
+            NS0ReferenceSignatureContext ctx = {
+                signature, UA_NodeId_hash(&node->head.nodeId),
+                reference->referenceTypeIndex, reference->isInverse};
+            UA_NodeReferenceKind_iterate(reference, addReferenceToSignature,
+                                         &ctx);
+        }
+        UA_NODESTORE_RELEASE(server, node);
+    }
+
+    UA_Array_delete(nodes, nodesSize, &UA_TYPES[UA_TYPES_EXPANDEDNODEID]);
+    return res;
+}
+
+static UA_Boolean
+ns0NodeIsUsed(UA_Server *server, size_t candidateIndex, UA_UInt32 nodeId) {
+    /* Keep a candidate if its hierarchy gained or lost a reference after NS0
+     * initialization. Runtime callbacks, contexts, and MonitoredItems also
+     * indicate use. Inspection errors retain the candidate. */
+    if(candidateIndex >= server->ns0CleanupSignaturesSize)
+        return true;
+
+    UA_NS0ReferenceSignature signature;
+    UA_Boolean configured;
+    UA_StatusCode res =
+        inspectNS0Hierarchy(server, nodeId, &signature, &configured);
+    if(res != UA_STATUSCODE_GOOD || configured)
+        return true;
+
+    UA_NS0ReferenceSignature *baseline =
+        &server->ns0CleanupSignatures[candidateIndex];
+    return (signature.hash != baseline->hash ||
+            signature.nodesSize != baseline->nodesSize ||
+            signature.referencesSize != baseline->referencesSize);
+}
+
+static const UA_UInt32 *
+ns0CleanupCandidates(size_t *size) {
+    static const UA_UInt32 candidates[] = {
+        /* Unused subtypes of ServerRedundancy */
+        UA_NS0ID_SERVER_SERVERREDUNDANCY_CURRENTSERVERID,
+        UA_NS0ID_SERVER_SERVERREDUNDANCY_REDUNDANTSERVERARRAY,
+        UA_NS0ID_SERVER_SERVERREDUNDANCY_SERVERURIARRAY,
+        UA_NS0ID_SERVER_SERVERREDUNDANCY_SERVERNETWORKGROUPS,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_CONFORMANCEUNITS,
+        UA_NS0ID_SERVER_URISVERSION,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXMONITOREDITEMS,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXMONITOREDITEMSPERSUBSCRIPTION,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXSELECTCLAUSEPARAMETERS,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXSESSIONS,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXSUBSCRIPTIONS,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXSUBSCRIPTIONSPERSESSION,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXWHERECLAUSEPARAMETERS,
+
+        /* Unused operation limit components */
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYREADDATA,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYREADEVENTS,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYUPDATEDATA,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_OPERATIONLIMITS_MAXNODESPERHISTORYUPDATEEVENTS,
+#ifndef UA_ENABLE_RBAC
+        /* With RBAC the RoleSet with the well-known Role Objects and their
+         * standard NodeIds (Part 18 v1.05 §4.3) is kept; initNS0RBAC fills
+         * the gaps and connects the data sources. */
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_ROLESET,
+#endif
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXSTRINGLENGTH,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXARRAYLENGTH,
+        UA_NS0ID_SERVER_SERVERCAPABILITIES_MAXBYTESTRINGLENGTH,
+
+        /* Unsupported server configurations */
+        UA_NS0ID_SERVER_ESTIMATEDRETURNTIME,
+        UA_NS0ID_SERVER_LOCALTIME,
+        UA_NS0ID_SERVER_REQUESTSERVERSTATECHANGE,
+        UA_NS0ID_SERVER_SETSUBSCRIPTIONDURABLE,
+        UA_NS0ID_SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTHTTPSGROUP,
+#ifdef UA_NS0ID_LLDP
+        UA_NS0ID_LLDP,
+#endif
+        UA_NS0ID_PROVISIONABLEDEVICE,
+        UA_NS0ID_USERMANAGEMENT,
+        UA_NS0ID_SERVERCONFIGURATION_TRANSACTIONDIAGNOSTICS,
+#ifdef UA_NS0ID_SERVERCONFIGURATION_CONFIGURATIONFILE
+        UA_NS0ID_SERVERCONFIGURATION_CONFIGURATIONFILE,
+#endif
+#ifndef UA_ENABLE_DRIVER_GDS_RECEIVER
+        UA_NS0ID_SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTAPPLICATIONGROUP,
+        UA_NS0ID_SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTUSERTOKENGROUP,
+#endif
+
+#ifndef UA_ENABLE_DIAGNOSTICS
+        /* OPC UA 1.04 allows these static diagnostics nodes to be omitted. */
+        UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SESSIONSDIAGNOSTICSSUMMARY,
+        UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SERVERDIAGNOSTICSSUMMARY,
+        UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SUBSCRIPTIONDIAGNOSTICSARRAY,
+#endif
+
+        /* The sampling diagnostics array is optional and unsupported. */
+        UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SAMPLINGINTERVALDIAGNOSTICSARRAY,
+
+#ifndef UA_ENABLE_PUBSUB
+        UA_NS0ID_PUBLISHSUBSCRIBE,
+#endif
+
+#ifndef UA_ENABLE_HISTORIZING
+        UA_NS0ID_HISTORYSERVERCAPABILITIES,
+#ifdef UA_NS0ID_DEFAULTHACONFIGURATION
+        UA_NS0ID_DEFAULTHACONFIGURATION,
+#endif
+#endif
+
+#ifdef UA_NS0ID_SERVERLOG
+        UA_NS0ID_SERVERLOG,
+#endif
+    };
+
+    *size = sizeof(candidates) / sizeof(candidates[0]);
+    return candidates;
+}
+
+#endif
+
+void
+snapshotNS0CleanupReferences(UA_Server *server) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+#ifdef UA_GENERATED_NAMESPACE_ZERO
+    size_t candidatesSize = 0;
+    const UA_UInt32 *candidates = ns0CleanupCandidates(&candidatesSize);
+    UA_NS0ReferenceSignature *signatures = (UA_NS0ReferenceSignature*)
+        UA_calloc(candidatesSize, sizeof(UA_NS0ReferenceSignature));
+    if(!signatures) {
+        UA_LOG_WARNING(server->config.logging, UA_LOGCATEGORY_SERVER,
+                       "Could not allocate NS0 cleanup state. "
+                       "Unused nodes will be retained");
+        return;
+    }
+
+    for(size_t i = 0; i < candidatesSize; i++) {
+        UA_Boolean configured;
+        UA_StatusCode res =
+            inspectNS0Hierarchy(server, candidates[i], &signatures[i],
+                                &configured);
+        if(res != UA_STATUSCODE_GOOD) {
+            UA_LOG_WARNING(server->config.logging, UA_LOGCATEGORY_SERVER,
+                           "Could not inspect NS0 cleanup candidates with %s. "
+                           "Unused nodes will be retained",
+                           UA_StatusCode_name(res));
+            UA_free(signatures);
+            return;
+        }
+    }
+
+    server->ns0CleanupSignatures = signatures;
+    server->ns0CleanupSignaturesSize = candidatesSize;
+#endif
+}
+
+void
+removeUnusedNS0Nodes(UA_Server *server) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+
+#ifdef UA_GENERATED_NAMESPACE_ZERO
+    size_t candidatesSize = 0;
+    const UA_UInt32 *candidates = ns0CleanupCandidates(&candidatesSize);
+    if(server->ns0CleanupSignaturesSize == candidatesSize) {
+        UA_Boolean *used =
+            (UA_Boolean*)UA_calloc(candidatesSize, sizeof(UA_Boolean));
+        if(used) {
+            /* Inspect every candidate before deletion changes the references
+             * of another candidate. */
+            for(size_t i = 0; i < candidatesSize; i++)
+                used[i] = ns0NodeIsUsed(server, i, candidates[i]);
+            for(size_t i = 0; i < candidatesSize; i++) {
+                if(!used[i])
+                    deleteNode(server, UA_NODEID_NUMERIC(0, candidates[i]),
+                               true);
+            }
+            UA_free(used);
+        } else {
+            UA_LOG_WARNING(server->config.logging, UA_LOGCATEGORY_SERVER,
+                           "Could not allocate NS0 cleanup state. "
+                           "Unused nodes will be retained");
+        }
+    }
+
+    UA_free(server->ns0CleanupSignatures);
+    server->ns0CleanupSignatures = NULL;
+    server->ns0CleanupSignaturesSize = 0;
+#endif
+}
+
 /* Public function for external nodestores (e.g., ROM nodestore) that have
  * NS0 pre-loaded and only need to connect the dynamic data sources and
- * configure values/deletions. */
+ * configure values. */
 UA_StatusCode
 initNS0_dataSources(UA_Server *server) {
     UA_LOCK_ASSERT(&server->serviceMutex);
 
     UA_LOG_INFO(server->config.logging, UA_LOGCATEGORY_SERVER,
-                "Configuring pre-loaded NS0 nodes (data sources, values, deletions)");
+                "Configuring pre-loaded NS0 nodes (data sources and values)");
 
     /* Connect all data source callbacks (shared with initNS0) */
     UA_StatusCode retVal = connectNS0_dataSources(server);
 
-    /* Configure NS0: write values, delete unused nodes, add references */
+    /* Configure NS0 values and references */
     retVal |= configureNS0(server);
 
     if(retVal != UA_STATUSCODE_GOOD) {

--- a/src/server/ua_server_ns0.c
+++ b/src/server/ua_server_ns0.c
@@ -1096,7 +1096,7 @@ configureNS0(UA_Server *server) {
     deleteNode(server, UA_NS0ID(SERVER_REQUESTSERVERSTATECHANGE), true);
     deleteNode(server, UA_NS0ID(SERVER_SETSUBSCRIPTIONDURABLE), true);
     deleteNode(server, UA_NS0ID(SERVERCONFIGURATION_CERTIFICATEGROUPS_DEFAULTHTTPSGROUP), true);
-#ifdef UA_NS0ID_SERVERLOG
+#if defined(UA_NS0ID_SERVERLOG) && !defined(UA_NODESET_INJECTOR_NEEDS_SERVERLOG)
     deleteNode(server, UA_NS0ID(SERVERLOG), true);
 #endif
 #ifdef UA_NS0ID_LLDP

--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -133,3 +133,6 @@ add_test(NAME test_generate_datatypes_cross_ns
 add_test(NAME test_generate_datatypes_symbolic_names
          COMMAND "${Python3_EXECUTABLE}"
                  "${CMAKE_CURRENT_SOURCE_DIR}/test_symbolic_names.py")
+add_test(NAME test_generate_datatypes_optional_fields
+         COMMAND "${Python3_EXECUTABLE}"
+                 "${CMAKE_CURRENT_SOURCE_DIR}/test_optional_fields.py")

--- a/tests/nodeset-compiler/test_optional_fields.py
+++ b/tests/nodeset-compiler/test_optional_fields.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GENERATOR = os.path.join(HERE, "..", "..", "tools", "generate_datatypes.py")
+
+BSD = """<?xml version="1.0" encoding="utf-8"?>
+<opc:TypeDictionary
+  xmlns:opc="http://opcfoundation.org/BinarySchema/"
+  xmlns:ua="http://opcfoundation.org/UA/"
+  xmlns:tns="urn:open62541:test"
+  TargetNamespace="urn:open62541:test">
+  <opc:StructuredType Name="OptionalStructure" BaseType="ua:ExtensionObject">
+    <opc:Field Name="Required" TypeName="opc:UInt32" />
+    <opc:Field Name="Optional" TypeName="opc:String" />
+  </opc:StructuredType>
+</opc:TypeDictionary>
+"""
+
+NODESET = """<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>urn:open62541:test</Uri>
+  </NamespaceUris>
+  <UADataType NodeId="ns=1;i=1" BrowseName="1:OptionalStructure">
+    <Definition Name="OptionalStructure">
+      <Field Name="Required" DataType="i=7" />
+      <Field Name="Optional" DataType="i=12" IsOptional="true" />
+    </Definition>
+  </UADataType>
+</UANodeSet>
+"""
+
+CSV = """OptionalStructure,1,DataType
+OptionalStructure_Encoding_DefaultBinary,2,Object
+"""
+
+
+def write(path, content):
+    with open(path, "w", encoding="utf-8") as output:
+        output.write(content)
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bsd = os.path.join(tmpdir, "types.bsd")
+        nodeset = os.path.join(tmpdir, "nodeset.xml")
+        csv = os.path.join(tmpdir, "nodeids.csv")
+        output = os.path.join(tmpdir, "types_test")
+        write(bsd, BSD)
+        write(nodeset, NODESET)
+        write(csv, CSV)
+
+        command = [
+            sys.executable,
+            GENERATOR,
+            f"--type-bsd={bsd}",
+            f"--type-csv={csv}",
+            f"--xml={nodeset}",
+            "--no-builtin",
+            output,
+        ]
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr)
+            return 1
+
+        with open(output + "_generated.h", encoding="utf-8") as generated:
+            header = generated.read()
+        with open(output + "_generated.c", encoding="utf-8") as generated:
+            source = generated.read()
+
+        expected = {
+            "optional member pointer": "UA_String *optional;" in header,
+            "optional structure kind": "UA_DATATYPEKIND_OPTSTRUCT" in source,
+            "optional member metadata": "true  /* .isOptional */" in source,
+        }
+        failures = [name for name, present in expected.items() if not present]
+        for failure in failures:
+            print(f"FAIL: generated output lacks {failure}")
+        return len(failures)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/server/check_server.c
+++ b/tests/server/check_server.c
@@ -147,6 +147,148 @@ START_TEST(checkGetLifecycleState) {
     ck_assert_int_eq(state, UA_LIFECYCLESTATE_STOPPED);
 } END_TEST
 
+#ifdef UA_NS0ID_SERVERLOG
+
+static UA_StatusCode
+serverLogMethod(UA_Server *server_, const UA_NodeId *sessionId,
+                void *sessionContext, const UA_NodeId *methodId,
+                void *methodContext, const UA_NodeId *objectId,
+                void *objectContext, size_t inputSize, const UA_Variant *input,
+                size_t outputSize, UA_Variant *output) {
+    return UA_STATUSCODE_GOOD;
+}
+
+START_TEST(checkUnusedServerLogRemovedOnStartup) {
+    UA_NodeId serverLog = UA_NS0ID(SERVERLOG);
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, serverLog, &nodeClass),
+                      UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, serverLog, &nodeClass),
+                      UA_STATUSCODE_BADNODEIDUNKNOWN);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+START_TEST(checkConfiguredServerLogRetainedOnStartup) {
+    UA_NodeId getRecords = UA_NS0ID(SERVERLOG_GETRECORDS);
+    ck_assert_uint_eq(UA_Server_setMethodNodeCallback(server, getRecords,
+                                                     serverLogMethod),
+                      UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, UA_NS0ID(SERVERLOG),
+                                             &nodeClass),
+                      UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+START_TEST(checkReferencedServerLogRetainedOnStartup) {
+    ck_assert_uint_eq(
+        UA_Server_addReference(server, UA_NS0ID(OBJECTSFOLDER),
+                               UA_NS0ID(ORGANIZES),
+                               UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_SERVERLOG),
+                               true),
+        UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, UA_NS0ID(SERVERLOG),
+                                             &nodeClass),
+                      UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+#endif
+
+#ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+
+START_TEST(checkUnusedNs0NodeRemovedOnStartup) {
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, UA_NS0ID(SERVER_LOCALTIME),
+                                             &nodeClass),
+                      UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, UA_NS0ID(SERVER_LOCALTIME),
+                                             &nodeClass),
+                      UA_STATUSCODE_BADNODEIDUNKNOWN);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+START_TEST(checkConfiguredNs0NodeRetainedOnStartup) {
+    UA_UInt32 context = 0;
+    ck_assert_uint_eq(UA_Server_setNodeContext(server, UA_NS0ID(SERVER_LOCALTIME),
+                                              &context),
+                      UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, UA_NS0ID(SERVER_LOCALTIME),
+                                             &nodeClass),
+                      UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+START_TEST(checkReferencedNs0NodeRetainedOnStartup) {
+    ck_assert_uint_eq(
+        UA_Server_addReference(server, UA_NS0ID(OBJECTSFOLDER),
+                               UA_NS0ID(ORGANIZES),
+                               UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_SERVER_LOCALTIME),
+                               true),
+        UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(UA_Server_readNodeClass(server, UA_NS0ID(SERVER_LOCALTIME),
+                                             &nodeClass),
+                      UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+START_TEST(checkUnusedRoleSetRemovedOnStartup) {
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(
+        UA_Server_readNodeClass(server,
+                                UA_NS0ID(SERVER_SERVERCAPABILITIES_ROLESET),
+                                &nodeClass),
+        UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(
+        UA_Server_readNodeClass(server,
+                                UA_NS0ID(SERVER_SERVERCAPABILITIES_ROLESET),
+                                &nodeClass),
+        UA_STATUSCODE_BADNODEIDUNKNOWN);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+START_TEST(checkCompanionNodeRetainsRoleSetOnStartup) {
+    UA_UInt16 ns = UA_Server_addNamespace(server, "urn:open62541:test");
+    UA_ObjectAttributes attributes = UA_ObjectAttributes_default;
+    attributes.displayName = UA_LOCALIZEDTEXT("", "CustomRole");
+    ck_assert_uint_eq(
+        UA_Server_addObjectNode(server, UA_NODEID_NUMERIC(ns, 1),
+                                UA_NS0ID(SERVER_SERVERCAPABILITIES_ROLESET),
+                                UA_NS0ID(HASCOMPONENT),
+                                UA_QUALIFIEDNAME(ns, "CustomRole"),
+                                UA_NS0ID(BASEOBJECTTYPE), attributes,
+                                NULL, NULL),
+        UA_STATUSCODE_GOOD);
+
+    ck_assert_uint_eq(UA_Server_run_startup(server), UA_STATUSCODE_GOOD);
+    UA_NodeClass nodeClass;
+    ck_assert_uint_eq(
+        UA_Server_readNodeClass(server,
+                                UA_NS0ID(SERVER_SERVERCAPABILITIES_ROLESET),
+                                &nodeClass),
+        UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+} END_TEST
+
+#endif
+
 /* ---- Additional coverage tests ---- */
 
 START_TEST(checkGetDataTypes) {
@@ -699,6 +841,18 @@ int main(void) {
     tcase_add_test(tc_call, checkServer_run);
     tcase_add_test(tc_call, checkGetStatistics);
     tcase_add_test(tc_call, checkGetLifecycleState);
+#ifdef UA_NS0ID_SERVERLOG
+    tcase_add_test(tc_call, checkUnusedServerLogRemovedOnStartup);
+    tcase_add_test(tc_call, checkConfiguredServerLogRetainedOnStartup);
+    tcase_add_test(tc_call, checkReferencedServerLogRetainedOnStartup);
+#endif
+#ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+    tcase_add_test(tc_call, checkUnusedNs0NodeRemovedOnStartup);
+    tcase_add_test(tc_call, checkConfiguredNs0NodeRetainedOnStartup);
+    tcase_add_test(tc_call, checkReferencedNs0NodeRetainedOnStartup);
+    tcase_add_test(tc_call, checkUnusedRoleSetRemovedOnStartup);
+    tcase_add_test(tc_call, checkCompanionNodeRetainsRoleSetOnStartup);
+#endif
     suite_add_tcase(s, tc_call);
 
     TCase *tc_ext = tcase_create("server - extended");

--- a/tests/server/check_server_ns0_diagnostics.c
+++ b/tests/server/check_server_ns0_diagnostics.c
@@ -456,7 +456,11 @@ START_TEST(read_samplingIntervalDiagnosticsArray) {
     UA_StatusCode res = readNodeValue(
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SAMPLINGINTERVALDIAGNOSTICSARRAY), &out);
     if(res == UA_STATUSCODE_GOOD) {
-        ck_assert(out.type == &UA_TYPES[UA_TYPES_SAMPLINGINTERVALDIAGNOSTICSDATATYPE]);
+        /* Before startup, an unconfigured generated node can still contain an
+         * empty variant. */
+        ck_assert(UA_Variant_hasArrayType(
+                      &out, &UA_TYPES[UA_TYPES_SAMPLINGINTERVALDIAGNOSTICSDATATYPE]) ||
+                  UA_Variant_isEmpty(&out));
         ck_assert_uint_eq(out.arrayLength, 0);
     }
     UA_Variant_clear(&out);
@@ -603,8 +607,11 @@ START_TEST(diagnostics_samplingInterval) {
     UA_StatusCode res = readNodeValue(
         UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_SERVERDIAGNOSTICS_SAMPLINGINTERVALDIAGNOSTICSARRAY), &out);
     if(res == UA_STATUSCODE_GOOD) {
-        /* If present, should be an array of SamplingIntervalDiagnosticsDataType */
-        ck_assert(out.type == &UA_TYPES[UA_TYPES_SAMPLINGINTERVALDIAGNOSTICSDATATYPE]);
+        /* Before startup, an unconfigured generated node can still contain an
+         * empty variant. */
+        ck_assert(UA_Variant_hasArrayType(
+                      &out, &UA_TYPES[UA_TYPES_SAMPLINGINTERVALDIAGNOSTICSDATATYPE]) ||
+                  UA_Variant_isEmpty(&out));
         ck_assert_uint_eq(out.arrayLength, 0);
     }
     UA_Variant_clear(&out);

--- a/tests/server/check_services_call.c
+++ b/tests/server/check_services_call.c
@@ -92,13 +92,13 @@ START_TEST(callKnownMethodOnUnknownObject) {
 
     UA_CallMethodRequest callMethodRequest;
     UA_CallMethodRequest_init(&callMethodRequest);
-    callMethodRequest.methodId = UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER_REQUESTSERVERSTATECHANGE);
+    callMethodRequest.methodId = UA_NODEID_STRING(1, "nofunctionpointer");
     callMethodRequest.objectId = UA_NODEID_NUMERIC(0, UA_NS0ID_UNKNOWN_OBJECT);
 
     UA_CallMethodResult result;
     UA_CallMethodResult_init(&result);
     result = UA_Server_call(server, &callMethodRequest);
-    ck_assert_int_eq(result.statusCode, UA_STATUSCODE_BADMETHODINVALID);
+    ck_assert_int_eq(result.statusCode, UA_STATUSCODE_BADNODEIDUNKNOWN);
 } END_TEST
 
 START_TEST(callMethodAndObjectExistsButMethodHasWrongNodeClass) {

--- a/tools/nodeset_compiler/type_parser.py
+++ b/tools/nodeset_compiler/type_parser.py
@@ -437,12 +437,37 @@ class CSVBSDTypeParser(TypeParser):
             raise Exception("contains no or more then 1 nodeset")
         nodeset = nodesets[0]
         dataTypeNodes = nodeset.getElementsByTagName("UADataType")
+        self.applyNodeSetOptionalFields(dataTypeNodes)
         for nd in dataTypeNodes:
             if nd.hasAttribute("SymbolicName"):
                 # Remove the optional namespace index prefix.
                 result_string = re.sub(r'^\d+:', '', nd.attributes["BrowseName"].nodeValue)
                 table[nd.attributes["SymbolicName"].nodeValue] = result_string
         return table
+
+    def applyNodeSetOptionalFields(self, dataTypeNodes):
+        """Marks members optional when the NodeSet DataTypeDefinition does."""
+        for node in dataTypeNodes:
+            browseName = node.getAttribute("BrowseName")
+            typeName = re.sub(r'^\d+:', '', browseName)
+            ns, key = self._find_type_ns(typeName)
+            if ns is None:
+                continue
+            dataType = self.types[ns][key]
+            if not isinstance(dataType, StructType):
+                continue
+
+            optionalFields = {
+                field.getAttribute("Name")
+                for definition in node.getElementsByTagName("Definition")
+                for field in definition.getElementsByTagName("Field")
+                if field.getAttribute("IsOptional").lower() == "true"
+            }
+            for member in dataType.members:
+                fieldName = member.name[:1].upper() + member.name[1:]
+                if fieldName in optionalFields:
+                    member.is_optional = True
+                    dataType.pointerfree = False
 
     def _find_type_ns(self, typeName):
         """Find the namespace URI of a type by name, preferring the namespace


### PR DESCRIPTION
This PR makes it possible to configure the NodeSet injector to retain the standard ServerLog subtree when providing a custom implementation.

It also makes generated data types honor optional fields declared in NodeSet DataTypeDefinitions. This fixes LogRecord encoding. Its optional fields were treated as required and encoded unconditionally instead of being controlled by an encoding mask. This led to encoding errors when attempting to fetch log records with UaExpert for example.