### PR TITLE
fix(core): Make session closure reentrant-safe

### DIFF
--- a/src/server/ua_server.c
+++ b/src/server/ua_server.c
@@ -535,6 +535,7 @@ UA_Server_init(UA_Server *server) {
 
     /* Initialize the adminSession */
     UA_Session_init(&server->adminSession);
+    server->adminSession.state = UA_SESSIONSTATE_ACTIVATED;
     server->adminSession.sessionId.identifierType = UA_NODEIDTYPE_GUID;
     server->adminSession.sessionId.identifier.guid.data1 = 1;
     server->adminSession.validTill = UA_INT64_MAX;

--- a/src/server/ua_server_async.c
+++ b/src/server/ua_server_async.c
@@ -596,6 +596,10 @@ Service_Read(UA_Server *server, UA_Session *session, const UA_ReadRequest *reque
             persistAsyncResponseOperation(server, &aopArray[i],
                                           UA_ASYNCOPERATIONTYPE_READ_REQUEST,
                                           ar, &response->results[i]);
+        if(session->state == UA_SESSIONSTATE_CLOSED) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+            break;
+        }
     }
 
     /* If async operations are pending, persist them and signal the service is
@@ -716,6 +720,10 @@ Service_Write(UA_Server *server, UA_Session *session,
         if(!done)
             persistAsyncResponseOperation(server, aop, UA_ASYNCOPERATIONTYPE_WRITE_REQUEST,
                                           ar, &response->results[i]);
+        if(session->state == UA_SESSIONSTATE_CLOSED) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+            break;
+        }
     }
 
     /* If async operations are pending, persist them and signal the service is
@@ -839,6 +847,10 @@ Service_Call(UA_Server *server, UA_Session *session,
             persistAsyncResponseOperation(server, &aopArray[i],
                                           UA_ASYNCOPERATIONTYPE_CALL_REQUEST,
                                           ar, &response->results[i]);
+        if(session->state == UA_SESSIONSTATE_CLOSED) {
+            response->responseHeader.serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+            break;
+        }
     }
 
     /* If async operations are pending, persist them and signal the service is

--- a/src/server/ua_server_binary.c
+++ b/src/server/ua_server_binary.c
@@ -117,7 +117,9 @@ deleteServerSecureChannel(UA_BinaryProtocolManager *bpm,
      * channel. Non-activated sessions are deleted (Part 4, §5.6.3). */
     while(channel->sessions) {
         UA_Session *session = channel->sessions;
-        if(!session->activated)
+        if(session->state == UA_SESSIONSTATE_CLOSED)
+            UA_Session_detachFromSecureChannel(server, session);
+        else if(session->state != UA_SESSIONSTATE_ACTIVATED)
             UA_Session_remove(server, session, UA_SHUTDOWNREASON_PURGE);
         else
             UA_Session_detachFromSecureChannel(server, session);
@@ -408,6 +410,11 @@ getBoundSession(UA_Server *server, const UA_SecureChannel *channel,
     for(UA_Session *s = channel->sessions; s; s = s->next) {
         if(!UA_NodeId_equal(token, &s->authenticationToken))
             continue;
+
+        /* The Session was closed by a reentrant callback but has not yet been
+         * detached from the SecureChannel. */
+        if(s->state == UA_SESSIONSTATE_CLOSED)
+            return UA_STATUSCODE_BADSESSIONCLOSED;
 
         /* Has the session timed out? */
         if(s->validTill < nowMonotonic)

--- a/src/server/ua_server_internal.h
+++ b/src/server/ua_server_internal.h
@@ -188,6 +188,7 @@ getServerComponentByName(UA_Server *server, UA_String name);
 
 typedef struct session_list_entry {
     UA_DelayedCallback cleanupCallback;
+    UA_ShutdownReason shutdownReason;
     LIST_ENTRY(session_list_entry) pointers;
     UA_Session session;
 } session_list_entry;

--- a/src/server/ua_services.c
+++ b/src/server/ua_services.c
@@ -194,6 +194,8 @@ allocProcessServiceOperations(UA_Server *server, UA_Session *session,
     uintptr_t reqOp = *(uintptr_t*)((uintptr_t)requestOperations + sizeof(size_t));
     for(size_t i = 0; i < ops; i++) {
         operationCallback(server, session, context, (void*)reqOp, (void*)respOp);
+        if(session && session->state == UA_SESSIONSTATE_CLOSED)
+            return UA_STATUSCODE_BADSESSIONCLOSED;
         reqOp += requestOperationsType->memSize;
         respOp += responseOperationsType->memSize;
     }
@@ -205,6 +207,12 @@ processServiceInternal(UA_Server *server, UA_SecureChannel *channel, UA_Session 
                        UA_UInt32 requestId, UA_ServiceDescription *sd,
                        const UA_Request *request, UA_Response *response) {
     UA_ResponseHeader *rh = &response->responseHeader;
+
+    /* A callback before service execution can close the resolved Session. */
+    if(session && session->state == UA_SESSIONSTATE_CLOSED) {
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+        return true;
+    }
 
     /* Check timestamp in the request header */
     if(request->requestHeader.timestamp == 0 &&
@@ -260,7 +268,7 @@ processServiceInternal(UA_Server *server, UA_SecureChannel *channel, UA_Session 
     }
 
     /* Trying to use a non-activated session? */
-    if(sd->sessionRequired && !session->activated) {
+    if(sd->sessionRequired && session->state != UA_SESSIONSTATE_ACTIVATED) {
         UA_assert(session != &anonymousSession); /* because sd->sessionRequired */
 #ifdef UA_ENABLE_TYPEDESCRIPTION
         UA_LOG_WARNING_SESSION(server->config.logging, session,
@@ -286,8 +294,13 @@ processServiceInternal(UA_Server *server, UA_SecureChannel *channel, UA_Session 
     server->asyncManager.currentRequestId = requestId;
     server->asyncManager.currentRequestHandle = request->requestHeader.requestHandle;
 
-    /* Execute the service */
-    return sd->serviceCallback(server, session, request, response);
+    /* Execute the service. A user callback inside the service can close the
+     * Session. For synchronous services, do not return a successful response
+     * for a Session that became closed during the operation. */
+    UA_Boolean done = sd->serviceCallback(server, session, request, response);
+    if(done && session->state == UA_SESSIONSTATE_CLOSED)
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+    return done;
 }
 
 UA_Boolean

--- a/src/server/ua_services_session.c
+++ b/src/server/ua_services_session.c
@@ -64,11 +64,45 @@ notifySession(UA_Server *server, UA_Session *session,
         server->config.globalNotificationCallback(server, type, payloadMap);
 }
 
-/* Delayed callback to free the session memory */
+/* Delayed callback for destructive session teardown. Logical closure and
+ * detachment happen synchronously in UA_Session_remove. Keeping the Session
+ * resources alive until the current jobs have completed lets callbacks safely
+ * close the Session they are currently using. */
 static void
 removeSessionCallback(UA_Server *server, session_list_entry *entry) {
     lockServer(server);
-    UA_Session_clear(&entry->session, server);
+    UA_Session *session = &entry->session;
+
+    /* When the session times out, detach subscriptions so they can be
+     * recovered via TransferSubscriptions. Otherwise delete them. */
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    UA_Subscription *sub, *tempsub;
+    TAILQ_FOREACH_SAFE(sub, &session->subscriptions, sessionListEntry, tempsub) {
+        if(entry->shutdownReason == UA_SHUTDOWNREASON_TIMEOUT) {
+            UA_LOG_INFO_SUBSCRIPTION(server->config.logging, sub,
+                                     "Detaching the Subscription from the timed-out Session");
+            UA_Session_detachSubscription(server, session, sub, true);
+        } else {
+            UA_Subscription_delete(server, sub);
+        }
+    }
+
+    UA_PublishResponseEntry *pre;
+    while((pre = UA_Session_dequeuePublishReq(session))) {
+        UA_PublishResponse_clear(&pre->response);
+        UA_free(pre);
+    }
+#endif
+
+    /* Callback into userland access control. The session context remains valid
+     * until this delayed teardown runs. */
+    if(server->config.accessControl.closeSession) {
+        server->config.accessControl.
+            closeSession(server, &server->config.accessControl,
+                         &session->sessionId, session->context);
+    }
+
+    UA_Session_clear(session, server);
     unlockServer(server);
     UA_free(entry);
 }
@@ -78,40 +112,21 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
                   UA_ShutdownReason shutdownReason) {
     UA_LOCK_ASSERT(&server->serviceMutex);
 
-    /* When the session times out, detach
-     * subscriptions so they can be recovered via TransferSubscriptions. */
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-    UA_Subscription *sub, *tempsub;
-    TAILQ_FOREACH_SAFE(sub, &session->subscriptions, sessionListEntry, tempsub) {
-        if(shutdownReason == UA_SHUTDOWNREASON_TIMEOUT) {
-            UA_LOG_INFO_SUBSCRIPTION(server->config.logging, sub,
-                                     "Detaching the Subscription from the timed-out Session");
-            UA_Session_detachSubscription(server, session, sub, true);
-        } else {
-            UA_Subscription_delete(server, sub);
-        }
-    }
+    /* Closing a Session can invoke user callbacks that re-enter the server.
+     * Mark it closed before teardown and make repeated removal idempotent. */
+    if(session->state == UA_SESSIONSTATE_CLOSED)
+        return;
+    UA_Boolean wasActivated =
+        (session->state == UA_SESSIONSTATE_ACTIVATED);
+    session->state = UA_SESSIONSTATE_CLOSED;
 
-    UA_PublishResponseEntry *entry;
-    while((entry = UA_Session_dequeuePublishReq(session))) {
-        UA_PublishResponse_clear(&entry->response);
-        UA_free(entry);
-    }
-#endif
-
-    /* Callback into userland access control */
-    if(server->config.accessControl.closeSession) {
-        server->config.accessControl.
-            closeSession(server, &server->config.accessControl,
-                         &session->sessionId, session->context);
-    }
-
-    /* Detach the Session from the SecureChannel */
+    /* Detach the Session from the SecureChannel immediately so channel
+     * teardown and new requests cannot retain the logically closed Session.
+     * Session-owned resources are kept until the delayed callback. */
     UA_Session_detachFromSecureChannel(server, session);
 
     /* Deactivate the session */
-    if(session->activated) {
-        session->activated = false;
+    if(wasActivated) {
         server->activeSessionCount--;
     }
 
@@ -120,6 +135,7 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
     session_list_entry *sentry = container_of(session, session_list_entry, session);
     LIST_REMOVE(sentry, pointers);
     server->sessionCount--;
+    sentry->shutdownReason = shutdownReason;
 
     switch(shutdownReason) {
     case UA_SHUTDOWNREASON_CLOSE:
@@ -145,8 +161,8 @@ UA_Session_remove(UA_Server *server, UA_Session *session,
     /* Notify the application */
     notifySession(server, session, UA_APPLICATIONNOTIFICATIONTYPE_SESSION_CLOSED);
 
-    /* Add a delayed callback to remove the session when the currently
-     * scheduled jobs have completed */
+    /* Destructively tear down and free the Session after the currently
+     * scheduled jobs have completed. */
     sentry->cleanupCallback.callback = (UA_Callback)removeSessionCallback;
     sentry->cleanupCallback.application = server;
     sentry->cleanupCallback.context = sentry;
@@ -182,6 +198,11 @@ getSessionByToken(UA_Server *server, const UA_NodeId *token) {
         if(!UA_NodeId_equal(&current->session.authenticationToken, token))
             continue;
 
+        /* A closed Session can still be visible during a reentrant close
+         * callback, before it is detached from the session manager. */
+        if(current->session.state == UA_SESSIONSTATE_CLOSED)
+            return NULL;
+
         /* Session has timed out */
         UA_EventLoop *el = server->config.eventLoop;
         UA_DateTime now = el->dateTime_nowMonotonic(el);
@@ -214,6 +235,11 @@ getSessionById(UA_Server *server, const UA_NodeId *sessionId) {
         /* Token does not match */
         if(!UA_NodeId_equal(&current->session.sessionId, sessionId))
             continue;
+
+        /* A closed Session can still be visible during a reentrant close
+         * callback, before it is detached from the session manager. */
+        if(current->session.state == UA_SESSIONSTATE_CLOSED)
+            return NULL;
 
         /* Session has timed out */
         UA_EventLoop *el = server->config.eventLoop;
@@ -464,6 +490,8 @@ UA_Session_create(UA_Server *server, UA_SecureChannel *channel,
     /* Notify the application */
     notifySession(server, &newentry->session,
                   UA_APPLICATIONNOTIFICATIONTYPE_SESSION_CREATED);
+    if(newentry->session.state == UA_SESSIONSTATE_CLOSED)
+        return UA_STATUSCODE_BADSESSIONCLOSED;
 
     /* Return */
     *session = &newentry->session;
@@ -1074,7 +1102,8 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
      * SecureChannel is not same as the one associated with the
      * CreateSession request. Subsequent calls to ActivateSession may be
      * associated with different SecureChannels. */
-    if(!session->activated && session->channel != channel) {
+    if(session->state != UA_SESSIONSTATE_ACTIVATED &&
+       session->channel != channel) {
         UA_LOG_ERROR_CHANNEL(server->config.logging, channel,
                              "ActivateSession: The Session has to be initially "
                              "activated on the SecureChannel that created it");
@@ -1191,6 +1220,10 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
         activateSession(server, &server->config.accessControl, ed,
                         &channel->remoteCertificate, &session->sessionId,
                         &req->userIdentityToken, &session->context);
+    if(session->state == UA_SESSIONSTATE_CLOSED) {
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+        return;
+    }
     if(rh->serviceResult != UA_STATUSCODE_GOOD) {
         UA_LOG_ERROR_SESSION(server->config.logging, session,
                              "ActivateSession: The AccessControl plugin "
@@ -1266,8 +1299,8 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
     }
 
     /* Activate the session */
-    if(!session->activated) {
-        session->activated = true;
+    if(session->state != UA_SESSIONSTATE_ACTIVATED) {
+        session->state = UA_SESSIONSTATE_ACTIVATED;
         server->activeSessionCount++;
         server->serverDiagnosticsSummary.cumulatedSessionCount++;
     }
@@ -1313,6 +1346,10 @@ Service_ActivateSession(UA_Server *server, UA_SecureChannel *channel,
 
     /* Notify the application */
     notifySession(server, session, UA_APPLICATIONNOTIFICATIONTYPE_SESSION_ACTIVATED);
+    if(session->state == UA_SESSIONSTATE_CLOSED) {
+        rh->serviceResult = UA_STATUSCODE_BADSESSIONCLOSED;
+        return;
+    }
 
     /* Log the user for which the Session was activated */
     UA_LOG_INFO_SESSION(server->config.logging, session,

--- a/src/server/ua_session.c
+++ b/src/server/ua_session.c
@@ -16,6 +16,7 @@
 
 void UA_Session_init(UA_Session *session) {
     memset(session, 0, sizeof(UA_Session));
+    session->state = UA_SESSIONSTATE_CREATED;
     TAILQ_INIT(&session->continuationPoints);
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     SIMPLEQ_INIT(&session->responseQueue);

--- a/src/server/ua_session.h
+++ b/src/server/ua_session.h
@@ -46,7 +46,7 @@ struct UA_Session {
     UA_NodeId sessionId;
     UA_NodeId authenticationToken;
     UA_String sessionName;
-    UA_Boolean activated;
+    UA_SessionState state;
 
     /* For ECC, client and server exchange ephemeral keys used for the
      * EccEncryptedSecret. The ephemeral keys have to be attached to the session

--- a/tests/fuzz/fuzz_server_services.cc
+++ b/tests/fuzz/fuzz_server_services.cc
@@ -56,7 +56,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     UA_Session session;
     UA_Session_init(&session);
-    session.activated = true;
+    session.state = UA_SESSIONSTATE_ACTIVATED;
     UA_NodeId_init(&session.sessionId);
     session.sessionId.identifierType = UA_NODEIDTYPE_NUMERIC;
     session.sessionId.identifier.numeric = 1;

--- a/tests/server/check_session.c
+++ b/tests/server/check_session.c
@@ -43,6 +43,41 @@ static void teardown(void) {
     UA_Server_delete(server);
 }
 
+/* Opening a new SecureChannel drives the server EventLoop through another
+ * iteration and therefore processes callbacks delayed by the preceding
+ * request. */
+static void
+processDelayedServerCallbacks(void) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+
+static UA_StatusCode
+createSessionRaw(UA_Client *client, UA_CreateSessionResponse *response) {
+    UA_CreateSessionRequest request;
+    UA_CreateSessionRequest_init(&request);
+    UA_CreateSessionResponse_init(response);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_CREATESESSIONREQUEST],
+                        response, &UA_TYPES[UA_TYPES_CREATESESSIONRESPONSE]);
+    return response->responseHeader.serviceResult;
+}
+
+static UA_StatusCode
+activateSessionRaw(UA_Client *client) {
+    UA_ActivateSessionRequest request;
+    UA_ActivateSessionRequest_init(&request);
+    UA_ActivateSessionResponse response;
+    UA_ActivateSessionResponse_init(&response);
+    __UA_Client_Service(client, &request, &UA_TYPES[UA_TYPES_ACTIVATESESSIONREQUEST],
+                        &response, &UA_TYPES[UA_TYPES_ACTIVATESESSIONRESPONSE]);
+    UA_StatusCode result = response.responseHeader.serviceResult;
+    UA_ActivateSessionResponse_clear(&response);
+    return result;
+}
+
 START_TEST(Session_close_before_activate) {
     UA_Client *client = UA_Client_newForUnitTest();
     UA_StatusCode retval = UA_Client_connectSecureChannel(client, "opc.tcp://localhost:4840");
@@ -87,7 +122,7 @@ START_TEST(Session_init_ShallWork) {
     UA_ApplicationDescription tmpAppDescription;
     UA_ApplicationDescription_init(&tmpAppDescription);
     UA_DateTime tmpDateTime = 0;
-    ck_assert_int_eq(session.activated, false);
+    ck_assert_int_eq(session.state, UA_SESSIONSTATE_CREATED);
     ck_assert_int_eq(session.authenticationToken.identifier.numeric, tmpNodeId.identifier.numeric);
     ck_assert_uint_eq(session.continuationPointsSize, 0);
     ck_assert_ptr_eq(session.channel, NULL);
@@ -139,6 +174,314 @@ START_TEST(Session_notificationCallback) {
     UA_Variant_clear(&val);
 
     UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_Boolean closeSessionAtServiceBegin;
+static UA_StatusCode closeSessionAtServiceBeginResult;
+
+static void
+closeSessionServiceNotification(UA_Server *server_,
+                                UA_ApplicationNotificationType type,
+                                const UA_KeyValueMap payload) {
+    if(type != UA_APPLICATIONNOTIFICATIONTYPE_SERVICE_BEGIN ||
+       !closeSessionAtServiceBegin)
+        return;
+
+    closeSessionAtServiceBegin = false;
+    const UA_NodeId *sessionId = (const UA_NodeId*)payload.map[1].value.data;
+    closeSessionAtServiceBeginResult = UA_Server_closeSession(server_, sessionId);
+}
+
+START_TEST(Session_serviceBeginCallbackClosesCurrentSession) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    cfg->serviceNotificationCallback = closeSessionServiceNotification;
+    closeSessionAtServiceBeginResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    closeSessionAtServiceBegin = true;
+
+    UA_Variant value;
+    UA_Variant_init(&value);
+    retval = UA_Client_readValueAttribute(
+        client, UA_NS0ID(SERVER_SERVERSTATUS_CURRENTTIME), &value);
+    UA_Variant_clear(&value);
+
+    ck_assert_uint_eq(closeSessionAtServiceBeginResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_ne(retval, UA_STATUSCODE_GOOD);
+
+    cfg->serviceNotificationCallback = NULL;
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static void (*originalAccessControlCloseSession)(
+    UA_Server*, UA_AccessControl*, const UA_NodeId*, void*);
+static UA_StatusCode reentrantAccessControlCloseResult;
+
+static void
+reentrantAccessControlCloseSession(UA_Server *server_, UA_AccessControl *ac,
+                                   const UA_NodeId *sessionId,
+                                   void *sessionContext) {
+    reentrantAccessControlCloseResult =
+        UA_Server_closeSession(server_, sessionId);
+    originalAccessControlCloseSession(server_, ac, sessionId, sessionContext);
+}
+
+START_TEST(Session_accessControlCloseSessionIsReentrant) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    UA_StatusCode retval = UA_Client_connect(client, "opc.tcp://localhost:4840");
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    originalAccessControlCloseSession = cfg->accessControl.closeSession;
+    cfg->accessControl.closeSession = reentrantAccessControlCloseSession;
+    reentrantAccessControlCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    UA_Client_disconnect(client);
+
+    /* closeSession is part of delayed destructive teardown. */
+    processDelayedServerCallbacks();
+
+    ck_assert_uint_eq(reentrantAccessControlCloseResult,
+                      UA_STATUSCODE_BADSESSIONIDINVALID);
+    cfg->accessControl.closeSession = originalAccessControlCloseSession;
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_Boolean closeAtSessionNotification;
+static UA_ApplicationNotificationType sessionNotificationToClose;
+static UA_StatusCode sessionNotificationCloseResult;
+
+static void
+closeFromSessionNotification(UA_Server *server_,
+                             UA_ApplicationNotificationType type,
+                             const UA_KeyValueMap payload) {
+    if(!closeAtSessionNotification || type != sessionNotificationToClose)
+        return;
+    closeAtSessionNotification = false;
+    const UA_NodeId *sessionId = (const UA_NodeId*)payload.map[0].value.data;
+    sessionNotificationCloseResult =
+        UA_Server_closeSession(server_, sessionId);
+}
+
+START_TEST(Session_createdNotificationCloseReturnsSessionClosed) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    cfg->sessionNotificationCallback = closeFromSessionNotification;
+    closeAtSessionNotification = true;
+    sessionNotificationToClose = UA_APPLICATIONNOTIFICATIONTYPE_SESSION_CREATED;
+    sessionNotificationCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    UA_CreateSessionResponse response;
+    UA_StatusCode result = createSessionRaw(client, &response);
+    ck_assert_uint_eq(sessionNotificationCloseResult, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(result, UA_STATUSCODE_BADSESSIONCLOSED);
+
+    cfg->sessionNotificationCallback = NULL;
+    UA_CreateSessionResponse_clear(&response);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Session_activatedNotificationCloseReturnsSessionClosed) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse createResponse;
+    ck_assert_uint_eq(createSessionRaw(client, &createResponse),
+                      UA_STATUSCODE_GOOD);
+    UA_NodeId_copy(&createResponse.authenticationToken,
+                   &client->authenticationToken);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    cfg->sessionNotificationCallback = closeFromSessionNotification;
+    closeAtSessionNotification = true;
+    sessionNotificationToClose = UA_APPLICATIONNOTIFICATIONTYPE_SESSION_ACTIVATED;
+    sessionNotificationCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    ck_assert_uint_eq(activateSessionRaw(client),
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+    ck_assert_uint_eq(sessionNotificationCloseResult, UA_STATUSCODE_GOOD);
+
+    cfg->sessionNotificationCallback = NULL;
+    UA_CreateSessionResponse_clear(&createResponse);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_StatusCode (*originalAccessControlActivateSession)(
+    UA_Server*, UA_AccessControl*, const UA_EndpointDescription*,
+    const UA_ByteString*, const UA_NodeId*, const UA_ExtensionObject*, void**);
+static UA_StatusCode accessControlActivateCloseResult;
+
+static UA_StatusCode
+closeFromAccessControlActivateSession(
+    UA_Server *server_, UA_AccessControl *ac,
+    const UA_EndpointDescription *endpoint,
+    const UA_ByteString *remoteCertificate, const UA_NodeId *sessionId,
+    const UA_ExtensionObject *identityToken, void **sessionContext) {
+    UA_StatusCode result = originalAccessControlActivateSession(
+        server_, ac, endpoint, remoteCertificate, sessionId, identityToken,
+        sessionContext);
+    if(result == UA_STATUSCODE_GOOD)
+        accessControlActivateCloseResult =
+            UA_Server_closeSession(server_, sessionId);
+    return result;
+}
+
+START_TEST(Session_accessControlActivateCloseReturnsSessionClosed) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse createResponse;
+    ck_assert_uint_eq(createSessionRaw(client, &createResponse),
+                      UA_STATUSCODE_GOOD);
+    UA_NodeId_copy(&createResponse.authenticationToken,
+                   &client->authenticationToken);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    originalAccessControlActivateSession = cfg->accessControl.activateSession;
+    cfg->accessControl.activateSession = closeFromAccessControlActivateSession;
+    accessControlActivateCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    ck_assert_uint_eq(activateSessionRaw(client),
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+    ck_assert_uint_eq(accessControlActivateCloseResult, UA_STATUSCODE_GOOD);
+
+    cfg->accessControl.activateSession = originalAccessControlActivateSession;
+    UA_CreateSessionResponse_clear(&createResponse);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+static UA_Byte (*originalAccessControlGetUserAccessLevel)(
+    UA_Server*, UA_AccessControl*, const UA_NodeId*, void*,
+    const UA_NodeId*, void*);
+static void (*originalDeferredAccessControlCloseSession)(
+    UA_Server*, UA_AccessControl*, const UA_NodeId*, void*);
+static UA_Boolean closeAtUserAccessLevel;
+static UA_Boolean accessControlCloseWasDeferred;
+static size_t userAccessLevelCalls;
+static size_t deferredAccessControlCloseCalls;
+static UA_StatusCode userAccessLevelCloseResult;
+
+static void
+observeDeferredAccessControlClose(UA_Server *server_, UA_AccessControl *ac,
+                                  const UA_NodeId *sessionId,
+                                  void *sessionContext) {
+    deferredAccessControlCloseCalls++;
+    originalDeferredAccessControlCloseSession(server_, ac, sessionId,
+                                              sessionContext);
+}
+
+static UA_Byte
+closeFromGetUserAccessLevel(UA_Server *server_, UA_AccessControl *ac,
+                            const UA_NodeId *sessionId, void *sessionContext,
+                            const UA_NodeId *nodeId, void *nodeContext) {
+    userAccessLevelCalls++;
+    if(closeAtUserAccessLevel) {
+        closeAtUserAccessLevel = false;
+        userAccessLevelCloseResult =
+            UA_Server_closeSession(server_, sessionId);
+        accessControlCloseWasDeferred =
+            (deferredAccessControlCloseCalls == 0);
+    }
+    return originalAccessControlGetUserAccessLevel(
+        server_, ac, sessionId, sessionContext, nodeId, nodeContext);
+}
+
+START_TEST(Session_accessControlCloseStopsMultiReadAndDefersContextClose) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connect(client, "opc.tcp://localhost:4840"),
+                      UA_STATUSCODE_GOOD);
+
+    UA_ServerConfig *cfg = UA_Server_getConfig(server);
+    originalAccessControlGetUserAccessLevel =
+        cfg->accessControl.getUserAccessLevel;
+    originalDeferredAccessControlCloseSession =
+        cfg->accessControl.closeSession;
+    cfg->accessControl.getUserAccessLevel = closeFromGetUserAccessLevel;
+    cfg->accessControl.closeSession = observeDeferredAccessControlClose;
+    closeAtUserAccessLevel = true;
+    accessControlCloseWasDeferred = false;
+    userAccessLevelCalls = 0;
+    deferredAccessControlCloseCalls = 0;
+    userAccessLevelCloseResult = UA_STATUSCODE_BADUNEXPECTEDERROR;
+
+    UA_ReadRequest request;
+    UA_ReadRequest_init(&request);
+    UA_ReadValueId items[2];
+    UA_ReadValueId_init(&items[0]);
+    UA_ReadValueId_init(&items[1]);
+    items[0].nodeId = UA_NS0ID(SERVER_SERVERSTATUS_CURRENTTIME);
+    items[1].nodeId = UA_NS0ID(SERVER_SERVERSTATUS_CURRENTTIME);
+    items[0].attributeId = UA_ATTRIBUTEID_VALUE;
+    items[1].attributeId = UA_ATTRIBUTEID_VALUE;
+    request.nodesToRead = items;
+    request.nodesToReadSize = 2;
+
+    UA_ReadResponse response = UA_Client_Service_read(client, request);
+    ck_assert_uint_eq(userAccessLevelCloseResult, UA_STATUSCODE_GOOD);
+    ck_assert(accessControlCloseWasDeferred);
+    ck_assert_uint_eq(userAccessLevelCalls, 1);
+    ck_assert_uint_eq(response.responseHeader.serviceResult,
+                      UA_STATUSCODE_BADSESSIONCLOSED);
+
+    processDelayedServerCallbacks();
+    ck_assert_uint_eq(deferredAccessControlCloseCalls, 1);
+
+    cfg->accessControl.getUserAccessLevel =
+        originalAccessControlGetUserAccessLevel;
+    cfg->accessControl.closeSession =
+        originalDeferredAccessControlCloseSession;
+    request.nodesToRead = NULL;
+    request.nodesToReadSize = 0;
+    UA_ReadResponse_clear(&response);
+    UA_Client_disconnect(client);
+    UA_Client_delete(client);
+}
+END_TEST
+
+START_TEST(Session_closedAttachedSessionDoesNotStallChannelTeardown) {
+    UA_Client *client = UA_Client_newForUnitTest();
+    ck_assert_uint_eq(UA_Client_connectSecureChannel(
+        client, "opc.tcp://localhost:4840"), UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse createResponse;
+    ck_assert_uint_eq(createSessionRaw(client, &createResponse),
+                      UA_STATUSCODE_GOOD);
+
+    lockServer(server);
+    UA_Session *session = getSessionById(server, &createResponse.sessionId);
+    ck_assert_ptr_nonnull(session);
+    session->state = UA_SESSIONSTATE_CLOSED;
+    unlockServer(server);
+
+    /* Channel teardown must detach the already-closed Session and terminate. */
+    UA_Client_disconnect(client);
+
+    lockServer(server);
+    ck_assert_ptr_null(session->channel);
+    session->state = UA_SESSIONSTATE_CREATED;
+    unlockServer(server);
+    ck_assert_uint_eq(UA_Server_closeSession(server, &createResponse.sessionId),
+                      UA_STATUSCODE_GOOD);
+
+    UA_CreateSessionResponse_clear(&createResponse);
     UA_Client_delete(client);
 }
 END_TEST
@@ -596,6 +939,13 @@ static Suite* testSuite_Session(void) {
     tcase_add_test(tc_session, Session_init_ShallWork);
     tcase_add_test(tc_session, Session_updateLifetime_ShallWork);
     tcase_add_test(tc_session, Session_notificationCallback);
+    tcase_add_test(tc_session, Session_serviceBeginCallbackClosesCurrentSession);
+    tcase_add_test(tc_session, Session_accessControlCloseSessionIsReentrant);
+    tcase_add_test(tc_session, Session_createdNotificationCloseReturnsSessionClosed);
+    tcase_add_test(tc_session, Session_activatedNotificationCloseReturnsSessionClosed);
+    tcase_add_test(tc_session, Session_accessControlActivateCloseReturnsSessionClosed);
+    tcase_add_test(tc_session, Session_accessControlCloseStopsMultiReadAndDefersContextClose);
+    tcase_add_test(tc_session, Session_closedAttachedSessionDoesNotStallChannelTeardown);
     tcase_add_test(tc_session, Session_setSessionAttribute_ShallWork);
 
     TCase *tc_session_ext = tcase_create("Extended");


### PR DESCRIPTION
Model server sessions with explicit CREATED, ACTIVATED, and CLOSED states. Mark a session CLOSED and detach it before user callbacks can re-enter, while delaying destructive resource and access-control teardown until current jobs finish.

Reject sessions closed by service, notification, and access-control callbacks, stop multi-operation processing after closure, preserve progress during channel teardown, and add raw-client regression coverage for the reentrant paths.