### PR TITLE
ci: enforce CERT C checks with clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,10 @@
+---
+Checks: '-*,cert-*,-cert-*-cpp,-cert-dcl37-c'
+WarningsAsErrors: 'cert-*'
+HeaderFilterRegex: '(^|/)(arch|deps|include|plugins|src)/'
+SystemHeaders: false
+FormatStyle: none
+CheckOptions:
+  # UA_SByte is a signed numeric type; conversions intentionally preserve its sign.
+  cert-str34-c.CharTypedefsToIgnore: 'UA_SByte'
+...

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,58 @@
+name: CERT C clang-tidy
+
+on:
+  push:
+    branches: [ 'master' ]
+    paths:
+      - '.clang-tidy'
+      - '.github/workflows/clang-tidy.yml'
+      - 'tools/ci.sh'
+      - 'arch/**/*.c'
+      - 'arch/**/*.h'
+      - 'deps/**/*.c'
+      - 'deps/**/*.h'
+      - 'include/**/*.h'
+      - 'plugins/**/*.c'
+      - 'plugins/**/*.h'
+      - 'src/**/*.c'
+      - 'src/**/*.h'
+  pull_request:
+    branches: [ 'master' ]
+    paths:
+      - '.clang-tidy'
+      - '.github/workflows/clang-tidy.yml'
+      - 'tools/ci.sh'
+      - 'arch/**/*.c'
+      - 'arch/**/*.h'
+      - 'deps/**/*.c'
+      - 'deps/**/*.h'
+      - 'include/**/*.h'
+      - 'plugins/**/*.c'
+      - 'plugins/**/*.h'
+      - 'src/**/*.c'
+      - 'src/**/*.h'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clang-tidy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-tidy:
+    name: Production code
+    runs-on: ubuntu-26.04
+
+    steps:
+      - name: Checkout open62541
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Show clang-tidy version
+        run: clang-tidy-22 --version
+
+      - name: Check production code
+        run: source tools/ci.sh && clang_tidy_all

