### PR TITLE
fix(plugin): open an outbound socket for mDNS sends

### DIFF
--- a/drivers/discovery_mdns_mdnsd.c
+++ b/drivers/discovery_mdns_mdnsd.c
@@ -1054,6 +1054,7 @@ createMulticastSocket(MdnsdDriver *md) {
     }
 
     /* Open the send connection */
+    listen = false;
     if((md->announce || md->queryPresence || md->queryDetails) &&
        md->mdnsSendConnection == 0) {
         res = md->cm->openConnection(md->cm, &kvm, md->mdns.drv.server, md,

--- a/tests/server/check_discovery_mdnsd.c
+++ b/tests/server/check_discovery_mdnsd.c
@@ -1671,6 +1671,8 @@ START_TEST(MdnsStartupOpensReceiveAndSendConnections) {
 }
 END_TEST
 
+#if defined(UA_ARCHITECTURE_POSIX) && !defined(UA_ARCHITECTURE_LWIP)
+
 static UA_Server *realUdpReceiver, *realUdpSender;
 
 static void
@@ -1743,6 +1745,8 @@ START_TEST(MdnsAnnouncementTraversesRealUdpMulticastLoopback) {
     ck_assert_uint_eq(countServersOnNetworkByName(realUdpReceiver, expectedName), 1);
 }
 END_TEST
+
+#endif
 
 static UA_Server *
 createMdnsQueryTestServer(UA_ConnectionManager **outCm,
@@ -2510,10 +2514,13 @@ testSuite_DiscoveryMdnsd(void) {
     tcase_add_test(tc, PublicApiRegisterDeregisterServerOnNetworkTriggersMdnsSendPath);
     suite_add_tcase(s, tc);
 
+#if defined(UA_ARCHITECTURE_POSIX) && !defined(UA_ARCHITECTURE_LWIP)
     TCase *tc_real_udp = tcase_create("Real UDP integration");
-    tcase_add_checked_fixture(tc_real_udp, setupRealUdpMdnsServers, teardownRealUdpMdnsServers);
+    tcase_add_checked_fixture(tc_real_udp, setupRealUdpMdnsServers,
+                             teardownRealUdpMdnsServers);
     tcase_add_test(tc_real_udp, MdnsAnnouncementTraversesRealUdpMulticastLoopback);
     suite_add_tcase(s, tc_real_udp);
+#endif
 
     TCase *tc_query = tcase_create("Query behavior");
     tcase_add_test(tc_query, MdnsQueryPresenceSendsStartupPtrQuery);

--- a/tests/server/check_discovery_mdnsd.c
+++ b/tests/server/check_discovery_mdnsd.c
@@ -255,7 +255,7 @@ resetDiscoveryCounters(void) {
     memset(&discoveryCounters, 0, sizeof(discoveryCounters));
 }
 
-static void
+static UA_MdnsDriver *
 addMdnsDriverWithQueries(UA_Server *s, UA_Boolean listen, UA_Boolean announce,
                          UA_Boolean queryPresence, UA_Boolean queryDetails,
                          UA_UInt32 queryInterval) {
@@ -278,6 +278,7 @@ addMdnsDriverWithQueries(UA_Server *s, UA_Boolean listen, UA_Boolean announce,
     UA_MdnsDriver *mdns = UA_MdnsDriver_Mdnsd(paramsMap);
     ck_assert_ptr_ne(mdns, NULL);
     ck_assert_uint_eq(UA_Server_addDriver(s, &mdns->drv), UA_STATUSCODE_GOOD);
+    return mdns;
 }
 
 static void
@@ -1670,6 +1671,79 @@ START_TEST(MdnsStartupOpensReceiveAndSendConnections) {
 }
 END_TEST
 
+static UA_Server *realUdpReceiver, *realUdpSender;
+
+static void
+useLoopbackInterface(UA_MdnsDriver *mdns) {
+#ifdef __APPLE__
+    UA_String interface = UA_STRING("lo0");
+#else
+    UA_String interface = UA_STRING("lo");
+#endif
+    ck_assert_uint_eq(UA_KeyValueMap_setScalar(
+                          &mdns->drv.params, UA_QUALIFIEDNAME(0, "interface"),
+                          &interface, &UA_TYPES[UA_TYPES_STRING]),
+                      UA_STATUSCODE_GOOD);
+}
+
+static UA_Server *
+newRealUdpMdnsServer(UA_UInt16 port) {
+    UA_ServerConfig config;
+    memset(&config, 0, sizeof(config));
+    ck_assert_uint_eq(UA_ServerConfig_setMinimal(&config, port, NULL), UA_STATUSCODE_GOOD);
+    config.tcpReuseAddr = true;
+    config.serversOnNetworkEnabled = true;
+    return UA_Server_newWithConfig(&config);
+}
+
+static void
+setupRealUdpMdnsServers(void) {
+    realUdpReceiver = newRealUdpMdnsServer(4840);
+    ck_assert_ptr_ne(realUdpReceiver, NULL);
+    UA_MdnsDriver *receiverMdns =
+        addMdnsDriverWithQueries(realUdpReceiver, true, false, true, false, 0);
+    useLoopbackInterface(receiverMdns);
+    ck_assert_uint_eq(UA_Server_run_startup(realUdpReceiver), UA_STATUSCODE_GOOD);
+
+    realUdpSender = newRealUdpMdnsServer(16664);
+    ck_assert_ptr_ne(realUdpSender, NULL);
+    UA_MdnsDriver *senderMdns =
+        addMdnsDriverWithQueries(realUdpSender, false, true, false, false, 0);
+    useLoopbackInterface(senderMdns);
+    ck_assert_uint_eq(UA_Server_run_startup(realUdpSender), UA_STATUSCODE_GOOD);
+
+    const char *capabilities[] = {"E2E"};
+    registerServerOnNetwork(realUdpSender, "mdns-real-udp-e2e",
+                            "opc.tcp://mdns-e2e-host:16664/e2e", capabilities, 1);
+}
+
+static void
+teardownRealUdpMdnsServers(void) {
+    if(realUdpSender) {
+        UA_Server_run_shutdown(realUdpSender);
+        UA_Server_delete(realUdpSender);
+    }
+    if(realUdpReceiver) {
+        UA_Server_run_shutdown(realUdpReceiver);
+        UA_Server_delete(realUdpReceiver);
+    }
+}
+
+START_TEST(MdnsAnnouncementTraversesRealUdpMulticastLoopback) {
+    const char *expectedName = "mdns-real-udp-e2e";
+    for(size_t i = 0;
+        i < 2000 && countServersOnNetworkByName(realUdpReceiver, expectedName) == 0;
+        i++) {
+        UA_Server_run_iterate(realUdpSender, false);
+        UA_Server_run_iterate(realUdpReceiver, false);
+        struct timespec ts = {0, 1000000}; /* Let the kernel deliver multicast. */
+        nanosleep(&ts, NULL);
+    }
+
+    ck_assert_uint_eq(countServersOnNetworkByName(realUdpReceiver, expectedName), 1);
+}
+END_TEST
+
 static UA_Server *
 createMdnsQueryTestServer(UA_ConnectionManager **outCm,
                           TestUdpIntercept **outIntercept,
@@ -2435,6 +2509,11 @@ testSuite_DiscoveryMdnsd(void) {
     tcase_add_test(tc, MdnsUpdateOnlineOfflineIsIdempotent);
     tcase_add_test(tc, PublicApiRegisterDeregisterServerOnNetworkTriggersMdnsSendPath);
     suite_add_tcase(s, tc);
+
+    TCase *tc_real_udp = tcase_create("Real UDP integration");
+    tcase_add_checked_fixture(tc_real_udp, setupRealUdpMdnsServers, teardownRealUdpMdnsServers);
+    tcase_add_test(tc_real_udp, MdnsAnnouncementTraversesRealUdpMulticastLoopback);
+    suite_add_tcase(s, tc_real_udp);
 
     TCase *tc_query = tcase_create("Query behavior");
     tcase_add_test(tc_query, MdnsQueryPresenceSendsStartupPtrQuery);

--- a/tests/server/check_discovery_mdnsd.c
+++ b/tests/server/check_discovery_mdnsd.c
@@ -195,6 +195,8 @@ static THREAD_HANDLE serverThreadLds;
 static THREAD_HANDLE serverThreadRegister;
 
 typedef struct {
+    size_t openedListenConnections;
+    size_t openedSendConnections;
     size_t sentMessages;
     size_t sentNonEmptyMessages;
     UA_ByteString lastMessage;
@@ -405,6 +407,35 @@ serverOnNetworkHasTxtData(const UA_ServerOnNetwork *serverOnNetwork) {
 }
 
 static UA_StatusCode
+interceptingOpen(UA_ConnectionManager *cm, const UA_KeyValueMap *params,
+                 void *application, void *context,
+                 UA_ConnectionManager_connectionCallback callback) {
+    TestUdpIntercept *intercept =
+        (TestUdpIntercept*)TestConnectionManager_getContext(cm);
+    const UA_Boolean *listen = (const UA_Boolean*)
+        UA_KeyValueMap_getScalar(params, UA_QUALIFIEDNAME(0, "listen"),
+                                 &UA_TYPES[UA_TYPES_BOOLEAN]);
+    if(!intercept || !listen)
+        return UA_STATUSCODE_BADINTERNALERROR;
+
+    if(*listen)
+        intercept->openedListenConnections++;
+    else
+        intercept->openedSendConnections++;
+
+    uintptr_t connectionId;
+    UA_StatusCode res =
+        TestConnectionManager_createConnection(cm, application, context,
+                                               callback, &connectionId);
+    if(res != UA_STATUSCODE_GOOD)
+        return res;
+
+    return TestConnectionManager_inject(cm, connectionId,
+                                        UA_CONNECTIONSTATE_ESTABLISHED,
+                                        NULL, NULL);
+}
+
+static UA_StatusCode
 interceptingSend(UA_ConnectionManager *cm, uintptr_t connectionId,
                  const UA_KeyValueMap *params, UA_ByteString *buf) {
     (void)connectionId;
@@ -449,7 +480,7 @@ interceptingSend(UA_ConnectionManager *cm, uintptr_t connectionId,
 }
 
 static const TestConnectionManager_CallbackOverloads interceptingUdpOverloads = {
-    NULL, interceptingSend, NULL
+    interceptingOpen, interceptingSend, NULL
 };
 
 static void
@@ -1633,6 +1664,12 @@ START_TEST(MdnsStartupTriggersSendPath) {
 }
 END_TEST
 
+START_TEST(MdnsStartupOpensReceiveAndSendConnections) {
+    ck_assert_uint_eq(testUdpIntercept->openedListenConnections, 1);
+    ck_assert_uint_eq(testUdpIntercept->openedSendConnections, 1);
+}
+END_TEST
+
 static UA_Server *
 createMdnsQueryTestServer(UA_ConnectionManager **outCm,
                           TestUdpIntercept **outIntercept,
@@ -2391,6 +2428,7 @@ testSuite_DiscoveryMdnsd(void) {
 #if defined(UA_ENABLE_DISCOVERY_MULTICAST_MDNSD)
     TCase *tc = tcase_create("Send path scaffolding");
     tcase_add_unchecked_fixture(tc, setup_server, teardown_server);
+    tcase_add_test(tc, MdnsStartupOpensReceiveAndSendConnections);
     tcase_add_test(tc, MdnsStartupTriggersSendPath);
     tcase_add_test(tc, MdnsShutdownSendsSelfGoodbyeAndDrainsQueue);
     tcase_add_test(tc, MdnsUpdateOnlineOfflineTriggersSendPath);


### PR DESCRIPTION
The mDNSd driver used listen=true for both UDP connections. The POSIX connection manager therefore created two receive sockets. Calls to sendto on the second socket failed with EINVAL.

Set listen=false before the driver opens the send connection. The regression test verifies one receive connection and one send connection at startup.