### PR TITLE
Fix NULL dereference in EventFilter parser on allocation failure

### DIFF
--- a/src/util/ua_eventfilter_lex.c
+++ b/src/util/ua_eventfilter_lex.c
@@ -8453,11 +8453,13 @@ binary_op:
 
 make_op:
     *token = create_operand(ctx, OT_OPERATOR);
+    if(!*token) { tokenId = 0; goto finish; }
     (*token)->operand.op.filter = f;
     goto finish;
 
 namedoperand:
     *token = create_operand(ctx, OT_REF);
+    if(!*token) { tokenId = 0; goto finish; }
     size_t nameSize = (uintptr_t)(pos - b);
     (*token)->operand.ref = (char*)UA_malloc(nameSize+1);
     memcpy((*token)->operand.ref, b, nameSize);
@@ -8470,6 +8472,7 @@ json:
     match.length = (uintptr_t)(end-b);
     match.data = (UA_Byte*)(uintptr_t)b;
     *token = create_operand(ctx, OT_LITERAL);
+    if(!*token) { tokenId = 0; goto finish; }
     UA_DecodeJsonOptions options;
     memset(&options, 0, sizeof(UA_DecodeJsonOptions));
     size_t jsonOffset = 0;
@@ -8485,6 +8488,7 @@ lit:
     match.length = (uintptr_t)(pos-b);
     match.data = (UA_Byte*)(uintptr_t)b;
     *token = create_operand(ctx, OT_LITERAL);
+    if(!*token) { tokenId = 0; goto finish; }
     (*token)->operand.literal.data = UA_new(lt);
     (*token)->operand.literal.type = lt;
     if(lt == &UA_TYPES[UA_TYPES_NODEID]) {
@@ -8504,6 +8508,7 @@ sao:
     match.length = (uintptr_t)(pos-b);
     match.data = (UA_Byte*)(uintptr_t)b;
     *token = create_operand(ctx, OT_SAO);
+    if(!*token) { tokenId = 0; goto finish; }
     res = UA_SimpleAttributeOperand_parse(&(*token)->operand.sao, match);
     tokenId = (res == UA_STATUSCODE_GOOD) ? EF_TOK_SAO : 0;
 

--- a/src/util/ua_eventfilter_lex.re
+++ b/src/util/ua_eventfilter_lex.re
@@ -170,11 +170,13 @@ binary_op:
 
 make_op:
     *token = create_operand(ctx, OT_OPERATOR);
+    if(!*token) { tokenId = 0; goto finish; }
     (*token)->operand.op.filter = f;
     goto finish;
 
 namedoperand:
     *token = create_operand(ctx, OT_REF);
+    if(!*token) { tokenId = 0; goto finish; }
     size_t nameSize = (uintptr_t)(pos - b);
     (*token)->operand.ref = (char*)UA_malloc(nameSize+1);
     memcpy((*token)->operand.ref, b, nameSize);
@@ -187,6 +189,7 @@ json:
     match.length = (uintptr_t)(end-b);
     match.data = (UA_Byte*)(uintptr_t)b;
     *token = create_operand(ctx, OT_LITERAL);
+    if(!*token) { tokenId = 0; goto finish; }
     UA_DecodeJsonOptions options;
     memset(&options, 0, sizeof(UA_DecodeJsonOptions));
     size_t jsonOffset = 0;
@@ -202,6 +205,7 @@ lit:
     match.length = (uintptr_t)(pos-b);
     match.data = (UA_Byte*)(uintptr_t)b;
     *token = create_operand(ctx, OT_LITERAL);
+    if(!*token) { tokenId = 0; goto finish; }
     (*token)->operand.literal.data = UA_new(lt);
     (*token)->operand.literal.type = lt;
     if(lt == &UA_TYPES[UA_TYPES_NODEID]) {
@@ -221,6 +225,7 @@ sao:
     match.length = (uintptr_t)(pos-b);
     match.data = (UA_Byte*)(uintptr_t)b;
     *token = create_operand(ctx, OT_SAO);
+    if(!*token) { tokenId = 0; goto finish; }
     res = UA_SimpleAttributeOperand_parse(&(*token)->operand.sao, match);
     tokenId = (res == UA_STATUSCODE_GOOD) ? EF_TOK_SAO : 0;
 

--- a/src/util/ua_eventfilter_parser.c
+++ b/src/util/ua_eventfilter_parser.c
@@ -32,6 +32,10 @@ pos2lines(const UA_ByteString content, size_t pos,
 static Operand *
 newOperand(EFParseContext *ctx) {
     Operand *op = (Operand*)UA_calloc(1, sizeof(Operand));
+    if(!op) {
+        ctx->error = UA_STATUSCODE_BADOUTOFMEMORY;
+        return NULL;
+    }
     LIST_INSERT_HEAD(&ctx->operands, op, entries);
     ctx->operandsSize++;
     return op;
@@ -100,6 +104,8 @@ char *
 save_string(char *str) {
     size_t strLen = strlen(str);
     char *local_str = (char*) UA_calloc(strLen + 1, sizeof(char));
+    if(!local_str)
+        return NULL;
     memcpy(local_str, str, strLen + 1);
     return local_str;
 }
@@ -107,6 +113,8 @@ save_string(char *str) {
 Operand *
 create_operand(EFParseContext *ctx, OperandType ot) {
     Operand *on = newOperand(ctx);
+    if(!on)
+        return NULL;
     on->type = ot;
     return on;
 }
@@ -114,6 +122,8 @@ create_operand(EFParseContext *ctx, OperandType ot) {
 Operand *
 create_operator(EFParseContext *ctx, UA_FilterOperator fo) {
     Operand *on = create_operand(ctx, OT_OPERATOR);
+    if(!on)
+        return NULL;
     on->operand.op.filter = fo;
     return on;
 }


### PR DESCRIPTION
Fixes #7675.

`newOperand()` in `ua_eventfilter_parser.c` calls `UA_calloc` and hands the result straight to `LIST_INSERT_HEAD` without checking it. When the allocation fails, that macro dereferences a NULL pointer. The two wrappers built on top of it, `create_operand()` and `create_operator()`, have the same problem one level up, and so do all five places in the lexer (`ua_eventfilter_lex.re` / the generated `.c`) that call `create_operand()` and immediately write into the operand it returns.

I added the missing checks along that whole chain: `newOperand()` now sets `ctx->error = UA_STATUSCODE_BADOUTOFMEMORY` and returns NULL instead of inserting garbage into the list, `create_operand()`/`create_operator()` bail out early if the operand is NULL, and each of the five lexer sites sets `tokenId = 0` and jumps to `finish` in that case, which is exactly the existing convention this file already uses for a failed parse.

While in there I noticed `save_string()` has the identical calloc-then-use pattern (calloc followed by an unconditional memcpy), a few lines above these functions, so I gave it the same one-line guard.

To verify, I built the library with `UA_ENABLE_MALLOC_SINGLETON` on and wrote a small standalone program linking against the repo's own `tests/fuzz/custom_memory_manager.c`, which lets you cap available memory and force allocations to fail at a chosen point. Parsing a normal, valid filter string (`SELECT $1 WHERE $1 := 1 == 1`) with the memory cap set low enough to fail partway through:

- Before this change: segfaults inside `newOperand`, same stack as the one in the issue (`newOperand` -> `create_operand` -> `UA_EventFilter_lex` -> `UA_EventFilter_parse`).
- After this change: `UA_EventFilter_parse` returns `BadInternalError` and nothing crashes.

I also ran the existing `check_eventfilter_parser` suite against the fix, still 21/21.

This is against the `1.5` branch per the request in the issue thread.