### PR TITLE
fix(core): validate asymmetric OPN header bounds

### DIFF
--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -202,7 +202,8 @@ UA_SecureChannel_sendAsymmetricOPNMessage(UA_SecureChannel *channel,
     /* Restrict buffer to the available space for the payload */
     UA_Byte *buf_pos = buf.data;
     const UA_Byte *buf_end = &buf.data[buf.length];
-    hideBytesAsym(channel, &buf_pos, &buf_end);
+    res = hideBytesAsym(channel, &buf_pos, &buf_end);
+    UA_CHECK_STATUS(res, conn->releaseSendBuffer(conn, &buf); return res);
 
     /* Encode the message type and content */
     res |= UA_NodeId_encodeBinary(&contentType->binaryEncodingId, &buf_pos, buf_end);

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -282,7 +282,7 @@ UA_SecureChannel_receive(UA_SecureChannel *channel, void *application,
 
 /* Internal methods in ua_securechannel_crypto.h */
 
-void
+UA_StatusCode
 hideBytesAsym(const UA_SecureChannel *channel, UA_Byte **buf_start,
               const UA_Byte **buf_end);
 

--- a/src/ua_securechannel_crypto.c
+++ b/src/ua_securechannel_crypto.c
@@ -134,13 +134,19 @@ calculateAsymAlgSecurityHeaderLength(const UA_SecureChannel *channel) {
     const UA_SecurityPolicy *sp = channel->securityPolicy;
     UA_CHECK_MEM(sp, return UA_STATUSCODE_BADINTERNALERROR);
 
-    size_t asymHeaderLength = UA_SECURECHANNEL_ASYMMETRIC_SECURITYHEADER_FIXED_LENGTH +
-                              sp->policyUri.length;
+    size_t asymHeaderLength = UA_SECURECHANNEL_ASYMMETRIC_SECURITYHEADER_FIXED_LENGTH;
+    if(sp->policyUri.length > SIZE_MAX - asymHeaderLength)
+        return SIZE_MAX;
+    asymHeaderLength += sp->policyUri.length;
     if(channel->securityMode == UA_MESSAGESECURITYMODE_NONE)
         return asymHeaderLength;
 
     /* OPN is always encrypted even if the mode is sign only */
+    if(asymHeaderLength > SIZE_MAX - 20)
+        return SIZE_MAX;
     asymHeaderLength += 20; /* Thumbprints are always 20 byte long */
+    if(sp->localCertificate.length > SIZE_MAX - asymHeaderLength)
+        return SIZE_MAX;
     asymHeaderLength += sp->localCertificate.length;
     return asymHeaderLength;
 }
@@ -202,41 +208,74 @@ prependHeadersAsym(UA_SecureChannel *const channel, UA_Byte *header_pos,
     return retval;
 }
 
-void
+UA_StatusCode
 hideBytesAsym(const UA_SecureChannel *channel, UA_Byte **buf_start,
               const UA_Byte **buf_end) {
-    /* Set buf_start to the beginning of the payload body */
-    *buf_start += UA_SECURECHANNEL_CHANNELHEADER_LENGTH;
-    *buf_start += calculateAsymAlgSecurityHeaderLength(channel);
-    *buf_start += UA_SECURECHANNEL_SEQUENCEHEADER_LENGTH;
+    UA_Byte *const bufferStart = *buf_start;
+    const size_t bufferLength = (size_t)(*buf_end - bufferStart);
+
+    /* Check the complete unencrypted header before constructing pointers into
+     * the payload. The certificate is already constrained by the negotiated
+     * send-buffer size; it does not need a separate policy limit. */
+    const size_t asymHeaderLength = calculateAsymAlgSecurityHeaderLength(channel);
+    if(asymHeaderLength > bufferLength ||
+       UA_SECURECHANNEL_CHANNELHEADER_LENGTH > bufferLength - asymHeaderLength)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+    const size_t headerLength =
+        UA_SECURECHANNEL_CHANNELHEADER_LENGTH + asymHeaderLength;
+    if(UA_SECURECHANNEL_SEQUENCEHEADER_LENGTH > bufferLength - headerLength)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+
+    const size_t payloadOffset =
+        headerLength + UA_SECURECHANNEL_SEQUENCEHEADER_LENGTH;
 
 #ifdef UA_ENABLE_ENCRYPTION
-    if(channel->securityMode == UA_MESSAGESECURITYMODE_NONE)
-        return;
+    if(channel->securityMode == UA_MESSAGESECURITYMODE_NONE) {
+        *buf_start = bufferStart + payloadOffset;
+        return UA_STATUSCODE_GOOD;
+    }
 
-    /* Make space for the certificate */
+    /* Reserve the signature before determining how many complete encrypted
+     * blocks fit into the chunk. */
     const UA_SecurityPolicy *sp = channel->securityPolicy;
-    *buf_end -= sp->asymmetricModule.cryptoModule.signatureAlgorithm.
-        getLocalSignatureSize(channel->channelContext);
+    const size_t signatureSize = sp->asymmetricModule.cryptoModule.
+        signatureAlgorithm.getLocalSignatureSize(channel->channelContext);
+    if(signatureSize > bufferLength - headerLength)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
 
     /* Block sizes depend on the remote key (certificate) */
-    size_t plainTextBlockSize = sp->asymmetricModule.cryptoModule.
+    const size_t plainTextBlockSize = sp->asymmetricModule.cryptoModule.
         encryptionAlgorithm.getRemotePlainTextBlockSize(channel->channelContext);
-    size_t encryptedBlockSize = sp->asymmetricModule.cryptoModule.
+    const size_t encryptedBlockSize = sp->asymmetricModule.cryptoModule.
         encryptionAlgorithm.getRemoteBlockSize(channel->channelContext);
-    UA_Boolean extraPadding = (sp->asymmetricModule.cryptoModule.encryptionAlgorithm.
-                               getRemoteKeyLength(channel->channelContext) > 2048);
+    if(plainTextBlockSize == 0 || encryptedBlockSize == 0)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    const UA_Boolean extraPadding =
+        (sp->asymmetricModule.cryptoModule.encryptionAlgorithm.
+         getRemoteKeyLength(channel->channelContext) > 2048);
 
     /* Compute the maximum number of encrypted blocks that can fit entirely
      * before the signature. From that compute the maximum usable plaintext
      * size. */
-    size_t maxEncrypted = (size_t)(*buf_end - *buf_start) +
-        UA_SECURECHANNEL_SEQUENCEHEADER_LENGTH;
-    size_t max_blocks = maxEncrypted / encryptedBlockSize;
-    size_t paddingBytes = (UA_LIKELY(!extraPadding)) ? 1u : 2u;
-    *buf_end = *buf_start + (max_blocks * plainTextBlockSize) -
-        UA_SECURECHANNEL_SEQUENCEHEADER_LENGTH - paddingBytes;
+    const size_t maxEncrypted = bufferLength - headerLength - signatureSize;
+    const size_t maxBlocks = maxEncrypted / encryptedBlockSize;
+    if(maxBlocks > SIZE_MAX / plainTextBlockSize)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+    const size_t maxPlaintext = maxBlocks * plainTextBlockSize;
+    const size_t paddingBytes = (UA_LIKELY(!extraPadding)) ? 1u : 2u;
+    const size_t payloadOverhead =
+        UA_SECURECHANNEL_SEQUENCEHEADER_LENGTH + paddingBytes;
+    if(maxPlaintext < payloadOverhead)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+
+    const size_t payloadCapacity = maxPlaintext - payloadOverhead;
+    if(payloadCapacity > bufferLength - payloadOffset)
+        return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+    *buf_end = bufferStart + payloadOffset + payloadCapacity;
 #endif
+
+    *buf_start = bufferStart + payloadOffset;
+    return UA_STATUSCODE_GOOD;
 }
 
 #ifdef UA_ENABLE_ENCRYPTION

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -209,6 +209,75 @@ START_TEST(SecureChannel_sendAsymmetricOPNMessage_SecurityModeSignAndEncrypt) {
     ck_assert_msg(fCalled.asym_sign, "Expected message to have been signed but it was not");
 }END_TEST
 
+static size_t
+asymmetricHeaderLengthWithoutCertificate(void) {
+    return UA_SECURECHANNEL_CHANNELHEADER_LENGTH +
+        calculateAsymAlgSecurityHeaderLength(&testChannel) -
+        dummyPolicy.localCertificate.length;
+}
+
+static void
+resizeLocalCertificate(size_t certificateLength) {
+    UA_ByteString_clear(&dummyPolicy.localCertificate);
+    ck_assert_uint_eq(UA_ByteString_allocBuffer(&dummyPolicy.localCertificate,
+                                               certificateLength),
+                      UA_STATUSCODE_GOOD);
+    memset(dummyPolicy.localCertificate.data, 'A', certificateLength);
+}
+
+START_TEST(SecureChannel_sendAsymmetricOPNMessage_oversizedSecurityHeader) {
+    UA_OpenSecureChannelResponse dummyResponse;
+    createDummyResponse(&dummyResponse);
+    testChannel.securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
+    testChannel.config.sendBufferSize = 8192;
+    keySizes.asym_rmt_ptext_blocksize = 214;
+
+    resizeLocalCertificate(8200);
+
+    UA_StatusCode retval =
+        UA_SecureChannel_sendAsymmetricOPNMessage(&testChannel, 42, &dummyResponse,
+                                                  &UA_TYPES[UA_TYPES_OPENSECURECHANNELRESPONSE]);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+}END_TEST
+
+START_TEST(SecureChannel_sendAsymmetricOPNMessage_requiresEncryptedBlock) {
+    UA_OpenSecureChannelResponse dummyResponse;
+    createDummyResponse(&dummyResponse);
+    testChannel.securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
+    testChannel.config.sendBufferSize = 8192;
+    keySizes.asym_rmt_ptext_blocksize = 214;
+
+    const size_t fixedHeaderLength = asymmetricHeaderLengthWithoutCertificate();
+    const size_t signatureSize = keySizes.asym_lcl_sig_size;
+    const size_t encryptedBlockSize = keySizes.asym_rmt_blocksize;
+    resizeLocalCertificate(testChannel.config.sendBufferSize - fixedHeaderLength -
+                           signatureSize - encryptedBlockSize + 1);
+
+    UA_StatusCode retval =
+        UA_SecureChannel_sendAsymmetricOPNMessage(&testChannel, 42, &dummyResponse,
+                                                  &UA_TYPES[UA_TYPES_OPENSECURECHANNELRESPONSE]);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED);
+}END_TEST
+
+START_TEST(SecureChannel_sendAsymmetricOPNMessage_acceptsOneEncryptedBlock) {
+    UA_OpenSecureChannelResponse dummyResponse;
+    createDummyResponse(&dummyResponse);
+    testChannel.securityMode = UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
+    testChannel.config.sendBufferSize = 8192;
+    keySizes.asym_rmt_ptext_blocksize = 214;
+
+    const size_t fixedHeaderLength = asymmetricHeaderLengthWithoutCertificate();
+    const size_t signatureSize = keySizes.asym_lcl_sig_size;
+    const size_t encryptedBlockSize = keySizes.asym_rmt_blocksize;
+    resizeLocalCertificate(testChannel.config.sendBufferSize - fixedHeaderLength -
+                           signatureSize - encryptedBlockSize);
+
+    UA_StatusCode retval =
+        UA_SecureChannel_sendAsymmetricOPNMessage(&testChannel, 42, &dummyResponse,
+                                                  &UA_TYPES[UA_TYPES_OPENSECURECHANNELRESPONSE]);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+}END_TEST
+
 #endif /* UA_ENABLE_ENCRYPTION */
 
 START_TEST(SecureChannel_sendAsymmetricOPNMessage_sentDataIsValid) {
@@ -576,6 +645,12 @@ testSuite_SecureChannel(void) {
 #ifdef UA_ENABLE_ENCRYPTION
     tcase_add_test(tc_sendAsymmetricOPNMessage, SecureChannel_sendAsymmetricOPNMessage_SecurityModeSign);
     tcase_add_test(tc_sendAsymmetricOPNMessage, SecureChannel_sendAsymmetricOPNMessage_SecurityModeSignAndEncrypt);
+    tcase_add_test(tc_sendAsymmetricOPNMessage,
+                   SecureChannel_sendAsymmetricOPNMessage_oversizedSecurityHeader);
+    tcase_add_test(tc_sendAsymmetricOPNMessage,
+                   SecureChannel_sendAsymmetricOPNMessage_requiresEncryptedBlock);
+    tcase_add_test(tc_sendAsymmetricOPNMessage,
+                   SecureChannel_sendAsymmetricOPNMessage_acceptsOneEncryptedBlock);
     tcase_add_test(tc_sendAsymmetricOPNMessage,
                    Securechannel_sendAsymmetricOPNMessage_extraPaddingPresentWhenKeyLargerThan2048Bits);
 #endif


### PR DESCRIPTION
The asymmetric security header includes the local certificate and must fit into the peer-negotiated send buffer. Computing payload pointers before checking that relationship could underflow the remaining capacity and move the encoder bounds outside the allocated chunk.

Validate the header, signature, encryption-block and padding requirements as lengths first. Return BadEncodingLimitsExceeded when the negotiated chunk cannot carry them, and cover the oversized, incomplete-block and exact-boundary cases.