### PR TITLE
perf(client): skip the notification re-key scan when none is pending

### DIFF
--- a/src/client/ua_client_internal.h
+++ b/src/client/ua_client_internal.h
@@ -63,6 +63,10 @@ typedef struct UA_Client_Subscription {
     UA_UInt32 sequenceNumber;
     UA_DateTime lastActivity;
     MonitorItemsTree monitoredItems;
+    size_t pendingRekeys; /* MonitoredItems with a pending clientHandle
+                           * re-key (pendingParameters.clientHandle != 0).
+                           * Gates the O(n) fallback scan in the
+                           * notification dispatch. */
 } UA_Client_Subscription;
 
 void

--- a/src/client/ua_client_subscriptions.c
+++ b/src/client/ua_client_subscriptions.c
@@ -75,6 +75,7 @@ Subscription_create(UA_Client *client, UA_Client_Subscription *newSub,
     newSub->publishingInterval = response->revisedPublishingInterval;
     newSub->maxKeepAliveCount = response->revisedMaxKeepAliveCount;
     ZIP_INIT(&newSub->monitoredItems);
+    newSub->pendingRekeys = 0;
     LIST_INSERT_HEAD(&client->subscriptions, newSub, listEntry);
 
     /* Immediately send the first publish requests if there are none
@@ -517,6 +518,8 @@ MonitoredItem_delete(UA_Client *client, UA_Client_Subscription *sub,
                             mon->monitoredItemId, mon->context);
     EventFields_clear(&mon->eventFields);
     UA_MonitoringParameters_clear(&mon->parameters);
+    if(mon->pendingParameters.clientHandle != 0)
+        sub->pendingRekeys--;
     UA_MonitoringParameters_clear(&mon->pendingParameters);
     UA_free(mon);
 }
@@ -1189,6 +1192,10 @@ MonitoredItems_prepareModify(UA_Client *client, UA_Client_Subscription *sub,
         UA_Client_MonitoredItem *mon = mons[i];
         if(!mon)
             continue;
+        /* Newly entering the pending re-key state (a fresh handle is
+         * always non-zero); a supersede keeps it pending, no double count. */
+        if(mon->pendingParameters.clientHandle == 0)
+            sub->pendingRekeys++;
         UA_MonitoringParameters_clear(&mon->pendingParameters);
         mon->pendingParameters = preparedParameters[i];
         memset(&preparedParameters[i], 0, sizeof(UA_MonitoringParameters));
@@ -1214,8 +1221,10 @@ MonitoredItems_reconcileModify(UA_Client_Subscription *sub,
         UA_Client_MonitoredItem *mon =
             findMonitoredItemById(sub, mimr->monitoredItemId);
         if(mon && mon->pendingParameters.clientHandle ==
-                  mimr->requestedParameters.clientHandle)
+                  mimr->requestedParameters.clientHandle) {
             UA_MonitoringParameters_clear(&mon->pendingParameters);
+            sub->pendingRekeys--;
+        }
     }
 }
 
@@ -1457,6 +1466,11 @@ findMonitoredItemForNotification(UA_Client_Subscription *sub,
     /* A notification is the authoritative signal that the server has started
      * to use the modified settings. Promote the embedded pending slot and
      * re-key the existing tree node. */
+    /* Skip the O(n) scan entirely when no re-key is pending: stops a
+     * malicious server from burning CPU on the single client thread by
+     * flooding notifications with unknown clientHandles (O(N*n)). */
+    if(sub->pendingRekeys == 0)
+        return NULL;
     mon = (UA_Client_MonitoredItem*)
         ZIP_ITER(MonitorItemsTree, &sub->monitoredItems,
                  MonitoredItem_findPendingByHandle, &clientHandle);
@@ -1467,6 +1481,7 @@ findMonitoredItemForNotification(UA_Client_Subscription *sub,
     UA_MonitoringParameters_clear(&mon->parameters);
     mon->parameters = mon->pendingParameters;
     UA_MonitoringParameters_init(&mon->pendingParameters);
+    sub->pendingRekeys--;
     EventFields_clear(&mon->eventFields);
     ZIP_INSERT(MonitorItemsTree, &sub->monitoredItems, mon);
     return mon;

--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -835,6 +835,13 @@ START_TEST(Client_subscription_modifyMonitoredItem_doubleBuffer) {
     UA_UInt32 oldHandle =
         mon->parameters.clientHandle;
     UA_Double oldSamplingInterval = mon->parameters.samplingInterval;
+    ck_assert_uint_eq(sub->pendingRekeys, 0);
+    /* A notification with an unknown clientHandle while nothing is pending
+     * must be dropped without scanning the tree (the O(N*n) guard). */
+    notificationReceived = false;
+    injectDataChangeNotification(client, sub, 0xDEADBEEFu);
+    ck_assert(!notificationReceived);
+    ck_assert_uint_eq(sub->pendingRekeys, 0);
 
     UA_MonitoredItemModifyRequest item;
     UA_MonitoredItemModifyRequest_init(&item);
@@ -864,6 +871,7 @@ START_TEST(Client_subscription_modifyMonitoredItem_doubleBuffer) {
     UA_UInt32 newHandle =
         mon->pendingParameters.clientHandle;
     ck_assert_uint_ne(oldHandle, newHandle);
+    ck_assert_uint_eq(sub->pendingRekeys, 1);
 
     notificationReceived = false;
     countNotificationReceived = 0;
@@ -878,6 +886,7 @@ START_TEST(Client_subscription_modifyMonitoredItem_doubleBuffer) {
     ck_assert_uint_eq(mon->parameters.clientHandle, newHandle);
     ck_assert(!mon->pendingParameters.clientHandle);
     ck_assert(mon->parameters.samplingInterval == 1000.0);
+    ck_assert_uint_eq(sub->pendingRekeys, 0);
 
     /* Now deliver the new handle before the asynchronous modify response. */
     pauseServer();


### PR DESCRIPTION
findMonitoredItemForNotification falls back to a full linear scan of the MonitoredItem ziptree when a notification clientHandle is not found, to promote a pending re-key from a ModifyMonitoredItems. A malicious or buggy server can send a PublishResponse full of notifications with unknown clientHandles: each triggers the full O(n) scan, i.e. O(N*n) CPU burn on the single client event-loop thread, stalling reconnection and every other subscription.

Track the number of pending re-keys per subscription (pendingRekeys) and skip the scan when it is zero, which is the common case since a re-key is pending only briefly after a ModifyMonitoredItems. The counter is maintained where pendingParameters is set (modify), cleared (rollback, delete) and promoted (on the authoritative notification).

Extend Client_subscription_modifyMonitoredItem_doubleBuffer to assert the counter (0 -> 1 -> 0) and that a notification with an unknown handle is dropped without a scan while nothing is pending.