### PR TITLE
[REVIEW] fix(arch,plugins): remove the non-threadsafe gmtime and inet_ntoa calls

### DIFF
--- a/arch/lwip/eventloop_lwip.h
+++ b/arch/lwip/eventloop_lwip.h
@@ -83,10 +83,10 @@ lwip_getnameinfo(const struct sockaddr *sa, socklen_t salen,
         if(host) {
             if(flags & NI_NUMERICHOST) {
                 /* Return numeric IP address */
-                strncpy(host, inet_ntoa(addr_in->sin_addr), hostlen);
+                ip4addr_ntoa_r((const ip4_addr_t *)&addr_in->sin_addr, host, (int)hostlen);
             } else {
                 /* Perform reverse DNS lookup (not provided by lwIP, can use lwIP's DNS if desired) */
-                strncpy(host, inet_ntoa(addr_in->sin_addr), hostlen); // Fallback to numeric IP
+                ip4addr_ntoa_r((const ip4_addr_t *)&addr_in->sin_addr, host, (int)hostlen); // Fallback to numeric IP
             }
         }
     } else {

--- a/arch/zephyr/clock_zephyr.c
+++ b/arch/zephyr/clock_zephyr.c
@@ -30,7 +30,8 @@ UA_DateTime_now(void) {
 UA_Int64
 UA_DateTime_localTimeUtcOffset(void) {
     time_t rawtime = time(NULL);
-    struct tm *ptm = gmtime(&rawtime);
+    struct tm gbuf;
+    struct tm *ptm = gmtime_r(&rawtime, &gbuf);
     /* Request mktime() to look up dst in timezone database */
     ptm->tm_isdst = -1;
     time_t gmt = mktime(ptm);

--- a/plugins/crypto/mbedtls/create_certificate.c
+++ b/plugins/crypto/mbedtls/create_certificate.c
@@ -13,8 +13,7 @@
 
 #include "securitypolicy_common.h"
 #include "../deps/musl_inet_pton.h"
-
-#include <time.h>
+#include "mp_printf.h"
 
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/oid.h>
@@ -351,22 +350,24 @@ UA_CreateCertificate(const UA_Logger *logger, const UA_String *subject,
 #endif
 
     /* Get the current time */
-    time_t rawTime;
-    struct tm *timeInfo;
-    time(&rawTime);
-    timeInfo = gmtime(&rawTime);
+    UA_DateTime now = UA_DateTime_now();
+    UA_DateTimeStruct nowStruct = UA_DateTime_toStruct(now);
 
     /* Format the current timestamp */
     char current_timestamp[15];  // YYYYMMDDhhmmss + '\0'
-    strftime(current_timestamp, sizeof(current_timestamp), "%Y%m%d%H%M%S", timeInfo);
+    mp_snprintf(current_timestamp, sizeof(current_timestamp), "%04d%02u%02u%02u%02u%02u",
+                nowStruct.year, nowStruct.month, nowStruct.day,
+                nowStruct.hour, nowStruct.min, nowStruct.sec);
 
     /* Calculate the future timestamp */
-    timeInfo->tm_mday += expiresInDays;
-    time_t future_time = mktime(timeInfo);
+    UA_DateTime future = now + (UA_DateTime)expiresInDays * 24 * 60 * 60 * UA_DATETIME_SEC;
+    UA_DateTimeStruct futureStruct = UA_DateTime_toStruct(future);
 
     /* Format the future timestamp */
     char future_timestamp[15];  // YYYYMMDDhhmmss + '\0'
-    strftime(future_timestamp, sizeof(future_timestamp), "%Y%m%d%H%M%S", gmtime(&future_time));
+    mp_snprintf(future_timestamp, sizeof(future_timestamp), "%04d%02u%02u%02u%02u%02u",
+                futureStruct.year, futureStruct.month, futureStruct.day,
+                futureStruct.hour, futureStruct.min, futureStruct.sec);
 
     if(mbedtls_x509write_crt_set_validity(&crt, current_timestamp, future_timestamp) != 0) {
         UA_LOG_ERROR(logger, UA_LOGCATEGORY_SECURECHANNEL,


### PR DESCRIPTION
gmtime and lwIP's inet_ntoa return a pointer to a static buffer shared by all threads. The mbedTLS certificate creation now derives its validity dates from UA_DateTime_now/UA_DateTime_toStruct, which also keeps the expiry date in UTC (mktime interpreted the gmtime result as local time). Zephyr uses gmtime_r and lwIP inet_ntoa_r.

Fixes #7997