### PR TITLE
fix(plugins): announce the UserName policy when only a login callback is set

### DIFF
--- a/plugins/ua_accesscontrol_default.c
+++ b/plugins/ua_accesscontrol_default.c
@@ -364,12 +364,18 @@ static void clear_default(UA_AccessControl *ac) {
     }
 }
 
-UA_StatusCode
-UA_AccessControl_default(UA_ServerConfig *config,
-                         UA_Boolean allowAnonymous,
-                         const UA_String *userTokenPolicyUri,
-                         size_t usernamePasswordLoginSize,
-                         const UA_UsernamePasswordLogin *usernamePasswordLogin) {
+/* Shared implementation. The login callback has to be known *here*, before the
+ * UserTokenPolicies are built: the UserName policy is only announced when
+ * username/password login is actually possible, which is the case either when a
+ * login list is configured or when a callback verifies the credentials itself. */
+static UA_StatusCode
+setDefaultAccessControl(UA_ServerConfig *config,
+                        UA_Boolean allowAnonymous,
+                        const UA_String *userTokenPolicyUri,
+                        size_t usernamePasswordLoginSize,
+                        const UA_UsernamePasswordLogin *usernamePasswordLogin,
+                        UA_UsernamePasswordLoginCallback loginCallback,
+                        void *loginContext) {
     UA_LOG_WARNING(config->logging, UA_LOGCATEGORY_SERVER,
                    "AccessControl: Unconfigured AccessControl. Users have all permissions.");
     UA_AccessControl *ac = &config->accessControl;
@@ -406,6 +412,9 @@ UA_AccessControl_default(UA_ServerConfig *config,
         return UA_STATUSCODE_BADOUTOFMEMORY;
     memset(context, 0, sizeof(AccessControlContext));
     ac->context = context;
+
+    context->loginCallback = loginCallback;
+    context->loginContext = loginContext;
 
     /* Allow anonymous? */
     context->allowAnonymous = allowAnonymous;
@@ -444,7 +453,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
     size_t policies = 0;
     if(allowAnonymous)
         policies++;
-    if(usernamePasswordLoginSize > 0)
+    if(usernamePasswordLoginSize > 0 || loginCallback)
         policies++;
     if(config->sessionPKI.verifyCertificate)
         policies++;
@@ -493,7 +502,7 @@ UA_AccessControl_default(UA_ServerConfig *config,
             policies++;
         }
 
-        if(usernamePasswordLoginSize > 0) {
+        if(usernamePasswordLoginSize > 0 || loginCallback) {
             ac->userTokenPolicies[policies].tokenType = UA_USERTOKENTYPE_USERNAME;
             ac->userTokenPolicies[policies].policyId = UA_STRING_ALLOC(USERNAME_POLICY);
 #if UA_LOGLEVEL <= 400
@@ -513,6 +522,17 @@ UA_AccessControl_default(UA_ServerConfig *config,
 }
 
 UA_StatusCode
+UA_AccessControl_default(UA_ServerConfig *config,
+                         UA_Boolean allowAnonymous,
+                         const UA_String *userTokenPolicyUri,
+                         size_t usernamePasswordLoginSize,
+                         const UA_UsernamePasswordLogin *usernamePasswordLogin) {
+    return setDefaultAccessControl(config, allowAnonymous, userTokenPolicyUri,
+                                   usernamePasswordLoginSize, usernamePasswordLogin,
+                                   NULL, NULL);
+}
+
+UA_StatusCode
 UA_AccessControl_defaultWithLoginCallback(UA_ServerConfig *config,
                                           UA_Boolean allowAnonymous,
                                           const UA_String *userTokenPolicyUri,
@@ -520,17 +540,8 @@ UA_AccessControl_defaultWithLoginCallback(UA_ServerConfig *config,
                                           const UA_UsernamePasswordLogin *usernamePasswordLogin,
                                           UA_UsernamePasswordLoginCallback loginCallback,
                                           void *loginContext) {
-    AccessControlContext *context;
-    UA_StatusCode sc =
-        UA_AccessControl_default(config, allowAnonymous, userTokenPolicyUri,
-                                 usernamePasswordLoginSize, usernamePasswordLogin);
-    if(sc != UA_STATUSCODE_GOOD)
-        return sc;
-
-    context = (AccessControlContext *)config->accessControl.context;
-    context->loginCallback = loginCallback;
-    context->loginContext = loginContext;
-
-    return UA_STATUSCODE_GOOD;
+    return setDefaultAccessControl(config, allowAnonymous, userTokenPolicyUri,
+                                   usernamePasswordLoginSize, usernamePasswordLogin,
+                                   loginCallback, loginContext);
 }
 

--- a/tests/server/check_accesscontrol.c
+++ b/tests/server/check_accesscontrol.c
@@ -233,6 +233,51 @@ START_TEST(Server_setSessionParameter) {
     UA_Server_delete(server);
 } END_TEST
 
+static UA_StatusCode
+loginCallbackStub(const UA_String *userName, const UA_ByteString *password,
+                  size_t loginSize, const UA_UsernamePasswordLogin *login,
+                  void **sessionContext, void *loginContext) {
+    (void)userName; (void)password; (void)loginSize;
+    (void)login; (void)sessionContext; (void)loginContext;
+    return UA_STATUSCODE_BADUSERACCESSDENIED;
+}
+
+/* A login callback verifies the credentials itself, so the caller has no list to
+ * hand over -- that is the point of the callback variant. The UserName policy has
+ * to be announced all the same, otherwise no client is ever told that
+ * username/password login exists and the callback is never reached.
+ * Passing a dummy list to work around it is not a neutral workaround: the obvious
+ * filler, an empty password, makes the built-in comparison succeed (a
+ * constant-time compare over zero bytes returns true), so anyone knowing the user
+ * name would get in. */
+START_TEST(Server_usernamePolicyWithLoginCallbackOnly) {
+    UA_Server *s = UA_Server_newForUnitTest();
+    ck_assert_ptr_ne(s, NULL);
+    UA_ServerConfig *config = UA_Server_getConfig(s);
+
+    UA_String policy = UA_STRING_STATIC("http://opcfoundation.org/UA/SecurityPolicy#None");
+    UA_StatusCode retval =
+        UA_AccessControl_defaultWithLoginCallback(config, true, &policy,
+                                                  0, NULL, loginCallbackStub, NULL);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+
+    UA_Boolean foundUserName = false;
+    UA_Boolean foundAnonymous = false;
+    for(size_t i = 0; i < config->accessControl.userTokenPoliciesSize; i++) {
+        if(config->accessControl.userTokenPolicies[i].tokenType == UA_USERTOKENTYPE_USERNAME)
+            foundUserName = true;
+        if(config->accessControl.userTokenPolicies[i].tokenType == UA_USERTOKENTYPE_ANONYMOUS)
+            foundAnonymous = true;
+    }
+
+    /* Anonymous was requested and must still be there: without this witness, a
+     * configuration that announced nothing at all would pass the check below. */
+    ck_assert(foundAnonymous);
+    ck_assert(foundUserName);
+
+    UA_Server_delete(s);
+} END_TEST
+
 static Suite* testSuite_Client(void) {
     Suite *s = suite_create("Client");
     TCase *tc_client_user = tcase_create("Client User/Password");
@@ -246,6 +291,7 @@ static Suite* testSuite_Client(void) {
     TCase *tc_server = tcase_create("Server-Side Access Control");
     tcase_add_test(tc_server, Server_sessionParameter);
     tcase_add_test(tc_server, Server_setSessionParameter);
+    tcase_add_test(tc_server, Server_usernamePolicyWithLoginCallbackOnly);
     suite_add_tcase(s,tc_server);
     return s;
 }


### PR DESCRIPTION
### Problem

`UA_AccessControl_defaultWithLoginCallback()` delegates to
`UA_AccessControl_default()` and attaches the callback **afterwards**. The
UserTokenPolicies are built inside that first call, so the callback does not exist
yet when they are assembled — and the UserName policy is only added when
`usernamePasswordLoginSize > 0`.

The consequence is that a caller who verifies credentials in its own callback — the
whole point of this variant — still has to hand over a login list. Without one, no
client is ever told that username/password login is available, so the callback is
never reached.

### Why this is worth fixing rather than documenting

Passing a dummy list looks like a harmless workaround, but the obvious filler — an
empty password — **fails open**:

```c
if(userToken->password.length != upl->password.length) continue;  /* 0 == 0 */
if(!UA_constantTimeEqual(..., ..., 0))                 continue;  /* returns true */
match = true;
```

`UA_constantTimeEqual()` over zero bytes returns true, and the guard above it only
rejects the case where the user name **and** the password are empty. A valid user
name with an empty password would open a session.

So the API, as it stands, pushes integrators toward a credential bypass. That is
what makes it a defect rather than an inconvenience.

### Change

Move the body into a shared static function that receives the callback, so both
entry points build the policies with the same knowledge, and announce the UserName
policy when a login list is configured **or** a callback is set. The post-hoc
attachment is gone; no public signature changes and no behaviour change for
existing callers.

### Test

`Server_usernamePolicyWithLoginCallbackOnly` in `tests/server/check_accesscontrol.c`
asserts the UserName policy is present with an empty list and a callback. Verified
in both directions: it fails on `1.5` without the change
(`Assertion 'foundUserName' failed`) and passes with it. It also asserts the
Anonymous policy, so a configuration that announced nothing at all could not pass
it. Added to the existing `tc_server` case — no server, no fixture, no CMake change.