### PR TITLE
fix(server): correct FX PubSub creation and monitored-item filter lifetime

### DIFF
--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -2050,9 +2050,7 @@ addDataSetWriterRepresentation(UA_Server *server, UA_DataSetWriter *dataSetWrite
 
     UA_Variant value;
     UA_Variant_init(&value);
-    UA_Variant_setScalar(&value, &dataSetWriter->config.dataSetWriterId,
-                         &UA_TYPES[UA_TYPES_UINT16]);
-    writeValueAttribute(server, dataSetWriterIdNode, &value);
+    /* DataSetWriterId is supplied by its read-only value callback above. */
 
     UA_Variant_setScalar(&value, &dataSetWriter->config.keyFrameCount,
                          &UA_TYPES[UA_TYPES_UINT32]);

--- a/src/pubsub/ua_pubsub_ns0.c
+++ b/src/pubsub/ua_pubsub_ns0.c
@@ -662,74 +662,35 @@ addWriterGroupConfig(UA_Server *server, UA_NodeId connectionId,
     if(!psm)
         return UA_STATUSCODE_BADINTERNALERROR;
 
-    /* Now we create a new WriterGroupConfig and add the group to the existing
-     * PubSubConnection. */
-    UA_WriterGroupConfig writerGroupConfig;
-    memset(&writerGroupConfig, 0, sizeof(UA_WriterGroupConfig));
-    writerGroupConfig.name = writerGroup->name;
-    writerGroupConfig.publishingInterval = writerGroup->publishingInterval;
-    writerGroupConfig.writerGroupId = writerGroup->writerGroupId;
-    writerGroupConfig.priority = writerGroup->priority;
-
-    UA_ExtensionObject *eoWG = &writerGroup->messageSettings;
-    UA_UadpWriterGroupMessageDataType uadpWriterGroupMessage;
-    UA_JsonWriterGroupMessageDataType jsonWriterGroupMessage;
-    if(eoWG->encoding == UA_EXTENSIONOBJECT_DECODED){
-        writerGroupConfig.messageSettings.encoding  = UA_EXTENSIONOBJECT_DECODED;
-        if(eoWG->content.decoded.type == &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE]){
-            writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
-            if(UA_UadpWriterGroupMessageDataType_copy(
-                    (UA_UadpWriterGroupMessageDataType *)eoWG->content.decoded.data,
-                    &uadpWriterGroupMessage) != UA_STATUSCODE_GOOD) {
-                return UA_STATUSCODE_BADOUTOFMEMORY;
-            }
-            writerGroupConfig.messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE];
-            writerGroupConfig.messageSettings.content.decoded.data = &uadpWriterGroupMessage;
-        } else if(eoWG->content.decoded.type == &UA_TYPES[UA_TYPES_JSONWRITERGROUPMESSAGEDATATYPE]) {
-            writerGroupConfig.encodingMimeType = UA_PUBSUB_ENCODING_JSON;
-            if(UA_JsonWriterGroupMessageDataType_copy(
-                   (UA_JsonWriterGroupMessageDataType *)eoWG->content.decoded.data,
-                   &jsonWriterGroupMessage) != UA_STATUSCODE_GOOD) {
-                return UA_STATUSCODE_BADOUTOFMEMORY;
-            }
-            writerGroupConfig.messageSettings.content.decoded.type = &UA_TYPES[UA_TYPES_JSONWRITERGROUPMESSAGEDATATYPE];
-            writerGroupConfig.messageSettings.content.decoded.data = &jsonWriterGroupMessage;
-        }
+    /* The native create operation copies the borrowed configuration. Preserve
+     * complete transport ExtensionObjects, including DatagramWriterGroupTransport2.
+     * Selecting a few older types here loses addresses and QoS settings. */
+    UA_WriterGroupConfig config;
+    memset(&config, 0, sizeof(config));
+    config.name = writerGroup->name;
+    config.publishingInterval = writerGroup->publishingInterval;
+    config.writerGroupId = writerGroup->writerGroupId;
+    config.priority = writerGroup->priority;
+    config.securityMode = writerGroup->securityMode;
+    config.securityGroupId = writerGroup->securityGroupId;
+    config.groupProperties.map = writerGroup->groupProperties;
+    config.groupProperties.mapSize = writerGroup->groupPropertiesSize;
+    config.messageSettings = writerGroup->messageSettings;
+    config.transportSettings = writerGroup->transportSettings;
+    if(UA_ExtensionObject_hasDecodedType(&config.messageSettings,
+            &UA_TYPES[UA_TYPES_JSONWRITERGROUPMESSAGEDATATYPE])) {
+        config.encodingMimeType = UA_PUBSUB_ENCODING_JSON;
+        if(!UA_ExtensionObject_hasDecodedType(&config.transportSettings,
+                &UA_TYPES[UA_TYPES_BROKERWRITERGROUPTRANSPORTDATATYPE]))
+            return UA_STATUSCODE_BADCONFIGURATIONERROR;
+    } else if(config.messageSettings.encoding == UA_EXTENSIONOBJECT_ENCODED_NOBODY ||
+              UA_ExtensionObject_hasDecodedType(&config.messageSettings,
+                &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE])) {
+        config.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
+    } else {
+        return UA_STATUSCODE_BADTYPEMISMATCH;
     }