--- a/plugins/ua_config_json.c
+++ b/plugins/ua_config_json.c
@@ -1825,14 +1825,14 @@ loadCertificateFile(const char *const path) {
 
     /* Get the file length, allocate the data and read */
     if(fseek(fp, 0, SEEK_END) != 0) {
-        fclose(fp);
+        (void)fclose(fp); /* The preceding file operation already failed. */
         errno = 0;
         return fileContents;
     }
 
     long length = ftell(fp);
     if(length < 0) {
-        fclose(fp);
+        (void)fclose(fp); /* The preceding file operation already failed. */
         errno = 0;
         return fileContents;
     }
@@ -1841,7 +1841,7 @@ loadCertificateFile(const char *const path) {
     fileContents.data = (UA_Byte *)UA_malloc(fileContents.length * sizeof(UA_Byte));
     if(fileContents.data) {
         if(fseek(fp, 0, SEEK_SET) != 0) {
-            fclose(fp);
+            (void)fclose(fp); /* The preceding file operation already failed. */
             UA_ByteString_clear(&fileContents);
             errno = 0;
             return fileContents;
@@ -1852,7 +1852,8 @@ loadCertificateFile(const char *const path) {
     } else {
         fileContents.length = 0;
     }
-    fclose(fp);
+    if(fclose(fp) != 0)
+        UA_ByteString_clear(&fileContents);
 
     return fileContents;
 }

--- a/plugins/ua_log_stdout.c
+++ b/plugins/ua_log_stdout.c
@@ -93,7 +93,7 @@ UA_Log_Stdout_log(void *context, UA_LogLevel level, UA_LogCategory category,
            logCategoryNames[category]);
     mp_vsnprintf(logbuf, STDOUT_LOGBUFSIZE, msg, args);
     printf("%s\n", logbuf);
-    fflush(stdout);
+    (void)fflush(stdout); /* Logging is best-effort and cannot report failure. */
 
     /* Unlock */
 #if UA_MULTITHREADING >= 100

--- a/src/util/ua_eventfilter_grammar.c
+++ b/src/util/ua_eventfilter_grammar.c
@@ -770,7 +770,7 @@ static YYACTIONTYPE yy_find_reduce_action(
 #else
   assert( stateno<=YY_REDUCE_COUNT );
 #endif
-  i = yy_reduce_ofst[stateno];
+  i = yy_reduce_ofst[stateno]; /* NOLINT(cert-str34-c): Signed parser offset. */
   assert( iLookAhead!=YYNOCODE );
   i += iLookAhead;
 #ifdef YYERRORSYMBOL
@@ -1055,7 +1055,7 @@ static YYACTIONTYPE yy_reduce(
   }
   assert( yyruleno<sizeof(yyRuleInfoLhs)/sizeof(yyRuleInfoLhs[0]) );
   yygoto = yyRuleInfoLhs[yyruleno];
-  yysize = yyRuleInfoNRhs[yyruleno];
+  yysize = yyRuleInfoNRhs[yyruleno]; /* NOLINT(cert-str34-c): Signed rule length. */
   yyact = yy_find_reduce_action(yymsp[yysize].stateno,(YYCODETYPE)yygoto);
 
   /* There are no SHIFTREDUCE actions on nonterminals because the table

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Reusable CI functions. Source this file before invoking a function.
+
+set -e
+set -o pipefail
+set -o nounset
+
+CI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CI_REPOSITORY_ROOT="$(cd "${CI_SCRIPT_DIR}/.." && pwd)"
+
+function clang_tidy_all {
+    local build_dir="${CLANG_TIDY_BUILD_DIR:-${CI_REPOSITORY_ROOT}/build-clang-tidy}"
+    local c_compiler="${CLANG_TIDY_C_COMPILER:-clang-22}"
+    local clang_tidy="${CLANG_TIDY_BINARY:-clang-tidy-22}"
+    local run_clang_tidy="${RUN_CLANG_TIDY_BINARY:-run-clang-tidy-22}"
+    local jobs="${CLANG_TIDY_JOBS:-2}"
+
+    (cd "${CI_REPOSITORY_ROOT}" && "${clang_tidy}" --verify-config)
+    cmake -S "${CI_REPOSITORY_ROOT}" -B "${build_dir}" \
+        -DCMAKE_C_COMPILER="${c_compiler}" \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DUA_BUILD_EXAMPLES=OFF \
+        -DUA_BUILD_UNIT_TESTS=OFF
+    cmake --build "${build_dir}" \
+        --target open62541-code-generation \
+        --parallel "${jobs}"
+
+    "${run_clang_tidy}" \
+        -p "${build_dir}" \
+        -clang-tidy-binary "${clang_tidy}" \
+        -j "${jobs}" \
+        '(^|/)(arch|deps|plugins|src)/.*\.c$'
+}


### PR DESCRIPTION
## Summary

- add a repository-wide clang-tidy configuration for applicable CERT C checks
- run clang-tidy 22 over configured production C sources, including vendored dependencies
- provide reusable full-tree and changed-line functions in `tools/ci.sh`
- resolve the existing checked-I/O findings and document two generated-parser conversions

## Policy

The C++ aliases of CERT checks are disabled because open62541 is checked as C. `cert-dcl37-c` is also disabled: enforcing reserved-identifier naming across the established codebase creates broad churn without adding a meaningful security gate. The intentional signed conversion of `UA_SByte` is documented as an exact configuration exception.

## CI

The new workflow uses Ubuntu 26.04 and clang-tidy 22. The full configured production tree is authoritative in CI; the changed-line helper remains available for faster local checks.

## Verification

- full clang-tidy scan of 94 configured production translation units: clean
- open62541 build: successful
- clang-tidy configuration, workflow syntax, shell syntax, and whitespace checks: successful
