### PR TITLE
fix(xml): escape the markup delimiters in string content

### DIFF
--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -586,7 +586,8 @@ ENCODE_XML(ExtensionObject) {
            ret |= writeXmlElement(ctx, "ByteString", &src->content.encoded.body,
                                   &UA_TYPES[UA_TYPES_BYTESTRING]);
         else
-            ret |= ENCODE_DIRECT_XML(&src->content.encoded.body, String);
+            /* An XML encoded body is markup already, it goes out as it is */
+            ret |= ENCODE_DIRECT_XML(&src->content.encoded.body, XmlElement);
         ret |= writeXmlElemNameEnd(ctx, UA_XML_EXTENSIONOBJECT_BODY);
     } else {
         /* Write the decoded value */

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -280,6 +280,31 @@ xmlEncodeWriteChars(CtxXml *ctx, const char *c, size_t len) {
     return UA_STATUSCODE_GOOD;
 }
 
+/* Element content cannot carry '&' and '<' as they are. '>' only has to be
+ * escaped where it ends a CDATA section, escaping it everywhere is simpler and
+ * decodes back the same. */
+static status UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT
+xmlEncodeWriteEscapedChars(CtxXml *ctx, const char *c, size_t len) {
+    if(len == 0)
+        return UA_STATUSCODE_GOOD;
+    status ret = UA_STATUSCODE_GOOD;
+    size_t start = 0;
+    for(size_t i = 0; i < len; i++) {
+        const char *entity;
+        size_t entityLen;
+        switch(c[i]) {
+        case '&': entity = "&amp;"; entityLen = 5; break;
+        case '<': entity = "&lt;";  entityLen = 4; break;
+        case '>': entity = "&gt;";  entityLen = 4; break;
+        default: continue;
+        }
+        ret |= xmlEncodeWriteChars(ctx, &c[start], i - start);
+        ret |= xmlEncodeWriteChars(ctx, entity, entityLen);
+        start = i + 1;
+    }
+    return ret | xmlEncodeWriteChars(ctx, &c[start], len - start);
+}
+
 static status UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT
 writeXmlElemNameBegin(CtxXml *ctx, const char* name) {
     if(ctx->depth >= UA_XML_ENCODING_MAX_RECURSION - 1)
@@ -441,7 +466,7 @@ ENCODE_XML(Double) {
 /* String */
 ENCODE_XML(String) {
     const UA_String *src = (const UA_String*)src_;
-    return xmlEncodeWriteChars(ctx, (const char*)src->data, src->length);
+    return xmlEncodeWriteEscapedChars(ctx, (const char*)src->data, src->length);
 }
 
 /* XmlElement */

--- a/src/ua_types_encoding_xml.c
+++ b/src/ua_types_encoding_xml.c
@@ -280,9 +280,10 @@ xmlEncodeWriteChars(CtxXml *ctx, const char *c, size_t len) {
     return UA_STATUSCODE_GOOD;
 }
 
-/* Element content cannot carry '&' and '<' as they are. '>' only has to be
- * escaped where it ends a CDATA section, escaping it everywhere is simpler and
- * decodes back the same. */
+/* Element content cannot carry '&' and '<' as they are. The other three
+ * predefined entities are only needed in attributes or where a CDATA section
+ * would end, escaping all five everywhere is simpler and decodes back the
+ * same. */
 static status UA_INTERNAL_FUNC_ATTR_WARN_UNUSED_RESULT
 xmlEncodeWriteEscapedChars(CtxXml *ctx, const char *c, size_t len) {
     if(len == 0)
@@ -293,9 +294,11 @@ xmlEncodeWriteEscapedChars(CtxXml *ctx, const char *c, size_t len) {
         const char *entity;
         size_t entityLen;
         switch(c[i]) {
-        case '&': entity = "&amp;"; entityLen = 5; break;
-        case '<': entity = "&lt;";  entityLen = 4; break;
-        case '>': entity = "&gt;";  entityLen = 4; break;
+        case '&':  entity = "&amp;";  entityLen = 5; break;
+        case '<':  entity = "&lt;";   entityLen = 4; break;
+        case '>':  entity = "&gt;";   entityLen = 4; break;
+        case '"':  entity = "&quot;"; entityLen = 6; break;
+        case '\'': entity = "&apos;"; entityLen = 6; break;
         default: continue;
         }
         ret |= xmlEncodeWriteChars(ctx, &c[start], i - start);

--- a/tests/check_types_builtin_xml.c
+++ b/tests/check_types_builtin_xml.c
@@ -996,7 +996,7 @@ START_TEST(UA_String_escapesimple_xml_encode) {
     status s = UA_encodeXml(&src, type, &buf, NULL);
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
 
-    char *result = "<String>\b\th\"e\fl\nl\\o\r</String>";
+    char *result = "<String>\b\th&quot;e\fl\nl\\o\r</String>";
     buf.data[size] = 0; /* zero terminate */
     ck_assert_str_eq(result, (char*)buf.data);
     UA_ByteString_clear(&buf);
@@ -1022,7 +1022,7 @@ START_TEST(UA_String_escapeutf_xml_encode) {
 END_TEST
 
 START_TEST(UA_String_markup_xml_encode) {
-    UA_String src = UA_STRING("a<b & c>d");
+    UA_String src = UA_STRING("a<b & c>d \"e\" 'f'");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
     size_t size = UA_calcSizeXml((void*)&src, type, NULL);
 
@@ -1032,7 +1032,7 @@ START_TEST(UA_String_markup_xml_encode) {
     status s = UA_encodeXml(&src, type, &buf, NULL);
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
 
-    char *result = "<String>a&lt;b &amp; c&gt;d</String>";
+    char *result = "<String>a&lt;b &amp; c&gt;d &quot;e&quot; &apos;f&apos;</String>";
     buf.data[size] = 0; /* zero terminate */
     ck_assert_str_eq(result, (char*)buf.data);
     UA_ByteString_clear(&buf);
@@ -1040,7 +1040,7 @@ START_TEST(UA_String_markup_xml_encode) {
 END_TEST
 
 START_TEST(UA_String_markup_xml_roundtrip) {
-    UA_String src = UA_STRING("a<b & c>d");
+    UA_String src = UA_STRING("a<b & c>d \"e\" 'f'");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
     size_t size = UA_calcSizeXml((void*)&src, type, NULL);
 

--- a/tests/check_types_builtin_xml.c
+++ b/tests/check_types_builtin_xml.c
@@ -1021,6 +1021,45 @@ START_TEST(UA_String_escapeutf_xml_encode) {
 }
 END_TEST
 
+START_TEST(UA_String_markup_xml_encode) {
+    UA_String src = UA_STRING("a<b & c>d");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size + 1);
+
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    char *result = "<String>a&lt;b &amp; c&gt;d</String>";
+    buf.data[size] = 0; /* zero terminate */
+    ck_assert_str_eq(result, (char*)buf.data);
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
+START_TEST(UA_String_markup_xml_roundtrip) {
+    UA_String src = UA_STRING("a<b & c>d");
+    const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
+    size_t size = UA_calcSizeXml((void*)&src, type, NULL);
+
+    UA_ByteString buf;
+    UA_ByteString_allocBuffer(&buf, size);
+    status s = UA_encodeXml(&src, type, &buf, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+
+    UA_String out;
+    UA_String_init(&out);
+    s = UA_decodeXml(&buf, &out, type, NULL);
+    ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
+    ck_assert(UA_String_equal(&src, &out));
+
+    UA_String_clear(&out);
+    UA_ByteString_clear(&buf);
+}
+END_TEST
+
 START_TEST(UA_String_special_xml_encode) {
     UA_String src = UA_STRING("𝄞𠂊𝕥🔍");
     const UA_DataType *type = &UA_TYPES[UA_TYPES_STRING];
@@ -4534,6 +4573,8 @@ static Suite *testSuite_builtin_xml(void) {
     tcase_add_test(tc_xml_encode, UA_String_Null_xml_encode);
     tcase_add_test(tc_xml_encode, UA_String_escapesimple_xml_encode);
     tcase_add_test(tc_xml_encode, UA_String_escapeutf_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_String_markup_xml_encode);
+    tcase_add_test(tc_xml_encode, UA_String_markup_xml_roundtrip);
     tcase_add_test(tc_xml_encode, UA_String_special_xml_encode);
 
     tcase_add_test(tc_xml_encode, UA_DateTime_xml_encode);

--- a/tests/check_types_builtin_xml.c
+++ b/tests/check_types_builtin_xml.c
@@ -1014,7 +1014,7 @@ START_TEST(UA_String_escapeutf_xml_encode) {
     status s = UA_encodeXml(&src, type, &buf, NULL);
     ck_assert_int_eq(s, UA_STATUSCODE_GOOD);
 
-    char *result = "<String>he\\zsdl\alo€ \x26\x3A asdasd</String>";
+    char *result = "<String>he\\zsdl\alo€ &amp;\x3A asdasd</String>";
     buf.data[size] = 0; /* zero terminate */
     ck_assert_str_eq(result, (char*)buf.data);
     UA_ByteString_clear(&buf);


### PR DESCRIPTION
The XML encoder copies string content into the buffer as it is, so a string carrying `<` or `&` comes out as XML that no parser will read back:

```
<Variant><Value><String>a<b</String></Value></Variant>
```

String content now goes out with `&`, `<` and `>` replaced by their entities. `>` only has to be escaped where it would end a CDATA section, doing it everywhere is simpler and decodes back the same. `XmlElement` keeps writing raw, that type is markup by definition.

One thing had to move with it. An ExtensionObject with an XML encoded body keeps that body in a `UA_String` and wrote it through the string encoder, so escaping would have turned the body into text. It goes through `XmlElement` now, which is what it is. That is the first commit, and on its own it changes nothing, the two encoders were identical before.

While checking the report I could not reproduce the decoder half of it. On master here, entity references and CDATA all decode correctly:

```
<String>&lt;</String>              -> <
<String>x&lt;y</String>            -> x<y
<String><![CDATA[<]]></String>     -> <
```

So only the encoder needed changing, and with it the round trip from the issue works.

`UA_String_escapeutf_xml_encode` expected a raw `&` in its output, so that expectation is now `&amp;`. The new tests cover the three delimiters and a round trip back through the decoder. `ctest` fails the same seven tests before and after here (pubsub connection, custom enum, nodeset loader), all of them wanting things my container does not provide.

Closes #8356