-
-    eoWG = &writerGroup->transportSettings;
-    UA_BrokerWriterGroupTransportDataType brokerWriterGroupTransport;
-    UA_DatagramWriterGroupTransportDataType datagramWriterGroupTransport;
-    if(eoWG->encoding == UA_EXTENSIONOBJECT_DECODED) {
-        writerGroupConfig.transportSettings.encoding = UA_EXTENSIONOBJECT_DECODED;
-        if(eoWG->content.decoded.type == &UA_TYPES[UA_TYPES_BROKERWRITERGROUPTRANSPORTDATATYPE]) {
-            if(UA_BrokerWriterGroupTransportDataType_copy(
-                    (UA_BrokerWriterGroupTransportDataType*)eoWG->content.decoded.data,
-                    &brokerWriterGroupTransport) != UA_STATUSCODE_GOOD) {
-                return UA_STATUSCODE_BADOUTOFMEMORY;
-            }
-            writerGroupConfig.transportSettings.content.decoded.type = &UA_TYPES[UA_TYPES_BROKERWRITERGROUPTRANSPORTDATATYPE];
-            writerGroupConfig.transportSettings.content.decoded.data = &brokerWriterGroupTransport;
-        } else if(eoWG->content.decoded.type == &UA_TYPES[UA_TYPES_DATAGRAMWRITERGROUPTRANSPORTDATATYPE]) {
-            if(UA_DatagramWriterGroupTransportDataType_copy(
-                   (UA_DatagramWriterGroupTransportDataType *)eoWG->content.decoded.data,
-                   &datagramWriterGroupTransport) != UA_STATUSCODE_GOOD) {
-                return UA_STATUSCODE_BADOUTOFMEMORY;
-            }
-            writerGroupConfig.transportSettings.content.decoded.type = &UA_TYPES[UA_TYPES_DATAGRAMWRITERGROUPTRANSPORTDATATYPE];
-            writerGroupConfig.transportSettings.content.decoded.data = &datagramWriterGroupTransport;
-        }
-    }
-    if (writerGroupConfig.encodingMimeType == UA_PUBSUB_ENCODING_JSON
-        && (writerGroupConfig.transportSettings.encoding != UA_EXTENSIONOBJECT_DECODED ||
-        writerGroupConfig.transportSettings.content.decoded.type !=
-            &UA_TYPES[UA_TYPES_BROKERWRITERGROUPTRANSPORTDATATYPE])) {
-        UA_LOG_ERROR(server->config.logging, UA_LOGCATEGORY_SERVER,
-                     "JSON encoding is supported only for MQTT transport");
-        return UA_STATUSCODE_BADCONFIGURATIONERROR;
-    }
-
-    return UA_WriterGroup_create(psm, connectionId, &writerGroupConfig, writerGroupId);
+    return UA_WriterGroup_create(psm, connectionId, &config, writerGroupId);
 }
 
 /**
@@ -749,16 +710,19 @@ addDataSetWriterConfig(UA_Server *server, const UA_NodeId *writerGroupId,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     UA_NodeId publishedDataSetId = UA_NODEID_NULL;
-    UA_PublishedDataSet *tmpPDS;
-    TAILQ_FOREACH(tmpPDS, &psm->publishedDataSets, listEntry){
-        if(UA_String_equal(&dataSetWriter->dataSetName, &tmpPDS->config.name)) {
-            publishedDataSetId = tmpPDS->head.identifier;
-            break;
+    /* An empty DataSetName denotes a heartbeat writer with no PublishedDataSet.
+     * The core validates its KeyFrameCount. Resolve only named datasets here. */
+    if(dataSetWriter->dataSetName.length > 0) {
+        UA_PublishedDataSet *tmpPDS;
+        TAILQ_FOREACH(tmpPDS, &psm->publishedDataSets, listEntry) {
+            if(UA_String_equal(&dataSetWriter->dataSetName, &tmpPDS->config.name)) {
+                publishedDataSetId = tmpPDS->head.identifier;
+                break;
+            }
         }
+        if(UA_NodeId_isNull(&publishedDataSetId))
+            return UA_STATUSCODE_BADPARENTNODEIDINVALID;
     }
