### PR TITLE
fix(server): handle reentrant monitored item deletion

### DIFF
--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -366,7 +366,7 @@ struct createMonContext {
     UA_LocalMonitoredItem *localMon; /* used if non-null */
 };
 
-static void
+void
 notifyMonitoredItem(UA_Server *server, UA_MonitoredItem *mon,
                     UA_ApplicationNotificationType type) {
     /* Nothing to do? */
@@ -553,7 +553,7 @@ Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session,
                                  "Could not create a MonitoredItem "
                                  "with StatusCode %s",
                                  UA_StatusCode_name(result->statusCode));
-        UA_MonitoredItem_delete(server, newMon);
+        UA_MonitoredItem_delete(server, newMon, false);
         return;
     }
 
@@ -563,6 +563,10 @@ Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session,
 
     /* Register the Monitoreditem in the server and subscription */
     UA_MonitoredItem_register(server, newMon);
+
+    /* A register callback can reenter and delete the MonitoredItem. */
+    if(UA_MonitoredItem_isDeleting(newMon))
+        goto prepareResponse;
 
     UA_LOG_INFO_SUBSCRIPTION(server->config.logging, cmc->sub,
                              "MonitoredItem %" PRIi32 " | "
@@ -577,18 +581,21 @@ Operation_CreateMonitoredItem(UA_Server *server, UA_Session *session,
     notifyMonitoredItem(server, newMon,
                         UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_CREATED);
 
+    /* Deletion from the CREATED callback has already queued delayed cleanup.
+     * Do not reactivate or sample the logically removed MonitoredItem. */
+    if(UA_MonitoredItem_isDeleting(newMon))
+        goto prepareResponse;
+
     /* Activate the MonitoredItem */
     result->statusCode = UA_MonitoredItem_setMonitoringMode(server, newMon,
                                                             request->monitoringMode);
     if(result->statusCode != UA_STATUSCODE_GOOD) {
-        /* Notify again if the MonitoringMode could not be set */
-        notifyMonitoredItem(server, newMon,
-                            UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_DELETE);
-        UA_MonitoredItem_delete(server, newMon);
+        UA_MonitoredItem_delete(server, newMon, true);
         return;
     }
 
     /* Prepare the response */
+prepareResponse:
     result->revisedSamplingInterval = newMon->parameters.samplingInterval;
     result->revisedQueueSize = newMon->parameters.queueSize;
     result->monitoredItemId = newMon->monitoredItemId;
@@ -982,9 +989,7 @@ Operation_DeleteMonitoredItem(UA_Server *server, UA_Session *session, UA_Subscri
         *result = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
         return;
     }
-    notifyMonitoredItem(server, mon,
-                        UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_DELETE);
-    UA_MonitoredItem_delete(server, mon);
+    UA_MonitoredItem_delete(server, mon, true);
 }
 
 UA_Boolean
@@ -1035,9 +1040,7 @@ UA_Server_deleteMonitoredItem(UA_Server *server, UA_UInt32 monitoredItemId) {
 
     UA_StatusCode res = UA_STATUSCODE_BADMONITOREDITEMIDINVALID;
     if(mon) {
-        notifyMonitoredItem(server, mon,
-                            UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_DELETE);
-        UA_MonitoredItem_delete(server, mon);
+        UA_MonitoredItem_delete(server, mon, true);
         res = UA_STATUSCODE_GOOD;
     }
 

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -311,7 +311,7 @@ UA_Subscription_delete(UA_Server *server, UA_Subscription *sub) {
     UA_assert(server->monitoredItemsSize >= sub->monitoredItemsSize);
     UA_MonitoredItem *mon, *tmp_mon;
     LIST_FOREACH_SAFE(mon, &sub->monitoredItems, listEntry, tmp_mon) {
-        UA_MonitoredItem_delete(server, mon);
+        UA_MonitoredItem_delete(server, mon, false);
     }
     UA_assert(sub->monitoredItemsSize == 0);
 
@@ -1445,8 +1445,17 @@ delayedFreeMonitoredItem(void *application, void *context) {
 }
 
 void
-UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *mon) {
+UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *mon,
+                        UA_Boolean notify) {
     UA_LOCK_ASSERT(&server->serviceMutex);
+
+    /* Application callbacks can reenter deletion. Queue the embedded delayed
+     * callback only once. */
+    if(UA_MonitoredItem_isDeleting(mon))
+        return;
+    mon->delayedFreePointers.callback = delayedFreeMonitoredItem;
+    mon->delayedFreePointers.application = server;
+    mon->delayedFreePointers.context = mon;
 
     /* Remove the sampling callback */
     UA_MonitoredItem_unregisterSampling(server, mon);
@@ -1475,6 +1484,12 @@ UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *mon) {
         UA_Notification_delete(notification);
     }
 
+    /* Notify after logical removal. Recursive public deletion can no longer
+     * locate the MonitoredItem and cannot queue delayed cleanup a second time. */
+    if(notify)
+        notifyMonitoredItem(server, mon,
+                            UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_DELETE);
+
     /* No callback can still reference the MonitoredItem after shutdown. */
     if(server->state == UA_LIFECYCLESTATE_STOPPED) {
         clearMonitoredItem(server, mon);
@@ -1484,9 +1499,6 @@ UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *mon) {
     /* Add a delayed callback to remove the MonitoredItem when the current jobs
      * have completed. This is needed to allow that a local MonitoredItem can
      * remove itself in the callback. */
-    mon->delayedFreePointers.callback = delayedFreeMonitoredItem;
-    mon->delayedFreePointers.application = server;
-    mon->delayedFreePointers.context = mon;
     UA_EventLoop *el = server->config.eventLoop;
     el->addDelayedCallback(el, &mon->delayedFreePointers);
 }

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -176,10 +176,20 @@ struct UA_MonitoredItem {
                             * the queue size */
 };
 
+static UA_INLINE UA_Boolean
+UA_MonitoredItem_isDeleting(const UA_MonitoredItem *mon) {
+    return mon->delayedFreePointers.callback != NULL;
+}
+
 void UA_MonitoredItem_init(UA_MonitoredItem *mon);
-void UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *mon);
+void UA_MonitoredItem_delete(UA_Server *server, UA_MonitoredItem *mon,
+                             UA_Boolean notify);
 void UA_MonitoredItem_removeOverflowInfoBits(UA_MonitoredItem *mon);
 void UA_MonitoredItem_register(UA_Server *server, UA_MonitoredItem *mon);
+
+void
+notifyMonitoredItem(UA_Server *server, UA_MonitoredItem *mon,
+                    UA_ApplicationNotificationType type);
 
 /* Register sampling. Either by adding a repeated callback or by adding the
  * MonitoredItem to a linked list in the node. */

--- a/tests/server/check_local_monitored_item.c
+++ b/tests/server/check_local_monitored_item.c
@@ -37,6 +37,10 @@
 UA_Server *server;
 size_t callbackCount = 0;
 UA_StatusCode expectedDataValueStatus;
+static UA_Boolean deleteAtMonitoredItemCreated;
+static UA_StatusCode deleteAtMonitoredItemCreatedResult;
+static UA_Boolean deleteAtMonitoredItemDelete;
+static UA_StatusCode deleteAtMonitoredItemDeleteResult;
 
 UA_NodeId parentNodeId;
 UA_NodeId parentReferenceNodeId;
@@ -98,6 +102,90 @@ dataChangeNotificationCallback(UA_Server *thisServer,
     lastValue = currentValue;
     callbackCount++;
 }
+
+static void
+monitoredItemLifecycleCallback(UA_Server *thisServer,
+                               UA_ApplicationNotificationType type,
+                               const UA_KeyValueMap payload) {
+    if(type == UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_DELETE &&
+       deleteAtMonitoredItemDelete) {
+        deleteAtMonitoredItemDelete = false;
+        const UA_UInt32 *monitoredItemId =
+            (const UA_UInt32*)payload.map[2].value.data;
+        deleteAtMonitoredItemDeleteResult =
+            UA_Server_deleteMonitoredItem(thisServer, *monitoredItemId);
+        return;
+    }
+
+    if(type != UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_CREATED ||
+       !deleteAtMonitoredItemCreated)
+        return;
+
+    deleteAtMonitoredItemCreated = false;
+    const UA_UInt32 *monitoredItemId =
+        (const UA_UInt32*)payload.map[2].value.data;
+    deleteAtMonitoredItemCreatedResult =
+        UA_Server_deleteMonitoredItem(thisServer, *monitoredItemId);
+}
+
+START_TEST(Server_LocalMonitoredItem_deleteFromCreatedNotification) {
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    config->subscriptionNotificationCallback = monitoredItemLifecycleCallback;
+    deleteAtMonitoredItemCreated = true;
+    deleteAtMonitoredItemCreatedResult = UA_STATUSCODE_BADINTERNALERROR;
+    callbackCount = 0;
+
+    UA_MonitoredItemCreateRequest request =
+        UA_MonitoredItemCreateRequest_default(outNodeId);
+    request.monitoringMode = UA_MONITORINGMODE_REPORTING;
+    request.requestedParameters.samplingInterval = 0.0;
+
+    UA_MonitoredItemCreateResult result =
+        UA_Server_createDataChangeMonitoredItem(
+            server, UA_TIMESTAMPSTORETURN_BOTH, request, NULL,
+            dataChangeNotificationCallback);
+    ASSERT_STATUSCODE(result.statusCode, UA_STATUSCODE_GOOD);
+    ASSERT_STATUSCODE(deleteAtMonitoredItemCreatedResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(callbackCount, 0);
+
+    /* The outer create path must not reactivate a MonitoredItem that the
+     * notification callback already deleted. */
+    UA_Server_run_iterate(server, false);
+    ck_assert_uint_eq(callbackCount, 0);
+    ASSERT_STATUSCODE(UA_Server_deleteMonitoredItem(
+        server, result.monitoredItemId),
+        UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
+    config->subscriptionNotificationCallback = NULL;
+}
+END_TEST
+
+START_TEST(Server_LocalMonitoredItem_deleteFromDeleteNotification) {
+    UA_MonitoredItemCreateRequest request =
+        UA_MonitoredItemCreateRequest_default(outNodeId);
+    UA_MonitoredItemCreateResult result =
+        UA_Server_createDataChangeMonitoredItem(
+            server, UA_TIMESTAMPSTORETURN_BOTH, request, NULL,
+            dataChangeNotificationCallback);
+    ASSERT_STATUSCODE(result.statusCode, UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    config->subscriptionNotificationCallback = monitoredItemLifecycleCallback;
+    deleteAtMonitoredItemDelete = true;
+    deleteAtMonitoredItemDeleteResult = UA_STATUSCODE_BADINTERNALERROR;
+
+    ASSERT_STATUSCODE(UA_Server_deleteMonitoredItem(
+        server, result.monitoredItemId), UA_STATUSCODE_GOOD);
+    ASSERT_STATUSCODE(deleteAtMonitoredItemDeleteResult,
+                      UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
+
+    /* Recursive deletion must not enqueue the embedded delayed callback twice. */
+    UA_Server_run_iterate(server, false);
+    ASSERT_STATUSCODE(UA_Server_deleteMonitoredItem(
+        server, result.monitoredItemId),
+        UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
+    config->subscriptionNotificationCallback = NULL;
+}
+END_TEST
 
 START_TEST(Server_LocalMonitoredItem) {
     callbackCount = 0;
@@ -464,6 +552,10 @@ static Suite * testSuite_Client(void) {
     TCase *tc_server = tcase_create("Local Monitored Item Basic");
     tcase_add_checked_fixture(tc_server, setup, teardown);
     tcase_add_test(tc_server, Server_LocalMonitoredItem);
+    tcase_add_test(tc_server,
+                   Server_LocalMonitoredItem_deleteFromCreatedNotification);
+    tcase_add_test(tc_server,
+                   Server_LocalMonitoredItem_deleteFromDeleteNotification);
     tcase_add_test(tc_server, Server_LocalMonitoredItem_deleteInCallback);
     tcase_add_test(tc_server, Server_LocalMonitoredItem_dataSource);
     tcase_add_test(tc_server, Server_LocalMonitoredItem_CustomType);


### PR DESCRIPTION
Mark MonitoredItem deletion before application callbacks and emit DELETE notifications after logical removal so recursive deletion cannot enqueue delayed cleanup twice.

Stop the outer create operation when a register or CREATED callback has already deleted the new MonitoredItem. Add focused regressions for both lifecycle callbacks.