### PR TITLE
feat(xml): accept numeric enum values

### DIFF
--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -1070,6 +1070,15 @@ Enum_decodeXml(ParseCtxXml *ctx, void *dst, const UA_DataType *type) {
             return UA_STATUSCODE_GOOD;
         }
     }
+
+    /* Be lenient with XML produced by implementations that encode enum values
+     * as bare integers instead of the schema-defined "Name_Value" form. */
+    UA_Int64 value = 0;
+    UA_StatusCode ret = decodeSigned(data, length, &value);
+    if(ret == UA_STATUSCODE_GOOD && value >= UA_INT32_MIN && value <= UA_INT32_MAX) {
+        *(UA_Int32*)dst = (UA_Int32)value;
+        return UA_STATUSCODE_GOOD;
+    }
     return UA_STATUSCODE_BADDECODINGERROR;
 }
 

--- a/tests/check_xml_encoding_roundtrip.c
+++ b/tests/check_xml_encoding_roundtrip.c
@@ -549,6 +549,15 @@ START_TEST(xml_decode_string) {
     UA_String_clear(&dst);
 } END_TEST
 
+START_TEST(xml_decode_numeric_enum) {
+    UA_ByteString xml = UA_BYTESTRING("<ServerState>5</ServerState>");
+    UA_ServerState dst = UA_SERVERSTATE_RUNNING;
+    UA_StatusCode res =
+        UA_decodeXml(&xml, &dst, &UA_TYPES[UA_TYPES_SERVERSTATE], NULL);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(dst, UA_SERVERSTATE_TEST);
+} END_TEST
+
 START_TEST(xml_decode_character_references) {
     const struct {
         const char *xml;
@@ -665,6 +674,7 @@ int main(void) {
     tcase_add_test(tc_misc, xml_decode_double_neginf);
     tcase_add_test(tc_misc, xml_decode_double_nan);
     tcase_add_test(tc_misc, xml_decode_string);
+    tcase_add_test(tc_misc, xml_decode_numeric_enum);
     tcase_add_test(tc_misc, xml_decode_character_references);
     tcase_add_test(tc_misc, xml_decode_invalid_character_reference);
     suite_add_tcase(s, tc_misc);


### PR DESCRIPTION
XML Schema encodes enum values as `Name_Value`, but some NodeSet producers emit bare integer values. Keep the standard symbolic decoding first and fall back to a signed 32-bit integer.\n\nThis allows existing non-standard NodeSets to load without weakening range validation.\n\nTests:\n- `check_xml_encoding_roundtrip`: 54/54 passed\n- standalone NodesetLoader unit suite: 25/25 passed