-
-    if(UA_NodeId_isNull(&publishedDataSetId))
-        return UA_STATUSCODE_BADPARENTNODEIDINVALID;
 
     /* We need now a DataSetWriter within the WriterGroup. This means we must
      * create a new DataSetWriterConfig and add call the addWriterGroup function. */
@@ -812,9 +776,12 @@ addSubscribedVariables(UA_Server *server, UA_NodeId dataSetReaderId,
         return UA_STATUSCODE_BADINTERNALERROR;
 
     UA_ExtensionObject *eoTargetVar = &dataSetReader->subscribedDataSet;
-    if(eoTargetVar->encoding != UA_EXTENSIONOBJECT_DECODED ||
-       eoTargetVar->content.decoded.type != &UA_TYPES[UA_TYPES_TARGETVARIABLESDATATYPE])
-        return UA_STATUSCODE_BADUNEXPECTEDERROR;
+    /* FX may create the reader before assigning its target variables. */
+    if(eoTargetVar->encoding == UA_EXTENSIONOBJECT_ENCODED_NOBODY)
+        return UA_STATUSCODE_GOOD;
+    if(!UA_ExtensionObject_hasDecodedType(eoTargetVar,
+            &UA_TYPES[UA_TYPES_TARGETVARIABLESDATATYPE]))
+        return UA_STATUSCODE_BADTYPEMISMATCH;
 
     const UA_TargetVariablesDataType *targetVars =
         (UA_TargetVariablesDataType*)eoTargetVar->content.decoded.data;
@@ -924,12 +891,14 @@ addDataSetReaderConfig(UA_Server *server, UA_NodeId readerGroupId,
                                       &readerConfig, dataSetReaderId);
     UA_PublisherId_clear(&readerConfig.publisherId);
     if(retVal != UA_STATUSCODE_GOOD) {
-        UA_free(pMetaData->fields);
+        if(pMetaData->fieldsSize > 0)
+            UA_free(pMetaData->fields);
         return retVal;
     }
 
     retVal |= addSubscribedVariables(server, *dataSetReaderId, dataSetReader, pMetaData);
-    UA_free(pMetaData->fields);
+    if(pMetaData->fieldsSize > 0)
+        UA_free(pMetaData->fields);
     return retVal;
 }
 

--- a/src/server/ua_services_monitoreditem.c
+++ b/src/server/ua_services_monitoreditem.c
@@ -416,6 +416,8 @@ notifyMonitoredItem(UA_Server *server, UA_MonitoredItem *mon,
                          &UA_TYPES[UA_TYPES_UINT32]);
     UA_Variant_setScalar(&notifyMonData[9].value, &mon->parameters.samplingInterval,
                          &UA_TYPES[UA_TYPES_DOUBLE]);
