### PR TITLE
fix(core): Make session closure reentrant-safe

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -436,6 +436,7 @@ UA_Server_init(UA_Server *server) {
 
     /* Initialize the adminSession */
     UA_Session_init(&server->adminSession);
+    server->adminSession.state = UA_SESSIONSTATE_ACTIVATED;
     server->adminSession.sessionId.identifierType = UA_NODEIDTYPE_GUID;
     server->adminSession.sessionId.identifier.guid.data1 = 1;
     server->adminSession.validTill = UA_INT64_MAX;

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -265,6 +265,22 @@ UA_AsyncManager_processReady(void *application /* UA_Server */,
 }
 
 static void
+processReadyLater(UA_Server *server) {
+    UA_AsyncManager *am = &server->asyncManager;
+    /* UA_AsyncManager_clear drains ready work synchronously after stop. */
+    if(am->dc.callback != NULL ||
+       server->state == UA_LIFECYCLESTATE_STOPPED)
+        return;
+
+    UA_EventLoop *el = server->config.eventLoop;
+    am->dc.callback = UA_AsyncManager_processReady;
+    am->dc.application = server;
+    am->dc.context = am;
+    el->addDelayedCallback(el, &am->dc);
+    el->cancel(el); /* Wake up the EventLoop if currently waiting in select() */
+}
+
+static void
 processOperationResult(UA_Server *server, UA_AsyncOperation *op) {
     UA_AsyncManager *am = &server->asyncManager;
     if(op->asyncOperationType >= UA_ASYNCOPERATIONTYPE_CALL_DIRECT) {
@@ -287,14 +303,7 @@ processOperationResult(UA_Server *server, UA_AsyncOperation *op) {
     }
 
     /* Trigger the main server thread to handle ready operations and responses */
-    if(am->dc.callback == NULL) {
-        UA_EventLoop *el = server->config.eventLoop;
-        am->dc.callback = UA_AsyncManager_processReady;
-        am->dc.application = server;
-        am->dc.context = am;
-        el->addDelayedCallback(el, &am->dc);
-        el->cancel(el); /* Wake up the EventLoop if currently waiting in select() */
-    }
+    processReadyLater(server);
 }
 
 /* Check if any operations have timed out */
@@ -418,11 +427,15 @@ UA_AsyncManager_cancelSession(UA_Server *server, const UA_NodeId *sessionId,
         UA_AsyncOperation_cancel(server, op, status);
     }
 
+    UA_Boolean responseReady = false;
     while((ar = TAILQ_FIRST(&canceledResponses))) {
         TAILQ_REMOVE(&canceledResponses, ar, pointers);
         UA_assert(ar->opCountdown == 0);
-        UA_AsyncResponse_delete(ar);
+        TAILQ_INSERT_TAIL(&am->readyResponses, ar, pointers);
+        responseReady = true;
     }
+    if(responseReady)
+        processReadyLater(server);
 }
 
 UA_UInt32

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -381,6 +381,50 @@ UA_AsyncManager_clear(UA_AsyncManager *am, UA_Server *server) {
     UA_assert(am->opsCount == 0);
 }
 
+void
+UA_AsyncManager_cancelSession(UA_Server *server, const UA_NodeId *sessionId,
+                              UA_StatusCode status) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
+    UA_AsyncManager *am = &server->asyncManager;
+    TAILQ_HEAD(, UA_AsyncResponse) canceledResponses;
+    TAILQ_HEAD(, UA_AsyncOperation) canceledOps;
+    TAILQ_INIT(&canceledResponses);
+    TAILQ_INIT(&canceledOps);
+
+    /* Unlink all matching responses and operations before invoking user
+     * cancellation callbacks, which may reenter and mutate the manager. */
+    UA_AsyncResponse *ar, *ar_tmp;
+    TAILQ_FOREACH_SAFE(ar, &am->waitingResponses, pointers, ar_tmp) {
+        if(!UA_NodeId_equal(&ar->sessionId, sessionId))
+            continue;
+        TAILQ_REMOVE(&am->waitingResponses, ar, pointers);
+        TAILQ_INSERT_TAIL(&canceledResponses, ar, pointers);
+    }
+
+    UA_AsyncOperation *op, *op_tmp;
+    TAILQ_FOREACH_SAFE(op, &am->waitingOps, pointers, op_tmp) {
+        if(op->asyncOperationType >= UA_ASYNCOPERATIONTYPE_CALL_DIRECT ||
+           !UA_NodeId_equal(&op->handling.response->sessionId, sessionId))
+            continue;
+        TAILQ_REMOVE(&am->waitingOps, op, pointers);
+        TAILQ_INSERT_TAIL(&canceledOps, op, pointers);
+        am->opsCount--;
+        UA_assert(op->handling.response->opCountdown > 0);
+        op->handling.response->opCountdown--;
+    }
+
+    while((op = TAILQ_FIRST(&canceledOps))) {
+        TAILQ_REMOVE(&canceledOps, op, pointers);
+        UA_AsyncOperation_cancel(server, op, status);
+    }
+
+    while((ar = TAILQ_FIRST(&canceledResponses))) {
+        TAILQ_REMOVE(&canceledResponses, ar, pointers);
+        UA_assert(ar->opCountdown == 0);
+        UA_AsyncResponse_delete(ar);
+    }
+}
+
 UA_UInt32
 UA_AsyncManager_cancel(UA_Server *server, UA_Session *session, UA_UInt32 requestHandle) {
     UA_LOCK_ASSERT(&server->serviceMutex);
@@ -485,6 +529,41 @@ persistAsyncResponseOperation(UA_Server *server, UA_AsyncOperation *op,
     TAILQ_INSERT_TAIL(&am->waitingOps, op, pointers);
     ar->opCountdown++;
     am->opsCount++;
+}
+
+/* A service callback can close its own session after earlier operations in the
+ * same request have already gone asynchronous. The session is removed from the
+ * server immediately, so such a response can no longer be delivered. Cancel
+ * the pending operations and let the service return BadSessionClosed
+ * synchronously instead of retaining an orphaned response. */
+static void
+cancelAsyncResponseOperations(UA_Server *server, UA_AsyncResponse *ar,
+                              UA_StatusCode status) {
+    UA_AsyncManager *am = &server->asyncManager;
+    TAILQ_HEAD(, UA_AsyncOperation) canceledOps;
+    TAILQ_INIT(&canceledOps);
+    UA_AsyncOperation *op, *op_tmp;
+    TAILQ_FOREACH_SAFE(op, &am->waitingOps, pointers, op_tmp) {
+        if(op->asyncOperationType >= UA_ASYNCOPERATIONTYPE_CALL_DIRECT ||
+           op->handling.response != ar)
+            continue;
+
+        /* Unlink first. The cancellation callback may reenter the server and
+         * attempt to complete this operation. */
+        TAILQ_REMOVE(&am->waitingOps, op, pointers);
+        TAILQ_INSERT_TAIL(&canceledOps, op, pointers);
+        am->opsCount--;
+        UA_assert(ar->opCountdown > 0);
+        ar->opCountdown--;
+    }
+    UA_assert(ar->opCountdown == 0);
+
+    /* Notify only after every matching operation has been unlinked. A
+     * cancellation callback may reenter and mutate the waiting queue. */
+    while((op = TAILQ_FIRST(&canceledOps))) {
+        TAILQ_REMOVE(&canceledOps, op, pointers);
+        UA_AsyncOperation_cancel(server, op, status);
+    }
 }
 
 static UA_StatusCode
@@ -629,6 +708,8 @@ Service_Read(UA_Server *server, UA_Session *session, const void *request_, void 
 
     /* If async operations are pending, persist them and signal the service is
      * not done */
+    if(session->state == UA_SESSIONSTATE_CLOSED && ar->opCountdown > 0)
+        cancelAsyncResponseOperations(server, ar, UA_STATUSCODE_BADSESSIONCLOSED);
     if(ar->opCountdown > 0) {
         ar->responseType = &UA_TYPES[UA_TYPES_READRESPONSE];
         persistAsyncResponse(server, session, response, ar);
@@ -783,6 +864,8 @@ Service_Write(UA_Server *server, UA_Session *session,
 
     /* If async operations are pending, persist them and signal the service is
      * not done */
+    if(session->state == UA_SESSIONSTATE_CLOSED && ar->opCountdown > 0)
+        cancelAsyncResponseOperations(server, ar, UA_STATUSCODE_BADSESSIONCLOSED);
     if(ar->opCountdown > 0) {
         ar->responseType = &UA_TYPES[UA_TYPES_WRITERESPONSE];
         persistAsyncResponse(server, session, response, ar);
@@ -938,6 +1021,8 @@ Service_Call(UA_Server *server, UA_Session *session,
 
     /* If async operations are pending, persist them and signal the service is
      * not done */
+    if(session->state == UA_SESSIONSTATE_CLOSED && ar->opCountdown > 0)
+        cancelAsyncResponseOperations(server, ar, UA_STATUSCODE_BADSESSIONCLOSED);
     if(ar->opCountdown > 0) {
         ar->responseType = &UA_TYPES[UA_TYPES_CALLRESPONSE];
         persistAsyncResponse(server, session, response, ar);

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -621,6 +621,10 @@ Service_Read(UA_Server *server, UA_Session *session, const void *request_, void 
             persistAsyncResponseOperation(server, &aopArray[i],
                                           UA_ASYNCOPERATIONTYPE_READ_REQUEST,
                                           ar, &response->results[i]);
+        if(session->state == UA_SESSIONSTATE_CLOSED) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+            break;
+        }
     }
 
     /* If async operations are pending, persist them and signal the service is
@@ -771,6 +775,10 @@ Service_Write(UA_Server *server, UA_Session *session,
         if(!done)
             persistAsyncResponseOperation(server, aop, UA_ASYNCOPERATIONTYPE_WRITE_REQUEST,
                                           ar, &response->results[i]);
+        if(session->state == UA_SESSIONSTATE_CLOSED) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+            break;
+        }
     }
 
     /* If async operations are pending, persist them and signal the service is
@@ -922,6 +930,10 @@ Service_Call(UA_Server *server, UA_Session *session,
             persistAsyncResponseOperation(server, &aopArray[i],
                                           UA_ASYNCOPERATIONTYPE_CALL_REQUEST,
                                           ar, &response->results[i]);
+        if(session->state == UA_SESSIONSTATE_CLOSED) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+            break;
+        }
     }
 
     /* If async operations are pending, persist them and signal the service is

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -424,6 +424,10 @@ UA_AsyncManager_cancelSession(UA_Server *server, const UA_NodeId *sessionId,
 
     while((op = TAILQ_FIRST(&canceledOps))) {
         TAILQ_REMOVE(&canceledOps, op, pointers);
+        /* TAILQ_REMOVE does not clear the links in release builds. Avoid
+         * retaining the stack-local queue head across the callback. */
+        op->pointers.tqe_next = NULL;
+        op->pointers.tqe_prev = NULL;
         UA_AsyncOperation_cancel(server, op, status);
     }
 
@@ -575,6 +579,10 @@ cancelAsyncResponseOperations(UA_Server *server, UA_AsyncResponse *ar,
      * cancellation callback may reenter and mutate the waiting queue. */
     while((op = TAILQ_FIRST(&canceledOps))) {
         TAILQ_REMOVE(&canceledOps, op, pointers);
+        /* TAILQ_REMOVE does not clear the links in release builds. Avoid
+         * retaining the stack-local queue head across the callback. */
+        op->pointers.tqe_next = NULL;
+        op->pointers.tqe_prev = NULL;
         UA_AsyncOperation_cancel(server, op, status);
     }
 }

--- a/src/server/ua_server_async.h
+++ b/src/server/ua_server_async.h
@@ -140,7 +140,7 @@ void UA_AsyncManager_start(UA_AsyncManager *am, UA_Server *server);
 void UA_AsyncManager_stop(UA_AsyncManager *am, UA_Server *server);
 void UA_AsyncManager_clear(UA_AsyncManager *am, UA_Server *server);
 
-/* Cancel and discard pending service responses for a closed Session. */
+/* Cancel pending service responses for a closed Session. */
 void
 UA_AsyncManager_cancelSession(UA_Server *server, const UA_NodeId *sessionId,
                               UA_StatusCode status);

--- a/src/server/ua_server_async.h
+++ b/src/server/ua_server_async.h
@@ -140,6 +140,11 @@ void UA_AsyncManager_start(UA_AsyncManager *am, UA_Server *server);
 void UA_AsyncManager_stop(UA_AsyncManager *am, UA_Server *server);
 void UA_AsyncManager_clear(UA_AsyncManager *am, UA_Server *server);
 
+/* Cancel and discard pending service responses for a closed Session. */
+void
+UA_AsyncManager_cancelSession(UA_Server *server, const UA_NodeId *sessionId,
+                              UA_StatusCode status);
+
 /* Cancel all outstanding operations for matching session+requestHandle.
  * Then sends out the responses with a StatusCode. */
 UA_UInt32

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -99,7 +99,6 @@ typedef struct RegisteredServerRecord {
 
 typedef struct session_list_entry {
     UA_DelayedCallback cleanupCallback;
-    UA_ShutdownReason shutdownReason;
     LIST_ENTRY(session_list_entry) pointers;
     UA_Session session;
 } session_list_entry;

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -99,6 +99,7 @@ typedef struct RegisteredServerRecord {
 
 typedef struct session_list_entry {
     UA_DelayedCallback cleanupCallback;
+    UA_ShutdownReason shutdownReason;
     LIST_ENTRY(session_list_entry) pointers;
     UA_Session session;
 } session_list_entry;

--- a/src/server/ua_services.c
+++ b/src/server/ua_services.c
@@ -235,6 +235,8 @@ allocProcessServiceOperations(UA_Server *server, UA_Session *session,
     uintptr_t reqOp = *(uintptr_t*)((uintptr_t)requestOperations + sizeof(size_t));
     for(size_t i = 0; i < ops; i++) {
         operationCallback(server, session, context, (void*)reqOp, (void*)respOp);
+        if(session && session->state == UA_SESSIONSTATE_CLOSED)
+            return UA_STATUSCODE_BADSESSIONCLOSED;
         reqOp += requestOperationsType->memSize;
         respOp += responseOperationsType->memSize;
     }
@@ -254,6 +256,12 @@ processServiceInternal(UA_Server *server, UA_SecureChannel *channel, UA_Session 
                        UA_UInt64 responseToken, UA_ServiceDescription *sd,
                        const UA_Request *request, UA_Response *response) {
     UA_ResponseHeader *rh = &response->responseHeader;
+
+    /* A callback before service execution can close the resolved Session. */
+    if(session && session->state == UA_SESSIONSTATE_CLOSED) {
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+        return true;
+    }
 
     /* Check timestamp in the request header */
     if(request->requestHeader.timestamp == 0 &&
@@ -313,7 +321,8 @@ processServiceInternal(UA_Server *server, UA_SecureChannel *channel, UA_Session 
     }
 
     /* Trying to use a non-activated session? */
-    if(sd->sessionRequired && !session->activated) {
+    if(sd->sessionRequired &&
+       session->state != UA_SESSIONSTATE_ACTIVATED) {
         UA_assert(session != &anonymousSession); /* because sd->sessionRequired */
 #ifdef UA_ENABLE_TYPEDESCRIPTION
         UA_LOG_WARNING_SESSION(server->config.logging, session,
@@ -341,8 +350,13 @@ processServiceInternal(UA_Server *server, UA_SecureChannel *channel, UA_Session 
         getUacpRequestId(channel, responseToken);
     server->asyncManager.currentRequestHandle = request->requestHeader.requestHandle;
 
-    /* Execute the service */
-    return sd->serviceCallback(server, session, request, response);
+    /* Execute the service. A user callback inside the service can close the
+     * Session. For synchronous services, do not return a successful response
+     * for a Session that became closed during the operation. */
+    UA_Boolean done = sd->serviceCallback(server, session, request, response);
+    if(done && session->state == UA_SESSIONSTATE_CLOSED)
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+    return done;
 }
 
 UA_Boolean

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -59,14 +59,48 @@ notifySession(UA_Server *server, UA_Session *session,
     notifyApplication(server, type, payloadMap);
 }
 
-/* Delayed callback to free the session memory */
+/* Delayed callback for destructive session teardown. Logical closure and
+ * detachment happen synchronously in UA_Session_remove. Keeping the Session
+ * resources alive until the current jobs have completed lets callbacks safely
+ * close the Session they are currently using. */
 static void
 removeSessionCallback(void *application /* UA_Server */,
                       void *context /* session_list_entry */) {
     UA_Server *server = (UA_Server*)application;
     session_list_entry *entry = (session_list_entry*)context;
     lockServer(server);
-    UA_Session_clear(&entry->session, server);
+    UA_Session *session = &entry->session;
+
+    /* When the session times out, detach subscriptions so they can be
+     * recovered via TransferSubscriptions. Otherwise delete them. */
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    UA_Subscription *sub, *tempsub;
+    TAILQ_FOREACH_SAFE(sub, &session->subscriptions, sessionListEntry, tempsub) {
+        if(entry->shutdownReason == UA_SHUTDOWNREASON_TIMEOUT) {
+            UA_LOG_INFO_SUBSCRIPTION(server->config.logging, sub,
+                                     "Detaching the Subscription from the timed-out Session");
+            UA_Session_detachSubscription(server, session, sub, true);
+        } else {
+            UA_Subscription_delete(server, sub, true);
+        }
+    }
+
+    UA_PublishResponseEntry *pre;
+    while((pre = UA_Session_dequeuePublishReq(session))) {
+        UA_PublishResponse_clear(&pre->response);
+        UA_free(pre);
+    }
+#endif
+
+    /* Callback into userland access control. The session context remains valid
+     * until this delayed teardown runs. */
+    if(server->config.accessControl.closeSession) {
+        server->config.accessControl.
+            closeSession(server, &server->config.accessControl,
+                         &session->sessionId, session->context);
+    }
+
+    UA_Session_clear(session, server);
     unlockServer(server);
     UA_free(entry);
 }
@@ -76,48 +110,29 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
                   UA_ShutdownReason shutdownReason) {
     UA_LOCK_ASSERT(&server->serviceMutex);
 
-    /* When the session times out, detach
-     * subscriptions so they can be recovered via TransferSubscriptions. */
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-    UA_Subscription *sub, *tempsub;
-    TAILQ_FOREACH_SAFE(sub, &session->subscriptions, sessionListEntry, tempsub) {
-        if(shutdownReason == UA_SHUTDOWNREASON_TIMEOUT) {
-            UA_LOG_INFO_SUBSCRIPTION(server->config.logging, sub,
-                                     "Detaching the Subscription from the timed-out Session");
-            UA_Session_detachSubscription(server, session, sub, true);
-        } else {
-            UA_Subscription_delete(server, sub, true);
-        }
-    }
+    /* Closing a Session can invoke user callbacks that re-enter the server.
+     * Mark it closed before teardown and make repeated removal idempotent. */
+    if(session->state == UA_SESSIONSTATE_CLOSED)
+        return;
+    UA_Boolean wasActivated =
+        (session->state == UA_SESSIONSTATE_ACTIVATED);
+    session->state = UA_SESSIONSTATE_CLOSED;
 
-    UA_PublishResponseEntry *entry;
-    while((entry = UA_Session_dequeuePublishReq(session))) {
-        UA_PublishResponse_clear(&entry->response);
-        UA_free(entry);
-    }
-#endif
-
-    /* Callback into userland access control */
-    if(server->config.accessControl.closeSession) {
-        server->config.accessControl.
-            closeSession(server, &server->config.accessControl,
-                         &session->sessionId, session->context);
-    }
-
-    /* Detach the Session from the SecureChannel */
+    /* Detach the Session from the SecureChannel immediately so transport
+     * teardown and new requests cannot retain the logically closed Session.
+     * Session-owned resources are kept until the delayed callback. */
     UA_Session_detachFromSecureChannel(server, session);
 
     /* Deactivate the session */
-    if(session->activated) {
-        session->activated = false;
+    if(wasActivated)
         server->activeSessionCount--;
-    }
 
     /* Detach the session from the session manager and make the capacity
      * available */
     session_list_entry *sentry = container_of(session, session_list_entry, session);
     LIST_REMOVE(sentry, pointers);
     server->sessionCount--;
+    sentry->shutdownReason = shutdownReason;
 
     switch(shutdownReason) {
     case UA_SHUTDOWNREASON_CLOSE:
@@ -149,8 +164,8 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
     /* Notify the application */
     notifySession(server, session, UA_APPLICATIONNOTIFICATIONTYPE_SESSION_CLOSED);
 
-    /* Add a delayed callback to remove the session when the currently
-     * scheduled jobs have completed */
+    /* Destructively tear down and free the Session after the currently
+     * scheduled jobs have completed. */
     sentry->cleanupCallback.callback = removeSessionCallback;
     sentry->cleanupCallback.application = server;
     sentry->cleanupCallback.context = sentry;
@@ -480,6 +495,8 @@ UA_Session_create(UA_Server *server, UA_SecureChannel *channel,
     /* Notify the application */
     notifySession(server, &newentry->session,
                   UA_APPLICATIONNOTIFICATIONTYPE_SESSION_CREATED);
+    if(newentry->session.state == UA_SESSIONSTATE_CLOSED)
+        return UA_STATUSCODE_BADSESSIONCLOSED;
 
     /* Return */
     *session = &newentry->session;
@@ -1126,7 +1143,8 @@ Service_ActivateSession_inner(UA_Server *server, UA_SecureChannel *channel,
      * SecureChannel is not same as the one associated with the
      * CreateSession request. Subsequent calls to ActivateSession may be
      * associated with different SecureChannels. */
-    if(!session->activated && session->channel != channel) {
+    if(session->state == UA_SESSIONSTATE_CREATED &&
+       session->channel != channel) {
         UA_LOG_ERROR_CHANNEL(server->config.logging, channel,
                              "ActivateSession: The Session has to be initially "
                              "activated on the SecureChannel that created it");
@@ -1242,6 +1260,10 @@ Service_ActivateSession_inner(UA_Server *server, UA_SecureChannel *channel,
         activateSession(server, &server->config.accessControl, ed,
                         &channel->remoteCertificate, &session->sessionId,
                         &req->userIdentityToken, &session->context);
+    if(session->state == UA_SESSIONSTATE_CLOSED) {
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+        return;
+    }
     if(rh->serviceResult != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR_SESSION(server->config.logging, session,
                              "ActivateSession: The AccessControl plugin "
@@ -1348,8 +1370,8 @@ Service_ActivateSession_inner(UA_Server *server, UA_SecureChannel *channel,
     }
 
     /* Activate the session */
-    if(!session->activated) {
-        session->activated = true;
+    if(session->state != UA_SESSIONSTATE_ACTIVATED) {
+        session->state = UA_SESSIONSTATE_ACTIVATED;
         server->activeSessionCount++;
         server->serverDiagnosticsSummary.cumulatedSessionCount++;
     }
@@ -1395,6 +1417,10 @@ Service_ActivateSession_inner(UA_Server *server, UA_SecureChannel *channel,
 
     /* Notify the application */
     notifySession(server, session, UA_APPLICATIONNOTIFICATIONTYPE_SESSION_ACTIVATED);
+    if(session->state == UA_SESSIONSTATE_CLOSED) {
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+        return;
+    }
 
     /* Log the user for which the Session was activated */
     UA_LOG_INFO_SESSION(server->config.logging, session,

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -60,30 +60,9 @@ notifySession(UA_Server *server, UA_Session *session,
 }
 
 static void
-cleanupSession(UA_Server *server, session_list_entry *entry) {
+cleanupSessionEntry(UA_Server *server, session_list_entry *entry) {
     UA_LOCK_ASSERT(&server->serviceMutex);
     UA_Session *session = &entry->session;
-
-    /* When the session times out, detach subscriptions so they can be
-     * recovered via TransferSubscriptions. Otherwise delete them. */
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-    UA_Subscription *sub, *tempsub;
-    TAILQ_FOREACH_SAFE(sub, &session->subscriptions, sessionListEntry, tempsub) {
-        if(entry->shutdownReason == UA_SHUTDOWNREASON_TIMEOUT) {
-            UA_LOG_INFO_SUBSCRIPTION(server->config.logging, sub,
-                                     "Detaching the Subscription from the timed-out Session");
-            UA_Session_detachSubscription(server, session, sub, true);
-        } else {
-            UA_Subscription_delete(server, sub, true);
-        }
-    }
-
-    UA_PublishResponseEntry *pre;
-    while((pre = UA_Session_dequeuePublishReq(session))) {
-        UA_PublishResponse_clear(&pre->response);
-        UA_free(pre);
-    }
-#endif
 
     /* Callback into userland access control. The session context remains valid
      * until this delayed teardown runs. */
@@ -102,12 +81,12 @@ cleanupSession(UA_Server *server, session_list_entry *entry) {
  * resources alive until the current jobs have completed lets callbacks safely
  * close the Session they are currently using. */
 static void
-cleanupSessionCallback(void *application /* UA_Server */,
-                       void *context /* session_list_entry */) {
+cleanupSessionEntryCallback(void *application /* UA_Server */,
+                            void *context /* session_list_entry */) {
     UA_Server *server = (UA_Server*)application;
     session_list_entry *entry = (session_list_entry*)context;
     lockServer(server);
-    cleanupSession(server, entry);
+    cleanupSessionEntry(server, entry);
     unlockServer(server);
 }
 
@@ -138,7 +117,6 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
     session_list_entry *sentry = container_of(session, session_list_entry, session);
     LIST_REMOVE(sentry, pointers);
     server->sessionCount--;
-    sentry->shutdownReason = shutdownReason;
 
 #if UA_MULTITHREADING >= 100
     /* Pending service responses cannot be delivered after the Session has
@@ -146,6 +124,30 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
      * without sending them on the closed Session. */
     UA_AsyncManager_cancelSession(server, &session->sessionId,
                                   UA_STATUSCODE_BADSESSIONCLOSED);
+#endif
+
+    /* Detach recoverable Subscriptions immediately when the Session times out.
+     * Otherwise remove them now. The Session is already closed and absent from
+     * lookup, so callbacks during Subscription teardown cannot remove it again.
+     * Keeping this synchronous also makes the Subscription state consistent
+     * as soon as UA_Session_remove returns. */
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    UA_Subscription *sub, *tempsub;
+    TAILQ_FOREACH_SAFE(sub, &session->subscriptions, sessionListEntry, tempsub) {
+        if(shutdownReason == UA_SHUTDOWNREASON_TIMEOUT) {
+            UA_LOG_INFO_SUBSCRIPTION(server->config.logging, sub,
+                                     "Detaching the Subscription from the timed-out Session");
+            UA_Session_detachSubscription(server, session, sub, true);
+        } else {
+            UA_Subscription_delete(server, sub, true);
+        }
+    }
+
+    UA_PublishResponseEntry *pre;
+    while((pre = UA_Session_dequeuePublishReq(session))) {
+        UA_PublishResponse_clear(&pre->response);
+        UA_free(pre);
+    }
 #endif
 
     switch(shutdownReason) {
@@ -182,13 +184,13 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
      * stopped. In particular, UA_Server_delete should not enqueue work into an
      * EventLoop that it is about to delete. */
     if(server->state == UA_LIFECYCLESTATE_STOPPED) {
-        cleanupSession(server, sentry);
+        cleanupSessionEntry(server, sentry);
         return;
     }
 
     /* Destructively tear down and free the Session after the currently
      * scheduled jobs have completed. */
-    sentry->cleanupCallback.callback = cleanupSessionCallback;
+    sentry->cleanupCallback.callback = cleanupSessionEntryCallback;
     sentry->cleanupCallback.application = server;
     sentry->cleanupCallback.context = sentry;
     UA_EventLoop *el = server->config.eventLoop;

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -59,16 +59,9 @@ notifySession(UA_Server *server, UA_Session *session,
     notifyApplication(server, type, payloadMap);
 }
 
-/* Delayed callback for destructive session teardown. Logical closure and
- * detachment happen synchronously in UA_Session_remove. Keeping the Session
- * resources alive until the current jobs have completed lets callbacks safely
- * close the Session they are currently using. */
 static void
-removeSessionCallback(void *application /* UA_Server */,
-                      void *context /* session_list_entry */) {
-    UA_Server *server = (UA_Server*)application;
-    session_list_entry *entry = (session_list_entry*)context;
-    lockServer(server);
+cleanupSession(UA_Server *server, session_list_entry *entry) {
+    UA_LOCK_ASSERT(&server->serviceMutex);
     UA_Session *session = &entry->session;
 
     /* When the session times out, detach subscriptions so they can be
@@ -101,8 +94,21 @@ removeSessionCallback(void *application /* UA_Server */,
     }
 
     UA_Session_clear(session, server);
-    unlockServer(server);
     UA_free(entry);
+}
+
+/* Delayed callback for destructive session teardown. Logical closure and
+ * detachment happen synchronously in UA_Session_remove. Keeping the Session
+ * resources alive until the current jobs have completed lets callbacks safely
+ * close the Session they are currently using. */
+static void
+cleanupSessionCallback(void *application /* UA_Server */,
+                       void *context /* session_list_entry */) {
+    UA_Server *server = (UA_Server*)application;
+    session_list_entry *entry = (session_list_entry*)context;
+    lockServer(server);
+    cleanupSession(server, entry);
+    unlockServer(server);
 }
 
 void
@@ -134,6 +140,14 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
     server->sessionCount--;
     sentry->shutdownReason = shutdownReason;
 
+#if UA_MULTITHREADING >= 100
+    /* Pending service responses cannot be delivered after the Session has
+     * been removed. Release them and tell the application to stop producing
+     * their asynchronous results. */
+    UA_AsyncManager_cancelSession(server, &session->sessionId,
+                                  UA_STATUSCODE_BADSESSIONCLOSED);
+#endif
+
     switch(shutdownReason) {
     case UA_SHUTDOWNREASON_CLOSE:
     case UA_SHUTDOWNREASON_PURGE:
@@ -164,9 +178,17 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
     /* Notify the application */
     notifySession(server, session, UA_APPLICATIONNOTIFICATIONTYPE_SESSION_CLOSED);
 
+    /* There cannot be callbacks still using the Session once the Server is
+     * stopped. In particular, UA_Server_delete should not enqueue work into an
+     * EventLoop that it is about to delete. */
+    if(server->state == UA_LIFECYCLESTATE_STOPPED) {
+        cleanupSession(server, sentry);
+        return;
+    }
+
     /* Destructively tear down and free the Session after the currently
      * scheduled jobs have completed. */
-    sentry->cleanupCallback.callback = removeSessionCallback;
+    sentry->cleanupCallback.callback = cleanupSessionCallback;
     sentry->cleanupCallback.application = server;
     sentry->cleanupCallback.context = sentry;
     UA_EventLoop *el = server->config.eventLoop;

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -142,8 +142,8 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
 
 #if UA_MULTITHREADING >= 100
     /* Pending service responses cannot be delivered after the Session has
-     * been removed. Release them and tell the application to stop producing
-     * their asynchronous results. */
+     * been removed. Cancel their operations and finish the response lifecycle
+     * without sending them on the closed Session. */
     UA_AsyncManager_cancelSession(server, &session->sessionId,
                                   UA_STATUSCODE_BADSESSIONCLOSED);
 #endif

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -20,6 +20,7 @@
 
 void UA_Session_init(UA_Session *session) {
     memset(session, 0, sizeof(UA_Session));
+    session->state = UA_SESSIONSTATE_CREATED;
     TAILQ_INIT(&session->continuationPoints);
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     SIMPLEQ_INIT(&session->responseQueue);

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -47,7 +47,7 @@ struct UA_Session {
     UA_NodeId sessionId;
     UA_NodeId authenticationToken;
     UA_String sessionName;
-    UA_Boolean activated;
+    UA_SessionState state;
 
     /* For ECC, client and server exchange ephemeral keys used for the
      * EccEncryptedSecret. The ephemeral keys have to be attached to the session

--- a/src/server/ua_transport_http.c
+++ b/src/server/ua_transport_http.c
@@ -363,7 +363,9 @@ shutdownHttpSecureChannel(UA_Server *server, UA_SecureChannel *channel,
     /* Detach activated Sessions and reject incomplete ones. */
     while(channel->sessions) {
         UA_Session *session = channel->sessions;
-        if(session->activated)
+        if(session->state == UA_SESSIONSTATE_CLOSED)
+            UA_Session_detachFromSecureChannel(server, session);
+        else if(session->state == UA_SESSIONSTATE_ACTIVATED)
             UA_Session_detachFromSecureChannel(server, session);
         else
             UA_Session_remove(server, session, reason);

--- a/src/server/ua_transport_tcp.c
+++ b/src/server/ua_transport_tcp.c
@@ -50,7 +50,9 @@ deleteServerSecureChannel(UA_Server *server, UA_SecureChannel *channel) {
      * channel. Non-activated sessions are deleted (Part 4, §5.6.3). */
     while(channel->sessions) {
         UA_Session *session = channel->sessions;
-        if(!session->activated)
+        if(session->state == UA_SESSIONSTATE_CLOSED)
+            UA_Session_detachFromSecureChannel(server, session);
+        else if(session->state != UA_SESSIONSTATE_ACTIVATED)
             UA_Session_remove(server, session, UA_SHUTDOWNREASON_PURGE);
         else
             UA_Session_detachFromSecureChannel(server, session);
@@ -337,6 +339,9 @@ getBoundSession(UA_Server *server, const UA_SecureChannel *channel,
     for(UA_Session *s = channel->sessions; s; s = s->next) {
         if(!UA_NodeId_equal(token, &s->authenticationToken))
             continue;
+
+        if(s->state == UA_SESSIONSTATE_CLOSED)
+            return UA_STATUSCODE_BADSESSIONCLOSED;
 
         /* Has the session timed out? */
         if(s->validTill < nowMonotonic)

--- a/tests/client/check_client_http.c
+++ b/tests/client/check_client_http.c
@@ -204,9 +204,25 @@ getAdvertisedPort(UA_ServerConfig *config, const char *prefix,
 typedef enum {
     HTTP_CLIENT_SCENARIO_SECURITY,
     HTTP_CLIENT_SCENARIO_SERVICES,
+    HTTP_CLIENT_SCENARIO_SESSION_REENTRANCY,
     HTTP_CLIENT_SCENARIO_ENDPOINT,
     HTTP_CLIENT_SCENARIO_JSON
 } HttpClientScenario;
+
+static UA_Boolean closeHttpSessionAtServiceBegin;
+static UA_StatusCode closeHttpSessionResult;
+
+static void
+closeHttpSessionFromServiceNotification(
+    UA_Server *server, UA_ApplicationNotificationType type,
+    const UA_KeyValueMap payload) {
+    if(type != UA_APPLICATIONNOTIFICATIONTYPE_SERVICE_BEGIN ||
+       !closeHttpSessionAtServiceBegin)
+        return;
+    closeHttpSessionAtServiceBegin = false;
+    const UA_NodeId *sessionId = (const UA_NodeId *)payload.map[1].value.data;
+    closeHttpSessionResult = UA_Server_closeSession(server, sessionId);
+}
 
 static void
 runClientScenario(HttpClientScenario scenario) {
@@ -690,6 +706,42 @@ runClientScenario(HttpClientScenario scenario) {
     UA_Client_delete(client);
     }
 
+    if(scenario == HTTP_CLIENT_SCENARIO_SESSION_REENTRANCY) {
+    memset(&clientConfig, 0, sizeof(clientConfig));
+    clientConfig.eventLoop = serverConfig->eventLoop;
+    clientConfig.externalEventLoop = true;
+    ck_assert_uint_eq(UA_ClientConfig_setDefault(&clientConfig),
+                      UA_STATUSCODE_GOOD);
+    clientConfig.httpAllowUnencrypted = true;
+    clientConfig.noReconnect = true;
+    clientConfig.noNewSession = true;
+    client = UA_Client_newWithConfig(&clientConfig);
+    ck_assert_ptr_nonnull(client);
+    ck_assert_uint_eq(UA_Client_connect(client, endpoint), UA_STATUSCODE_GOOD);
+
+    serverConfig->serviceNotificationCallback =
+        closeHttpSessionFromServiceNotification;
+    closeHttpSessionAtServiceBegin = true;
+    closeHttpSessionResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    UA_Variant_init(&value);
+    ck_assert_uint_eq(UA_Client_readValueAttribute(
+                          client, UA_NODEID_NUMERIC(
+                              0, UA_NS0ID_SERVER_SERVERSTATUS_STATE),
+                          &value),
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+    UA_Variant_clear(&value);
+    ck_assert_uint_eq(closeHttpSessionResult, UA_STATUSCODE_GOOD);
+
+    serverConfig->serviceNotificationCallback = NULL;
+    ck_assert_uint_eq(UA_Client_disconnect(client), UA_STATUSCODE_GOOD);
+    UA_Client_delete(client);
+    for(size_t i = 0; i < 10; i++)
+        serverConfig->eventLoop->run(serverConfig->eventLoop, 1);
+    lockServer(server);
+    ck_assert_uint_eq(server->sessionCount, 0);
+    unlockServer(server);
+    }
+
     if(scenario == HTTP_CLIENT_SCENARIO_ENDPOINT) {
     /* An explicitly selected EndpointDescription takes precedence over the
      * initial URL. This exercises the same URL handoff used after discovery. */
@@ -791,6 +843,11 @@ START_TEST(httpClientServicesSubscriptionsAndReconnect) {
 }
 END_TEST
 
+START_TEST(httpClientSessionNotificationCloseIsReentrant) {
+    runClientScenario(HTTP_CLIENT_SCENARIO_SESSION_REENTRANCY);
+}
+END_TEST
+
 START_TEST(httpClientEndpointSelection) {
     runClientScenario(HTTP_CLIENT_SCENARIO_ENDPOINT);
 }
@@ -809,6 +866,7 @@ int main(void) {
     tcase_set_timeout(tc, 30);
     tcase_add_test(tc, httpClientSecurityValidation);
     tcase_add_test(tc, httpClientServicesSubscriptionsAndReconnect);
+    tcase_add_test(tc, httpClientSessionNotificationCloseIsReentrant);
     tcase_add_test(tc, httpClientEndpointSelection);
 #ifdef UA_ENABLE_JSON_ENCODING
     tcase_add_test(tc, httpJsonClientServiceAndMalformedResponse);

--- a/tests/fuzz/fuzz_server_services.cc
+++ b/tests/fuzz/fuzz_server_services.cc
@@ -56,7 +56,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     UA_Session session;
     UA_Session_init(&session);
-    session.activated = true;
+    session.state = UA_SESSIONSTATE_ACTIVATED;
     UA_NodeId_init(&session.sessionId);
     session.sessionId.identifierType = UA_NODEIDTYPE_NUMERIC;
     session.sessionId.identifier.numeric = 1;

--- a/tests/server/check_server_asyncop.c
+++ b/tests/server/check_server_asyncop.c
@@ -39,6 +39,8 @@ static UA_UInt64 lastTimedCallback;
 static UA_StatusCode closeFromReadResult;
 static UA_Boolean closeAtServiceAsync;
 static UA_StatusCode closeAtServiceAsyncResult;
+static size_t closeServiceAsyncCount;
+static size_t closeServiceEndCount;
 
 static const void *canceledCallRequest = NULL;
 static const void *expectedCanceledCallRequest = NULL;
@@ -67,8 +69,15 @@ static void
 closeFromAsyncServiceNotification(
     UA_Server *server, UA_ApplicationNotificationType type,
     const UA_KeyValueMap payload) {
-    if(type != UA_APPLICATIONNOTIFICATIONTYPE_SERVICE_ASYNC ||
-       !closeAtServiceAsync)
+    if(type == UA_APPLICATIONNOTIFICATIONTYPE_SERVICE_END) {
+        closeServiceEndCount++;
+        return;
+    }
+    if(type != UA_APPLICATIONNOTIFICATIONTYPE_SERVICE_ASYNC)
+        return;
+
+    closeServiceAsyncCount++;
+    if(!closeAtServiceAsync)
         return;
     closeAtServiceAsync = false;
     const UA_NodeId *sessionId = (const UA_NodeId*)payload.map[1].value.data;
@@ -199,6 +208,8 @@ static void setup(void) {
     clientCounter = 0;
     completeCanceledRead = false;
     closeAtServiceAsync = false;
+    closeServiceAsyncCount = 0;
+    closeServiceEndCount = 0;
     running = true;
     server = UA_Server_newForUnitTest();
     ck_assert(server != NULL);
@@ -434,11 +445,19 @@ START_TEST(Async_serviceNotificationCloseCancelsPersistedResponse) {
         UA_Client_run_iterate(client, 0);
     }
     ck_assert_uint_eq(closeAtServiceAsyncResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(closeServiceAsyncCount, 1);
     ck_assert_ptr_nonnull(canceledCallRequest);
     ck_assert_uint_eq(completeCanceledReadResult, UA_STATUSCODE_BADNOTFOUND);
 
+    /* Async service notifications are paired with an eventual SERVICE_END,
+     * even when closing the session cancels the pending operation. */
+    for(size_t i = 0; i < 20 && closeServiceEndCount == 0; i++)
+        UA_Server_run_iterate(server, false);
+    ck_assert_uint_eq(closeServiceEndCount, 1);
+
     lockServer(server);
     ck_assert(TAILQ_EMPTY(&server->asyncManager.waitingResponses));
+    ck_assert(TAILQ_EMPTY(&server->asyncManager.readyResponses));
     ck_assert(TAILQ_EMPTY(&server->asyncManager.waitingOps));
     unlockServer(server);
 

--- a/tests/server/check_server_asyncop.c
+++ b/tests/server/check_server_asyncop.c
@@ -36,9 +36,14 @@ THREAD_HANDLE server_thread;
 static UA_Server *server;
 static size_t clientCounter;
 static UA_UInt64 lastTimedCallback;
+static UA_StatusCode closeFromReadResult;
+static UA_Boolean closeAtServiceAsync;
+static UA_StatusCode closeAtServiceAsyncResult;
 
 static const void *canceledCallRequest = NULL;
 static const void *expectedCanceledCallRequest = NULL;
+static UA_Boolean completeCanceledRead;
+static UA_StatusCode completeCanceledReadResult;
 
 // Store active async reads and remove when cancelled
 static void *activeReads[16];
@@ -51,6 +56,23 @@ asyncOperationCancelCallback(UA_Server *server, const void *out) {
         if(activeReads[i] == out)
             activeReads[i] = NULL;
     }
+    if(completeCanceledRead) {
+        completeCanceledRead = false;
+        completeCanceledReadResult =
+            UA_Server_setAsyncReadResult(server, (UA_DataValue*)(uintptr_t)out);
+    }
+}
+
+static void
+closeFromAsyncServiceNotification(
+    UA_Server *server, UA_ApplicationNotificationType type,
+    const UA_KeyValueMap payload) {
+    if(type != UA_APPLICATIONNOTIFICATIONTYPE_SERVICE_ASYNC ||
+       !closeAtServiceAsync)
+        return;
+    closeAtServiceAsync = false;
+    const UA_NodeId *sessionId = (const UA_NodeId*)payload.map[1].value.data;
+    closeAtServiceAsyncResult = UA_Server_closeSession(server, sessionId);
 }
 
 static void
@@ -90,6 +112,15 @@ readCallback_async(UA_Server *server, const UA_NodeId *sessionId,
     UA_Server_addTimedCallback(server, asyncRead, value, callTime, &lastTimedCallback);
     activeReads[i] = value; /* store to see if canceled */
     return UA_STATUSCODE_GOODCOMPLETESASYNCHRONOUSLY;
+}
+
+static UA_StatusCode
+readCallback_closeSession(UA_Server *server, const UA_NodeId *sessionId,
+                          void *sessionContext, const UA_NodeId *nodeId,
+                          void *nodeContext, UA_Boolean includeSourceTimeStamp,
+                          const UA_NumericRange *range, UA_DataValue *value) {
+    closeFromReadResult = UA_Server_closeSession(server, sessionId);
+    return UA_STATUSCODE_GOOD;
 }
 
 static void
@@ -166,6 +197,8 @@ THREAD_CALLBACK(serverloop) {
 
 static void setup(void) {
     clientCounter = 0;
+    completeCanceledRead = false;
+    closeAtServiceAsync = false;
     running = true;
     server = UA_Server_newForUnitTest();
     ck_assert(server != NULL);
@@ -221,13 +254,28 @@ static void setup(void) {
 
     UA_Server_setVariableNode_callbackValueSource(server, UA_NODEID_STRING(1, "asyncVar"), evs);
 
+    /* Variable that closes the calling Session from its read callback */
+    UA_CallbackValueSource closeSessionSource = {readCallback_closeSession, NULL};
+    res = UA_Server_addVariableNode(server,
+                                    UA_NODEID_STRING(1, "closeSessionVar"),
+                                    UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+                                    UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                                    UA_QUALIFIEDNAME(1, "closeSessionVar"),
+                                    UA_NS0ID(BASEDATAVARIABLETYPE),
+                                    varAttr, NULL, NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    UA_Server_setVariableNode_callbackValueSource(
+        server, UA_NODEID_STRING(1, "closeSessionVar"), closeSessionSource);
+
     UA_Server_run_startup(server);
     THREAD_CREATE(server_thread, serverloop);
 }
 
 static void teardown(void) {
-    running = false;
-    THREAD_JOIN(server_thread);
+    if(running) {
+        running = false;
+        THREAD_JOIN(server_thread);
+    }
     UA_Server_run_shutdown(server);
     UA_Server_delete(server);
 }
@@ -257,7 +305,7 @@ START_TEST(Async_call) {
 
     /* Receive the answer of the sync call */
     while(clientCounter == 0) {
-        UA_Server_run_iterate(server, true);
+        UA_Server_run_iterate(server, false);
         UA_Client_run_iterate(client, 0);
     }
     ck_assert_uint_eq(clientCounter, 1);
@@ -300,7 +348,7 @@ START_TEST(Async_read) {
 
     /* Receive the answer of the sync call */
     while(clientCounter == 0) {
-        UA_Server_run_iterate(server, true);
+        UA_Server_run_iterate(server, false);
         UA_Client_run_iterate(client, 0);
     }
     ck_assert_uint_eq(clientCounter, 1);
@@ -316,6 +364,87 @@ START_TEST(Async_read) {
     running = true;
     THREAD_CREATE(server_thread, serverloop);
 
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+} END_TEST
+
+START_TEST(Async_multiRead_closingSessionCancelsPendingOperation) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_ReadValueId nodes[2];
+    UA_ReadValueId_init(&nodes[0]);
+    nodes[0].nodeId = UA_NODEID_STRING(1, "asyncVar");
+    nodes[0].attributeId = UA_ATTRIBUTEID_VALUE;
+    UA_ReadValueId_init(&nodes[1]);
+    nodes[1].nodeId = UA_NODEID_STRING(1, "closeSessionVar");
+    nodes[1].attributeId = UA_ATTRIBUTEID_VALUE;
+
+    UA_ReadRequest request;
+    UA_ReadRequest_init(&request);
+    request.timestampsToReturn = UA_TIMESTAMPSTORETURN_NEITHER;
+    request.nodesToRead = nodes;
+    request.nodesToReadSize = 2;
+
+    closeFromReadResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    canceledCallRequest = NULL;
+    completeCanceledRead = true;
+    completeCanceledReadResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    UA_ReadResponse response = UA_Client_Service_read(client, request);
+    ck_assert_uint_eq(closeFromReadResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(response.responseHeader.serviceResult,
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+    ck_assert_ptr_nonnull(canceledCallRequest);
+    ck_assert_uint_eq(completeCanceledReadResult, UA_STATUSCODE_BADNOTFOUND);
+    for(size_t i = 0; i < 16; i++)
+        ck_assert_ptr_null(activeReads[i]);
+    UA_ReadResponse_clear(&response);
+
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+} END_TEST
+
+START_TEST(Async_serviceNotificationCloseCancelsPersistedResponse) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_Client_getConfig(client)->noReconnect = true;
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    running = false;
+    THREAD_JOIN(server_thread);
+
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    config->serviceNotificationCallback = closeFromAsyncServiceNotification;
+    closeAtServiceAsync = true;
+    closeAtServiceAsyncResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    canceledCallRequest = NULL;
+    completeCanceledRead = true;
+    completeCanceledReadResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    retval = UA_Client_readValueAttribute_async(
+        client, UA_NODEID_STRING(1, "asyncVar"),
+        clientReadCallback, NULL, NULL);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    for(size_t i = 0;
+        i < 20 && closeAtServiceAsyncResult == UA_STATUSCODE_BADUNEXPECTEDERROR;
+        i++) {
+        UA_Server_run_iterate(server, false);
+        UA_Client_run_iterate(client, 0);
+    }
+    ck_assert_uint_eq(closeAtServiceAsyncResult, UA_STATUSCODE_GOOD);
+    ck_assert_ptr_nonnull(canceledCallRequest);
+    ck_assert_uint_eq(completeCanceledReadResult, UA_STATUSCODE_BADNOTFOUND);
+
+    lockServer(server);
+    ck_assert(TAILQ_EMPTY(&server->asyncManager.waitingResponses));
+    ck_assert(TAILQ_EMPTY(&server->asyncManager.waitingOps));
+    unlockServer(server);
+
+    config->serviceNotificationCallback = NULL;
+    running = true;
+    THREAD_CREATE(server_thread, serverloop);
     UA_Client_disconnect(client);
     UA_Client_delete(client);
 } END_TEST
@@ -346,7 +475,7 @@ START_TEST(Async_write) {
 
     /* Receive the answer of the sync call */
     while(clientCounter == 0) {
-        UA_Server_run_iterate(server, true);
+        UA_Server_run_iterate(server, false);
         UA_Client_run_iterate(client, 0);
     }
     ck_assert_uint_eq(clientCounter, 1);
@@ -1257,6 +1386,9 @@ static Suite* method_async_suite(void) {
     tcase_add_checked_fixture(tc_manager, setup, teardown);
     tcase_add_test(tc_manager, Async_call);
     tcase_add_test(tc_manager, Async_read);
+    tcase_add_test(tc_manager, Async_multiRead_closingSessionCancelsPendingOperation);
+    tcase_add_test(tc_manager,
+                   Async_serviceNotificationCloseCancelsPersistedResponse);
     tcase_add_test(tc_manager, Async_write);
     tcase_add_test(tc_manager, Async_timeout);
     tcase_add_test(tc_manager, Async_forget);

--- a/tests/server/check_session.c
+++ b/tests/server/check_session.c
@@ -43,6 +43,41 @@ static void teardown(void) {
     UA_Server_delete(server);
 }
 
+/* Opening a new SecureChannel drives the server EventLoop through another
+ * iteration and therefore processes callbacks delayed by the preceding
+ * request. */
+static void
+processDelayedServerCallbacks(void) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+
+static UA_StatusCode
+createSessionRaw(UA_Client *client, UA_CreateSessionResponse *response) {
+    UA_CreateSessionRequest request;
+    UA_CreateSessionRequest_init(&request);
+    UA_CreateSessionResponse_init(response);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_CREATESESSIONREQUEST],
+                        response, &UA_TYPES[UA_TYPES_CREATESESSIONRESPONSE]);
+    return response->responseHeader.serviceResult;
+}
+
+static UA_StatusCode
+activateSessionRaw(UA_Client *client) {
+    UA_ActivateSessionRequest request;
+    UA_ActivateSessionRequest_init(&request);
+    UA_ActivateSessionResponse response;
+    UA_ActivateSessionResponse_init(&response);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_ACTIVATESESSIONREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_ACTIVATESESSIONRESPONSE]);
+    UA_StatusCode result = response.responseHeader.serviceResult;
+    UA_ActivateSessionResponse_clear(&response);
+    return result;
+}
+
 START_TEST(Session_close_before_activate) {
     UA_Client *client = UA_Client_newForUnitTest();
     UA_StatusCode retval = UA_Client_connectSecureChannel(client, "opc.tcp://localhost:4840");
@@ -87,7 +122,7 @@ START_TEST(Session_init_ShallWork) {
     UA_ApplicationDescription tmpAppDescription;
     UA_ApplicationDescription_init(&tmpAppDescription);
     UA_DateTime tmpDateTime = 0;
-    ck_assert_int_eq(session.activated, false);
+    ck_assert_int_eq(session.state, UA_SESSIONSTATE_CREATED);
     ck_assert_int_eq(session.authenticationToken.identifier.numeric, tmpNodeId.identifier.numeric);
     ck_assert_uint_eq(session.continuationPointsSize, 0);
     ck_assert_ptr_eq(session.channel, NULL);
@@ -139,6 +174,312 @@ START_TEST(Session_notificationCallback) {
     UA_Variant_clear(&val);
 
     UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_Boolean closeSessionAtServiceBegin;
+static UA_StatusCode closeSessionAtServiceBeginResult;
+
+static void
+closeSessionServiceNotification(UA_Server *server_,
+                                UA_ApplicationNotificationType type,
+                                const UA_KeyValueMap payload) {
+    if(type != UA_APPLICATIONNOTIFICATIONTYPE_SERVICE_BEGIN ||
+       !closeSessionAtServiceBegin)
+        return;
+
+    closeSessionAtServiceBegin = false;
+    const UA_NodeId *sessionId = (const UA_NodeId*)payload.map[1].value.data;
+    closeSessionAtServiceBeginResult = UA_Server_closeSession(server_, sessionId);
+}
+
+START_TEST(Session_serviceBeginCallbackClosesCurrentSession) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connect(client, "opc.tcp://localhost:4840"),
+                      UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    cfg->serviceNotificationCallback = closeSessionServiceNotification;
+    closeSessionAtServiceBeginResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    closeSessionAtServiceBegin = true;
+
+    UA_Variant value;
+    UA_Variant_init(&value);
+    UA_StatusCode result = UA_Client_readValueAttribute(
+        client, UA_NS0ID(SERVER_SERVERSTATUS_CURRENTTIME), &value);
+    UA_Variant_clear(&value);
+
+    ck_assert_uint_eq(closeSessionAtServiceBeginResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(result, UA_STATUSCODE_BADSESSIONCLOSED);
+
+    cfg->serviceNotificationCallback = NULL;
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static void (*originalAccessControlCloseSession)(
+    UA_Server*, UA_AccessControl*, const UA_NodeId*, void*);
+static UA_StatusCode reentrantAccessControlCloseResult;
+
+static void
+reentrantAccessControlCloseSession(UA_Server *server_, UA_AccessControl *ac,
+                                   const UA_NodeId *sessionId,
+                                   void *sessionContext) {
+    reentrantAccessControlCloseResult =
+        UA_Server_closeSession(server_, sessionId);
+    originalAccessControlCloseSession(server_, ac, sessionId, sessionContext);
+}
+
+START_TEST(Session_accessControlCloseSessionIsReentrant) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connect(client, "opc.tcp://localhost:4840"),
+                      UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    originalAccessControlCloseSession = cfg->accessControl.closeSession;
+    cfg->accessControl.closeSession = reentrantAccessControlCloseSession;
+    reentrantAccessControlCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    UA_Client_disconnect(client);
+    processDelayedServerCallbacks();
+
+    ck_assert_uint_eq(reentrantAccessControlCloseResult,
+                      UA_STATUSCODE_BADSESSIONIDINVALID);
+    cfg->accessControl.closeSession = originalAccessControlCloseSession;
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_Boolean closeAtSessionNotification;
+static UA_ApplicationNotificationType sessionNotificationToClose;
+static UA_StatusCode sessionNotificationCloseResult;
+
+static void
+closeFromSessionNotification(UA_Server *server_,
+                             UA_ApplicationNotificationType type,
+                             const UA_KeyValueMap payload) {
+    if(!closeAtSessionNotification || type != sessionNotificationToClose)
+        return;
+    closeAtSessionNotification = false;
+    const UA_NodeId *sessionId = (const UA_NodeId*)payload.map[0].value.data;
+    sessionNotificationCloseResult =
+        UA_Server_closeSession(server_, sessionId);
+}
+
+START_TEST(Session_createdNotificationCloseReturnsSessionClosed) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    cfg->sessionNotificationCallback = closeFromSessionNotification;
+    closeAtSessionNotification = true;
+    sessionNotificationToClose = UA_APPLICATIONNOTIFICATIONTYPE_SESSION_CREATED;
+    sessionNotificationCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    UA_CreateSessionResponse response;
+    UA_StatusCode result = createSessionRaw(client, &response);
+    ck_assert_uint_eq(sessionNotificationCloseResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(result, UA_STATUSCODE_BADSESSIONCLOSED);
+
+    cfg->sessionNotificationCallback = NULL;
+    UA_CreateSessionResponse_clear(&response);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Session_activatedNotificationCloseReturnsSessionClosed) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse createResponse;
+    ck_assert_uint_eq(createSessionRaw(client, &createResponse),
+                      UA_STATUSCODE_GOOD);
+    UA_NodeId_copy(&createResponse.authenticationToken,
+                   &client->authenticationToken);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    cfg->sessionNotificationCallback = closeFromSessionNotification;
+    closeAtSessionNotification = true;
+    sessionNotificationToClose = UA_APPLICATIONNOTIFICATIONTYPE_SESSION_ACTIVATED;
+    sessionNotificationCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    ck_assert_uint_eq(activateSessionRaw(client),
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+    ck_assert_uint_eq(sessionNotificationCloseResult, UA_STATUSCODE_GOOD);
+
+    cfg->sessionNotificationCallback = NULL;
+    UA_CreateSessionResponse_clear(&createResponse);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_StatusCode (*originalAccessControlActivateSession)(
+    UA_Server*, UA_AccessControl*, const UA_EndpointDescription*,
+    const UA_ByteString*, const UA_NodeId*, const UA_ExtensionObject*, void**);
+static UA_StatusCode accessControlActivateCloseResult;
+
+static UA_StatusCode
+closeFromAccessControlActivateSession(
+    UA_Server *server_, UA_AccessControl *ac,
+    const UA_EndpointDescription *endpoint,
+    const UA_ByteString *remoteCertificate, const UA_NodeId *sessionId,
+    const UA_ExtensionObject *identityToken, void **sessionContext) {
+    UA_StatusCode result = originalAccessControlActivateSession(
+        server_, ac, endpoint, remoteCertificate, sessionId, identityToken,
+        sessionContext);
+    if(result == UA_STATUSCODE_GOOD)
+        accessControlActivateCloseResult =
+            UA_Server_closeSession(server_, sessionId);
+    return result;
+}
+
+START_TEST(Session_accessControlActivateCloseReturnsSessionClosed) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse createResponse;
+    ck_assert_uint_eq(createSessionRaw(client, &createResponse),
+                      UA_STATUSCODE_GOOD);
+    UA_NodeId_copy(&createResponse.authenticationToken,
+                   &client->authenticationToken);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    originalAccessControlActivateSession = cfg->accessControl.activateSession;
+    cfg->accessControl.activateSession = closeFromAccessControlActivateSession;
+    accessControlActivateCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    ck_assert_uint_eq(activateSessionRaw(client),
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+    ck_assert_uint_eq(accessControlActivateCloseResult, UA_STATUSCODE_GOOD);
+
+    cfg->accessControl.activateSession = originalAccessControlActivateSession;
+    UA_CreateSessionResponse_clear(&createResponse);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_Byte (*originalAccessControlGetUserAccessLevel)(
+    UA_Server*, UA_AccessControl*, const UA_NodeId*, void*,
+    const UA_NodeId*, void*);
+static void (*originalDeferredAccessControlCloseSession)(
+    UA_Server*, UA_AccessControl*, const UA_NodeId*, void*);
+static UA_Boolean closeAtUserAccessLevel;
+static UA_Boolean accessControlCloseWasDeferred;
+static size_t userAccessLevelCalls;
+static size_t deferredAccessControlCloseCalls;
+static UA_StatusCode userAccessLevelCloseResult;
+
+static void
+observeDeferredAccessControlClose(UA_Server *server_, UA_AccessControl *ac,
+                                  const UA_NodeId *sessionId,
+                                  void *sessionContext) {
+    deferredAccessControlCloseCalls++;
+    originalDeferredAccessControlCloseSession(server_, ac, sessionId,
+                                              sessionContext);
+}
+
+static UA_Byte
+closeFromGetUserAccessLevel(UA_Server *server_, UA_AccessControl *ac,
+                            const UA_NodeId *sessionId, void *sessionContext,
+                            const UA_NodeId *nodeId, void *nodeContext) {
+    userAccessLevelCalls++;
+    if(closeAtUserAccessLevel) {
+        closeAtUserAccessLevel = false;
+        userAccessLevelCloseResult =
+            UA_Server_closeSession(server_, sessionId);
+        accessControlCloseWasDeferred =
+            (deferredAccessControlCloseCalls == 0);
+    }
+    return originalAccessControlGetUserAccessLevel(
+        server_, ac, sessionId, sessionContext, nodeId, nodeContext);
+}
+
+START_TEST(Session_accessControlCloseStopsMultiReadAndDefersContextClose) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connect(client, "opc.tcp://localhost:4840"),
+                      UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    originalAccessControlGetUserAccessLevel =
+        cfg->accessControl.getUserAccessLevel;
+    originalDeferredAccessControlCloseSession =
+        cfg->accessControl.closeSession;
+    cfg->accessControl.getUserAccessLevel = closeFromGetUserAccessLevel;
+    cfg->accessControl.closeSession = observeDeferredAccessControlClose;
+    closeAtUserAccessLevel = true;
+    accessControlCloseWasDeferred = false;
+    userAccessLevelCalls = 0;
+    deferredAccessControlCloseCalls = 0;
+    userAccessLevelCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    UA_ReadRequest request;
+    UA_ReadRequest_init(&request);
+    UA_ReadValueId items[2];
+    UA_ReadValueId_init(&items[0]);
+    UA_ReadValueId_init(&items[1]);
+    items[0].nodeId = UA_NS0ID(SERVER_SERVERSTATUS_CURRENTTIME);
+    items[1].nodeId = UA_NS0ID(SERVER_SERVERSTATUS_CURRENTTIME);
+    items[0].attributeId = UA_ATTRIBUTEID_VALUE;
+    items[1].attributeId = UA_ATTRIBUTEID_VALUE;
+    request.nodesToRead = items;
+    request.nodesToReadSize = 2;
+
+    UA_ReadResponse response = UA_Client_Service_read(client, request);
+    ck_assert_uint_eq(userAccessLevelCloseResult, UA_STATUSCODE_GOOD);
+    ck_assert(accessControlCloseWasDeferred);
+    ck_assert_uint_eq(userAccessLevelCalls, 1);
+    ck_assert_uint_eq(response.responseHeader.serviceResult,
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+
+    processDelayedServerCallbacks();
+    ck_assert_uint_eq(deferredAccessControlCloseCalls, 1);
+
+    cfg->accessControl.getUserAccessLevel =
+        originalAccessControlGetUserAccessLevel;
+    cfg->accessControl.closeSession =
+        originalDeferredAccessControlCloseSession;
+    request.nodesToRead = NULL;
+    request.nodesToReadSize = 0;
+    UA_ReadResponse_clear(&response);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+/* TCP and WebSocket both use the UACP SecureChannel teardown below. */
+START_TEST(Session_closedAttachedSessionDoesNotStallUacpTeardown) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse createResponse;
+    ck_assert_uint_eq(createSessionRaw(client, &createResponse),
+                      UA_STATUSCODE_GOOD);
+
+    lockServer(server);
+    UA_Session *session = getSessionById(server, &createResponse.sessionId);
+    ck_assert_ptr_nonnull(session);
+    session->state = UA_SESSIONSTATE_CLOSED;
+    unlockServer(server);
+
+    UA_Client_disconnect(client);
+
+    lockServer(server);
+    ck_assert_ptr_null(session->channel);
+    session->state = UA_SESSIONSTATE_CREATED;
+    unlockServer(server);
+    ck_assert_uint_eq(UA_Server_closeSession(server, &createResponse.sessionId),
+                      UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse_clear(&createResponse);
     UA_Client_delete(client);
 }
 END_TEST
@@ -596,6 +937,14 @@ static Suite* testSuite_Session(void) {
     tcase_add_test(tc_session, Session_init_ShallWork);
     tcase_add_test(tc_session, Session_updateLifetime_ShallWork);
     tcase_add_test(tc_session, Session_notificationCallback);
+    tcase_add_test(tc_session, Session_serviceBeginCallbackClosesCurrentSession);
+    tcase_add_test(tc_session, Session_accessControlCloseSessionIsReentrant);
+    tcase_add_test(tc_session, Session_createdNotificationCloseReturnsSessionClosed);
+    tcase_add_test(tc_session, Session_activatedNotificationCloseReturnsSessionClosed);
+    tcase_add_test(tc_session, Session_accessControlActivateCloseReturnsSessionClosed);
+    tcase_add_test(tc_session, Session_accessControlCloseStopsMultiReadAndDefersContextClose);
+    tcase_add_test(tc_session,
+                   Session_closedAttachedSessionDoesNotStallUacpTeardown);
     tcase_add_test(tc_session, Session_setSessionAttribute_ShallWork);
 
     TCase *tc_session_ext = tcase_create("Extended");

--- a/tests/server/check_session.c
+++ b/tests/server/check_session.c
@@ -37,6 +37,8 @@ static void setup(void) {
 }
 
 static void teardown(void) {
+    if(!server)
+        return;
     running = false;
     THREAD_JOIN(server_thread);
     UA_Server_run_shutdown(server);
@@ -134,6 +136,39 @@ START_TEST(Session_init_ShallWork) {
     ck_assert_ptr_eq(session.sessionName.data, NULL);
     ck_assert_int_eq((int)session.timeout, 0);
     ck_assert_int_eq(session.validTill, tmpDateTime);
+}
+END_TEST
+
+static void (*originalDeleteCloseSession)(
+    UA_Server*, UA_AccessControl*, const UA_NodeId*, void*);
+static size_t deleteCloseSessionCalls;
+
+static void
+observeDeleteCloseSession(UA_Server *server_, UA_AccessControl *ac,
+                          const UA_NodeId *sessionId, void *sessionContext) {
+    deleteCloseSessionCalls++;
+    originalDeleteCloseSession(server_, ac, sessionId, sessionContext);
+}
+
+START_TEST(Session_deleteStoppedServerCleansSessionSynchronously) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connect(client, "opc.tcp://localhost:4840"),
+                      UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    originalDeleteCloseSession = cfg->accessControl.closeSession;
+    cfg->accessControl.closeSession = observeDeleteCloseSession;
+    deleteCloseSessionCalls = 0;
+
+    running = false;
+    THREAD_JOIN(server_thread);
+    ck_assert_uint_eq(UA_Server_run_shutdown(server), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(deleteCloseSessionCalls, 0);
+    ck_assert_uint_eq(UA_Server_delete(server), UA_STATUSCODE_GOOD);
+    server = NULL;
+    ck_assert_uint_eq(deleteCloseSessionCalls, 1);
+
+    UA_Client_delete(client);
 }
 END_TEST
 
@@ -937,6 +972,8 @@ static Suite* testSuite_Session(void) {
     tcase_add_test(tc_session, Session_init_ShallWork);
     tcase_add_test(tc_session, Session_updateLifetime_ShallWork);
     tcase_add_test(tc_session, Session_notificationCallback);
+    tcase_add_test(tc_session,
+                   Session_deleteStoppedServerCleansSessionSynchronously);
     tcase_add_test(tc_session, Session_serviceBeginCallbackClosesCurrentSession);
     tcase_add_test(tc_session, Session_accessControlCloseSessionIsReentrant);
     tcase_add_test(tc_session, Session_createdNotificationCloseReturnsSessionClosed);


### PR DESCRIPTION
Model server sessions with explicit CREATED, ACTIVATED, and CLOSED states. Mark a session CLOSED, detach it, and remove it from lookup before callbacks can re-enter, while delaying destructive access-control and resource teardown until current jobs finish.

Reject sessions closed by service, notification, and access-control callbacks, stop multi-operation processing after closure, and preserve progress during UACP and HTTP channel teardown. Add regression coverage for callback reentrancy, shared TCP/WebSocket UACP teardown, and HTTP session cleanup.