### PR TITLE
test(client): make the notification wait loop actually wait

### DIFF
--- a/tests/client/check_client_subscriptions.c
+++ b/tests/client/check_client_subscriptions.c
@@ -94,7 +94,9 @@ iterateUntilNotification(UA_Client *client, UA_UInt32 maxIterations) {
     UA_StatusCode retval = UA_STATUSCODE_GOOD;
     for(UA_UInt32 i = 0; i < maxIterations && !notificationReceived; ++i) {
         UA_Server_run_iterate(server, false);
-        retval = UA_Client_run_iterate(client, 0);
+        /* Wait 1ms per iteration. A zero timeout makes this a busy-poll that
+         * can return before the PublishResponse is readable on the socket. */
+        retval = UA_Client_run_iterate(client, 1);
         ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
         UA_fakeSleep(1);
     }


### PR DESCRIPTION
iterateUntilNotification polls the client with a zero timeout, so its maxIterations budget is not a duration: the loop spins as fast as the CPU allows and can return long before a PublishResponse becomes readable on the socket. Whether the test passes therefore depends on the ratio between the machine's loopback delivery latency and the cost of one spin. That ratio is not controlled by the test, which is why the loop can be green on one host and red on another.

On a WSL2 host the 100 spins take about 0.08ms while the response needs about 0.6-1.0ms to be delivered, so Client_subscription_modifyMonitoredItem fails on the initial-value assertion (notificationReceived == 0) on every run, on unmodified 1.5 and with the CI build options.

Advancing the simulated clock does not help: UA_fakeSleep drives the OPC UA timers, not the kernel. Measured on the failing host, +2000ms of simulated time still fails, while giving the same loop real time succeeds after 0.6-1.0ms.

Use a 1ms client timeout so each iteration actually waits, which is what Client_subscription_createDataChanges in the same file already does. The assertions are unchanged.