+    /* The filter is borrowed. Reset it without freeing the previous item's data. */
+    UA_Variant_init(&notifyMonData[10].value);
     if(mon->parameters.filter.encoding == UA_EXTENSIONOBJECT_DECODED ||
        mon->parameters.filter.encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE) {
         UA_Variant_setScalar(&notifyMonData[10].value,

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -1962,6 +1962,18 @@ START_TEST(HeartbeatWriterViaInformationModel) {
         UA_StatusCode expected = (i == 1) ? UA_STATUSCODE_GOOD :
             ((i == 3) ? UA_STATUSCODE_BADPARENTNODEIDINVALID : UA_STATUSCODE_BADCONFIGURATIONERROR);
         ck_assert_uint_eq(result.statusCode, expected);
+        if(expected == UA_STATUSCODE_GOOD) {
+            UA_NodeId writerId = *(UA_NodeId*)result.outputArguments[0].data;
+            UA_NodeId property = findSingleChildNode(
+                UA_QUALIFIEDNAME(0, "DataSetWriterId"), UA_NS0ID(HASPROPERTY), writerId);
+            UA_Variant value;
+            UA_Variant_init(&value);
+            ck_assert_uint_eq(UA_Server_readValue(server, property, &value), UA_STATUSCODE_GOOD);
+            ck_assert(UA_Variant_hasScalarType(&value, &UA_TYPES[UA_TYPES_UINT16]));
+            ck_assert_uint_eq(*(UA_UInt16*)value.data, writer.dataSetWriterId);
+            UA_Variant_clear(&value);
+            UA_NodeId_clear(&property);
+        }
         UA_CallMethodResult_clear(&result);
     }
     UA_NodeId_clear(&groupId);

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -2027,6 +2027,83 @@ START_TEST(WriterGroupTransport2PreservesAddress) {
     UA_NodeId_clear(&connection);
 } END_TEST
 
+START_TEST(WriterGroupOwnsConfigurationAfterMethodCall) {
+    UA_NodeId connection = addPubSubConnection();
+    UA_NetworkAddressUrlDataType address = {UA_STRING_NULL, UA_STRING("opc.udp://127.0.0.1:4841/")};
+    UA_DatagramWriterGroupTransport2DataType transport;
+    UA_DatagramWriterGroupTransport2DataType_init(&transport);
+    UA_ExtensionObject_setValueNoDelete(&transport.address, &address,
+                                       &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    UA_UadpWriterGroupMessageDataType message;
+    UA_UadpWriterGroupMessageDataType_init(&message);
+    UA_WriterGroupDataType group;
+    UA_WriterGroupDataType_init(&group);
+    group.name = UA_STRING("OwnedConfiguration");
+    group.writerGroupId = 7;
+    group.publishingInterval = 100;
+    group.securityMode = UA_MESSAGESECURITYMODE_NONE;
+    group.securityGroupId = UA_STRING("SecurityGroup");
+    UA_KeyValuePair property = {0};
+    property.key = UA_QUALIFIEDNAME(1, "Property");
+    UA_String propertyValue = UA_STRING("PropertyValue");
+    UA_Variant_setScalar(&property.value, &propertyValue, &UA_TYPES[UA_TYPES_STRING]);
+    group.groupProperties = &property;
+    group.groupPropertiesSize = 1;
+    UA_Double offset = 12.5;
+    message.publishingOffset = &offset;
+    message.publishingOffsetSize = 1;
+    UA_ExtensionObject_setValueNoDelete(&group.transportSettings, &transport,
+                                       &UA_TYPES[UA_TYPES_DATAGRAMWRITERGROUPTRANSPORT2DATATYPE]);
+    UA_ExtensionObject_setValueNoDelete(&group.messageSettings, &message,
+                                       &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE]);
+    UA_Variant input;
+    /* Model a decoded method argument whose allocations belong to the caller. */
+    UA_WriterGroupDataType ownedGroup;
+    ck_assert_uint_eq(UA_WriterGroupDataType_copy(&group, &ownedGroup), UA_STATUSCODE_GOOD);
+    UA_Variant_setScalar(&input, &ownedGroup, &UA_TYPES[UA_TYPES_WRITERGROUPDATATYPE]);
+    UA_CallMethodRequest request;
+    UA_CallMethodRequest_init(&request);
+    request.objectId = connection;
+    request.methodId = UA_NS0ID(PUBSUBCONNECTIONTYPE_ADDWRITERGROUP);
+    request.inputArguments = &input;
+    request.inputArgumentsSize = 1;
+    UA_CallMethodResult result = UA_Server_call(server, &request);
+    /* The saved configuration must outlive all method argument allocations. */
+    UA_WriterGroupDataType_clear(&ownedGroup);
+    ck_assert_uint_eq(result.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(result.outputArgumentsSize, 1);
+    UA_WriterGroupConfig snapshot;
+    memset(&snapshot, 0, sizeof(snapshot));
+    ck_assert_uint_eq(UA_Server_getWriterGroupConfig(server,
+        *(UA_NodeId*)result.outputArguments[0].data, &snapshot), UA_STATUSCODE_GOOD);
+    ck_assert(UA_ExtensionObject_hasDecodedType(&snapshot.transportSettings,
+        &UA_TYPES[UA_TYPES_DATAGRAMWRITERGROUPTRANSPORT2DATATYPE]));
+    UA_DatagramWriterGroupTransport2DataType *saved =
+        (UA_DatagramWriterGroupTransport2DataType*)snapshot.transportSettings.content.decoded.data;
+    ck_assert(UA_ExtensionObject_hasDecodedType(&saved->address,
+        &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]));
+    UA_NetworkAddressUrlDataType *savedAddress =
+        (UA_NetworkAddressUrlDataType*)saved->address.content.decoded.data;
+    ck_assert(UA_String_equal(&savedAddress->url, &address.url));
+    ck_assert_uint_eq(snapshot.securityMode, UA_MESSAGESECURITYMODE_NONE);
+    ck_assert(UA_String_equal(&snapshot.securityGroupId, &group.securityGroupId));
+    ck_assert_uint_eq(snapshot.groupProperties.mapSize, 1);
+    ck_assert(UA_QualifiedName_equal(&snapshot.groupProperties.map[0].key, &property.key));
+    ck_assert(UA_Variant_hasScalarType(&snapshot.groupProperties.map[0].value,
+                                       &UA_TYPES[UA_TYPES_STRING]));
+    ck_assert(UA_String_equal((UA_String*)snapshot.groupProperties.map[0].value.data,
+                              &propertyValue));
+    ck_assert(UA_ExtensionObject_hasDecodedType(&snapshot.messageSettings,
+        &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE]));
+    UA_UadpWriterGroupMessageDataType *savedMessage =
+        (UA_UadpWriterGroupMessageDataType*)snapshot.messageSettings.content.decoded.data;
+    ck_assert_uint_eq(savedMessage->publishingOffsetSize, 1);
+    ck_assert(savedMessage->publishingOffset[0] == offset);
+    UA_WriterGroupConfig_clear(&snapshot);
+    UA_CallMethodResult_clear(&result);
+    UA_NodeId_clear(&connection);
+} END_TEST
+
 START_TEST(DataSetReaderAllowsNullSubscribedDataSet) {
     UA_NodeId connection = addPubSubConnection();
     UA_ReaderGroupConfig group;
@@ -2068,6 +2145,7 @@ int main(void) {
     tcase_add_checked_fixture(tc_add_pubsub_informationmodel_methods_connection, setup, teardown);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, DataSetReaderAllowsNullSubscribedDataSet);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, WriterGroupTransport2PreservesAddress);
+    tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, WriterGroupOwnsConfigurationAfterMethodCall);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, HeartbeatWriterViaInformationModel);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddNewPubSubConnectionUsingTheInformationModelMethod);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddConnectionRollsBackOnChildFailure);

