### PR TITLE
Fix PubSub dataset contracts and add immutable-name settings updates

### DIFF
--- a/include/open62541/server_pubsub.h
+++ b/include/open62541/server_pubsub.h
@@ -477,7 +477,7 @@ UA_Server_addPublishedDataSet(UA_Server *server,
                               const UA_PublishedDataSetConfig *pdsConfig,
                               UA_NodeId *pdsId);
 
-/* Returns a deep copy of the config */
+/* Return an owned copy; release it with UA_PublishedDataSetConfig_clear. */
 UA_EXPORT UA_StatusCode UA_THREADSAFE
 UA_Server_getPublishedDataSetConfig(UA_Server *server, const UA_NodeId pdsId,
                                     UA_PublishedDataSetConfig *config);
@@ -931,6 +931,21 @@ UA_Server_setReaderGroupEncryptionKeys(UA_Server *server,
                                        const UA_ByteString signingKey,
                                        const UA_ByteString encryptingKey,
                                        const UA_ByteString keyNonce);
+
+/* Return an owned copy; release it with UA_SubscribedDataSetConfig_clear. */
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_getSubscribedDataSetConfig(UA_Server *server, const UA_NodeId id,
+                                    UA_SubscribedDataSetConfig *config);
+
+/* Update the settings of a disabled dataset in place. Name and NodeId are
+ * immutable. Disable attached writers/readers before updating and restore
+ * their states afterwards. Plain PublishedItems fields are retained. */
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_updatePublishedDataSetConfig(UA_Server *server, const UA_NodeId id,
+                                      const UA_PublishedDataSetConfig *config);
+UA_EXPORT UA_StatusCode UA_THREADSAFE
+UA_Server_updateSubscribedDataSetConfig(UA_Server *server, const UA_NodeId id,
+                                       const UA_SubscribedDataSetConfig *config);
 
 #ifdef UA_ENABLE_PUBSUB_FILE_CONFIG
 

--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -13,6 +13,7 @@
 
 #include <open62541/server_pubsub.h>
 #include "ua_pubsub_internal.h"
+#include <stdio.h>
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 
@@ -251,7 +252,8 @@ UA_DataSetField_create(UA_PubSubManager *psm, const UA_NodeId publishedDataSet,
         return result;
     }
 
