### PR TITLE
docs: remove dead wiki link from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,9 +4,7 @@ about: 'Report a bug'
 ---
 <!--
 !ATTENTION!
-Please read the following page carefully and provide us with all the
-information requested:
-https://github.com/open62541/open62541/wiki/Writing-Good-Issue-Reports
+Please provide us with all the information requested below.
 
 Use Github Markdown to format your text:
 https://help.github.com/articles/basic-writing-and-formatting-syntax/


### PR DESCRIPTION
The bug report issue template linked to `https://github.com/open62541/open62541/wiki/Writing-Good-Issue-Reports`, which 404s because the project wiki is disabled.

This change drops that dead wiki link and keeps the in-template checklist (description, reproduction steps, CMake options, and the existing information checklist) as the source of requested details. The GitHub Markdown formatting link is unchanged.

Fixes https://github.com/open62541/open62541/issues/8355