--- a/tests/pubsub/check_pubsub_informationmodel_methods.c
+++ b/tests/pubsub/check_pubsub_informationmodel_methods.c
@@ -1935,9 +1935,128 @@ START_TEST(TestEnableDisableTopLevelPublishSubscribe){
     UA_Client_delete(client);
 } END_TEST
 
+START_TEST(HeartbeatWriterViaInformationModel) {
+    UA_NodeId connection = addPubSubConnection();
+    UA_WriterGroupConfig group = {0};
+    group.name = UA_STRING("HeartbeatGroup");
+    group.publishingInterval = 100;
+    group.encodingMimeType = UA_PUBSUB_ENCODING_UADP;
+    UA_NodeId groupId;
+    ck_assert_uint_eq(UA_Server_addWriterGroup(server, connection, &group, &groupId),
+                      UA_STATUSCODE_GOOD);
+    for(unsigned i = 0; i < 4; i++) {
+        UA_DataSetWriterDataType writer = {0};
+        writer.name = UA_STRING("Heartbeat");
+        writer.dataSetWriterId = 1;
+        writer.keyFrameCount = (i == 3) ? 1 : i;
+        if(i == 3)
+            writer.dataSetName = UA_STRING("MissingDataSet");
+        UA_Variant input;
+        UA_Variant_setScalar(&input, &writer, &UA_TYPES[UA_TYPES_DATASETWRITERDATATYPE]);
+        UA_CallMethodRequest request = {0};
+        request.objectId = groupId;
+        request.methodId = UA_NS0ID(WRITERGROUPTYPE_ADDDATASETWRITER);
+        request.inputArguments = &input;
+        request.inputArgumentsSize = 1;
+        UA_CallMethodResult result = UA_Server_call(server, &request);
+        UA_StatusCode expected = (i == 1) ? UA_STATUSCODE_GOOD :
+            ((i == 3) ? UA_STATUSCODE_BADPARENTNODEIDINVALID : UA_STATUSCODE_BADCONFIGURATIONERROR);
+        ck_assert_uint_eq(result.statusCode, expected);
+        UA_CallMethodResult_clear(&result);
+    }
+    UA_NodeId_clear(&groupId);
+    UA_NodeId_clear(&connection);
+} END_TEST
+
+START_TEST(WriterGroupTransport2PreservesAddress) {
+    UA_NodeId connection = addPubSubConnection();
+    UA_NetworkAddressUrlDataType address = {UA_STRING_NULL, UA_STRING("opc.udp://127.0.0.1:4841/")};
+    UA_DatagramWriterGroupTransport2DataType transport;
+    UA_DatagramWriterGroupTransport2DataType_init(&transport);
+    UA_ExtensionObject_setValueNoDelete(&transport.address, &address,
+                                       &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]);
+    UA_UadpWriterGroupMessageDataType message;
+    UA_UadpWriterGroupMessageDataType_init(&message);
+    UA_WriterGroupDataType group;
+    UA_WriterGroupDataType_init(&group);
+    group.name = UA_STRING("Transport2Regression");
+    group.writerGroupId = 7;
+    group.publishingInterval = 100;
+    UA_ExtensionObject_setValueNoDelete(&group.transportSettings, &transport,
+                                       &UA_TYPES[UA_TYPES_DATAGRAMWRITERGROUPTRANSPORT2DATATYPE]);
+    UA_ExtensionObject_setValueNoDelete(&group.messageSettings, &message,
+                                       &UA_TYPES[UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE]);
+    UA_Variant input;
+    UA_Variant_setScalar(&input, &group, &UA_TYPES[UA_TYPES_WRITERGROUPDATATYPE]);
+    UA_CallMethodRequest request;
+    UA_CallMethodRequest_init(&request);
+    request.objectId = connection;
+    request.methodId = UA_NS0ID(PUBSUBCONNECTIONTYPE_ADDWRITERGROUP);
+    request.inputArguments = &input;
+    request.inputArgumentsSize = 1;
+    UA_CallMethodResult result = UA_Server_call(server, &request);
+    ck_assert_uint_eq(result.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(result.outputArgumentsSize, 1);
+    UA_WriterGroupConfig snapshot;
+    memset(&snapshot, 0, sizeof(snapshot));
+    ck_assert_uint_eq(UA_Server_getWriterGroupConfig(server,
+        *(UA_NodeId*)result.outputArguments[0].data, &snapshot), UA_STATUSCODE_GOOD);
+    ck_assert(UA_ExtensionObject_hasDecodedType(&snapshot.transportSettings,
+        &UA_TYPES[UA_TYPES_DATAGRAMWRITERGROUPTRANSPORT2DATATYPE]));
+    UA_DatagramWriterGroupTransport2DataType *saved =
+        (UA_DatagramWriterGroupTransport2DataType*)snapshot.transportSettings.content.decoded.data;
+    ck_assert(UA_ExtensionObject_hasDecodedType(&saved->address,
+        &UA_TYPES[UA_TYPES_NETWORKADDRESSURLDATATYPE]));
+    UA_NetworkAddressUrlDataType *savedAddress =
+        (UA_NetworkAddressUrlDataType*)saved->address.content.decoded.data;
+    ck_assert(UA_String_equal(&savedAddress->url, &address.url));
+    UA_WriterGroupConfig_clear(&snapshot);
+    UA_CallMethodResult_clear(&result);
+    UA_NodeId_clear(&connection);
+} END_TEST
+
+START_TEST(DataSetReaderAllowsNullSubscribedDataSet) {
+    UA_NodeId connection = addPubSubConnection();
+    UA_ReaderGroupConfig group;
+    memset(&group, 0, sizeof(group));
+    group.name = UA_STRING("UnlinkedReaderGroup");
+    UA_NodeId groupId = UA_NODEID_NULL;
+    ck_assert_uint_eq(UA_Server_addReaderGroup(server, connection, &group, &groupId), UA_STATUSCODE_GOOD);
+    UA_DataSetReaderDataType reader;
+    UA_DataSetReaderDataType_init(&reader);
+    reader.name = UA_STRING("HeartbeatReader");
+    UA_UInt16 publisherId = 12;
+    UA_Variant_setScalar(&reader.publisherId, &publisherId, &UA_TYPES[UA_TYPES_UINT16]);
+    reader.writerGroupId = 1;
+    reader.dataSetWriterId = 1;
+    UA_Variant input;
+    UA_Variant_setScalar(&input, &reader, &UA_TYPES[UA_TYPES_DATASETREADERDATATYPE]);
+    UA_CallMethodRequest request;
+    UA_CallMethodRequest_init(&request);
+    request.objectId = groupId;
+    request.methodId = UA_NS0ID(READERGROUPTYPE_ADDDATASETREADER);
+    request.inputArguments = &input;
+    request.inputArgumentsSize = 1;
+    UA_CallMethodResult result = UA_Server_call(server, &request);
+    ck_assert_uint_eq(result.statusCode, UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(result.outputArgumentsSize, 1);
+    UA_DataSetReaderConfig snapshot;
+    memset(&snapshot, 0, sizeof(snapshot));
+    ck_assert_uint_eq(UA_Server_getDataSetReaderConfig(server,
+        *(UA_NodeId*)result.outputArguments[0].data, &snapshot), UA_STATUSCODE_GOOD);
+    ck_assert_uint_eq(snapshot.dataSetMetaData.fieldsSize, 0);
+    UA_DataSetReaderConfig_clear(&snapshot);
+    UA_CallMethodResult_clear(&result);
+    UA_NodeId_clear(&groupId);
+    UA_NodeId_clear(&connection);
+} END_TEST
+
 int main(void) {
     TCase *tc_add_pubsub_informationmodel_methods_connection = tcase_create("PubSub connection delete and creation using the information model methods");
     tcase_add_checked_fixture(tc_add_pubsub_informationmodel_methods_connection, setup, teardown);
+    tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, DataSetReaderAllowsNullSubscribedDataSet);
+    tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, WriterGroupTransport2PreservesAddress);
+    tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, HeartbeatWriterViaInformationModel);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddNewPubSubConnectionUsingTheInformationModelMethod);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddConnectionRollsBackOnChildFailure);
     tcase_add_test(tc_add_pubsub_informationmodel_methods_connection, AddConnectionRejectsInvalidPublisherIdWithoutSideEffects);

