### PR TITLE
fix(client): do not run the connectivity check before the Session is …

### DIFF
--- a/src/client/ua_client.c
+++ b/src/client/ua_client.c
@@ -1019,6 +1019,12 @@ __Client_backgroundConnectivity(UA_Client *client) {
     if(!client->config.connectivityCheckInterval)
         return;
 
+    /* Only probe the server once the Session is activated. A Read sent
+     * before the server returns ActivateSessionResponse triggers a
+     * ServiceFault that aborts a slow connect (issue #8195). */
+    if(client->sessionState != UA_SESSIONSTATE_ACTIVATED)
+        return;
+
     if(client->pendingConnectivityCheck)
         return;
 


### PR DESCRIPTION
…activated

__Client_backgroundConnectivity sent its ServerStatus Read regardless of the Session state. When the SecureChannel and Session setup take a while, the housekeeping timer can fire the Read before the server has returned ActivateSessionResponse; the resulting ServiceFault aborts the connect.

Guard the check on client->sessionState == UA_SESSIONSTATE_ACTIVATED: per the spec a Session must not be used before ActivateSession completes.

Fixes #8195.