### PR TITLE
feat(xml): decode character references correctly

### DIFF
--- a/deps/yxml.c
+++ b/deps/yxml.c
@@ -222,7 +222,7 @@ static yxml_ret_t yxml_selfclose(yxml_t *x, unsigned ch) {
 		return YXML_ELEMEND;
 	}
 	x->elem = (char *)x->stack;
-	x->state = YXMLS_misc3;
+	x->state = x->contentmode ? YXMLS_misc2 : YXMLS_misc3;
 	return YXML_ELEMEND;
 }
 
@@ -292,6 +292,7 @@ static yxml_ret_t yxml_refend(yxml_t *x, yxml_ret_t ret) {
 	if(!ch || ch > 0x10FFFF || ch == 0xFFFE || ch == 0xFFFF || (ch-0xDFFF) < 0x7FF)
 		return YXML_EREF;
 	yxml_setutf8(x->data, ch);
+	x->isReference = true;
 	return ret;
 }
 
@@ -308,7 +309,15 @@ void yxml_init(yxml_t *x, void *stack, size_t stacksize) {
 	x->state = YXMLS_init;
 }
 
+void yxml_init_content(yxml_t *x, void *stack, size_t stacksize) {
+	yxml_init(x, stack, stacksize);
+	x->contentmode = true;
+	x->state = YXMLS_misc2;
+}
+
 yxml_ret_t yxml_parse(yxml_t *x, int _ch) {
+	x->isReference = false;
+
 	/* Ensure that characters are in the range of 0..255 rather than -126..125.
 	 * All character comparisons are done with positive integers. */
 	unsigned ch = (unsigned)(_ch+256) & 0xff;
@@ -1026,8 +1035,8 @@ yxml_ret_t yxml_parse(yxml_t *x, int _ch) {
 }
 
 yxml_ret_t yxml_eof(yxml_t *x) {
-	if(x->state != YXMLS_misc3)
+	if(x->state != YXMLS_misc3 &&
+	   !(x->contentmode && x->state == YXMLS_misc2 && x->stacklen == 0))
 		return YXML_EEOF;
 	return YXML_OK;
 }
-

--- a/deps/yxml.h
+++ b/deps/yxml.h
@@ -23,6 +23,7 @@
 #ifndef YXML_H
 #define YXML_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -94,6 +95,10 @@ typedef struct {
 	 */
 	char data[8];
 
+	/* True if the current YXML_CONTENT or YXML_ATTRVAL event was produced from
+	 * a character or entity reference. Valid until the next yxml_parse() call. */
+	bool isReference;
+
 	/* Name of the current attribute. Changed after YXML_ATTRSTART, valid up to
 	 * and including the next YXML_ATTREND. */
 	char *attr;
@@ -119,6 +124,7 @@ typedef struct {
 	int nextstate; /* Used for '@' state remembering and for the "string" consuming state */
 	unsigned ignore;
 	unsigned char *string;
+	bool contentmode;
 } yxml_t;
 
 #ifdef __cplusplus
@@ -127,14 +133,20 @@ extern "C" {
 
 void yxml_init(yxml_t *, void *, size_t);
 
+/* Initialize the parser for an XML content fragment without an enclosing
+ * element. Character data, references, CDATA sections, comments, processing
+ * instructions and balanced child elements are accepted. */
+void yxml_init_content(yxml_t *, void *, size_t);
+
 yxml_ret_t yxml_parse(yxml_t *, int);
 
 /* May be called after the last character has been given to yxml_parse().
- * Returns YXML_OK if the XML document is valid, YXML_EEOF otherwise.  Using
- * this function isn't really necessary, but can be used to detect documents
- * that don't end correctly. In particular, an error is returned when the XML
- * document did not contain a (complete) root element, or when the document
- * ended while in a comment or processing instruction. */
+ * Returns YXML_OK if the XML document or content fragment is valid, YXML_EEOF
+ * otherwise. Using this function isn't really necessary, but can be used to
+ * detect input that doesn't end correctly. In document mode, an error is
+ * returned when there is no complete root element. In content mode, an error
+ * is returned for unbalanced child elements. Both modes reject input ending
+ * inside a reference, CDATA section, comment or processing instruction. */
 yxml_ret_t yxml_eof(yxml_t *);
 
 #ifdef __cplusplus

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -12,6 +12,7 @@
 
 #include <float.h>
 #include <math.h>
+#include <stdint.h>
 
 #include "../deps/itoa.h"
 #include "../deps/parse_num.h"
@@ -263,9 +264,16 @@ typedef struct {
 
 static status UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT
 xmlEncodeWriteChars(CtxXml *ctx, const char *c, size_t len) {
-    if(ctx->pos + len > ctx->end)
+    if(ctx->calcOnly) {
+        uintptr_t pos = (uintptr_t)ctx->pos;
+        if(len > UINTPTR_MAX - pos)
+            return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
+        ctx->pos = (uint8_t*)(pos + len);
+        return UA_STATUSCODE_GOOD;
+    }
+    if(len > (size_t)(ctx->end - ctx->pos))
         return UA_STATUSCODE_BADENCODINGLIMITSEXCEEDED;
-    if(!ctx->calcOnly && len)
+    if(len)
         memcpy(ctx->pos, c, len);
     ctx->pos += len;
     return UA_STATUSCODE_GOOD;

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -106,6 +106,8 @@ xml_tokenize(const char *xml, unsigned int len,
         }
         case YXML_CONTENT:
         case YXML_ATTRVAL:
+            if(ctx.isReference && xml_status == YXML_CONTENT)
+                stack[top]->contentEscaped = true;
             if(val_begin == 0)
                 val_begin = pos;
             stack[top]->end = pos;
@@ -150,6 +152,75 @@ xml_tokenize(const char *xml, unsigned int len,
     res.error_pos = pos;
     res.error = XML_ERROR_INVALID;
     return res;
+}
+
+/* Get the complete raw element content, including CDATA markers. */
+static status
+getTokenContent(const char *xml, const xml_token *token, UA_String *content) {
+    size_t begin = token->start;
+    char quote = 0;
+    for(; begin < token->end; begin++) {
+        char c = xml[begin];
+        if(quote) {
+            if(c == quote)
+                quote = 0;
+        } else if(c == '\'' || c == '"') {
+            quote = c;
+        } else if(c == '>') {
+            begin++;
+            break;
+        }
+    }
+    if(begin >= token->end)
+        return UA_STATUSCODE_BADDECODINGERROR;
+
+    size_t end = token->end;
+    while(end > begin && xml[end - 1] != '<')
+        end--;
+    if(end <= begin)
+        return UA_STATUSCODE_BADDECODINGERROR;
+    end--;
+
+    content->data = (UA_Byte*)(uintptr_t)&xml[begin];
+    content->length = end - begin;
+    return UA_STATUSCODE_GOOD;
+}
+
+/* Decode character and entity references and remove CDATA markers in the
+ * already copied content. Output never overtakes unread input, so rewriting
+ * in-place is safe. */
+static status
+decodeTokenContentInPlace(UA_String *content) {
+    yxml_t parser;
+    char parserStack[512];
+    yxml_init_content(&parser, parserStack, sizeof(parserStack));
+    unsigned depth = 0;
+    size_t outPos = 0;
+
+    for(size_t pos = 0; pos < content->length; pos++) {
+        yxml_ret_t event = yxml_parse(&parser, content->data[pos]);
+        if(event < YXML_OK)
+            return UA_STATUSCODE_BADDECODINGERROR;
+        if(event == YXML_ELEMSTART) {
+            depth++;
+        } else if(event == YXML_ELEMEND) {
+            if(depth == 0)
+                return UA_STATUSCODE_BADDECODINGERROR;
+            depth--;
+        } else if(event == YXML_CONTENT && depth == 0) {
+            size_t eventLength = strlen(parser.data);
+            if(outPos > content->length ||
+               eventLength > content->length - outPos)
+                return UA_STATUSCODE_BADDECODINGERROR;
+            memcpy(&content->data[outPos], parser.data, eventLength);
+            outPos += eventLength;
+        }
+    }
+
+    if(depth != 0 || yxml_eof(&parser) != YXML_OK)
+        return UA_STATUSCODE_BADDECODINGERROR;
+    content->length = outPos;
+    return UA_STATUSCODE_GOOD;
 }
 
 /* Map for decoding a XML complex object type. An array of this is passed to the
@@ -1099,6 +1170,7 @@ DECODE_XML(Float) {
 DECODE_XML(String) {
     UA_String *dst = (UA_String*)dst_;
     CHECK_DATA_BOUNDS;
+    const xml_token *token = &ctx->tokens[ctx->index];
     GET_ELEM_CONTENT;
     skipXmlObject(ctx);
 
@@ -1110,7 +1182,20 @@ DECODE_XML(String) {
     }
 
     UA_String str = {length, (UA_Byte*)(uintptr_t)data};
-    return UA_String_copy(&str, dst);
+    status ret = UA_STATUSCODE_GOOD;
+    if(token->contentEscaped)
+        ret = getTokenContent(ctx->xml, token, &str);
+    if(ret != UA_STATUSCODE_GOOD)
+        return ret;
+
+    ret = UA_String_copy(&str, dst);
+    if(ret != UA_STATUSCODE_GOOD || !token->contentEscaped)
+        return ret;
+
+    ret = decodeTokenContentInPlace(dst);
+    if(ret != UA_STATUSCODE_GOOD)
+        UA_String_clear(dst);
+    return ret;
 }
 
 DECODE_XML(DateTime) {

--- a/src/ua_types_encoding_xml.h
+++ b/src/ua_types_encoding_xml.h
@@ -26,6 +26,7 @@ typedef struct {
     xml_token_type type;
     UA_String name;
     UA_String content;
+    UA_Boolean contentEscaped; /* Content contains a character or entity reference */
     unsigned attributes; // For elements only: the number of attributes
     unsigned children;   // For elements only: the number of child elements
     unsigned start;      // First character of the token in the xml

--- a/tests/check_xml_encoding_roundtrip.c
+++ b/tests/check_xml_encoding_roundtrip.c
@@ -549,6 +549,58 @@ START_TEST(xml_decode_string) {
     UA_String_clear(&dst);
 } END_TEST
 
+START_TEST(xml_decode_character_references) {
+    const struct {
+        const char *xml;
+        const char *expected;
+    } cases[] = {
+        {"<String>&lt;&gt;&amp;&apos;&quot;</String>", "<>&'\""},
+        {"<String>&#65;&#x20AC;&#x10000;</String>",
+         "A\xE2\x82\xAC\xF0\x90\x80\x80"},
+        {"<String>&amp;<![CDATA[&amp;]]> &#x20AC; goodbye</String>",
+         "&&amp; \xE2\x82\xAC goodbye"},
+        {"<String attr=\">\">&amp;</String>", "&"},
+        {"<String>a;b</String>", "a;b"}
+    };
+
+    for(size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        UA_ByteString xml = {
+            strlen(cases[i].xml), (UA_Byte*)(uintptr_t)cases[i].xml};
+        UA_String dst;
+        UA_String_init(&dst);
+        UA_StatusCode res =
+            UA_decodeXml(&xml, &dst, &UA_TYPES[UA_TYPES_STRING], NULL);
+        ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+        UA_String expected = {
+            strlen(cases[i].expected), (UA_Byte*)(uintptr_t)cases[i].expected};
+        ck_assert(UA_String_equal(&dst, &expected));
+        UA_String_clear(&dst);
+    }
+
+    char mutableXml[] = "<String>&amp;&#x20AC;</String>";
+    char unchanged[sizeof(mutableXml)];
+    memcpy(unchanged, mutableXml, sizeof(mutableXml));
+    UA_ByteString xml = {
+        sizeof(mutableXml) - 1, (UA_Byte*)(uintptr_t)mutableXml};
+    UA_String dst;
+    UA_String_init(&dst);
+    UA_StatusCode res =
+        UA_decodeXml(&xml, &dst, &UA_TYPES[UA_TYPES_STRING], NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_mem_eq(mutableXml, unchanged, sizeof(mutableXml));
+    UA_String_clear(&dst);
+} END_TEST
+
+START_TEST(xml_decode_invalid_character_reference) {
+    UA_ByteString xml = UA_BYTESTRING("<String>&unknown;</String>");
+    UA_String dst;
+    UA_String_init(&dst);
+    UA_StatusCode res =
+        UA_decodeXml(&xml, &dst, &UA_TYPES[UA_TYPES_STRING], NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_BADDECODINGERROR);
+    UA_String_clear(&dst);
+} END_TEST
+
 int main(void) {
     Suite *s = suite_create("XML Encoding Ext");
 
@@ -613,6 +665,8 @@ int main(void) {
     tcase_add_test(tc_misc, xml_decode_double_neginf);
     tcase_add_test(tc_misc, xml_decode_double_nan);
     tcase_add_test(tc_misc, xml_decode_string);
+    tcase_add_test(tc_misc, xml_decode_character_references);
+    tcase_add_test(tc_misc, xml_decode_invalid_character_reference);
     suite_add_tcase(s, tc_misc);
 
     SRunner *sr = srunner_create(s);

--- a/tests/check_yxml.c
+++ b/tests/check_yxml.c
@@ -37,6 +37,31 @@ yxml_parse_full(const char *xml, size_t len, char *buf, size_t buflen,
     return yxml_eof(&x);
 }
 
+static yxml_ret_t
+yxml_parse_content_full(const char *xml, char *buf, size_t buflen,
+                        char *out, size_t outsize, size_t *outlen,
+                        size_t *references) {
+    yxml_t x;
+    yxml_init_content(&x, buf, buflen);
+    *outlen = 0;
+    *references = 0;
+    for(size_t i = 0; i < strlen(xml); i++) {
+        yxml_ret_t ret = yxml_parse(&x, (unsigned char)xml[i]);
+        if(ret < YXML_OK)
+            return ret;
+        if(x.isReference)
+            (*references)++;
+        if(ret != YXML_CONTENT)
+            continue;
+        size_t length = strlen(x.data);
+        if(*outlen > outsize || length > outsize - *outlen)
+            return YXML_ESTACK;
+        memcpy(&out[*outlen], x.data, length);
+        *outlen += length;
+    }
+    return yxml_eof(&x);
+}
+
 /* === xml_tokenize wrapper tests === */
 
 START_TEST(parseElement) {
@@ -342,6 +367,75 @@ START_TEST(yxmlEntityRef_content) {
                                      NULL, NULL, NULL, &cnt, NULL, NULL, NULL);
     ck_assert_int_eq(ret, YXML_OK);
     ck_assert_int_gt(cnt, 0);
+} END_TEST
+
+START_TEST(yxmlEntityRef_flag) {
+    char buf[512];
+    const char *xml = "<r a=\"plain;&amp;plain\">plain;&#65;plain</r>";
+    yxml_t x;
+    yxml_init(&x, buf, sizeof(buf));
+    size_t contentReferences = 0;
+    size_t attributeReferences = 0;
+    for(size_t i = 0; i < strlen(xml); i++) {
+        yxml_ret_t ret = yxml_parse(&x, (unsigned char)xml[i]);
+        ck_assert_int_ge(ret, YXML_OK);
+        if(x.isReference) {
+            if(ret == YXML_CONTENT)
+                contentReferences++;
+            else if(ret == YXML_ATTRVAL)
+                attributeReferences++;
+            else
+                ck_abort_msg("Reference flag set for event %d", ret);
+        }
+    }
+    ck_assert_uint_eq(contentReferences, 1);
+    ck_assert_uint_eq(attributeReferences, 1);
+} END_TEST
+
+START_TEST(yxmlContentFragment) {
+    char buf[512];
+    char out[128];
+    size_t outlen;
+    size_t references;
+    const char *content =
+        "a&amp;<?pi data?><!--ignored-->&lt;&#65;&#x20AC;"
+        "<![CDATA[&gt;]]>z";
+    yxml_ret_t ret = yxml_parse_content_full(
+        content, buf, sizeof(buf), out, sizeof(out) - 1,
+        &outlen, &references);
+    ck_assert_int_eq(ret, YXML_OK);
+    out[outlen] = 0;
+    ck_assert_str_eq(out, "a&<A\xE2\x82\xAC&gt;z");
+    ck_assert_uint_eq(references, 4);
+
+    yxml_t empty;
+    yxml_init_content(&empty, buf, sizeof(buf));
+    ck_assert_int_eq(yxml_eof(&empty), YXML_OK);
+} END_TEST
+
+START_TEST(yxmlContentFragment_nested) {
+    char buf[512];
+    yxml_t x;
+    yxml_init_content(&x, buf, sizeof(buf));
+    const char *content = "before<child>inside</child>after";
+    for(size_t i = 0; i < strlen(content); i++)
+        ck_assert_int_ge(yxml_parse(&x, (unsigned char)content[i]), YXML_OK);
+    ck_assert_int_eq(yxml_eof(&x), YXML_OK);
+} END_TEST
+
+START_TEST(yxmlContentFragment_incomplete) {
+    const char *invalid[] = {
+        "&amp", "<![CDATA[text", "<!-- comment", "<?pi data", "<child>"
+    };
+    for(size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        char buf[512];
+        yxml_t x;
+        yxml_init_content(&x, buf, sizeof(buf));
+        for(size_t j = 0; j < strlen(invalid[i]); j++)
+            ck_assert_int_ge(yxml_parse(&x, (unsigned char)invalid[i][j]),
+                             YXML_OK);
+        ck_assert_int_eq(yxml_eof(&x), YXML_EEOF);
+    }
 } END_TEST
 
 START_TEST(yxmlEntityRef_unknown) {
@@ -898,6 +992,10 @@ static Suite *testSuite_yxml(void) {
 
     TCase *tc_ref = tcase_create("yxml_refs");
     tcase_add_test(tc_ref, yxmlEntityRef_content);
+    tcase_add_test(tc_ref, yxmlEntityRef_flag);
+    tcase_add_test(tc_ref, yxmlContentFragment);
+    tcase_add_test(tc_ref, yxmlContentFragment_nested);
+    tcase_add_test(tc_ref, yxmlContentFragment_incomplete);
     tcase_add_test(tc_ref, yxmlEntityRef_unknown);
     tcase_add_test(tc_ref, yxmlEntityRef_tooLong);
     tcase_add_test(tc_ref, yxmlCharRef_decimalASCII);


### PR DESCRIPTION
## Summary

- add a yxml content-fragment mode with `yxml_init_content` and an event-local `isReference` flag
- mark complete open62541 XML tokens when any character or entity reference is encountered
- copy strings with `UA_String_copy` and, only for flagged tokens, decode references and CDATA in place in the mutable destination
- leave the original XML input untouched
- avoid undefined null-pointer arithmetic during XML size calculation

## Commit structure

1. `feat(yxml): support content fragment parsing`
2. `feat(xml): decode character references correctly`
3. `fix(xml): avoid pointer arithmetic during size calculation`

The yxml commit builds and passes `check_yxml` independently. The open62541 feature builds on that API.

## Coverage

- content and attribute reference-event flags, including reset behavior
- named, decimal, hexadecimal, consecutive and multibyte references
- CDATA, comments, processing instructions, balanced child elements and empty fragments
- incomplete fragments and invalid references
- references at content boundaries and opening attributes containing `>`
- preservation of the original input buffer

## Tests

- `check_yxml`
- `check_types_builtin_xml`
- `check_xml_encoding_roundtrip`

All tests passed in a Debug build with AddressSanitizer and UndefinedBehaviorSanitizer enabled.