--- a/tests/server/check_local_monitored_item.c
+++ b/tests/server/check_local_monitored_item.c
@@ -547,10 +547,49 @@ START_TEST(Server_Subscription_resendData_withDataChangeItem) {
 }
 END_TEST
 
+static UA_Boolean expectNotificationFilter;
+static unsigned filterNotifications;
+static void
+checkNotificationFilter(UA_Server *thisServer, UA_ApplicationNotificationType type,
+                        const UA_KeyValueMap payload) {
+    if(type != UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_CREATED &&
+       type != UA_APPLICATIONNOTIFICATIONTYPE_MONITOREDITEM_DELETE)
+        return;
+    const UA_Variant *filter = &payload.map[10].value;
+    if(expectNotificationFilter)
+        ck_assert(UA_Variant_hasScalarType(filter, &UA_TYPES[UA_TYPES_DATACHANGEFILTER]));
+    else
+        ck_assert_ptr_null(filter->type);
+    filterNotifications++;
+}
+
+START_TEST(Server_NotificationFilterDoesNotOutliveItem) {
+    UA_Server_getConfig(server)->globalNotificationCallback = checkNotificationFilter;
+    filterNotifications = 0;
+    for(unsigned i = 0; i < 2; i++) {
+        expectNotificationFilter = (i == 0);
+        UA_MonitoredItemCreateRequest request =
+            UA_MonitoredItemCreateRequest_default(outNodeId);
+        UA_DataChangeFilter filter;
+        UA_DataChangeFilter_init(&filter);
+        filter.trigger = UA_DATACHANGETRIGGER_STATUSVALUE;
+        if(expectNotificationFilter)
+            UA_ExtensionObject_setValueNoDelete(&request.requestedParameters.filter,
+                &filter, &UA_TYPES[UA_TYPES_DATACHANGEFILTER]);
+        UA_MonitoredItemCreateResult result = UA_Server_createDataChangeMonitoredItem(
+            server, UA_TIMESTAMPSTORETURN_BOTH, request, NULL, dataChangeNotificationCallback);
+        ck_assert_uint_eq(result.statusCode, UA_STATUSCODE_GOOD);
+        ck_assert_uint_eq(UA_Server_deleteMonitoredItem(server, result.monitoredItemId), UA_STATUSCODE_GOOD);
+        UA_MonitoredItemCreateResult_clear(&result);
+    }
+    ck_assert_uint_eq(filterNotifications, 4);
+} END_TEST
+
 static Suite * testSuite_Client(void) {
     Suite *s = suite_create("Local Monitored Item");
     TCase *tc_server = tcase_create("Local Monitored Item Basic");
     tcase_add_checked_fixture(tc_server, setup, teardown);
+    tcase_add_test(tc_server, Server_NotificationFilterDoesNotOutliveItem);
     tcase_add_test(tc_server, Server_LocalMonitoredItem);
     tcase_add_test(tc_server,
                    Server_LocalMonitoredItem_deleteFromCreatedNotification);


### PR DESCRIPTION
AddWriterGroup now preserves complete message/transport ExtensionObjects, including DatagramWriterGroupTransport2 addresses. AddDataSetReader accepts an initially null subscribed dataset, and its zero-field metadata cleanup does not free the empty-array sentinel. AddDataSetWriter permits empty-dataset heartbeat writers while retaining core KeyFrameCount validation and rejecting unknown named datasets.

Monitored-item notifications retained a borrowed filter pointer after a filtered item was deleted. Later unfiltered items could expose freed memory through application callbacks, causing spurious BadOutOfMemory errors or crashes. Retain the existing static thread-local notification map and initialize only its filter variant before assigning the current filter. UA_Variant_init does not free the previously borrowed data. This avoids rebuilding the entire map per notification and leaves the existing callback reentrancy behavior unchanged.

The changes are ported directly onto 1.5; unrelated master changes are excluded. Regression coverage includes default/Transport2 writer behavior, heartbeat writer validation, initially unlinked readers, and filtered-item deletion followed by unfiltered notifications.

Validation on 1.5: sanitizer-enabled Debug build passes all 12 local monitored-item checks and all 26 PubSub information-model method checks (38 total).

DataSetWriter creation also installed a read-only DataSetWriterId callback and then redundantly wrote that property, causing an ignored BadWriteNotSupported. Remove that write; the callback supplies the configured ID. A regression assertion verifies the readable ID. The 26-check PubSub suite still passes with sanitizers and its BadWriteNotSupported log count drops from four to zero. This removes a misleading creation diagnostic; it does not explain a reader waiting in PreOperational.
