### PR TITLE
feat(server): let applications tighten the message size limit on a channel

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -237,6 +237,59 @@ UA_Server_closeSecureChannel(UA_Server *server, UA_UInt32 channelId,
                              UA_ShutdownReason reason);
 
 /**
+ * A SecureChannel carries application-defined attributes in a key-value map,
+ * mirroring the :ref:`session attributes <server-session-handling>` below.
+ * This lets the application attach its own per-channel state, for example
+ * from the secureChannelNotificationCallback once it has looked at the
+ * channel's SecurityMode.
+ *
+ * One attribute key is interpreted by the server itself:
+ *
+ * - ``0:maxMessageSize`` (``UA_UInt32``): If set, tightens (but never
+ *   loosens) UA_ServerConfig.tcpMaxMsgSize for this specific channel. Useful
+ *   to cap messages on a channel the application does not yet consider
+ *   trusted, e.g. because it is unsigned/unencrypted or has no Session with
+ *   a completed ActivateSession. Delete the attribute (or never set it) to
+ *   fall back to the server-wide tcpMaxMsgSize. */
+
+/* Returns a shallow copy of the attribute (don't _clear or _delete manually).
+ * While the method is thread-safe, the returned value is not protected. Only
+ * use it in a (callback) context where the server is locked for the current
+ * thread. */
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_getSecureChannelAttribute(UA_Server *server, UA_UInt32 channelId,
+                                    const UA_QualifiedName key,
+                                    UA_Variant *outValue);
+
+/* Return a deep copy of the attribute */
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_getSecureChannelAttributeCopy(UA_Server *server, UA_UInt32 channelId,
+                                        const UA_QualifiedName key,
+                                        UA_Variant *outValue);
+
+/* Returns NULL if the attribute is not defined or not a scalar or not of the
+ * right datatype. Otherwise a shallow copy of the scalar value is created at
+ * the target location of the void pointer (don't _clear or _delete manually).
+ * While the method is thread-safe, the returned value is not protected. Only
+ * use it in a (callback) context where the server is locked for the current
+ * thread. */
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_getSecureChannelAttribute_scalar(UA_Server *server,
+                                           UA_UInt32 channelId,
+                                           const UA_QualifiedName key,
+                                           const UA_DataType *type,
+                                           void *outValue);
+
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_setSecureChannelAttribute(UA_Server *server, UA_UInt32 channelId,
+                                    const UA_QualifiedName key,
+                                    const UA_Variant *value);
+
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_deleteSecureChannelAttribute(UA_Server *server, UA_UInt32 channelId,
+                                       const UA_QualifiedName key);
+
+/**
  * .. _server-session-handling:
  *
  * Session Handling

--- a/src/server/ua_server_utils.c
+++ b/src/server/ua_server_utils.c
@@ -519,6 +519,116 @@ UA_Server_closeSecureChannel(UA_Server *server, UA_UInt32 channelId,
     return UA_STATUSCODE_BADNOTFOUND;
 }
 
+/* The one SecureChannel attribute key interpreted by the server itself. See
+ * the doc comment on UA_Server_setSecureChannelAttribute in server.h. */
+static const UA_QualifiedName maxMessageSizeAttributeKey =
+    {0, UA_STRING_STATIC("maxMessageSize")};
+
+UA_StatusCode
+UA_Server_getSecureChannelAttribute(UA_Server *server, UA_UInt32 channelId,
+                                    const UA_QualifiedName key,
+                                    UA_Variant *outValue) {
+    if(!outValue)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    lockServer(server);
+    UA_SecureChannel *channel = findSecureChannel(server, channelId);
+    if(!channel) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+    const UA_Variant *attr = UA_KeyValueMap_get(&channel->attributes, key);
+    if(!attr) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+    *outValue = *attr;
+    outValue->storageType = UA_VARIANT_DATA_NODELETE;
+    unlockServer(server);
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_getSecureChannelAttributeCopy(UA_Server *server, UA_UInt32 channelId,
+                                        const UA_QualifiedName key,
+                                        UA_Variant *outValue) {
+    if(!outValue)
+        return UA_STATUSCODE_BADINTERNALERROR;
+    lockServer(server);
+    UA_SecureChannel *channel = findSecureChannel(server, channelId);
+    if(!channel) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+    const UA_Variant *attr = UA_KeyValueMap_get(&channel->attributes, key);
+    UA_StatusCode res = attr ?
+        UA_Variant_copy(attr, outValue) : UA_STATUSCODE_BADNOTFOUND;
+    unlockServer(server);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_getSecureChannelAttribute_scalar(UA_Server *server,
+                                           UA_UInt32 channelId,
+                                           const UA_QualifiedName key,
+                                           const UA_DataType *type,
+                                           void *outValue) {
+    lockServer(server);
+    UA_SecureChannel *channel = findSecureChannel(server, channelId);
+    if(!channel) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+    const UA_Variant *attr = UA_KeyValueMap_get(&channel->attributes, key);
+    if(!attr || !UA_Variant_hasScalarType(attr, type)) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+    memcpy(outValue, attr->data, type->memSize);
+    unlockServer(server);
+    return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode
+UA_Server_setSecureChannelAttribute(UA_Server *server, UA_UInt32 channelId,
+                                    const UA_QualifiedName key,
+                                    const UA_Variant *value) {
+    lockServer(server);
+    UA_SecureChannel *channel = findSecureChannel(server, channelId);
+    if(!channel) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+    UA_Boolean isMaxMessageSize =
+        UA_QualifiedName_equal(&key, &maxMessageSizeAttributeKey);
+    if(isMaxMessageSize &&
+       (!value || !UA_Variant_hasScalarType(value, &UA_TYPES[UA_TYPES_UINT32]))) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADTYPEMISMATCH;
+    }
+    UA_StatusCode res = UA_KeyValueMap_set(&channel->attributes, key, value);
+    if(res == UA_STATUSCODE_GOOD && isMaxMessageSize)
+        channel->maxMessageSizeOverride = *(const UA_UInt32*)value->data;
+    unlockServer(server);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_deleteSecureChannelAttribute(UA_Server *server, UA_UInt32 channelId,
+                                       const UA_QualifiedName key) {
+    lockServer(server);
+    UA_SecureChannel *channel = findSecureChannel(server, channelId);
+    if(!channel) {
+        unlockServer(server);
+        return UA_STATUSCODE_BADNOTFOUND;
+    }
+    UA_StatusCode res = UA_KeyValueMap_remove(&channel->attributes, key);
+    if(res == UA_STATUSCODE_GOOD &&
+       UA_QualifiedName_equal(&key, &maxMessageSizeAttributeKey))
+        channel->maxMessageSizeOverride = 0;
+    unlockServer(server);
+    return res;
+}
+
 UA_StatusCode
 registerSecureChannel(UA_Server *server, UA_SecureChannel *channel) {
     UA_LOCK_ASSERT(&server->serviceMutex);

--- a/src/ua_securechannel.c
+++ b/src/ua_securechannel.c
@@ -291,6 +291,10 @@ UA_SecureChannel_clear(UA_SecureChannel *channel) {
     UA_NamespaceMapping_delete(channel->namespaceMapping);
     channel->namespaceMapping = NULL;
 
+    /* Clean up the generic per-channel attributes */
+    UA_KeyValueMap_clear(&channel->attributes);
+    channel->maxMessageSizeOverride = 0;
+
     /* Reset the SecureChannel for reuse (in the client) */
     channel->securityMode = UA_MESSAGESECURITYMODE_INVALID;
     channel->shutdownReason = UA_SHUTDOWNREASON_CLOSE;
@@ -972,6 +976,20 @@ UA_SecureChannel_loadBuffer(UA_SecureChannel *channel, const UA_ByteString buffe
     return UA_STATUSCODE_GOOD;
 }
 
+/* The effective message-size limit for the message currently being
+ * received: config.localMaxMessageSize (which may be 0 for "unbounded"),
+ * tightened by maxMessageSizeOverride if the application has set one via
+ * UA_Server_setSecureChannelAttribute -- it can only lower the static
+ * ceiling, never raise it. */
+static UA_UInt32
+getEffectiveMaxMessageSize(const UA_SecureChannel *channel) {
+    UA_UInt32 max = channel->config.localMaxMessageSize;
+    if(channel->maxMessageSizeOverride != 0 &&
+       (max == 0 || channel->maxMessageSizeOverride < max))
+        max = channel->maxMessageSizeOverride;
+    return max;
+}
+
 UA_StatusCode
 UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
                                     UA_MessageType *messageType, UA_UInt32 *requestId,
@@ -996,12 +1014,13 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
             UA_ByteString_clear(&chunk.bytes);
         goto extract_chunk;
 
-    case UA_CHUNKTYPE_INTERMEDIATE:
+    case UA_CHUNKTYPE_INTERMEDIATE: {
         /* Validate the resource limits */
+        UA_UInt32 maxMessageSize = getEffectiveMaxMessageSize(channel);
         if((channel->config.localMaxChunkCount != 0 &&
             channel->chunksCount >= channel->config.localMaxChunkCount) ||
-           (channel->config.localMaxMessageSize != 0 &&
-            channel->chunksLength + chunk.bytes.length > channel->config.localMaxMessageSize)) {
+           (maxMessageSize != 0 &&
+            channel->chunksLength + chunk.bytes.length > maxMessageSize)) {
             if(chunk.copied)
                 UA_ByteString_clear(&chunk.bytes);
             return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;
@@ -1019,6 +1038,7 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
         channel->chunksCount++;
         channel->chunksLength += pchunk->bytes.length;
         goto extract_chunk;
+    }
 
     case UA_CHUNKTYPE_FINAL:
     default:
@@ -1046,10 +1066,10 @@ UA_SecureChannel_getCompleteMessage(UA_SecureChannel *channel,
 
     /* Validate the assembled message limits. The final chunk also counts
      * towards localMaxChunkCount. */
+    UA_UInt32 maxMessageSize = getEffectiveMaxMessageSize(channel);
     if((channel->config.localMaxChunkCount != 0 &&
         messageChunks > channel->config.localMaxChunkCount) ||
-       (channel->config.localMaxMessageSize != 0 &&
-        messageSize > channel->config.localMaxMessageSize)) {
+       (maxMessageSize != 0 && messageSize > maxMessageSize)) {
         if(chunk.copied)
             UA_ByteString_clear(&chunk.bytes);
         return UA_STATUSCODE_BADTCPMESSAGETOOLARGE;

--- a/src/ua_securechannel.h
+++ b/src/ua_securechannel.h
@@ -229,6 +229,18 @@ struct UA_SecureChannel {
      * used in the server) */
     UA_Session *sessions;
 
+    /* Generic per-channel storage for the application, addressable via
+     * UA_Server_{get,set,delete}SecureChannelAttribute. Mirrors
+     * UA_Session.attributes. */
+    UA_KeyValueMap attributes;
+
+    /* Cached from the reserved "0:maxMessageSize" entry in attributes
+     * whenever it is written, so the per-chunk size checks in
+     * UA_SecureChannel_getCompleteMessage never need to touch the map. Zero
+     * means "not set" -> config.localMaxMessageSize applies unmodified. A
+     * non-zero value can only tighten, never loosen, that static ceiling. */
+    UA_UInt32 maxMessageSizeOverride;
+
     /* (Decrypted) chunks waiting to be processed */
     UA_ChunkQueue chunks;
     size_t chunksCount;

--- a/tests/check_securechannel.c
+++ b/tests/check_securechannel.c
@@ -601,6 +601,70 @@ START_TEST(SecureChannel_countFinalChunkAgainstLimit) {
     ck_assert_uint_eq(retval, UA_STATUSCODE_BADTCPMESSAGETOOLARGE);
 } END_TEST
 
+/* ==== UA_SecureChannel.maxMessageSizeOverride ====
+ *
+ * Reuses the single-chunk "HELF" fixture above: a full 32-byte chunk
+ * (8-byte header + 24-byte body) whose declared MessageSize (bytes 4-7,
+ * little-endian) is 32. In the server, maxMessageSizeOverride is only ever
+ * written through UA_Server_setSecureChannelAttribute (see
+ * check_server_http_protocol.c) -- these tests set the field directly to
+ * exercise the enforcement logic in isolation from that public API. */
+
+START_TEST(SecureChannel_maxMessageSizeOverride_tightensBelowStaticLimit) {
+    /* The static localMaxMessageSize (from UA_ConnectionConfig_default) is
+     * generous enough to admit the 32-byte test message on its own. An
+     * override below the message size must still reject it. */
+    int chunks_processed = 0;
+    testChannel.maxMessageSizeOverride = 16;
+
+    UA_ByteString buffer = UA_BYTESTRING_NULL;
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 32;
+
+    UA_StatusCode retval =
+        UA_SecureChannel_processBuffer(&testChannel, &chunks_processed, buffer);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADTCPMESSAGETOOLARGE);
+    ck_assert_int_eq(chunks_processed, 0);
+} END_TEST
+
+START_TEST(SecureChannel_maxMessageSizeOverride_zeroMeansUnset) {
+    /* maxMessageSizeOverride == 0 is the default (never written) state --
+     * the static localMaxMessageSize (large enough here) applies unmodified
+     * and the 32-byte message is accepted. */
+    int chunks_processed = 0;
+    ck_assert_uint_eq(testChannel.maxMessageSizeOverride, 0);
+
+    UA_ByteString buffer = UA_BYTESTRING_NULL;
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 32;
+
+    UA_StatusCode retval =
+        UA_SecureChannel_processBuffer(&testChannel, &chunks_processed, buffer);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(chunks_processed, 1);
+} END_TEST
+
+START_TEST(SecureChannel_maxMessageSizeOverride_cannotExceedStaticLimit) {
+    /* The override can only tighten the static ceiling, never loosen it --
+     * an application cannot use it to bypass the administrator-configured
+     * tcpMaxMsgSize. */
+    int chunks_processed = 0;
+    testChannel.config.localMaxMessageSize = 8; /* smaller than the 32-byte message */
+    testChannel.maxMessageSizeOverride = 1000;  /* would admit it on its own */
+
+    UA_ByteString buffer = UA_BYTESTRING_NULL;
+    buffer.data = (UA_Byte *)"HELF \x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00"
+                             "\x10\x00\x00\x00@\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff";
+    buffer.length = 32;
+
+    UA_StatusCode retval =
+        UA_SecureChannel_processBuffer(&testChannel, &chunks_processed, buffer);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_BADTCPMESSAGETOOLARGE);
+    ck_assert_int_eq(chunks_processed, 0);
+} END_TEST
+
 #if defined(UA_ENABLE_ENCRYPTION_OPENSSL) && !defined(LIBRESSL_VERSION_NUMBER)
 /* OPC UA Part 6 v1.05.07 §6.8.1 step 2 "Extract" — IKM chaining on
  * SecureChannel renewal. This exercises the OpenSSL helper directly
@@ -791,6 +855,9 @@ testSuite_SecureChannel(void) {
     tcase_add_checked_fixture(tc_processBuffer, setup_secureChannel, teardown_secureChannel);
     tcase_add_test(tc_processBuffer, SecureChannel_assemblePartialChunks);
     tcase_add_test(tc_processBuffer, SecureChannel_countFinalChunkAgainstLimit);
+    tcase_add_test(tc_processBuffer, SecureChannel_maxMessageSizeOverride_tightensBelowStaticLimit);
+    tcase_add_test(tc_processBuffer, SecureChannel_maxMessageSizeOverride_zeroMeansUnset);
+    tcase_add_test(tc_processBuffer, SecureChannel_maxMessageSizeOverride_cannotExceedStaticLimit);
     suite_add_tcase(s, tc_processBuffer);
 
 #if defined(UA_ENABLE_ENCRYPTION_OPENSSL) && !defined(LIBRESSL_VERSION_NUMBER)

--- a/tests/server/check_server_http_protocol.c
+++ b/tests/server/check_server_http_protocol.c
@@ -723,6 +723,139 @@ START_TEST(uascZeroLimitIsUnlimited) {
 }
 END_TEST
 
+START_TEST(secureChannelAttribute_maxMessageSizeRoundtrips) {
+    /* The reserved "0:maxMessageSize" attribute key is the one piece of
+     * server-interpreted behavior in the otherwise-generic SecureChannel
+     * attribute map: writing it caches the value into
+     * channel->maxMessageSizeOverride for the per-chunk hot path. */
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_nonnull(server);
+
+    UA_SecureChannel channel;
+    lockServer(server);
+    prepareRegisteredChannel(server, &channel, true, NULL);
+    UA_UInt32 channelId = channel.securityToken.channelId;
+    unlockServer(server);
+
+    ck_assert_uint_eq(channel.maxMessageSizeOverride, 0);
+
+    UA_UInt32 limit = 65536;
+    UA_Variant value;
+    UA_Variant_setScalar(&value, &limit, &UA_TYPES[UA_TYPES_UINT32]);
+    UA_QualifiedName key = UA_QUALIFIEDNAME(0, "maxMessageSize");
+    ck_assert_uint_eq(
+        UA_Server_setSecureChannelAttribute(server, channelId, key, &value),
+        UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(channel.maxMessageSizeOverride, limit);
+
+    UA_Variant readBack;
+    ck_assert_uint_eq(
+        UA_Server_getSecureChannelAttribute(server, channelId, key, &readBack),
+        UA_STATUSCODE_GOOD);
+    ck_assert(UA_Variant_hasScalarType(&readBack, &UA_TYPES[UA_TYPES_UINT32]));
+    ck_assert_uint_eq(*(UA_UInt32*)readBack.data, limit);
+
+    UA_UInt32 scalarOut = 0;
+    ck_assert_uint_eq(
+        UA_Server_getSecureChannelAttribute_scalar(
+            server, channelId, key, &UA_TYPES[UA_TYPES_UINT32], &scalarOut),
+        UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(scalarOut, limit);
+
+    ck_assert_uint_eq(
+        UA_Server_deleteSecureChannelAttribute(server, channelId, key),
+        UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(channel.maxMessageSizeOverride, 0);
+    ck_assert_uint_eq(
+        UA_Server_getSecureChannelAttribute(server, channelId, key, &readBack),
+        UA_STATUSCODE_BADNOTFOUND);
+
+    lockServer(server);
+    unregisterSecureChannel(server, &channel);
+    unlockServer(server);
+    UA_SecureChannel_clear(&channel);
+    ck_assert_uint_eq(UA_Server_delete(server), UA_STATUSCODE_GOOD);
+}
+END_TEST
+
+START_TEST(secureChannelAttribute_arbitraryKeyIsGenericStorage) {
+    /* Any other key behaves as plain application-defined storage. */
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_nonnull(server);
+
+    UA_SecureChannel channel;
+    lockServer(server);
+    prepareRegisteredChannel(server, &channel, true, NULL);
+    UA_UInt32 channelId = channel.securityToken.channelId;
+    unlockServer(server);
+
+    UA_String tag = UA_STRING("example-tag");
+    UA_Variant value;
+    UA_Variant_setScalar(&value, &tag, &UA_TYPES[UA_TYPES_STRING]);
+    UA_QualifiedName key = UA_QUALIFIEDNAME(1, "application-tag");
+    ck_assert_uint_eq(
+        UA_Server_setSecureChannelAttribute(server, channelId, key, &value),
+        UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(channel.maxMessageSizeOverride, 0);
+
+    UA_Variant readBack;
+    ck_assert_uint_eq(
+        UA_Server_getSecureChannelAttributeCopy(server, channelId, key, &readBack),
+        UA_STATUSCODE_GOOD);
+    ck_assert(UA_String_equal((UA_String*)readBack.data, &tag));
+    UA_Variant_clear(&readBack);
+
+    lockServer(server);
+    unregisterSecureChannel(server, &channel);
+    unlockServer(server);
+    UA_SecureChannel_clear(&channel);
+    ck_assert_uint_eq(UA_Server_delete(server), UA_STATUSCODE_GOOD);
+}
+END_TEST
+
+START_TEST(secureChannelAttribute_wrongTypeForMaxMessageSizeRejected) {
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_nonnull(server);
+
+    UA_SecureChannel channel;
+    lockServer(server);
+    prepareRegisteredChannel(server, &channel, true, NULL);
+    UA_UInt32 channelId = channel.securityToken.channelId;
+    unlockServer(server);
+
+    UA_String notANumber = UA_STRING("nope");
+    UA_Variant value;
+    UA_Variant_setScalar(&value, &notANumber, &UA_TYPES[UA_TYPES_STRING]);
+    UA_QualifiedName key = UA_QUALIFIEDNAME(0, "maxMessageSize");
+    ck_assert_uint_eq(
+        UA_Server_setSecureChannelAttribute(server, channelId, key, &value),
+        UA_STATUSCODE_BADTYPEMISMATCH);
+    ck_assert_uint_eq(channel.maxMessageSizeOverride, 0);
+
+    lockServer(server);
+    unregisterSecureChannel(server, &channel);
+    unlockServer(server);
+    UA_SecureChannel_clear(&channel);
+    ck_assert_uint_eq(UA_Server_delete(server), UA_STATUSCODE_GOOD);
+}
+END_TEST
+
+START_TEST(secureChannelAttribute_unknownChannelIdRejected) {
+    UA_Server *server = UA_Server_new();
+    ck_assert_ptr_nonnull(server);
+
+    UA_UInt32 limit = 1024;
+    UA_Variant value;
+    UA_Variant_setScalar(&value, &limit, &UA_TYPES[UA_TYPES_UINT32]);
+    UA_QualifiedName key = UA_QUALIFIEDNAME(0, "maxMessageSize");
+    ck_assert_uint_eq(
+        UA_Server_setSecureChannelAttribute(server, 424242, key, &value),
+        UA_STATUSCODE_BADNOTFOUND);
+
+    ck_assert_uint_eq(UA_Server_delete(server), UA_STATUSCODE_GOOD);
+}
+END_TEST
+
 START_TEST(mixedTransportChannelIdsAreUnique) {
     UA_Server *server = UA_Server_new();
     ck_assert_ptr_nonnull(server);
@@ -868,6 +1001,10 @@ testSuite(void) {
     tcase_add_test(tc, trustUpdateClosesOpenUascChannel);
     tcase_add_test(tc, uascLimitDoesNotPurgeDirectChannel);
     tcase_add_test(tc, uascZeroLimitIsUnlimited);
+    tcase_add_test(tc, secureChannelAttribute_maxMessageSizeRoundtrips);
+    tcase_add_test(tc, secureChannelAttribute_arbitraryKeyIsGenericStorage);
+    tcase_add_test(tc, secureChannelAttribute_wrongTypeForMaxMessageSizeRejected);
+    tcase_add_test(tc, secureChannelAttribute_unknownChannelIdRejected);
     tcase_add_test(tc, mixedTransportChannelIdsAreUnique);
     tcase_add_test(tc, closingHttpChannelDrainsUntilCarrierCloses);
     tcase_add_test(tc, httpRequestTimeoutAndEncodingMetadata);


### PR DESCRIPTION
Related to #8321, but instead of open62541 enforcing a fixed default limit on untrusted messages, adds a generic `SecureChannel` attribute map (mirroring the existing per-Session attributes) with `UA_Server_{get,set,delete}SecureChannelAttribute`. Writing the reserved `0:maxMessageSize` key caps `tcpMaxMsgSize` for that one channel, it can only tighten, never loosen, the configured ceiling. The application decides when to write it, using the already-existing `secureChannelNotificationCallback` rather than a new dedicated callback.

Also includes unit/integration tests covering the attribute API and the size-limit enforcement.