### PR TITLE
perf(server): O(1) MonitoredItem removal via the intrusive LIST macros

### DIFF
--- a/src/server/ua_nodes.c
+++ b/src/server/ua_nodes.c
@@ -681,6 +681,10 @@ UA_Node_moveMonitoredItems(UA_Node *src, UA_Node *dst) {
     UA_assert(dst->head.monitoredItems == NULL);
     dst->head.monitoredItems = src->head.monitoredItems;
     src->head.monitoredItems = NULL;
+    if(dst->head.monitoredItems) {
+        dst->head.monitoredItems->sampling.nodeListEntry.le_prev =
+            &dst->head.monitoredItems;
+    }
 #else
     (void)src;
     (void)dst;

--- a/src/server/ua_services_attribute.c
+++ b/src/server/ua_services_attribute.c
@@ -1672,8 +1672,9 @@ updateLocalizedText(const UA_LocalizedText *source, UA_LocalizedText *target) {
 static void
 triggerImmediateDataChange(UA_Server *server, UA_Session *session,
                            UA_Node *node, const UA_WriteValue *wvalue) {
-    UA_MonitoredItem *mon = node->head.monitoredItems;
-    for(; mon != NULL; mon = mon->sampling.nodeListNext) {
+    UA_MonitoredItem *mon;
+    LIST_FOREACH(mon, (UA_MonitoredItemList*)&node->head.monitoredItems,
+                 sampling.nodeListEntry) {
         if(mon->itemToMonitor.attributeId != wvalue->attributeId)
             continue;
         /* TODO: Allow async read for datachanges */

--- a/src/server/ua_subscription.c
+++ b/src/server/ua_subscription.c
@@ -1276,8 +1276,8 @@ addMonitoredItemBackpointer(UA_Server *server, UA_Session *session,
                             UA_Node *node, void *data) {
     UA_MonitoredItem *mon = (UA_MonitoredItem*)data;
     UA_assert(mon != (UA_MonitoredItem*)~0);
-    mon->sampling.nodeListNext = node->head.monitoredItems;
-    node->head.monitoredItems = mon;
+    LIST_INSERT_HEAD((UA_MonitoredItemList*)&node->head.monitoredItems,
+                     mon, sampling.nodeListEntry);
     return UA_STATUSCODE_GOOD;
 }
 
@@ -1287,22 +1287,8 @@ removeMonitoredItemBackPointer(UA_Server *server, UA_Session *session,
     if(!node->head.monitoredItems)
         return UA_STATUSCODE_GOOD;
 
-    /* Edge case that it's the first element */
     UA_MonitoredItem *remove = (UA_MonitoredItem*)data;
-    if(node->head.monitoredItems == remove) {
-        node->head.monitoredItems = remove->sampling.nodeListNext;
-        return UA_STATUSCODE_GOOD;
-    }
-
-    UA_MonitoredItem *prev = node->head.monitoredItems;
-    UA_MonitoredItem *entry = prev->sampling.nodeListNext;
-    for(; entry != NULL; prev = entry, entry = entry->sampling.nodeListNext) {
-        if(entry == remove) {
-            prev->sampling.nodeListNext = entry->sampling.nodeListNext;
-            break;
-        }
-    }
-
+    LIST_REMOVE(remove, sampling.nodeListEntry);
     return UA_STATUSCODE_GOOD;
 }
 

--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -158,7 +158,9 @@ struct UA_MonitoredItem {
     UA_MonitoredItemSamplingType samplingType;
     union {
         UA_UInt64 callbackId;
-        UA_MonitoredItem *nodeListNext; /* Event-Based: Attached to Node */
+        LIST_ENTRY(UA_MonitoredItem) nodeListEntry; /* Event-Based: linked into
+                                                     * the Node's MonitoredItem
+                                                     * list */
         LIST_ENTRY(UA_MonitoredItem) subscriptionSampling; /* Linked to publish
                                                             * interval */
     } sampling;
@@ -206,6 +208,12 @@ UA_MonitoredItemIdTree_cmp(const UA_UInt32 *a,
 
 ZIP_FUNCTIONS(UA_MonitoredItemIdTree, UA_MonitoredItem, idTreeEntry,
               UA_UInt32, monitoredItemId, UA_MonitoredItemIdTree_cmp)
+
+/* UA_NodeHead.monitoredItems is a bare UA_MonitoredItem* in the public
+ * nodestore.h, which is layout-compatible with this LIST_HEAD. The server runs
+ * the LIST_* macros over the per-node MonitoredItem list by casting the field's
+ * address to UA_MonitoredItemList*. */
+typedef LIST_HEAD(UA_MonitoredItemList, UA_MonitoredItem) UA_MonitoredItemList;
 
 /* Register sampling. Either by adding a repeated callback or by adding the
  * MonitoredItem to a linked list in the node. */

--- a/src/server/ua_subscription_event.c
+++ b/src/server/ua_subscription_event.c
@@ -1671,8 +1671,9 @@ createEvent(UA_Server *server, const UA_EventDescription *ed,
         }
 
         /* Iterate over all MonitoredItems registered in the node  */
-        for(UA_MonitoredItem *mon = node->head.monitoredItems;
-            mon != NULL; mon = mon->sampling.nodeListNext) {
+        UA_MonitoredItem *mon;
+        LIST_FOREACH(mon, (const UA_MonitoredItemList*)&node->head.monitoredItems,
+                     sampling.nodeListEntry) {
             /* Is this an Event-MonitoredItem? */
             if(mon->itemToMonitor.attributeId != UA_ATTRIBUTEID_EVENTNOTIFIER)
                 continue;

--- a/tests/server/check_nodestore.c
+++ b/tests/server/check_nodestore.c
@@ -7,6 +7,9 @@
 #include <open62541/plugin/nodestore_default.h>
 #include "open62541/plugin/nodestore.h"
 #include "open62541/types_generated.h"
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+#include "server/ua_subscription.h"
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -335,7 +338,10 @@ START_TEST(moveMonitoredItems_sameNodeIsNoop) {
 
 START_TEST(replaceNode_movesMonitoredItems) {
     UA_Node *source = createNode(0, 7002);
-    source->head.monitoredItems = (UA_MonitoredItem*)(uintptr_t)0x01;
+    UA_MonitoredItem monitoredItem;
+    memset(&monitoredItem, 0, sizeof(monitoredItem));
+    LIST_INSERT_HEAD((UA_MonitoredItemList*)&source->head.monitoredItems,
+                     &monitoredItem, sampling.nodeListEntry);
     UA_StatusCode retval = ns->insertNode(ns, source, NULL);
     ck_assert_int_eq(retval, UA_STATUSCODE_GOOD);
 
@@ -352,7 +358,9 @@ START_TEST(replaceNode_movesMonitoredItems) {
                                           UA_BROWSEDIRECTION_BOTH);
     ck_assert_ptr_ne(replaced, NULL);
     ck_assert_ptr_eq(replaced->head.monitoredItems,
-                     (UA_MonitoredItem*)(uintptr_t)0x01);
+                     &monitoredItem);
+    ck_assert_ptr_eq(monitoredItem.sampling.nodeListEntry.le_prev,
+                     &replaced->head.monitoredItems);
     ns->releaseNode(ns, replaced);
 } END_TEST
 

--- a/tests/server/check_services_subscriptions.c
+++ b/tests/server/check_services_subscriptions.c
@@ -2285,6 +2285,95 @@ START_TEST(Server_deleteMonitoredItems_partial_keepsTreeConsistent) {
     UA_DeleteMonitoredItemsResponse_clear(&response);
 } END_TEST
 
+/* Coverage for the per-node MonitoredItem list (samplingInterval == 0 "on
+ * write" sampling). Exercises the O(1) unlink (head, interior and tail) and
+ * the on-write iterator, asserting the LIST back-pointer invariant
+ * (*le_prev == element) on every element throughout. */
+
+static void
+nodeBpSampleCallback(UA_Server *s, UA_UInt32 monId, void *monCtx,
+                     const UA_NodeId *nid, void *nodeCtx, UA_UInt32 attrId,
+                     const UA_DataValue *value) {
+    (void)s; (void)monId; (void)monCtx; (void)nid;
+    (void)nodeCtx; (void)attrId; (void)value;
+}
+
+/* Walk the node's MonitoredItem list, assert the LIST back-pointer invariant
+ * (*le_prev == element) for every element and return the length. The invariant
+ * also catches a stale le_prev after the copy-on-write of a Node. */
+static size_t
+nodeBackpointerCount(UA_NodeId nodeId) {
+    lockServer(server);
+    const UA_Node *n = UA_NODESTORE_GET(server, &nodeId);
+    ck_assert(n != NULL);
+    size_t cnt = 0;
+    for(UA_MonitoredItem *m = n->head.monitoredItems; m;
+        m = m->sampling.nodeListEntry.le_next) {
+        ck_assert_ptr_eq(*(m->sampling.nodeListEntry.le_prev), m);
+        cnt++;
+    }
+    UA_NODESTORE_RELEASE(server, n);
+    unlockServer(server);
+    return cnt;
+}
+
+START_TEST(Server_monitoredItems_sameNode_backpointer) {
+    /* A regular, writable variable node. */
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    UA_Int32 val = 1;
+    UA_Variant_setScalar(&attr.value, &val, &UA_TYPES[UA_TYPES_INT32]);
+    attr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+    UA_NodeId nodeId = UA_NODEID_STRING(1, "node.backpointer");
+    ck_assert_uint_eq(UA_Server_addVariableNode(server, nodeId,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "bp"), UA_NODEID_NULL, attr, NULL, NULL),
+        UA_STATUSCODE_GOOD);
+
+    /* Five local MonitoredItems with samplingInterval == 0 on the SAME node:
+     * they all land on the per-node "on write" list. */
+    const size_t K = 5;
+    UA_UInt32 ids[5];
+    UA_MonitoredItemCreateRequest item;
+    UA_MonitoredItemCreateRequest_init(&item);
+    item.itemToMonitor.nodeId = nodeId;
+    item.itemToMonitor.attributeId = UA_ATTRIBUTEID_VALUE;
+    item.monitoringMode = UA_MONITORINGMODE_REPORTING;
+    item.requestedParameters.samplingInterval = 0.0;
+    for(size_t i = 0; i < K; i++) {
+        UA_MonitoredItemCreateResult r = UA_Server_createDataChangeMonitoredItem(
+            server, UA_TIMESTAMPSTORETURN_NEITHER, item, NULL, nodeBpSampleCallback);
+        ck_assert_uint_eq(r.statusCode, UA_STATUSCODE_GOOD);
+        ids[i] = r.monitoredItemId;
+    }
+    ck_assert_uint_eq(nodeBackpointerCount(nodeId), K);
+
+    /* Write the node: runs the on-write iterator over the whole list. The
+     * list and its back-pointers must survive intact. */
+    UA_Int32 nv = 2;
+    UA_Variant v;
+    UA_Variant_setScalar(&v, &nv, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_uint_eq(UA_Server_writeValue(server, nodeId, v), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(nodeBackpointerCount(nodeId), K);
+
+    /* Remove an interior element, then the head-of-list and the tail-of-list
+     * elements: exercises every branch of the O(1) unlink. */
+    ck_assert_uint_eq(UA_Server_deleteMonitoredItem(server, ids[2]), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(nodeBackpointerCount(nodeId), K - 1);
+    ck_assert_uint_eq(UA_Server_deleteMonitoredItem(server, ids[4]), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(nodeBackpointerCount(nodeId), K - 2);
+    ck_assert_uint_eq(UA_Server_deleteMonitoredItem(server, ids[0]), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(nodeBackpointerCount(nodeId), K - 3);
+
+    /* Write again with the shortened list, then remove the remainder. */
+    nv = 3;
+    UA_Variant_setScalar(&v, &nv, &UA_TYPES[UA_TYPES_INT32]);
+    ck_assert_uint_eq(UA_Server_writeValue(server, nodeId, v), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_deleteMonitoredItem(server, ids[1]), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_deleteMonitoredItem(server, ids[3]), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(nodeBackpointerCount(nodeId), 0);
+} END_TEST
+
 #endif /* UA_ENABLE_SUBSCRIPTIONS */
 
 static Suite* testSuite_Client(void) {
@@ -2334,6 +2423,7 @@ static Suite* testSuite_Client(void) {
     tcase_add_test(tc_server, Server_subscriptionSurvivesSessionTimeoutButIsNotTransferable);
     tcase_add_test(tc_server, Server_subscriptionRecoverableWithOverride);
     tcase_add_test(tc_server, Server_dataSourceSamplingIntervalZero);
+    tcase_add_test(tc_server, Server_monitoredItems_sameNode_backpointer);
 #endif /* UA_ENABLE_SUBSCRIPTIONS */
     suite_add_tcase(s, tc_server);
 


### PR DESCRIPTION
The per-node MonitoredItem back-pointer list (UA_NodeHead.monitoredItems) was a hand-rolled singly-linked list. Removing an item scanned the list to find its predecessor, so tearing down all MonitoredItems attached to one node was O(n^2).

Switch the list to the intrusive BSD-style LIST_* macros from deps/open62541_queue.h, already used for the subscription sampling list. Removal follows the le_prev back-pointer and is O(1); no search is needed.

The list head stays the bare UA_MonitoredItem* in the public UA_NodeHead (plugin/nodestore.h): it is layout-compatible with a LIST_HEAD, so the server casts the address of that field to UA_MonitoredItemList* to run the LIST_* macros over it. The public header and the generated amalgamation therefore stay independent of open62541_queue.h. The cast is type-punning that relies on this layout compatibility, and the build already sets -fno-strict-aliasing.

The intrusive list adds an invariant the previous one did not have: the le_prev of the first element points into the node that holds the list head. Nothing has to be re-anchored on a node copy, because the server only edits nodes in place -- UA_Server_editNode goes through getEditNode, which the ziptree nodestore implements in-situ -- so a live node never moves. A nodestore that instead relocates a node (getNodeCopy followed by replaceNode, which no caller in the server uses today) has to re-anchor le_prev onto the replacement after a successful replace: carrying the head pointer over on its own is not sufficient. Re-anchoring at copy time would be wrong, since the copy still shares the list with the source and the replace may still fail.

Add a regression test on the per-node list (samplingInterval == 0, "on write" sampling) covering head, interior and tail removal as well as the on-write iterator, asserting the *le_prev == element invariant on every element throughout.

Tearing down N MonitoredItems attached to a single node was O(n^2). Deleting them now scales linearly:

    N         delete before    delete after
    20000       669 ms           29 ms   (x23)
    50000      6477 ms           71 ms   (x92)
    80000     25756 ms          120 ms  (x215)
   100000     66072 ms          169 ms  (x391)

(amalgamation of each revision built identically with -O2 -DNDEBUG.)