### PR TITLE
fix: preserve digits in NodeSet symbolic names

### DIFF
--- a/tests/nodeset-compiler/CMakeLists.txt
+++ b/tests/nodeset-compiler/CMakeLists.txt
@@ -129,3 +129,7 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
 add_test(NAME test_generate_datatypes_cross_ns
          COMMAND "${Python3_EXECUTABLE}"
                  "${CMAKE_CURRENT_SOURCE_DIR}/test_cross_ns_types.py")
+
+add_test(NAME test_generate_datatypes_symbolic_names
+         COMMAND "${Python3_EXECUTABLE}"
+                 "${CMAKE_CURRENT_SOURCE_DIR}/test_symbolic_names.py")

--- a/tests/nodeset-compiler/test_symbolic_names.py
+++ b/tests/nodeset-compiler/test_symbolic_names.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GENERATOR = os.path.join(HERE, "..", "..", "tools", "generate_datatypes.py")
+
+BSD = """<?xml version="1.0" encoding="utf-8"?>
+<opc:TypeDictionary
+  xmlns:opc="http://opcfoundation.org/BinarySchema/"
+  xmlns:ua="http://opcfoundation.org/UA/"
+  xmlns:tns="urn:open62541:test"
+  TargetNamespace="urn:open62541:test">
+  <opc:StructuredType Name="ThreeDFrame" BaseType="ua:ExtensionObject">
+    <opc:Field Name="Value" TypeName="opc:UInt32" />
+  </opc:StructuredType>
+</opc:TypeDictionary>
+"""
+
+NODESET = """<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>urn:open62541:test</Uri>
+  </NamespaceUris>
+  <UADataType NodeId="ns=1;i=1" BrowseName="1:3DFrame"
+              SymbolicName="ThreeDFrame">
+    <Definition Name="3DFrame" SymbolicName="ThreeDFrame">
+      <Field Name="Value" DataType="i=7" />
+    </Definition>
+  </UADataType>
+</UANodeSet>
+"""
+
+CSV = """ThreeDFrame,1,DataType
+ThreeDFrame_Encoding_DefaultBinary,2,Object
+"""
+
+
+def write(path, content):
+    with open(path, "w", encoding="utf-8") as output:
+        output.write(content)
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bsd = os.path.join(tmpdir, "types.bsd")
+        nodeset = os.path.join(tmpdir, "nodeset.xml")
+        nodeids = os.path.join(tmpdir, "nodeids.csv")
+        output = os.path.join(tmpdir, "types_test")
+        write(bsd, BSD)
+        write(nodeset, NODESET)
+        write(nodeids, CSV)
+
+        command = [
+            sys.executable,
+            GENERATOR,
+            f"--type-bsd={bsd}",
+            f"--type-csv={nodeids}",
+            f"--xml={nodeset}",
+            "--no-builtin",
+            output,
+        ]
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr)
+            return 1
+
+        with open(output + "_generated.c", encoding="utf-8") as generated:
+            source = generated.read()
+
+        type_id = "{0, UA_NODEIDTYPE_NUMERIC, {1LU}}, /* .typeId */"
+        if type_id not in source:
+            print("FAIL: generated output lacks the ThreeDFrame NodeId")
+            return 1
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/nodeset_compiler/type_parser.py
+++ b/tools/nodeset_compiler/type_parser.py
@@ -439,8 +439,8 @@ class CSVBSDTypeParser(TypeParser):
         dataTypeNodes = nodeset.getElementsByTagName("UADataType")
         for nd in dataTypeNodes:
             if nd.hasAttribute("SymbolicName"):
-                # Remove any digit and the colon
-                result_string = re.sub(r'\d|:', '', nd.attributes["BrowseName"].nodeValue)
+                # Remove the optional namespace index prefix.
+                result_string = re.sub(r'^\d+:', '', nd.attributes["BrowseName"].nodeValue)
                 table[nd.attributes["SymbolicName"].nodeValue] = result_string
         return table
 
@@ -513,9 +513,10 @@ class CSVBSDTypeParser(TypeParser):
                 typeName = "ExtensionObject"
             if typeName in rename_types:
                 typeName = rename_types[typeName]
-            # check if typeName is a symbolicName and replace it with the browseName
-            if typeName in table:
-                typeName = table[typeName]
             ns, key = self._find_type_ns(typeName)
+            # If the CSV uses a SymbolicName that differs from the type name in
+            # the BSD, retry with the corresponding BrowseName.
+            if ns is None and typeName in table:
+                ns, key = self._find_type_ns(table[typeName])
             if ns is not None:
                 self.types[ns][key].nodeId = row[1]


### PR DESCRIPTION
NodeSet BrowseNames can contain digits that are part of the type name. Removing all digits causes ThreeDFrame to lose its NodeId.