-    if(currDS->config.publishedDataSetType != UA_PUBSUB_DATASET_PUBLISHEDITEMS) {
+    if(currDS->config.publishedDataSetType != UA_PUBSUB_DATASET_PUBLISHEDITEMS &&
+       currDS->config.publishedDataSetType != UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE) {
         result.result = UA_STATUSCODE_BADNOTIMPLEMENTED;
         return result;
     }
@@ -477,7 +479,8 @@ UA_PublishedDataSet_create(UA_PubSubManager *psm,
         return result;
     }
 
-    if(publishedDataSetConfig->publishedDataSetType != UA_PUBSUB_DATASET_PUBLISHEDITEMS){
+    if(publishedDataSetConfig->publishedDataSetType != UA_PUBSUB_DATASET_PUBLISHEDITEMS &&
+       publishedDataSetConfig->publishedDataSetType != UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE) {
         UA_LOG_ERROR(psm->logging, UA_LOGCATEGORY_PUBSUB,
                      "PublishedDataSet creation failed. Unsupported PublishedDataSet type.");
         return result;
@@ -523,9 +526,6 @@ UA_PublishedDataSet_create(UA_PubSubManager *psm,
         return result;
     }
 
-    /* TODO: Parse template config and add fields (later PubSub batch) */
-    if(newConfig->publishedDataSetType == UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE) {
-    }
 
     /* Fill the DataSetMetaData */
     UA_EventLoop *el = psm->drv.server->config.eventLoop;
@@ -548,8 +548,9 @@ UA_PublishedDataSet_create(UA_PubSubManager *psm,
         res = UA_String_copy(&newConfig->name, &newPDS->dataSetMetaData.name);
         break;
     case UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE:
-        res = UA_DataSetMetaDataType_copy(&newConfig->config.itemsTemplate.metaData,
-                                          &newPDS->dataSetMetaData);
+        if(newConfig->config.itemsTemplate.metaData.fieldsSize !=
+           newConfig->config.itemsTemplate.variablesToAddSize)
+            res = UA_STATUSCODE_BADINVALIDARGUMENT;
         break;
     default:
         res = UA_STATUSCODE_BADINTERNALERROR;
@@ -582,9 +583,62 @@ UA_PublishedDataSet_create(UA_PubSubManager *psm,
 
     UA_LOG_INFO_PUBSUB(psm->logging, newPDS, "DataSet created");
 
+    /* A template supplies both the field contract and the published variables.
+     * Build and validate every field before exposing the completed dataset. */
+    if(newConfig->publishedDataSetType == UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE) {
+        UA_PublishedDataItemsTemplateConfig *t = &newConfig->config.itemsTemplate;
+        for(size_t i = 0; i < t->variablesToAddSize; i++) {
+            UA_FieldMetaData *metadata = &t->metaData.fields[i];
+            UA_DataSetFieldConfig fc;
+            memset(&fc, 0, sizeof(fc));
+            fc.dataSetFieldType = UA_PUBSUB_DATASETFIELD_VARIABLE;
+            fc.field.variable.fieldNameAlias = metadata->name;
+            fc.field.variable.description = metadata->description;
+            fc.field.variable.promotedField =
+                (metadata->fieldFlags & UA_DATASETFIELDFLAGS_PROMOTEDFIELD) != 0;
+            fc.field.variable.maxStringLength = metadata->maxStringLength;
+            fc.field.variable.publishParameters = t->variablesToAdd[i];
+            result.addResult = UA_DataSetField_create(psm, newPDS->head.identifier,
+                                                      &fc, NULL).result;
+            if(result.addResult != UA_STATUSCODE_GOOD)
+                break;
+            UA_DataSetField *field = TAILQ_FIRST(&newPDS->fields);
+            while(TAILQ_NEXT(field, listEntry))
+                field = TAILQ_NEXT(field, listEntry);
+            if(!UA_NodeId_equal(&metadata->dataType, &field->fieldMetaData.dataType) ||
+               metadata->builtInType != field->fieldMetaData.builtInType ||
+               (field->fieldMetaData.valueRank != UA_VALUERANK_ANY &&
+                !(field->fieldMetaData.valueRank == UA_VALUERANK_SCALAR_OR_ONE_DIMENSION &&
+                  (metadata->valueRank == UA_VALUERANK_SCALAR || metadata->valueRank == 1)) &&
+                metadata->valueRank != field->fieldMetaData.valueRank)) {
+                result.addResult = UA_STATUSCODE_BADTYPEMISMATCH;
+                break;
+            }
+            UA_FieldMetaData_clear(&field->fieldMetaData);
+            result.addResult = UA_FieldMetaData_copy(metadata, &field->fieldMetaData);
+            if(result.addResult != UA_STATUSCODE_GOOD)
+                break;
+            /* The contract's FieldId can be shared by multiple datasets.
+             * Keep the generated native component identifier globally unique. */
+        }
+        if(result.addResult == UA_STATUSCODE_GOOD) {
+            UA_DataSetMetaDataType_clear(&newPDS->dataSetMetaData);
+            result.addResult = UA_DataSetMetaDataType_copy(&t->metaData,
+                                                          &newPDS->dataSetMetaData);
+        }
+        if(result.addResult != UA_STATUSCODE_GOOD) {
+            UA_PublishedDataSet_remove(psm, newPDS);
+            return result;
+        }
+        result.configurationVersion = t->metaData.configurationVersion;
+    }
+
     /* Return the created identifier */
-    if(pdsIdentifier)
-        UA_NodeId_copy(&newPDS->head.identifier, pdsIdentifier);
+    if(pdsIdentifier) {
+        result.addResult = UA_NodeId_copy(&newPDS->head.identifier, pdsIdentifier);
+        if(result.addResult != UA_STATUSCODE_GOOD)
+            UA_PublishedDataSet_remove(psm, newPDS);
+    }
     return result;
 }
 
@@ -895,6 +949,139 @@ UA_Server_removeSubscribedDataSet(UA_Server *server, const UA_NodeId sdsId) {
         UA_SubscribedDataSet_remove(psm, sds);
         res = UA_STATUSCODE_GOOD;
     }
+    unlockServer(server);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_getSubscribedDataSetConfig(UA_Server *server, const UA_NodeId id,
+                                    UA_SubscribedDataSetConfig *config) {
+    if(!server || !config)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    lockServer(server);
+    UA_SubscribedDataSet *dataset = UA_SubscribedDataSet_find(getPSM(server), id);
+    UA_StatusCode res = dataset ? UA_SubscribedDataSetConfig_copy(&dataset->config, config)
+                               : UA_STATUSCODE_BADNOTFOUND;
+    unlockServer(server);
+    return res;
+}
+
+/* Stage and validate a replacement before touching the existing dataset. */
+UA_StatusCode
+UA_Server_updatePublishedDataSetConfig(UA_Server *server, const UA_NodeId id,
+                                      const UA_PublishedDataSetConfig *config) {
+    if(!server || !config)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    lockServer(server);
+    UA_PubSubManager *psm = getPSM(server);
+    UA_PublishedDataSet *current = UA_PublishedDataSet_find(psm, id);
+    UA_StatusCode res = UA_STATUSCODE_GOOD;
+    if(!current) { res = UA_STATUSCODE_BADNOTFOUND; goto done; }
+    if(current->configurationFreezeCounter) { res = UA_STATUSCODE_BADINVALIDSTATE; goto done; }
+    if(!UA_String_equal(&config->name, &current->config.name)) {
+        res = UA_STATUSCODE_BADINVALIDARGUMENT; goto done;
+    }
+    if(config->publishedDataSetType == UA_PUBSUB_DATASET_PUBLISHEDITEMS &&
+       current->config.publishedDataSetType == UA_PUBSUB_DATASET_PUBLISHEDITEMS)
+        goto done;
+    UA_PublishedDataSetConfig stagedConfig = *config;
+    char name[64];
+    UA_Guid guid = UA_Guid_random();
+    int nameLength = snprintf(name, sizeof(name), "update-" UA_PRINTF_GUID_FORMAT,
+                              UA_PRINTF_GUID_DATA(guid));
+    if(nameLength < 0 || (size_t)nameLength >= sizeof(name)) {
+        res = UA_STATUSCODE_BADINTERNALERROR;
+        goto done;
+    }
+    stagedConfig.name = UA_STRING(name);
+    UA_NodeId stagedId = UA_NODEID_NULL;
+    res = UA_PublishedDataSet_create(psm, &stagedConfig, &stagedId).addResult;
+    if(res != UA_STATUSCODE_GOOD)
+        goto done;
+    UA_PublishedDataSet *staged = UA_PublishedDataSet_find(psm, stagedId);
+    size_t count = (size_t)current->fieldSize + staged->fieldSize;
+    UA_NodeId *parents = (UA_NodeId*)UA_Array_new(count, &UA_TYPES[UA_TYPES_NODEID]);
+    if(!parents && count) { res = UA_STATUSCODE_BADOUTOFMEMORY; goto cleanup; }
+    for(size_t i = 0; i < count; i++) {
+        res = UA_NodeId_copy(i < current->fieldSize ? &stagedId : &id, &parents[i]);
+        if(res != UA_STATUSCODE_GOOD) {
+            UA_Array_delete(parents, count, &UA_TYPES[UA_TYPES_NODEID]);
+            goto cleanup;
+        }
+    }
+    UA_PublishedDataSet temporary;
+    TAILQ_INIT(&temporary.fields);
+    UA_DataSetField *field;
+    size_t index = 0;
+    while((field = TAILQ_FIRST(&current->fields))) {
+        TAILQ_REMOVE(&current->fields, field, listEntry);
+        UA_NodeId_clear(&field->publishedDataSet);
+        field->publishedDataSet = parents[index++];
+        TAILQ_INSERT_TAIL(&temporary.fields, field, listEntry);
+    }
+    while((field = TAILQ_FIRST(&staged->fields))) {
+        TAILQ_REMOVE(&staged->fields, field, listEntry);
+        UA_NodeId_clear(&field->publishedDataSet);
+        field->publishedDataSet = parents[index++];
+        TAILQ_INSERT_TAIL(&current->fields, field, listEntry);
+    }
+    while((field = TAILQ_FIRST(&temporary.fields))) {
+        TAILQ_REMOVE(&temporary.fields, field, listEntry);
+        TAILQ_INSERT_TAIL(&staged->fields, field, listEntry);
+    }
+    UA_free(parents); /* NodeId ownership moved into the fields. */
+#define SWAP_DATASET_MEMBER(member, type) do { \
+    type tmp = current->member; current->member = staged->member; staged->member = tmp; \
+} while(0)
+    SWAP_DATASET_MEMBER(config, UA_PublishedDataSetConfig);
+    SWAP_DATASET_MEMBER(config.name, UA_String); /* Keep each dataset's identity. */
+    SWAP_DATASET_MEMBER(dataSetMetaData, UA_DataSetMetaDataType);
+    SWAP_DATASET_MEMBER(fieldSize, UA_UInt16);
+    SWAP_DATASET_MEMBER(promotedFieldsCount, UA_UInt16);
+#undef SWAP_DATASET_MEMBER
+ cleanup:
+    UA_PublishedDataSet_remove(psm, staged);
+    UA_NodeId_clear(&stagedId);
+ done:
+    unlockServer(server);
+    return res;
+}
+
+UA_StatusCode
+UA_Server_updateSubscribedDataSetConfig(UA_Server *server, const UA_NodeId id,
+                                       const UA_SubscribedDataSetConfig *config) {
+    if(!server || !config)
+        return UA_STATUSCODE_BADINVALIDARGUMENT;
+    lockServer(server);
+    UA_PubSubManager *psm = getPSM(server);
+    UA_SubscribedDataSet *dataset = UA_SubscribedDataSet_find(psm, id);
+    UA_StatusCode res = UA_STATUSCODE_GOOD;
+    if(!dataset) { res = UA_STATUSCODE_BADNOTFOUND; goto done; }
+    if(!UA_String_equal(&config->name, &dataset->config.name) ||
+       config->subscribedDataSetType != UA_PUBSUB_SDS_TARGET ||
+       config->dataSetMetaData.fieldsSize != config->subscribedDataSet.target.targetVariablesSize) {
+        res = UA_STATUSCODE_BADINVALIDARGUMENT; goto done;
+    }
+    if(dataset->connectedReader && UA_PubSubState_isEnabled(dataset->connectedReader->head.state)) {
+        res = UA_STATUSCODE_BADINVALIDSTATE; goto done;
+    }
+    UA_SubscribedDataSetConfig copy = {0};
+    res = UA_SubscribedDataSetConfig_copy(config, &copy);
+    if(res != UA_STATUSCODE_GOOD)
+        goto done;
+    if(dataset->connectedReader) {
+        UA_DataSetReaderConfig reader = dataset->connectedReader->config;
+        reader.dataSetMetaData = copy.dataSetMetaData;
+        reader.subscribedDataSet.target = copy.subscribedDataSet.target;
+        res = UA_Server_updateDataSetReaderConfig(server, dataset->connectedReader->head.identifier, &reader);
+        if(res != UA_STATUSCODE_GOOD) {
+            UA_SubscribedDataSetConfig_clear(&copy);
+            goto done;
+        }
+    }
+    UA_SubscribedDataSetConfig_clear(&dataset->config);
+    dataset->config = copy;
+ done:
     unlockServer(server);
     return res;
 }

--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -13,7 +13,6 @@
 
 #include <open62541/server_pubsub.h>
 #include "ua_pubsub_internal.h"
-#include <stdio.h>
 
 #ifdef UA_ENABLE_PUBSUB /* conditional compilation */
 
@@ -987,8 +986,8 @@ UA_Server_updatePublishedDataSetConfig(UA_Server *server, const UA_NodeId id,
     UA_PublishedDataSetConfig stagedConfig = *config;
     char name[64];
     UA_Guid guid = UA_Guid_random();
-    int nameLength = snprintf(name, sizeof(name), "update-" UA_PRINTF_GUID_FORMAT,
-                              UA_PRINTF_GUID_DATA(guid));
+    int nameLength = mp_snprintf(name, sizeof(name), "update-" UA_PRINTF_GUID_FORMAT,
+                                 UA_PRINTF_GUID_DATA(guid));
     if(nameLength < 0 || (size_t)nameLength >= sizeof(name)) {
         res = UA_STATUSCODE_BADINTERNALERROR;
         goto done;

--- a/src/pubsub/ua_pubsub_dataset.c
+++ b/src/pubsub/ua_pubsub_dataset.c
@@ -1001,7 +1001,7 @@ UA_Server_updatePublishedDataSetConfig(UA_Server *server, const UA_NodeId id,
     UA_PublishedDataSet *staged = UA_PublishedDataSet_find(psm, stagedId);
     size_t count = (size_t)current->fieldSize + staged->fieldSize;
     UA_NodeId *parents = (UA_NodeId*)UA_Array_new(count, &UA_TYPES[UA_TYPES_NODEID]);
-    if(!parents && count) { res = UA_STATUSCODE_BADOUTOFMEMORY; goto cleanup; }
+    if(!parents) { res = UA_STATUSCODE_BADOUTOFMEMORY; goto cleanup; }
     for(size_t i = 0; i < count; i++) {
         res = UA_NodeId_copy(i < current->fieldSize ? &stagedId : &id, &parents[i]);
         if(res != UA_STATUSCODE_GOOD) {
@@ -1029,7 +1029,8 @@ UA_Server_updatePublishedDataSetConfig(UA_Server *server, const UA_NodeId id,
         TAILQ_REMOVE(&temporary.fields, field, listEntry);
         TAILQ_INSERT_TAIL(&staged->fields, field, listEntry);
     }
-    UA_free(parents); /* NodeId ownership moved into the fields. */
+    /* NodeId ownership moved into the fields. Also handle the empty-array sentinel. */
+    UA_Array_delete(parents, 0, &UA_TYPES[UA_TYPES_NODEID]);
 #define SWAP_DATASET_MEMBER(member, type) do { \
     type tmp = current->member; current->member = staged->member; staged->member = tmp; \
 } while(0)

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -377,6 +377,12 @@ ReadCallback(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext
         if(!sds)
             return UA_STATUSCODE_BADNOTFOUND;
         switch(nodeContext->elementClassiefier) {
+        case UA_NS0ID_TARGETVARIABLESTYPE_TARGETVARIABLES:
+            value->hasValue = true;
+            return UA_Variant_setArrayCopy(&value->value,
+                sds->config.subscribedDataSet.target.targetVariables,
+                sds->config.subscribedDataSet.target.targetVariablesSize,
+                &UA_TYPES[UA_TYPES_FIELDTARGETDATATYPE]);
         case UA_NS0ID_STANDALONESUBSCRIBEDDATASETTYPE_ISCONNECTED: {
             UA_Boolean isConnected = (sds->connectedReader != NULL);
             value->hasValue = true;
@@ -469,7 +475,8 @@ addPubSubConnectionConfig(UA_Server *server, UA_PubSubConnectionDataType *pubsub
     UA_NetworkAddressUrlDataType networkAddressUrl;
     memset(&networkAddressUrl, 0, sizeof(networkAddressUrl));
     UA_ExtensionObject *eo = &pubsubConnection->address;
-    if(eo->encoding == UA_EXTENSIONOBJECT_DECODED &&
+    if((eo->encoding == UA_EXTENSIONOBJECT_DECODED ||
+        eo->encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE) &&
        eo->content.decoded.type == &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]) {
         void *data = eo->content.decoded.data;
         retVal =
@@ -525,7 +532,8 @@ addWriterGroupConfig(UA_Server *server, UA_NodeId connectionId,
     UA_ExtensionObject *eoWG = &writerGroup->messageSettings;
     UA_UadpWriterGroupMessageDataType uadpWriterGroupMessage;
     UA_JsonWriterGroupMessageDataType jsonWriterGroupMessage;
-    if(eoWG->encoding == UA_EXTENSIONOBJECT_DECODED){
+    if(eoWG->encoding == UA_EXTENSIONOBJECT_DECODED ||
+       eoWG->encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE) {
         writerGroupConfig.messageSettings.encoding  = UA_EXTENSIONOBJECT_DECODED;
         if(eoWG->content.decoded.type == &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE]){
             writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
@@ -734,6 +742,17 @@ addSubscribedVariables(UA_Server *server, UA_NodeId dataSetReaderId,
 
     /* Add variable for the fields. */
     for(size_t i = 0; i < targetVars->targetVariablesSize; i++) {
+        /* Existing FE inputs are mappings, not requests to create new nodes.
+         * Re-adding them overwrites the target NodeId output on failure. */
+        const UA_Node *existing = UA_NODESTORE_GET(
+            server, &targetVars->targetVariables[i].targetNodeId);
+        if(existing) {
+            UA_Boolean isVariable = existing->head.nodeClass == UA_NODECLASS_VARIABLE;
+            UA_NODESTORE_RELEASE(server, existing);
+            if(!isVariable)
+                return UA_STATUSCODE_BADNODECLASSINVALID;
+            continue;
+        }
         UA_VariableAttributes vAttr = UA_VariableAttributes_default;
         vAttr.description = pMetaData->fields[i].description;
         vAttr.displayName.locale = UA_STRING("");
@@ -809,6 +828,23 @@ addDataSetReaderConfig(UA_Server *server, UA_NodeId readerGroupId,
         return retVal;
     }
 
+    UA_ExtensionObject *subscribed = &dataSetReader->subscribedDataSet;
+    UA_Boolean standalone =
+        (subscribed->encoding == UA_EXTENSIONOBJECT_DECODED ||
+         subscribed->encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE) &&
+        subscribed->content.decoded.type ==
+            &UA_TYPES[UA_TYPES_STANDALONESUBSCRIBEDDATASETREFDATATYPE];
+    if(standalone) {
+        UA_StandaloneSubscribedDataSetRefDataType *ref =
+            (UA_StandaloneSubscribedDataSetRefDataType*)subscribed->content.decoded.data;
+        retVal = UA_String_copy(&ref->dataSetName,
+                                &readerConfig.linkedStandaloneSubscribedDataSetName);
+        if(retVal != UA_STATUSCODE_GOOD || UA_String_isEmpty(&ref->dataSetName)) {
+            UA_DataSetReaderConfig_clear(&readerConfig);
+            return retVal != UA_STATUSCODE_GOOD ? retVal : UA_STATUSCODE_BADINVALIDARGUMENT;
+        }
+    }
+
     retVal |= UA_DataSetReader_create(psm, readerGroupId,
                                       &readerConfig, dataSetReaderId);
     UA_DataSetMetaDataType *pMetaData = &readerConfig.dataSetMetaData;
@@ -817,7 +853,8 @@ addDataSetReaderConfig(UA_Server *server, UA_NodeId readerGroupId,
         return retVal;
     }
 
-    retVal |= addSubscribedVariables(server, *dataSetReaderId, dataSetReader, pMetaData);
+    if(!standalone)
+        retVal |= addSubscribedVariables(server, *dataSetReaderId, dataSetReader, pMetaData);
     UA_DataSetReaderConfig_clear(&readerConfig);
     return retVal;
 }
@@ -1690,8 +1727,7 @@ addSubscribedDataSetRepresentation(UA_Server *server,
         attr.valueRank = UA_VALUERANK_ONE_DIMENSION;
         attr.arrayDimensionsSize = 1;
         UA_UInt32 arrayDimensions[1];
-        arrayDimensions[0] = (UA_UInt32)
-            subscribedDataSet->config.subscribedDataSet.target.targetVariablesSize;
+        arrayDimensions[0] = 0; /* Target count may change through settings updates. */
         attr.arrayDimensions = arrayDimensions;
         attr.accessLevel = UA_ACCESSLEVELMASK_READ;
         UA_Variant_setArray(&attr.value,
@@ -1702,6 +1738,15 @@ addSubscribedDataSetRepresentation(UA_Server *server,
                        UA_NS0ID(HASPROPERTY), UA_QUALIFIEDNAME(0, "TargetVariables"),
                        UA_NS0ID(PROPERTYTYPE), &attr, &UA_TYPES[UA_TYPES_VARIABLEATTRIBUTES],
                        NULL, &targetVarsId);
+        UA_NodePropertyContext *context = (UA_NodePropertyContext*)UA_malloc(sizeof(UA_NodePropertyContext));
+        if(!context)
+            return UA_STATUSCODE_BADOUTOFMEMORY;
+        context->parentNodeId = subscribedDataSet->head.identifier;
+        context->parentClassifier = UA_NS0ID_STANDALONESUBSCRIBEDDATASETREFDATATYPE;
+        context->elementClassiefier = UA_NS0ID_TARGETVARIABLESTYPE_TARGETVARIABLES;
+        UA_CallbackValueSource source = {0};
+        source.read = ReadCallback;
+        ret |= setVariableValueSource(server, source, targetVarsId, context);
     }
 
     UA_NodePropertyContext *isConnectedNodeContext = (UA_NodePropertyContext *)

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -2454,6 +2454,14 @@ subscribedDataSetTypeDestructor(UA_Server *server,
     node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "IsConnected"),
                                UA_NS0ID(HASPROPERTY), *nodeId);
     freeNodeContext(server, &node);
+    UA_NodeId subscribedDataSetNode =
+        findSingleChildNode(server, UA_QUALIFIEDNAME(0, "SubscribedDataSet"),
+                            UA_NS0ID(HASCOMPONENT), *nodeId);
+    if(!UA_NodeId_isNull(&subscribedDataSetNode)) {
+        node = findSingleChildNode(server, UA_QUALIFIEDNAME(0, "TargetVariables"),
+                                   UA_NS0ID(HASPROPERTY), subscribedDataSetNode);
+        freeNodeContext(server, &node);
+    }
 }
 
 /*************************************/

--- a/src/pubsub/ua_pubsub_writer.c
+++ b/src/pubsub/ua_pubsub_writer.c
@@ -806,7 +806,8 @@ UA_DataSetWriter_generateDataSetMessage(UA_PubSubManager *psm,
 
     /* JSON does not differ between deltaframes and keyframes, only keyframes
      * are currently used. */
-    if(dsm && psm->drv.server->config.pubSubConfig.enableDeltaFrames) {
+    if(dsm && psm->drv.server->config.pubSubConfig.enableDeltaFrames &&
+       dataSetMessage->header.fieldEncoding != UA_FIELDENCODING_RAWDATA) {
         /* Check if the PublishedDataSet version has changed -> if yes flush the
          * lastValue store and send a KeyFrame */
         if(dsw->lastSamplesCount != pds->fieldSize ||

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -2161,9 +2161,160 @@ START_TEST(TestEnableDisableTopLevelPublishSubscribe){
     UA_Client_delete(client);
 } END_TEST
 
+START_TEST(FailedConnectionCreationRemovesEarlierGroups) {
+    UA_PubSubConnectionDataType connection = {0};
+    connection.name = UA_STRING("AtomicConnection");
+    UA_UInt16 publisher = 123;
+    UA_Variant_setScalar(&connection.publisherId, &publisher, &UA_TYPES[UA_TYPES_UINT16]);
+    connection.transportProfileUri = UA_STRING("http://opcfoundation.org/UA-Profile/Transport/pubsub-udp-uadp");
+    UA_NetworkAddressUrlDataType address = UA_PUBSUB_TEST_NETWORKADDRESSURL("opc.udp://127.0.0.1:4841/");
+    UA_ExtensionObject_setValueNoDelete(&connection.address, &address,
+                                       &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    UA_WriterGroupDataType groups[2] = {{0}};
+    UA_UadpWriterGroupMessageDataType settings = {0};
+    for(size_t i = 0; i < 2; i++) {
+        groups[i].name = i == 0 ? UA_STRING("First") : UA_STRING("Rejected");
+        groups[i].writerGroupId = (UA_UInt16)(100 + i);
+        groups[i].publishingInterval = 50;
+        UA_ExtensionObject_setValueNoDelete(&groups[i].messageSettings, &settings,
+                                           &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE]);
+    }
+    UA_DataSetWriterDataType writer = {0};
+    writer.name = UA_STRING("MissingDatasetWriter");
+    writer.dataSetName = UA_STRING("MissingDataset");
+    groups[1].dataSetWritersSize = 1;
+    groups[1].dataSetWriters = &writer;
+    connection.writerGroupsSize = 2;
+    connection.writerGroups = groups;
+    UA_Variant input;
+    UA_Variant_setScalar(&input, &connection, &UA_TYPES[UA_TYPES_PUBSUBCONNECTIONDATATYPE]);
+    UA_CallMethodRequest request = {0};
+    request.objectId = UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE);
+    request.methodId = UA_NODEID_NUMERIC(0, UA_NS0ID_PUBLISHSUBSCRIBE_ADDCONNECTION);
+    request.inputArgumentsSize = 1;
+    request.inputArguments = &input;
+    UA_CallMethodResult result = UA_Server_call(server, &request);
+    ck_assert_uint_eq(result.statusCode, UA_STATUSCODE_BADPARENTNODEIDINVALID);
+    UA_CallMethodResult_clear(&result);
+    UA_NodeId connectionId = findSingleChildNode(UA_QUALIFIEDNAME(0, "AtomicConnection"),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_HASPUBSUBCONNECTION), request.objectId);
+    ck_assert(UA_NodeId_isNull(&connectionId));
+    UA_NodeId_clear(&connectionId);
+} END_TEST
+
+START_TEST(PublishedItemsTemplatePreservesContract) {
+    UA_PublishedVariableDataType variable = {0};
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    UA_Double initial = 1.0;
+    attr.dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_DOUBLE);
+    attr.valueRank = UA_VALUERANK_SCALAR;
+    UA_Variant_setScalar(&attr.value, &initial, &UA_TYPES[UA_TYPES_DOUBLE]);
+    ck_assert_uint_eq(UA_Server_addVariableNode(server, UA_NODEID_NUMERIC(1, 9001),
+        UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER), UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES),
+        UA_QUALIFIEDNAME(1, "Source"), UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+        attr, NULL, NULL), UA_STATUSCODE_GOOD);
+    variable.publishedVariable = UA_NODEID_NUMERIC(1, 9001);
+    variable.attributeId = UA_ATTRIBUTEID_VALUE;
+    UA_FieldMetaData field = {0};
+    field.name = UA_STRING("Clock");
+    field.dataType = UA_NODEID_NUMERIC(0, UA_NS0ID_DOUBLE);
+    field.builtInType = 11;
+    field.valueRank = UA_VALUERANK_SCALAR;
+    field.dataSetFieldId = UA_Guid_random();
+    UA_PublishedDataSetConfig config = {0};
+    config.name = UA_STRING("Template");
+    config.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE;
+    config.config.itemsTemplate.variablesToAddSize = 1;
+    config.config.itemsTemplate.variablesToAdd = &variable;
+    UA_DataSetMetaDataType *metadata = &config.config.itemsTemplate.metaData;
+    metadata->name = config.name;
+    metadata->fieldsSize = 1;
+    metadata->fields = &field;
+    metadata->dataSetClassId = UA_Guid_random();
+    metadata->configurationVersion.majorVersion = 123;
+    metadata->configurationVersion.minorVersion = 456;
+    UA_NodeId id = UA_NODEID_NULL;
+    UA_AddPublishedDataSetResult result = UA_Server_addPublishedDataSet(server, &config, &id);
+    ck_assert_uint_eq(result.addResult, UA_STATUSCODE_GOOD);
+    UA_DataSetMetaDataType actual = {0};
+    ck_assert_uint_eq(UA_Server_getPublishedDataSetMetaData(server, id, &actual), UA_STATUSCODE_GOOD);
+    ck_assert(UA_equal(&actual, metadata, &UA_TYPES[UA_TYPES_DATASETMETADATATYPE]));
+    UA_DataSetMetaDataType_clear(&actual);
+    metadata->configurationVersion.majorVersion = 789;
+    ck_assert_uint_eq(UA_Server_updatePublishedDataSetConfig(server, id, &config), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_getPublishedDataSetMetaData(server, id, &actual), UA_STATUSCODE_GOOD);
+    ck_assert(UA_equal(&actual, metadata, &UA_TYPES[UA_TYPES_DATASETMETADATATYPE]));
+    UA_DataSetMetaDataType_clear(&actual);
+    /* A rejected replacement leaves the old dataset and its contract intact. */
+    field.builtInType = 13;
+    ck_assert_uint_eq(UA_Server_updatePublishedDataSetConfig(server, id, &config), UA_STATUSCODE_BADTYPEMISMATCH);
+    field.builtInType = 11;
+    ck_assert_uint_eq(UA_Server_getPublishedDataSetMetaData(server, id, &actual), UA_STATUSCODE_GOOD);
+    ck_assert(UA_equal(&actual, metadata, &UA_TYPES[UA_TYPES_DATASETMETADATATYPE]));
+    UA_DataSetMetaDataType_clear(&actual);
+    config.name = UA_STRING("RenameNotSupported");
+    ck_assert_uint_eq(UA_Server_updatePublishedDataSetConfig(server, id, &config), UA_STATUSCODE_BADINVALIDARGUMENT);
+    config.name = UA_STRING("Template");
+    ck_assert_uint_eq(UA_Server_removePublishedDataSet(server, id), UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&id);
+    /* Reject a wrong contract and release the name so a corrected retry works. */
+    field.builtInType = 13;
+    result = UA_Server_addPublishedDataSet(server, &config, &id);
+    ck_assert_uint_eq(result.addResult, UA_STATUSCODE_BADTYPEMISMATCH);
+    field.builtInType = 11;
+    result = UA_Server_addPublishedDataSet(server, &config, &id);
+    ck_assert_uint_eq(result.addResult, UA_STATUSCODE_GOOD);
+    UA_NodeId_clear(&id);
+} END_TEST
+
+START_TEST(SubscribedDataSetUpdateRefreshesTargetVariables) {
+    UA_FieldMetaData field = {0};
+    field.name = UA_STRING("Time");
+    field.dataType = UA_TYPES[UA_TYPES_DATETIME].typeId;
+    field.builtInType = 13;
+    field.valueRank = -1;
+    UA_FieldTargetDataType target = {0};
+    target.targetNodeId = UA_NS0ID(SERVER_SERVERSTATUS_CURRENTTIME);
+    target.attributeId = UA_ATTRIBUTEID_VALUE;
+    UA_SubscribedDataSetConfig config = {0};
+    config.name = UA_STRING("Incoming");
+    config.subscribedDataSetType = UA_PUBSUB_SDS_TARGET;
+    config.dataSetMetaData.fields = &field;
+    config.dataSetMetaData.fieldsSize = 1;
+    config.subscribedDataSet.target.targetVariables = &target;
+    config.subscribedDataSet.target.targetVariablesSize = 1;
+    UA_NodeId dataset;
+    ck_assert_uint_eq(UA_Server_addSubscribedDataSet(server, &config, &dataset), UA_STATUSCODE_GOOD);
+    UA_SubscribedDataSetConfig snapshot;
+    memset(&snapshot, 0, sizeof(snapshot));
+    ck_assert_uint_eq(UA_Server_getSubscribedDataSetConfig(server, dataset, &snapshot), UA_STATUSCODE_GOOD);
+    UA_String_clear(&snapshot.name);
+    snapshot.name = UA_STRING_ALLOC("RenameNotSupported");
+    ck_assert_uint_eq(UA_Server_updateSubscribedDataSetConfig(server, dataset, &snapshot), UA_STATUSCODE_BADINVALIDARGUMENT);
+    UA_SubscribedDataSetConfig_clear(&snapshot);
+    target.targetNodeId = UA_NS0ID(SERVER_SERVERSTATUS_STARTTIME);
+    ck_assert_uint_eq(UA_Server_updateSubscribedDataSetConfig(server, dataset, &config), UA_STATUSCODE_GOOD);
+    UA_NodeId object = findSingleChildNode(UA_QUALIFIEDNAME(0, "SubscribedDataSet"), UA_NS0ID(HASCOMPONENT), dataset);
+    UA_NodeId variable = findSingleChildNode(UA_QUALIFIEDNAME(0, "TargetVariables"), UA_NS0ID(HASPROPERTY), object);
+    UA_Variant value;
+    UA_Variant_init(&value);
+    ck_assert_uint_eq(UA_Server_readValue(server, variable, &value), UA_STATUSCODE_GOOD);
+    ck_assert(UA_Variant_hasArrayType(&value, &UA_TYPES[UA_TYPES_FIELDTARGETDATATYPE]));
+    ck_assert(UA_NodeId_equal(&((UA_FieldTargetDataType*)value.data)[0].targetNodeId, &target.targetNodeId));
+    UA_Variant_clear(&value);
+    config.subscribedDataSet.target.targetVariablesSize = 0;
+    ck_assert_uint_eq(UA_Server_updateSubscribedDataSetConfig(server, dataset, &config), UA_STATUSCODE_BADINVALIDARGUMENT);
+    UA_NodeId_clear(&dataset);
+    UA_NodeId_clear(&object);
+    UA_NodeId_clear(&variable);
+} END_TEST
+
 int main(void) {
     TCase *tc_add_pubsub_informationmodel_methods_connection = tcase_create("PubSub connection delete and creation using the information model methods");
     tcase_add_checked_fixture(tc_add_pubsub_informationmodel_methods_connection, setup, teardown);
+    tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, FailedConnectionCreationRemovesEarlierGroups);
+    tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, PublishedItemsTemplatePreservesContract);
+    tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, SubscribedDataSetUpdateRefreshesTargetVariables);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddNewPubSubConnectionUsingTheInformationModelMethod);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddConnectionRollsBackOnChildFailure);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddConnectionRejectsInvalidPublisherIdWithoutSideEffects);

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -2256,6 +2256,25 @@ START_TEST(PublishedItemsTemplatePreservesContract) {
     config.name = UA_STRING("RenameNotSupported");
     ck_assert_uint_eq(UA_Server_updatePublishedDataSetConfig(server, id, &config), UA_STATUSCODE_BADINVALIDARGUMENT);
     config.name = UA_STRING("Template");
+    /* Empty replacements, including empty-to-empty, retain a valid contract. */
+    metadata->fieldsSize = 0;
+    metadata->fields = NULL;
+    config.config.itemsTemplate.variablesToAddSize = 0;
+    config.config.itemsTemplate.variablesToAdd = NULL;
+    for(size_t i = 0; i < 2; i++) {
+        ck_assert_uint_eq(UA_Server_updatePublishedDataSetConfig(server, id, &config), UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(UA_Server_getPublishedDataSetMetaData(server, id, &actual), UA_STATUSCODE_GOOD);
+        ck_assert(UA_equal(&actual, metadata, &UA_TYPES[UA_TYPES_DATASETMETADATATYPE]));
+        UA_DataSetMetaDataType_clear(&actual);
+    }
+    metadata->fieldsSize = 1;
+    metadata->fields = &field;
+    config.config.itemsTemplate.variablesToAddSize = 1;
+    config.config.itemsTemplate.variablesToAdd = &variable;
+    ck_assert_uint_eq(UA_Server_updatePublishedDataSetConfig(server, id, &config), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(UA_Server_getPublishedDataSetMetaData(server, id, &actual), UA_STATUSCODE_GOOD);
+    ck_assert(UA_equal(&actual, metadata, &UA_TYPES[UA_TYPES_DATASETMETADATATYPE]));
+    UA_DataSetMetaDataType_clear(&actual);
     ck_assert_uint_eq(UA_Server_removePublishedDataSet(server, id), UA_STATUSCODE_GOOD);
     UA_NodeId_clear(&id);
     /* Reject a wrong contract and release the name so a corrected retry works. */

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -2170,7 +2170,8 @@ START_TEST(FailedConnectionCreationRemovesEarlierGroups) {
     UA_NetworkAddressUrlDataType address = UA_PUBSUB_TEST_NETWORKADDRESSURL("opc.udp://127.0.0.1:4841/");
     UA_ExtensionObject_setValueNoDelete(&connection.address, &address,
                                        &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
-    UA_WriterGroupDataType groups[2] = {{0}};
+    UA_WriterGroupDataType groups[2];
+    memset(groups, 0, sizeof(groups));
     UA_UadpWriterGroupMessageDataType settings = {0};
     for(size_t i = 0; i < 2; i++) {
         groups[i].name = i == 0 ? UA_STRING("First") : UA_STRING("Rejected");

--- a/tests/pubsub/check_pubsub_pds.c
+++ b/tests/pubsub/check_pubsub_pds.c
@@ -80,16 +80,14 @@ START_TEST(AddPDSWithUnsupportedType){
     UA_PublishedDataSetConfig pdsConfig;
     memset(&pdsConfig, 0, sizeof(UA_PublishedDataSetConfig));
     pdsConfig.name = UA_STRING("TEST PDS 1");
-    pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDITEMS_TEMPLATE;
-    retVal |= UA_Server_addPublishedDataSet(server, &pdsConfig, NULL).addResult;
-    ck_assert_uint_eq(psm->publishedDataSetsSize, 0);
-    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDEVENTS;
+    retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, NULL).addResult;
     ck_assert_uint_eq(psm->publishedDataSetsSize, 0);
-    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_BADINVALIDARGUMENT);
     pdsConfig.publishedDataSetType = UA_PUBSUB_DATASET_PUBLISHEDEVENTS_TEMPLATE;
+    retVal = UA_Server_addPublishedDataSet(server, &pdsConfig, NULL).addResult;
     ck_assert_uint_eq(psm->publishedDataSetsSize, 0);
-    ck_assert_int_ne(retVal, UA_STATUSCODE_GOOD);
+    ck_assert_int_eq(retVal, UA_STATUSCODE_BADINVALIDARGUMENT);
 } END_TEST
 
 START_TEST(GetPDSConfigurationAndCompareValues){


### PR DESCRIPTION
PublishedItems templates and standalone subscribed datasets currently lose parts of their metadata or target mapping when created through the PubSub information model. This preserves the dataset contract, supports existing target nodes, accepts decoded borrowed extension objects, and fixes RawData keyframe handling.

Retains `UA_Server_updatePublishedDataSetConfig` and `UA_Server_updateSubscribedDataSetConfig`, with owned configuration getters for both. Updates require disabled consumers and reject a different dataset name with `BadInvalidArgument`; NodeId and BrowseName remain unchanged. Plain PublishedItems fields remain separately managed. No rename API or BrowseName/reference-index rewriting is included.

Validation: both PubSub dataset and information-model method suites passed with ASan/UBSan; clang-tidy passed. Regression coverage includes template metadata, target refresh, owned snapshots, unsupported types, and rejected name changes.
