### PR TITLE
feat(nodestore): support direct reference deltas and array defaults

### DIFF
--- a/include/open62541/plugin/nodestore.h
+++ b/include/open62541/plugin/nodestore.h
@@ -474,6 +474,8 @@ typedef union {
 
 typedef void (*UA_NodestoreVisitor)(void *visitorCtx, const UA_Node *node);
 
+#define UA_NODESTORE_HAS_EDITREFERENCE 1
+
 struct UA_Nodestore {
     /* Nodestore context and lifecycle */
     void (*free)(UA_Nodestore *ns);
@@ -570,6 +572,22 @@ struct UA_Nodestore {
 
     /* Removes a node from the nodestore. */
     UA_StatusCode (*removeNode)(UA_Nodestore *ns, const UA_NodeId *nodeId);
+
+    /* Optional single-reference mutation. Return BADNOTSUPPORTED to use the
+     * editable-node fallback. A failed operation must leave the node unchanged.
+     * The caller serializes access and performs validation/model-change events. */
+    UA_StatusCode (*editReference)(UA_Nodestore *ns, const UA_NodeId *nodeId,
+                                  UA_Byte referenceTypeIndex, UA_Boolean isForward,
+                                  const UA_ExpandedNodeId *target,
+                                  UA_UInt32 targetNameHash, UA_Boolean add);
+
+    /* Optional rollback checkpoint for a source-node reference update. Both
+     * callbacks must be supplied together. A NULL token requests the ordinary
+     * inverse-operation rollback. finish must not allocate or fail. Access is
+     * serialized; only the paired source/target updates may run before finish. */
+    UA_StatusCode (*beginReferenceEdit)(UA_Nodestore *ns, const UA_NodeId *nodeId,
+                                       void **token);
+    void (*finishReferenceEdit)(UA_Nodestore *ns, void *token, UA_Boolean rollback);
 
     /* Maps the ReferenceTypeIndex used for the references to the NodeId of the
      * ReferenceType. The returned pointer is stable until the Nodestore is

--- a/src/server/ua_server_modelchange.c
+++ b/src/server/ua_server_modelchange.c
@@ -112,7 +112,9 @@ addNodeVersionTracking(UA_Server *server, UA_ModelChangeAccumulator *acc,
     if(!UA_NodeId_isNull(&entry->nodeVersionId))
         return UA_STATUSCODE_GOOD;
 
-    const UA_Node *node = UA_NODESTORE_GET(server, affected);
+    /* Metadata uses forward references only (type definition and properties). */
+    const UA_Node *node = UA_NODESTORE_GET_SELECTIVE(server, affected, 0,
+                              UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_FORWARD);
     if(!node)
         return UA_STATUSCODE_BADNOTFOUND;
     UA_StatusCode res =
@@ -171,7 +173,9 @@ UA_ModelChangeAccumulator_record(UA_Server *server,
 
     /* A new entry needs metadata from the affected Node. Missing Nodes are
      * ignored: this can occur for changes reported after external teardown. */
-    const UA_Node *node = UA_NODESTORE_GET(server, affected);
+    /* Metadata uses forward references only (type definition and properties). */
+    const UA_Node *node = UA_NODESTORE_GET_SELECTIVE(server, affected, 0,
+                              UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_FORWARD);
     if(!node)
         return UA_STATUSCODE_GOOD;
 

--- a/src/server/ua_services_nodemanagement.c
+++ b/src/server/ua_services_nodemanagement.c
@@ -123,8 +123,8 @@ callEarlyConstructors(UA_Server *server, UA_Session *session,
             return UA_STATUSCODE_BADNODECLASSINVALID;
         }
         const UA_Node *type =
-            getNodeType(server, &node->head, ~(UA_UInt32)0,
-                        UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
+            getNodeType(server, &node->head, 0,
+                        UA_REFERENCETYPESET_NONE, UA_BROWSEDIRECTION_INVALID);
         UA_NODESTORE_RELEASE(server, node);
 
         if(type) {
@@ -1175,7 +1175,9 @@ addNode_addRefs(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId,
      * and type-nodes. See the above checks. */
     if(!UA_NodeId_isNull(typeDefinitionId)) {
         /* Get the type node */
-        type = UA_NODESTORE_GET(server, typeDefinitionId);
+        type = UA_NODESTORE_GET_SELECTIVE(server, typeDefinitionId,
+                                         UA_NODEATTRIBUTESMASK_ISABSTRACT,
+                                         UA_REFERENCETYPESET_NONE, UA_BROWSEDIRECTION_INVALID);
         if(!type) {
             UA_LOG_INFO_SESSION(server->config.logging, session,
                                 "AddNode (%N): Node type %N not found ",
@@ -1558,13 +1560,13 @@ recursiveCallConstructors(UA_Server *server, UA_Session *session,
             continue;
         }
 
-        /* TODO: Do we need all attributes and references here?  */
+        /* Only lifecycle state is used from the child type. */
         const UA_Node *targetType = NULL;
         if(target->head.nodeClass == UA_NODECLASS_VARIABLE ||
            target->head.nodeClass == UA_NODECLASS_OBJECT) {
-            targetType = getNodeType(server, &target->head, ~(UA_UInt32)0,
-                                     UA_REFERENCETYPESET_ALL,
-                                     UA_BROWSEDIRECTION_BOTH);
+            targetType = getNodeType(server, &target->head, 0,
+                                     UA_REFERENCETYPESET_NONE,
+                                     UA_BROWSEDIRECTION_INVALID);
             if(!targetType) {
                 UA_NODESTORE_RELEASE(server, target);
                 retval = UA_STATUSCODE_BADTYPEDEFINITIONINVALID;
@@ -1592,6 +1594,7 @@ recursiveCallConstructors(UA_Server *server, UA_Session *session,
     if(!node)
         return UA_STATUSCODE_BADNODEIDUNKNOWN;
     void *context = node->head.context;
+    UA_NodeClass nodeClass = node->head.nodeClass;
     UA_NODESTORE_RELEASE(server, node);
 
     /* Call the global constructor */
@@ -1606,9 +1609,9 @@ recursiveCallConstructors(UA_Server *server, UA_Session *session,
 
     /* Call the local (per-type) constructor */
     const UA_NodeTypeLifecycle *lifecycle = NULL;
-    if(type && node->head.nodeClass == UA_NODECLASS_OBJECT)
+    if(type && nodeClass == UA_NODECLASS_OBJECT)
         lifecycle = &type->objectTypeNode.lifecycle;
-    else if(type && node->head.nodeClass == UA_NODECLASS_VARIABLE)
+    else if(type && nodeClass == UA_NODECLASS_VARIABLE)
         lifecycle = &type->variableTypeNode.lifecycle;
     if(lifecycle && lifecycle->constructor) {
         retval = lifecycle->constructor(server, &session->sessionId,
@@ -1790,13 +1793,13 @@ addNode_finish(UA_Server *server, UA_Session *session, const UA_NodeId *nodeId) 
             goto cleanup;
     }
 
-    /* Get the type node
-     * TODO: Do we need all attributes and references here?  */
+    /* Type checking and construction use attributes and lifecycle state.
+     * Child instantiation browses the type independently. */
     if(node->head.nodeClass == UA_NODECLASS_VARIABLE ||
        node->head.nodeClass == UA_NODECLASS_VARIABLETYPE ||
        node->head.nodeClass == UA_NODECLASS_OBJECT) {
         type = getNodeType(server, &node->head, ~(UA_UInt32)0,
-                           UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
+                           UA_REFERENCETYPESET_NONE, UA_BROWSEDIRECTION_INVALID);
         if(!type) {
             if(server->bootstrapNS0)
                 goto constructor;
@@ -2232,14 +2235,13 @@ deconstructNodeSet(UA_Server *server, UA_Session *session,
         if(!member)
             continue;
 
-        /* Call the type-level destructor
-         * TODO: Do we need all attributes and references here?  */
+        /* The type-level destructor only needs lifecycle state. */
         void *context = member->head.context; /* No longer needed after this function */
         if(member->head.nodeClass == UA_NODECLASS_OBJECT ||
            member->head.nodeClass == UA_NODECLASS_VARIABLE) {
             const UA_Node *type =
-                getNodeType(server, &member->head, ~(UA_UInt32)0,
-                            UA_REFERENCETYPESET_ALL, UA_BROWSEDIRECTION_BOTH);
+                getNodeType(server, &member->head, 0,
+                            UA_REFERENCETYPESET_NONE, UA_BROWSEDIRECTION_INVALID);
             if(type) {
                /* Get the lifecycle */
                const UA_NodeTypeLifecycle *lifecycle;
@@ -2538,6 +2540,30 @@ deleteNode(UA_Server *server, const UA_NodeId nodeId,
 /* Add References */
 /******************/
 
+/* The optional callback avoids materializing a complete ROM reference list.
+ * Fetch metadata separately; keep the ordinary editable-node fallback. */
+static UA_StatusCode
+editSingleReference(UA_Server *server, const UA_NodeId *nodeId, UA_Byte ri,
+                    UA_Boolean forward, const UA_ExpandedNodeId *target,
+                    UA_UInt32 nameHash, UA_Boolean add) {
+    UA_Nodestore *ns = server->config.nodestore;
+    if(ns->editReference) {
+        UA_StatusCode res = ns->editReference(ns, nodeId, ri, forward, target,
+                                             nameHash, add);
+        if(res != UA_STATUSCODE_BADNOTSUPPORTED)
+            return res;
+    }
+    UA_Node *node = UA_NODESTORE_GET_EDIT_SELECTIVE(server, nodeId, 0,
+                         UA_REFTYPESET(ri), forward ? UA_BROWSEDIRECTION_FORWARD :
+                                                    UA_BROWSEDIRECTION_INVERSE);
+    if(!node)
+        return UA_STATUSCODE_BADNODEIDUNKNOWN;
+    UA_StatusCode res = add ? UA_Node_addReference(node, ri, forward, target, nameHash) :
+                             UA_Node_deleteReference(node, ri, forward, target);
+    UA_NODESTORE_RELEASE(server, node);
+    return res;
+}
+
 static void
 Operation_addReference_inner(UA_Server *server, UA_Session *session, void *context,
                              const UA_AddReferencesItem *item, UA_StatusCode *retval) {
@@ -2564,7 +2590,8 @@ Operation_addReference_inner(UA_Server *server, UA_Session *session, void *conte
     }
 
     /* Check the ReferenceType and get the index */
-    const UA_Node *refType = UA_NODESTORE_GET(server, &item->referenceTypeId);
+    const UA_Node *refType = UA_NODESTORE_GET_SELECTIVE(server, &item->referenceTypeId, 0,
+                              UA_REFERENCETYPESET_NONE, UA_BROWSEDIRECTION_INVALID);
     if(!refType) {
         UA_LOG_DEBUG_SESSION(server->config.logging, session,
                              "Cannot add reference - ReferenceType %N unknown",
@@ -2583,10 +2610,10 @@ Operation_addReference_inner(UA_Server *server, UA_Session *session, void *conte
     UA_Byte refTypeIndex = refType->referenceTypeNode.referenceTypeIndex;
     UA_NODESTORE_RELEASE(server, refType);
 
-    /* Get the source and target node (editable). Include only the BrowseName
-     * and the relevant ReferenceType and direction. Don't modify the target
-     * node if it lives on a different server. */
-    UA_Node *targetNode = NULL;
+    /* Read source/target metadata for validation and target-name hashes.
+     * Reference mutation is dispatched separately. Remote targets have no
+     * local inverse reference. */
+    const UA_Node *targetNode = NULL;
     if(UA_ExpandedNodeId_isLocal(&item->targetNodeId)) {
         if(UA_NodeId_equal(&item->targetNodeId.nodeId, &item->sourceNodeId)) {
             *retval = UA_STATUSCODE_GOOD;
@@ -2596,11 +2623,9 @@ Operation_addReference_inner(UA_Server *server, UA_Session *session, void *conte
             return;
         }
         targetNode =
-            UA_NODESTORE_GET_EDIT_SELECTIVE(server, &item->targetNodeId.nodeId,
+            UA_NODESTORE_GET_SELECTIVE(server, &item->targetNodeId.nodeId,
                                             UA_NODEATTRIBUTESMASK_BROWSENAME,
-                                            UA_REFTYPESET(refTypeIndex),
-                                            (!item->isForward) ?
-                                            UA_BROWSEDIRECTION_FORWARD : UA_BROWSEDIRECTION_INVERSE);
+                                            UA_REFERENCETYPESET_NONE, UA_BROWSEDIRECTION_INVALID);
         if(!targetNode) {
             UA_LOG_DEBUG_SESSION(server->config.logging, session,
                                  "Cannot add reference - target %N does not exist",
@@ -2621,12 +2646,10 @@ Operation_addReference_inner(UA_Server *server, UA_Session *session, void *conte
         }
     }
 
-    UA_Node *sourceNode =
-        UA_NODESTORE_GET_EDIT_SELECTIVE(server, &item->sourceNodeId,
+    const UA_Node *sourceNode =
+        UA_NODESTORE_GET_SELECTIVE(server, &item->sourceNodeId,
                                         UA_NODEATTRIBUTESMASK_BROWSENAME,
-                                        UA_REFTYPESET(refTypeIndex),
-                                        item->isForward ?
-                                        UA_BROWSEDIRECTION_FORWARD : UA_BROWSEDIRECTION_INVERSE);
+                                        UA_REFERENCETYPESET_NONE, UA_BROWSEDIRECTION_INVALID);
     if(!sourceNode) {
         if(targetNode)
             UA_NODESTORE_RELEASE(server, targetNode);
@@ -2634,12 +2657,19 @@ Operation_addReference_inner(UA_Server *server, UA_Session *session, void *conte
         return;
     }
 
+    void *referenceUndo = NULL;
+    UA_Nodestore *store = server->config.nodestore;
+    if(store->beginReferenceEdit && store->finishReferenceEdit) {
+        *retval = store->beginReferenceEdit(store, &item->sourceNodeId, &referenceUndo);
+        if(*retval != UA_STATUSCODE_GOOD) goto cleanup;
+    }
+
     /* Add the first direction. Use hash 0 for non-local targets where
      * targetNode is NULL (their browse name is not available locally). */
     UA_UInt32 targetNameHash = targetNode ?
         UA_QualifiedName_hash(&targetNode->head.browseName) : 0;
-    *retval = UA_Node_addReference(sourceNode, refTypeIndex, item->isForward,
-                                   &item->targetNodeId, targetNameHash);
+    *retval = editSingleReference(server, &item->sourceNodeId, refTypeIndex, item->isForward,
+                                   &item->targetNodeId, targetNameHash, true);
     UA_Boolean firstExisted = false;
     if(*retval == UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED) {
         *retval = UA_STATUSCODE_GOOD;
@@ -2655,8 +2685,8 @@ Operation_addReference_inner(UA_Server *server, UA_Session *session, void *conte
         UA_ExpandedNodeId_init(&expSourceId);
         expSourceId.nodeId = item->sourceNodeId;
         UA_UInt32 sourceNameHash = UA_QualifiedName_hash(&sourceNode->head.browseName);
-        *retval = UA_Node_addReference(targetNode, refTypeIndex, !item->isForward,
-                                       &expSourceId, sourceNameHash);
+        *retval = editSingleReference(server, &item->targetNodeId.nodeId, refTypeIndex, !item->isForward,
+                                       &expSourceId, sourceNameHash, true);
         if(*retval == UA_STATUSCODE_GOOD)
             secondChanged = true;
 
@@ -2670,13 +2700,16 @@ Operation_addReference_inner(UA_Server *server, UA_Session *session, void *conte
         }
 
         /* Remove first direction if the second direction failed */
-        if(*retval != UA_STATUSCODE_GOOD) {
-            UA_Node_deleteReference(sourceNode, refTypeIndex, item->isForward, &item->targetNodeId);
+        if(*retval != UA_STATUSCODE_GOOD && firstChanged && !referenceUndo) {
+            (void)editSingleReference(server, &item->sourceNodeId, refTypeIndex,
+                                      item->isForward, &item->targetNodeId, 0, false);
             firstChanged = false;
         }
     }
 
  cleanup:
+    if(referenceUndo)
+        store->finishReferenceEdit(store, referenceUndo, *retval != UA_STATUSCODE_GOOD);
     if(*retval == UA_STATUSCODE_GOOD) {
         if(firstChanged)
             recordModelChangeEvent(server, &item->sourceNodeId,
@@ -2795,17 +2828,8 @@ Operation_deleteReference_inner(UA_Server *server, UA_Session *session, void *co
     // TODO: Check consistency constraints, remove the references.
 
     /* Delete the reference in this direction */
-    UA_Node *firstNode =
-        UA_NODESTORE_GET_EDIT_SELECTIVE(server, &item->sourceNodeId, 0,
-                                        UA_REFTYPESET(refTypeIndex),
-                                        item->isForward ?
-                                        UA_BROWSEDIRECTION_FORWARD : UA_BROWSEDIRECTION_INVERSE);
-    if(firstNode) {
-        *retval = UA_Node_deleteReference(firstNode, refTypeIndex, item->isForward, &item->targetNodeId);
-    } else {
-        *retval = UA_STATUSCODE_BADNODEIDUNKNOWN;
-    }
-    UA_NODESTORE_RELEASE(server, firstNode);
+    *retval = editSingleReference(server, &item->sourceNodeId, refTypeIndex,
+                                   item->isForward, &item->targetNodeId, 0, false);
     if(*retval != UA_STATUSCODE_GOOD)
         return;
     recordModelChangeEvent(server, &item->sourceNodeId,
@@ -2819,15 +2843,12 @@ Operation_deleteReference_inner(UA_Server *server, UA_Session *session, void *co
         UA_ExpandedNodeId target2;
         UA_ExpandedNodeId_init(&target2);
         target2.nodeId = item->sourceNodeId;
-        UA_Node *secondNode =
-            UA_NODESTORE_GET_EDIT_SELECTIVE(server, &item->targetNodeId.nodeId, 0,
-                                            UA_REFTYPESET(refTypeIndex),
-                                            (!item->isForward) ?
-                                            UA_BROWSEDIRECTION_FORWARD : UA_BROWSEDIRECTION_INVERSE);
-        if(secondNode) {
-            *retval = UA_Node_deleteReference(secondNode, refTypeIndex, !item->isForward, &target2);
-            UA_NODESTORE_RELEASE(server, secondNode);
-            if(*retval == UA_STATUSCODE_GOOD)
+        UA_StatusCode second = editSingleReference(server, &item->targetNodeId.nodeId,
+                                                   refTypeIndex, !item->isForward,
+                                                   &target2, 0, false);
+        if(second != UA_STATUSCODE_BADNODEIDUNKNOWN) {
+            *retval = second;
+            if(second == UA_STATUSCODE_GOOD)
                 recordModelChangeEvent(server, &item->targetNodeId.nodeId,
                                   UA_MODELCHANGESTRUCTUREVERBMASK_REFERENCEDELETED);
         }

--- a/tools/nodeset_compiler/backend_open62541.py
+++ b/tools/nodeset_compiler/backend_open62541.py
@@ -279,8 +279,12 @@ def generateCommonVariableCode(node, nodeset):
 
     if node.value:
         code.append("#ifdef UA_ENABLE_XML_ENCODING")
-        xmlenc = [makeCLiteral(line) for line in node.value.toxml().splitlines()]
-        line_lengths = [len(line.lstrip()) for line in node.value.toxml().splitlines()] # length without the C escaping
+        # Decode the complete Variant representation. The previous unwrapped
+        # form loses the array length for ListOf* values in the XML decoder,
+        # causing valid companion-model defaults to be treated as scalars.
+        value_xml = "<Variant>" + node.value.toxml() + "</Variant>"
+        xmlenc = [makeCLiteral(line) for line in value_xml.splitlines()]
+        line_lengths = [len(line.lstrip()) for line in value_xml.splitlines()] # length without the C escaping
         xmlLength = sum(line_lengths)
         xmlenc = [(" " * (len(line) - len(line.lstrip()))) + "\"" + line.lstrip() + "\"" for line in xmlenc]
         if xmlLength < 30000:
@@ -318,10 +322,18 @@ def generateCommonVariableCode(node, nodeset):
 
         code.append("""UA_DecodeXmlOptions opts;
 memset(&opts, 0, sizeof(UA_DecodeXmlOptions));
-opts.unwrapped = true;
+opts.unwrapped = false;
 opts.namespaceMapping = nsMapping;
 opts.customTypes = UA_Server_getConfig(server)->customDataTypes;
 retVal |= UA_decodeXml(&xmlValue, &attr.value, &UA_TYPES[UA_TYPES_VARIANT], &opts);""")
+        # Some published NodeSets carry stale fixed ArrayDimensions alongside
+        # a newer default-value array. Keep the runtime attributes internally
+        # consistent so open62541 can materialize the node.
+        if node.valueRank is not None and node.valueRank >= 1:
+            code.append("if(attr.arrayDimensionsSize == 1 && attr.value.arrayLength > 0 &&")
+            code.append("   attr.arrayDimensions[0] != attr.value.arrayLength) {")
+            code.append("    attr.arrayDimensions[0] = (UA_UInt32)attr.value.arrayLength;")
+            code.append("}")
         # Some companion specs (e.g. IOLink, PNENC, PNRIO) declare ValueRank=1
         # (one-dimensional array) but provide a scalar default value in the XML
         # (e.g. <String> instead of <ListOfString>). Wrap the scalar into a
@@ -704,4 +716,3 @@ UA_StatusCode retVal = UA_STATUSCODE_GOOD;""" % (outfilebase))
     outfilec.flush()
     os.fsync(outfilec)
     outfilec.close()
-


### PR DESCRIPTION
Adding or removing a single reference in a ROM-backed address space currently requires materializing an editable node. Add optional direct-reference callbacks and paired rollback checkpoints, retaining the editable-node fallback for other nodestores. Model-change handling validates source nodes without requiring an editable copy.

Also decode complete Variant XML when generating companion-model defaults so array lengths are retained, and reconcile stale one-dimensional ArrayDimensions with the supplied default.

Validation: node-management and browse/view test suites pass against current upstream. The ROM implementation and allocation-failure coverage are in https://github.com/o6-automation/o6-embedded/pull/9. Its direct-reference, patch-format, and patch-overlay suites pass with ASan/UBSan against this native library. This changes the nodestore plugin interface and needs upstream API review.
