### PR TITLE
feat(server): let applications cap message size on untrusted channels

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -111,6 +111,7 @@ add_example(server_instantiation server_instantiation.c)
 add_example(server_repeated_job server_repeated_job.c)
 add_example(server_inheritance server_inheritance.c)
 add_example(server_loglevel server_loglevel.c)
+add_example(server_untrusted_message_limit server_untrusted_message_limit.c)
 add_example(custom_datatype_client custom_datatype/client_types_custom.c)
 add_example(custom_datatype_server custom_datatype/server_types_custom.c)
 

--- a/examples/server_untrusted_message_limit.c
+++ b/examples/server_untrusted_message_limit.c
@@ -1,0 +1,75 @@
+/* This work is licensed under a Creative Commons CCZero 1.0 Universal License.
+ * See http://creativecommons.org/publicdomain/zero/1.0/ for more information. */
+
+/* This example shows how a server-side application defines its own policy
+ * for how strictly to limit the size of in-flight messages on SecureChannels
+ * it does not (yet) consider trusted, via UA_ServerConfig.
+ * messageSizeLimitCallback.
+ *
+ * The server always enforces UA_ServerConfig.tcpMaxMsgSize as a hard ceiling
+ * for every channel. messageSizeLimitCallback is an optional, additional
+ * hook: it is invoked for every chunk before it is fully received (so it
+ * must be cheap and non-blocking) and may tighten -- or loosen -- that
+ * ceiling for the specific channel currently receiving data. It exists
+ * because open62541 does not dictate a single definition of "trusted": some
+ * deployments want a strict cap on unauthenticated traffic (e.g. to blunt
+ * resource-exhaustion attempts against the Discovery Service Set before any
+ * Session exists), while others run in a closed network and want no extra
+ * restriction at all. Leaving the callback unset (the default) keeps
+ * today's behavior of a single static tcpMaxMsgSize for every channel. */
+
+#include <open62541/plugin/log_stdout.h>
+#include <open62541/server.h>
+#include <open62541/server_config_default.h>
+
+#include <signal.h>
+#include <stdlib.h>
+
+static UA_Boolean running = true;
+static void stopHandler(int sig) {
+    running = false;
+}
+
+/* SecureChannels that are neither signed nor encrypted, and that have no
+ * Session with a completed ActivateSession yet, are capped to this size.
+ * This mainly limits what an anonymous, unauthenticated client can throw at
+ * the Discovery Service Set before it has proven anything about itself. */
+#define UA_UNTRUSTED_MAX_MESSAGE_SIZE (64 * 1024) /* 64 KB */
+
+static UA_UInt32
+limitUntrustedMessageSize(UA_Server *server, void *context,
+                          UA_UInt32 secureChannelId,
+                          UA_MessageSecurityMode securityMode,
+                          UA_Boolean sessionActivated,
+                          UA_UInt32 defaultMaxMessageSize) {
+    (void)server;
+    (void)context;
+    (void)secureChannelId;
+
+    UA_Boolean trusted = sessionActivated ||
+        securityMode == UA_MESSAGESECURITYMODE_SIGN ||
+        securityMode == UA_MESSAGESECURITYMODE_SIGNANDENCRYPT;
+    if(trusted)
+        return 0; /* No override -- fall back to defaultMaxMessageSize
+                    * (the server's tcpMaxMsgSize) */
+
+    return UA_UNTRUSTED_MAX_MESSAGE_SIZE;
+}
+
+int
+main(void) {
+    signal(SIGINT, stopHandler);
+    signal(SIGTERM, stopHandler);
+
+    UA_Server *server = UA_Server_new();
+    UA_ServerConfig *config = UA_Server_getConfig(server);
+    UA_ServerConfig_setDefault(config);
+
+    config->messageSizeLimitCallback = limitUntrustedMessageSize;
+    config->messageSizeLimitContext = NULL; /* No extra state needed here */
+
+    UA_StatusCode retval = UA_Server_run(server, &running);
+
+    UA_Server_delete(server);
+    return retval == UA_STATUSCODE_GOOD ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -2296,6 +2296,27 @@ struct UA_ServerConfig {
                               * (default: 0 -> unbounded) */
     UA_Boolean tcpReuseAddr;
 
+    /* Optional hook to dynamically cap the size of an in-flight message
+     * before it is fully received, based on the deployment's own definition
+     * of "trusted". Invoked once per accepted chunk, so it must be cheap and
+     * non-blocking. securityMode and sessionActivated (true if any Session on
+     * this SecureChannel has already completed ActivateSession) are the only
+     * trust signals available this early -- the message itself has not been
+     * decoded yet, so its Session and Service are unknown. defaultMaxMessageSize
+     * is the channel's static tcpMaxMsgSize-derived ceiling.
+     *
+     * Return 0 to apply no additional restriction (defaultMaxMessageSize
+     * still applies). Return any other value -- smaller or larger than
+     * defaultMaxMessageSize -- to override it for this channel. Leave NULL
+     * (default) to keep a single static tcpMaxMsgSize limit for every
+     * channel regardless of security mode or session state. */
+    void *messageSizeLimitContext;
+    UA_UInt32 (*messageSizeLimitCallback)(UA_Server *server, void *context,
+                                          UA_UInt32 secureChannelId,
+                                          UA_MessageSecurityMode securityMode,
+                                          UA_Boolean sessionActivated,
+                                          UA_UInt32 defaultMaxMessageSize);
+
     /* The following settings are specific to OPC UA Binary over WebSockets.
      * The transport is opt-in and controlled via webSocketEnabled (default: false).
      * TLS credentials protect opc.wss:// endpoints independently of OPC UA SecurityPolicies. */

--- a/src/server/ua_transport_tcp.c
+++ b/src/server/ua_transport_tcp.c
@@ -504,6 +504,27 @@ purgeFirstUascChannelWithoutSession(UA_Server *server) {
     return false;
 }
 
+/* Adapter for UA_SecureChannel.messageSizeLimitCallback: translates the
+ * generic per-chunk hook into a call of the public, policy-carrying
+ * UA_ServerConfig.messageSizeLimitCallback. Kept here (rather than in
+ * ua_securechannel.c) so the shared SecureChannel code stays free of
+ * UA_Server/UA_Session knowledge. */
+static UA_UInt32
+serverMessageSizeLimit(void *application, const UA_SecureChannel *channel) {
+    UA_Server *server = (UA_Server*)application;
+    UA_Boolean sessionActivated = false;
+    for(UA_Session *s = channel->sessions; s; s = s->next) {
+        if(s->state == UA_SESSIONSTATE_ACTIVATED) {
+            sessionActivated = true;
+            break;
+        }
+    }
+    return server->config.messageSizeLimitCallback(
+        server, server->config.messageSizeLimitContext,
+        channel->securityToken.channelId, channel->securityMode,
+        sessionActivated, channel->config.localMaxMessageSize);
+}
+
 UA_StatusCode
 createServerSecureChannel(UA_Server *server,
                           const UA_ConnectionConfig *connectionConfig,
@@ -567,6 +588,10 @@ createServerSecureChannel(UA_Server *server,
     channel->config = connConfig;
     channel->processOPNHeader = processOPN_AsymHeader;
     channel->processOPNHeaderApplication = server;
+    if(config->messageSizeLimitCallback) {
+        channel->messageSizeLimitCallback = serverMessageSizeLimit;
+        channel->messageSizeLimitApplication = server;
+    }
     channel->connectionManager = cm;
     channel->connectionId = connectionId;
 

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -970,6 +970,22 @@ UA_SecureChannel_loadBuffer(UA_SecureChannel *channel, const UA_ByteString buffe
     return UA_STATUSCODE_GOOD;
 }
 
+/* The effective message-size limit for the message currently being
+ * received. Defers to the application's messageSizeLimitCallback (server
+ * only) if one is configured and returns a non-zero override; otherwise
+ * falls back to the channel's static config.localMaxMessageSize (which
+ * itself may be 0 for "unbounded"). */
+static UA_UInt32
+getEffectiveMaxMessageSize(const UA_SecureChannel *channel) {
+    if(channel->messageSizeLimitCallback) {
+        UA_UInt32 dynamicMax = channel->messageSizeLimitCallback(
+            channel->messageSizeLimitApplication, channel);
+        if(dynamicMax != 0)
+            return dynamicMax;
+    }
+    return channel->config.localMaxMessageSize;
+}
+
 UA_StatusCode
 UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
                                     UA_MessageType *messageType, UA_UInt32 *requestId,
@@ -994,12 +1010,13 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
             UA_ByteString_clear(&chunk.bytes);
         goto extract_chunk;
 
-    case UA_CHUNKTYPE_INTERMEDIATE:
+    case UA_CHUNKTYPE_INTERMEDIATE: {
         /* Validate the resource limits */
+        UA_UInt32 maxMessageSize = getEffectiveMaxMessageSize(channel);
         if((channel->config.localMaxChunkCount != 0 &&
             channel->chunksCount >= channel->config.localMaxChunkCount) ||
-           (channel->config.localMaxMessageSize != 0 &&
-            channel->chunksLength + chunk.bytes.length > channel->config.localMaxMessageSize)) {
+           (maxMessageSize != 0 &&
+            channel->chunksLength + chunk.bytes.length > maxMessageSize)) {
             if(chunk.copied)
                 UA_ByteString_clear(&chunk.bytes);
             return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;
@@ -1017,6 +1034,7 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
         channel->chunksCount++;
         channel->chunksLength += pchunk->bytes.length;
         goto extract_chunk;
+    }
 
     case UA_CHUNKTYPE_FINAL:
     default:
@@ -1041,8 +1059,8 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
     }
 
     /* Validate the assembled message size */
-    if(channel->config.localMaxMessageSize != 0 &&
-       messageSize > channel->config.localMaxMessageSize) {
+    UA_UInt32 maxMessageSize = getEffectiveMaxMessageSize(channel);
+    if(maxMessageSize != 0 && messageSize > maxMessageSize) {
         if(chunk.copied)
             UA_ByteString_clear(&chunk.bytes);
         return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -243,6 +243,17 @@ struct UA_SecureChannel {
     void *processOPNHeaderApplication;
     UA_StatusCode (*processOPNHeader)(void *application, UA_SecureChannel *channel,
                                       const UA_AsymmetricAlgorithmSecurityHeader *asymHeader);
+
+    /* Optional application-supplied hook (only used in the server) that
+     * dynamically overrides config.localMaxMessageSize for the message
+     * currently being received. Sibling to processOPNHeader/Application:
+     * this keeps the generic SecureChannel code free of UA_Server/UA_Session
+     * knowledge while still letting the server recompute the limit per
+     * channel, e.g. based on channel->securityMode or on whether a Session
+     * has been activated on this channel. See UA_ServerConfig.
+     * messageSizeLimitCallback for the public-facing policy hook. */
+    void *messageSizeLimitApplication;
+    UA_UInt32 (*messageSizeLimitCallback)(void *application, const UA_SecureChannel *channel);
 };
 
 /* Transport confidentiality and OPC UA application signatures are separate

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -502,6 +502,103 @@ START_TEST(SecureChannel_assemblePartialChunks) {
     ck_assert_int_eq(chunks_processed, 5);
 } END_TEST
 
+/* ==== UA_SecureChannel.messageSizeLimitCallback ====
+ *
+ * These reuse the single-chunk "HELF"/"HELC" fixture above: a full 32-byte
+ * chunk (8-byte header + 24-byte body) whose declared MessageSize (bytes
+ * 4-7, little-endian) is 32. Only the IsFinal byte (offset 3) differs
+ * between a FINAL chunk (exercises the assembled-message-size check) and an
+ * INTERMEDIATE/continuation chunk (exercises the chunk-accumulation check). */
+
+typedef struct {
+    UA_UInt32 limit;
+    unsigned callCount;
+    const UA_SecureChannel *lastChannel;
+} MessageSizeLimitTestContext;
+
+static UA_UInt32
+testMessageSizeLimitCallback(void *application, const UA_SecureChannel *channel) {
+    MessageSizeLimitTestContext *ctx = (MessageSizeLimitTestContext*)application;
+    ctx->callCount++;
+    ctx->lastChannel = channel;
+    return ctx->limit;
+}
+
+START_TEST(SecureChannel_messageSizeLimitCallback_capsBelowStaticLimit) {
+    /* The static localMaxMessageSize (from UA_ConnectionConfig_default) is
+     * generous enough to admit the 32-byte test message on its own. A
+     * callback that caps below the message size must still reject it. */
+    int chunks_processed = 0;
+    MessageSizeLimitTestContext ctx = {16, 0, NULL};
+    testChannel.messageSizeLimitCallback = testMessageSizeLimitCallback;
+    testChannel.messageSizeLimitApplication = &ctx;
+
+    UA_ByteString buffer = UA_BYTESTRING_NULL;
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 32;
+
+    UA_StatusCode retval =
+        UA_SecureChannel_processBuffer(&testChannel, &chunks_processed, buffer);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADTCPMESSAGETOOLARGE);
+    ck_assert_int_eq(chunks_processed, 0);
+    ck_assert_uint_gt(ctx.callCount, 0);
+    ck_assert_ptr_eq(ctx.lastChannel, &testChannel);
+} END_TEST
+
+START_TEST(SecureChannel_messageSizeLimitCallback_zeroFallsBackToStaticLimit) {
+    /* Returning 0 from the callback means "no override" -- the static
+     * localMaxMessageSize (large enough here) still applies and the
+     * 32-byte message is accepted. */
+    int chunks_processed = 0;
+    MessageSizeLimitTestContext ctx = {0, 0, NULL};
+    testChannel.messageSizeLimitCallback = testMessageSizeLimitCallback;
+    testChannel.messageSizeLimitApplication = &ctx;
+
+    UA_ByteString buffer = UA_BYTESTRING_NULL;
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 32;
+
+    UA_StatusCode retval =
+        UA_SecureChannel_processBuffer(&testChannel, &chunks_processed, buffer);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(chunks_processed, 1);
+    ck_assert_uint_gt(ctx.callCount, 0);
+} END_TEST
+
+START_TEST(SecureChannel_messageSizeLimitCallback_overridesAboveStaticLimit) {
+    /* A deployment that wants no strict limit for a channel/session it
+     * considers trusted can override upward, past a tight static
+     * localMaxMessageSize. */
+    int chunks_processed = 0;
+    testChannel.config.localMaxMessageSize = 8; /* smaller than the 32-byte message */
+    MessageSizeLimitTestContext ctx = {1000, 0, NULL};
+    testChannel.messageSizeLimitCallback = testMessageSizeLimitCallback;
+    testChannel.messageSizeLimitApplication = &ctx;
+
+    UA_ByteString buffer = UA_BYTESTRING_NULL;
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 32;
+
+    UA_StatusCode retval =
+        UA_SecureChannel_processBuffer(&testChannel, &chunks_processed, buffer);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(chunks_processed, 1);
+} END_TEST
+
+/* The chunk-accumulation check (UA_CHUNKTYPE_INTERMEDIATE, hit while a
+ * multi-chunk message is still arriving) calls the exact same
+ * getEffectiveMaxMessageSize() helper as the assembled-message check above,
+ * with an identical "!= 0 && length > max" guard. It is not covered by a
+ * dedicated test here: HEL-type frames (the only ones this file can
+ * hand-craft without a full symmetric-security roundtrip) are required by
+ * the wire format to always be FINAL, and building a legitimate
+ * intermediate MSG/CLO chunk needs a real SecureChannel token, sequence
+ * numbers and decrypt/verify -- machinery this file does not otherwise
+ * exercise on the receive path. */
+
 #if defined(UA_ENABLE_ENCRYPTION_OPENSSL) && !defined(LIBRESSL_VERSION_NUMBER)
 /* OPC UA Part 6 v1.05.07 §6.8.1 step 2 "Extract" — IKM chaining on
  * SecureChannel renewal. This exercises the OpenSSL helper directly
@@ -685,6 +782,9 @@ testSuite_SecureChannel(void) {
     tcase_add_checked_fixture(tc_processBuffer, setup_key_sizes, teardown_key_sizes);
     tcase_add_checked_fixture(tc_processBuffer, setup_secureChannel, teardown_secureChannel);
     tcase_add_test(tc_processBuffer, SecureChannel_assemblePartialChunks);
+    tcase_add_test(tc_processBuffer, SecureChannel_messageSizeLimitCallback_capsBelowStaticLimit);
+    tcase_add_test(tc_processBuffer, SecureChannel_messageSizeLimitCallback_zeroFallsBackToStaticLimit);
+    tcase_add_test(tc_processBuffer, SecureChannel_messageSizeLimitCallback_overridesAboveStaticLimit);
     suite_add_tcase(s, tc_processBuffer);
 
 #if defined(UA_ENABLE_ENCRYPTION_OPENSSL) && !defined(LIBRESSL_VERSION_NUMBER)

--- a/tests/server/check_server_http_protocol.c
+++ b/tests/server/check_server_http_protocol.c
@@ -723,6 +723,137 @@ START_TEST(uascZeroLimitIsUnlimited) {
 }
 END_TEST
 
+typedef struct {
+    UA_Boolean called;
+    UA_UInt32 secureChannelId;
+    UA_MessageSecurityMode securityMode;
+    UA_Boolean sessionActivated;
+    UA_UInt32 defaultMaxMessageSize;
+} MessageSizeLimitCallInfo;
+
+static UA_UInt32
+recordingMessageSizeLimitCallback(UA_Server *server, void *context,
+                                  UA_UInt32 secureChannelId,
+                                  UA_MessageSecurityMode securityMode,
+                                  UA_Boolean sessionActivated,
+                                  UA_UInt32 defaultMaxMessageSize) {
+    (void)server;
+    MessageSizeLimitCallInfo *info = (MessageSizeLimitCallInfo*)context;
+    info->called = true;
+    info->secureChannelId = secureChannelId;
+    info->securityMode = securityMode;
+    info->sessionActivated = sessionActivated;
+    info->defaultMaxMessageSize = defaultMaxMessageSize;
+    return 4242;
+}
+
+START_TEST(messageSizeLimitCallback_wiredWhenConfigured) {
+    /* createServerSecureChannel wires config->messageSizeLimitCallback into
+     * an internal per-channel adapter that forwards to it with the
+     * channel's securityMode/channelId/localMaxMessageSize and whether any
+     * Session on the channel has completed ActivateSession. */
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_nonnull(server);
+
+    MessageSizeLimitCallInfo info;
+    memset(&info, 0, sizeof(info));
+    server->config.messageSizeLimitCallback = recordingMessageSizeLimitCallback;
+    server->config.messageSizeLimitContext = &info;
+
+    UA_ConnectionManager cm;
+    memset(&cm, 0, sizeof(cm));
+    UA_ConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(connectionConfig));
+    UA_SecureChannel *created = NULL;
+
+    lockServer(server);
+    UA_StatusCode res = createServerSecureChannel(
+        server, &connectionConfig, &cm, 1, NULL, &created);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_ptr_nonnull(created);
+    ck_assert(created->messageSizeLimitCallback != NULL);
+    ck_assert_ptr_eq(created->messageSizeLimitApplication, server);
+
+    created->securityMode = UA_MESSAGESECURITYMODE_SIGN;
+    created->securityToken.channelId = 77;
+    created->config.localMaxMessageSize = 999;
+
+    /* No Session attached yet: sessionActivated must be reported false. */
+    UA_UInt32 result = created->messageSizeLimitCallback(
+        created->messageSizeLimitApplication, created);
+    ck_assert_uint_eq(result, 4242);
+    ck_assert(info.called);
+    ck_assert_uint_eq(info.secureChannelId, 77);
+    ck_assert_uint_eq(info.securityMode, UA_MESSAGESECURITYMODE_SIGN);
+    ck_assert(!info.sessionActivated);
+    ck_assert_uint_eq(info.defaultMaxMessageSize, 999);
+
+    /* An inactive Session on the channel still reports false ... */
+    UA_Session inactiveSession, activeSession;
+    memset(&inactiveSession, 0, sizeof(inactiveSession));
+    memset(&activeSession, 0, sizeof(activeSession));
+    activeSession.state = UA_SESSIONSTATE_ACTIVATED;
+    created->sessions = &inactiveSession;
+
+    info.called = false;
+    result = created->messageSizeLimitCallback(
+        created->messageSizeLimitApplication, created);
+    ck_assert(info.called);
+    ck_assert(!info.sessionActivated);
+
+    /* ... but any activated Session on the channel flips it to true. */
+    inactiveSession.next = &activeSession;
+
+    info.called = false;
+    result = created->messageSizeLimitCallback(
+        created->messageSizeLimitApplication, created);
+    ck_assert(info.called);
+    ck_assert(info.sessionActivated);
+
+    /* UA_SecureChannel_clear asserts that no Sessions remain attached. */
+    created->sessions = NULL;
+
+    unregisterSecureChannel(server, created);
+    server->secureChannelStatistics.currentChannelCount--;
+    UA_SecureChannel_clear(created);
+    UA_free(created);
+    unlockServer(server);
+
+    ck_assert_uint_eq(UA_Server_delete(server), UA_STATUSCODE_GOOD);
+}
+END_TEST
+
+START_TEST(messageSizeLimitCallback_notWiredByDefault) {
+    /* Leaving UA_ServerConfig.messageSizeLimitCallback NULL (the default)
+     * must not attach anything to the channel, preserving today's behavior
+     * of a single static tcpMaxMsgSize for every channel. */
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_nonnull(server);
+
+    UA_ConnectionManager cm;
+    memset(&cm, 0, sizeof(cm));
+    UA_ConnectionConfig connectionConfig;
+    memset(&connectionConfig, 0, sizeof(connectionConfig));
+    UA_SecureChannel *created = NULL;
+
+    lockServer(server);
+    UA_StatusCode res = createServerSecureChannel(
+        server, &connectionConfig, &cm, 1, NULL, &created);
+    ck_assert_uint_eq(res, UA_STATUSCODE_GOOD);
+    ck_assert_ptr_nonnull(created);
+    ck_assert(created->messageSizeLimitCallback == NULL);
+    ck_assert_ptr_null(created->messageSizeLimitApplication);
+
+    unregisterSecureChannel(server, created);
+    server->secureChannelStatistics.currentChannelCount--;
+    UA_SecureChannel_clear(created);
+    UA_free(created);
+    unlockServer(server);
+
+    ck_assert_uint_eq(UA_Server_delete(server), UA_STATUSCODE_GOOD);
+}
+END_TEST
+
 START_TEST(mixedTransportChannelIdsAreUnique) {
     UA_Server *server = UA_Server_new();
     ck_assert_ptr_nonnull(server);
@@ -868,6 +999,8 @@ testSuite(void) {
     tcase_add_test(tc, trustUpdateClosesOpenUascChannel);
     tcase_add_test(tc, uascLimitDoesNotPurgeDirectChannel);
     tcase_add_test(tc, uascZeroLimitIsUnlimited);
+    tcase_add_test(tc, messageSizeLimitCallback_wiredWhenConfigured);
+    tcase_add_test(tc, messageSizeLimitCallback_notWiredByDefault);
     tcase_add_test(tc, mixedTransportChannelIdsAreUnique);
     tcase_add_test(tc, closingHttpChannelDrainsUntilCarrierCloses);
     tcase_add_test(tc, httpRequestTimeoutAndEncodingMetadata);


### PR DESCRIPTION
Adds UA_ServerConfig.messageSizeLimitCallback, wired through `UA_SecureChannel` via a per-channel hook.

Related to #8321, but instead of open62541 enforcing a fixed default limit on untrusted messages, adds `UA_ServerConfig.messageSizeLimitCallback` so applications decide for themselves whether and how to cap message size on channels/sessions they don't yet trust.

Also includes unit/integration tests covering the callback wiring and override behavior, plus a small `server_untrusted_message_limit` example showing how to use it.