### PR TITLE
1.3: fix(historydata): prevent UAF in memory backend range-limited history…

### DIFF
--- a/plugins/historydata/ua_history_data_backend_memory.c
+++ b/plugins/historydata/ua_history_data_backend_memory.c
@@ -315,9 +315,15 @@ UA_DataValue_backend_copyRange(const UA_DataValue *src, UA_DataValue *dst,
                                const UA_NumericRange range)
 {
     memcpy(dst, src, sizeof(UA_DataValue));
-    if (src->hasValue)
-        return UA_Variant_copyRange(&src->value, &dst->value, range);
-    return UA_STATUSCODE_BADDATAUNAVAILABLE;
+    UA_Variant_init(&dst->value);
+
+    if (!src->hasValue)
+        return UA_STATUSCODE_BADDATAUNAVAILABLE;
+
+    UA_StatusCode retval = UA_Variant_copyRange(&src->value, &dst->value, range);
+    if (retval != UA_STATUSCODE_GOOD)
+        UA_Variant_clear(&dst->value);
+    return retval;
 }
 
 static UA_StatusCode
@@ -349,13 +355,19 @@ copyDataValues_backend_memory(UA_Server *server,
     size_t index = startIndex;
     size_t counter = 0;
     size_t skipedValues = 0;
+    UA_StatusCode retval = UA_STATUSCODE_GOOD;
     if (reverse) {
         while (index >= endIndex && index < item->storeEnd && counter < maxValues) {
             if (skipedValues++ >= skip) {
                 if (range.dimensionsSize > 0) {
-                    UA_DataValue_backend_copyRange(&item->dataStore[index]->value, &values[counter], range);
+                    retval = UA_DataValue_backend_copyRange(&item->dataStore[index]->value, &values[counter], range);
                 } else {
-                    UA_DataValue_copy(&item->dataStore[index]->value, &values[counter]);
+                    retval = UA_DataValue_copy(&item->dataStore[index]->value, &values[counter]);
+                }
+                if (retval != UA_STATUSCODE_GOOD) {
+                    if (providedValues)
+                        *providedValues = counter;
+                    return retval;
                 }
                 ++counter;
             }
@@ -365,9 +377,14 @@ copyDataValues_backend_memory(UA_Server *server,
         while (index <= endIndex && counter < maxValues) {
             if (skipedValues++ >= skip) {
                 if (range.dimensionsSize > 0) {
-                    UA_DataValue_backend_copyRange(&item->dataStore[index]->value, &values[counter], range);
+                    retval = UA_DataValue_backend_copyRange(&item->dataStore[index]->value, &values[counter], range);
                 } else {
-                    UA_DataValue_copy(&item->dataStore[index]->value, &values[counter]);
+                    retval = UA_DataValue_copy(&item->dataStore[index]->value, &values[counter]);
+                }
+                if (retval != UA_STATUSCODE_GOOD) {
+                    if (providedValues)
+                        *providedValues = counter;
+                    return retval;
                 }
                 ++counter;
             }


### PR DESCRIPTION
… reads

UA_DataValue_backend_copyRange() performed a shallow memcpy of the source UA_DataValue before attempting the range copy. Because the destination's UA_Variant fields were not reinitialized first, a failing UA_Variant_copyRange() (for example when the client-supplied indexRange exceeds UA_MAX_ARRAY_DIMS) left the destination value as an uninitialized alias of the backend-owned storage instead of an independent copy.

copyDataValues_backend_memory() also discarded the status code from both UA_DataValue_backend_copyRange() and UA_DataValue_copy(), so the aliased, partially-copied value was still counted as a successful result and forwarded to the HistoryRead response. Freeing that response later released the backend's live storage, leaving the backend with a dangling pointer that was dereferenced on a subsequent HistoryRead.

Reinitialize the destination variant before the range copy and clear it again on failure, mirroring the safe pattern already used by UA_DataValue_copyRange(). Propagate copy failures out of copyDataValues_backend_memory() immediately instead of counting a failed entry as provided.

Internal Vulnerability Advisory: open62541-SA-2026-0021
Reported by Chuan Wei [SCU]